### PR TITLE
Avoid comma on floating point numbers - solves issue #92

### DIFF
--- a/frontend/settings.lua
+++ b/frontend/settings.lua
@@ -114,6 +114,7 @@ function DocSettings:flush()
 	end
 	local f_out = io.open(self.file, "w")
 	if f_out ~= nil then
+		os.setlocale('C', 'numeric')
 		local out = {"-- we can read Lua syntax here!\nreturn "}
 		self:_serialize(self.data, out, 0)
 		table.insert(out, "\n")


### PR DESCRIPTION
Use "C" for LC_NUMERIC locale when serializing settings files.
Avoids comma in floating point numbers on some locales.
Solves issue #92.
