### PR TITLE
dirty hack to fix wrong zoom level

### DIFF
--- a/frontend/ui/readerui.lua
+++ b/frontend/ui/readerui.lua
@@ -264,6 +264,9 @@ function ReaderUI:init()
 	--DEBUG(self.doc_settings)
 	-- we only read settings after all the widgets are initialized
 	self:handleEvent(Event:new("ReadSettings", self.doc_settings))
+	-- dirty hack to make final rezoom
+	-- TODO: find out why we need this.
+	if self.zoom then self.zoom:onReZoom() end
 
 	for _,v in ipairs(self.postInitCallback) do
 		v()


### PR DESCRIPTION
This hack is to rescue wrong zoom level after removing unnecessary
`self:handleEvent(Event:new("SetDimensions", self.dimen))` at the
end of ReaderUI initialization which otherwise would confuse crengine
with two different dimens and would cause inconsistent reading progress.
