### PR TITLE
Safer installing process for Kobos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,9 @@ endif
 	# Kobo startup
 	mkdir -p $(INSTALL_DIR)/kobo/mnt/onboard/.kobo
 	ln -sf ../../../../../fmon $(INSTALL_DIR)/kobo/mnt/onboard/.kobo/
-	ln -sf ../../../../resources/koreader.png $(INSTALL_DIR)/kobo/mnt/onboard/
 	cd $(INSTALL_DIR)/kobo && tar -czhf ../KoboRoot.tgz mnt
+	cp resources/koreader.png $(INSTALL_DIR)/koreader.png
+	cp fmon/README.txt $(INSTALL_DIR)/README_kobo.txt
 	# clean up
 	rm -rf $(INSTALL_DIR)/koreader/data/{cr3.ini,cr3skin-format.txt,desktop,devices,manual}
 	rm $(INSTALL_DIR)/koreader/fonts/droid/DroidSansFallbackFull.ttf
@@ -86,7 +87,7 @@ koboupdate: all
 	cd $(INSTALL_DIR) && \
 		zip -9 -r \
 			../koreader-kobo-$(MACHINE)-$(VERSION).zip \
-			KoboRoot.tgz koreader \
+			KoboRoot.tgz koreader koreader.png README_kobo.txt \
 			-x "koreader/resources/fonts/*"
 
 pot:

--- a/fmon/README.txt
+++ b/fmon/README.txt
@@ -1,0 +1,8 @@
+Installation instructions for Kobo:
+- Install "Files Monitor" (http://www.mobileread.com/forums/showthread.php?t=218283)
+- Put the image included in the zip (called "koreader.png") in the main folder of your kobo and disconnect it from your computer. Open the image on the reader, go back to the home and then, just to be extra-safe, reboot it.
+- Extract the remaining content of the zip in the ".kobo" directory (both KoboRoot.tgz and the koreader folder).
+
+Selecting the KOReader icon in your home, you will be able to launch KOReader. Simple enough, isn't it? Just be sure to process the image properly (follow those steps carefully) if it's the first time you install koreader, if you made a factory reset or if you deleted it in some way, otherwise you could end up launching koreader automatically at every boot, being unable to exit it without a factory reset.
+
+When you update koreader, it should be sufficient to extract the koreader folder, without KoboRoot.tgz - that one is needed to add the launcher.


### PR DESCRIPTION
Right now a little care is needed when installing for the first time on Kobos, you could end up stuck in koreader with no means to exit it (especially for kobo mini). Those changes try to make it safer, if one follows the steps described in the newly created README it should not happen.
