### PR TITLE
revert zip file handler to crereader

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -387,6 +387,7 @@ function CreDocument:register(registry)
     registry:addProvider("pdb", "application/pdb", self)
     registry:addProvider("doc", "application/doc", self)
     registry:addProvider("tcr", "application/tcr", self)
+    registry:addProvider("zip", "application/zip", self)
 end
 
 return CreDocument

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -225,7 +225,6 @@ function PdfDocument:register(registry)
     registry:addProvider("pdf", "application/pdf", self)
     registry:addProvider("cbz", "application/cbz", self)
     registry:addProvider("xps", "application/xps", self)
-    registry:addProvider("zip", "application/zip", self)
 end
 
 return PdfDocument


### PR DESCRIPTION
It seems that fb2.zip is a conventional format for fb2 with compression
which cannot be handled properly by mupdf.
This should fix #642.
