### PR TITLE
UPDATE readerfrontlight.lua

### DIFF
--- a/frontend/ui/reader/readerfrontlight.lua
+++ b/frontend/ui/reader/readerfrontlight.lua
@@ -1,103 +1,77 @@
 local InputContainer = require("ui/widget/container/inputcontainer")
+local InputDialog = require("ui/widget/inputdialog")
+local Notification = require("ui/widget/notification")
+local GestureRange = require("ui/gesturerange")
+local UIManager = require("ui/uimanager")
 local Geom = require("ui/geometry")
 local Screen = require("ui/screen")
 local Device = require("ui/device")
-local GestureRange = require("ui/gesturerange")
-local InputDialog = require("ui/widget/inputdialog")
-local UIManager = require("ui/uimanager")
-local Notification = require("ui/widget/notification")
-local _ = require("gettext")
 local DEBUG = require("dbg")
+local _ = require("gettext")
 
-local ReaderFrontlight = {}
-if Device:getModel() ~= 'Kobo_phoenix' then
-	ReaderFrontLight = InputContainer:new{
-			steps = {0,1,2,3,4,5,6,7,8,9,10},
-		}
-	function ReaderFrontLight:onAdjust(arg, ges)
-		return ReaderFrontLight:onAdjustOther(arg, ges)
-	end
-else ReaderFrontLight = InputContainer:new{
-			steps = {1,1,1,1,1,2,2,2,3,3,4,5},
-		}
-	function ReaderFrontLight:onAdjust(arg, ges)
-		return ReaderFrontLight:onAdjustPhoenix(arg, ges)
-	end
-end
+local ReaderFrontLight = InputContainer:new{
+    steps = {0,1,2,3,4,5,6,7,8,9,10},
+}
 
 function ReaderFrontLight:init()
-	if Device:isTouchDevice() then
-		if Device:getModel() ~= 'Kobo_phoenix' then
-			self.ges_events = {
-				Adjust = {
-					GestureRange:new{
-						ges = "two_finger_pan",
-						range = Geom:new{
-							x = 0, y = 0,
-							w = Screen:getWidth(),
-							h = Screen:getHeight(),
-						},
-						rate = 2.0,
-					}
-				},
-			}
-		else self.ges_events = {
-				Adjust = {
-					GestureRange:new{
-						ges = "two_finger_pan",
-						range = Geom:new{
-							x = 0, y = 0,
-							w = Screen:getWidth(),
-							h = Screen:getHeight(),
-						},
-					}
-				},
-			}
-		end
-			self.ui.menu:registerToMainMenu(self)
-	end
+    if Device:isTouchDevice() then
+        self.ges_events = {
+            Adjust = {
+                GestureRange:new{
+                    ges = "two_finger_pan",
+                    rate = Device:getModel() == 'Kobo_phoenix' and nil or 3.0,
+                }
+            },
+            PanRelease= {
+                GestureRange:new{
+                    ges = "two_finger_pan_release",
+                }
+            },
+            Swipe = {
+                GestureRange:new{
+                    ges = "two_finger_swipe",
+                }
+            },
+        }
+        self.ui.menu:registerToMainMenu(self)
+    end
 end
 
-function ReaderFrontLight:onAdjustOther(arg, ges)
-	local powerd = Device:getPowerDevice()
-	if powerd.flIntensity ~= nil then
-		local rel_proportion = ges.distance / Screen:getWidth()
-		local delta_int = self.steps[math.ceil(#self.steps*rel_proportion)] or self.steps[#self.steps]
-		local msg = nil
-		if ges.direction == "north" then
-			msg = _("Increase front light intensity to ")
-			powerd:setIntensity(powerd.flIntensity + delta_int)
-		elseif ges.direction == "south" then
-			msg = _("Decrease front light intensity to ")
-			powerd:setIntensity(powerd.flIntensity - delta_int)
-		end
-		if msg ~= nil then
-			UIManager:show(Notification:new{
-				text = msg..powerd.flIntensity,
-				timeout = 1
-			})
-		end
-	end
-	return true
+function ReaderFrontLight:onAdjust(arg, ges)
+    local powerd = Device:getPowerDevice()
+    if powerd.flIntensity ~= nil then
+        DEBUG("frontlight intensity", powerd.flIntensity)
+        local rel_proportion = ges.distance / Screen:getWidth()
+        local delta_int = self.steps[math.ceil(#self.steps*rel_proportion)] or self.steps[#self.steps]
+        local msg = nil
+        if ges.direction == "north" then
+            powerd:setIntensity(powerd.flIntensity + delta_int)
+        elseif ges.direction == "south" then
+            powerd:setIntensity(powerd.flIntensity - delta_int)
+        end
+    end
+    return true
 end
 
-function ReaderFrontLight:onAdjustPhoenix(arg, ges)
-	local powerd = Device:getPowerDevice()
-	if powerd.flIntensity ~= nil then
-		local rel_proportion = ges.distance / Screen:getWidth()
-		DEBUG("rel_proportion = ",rel_proportion)
-		local delta_int = self.steps[math.ceil(#self.steps*rel_proportion)] or self.steps[#self.steps]
-		DEBUG("math.ceil(#self.steps*rel_proportion) = ",math.ceil(#self.steps*rel_proportion))
-		DEBUG("delta_int =", delta_int)
-		if ges.direction == "north" then
-			powerd:setIntensity(powerd.flIntensity + delta_int)
-		elseif ges.direction == "south" then
-			powerd:setIntensity(powerd.flIntensity - delta_int)
-		end
-	end
-	return true
+function ReaderFrontLight:onShowIntensity()
+    local powerd = Device:getPowerDevice()
+    if powerd.flIntensity ~= nil then
+        UIManager:show(Notification:new{
+            text = _("Frontlight intensity is set to ")..powerd.flIntensity,
+            timeout = 1.0,
+        })
+    end
 end
 
+function ReaderFrontLight:onSwipe(arg, ges)
+    if ges.direction == "north" or ges.direction == "south" then
+        return self:onShowIntensity()
+    end
+end
+
+function ReaderFrontLight:onPanRelease(arg, ges)
+    return self:onShowIntensity()
+end
 
 function ReaderFrontLight:addToMainMenu(tab_item_table)
 	-- insert fldial command to main reader menu


### PR DESCRIPTION
Code is added to switch between Kobo Aura (Phoenix) and others.

`ReaderFrontLight`, `self.ges_events` and the `function ReaderFrontLight:onAdjust` are now different for Kobo Aura. This enables me to do a two-fingered-pan over approx 1/4 Screenheight to change from full on to full off.

The difference to the default implementation is that both the `rate` and the `msg` are omitted and the `steps` are different.

FURTHER ROOM FOR IMPROVEMENT: It would be an improvement to get a final message after the two-fingered-pan is done stating the achieved setting.

Signed-off-by: Markismus zulde.zuldemans@gmail.com
