### PR TITLE
Fix touchscreen input on Kobo mini.

### DIFF
--- a/frontend/ui/inputevent.lua
+++ b/frontend/ui/inputevent.lua
@@ -322,6 +322,7 @@ function Input:init()
 			print(_("Auto-detected Kobo"))
 			self:adjustKoboEventMap()
 			if dev_mod ~= 'Kobo_trilogy' and firm_rev == "2.6.1"
+			or dev_mod == 'Kobo_pixie'
 			or dev_mod == 'Kobo_dragon' then
 				function Input:eventAdjustHook(ev)
 					if ev.type == EV_ABS then


### PR DESCRIPTION
This commit will fix touchscreen issues on Kobo mini running the latest FW 3.8.1.
