### PR TITLE
Consider as corrupt a null-area bbox

### DIFF
--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -161,7 +161,7 @@ function Document:getUsedBBoxDimensions(pageno, zoom, rotation)
     if bbox.x1 < 0 then bbox.x1 = 0 end
     if bbox.y1 < 0 then bbox.y1 = 0 end
     local ubbox_dimen = nil
-    if (bbox.x0 > bbox.x1) or (bbox.y0 > bbox.y1) then
+    if (bbox.x0 >= bbox.x1) or (bbox.y0 >= bbox.y1) then
         -- if document's bbox info is corrupted, we use the page size
         ubbox_dimen = self:getPageDimensions(pageno, zoom, rotation)
     else


### PR DESCRIPTION
The following crash happened with a pdf file containing some empty pages after I activated the "fit to width" zoom and scrolled near these empty pages. I don't know what exactly caused the regression, this file used to not cause any problems with previous revisions of koreader. I didn't do any bisect to see where it started. Discarding a bbox which has a null-area seems sensible, though. It prevents NaNs which currently appear in page state calculation which cause the page_states array not being populated and fixes the crash.

```
./luajit: frontend/apps/reader/modules/readerpaging.lua:620: attempt to index a nil value
stack traceback:
    frontend/apps/reader/modules/readerpaging.lua:620: in function 'onScrollPageRel'
    frontend/apps/reader/modules/readerpaging.lua:356: in function 'onPagingRel'
    frontend/apps/reader/modules/readerpaging.lua:174: in function 'handleEvent'
    frontend/ui/widget/container/widgetcontainer.lua:63: in function 'propagateEvent'
    frontend/ui/widget/container/widgetcontainer.lua:75: in function 'handleEvent'
    frontend/ui/uimanager.lua:121: in function 'sendEvent'
    frontend/ui/uimanager.lua:313: in function 'run'
    ./reader.lua:201: in main chunk
    [C]: in function 'dofile'
    ./koreader-base:22: in main chunk
    [C]: at 0x0000bbb8
```
