### PR TITLE
Further improvements on Input:handlePhoenixTouchEv

### DIFF
--- a/frontend/ui/gesturedetector.lua
+++ b/frontend/ui/gesturedetector.lua
@@ -81,6 +81,7 @@ function GestureDetector:feedEvent(tevs)
 	repeat
 		local tev = table.remove(tevs)
 		if tev then
+			DEBUG("tev fed to GestureDetector|",tev.x.."|"..tev.y.."|"..tev.id.."|"..tev.slot.."|"..tev.timev.sec.."|"..tev.timev.usec)
 			local slot = tev.slot
 			if not self.states[slot] then
 				self:clearState(slot) -- initiate state


### PR DESCRIPTION
Because of the lack of detection of pinch, spread or rotate, I double checked the function Input:handlePhoenixTouchEv(ev).

I put a DEBUG line in function GestureDetector:feedEvent(tevs) to check the data being sent to this function against the event log.

With the code of previous commit I sometimes saw 3 event input lines, where I expected 2, and the track id's weren't identical to their slots.
This is fixed, now.

The analysis of the new code shows that as soon as a gesture is detected, the gesture is returned directly. Hereby, the repeat loop is interrupted and the input of slot 0 is lost completely.
_Is this data loss intended?_

Signed-off-by: Markismus zulde.zuldemans@gmail.com
