### PR TITLE
bugfix: check if kpvbooklet was launched for more than once, if not pillow is disabled

### DIFF
--- a/koreader.sh
+++ b/koreader.sh
@@ -26,10 +26,11 @@ if test "$1" == "--framework_stop"; then
 	/etc/init.d/framework stop
 fi
 
-# dismiss chrome bar
-lipc-set-prop com.lab126.pillow disableEnablePillow disable
-# notify kpvbooklet that pillow is disabled
-lipc-send-event com.github.koreader.kpvbooklet disablePillow
+# check if kpvbooklet was launched for more than once, if not we will disable pillow
+count=`lipc-get-prop -eiq com.github.koreader.kpvbooklet.timer count`
+if [ "$count" == "" -o "$count" == "0" ]; then
+    lipc-set-prop com.lab126.pillow disableEnablePillow disable
+fi
 
 # stop cvm
 #killall -stop cvm


### PR DESCRIPTION
It will fix the blank screen bug and the first-time-launch-mess-up bug introduced by
kpvbooklet. Users who use KUAL exclusively will not be affected and pillow is disabled
each time koreader is launched. For those who have installed both kpvbooklet and KUAL
and use both launchers alternatively, it's better to reset the booklet counter with the
command `lipc-set-prop -i com.github.koreader.kpvbooklet.timer reset 0` before launching
koreader with KUAL. Otherwise, pillow might not be disabled.
