### PR TITLE
Persistent defaults.lua option added.

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -1,3 +1,6 @@
+-- To make configuration changes that persists between (nightly) releases,
+-- copy defaults.lua to defaults.persistent.lua and make the changes there.
+
 -- number of page turns between full screen refresh
 -- default to do a full refresh on every 6 page turns
 DRCOUNTMAX = 6

--- a/reader.lua
+++ b/reader.lua
@@ -7,6 +7,7 @@ freetype = require("ffi/freetype")
 Image = require("ffi/mupdfimg")
 
 require "defaults"
+pcall(dofile, "defaults.persistent.lua")
 package.path = "?.lua;common/?.lua;frontend/?.lua"
 package.cpath = "?.so;common/?.so;/usr/lib/lua/?.so"
 


### PR DESCRIPTION
To make configuration changes in `defaults.lua` that persists between (nightly) releases, copy defaults.lua to persistent.defaults.lua and make the changes there.
