### PR TITLE
missing require() of infomessage in UIManager

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -294,6 +294,7 @@ function UIManager:run()
 				Device:getFrontlight():toggle()
 			elseif (input_event == "Power" and not Device.screen_saver_mode) or
 			input_event == "Suspend" then
+				local InfoMessage = require("ui/widget/infomessage")
 				self:show(InfoMessage:new{
 					text = _("Standby"),
 					timeout = 1,


### PR DESCRIPTION
require() must be done locally in order to not create circular dependencies
fixes #338
