### PR TITLE
Avoid crash if trying to open a non-existent file

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -50,6 +50,12 @@ end
 
 function showReaderUI(file, pass)
 	DEBUG("opening file", file)
+	if lfs.attributes(file, "mode") ~= "file" then
+		UIManager:show(InfoMessage:new{
+			text = _("File does not exist")
+		})
+		return
+	end
 	UIManager:show(InfoMessage:new{
 		text = _("opening file") .. file,
 		timeout = 1,
@@ -172,11 +178,11 @@ end
 if ARGV[argidx] and ARGV[argidx] ~= "" then
 	if lfs.attributes(ARGV[argidx], "mode") == "directory" then
 		showHomePage(ARGV[argidx])
-	elseif lfs.attributes(ARGV[argidx], "mode") == "file" then
+	else
 		showReaderUI(ARGV[argidx])
 	end
 	UIManager:run()
-elseif last_file and lfs.attributes(last_file, "mode") == "file" then
+elseif last_file then
 	showReaderUI(last_file)
 	UIManager:run()
 else


### PR DESCRIPTION
...which currently might occur by clicking in the history entry of a file which was removed.

Also, remove the (now redundant) check of the cmdline argument and of last_file, which now produce an error message dialog instead of simply closing the reader.
