### PR TITLE
Fix bug #144

### DIFF
--- a/frontend/ui/inputevent.lua
+++ b/frontend/ui/inputevent.lua
@@ -318,22 +318,24 @@ function Input:init()
 			Device:setTouchInputDev("/dev/input/event1")
 			input.open("/dev/input/event0") -- Light button and sleep slider
 			print(_("Auto-detected Kobo"))
-			function Input:eventAdjustHook(ev)
-				if ev.type == EV_ABS then
-					if ev.code == ABS_X then
-						ev.code = ABS_Y
-					elseif ev.code == ABS_Y then
-						ev.code = ABS_X						
-						-- We always have to substract from the physical x,
-						-- regardless of the orientation
-						if (Screen.width<Screen.height) then
-							ev.value = Screen.width - ev.value
-						else
-							ev.value = Screen.height - ev.value
+			if dev_mod ~= 'Kobo_trilogy' then
+				function Input:eventAdjustHook(ev)
+					if ev.type == EV_ABS then
+						if ev.code == ABS_X then
+							ev.code = ABS_Y
+						elseif ev.code == ABS_Y then
+							ev.code = ABS_X						
+							-- We always have to substract from the physical x,
+							-- regardless of the orientation
+							if (Screen.width<Screen.height) then
+								ev.value = Screen.width - ev.value
+							else
+								ev.value = Screen.height - ev.value
+							end
 						end
 					end
+					return ev
 				end
-				return ev
 			end
 		elseif dev_mod == "Kindle4" then
 			print(_("Auto-detected Kindle 4"))


### PR DESCRIPTION
It seems that on Kobo touch swapping X and Y axis is not necessary. I have the doubt this is happening only on older revisions of the hardware, but I have no way to prove it other than waiting for users feedback.
