### PR TITLE
set title bar height to height of text widget in Menu widget

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -301,7 +301,7 @@ function Menu:init()
 	}
 	-- group for title bar
 	self.title_bar = OverlapGroup:new{
-		dimen = {w = self.dimen.w},
+		dimen = {w = self.dimen.w, h = self.menu_title:getSize().h},
 		self.menu_title,
 	}
 	-- group for items


### PR DESCRIPTION
without the height of the close button widget
This will make room for one more menu item entry and fix #355 and #394.
The larger tap zone for close button widget is still there.
