### PR TITLE
fix getAutoBBox failed bug

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -114,8 +114,16 @@ function KoptInterface:getAutoBBox(doc, pageno)
 		local page = doc._document:openPage(pageno)
 		local kc = self:createContext(doc, pageno, bbox)
 		--DEBUGBT()
-		bbox.x0, bbox.y0, bbox.x1, bbox.y1 = page:getAutoBBox(kc)
-		--DEBUG("Auto detected bbox", bbox)
+		--DEBUG("getAutoBBox:native page size", native_size)
+		local x0, y0, x1, y1 = page:getAutoBBox(kc)
+		local w, h = native_size.w, native_size.h
+		if (x1 - x0)/w > 0.1 or (y1 - y0)/h > 0.1 then
+			bbox.x0, bbox.y0, bbox.x1, bbox.y1 = x0, y0, x1, y1
+			--DEBUG("getAutoBBox:auto detected bbox", bbox)
+		else
+			bbox = Document.getPageBBox(doc, pageno)
+			--DEBUG("getAutoBBox:use manual bbox", bbox)
+		end
 		Cache:insert(hash, CacheItem:new{ autobbox = bbox })
 		page:close()
 		kc:free()


### PR DESCRIPTION
If getAutoBBox is fed with a blank page the returned bbox will be
much smaller than the native page dimensions. The problem is that
in zoom to 'content*' mode document renderer will try to render
the whole page at a zoom level that can cover the screen with the
bbox region of the page. That's if the blank page size is 3000x4000
and the returned autobbox is 300x400, the screen size is 600x800,
then the page will be rendered in 3000x(600/300)x4000x(800/400)
which is so large that the cache manager will not accept.

This patch just check if the returned autobbox is considerablely
much smaller than the native page dimensions. If so it will return
the manual bbox.

This patch should fix #293. And it's tested with the case provided
by @Markismus in #291. With this patch the second page of the djvu 
file is rendered properly.
