### PR TITLE
Avoid off-limits dictionary title and make font size adjustable

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -97,6 +97,9 @@ DGESDETECT_DISABLE_DOUBLE_TAP = true
 -- change this to any numerical value if you want to antomatically save settings when turning pages
 DAUTO_SAVE_PAGING_COUNT = nil
 
+-- dictionary font size
+DDICT_FONT_SIZE = 20
+
 -- ####################################################################
 -- following features are not supported right now
 -- ####################################################################

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -143,7 +143,7 @@ function RenderText:sizeUtf8Text(x, width, face, text, kerning)
 	return { x = pen_x, y_top = pen_y_top, y_bottom = pen_y_bottom}
 end
 
-function RenderText:renderUtf8Text(buffer, x, y, face, text, kerning, bgcolor, fgcolor)
+function RenderText:renderUtf8Text(buffer, x, y, face, text, kerning, bgcolor, fgcolor, width)
 	if not text then
 		DEBUG("renderUtf8Text called without text");
 		return 0
@@ -153,9 +153,12 @@ function RenderText:renderUtf8Text(buffer, x, y, face, text, kerning, bgcolor, f
 	-- see: http://freetype.org/freetype2/docs/glyphs/glyphs-4.html
 	local pen_x = 0
 	local prevcharcode = 0
-	local buffer_width = buffer:getWidth()
+	local text_width = buffer:getWidth() - x
+	if width and width < text_width then
+		text_width = width
+	end
 	for _, charcode, uchar in utf8Chars(text) do
-		if pen_x < buffer_width then
+		if pen_x < text_width then
 			local glyph = self:getGlyph(face, charcode, bgcolor, fgcolor)
 			if kerning and (prevcharcode ~= 0) then
 				pen_x = pen_x + face.ftface:getKerning(prevcharcode, charcode)
@@ -167,7 +170,7 @@ function RenderText:renderUtf8Text(buffer, x, y, face, text, kerning, bgcolor, f
 				glyph.bb:getWidth(), glyph.bb:getHeight(), 1)
 			pen_x = pen_x + glyph.ax
 			prevcharcode = charcode
-		end -- if pen_x < buffer_width
+		end -- if pen_x < text_width
 	end
 
 	return pen_x

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -31,7 +31,7 @@ local DictQuickLookup = InputContainer:new{
 	dict_index = 1,
 	title_face = Font:getFace("tfont", 22),
 	word_face = Font:getFace("tfont", 22),
-	content_face = Font:getFace("cfont", 20),
+	content_face = Font:getFace("cfont", DDICT_FONT_SIZE),
 	width = nil,
 	height = nil,
 	
@@ -85,7 +85,7 @@ function DictQuickLookup:update()
 		TextWidget:new{
 			text = self.dictionary,
 			face = self.title_face,
-			width = self.width,
+			width = self.width - self.button_padding,
 		}
 	}
 	-- lookup word

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -47,7 +47,7 @@ function TextWidget:paintTo(bb, x, y)
 	--bb:blitFrom(self._bb, x, y, 0, 0, self._length, self._bb:getHeight())
 	--@TODO Don't use kerning for monospaced fonts.    (houqp)
 	RenderText:renderUtf8Text(bb, x, y+self._height*0.7, self.face, self.text,
-					true, self.bgcolor, self.fgcolor)
+					true, self.bgcolor, self.fgcolor, self.width)
 end
 
 function TextWidget:free()


### PR DESCRIPTION
Implements the following features:
- Avoids dictionary title from going off-limits: currently, if the user has a dictionary whose name is too large, it will be rendered after the close button or even after the dict lookup window borders.
- Make font size adjustable: some dictionaries have embedded word-wrap, i.e. there are newlines, and spaces in the beginning of a line, which were added by the dictionary author in order to achieve the desired formatting. In those cases, the user may want to reduce the font size to one allowing to display the text with no additional word wrappings than those already embedded, thus making the text more readable.

Some remarks:
- The `RenderText:renderUtf8Text` was modified in a way such that the new `width` parameter is optional, so no changes are needed in other places which call this function.
- The `buffer_width` variable was renamed to `text_width`, as it apparently should be, because `x` is summed to `pen_x` when rendering, so perhaps the previous code might draw off bounds if `x > 0` and the text is sufficiently large.
- I did not test if the change above is sufficient to completely avoid drawing off-bounds. (Maybe we should sum the character width also?)
- The `button_padding` is subtracted from the width for avoiding drawing over the close button. This is not the ideal calculation, but I think getting the real button width would need messing too much with the code for only a cosmetic change.
