### PR TITLE
fail gracefully when the Kobo light device cannot be opened

### DIFF
--- a/frontend/ui/device/kobopowerd.lua
+++ b/frontend/ui/device/kobopowerd.lua
@@ -13,7 +13,8 @@ local KoboPowerD = BasePowerD:new{
 }
 
 function KoboPowerD:init()
-    self.fl = kobolight.open()
+    local ok, light = pcall(kobolight.open)
+    if ok then self.fl = light end
 end
 
 function KoboPowerD:toggleFrontlight()


### PR DESCRIPTION
This should prevent the error from propagating when opening the frontlight device fails.
