### PR TITLE
Fix rare bugs identified by fuzzing

### DIFF
--- a/frontend/ui/reader/readerdictionary.lua
+++ b/frontend/ui/reader/readerdictionary.lua
@@ -34,7 +34,7 @@ function ReaderDictionary:stardictLookup(word, box)
 end
 
 function ReaderDictionary:showDict(results, box)
-	if results and results[1] then
+	if results and results[1] and box then
 		DEBUG("showing quick lookup dictionary window")
 		local align = nil
 		local region = Geom:new{x = 0, w = Screen:getWidth()}

--- a/frontend/ui/reader/readerfooter.lua
+++ b/frontend/ui/reader/readerfooter.lua
@@ -77,6 +77,7 @@ function ReaderFooter:init()
 end
 
 function ReaderFooter:updateFooter()
+	if type(self.pageno) ~= "number" then return end
 	self.progress_bar.percentage = self.pageno / self.pages
 	if self.show_time then
 		self.progress_text.text = os.date("%H:%M")

--- a/frontend/ui/reader/readerlink.lua
+++ b/frontend/ui/reader/readerlink.lua
@@ -53,9 +53,11 @@ end
 function ReaderLink:onTap(arg, ges)
 	if self.ui.document.info.has_pages then
 		local pos = self.view:screenToPageTransform(ges.pos)
-		local link = self.ui.document:getLinkFromPosition(pos.page, pos)
-		if link then
-			return self:onGotoLink(link)
+		if pos then
+			local link = self.ui.document:getLinkFromPosition(pos.page, pos)
+			if link then
+				return self:onGotoLink(link)
+			end
 		end
 	else
 		local link = self.ui.document:getLinkFromPosition(ges.pos)


### PR DESCRIPTION
I have "manually fuzzed" the reader with input events after opening a number of files in different formats (an automatic fuzzer would be a nice tool to write in the future :P).

4 different errors were produced. All of them are very hard to reproduce. This PR fixes 3 of them.

The following I am not sure what would be the best way to prevent, because the "PageUpdate" event would be received in different objects and might produce other effects:

```
./luajit: ./frontend/document/document.lua:90: cannot open page #30, out of range (1-11)
stack traceback:
    [C]: in function 'openPage'
    ./frontend/document/document.lua:90: in function 'getNativePageDimensions'
    ./frontend/document/document.lua:109: in function 'getPageArea'
    ./frontend/ui/reader/readerview.lua:426: in function 'recalculate'
    ./frontend/ui/reader/readerview.lua:574: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/reader/readerlink.lua:85: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/uimanager.lua:119: in function 'sendEvent'
    ./frontend/ui/uimanager.lua:307: in function 'run'
    ./reader.lua:196: in main chunk
    [C]: in function 'dofile'
    ./koreader-base:37: in main chunk
    [C]: at 0x0000c604
```

The following 3 errors are hopefully avoided by the changes in this PR. Tracking the root cause of the errors would be better, but as we are next to release and the bugs are hard to reproduce, let's fix them this way by now.

The first error below is the most common. I have actually ran into it even before the "fuzzing", but I was never able to reproduce it consistently.

```
./luajit: ./frontend/ui/reader/readerfooter.lua:80: attempt to perform arithmetic on field 'pageno' (a string value)
stack traceback:
    ./frontend/ui/reader/readerfooter.lua:80: in function 'updateFooter'
    ./frontend/ui/reader/readerfooter.lua:91: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/reader/readerlink.lua:85: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/uimanager.lua:119: in function 'sendEvent'
    ./frontend/ui/uimanager.lua:307: in function 'run'
    ./reader.lua:196: in main chunk
    [C]: in function 'dofile'
    ./koreader-base:37: in main chunk
    [C]: at 0x0000c604
```

```
./luajit: ./frontend/ui/reader/readerlink.lua:56: attempt to index local 'pos' (a nil value)
stack traceback:
    ./frontend/ui/reader/readerlink.lua:56: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/uimanager.lua:119: in function 'sendEvent'
    ./frontend/ui/uimanager.lua:307: in function 'run'
    ./reader.lua:196: in main chunk
    [C]: in function 'dofile'
    ./koreader-base:37: in main chunk
    [C]: at 0x0000c604
```

```
./luajit: ./frontend/ui/reader/readerdictionary.lua:41: attempt to index local 'box' (a nil value)
stack traceback:
    ./frontend/ui/reader/readerdictionary.lua:41: in function 'showDict'
    ./frontend/ui/reader/readerdictionary.lua:31: in function 'stardictLookup'
    ./frontend/ui/reader/readerdictionary.lua:13: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/reader/readerhighlight.lua:297: in function 'lookup'
    ./frontend/ui/reader/readerhighlight.lua:320: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/uimanager.lua:119: in function 'sendEvent'
    ./frontend/ui/uimanager.lua:307: in function 'run'
    ./reader.lua:196: in main chunk
    [C]: in function 'dofile'
    ./koreader-base:37: in main chunk
    [C]: at 0x0000c604
```
