### PR TITLE
Cleanup link_states and fix a rare highlight bug

### DIFF
--- a/frontend/ui/reader/readerhighlight.lua
+++ b/frontend/ui/reader/readerhighlight.lua
@@ -302,7 +302,7 @@ function ReaderHighlight:lookup(selected_word)
 		local word_box = self.view:pageToScreenTransform(self.hold_pos.page, selected_word.sbox)
 		self.ui:handleEvent(Event:new("LookupWord", self, selected_word.word, word_box))
 	-- or we will do OCR
-	elseif selected_word.sbox then
+	elseif selected_word.sbox and self.hold_pos then
 		local word = self.ui.document:getOCRWord(self.hold_pos.page, selected_word)
 		DEBUG("OCRed word:", word)
 		local word_box = self.view:pageToScreenTransform(self.hold_pos.page, selected_word.sbox)

--- a/frontend/ui/reader/readerlink.lua
+++ b/frontend/ui/reader/readerlink.lua
@@ -16,6 +16,11 @@ function ReaderLink:init()
 	end
 end
 
+function ReaderLink:onReadSettings(config)
+	-- called when loading new document
+	self.link_states = {}
+end
+
 function ReaderLink:initGesListener()
 	if Device:isTouchDevice() then
 		self.ges_events = {


### PR DESCRIPTION
Found how to reproduce the bug which was unsolved in #485: @chrox was right, there was some cleanup missing. Also fix a rare highlight bug which got me a crash yesterday:

```
./luajit: ./frontend/ui/reader/readerhighlight.lua:300: attempt to index field 'hold_pos' (a nil value)
stack traceback:
    ./frontend/ui/reader/readerhighlight.lua:300: in function 'lookup'
    ./frontend/ui/reader/readerhighlight.lua:320: in function 'handleEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    ./frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    ./frontend/ui/uimanager.lua:119: in function 'sendEvent'
    ./frontend/ui/uimanager.lua:307: in function 'run'
    ./reader.lua:196: in main chunk
    [C]: in function 'dofile'
    ./koreader-base:37: in main chunk
    [C]: at 0x0000c604
```
