### PR TITLE
Remove ffi.cdef to avoid conflict with ffi/util.lua from koreader-base

### DIFF
--- a/frontend/lulip.lua
+++ b/frontend/lulip.lua
@@ -18,21 +18,11 @@ local string_sub = string.sub
 local string_gsub = string.gsub
 local string_format = string.format
 local ffi = require("ffi")
-
-ffi.cdef[[
-  typedef long time_t;
-
-  typedef struct timeval {
-    time_t tv_sec;
-    time_t tv_usec;
-  } timeval;
- 
-  int gettimeofday(struct timeval* t, void* tzp);
-]]
+local util = require("ffi/util")  -- ffi.C.gettimeofday
 
 module(...)
 
-local gettimeofday_struct = ffi.new("timeval")
+local gettimeofday_struct = ffi.new("struct timeval")
 local function gettimeofday()
    ffi.C.gettimeofday(gettimeofday_struct, nil)
    return tonumber(gettimeofday_struct.tv_sec) * 1000000 + tonumber(gettimeofday_struct.tv_usec)


### PR DESCRIPTION
Now that ffi/util.lua was added to koreader-base, we should avoid conflicting ffi.cdefs
