### PR TITLE
Updated Readme with Subversion and removed andLinux suggestion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To get and compile the source you must have `patch`, `wget`, `unzip`, `git`, `au
 
 Ubuntu users may need to run:
 ```
-sudo apt-get install build-essential
+sudo apt-get install build-essential libtool
 ```
 
 Cross toolchains are available to Ubuntu users through these commands:


### PR DESCRIPTION
Fetching all dependencies requires svn (for popen-noshell, for example). Also, removed andLinux, since it's not maintained, installs old toolchains from repositories and doesn't work on 64-bit Windows machines. Instead, added a link about installing Ubuntu in VM, which also mentions how to set up VMWare Tools for drag-n-drop, better video performance etc.
