### PR TITLE
calculate maximum global cache size from free RAM

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -19,7 +19,14 @@ DGLOBALGAMMA = 1.0
 -- See comments in djvureader.lua:DJVUReader:select_render_mode()
 DRENDER_MODE = 0 -- 0 is COLOUR
 
-DGLOBAL_CACHE_SIZE = 1024*1024*10
+-- minimum cache size
+DGLOBAL_CACHE_SIZE_MINIMUM = 1024*1024*10
+
+-- proportion of system free memory used as global cache
+DGLOBAL_CACHE_FREE_PROPORTION = 0.2
+
+-- maximum cache size
+DGLOBAL_CACHE_SIZE_MAXIMUM = 1024*1024*30
 
 -- background colour in non scroll mode: 8 = gray, 0 = white, 15 = black
 DBACKGROUND_COLOR = 0


### PR DESCRIPTION
In reflowing scroll mode with 2 pages hinting, 4 full page blitbuffers
and koptcontexts should stay well in cache in the most demanding cases,
with two pages shown on screen and two pages rendered in background.
Since blitbuffer size is halved the size of page, we need cache size
to be 6 times an average reflowed page size.

For Kobo Aura HD which has a resolution of 1440×1080, a reflowed page
could become 1080×4800. So 30MB of cache is demanded for this case.

This PR implements dynamic cache size allocating according to size of
system free memory. By default it will use 20 percent of free RAM with
a clip specified by DGLOBAL_CACHE_SIZE_MINIMUM and
DGLOBAL_CACHE_SIZE_MAXIMUM which are 10MB and 30MB respectively by default.
