### PR TITLE
Fix bug #448.

### DIFF
--- a/koreader_kobo.sh
+++ b/koreader_kobo.sh
@@ -13,8 +13,13 @@ export STARDICT_DATA_DIR="data/dict"
 # stop Nickel
 killall -STOP nickel
 
+# store the content of the framebuffer
+dd if=/dev/fb0 of=.last_screen_content
+
 # finally call reader
 ./reader.lua /mnt/onboard 2> crash.log
 
 # continue with nickel
+cat .last_screen_content | /usr/local/Kobo/pickel showpic
+rm .last_screen_content
 killall -CONT nickel


### PR DESCRIPTION
Quick fix, store the last content of the screen in a file then show it again when KOReader exits.
