### PR TITLE
Fix multiple ReaderFrontLight instances, i18n issues, and refactor event handling to follow codebase patterns

### DIFF
--- a/frontend/ui/inputevent.lua
+++ b/frontend/ui/inputevent.lua
@@ -3,7 +3,6 @@ require "ui/device"
 require "ui/time"
 require "ui/gesturedetector"
 require "ui/geometry"
-require "ui/reader/readerfrontlight"
 
 -- constants from <linux/input.h>
 EV_SYN = 0
@@ -423,12 +422,6 @@ function Input:handleKeyBoardEv(ev)
 	if keycode == "IntoSS" or keycode == "OutOfSS"
 	or keycode == "Charging" or keycode == "NotCharging" then
 		return keycode
-	end
-
-	if keycode == "Light" then
-		if ev.value == EVENT_VALUE_KEY_RELEASE then
-			ReaderFrontLight:toggle()
-		end
 	end
 
 	-- handle modifier keys

--- a/frontend/ui/reader/readermenu.lua
+++ b/frontend/ui/reader/readermenu.lua
@@ -56,14 +56,6 @@ function ReaderMenu:setUpdateItemTable()
 	for _, widget in pairs(self.registered_widgets) do
 		widget:addToMainMenu(self.tab_item_table)
 	end
-	if Device:hasFrontlight() then
-		table.insert(self.tab_item_table.main, {
-			text = _("Frontlight settings"),
-			callback = function()
-				ReaderFrontLight:onShowFlDialog()
-			end
-		})
-	end
 	table.insert(self.tab_item_table.main, {
 		text = _("Help"),
 		callback = function()


### PR DESCRIPTION
Currently, the "Frontlight settings" dialog does not work on Kindle, because the menu callback handler was being called in the base object ReaderFrontLight, not in the instance created in [frontend/ui/readerui.lua:134](https://github.com/koreader/koreader/blob/cea353323eae7f3fd04f9eef8844203fc3670f37/frontend/ui/readerui.lua#L134).

On Kobo, it was working because of various `if self.fl == nil then ReaderFrontLight:init() end` checks, that in fact caused two initializations to be carried, one on each object.

I changed the object to add itself to the menu using the same procedure as used by other menu items, i.e. by calling `self.ui.menu:registerToMainMenu(self)` inside `init()`. This should fix the first issue.

The second issue is related to i18n. No strings in `readerfrontlight.lua` where wrapped inside `_()` calls. For fixing that, one needs to remove the `require` from `inputevent.lua`, because at this point of execution `_()` is not defined yet. Thus, the `Light` key event cannot be handled in `inputevent.lua`. Therefore, I also changed it to be handled using `self.key_events`, as done by other objects in the codebase.

@giorgio130, Please verify if the my code is correct and if it still works in the Kobo. I do not have a Kobo to test, so I simulated a `Light` key event in order to test if the event was being triggered.
