### PR TITLE
Add InputText:setText and avoid non-intuitive UI behavior after light toggle

### DIFF
--- a/frontend/ui/reader/readerfrontlight.lua
+++ b/frontend/ui/reader/readerfrontlight.lua
@@ -69,6 +69,7 @@ function ReaderFrontLight:onShowFlDialog()
 					text = _("Toggle"),
 					enabled = true,
 					callback = function()
+						self.fl_dialog.input:setText("")
 						fl:toggle()
 					end,
 				},

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -114,6 +114,12 @@ function InputText:getText()
 	return self.text
 end
 
+function InputText:setText(text)
+	self:StringToCharlist(text)
+	self:initTextBox()
+	UIManager:setDirty(self.parent, "partial")
+end
+
 function InputText:StringToCharlist(text)
 	if text == nil then return end
 	-- clear


### PR DESCRIPTION
Discussed in #20. We could instead do something like that, which I think would be even more intuitive:

``` Lua
fl:toggle()
self.fl_dialog.input:setText(fl:isOn() and ("%d"):format(self.intensity) or "")
```

But for this to work we would need to implement `isOn()` both for Kindle and Kobo. For the Kindle, it could be implemented readily in pure Lua, however for the Kobo we would need to change the kobolight module in koreader-base to expose its `isOn` variable (or track the state independently, which is ugly), but I prefer not do to that now, let's move kobolight to FFI first :P
