### PR TITLE
Fix a rare crash on ReaderHighlight

### DIFF
--- a/frontend/ui/reader/readerhighlight.lua
+++ b/frontend/ui/reader/readerhighlight.lua
@@ -146,7 +146,7 @@ function ReaderHighlight:onHold(arg, ges)
 end
 
 function ReaderHighlight:onHoldPan(arg, ges)
-	if not self.page_boxes or #self.page_boxes == 0 then
+	if not self.page_boxes or #self.page_boxes == 0 or self.hold_pos == nil then
 		DEBUG("no page boxes detected")
 		return true
 	end


### PR DESCRIPTION
The following crash is very rare and hard to reproduce. However, it can be avoided by checking `self.hold_pos` in `ReaderHighlight:onHold`.

```
lua config error: ./frontend/ui/reader/readerhighlight.lua:373: attempt to index upvalue 'pos' (a nil value)
stack traceback:
    ./frontend/ui/reader/readerhighlight.lua:373: in function 'inside_box'
    ./frontend/ui/reader/readerhighlight.lua:381: in function 'box_distance'
    ./frontend/ui/reader/readerhighlight.lua:393: in function 'getWordBoxIndices'
    ./frontend/ui/reader/readerhighlight.lua:427: in function 'getTextFromPositions'
    ./frontend/ui/reader/readerhighlight.lua:155: in function 'handleEvent'
    ./frontend/ui/widget/container.lua:43: in function 'propagateEvent'
    ./frontend/ui/widget/container.lua:55: in function 'handleEvent'
    ./frontend/ui/uimanager.lua:101: in function 'sendEvent'
    ./frontend/ui/uimanager.lua:249: in function 'run'
    ./reader.lua:251: in main chunk
```
