### PR TITLE
Don't kill nickel software on kobo

### DIFF
--- a/koreader_kobo.sh
+++ b/koreader_kobo.sh
@@ -10,9 +10,6 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# stop nickel
-killall nickel
-
 # finally call reader
 ./reader.lua /mnt/onboard 2> crash.log
 


### PR DESCRIPTION
It's not really needed and might prevent issues with database corruption.
