### PR TITLE
Initialize FileChooser with root_path, otherwise the command line argument (directory) is ignored

### DIFF
--- a/frontend/apps/filemanager/fm.lua
+++ b/frontend/apps/filemanager/fm.lua
@@ -7,7 +7,7 @@ FileManager = InputContainer:extend{
 	title = _("FileManager"),
 	width = Screen:getWidth(),
 	height = Screen:getHeight(),
-	root_path = './',
+	root_path = lfs.currentdir(),
 	-- our own size
 	dimen = Geom:new{ w = 400, h = 600 },
 	onExit = function() end,


### PR DESCRIPTION
Just a small bug. Currently the KUAL launcher "Start in documents" makes koreader show its directory instead of `/mnt/us/documents` because of this.
BTW, the new FileManager and the shared library recent additions are simply great. Thank you guys for the good work.
