### PR TITLE
Reload workaround for cre: prefer using in-memory config

### DIFF
--- a/frontend/ui/reader/readertypeset.lua
+++ b/frontend/ui/reader/readertypeset.lua
@@ -34,7 +34,9 @@ function ReaderTypeset:onReadSettings(config)
 end
 
 function ReaderTypeset:_setPageMargins()
-	local copt_margins = self.ui.doc_settings:readSetting("copt_page_margins") or DCREREADER_CONFIG_MARGIN_SIZES_MEDIUM
+	local copt_margins = self.ui.document.configurable.page_margins or
+		self.ui.doc_settings:readSetting("copt_page_margins") or
+		DCREREADER_CONFIG_MARGIN_SIZES_MEDIUM
 	self.ui:handleEvent(Event:new("SetPageMargins", copt_margins))
 end
 
@@ -117,7 +119,8 @@ function ReaderTypeset:toggleFloatingPunctuation()
 	self.ui.document:setFloatingPunctuation(self.floating_punctuation)
 	--self.ui:handleEvent(Event:new("UpdatePos"))
 	-- workaround: set again things unset by crengine after changing floating punctuation
-	self.ui.document:setFontFace(self.ui.doc_settings:readSetting("font_face"))
+	self.ui.document:setFontFace(self.ui.font.font_face or
+		self.ui.doc_settings:readSetting("font_face"))
 	self:_setPageMargins()
 end
 

--- a/frontend/ui/readerui.lua
+++ b/frontend/ui/readerui.lua
@@ -222,11 +222,12 @@ function ReaderUI:init()
 			ui = self
 		})
 		-- font menu
-		table.insert(self, ReaderFont:new{
+		self.font = ReaderFont:new{
 			dialog = self.dialog,
 			view = self[1],
 			ui = self
-		})
+		}
+		table.insert(self, self.font) -- hold reference to font menu
 		table.insert(self, ReaderHyphenation:new{
 			dialog = self.dialog,
 			view = self[1],


### PR DESCRIPTION
Otherwise settings done by the user will be ignored unless they are already saved to disk.
This is to complement the workaround introduced in 132b5201f6ebbcc8fbe12420630bb17455bc69f3 (PR #483)
