### PR TITLE
Fix crash trying to select text in an empty page

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -593,6 +593,7 @@ end
 get word and word box around pos
 --]]
 function KoptInterface:getWordFromBoxes(boxes, pos)
+	if not pos or #boxes == 0 then return {} end
 	local i, j = getWordBoxIndices(boxes, pos)
 	local lb = boxes[i]
 	local wb = boxes[i][j]
@@ -613,7 +614,7 @@ end
 get text and text boxes between pos0 and pos1
 --]]
 function KoptInterface:getTextFromBoxes(boxes, pos0, pos1)
-	if not pos0 or not pos1 then return {} end
+	if not pos0 or not pos1 or #boxes == 0 then return {} end
     local line_text = ""
     local line_boxes = {}
     local i_start, j_start = getWordBoxIndices(boxes, pos0)

--- a/frontend/ui/reader/readerhighlight.lua
+++ b/frontend/ui/reader/readerhighlight.lua
@@ -296,7 +296,7 @@ function ReaderHighlight:lookup(selected_word)
 		local word_box = self.view:pageToScreenTransform(self.hold_pos.page, selected_word.sbox)
 		self.ui:handleEvent(Event:new("LookupWord", self, selected_word.word, word_box))
 	-- or we will do OCR
-	else
+	elseif selected_word.sbox then
 		local word = self.ui.document:getOCRWord(self.hold_pos.page, selected_word)
 		DEBUG("OCRed word:", word)
 		local word_box = self.view:pageToScreenTransform(self.hold_pos.page, selected_word.sbox)


### PR DESCRIPTION
If `boxes == {}`, which happens e.g. when we are in an empty page, `getWordFromBoxes` would crash and `getWordBoxIndices` would return `1,1`, making `getTextFromBoxes` also crash. We can avoid it by checking for `#boxes == 0` in the relevant functions.

The change in `readerhighlight.lua` is also needed because now `selected_word` might be an empty table (making `getWordFromBoxes` return `nil` would require to place checks in lots of points in the code).

Example of crash fixed by this PR:

```
# hold position in page {
    ["page"] = 2,
    ["x"] = 337,31398416887,
    ["y"] = 401,68337730871,
    ["rotation"] = 0,
    ["zoom"] = 1,2718120805369
}
./luajit: ./frontend/document/koptinterface.lua:598: attempt to index a nil value
stack traceback:
    ./frontend/document/koptinterface.lua:598: in function 'getWordFromBoxes'
    ./frontend/document/koptinterface.lua:738: in function 'getWordFromPosition'
    ./frontend/ui/reader/readerhighlight.lua:260: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/uimanager.lua:119: in function 'sendEvent'
    ./frontend/ui/uimanager.lua:307: in function 'run'
    ./reader.lua:196: in main chunk
    [C]: in function 'dofile'
    ./koreader-base:37: in main chunk
    [C]: at 0x0000bd45
```
