### PR TITLE
fix bug #179

### DIFF
--- a/frontend/ui/reader/readercopt.lua
+++ b/frontend/ui/reader/readercopt.lua
@@ -20,7 +20,7 @@ function ReaderCoptListener:onReadSettings(config)
 	    end)
 	end
 	
-	local copt_font_size = config:readSetting("copt_font_size") or 22
+	local copt_font_size = config:readSetting("copt_font_size")
 	if copt_font_size then
 		table.insert(self.ui.postInitCallback, function()
 		    self.ui.document:setFontSize(copt_font_size)


### PR DESCRIPTION
It seems that the setPageMargins method will mess up XPointer of current view.
This bugfix simply disables page margin restoring in readercopt.lua so that
reading position is restorable.
