### PR TITLE
Fix out-of-range page and tweak swipe

### DIFF
--- a/frontend/ui/reader/readerrolling.lua
+++ b/frontend/ui/reader/readerrolling.lua
@@ -183,7 +183,11 @@ function ReaderRolling:onTapBackward()
 end
 
 function ReaderRolling:onSwipe(arg, ges)
-	if ges.direction == "west" then
+	if ges.direction == "north" then
+		self:onGotoViewRel(1)
+	elseif ges.direction == "south" then
+		self:onGotoViewRel(-1)
+	elseif ges.direction == "west" then
 		self.ui.document:goForward()
 		self:onUpdateXPointer()
 	elseif ges.direction == "east" then


### PR DESCRIPTION
- Avoid PageUpdate from receiving out-of-range page

Otherwise, `current_page` can acquire negative values, or values greater than the page count, when the user tries to go back the first page or past the last page.
-  Restore north and south swipe gestures

Might be useful in pages covered with links, which make it difficult to tap in the correct point for flipping the page.
