### PR TITLE
Claim that Android devices do not have a keyboard

### DIFF
--- a/frontend/ui/device.lua
+++ b/frontend/ui/device.lua
@@ -100,11 +100,13 @@ function Device:isKobo()
     return string.find(self:getModel() or "", "Kobo_") == 1
 end
 
+Device.isAndroid = util.isAndroid
+
 function Device:hasNoKeyboard()
     if self.has_no_keyboard ~= nil then return self.has_no_keyboard end
     local model = self:getModel()
     self.has_no_keyboard = (model == "KindlePaperWhite") or (model == "KindlePaperWhite2")
-                        or (model == "KindleTouch") or self:isKobo()
+                        or (model == "KindleTouch") or self:isKobo() or self:isAndroid()
     return self.has_no_keyboard
 end
 


### PR DESCRIPTION
For now, we can probably live better with the assumption that
Android devices do not have keyboards. That should be replaced
by an actual check, though.

Fixes #608
