### PR TITLE
bugfix: fix screen ghosting after swiping north/south in scroll mode

### DIFF
--- a/frontend/ui/reader/readerpaging.lua
+++ b/frontend/ui/reader/readerpaging.lua
@@ -220,6 +220,8 @@ function ReaderPaging:onSwipe(arg, ges)
 		self:onPagingRel(1)
 	elseif ges.direction == "east" then
 		self:onPagingRel(-1)
+	else
+		UIManager.full_refresh = true
 	end
 	return true
 end


### PR DESCRIPTION
As swiping north/south will generate several pan gestures which will
set refresh mode to WAVEFORM_MODE_A2, we should explicitly do a full
refresh in order to switch refresh waveform from WAVEFORM_MODE_A2
to WAVEFORM_MODE_GC16 as in OnPanRelease.
