### PR TITLE
Offset and resize Kobo Aura screen because of obscuration by black bezel

### DIFF
--- a/frontend/ui/device/screen.lua
+++ b/frontend/ui/device/screen.lua
@@ -45,6 +45,27 @@ local Screen = {
 
 function Screen:init()
     self.bb = self.fb.bb
+    if self.device:getModel() ~= 'Kobo_phoenix' then
+        function Screen:getSize()
+            return Screen:getSizeBB()
+        end
+        function Screen:getWidth()
+            return Screen:getWidthBB()
+        end
+        function Screen:getHeight()
+            return Screen:getHeightBB()
+        end
+    else
+        function Screen:getSize()
+            return Screen:getSizePhoenix()
+        end
+        function Screen:getWidth()
+            return Screen:getWidthPhoenix()
+        end
+        function Screen:getHeight()
+            return Screen:getHeightPhoenix()
+        end
+    end
     self.blitbuffer_rotation_mode = self.bb:getRotation()
     -- asking the framebuffer for orientation is error prone,
     -- so we do this simple heuristic (for now)
@@ -60,24 +81,42 @@ function Screen:refresh(refresh_type, waveform_mode, x, y, w, h)
     self.fb:refresh(refresh_type, waveform_mode, x, y, w, h)
 end
 
-function Screen:getSize()
+function Screen:getSizeBB()
     return Geom:new{w = self.bb:getWidth(), h = self.bb:getHeight()}
 end
 
-function Screen:getWidth()
+function Screen:getSizePhoenix()
+    return Geom:new{w = self.getWidth(), h = self.getHeight()}
+end
+
+function Screen:getWidthBB()
     return self.bb:getWidth()
 end
 
-function Screen:getHeight()
+function Screen:getWidthPhoenix()
+    if self.cur_rotation_mode == 0 then return 752
+    else return 1012
+    end
+end
+
+function Screen:getHeightBB()
     return self.bb:getHeight()
+end
+
+function Screen:getHeightPhoenix()
+    if self.cur_rotation_mode == 0 then return 1012
+    else return 752
+    end
 end
 
 function Screen:getDPI()
     if self.dpi ~= nil then return self.dpi end
     local model = self.device:getModel()
     if model == "KindlePaperWhite" or model == "KindlePaperWhite2"
-        or model == "Kobo_kraken" or model == "Kobo_phoenix" then
+        or model == "Kobo_kraken" then
         self.dpi = 212
+    elseif model == "Kobo_phoenix" then
+        self.dpi = 212.8
     elseif model == "Kobo_dragon" then
         self.dpi = 265
     elseif model == "Kobo_pixie" then
@@ -165,3 +204,4 @@ function Screen:restoreFromBB(bb)
 end
 
 return Screen
+

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -20,7 +20,7 @@ local WAVEFORM_MODE_A2            = 0x4    -- Faster but even lower fidelity
 local WAVEFORM_MODE_GL16            = 0x5    -- High fidelity from white transition
 local WAVEFORM_MODE_GL16_FAST        = 0x6    -- Medium fidelity from white transition
 local WAVEFORM_MODE_AUTO            = 0x101
-
+ 
 -- there is only one instance of this
 local UIManager = {
     default_refresh_type = 0, -- 0 for partial refresh, 1 for full refresh
@@ -44,6 +44,36 @@ local UIManager = {
     _execution_stack = {},
     _dirty = {}
 }
+
+-- For the Kobo Aura an offset is needed, because the bezel make the visible screen smaller.
+if Device:getModel() ~= 'Kobo_phoenix' then
+    function UIManager:offsetX()
+        return 0
+    end
+    function UIManager:offsetY()
+        return 0
+    end
+else
+    function UIManager:offsetX()
+        if Screen.cur_rotation_mode == 0 then
+            return 4
+        elseif Screen.cur_rotation_mode == 1 then
+            return 15
+        else
+            return 3
+        end
+    end
+    function UIManager:offsetY()
+        if Screen.cur_rotation_mode == 0 then
+            return 3
+        elseif Screen.cur_rotation_mode == 1 then
+            return 4
+        else
+            return 4
+        end
+    end
+end
+
 
 -- register & show a widget
 function UIManager:show(widget, x, y)
@@ -197,7 +227,7 @@ function UIManager:run()
         local force_fast_refresh = false
         for _, widget in ipairs(self._window_stack) do
             if self.repaint_all or self._dirty[widget.widget] then
-                widget.widget:paintTo(Screen.bb, widget.x, widget.y)
+                widget.widget:paintTo(Screen.bb, widget.x + UIManager:offsetX(), widget.y + UIManager:offsetY() )
                 if self._dirty[widget.widget] == "auto" then
                     request_full_refresh = true
                 end
@@ -317,3 +347,4 @@ function UIManager:run()
 end
 
 return UIManager
+

--- a/wtest.lua
+++ b/wtest.lua
@@ -1,8 +1,16 @@
 #!./koreader-base
 
+require "libs/libkoreader-lfs"
+einkfb = require("ffi/framebuffer")
+input = require("ffi/input")
+freetype = require("ffi/freetype")
+Image = require("ffi/mupdfimg")
+
 require "defaults"
 print(package.path)
-package.path = "./frontend/?.lua;./?.lua"
+package.path = "?.lua;common/?.lua;frontend/?.lua"
+package.cpath = "?.so;common/?.so;/usr/lib/lua/?.so"
+
 local DocSettings = require("docsettings")
 local _ = require("gettext")
 
@@ -72,16 +80,17 @@ function TestVisible:paintTo(bb)
     end
     
     -- Handtunable minimal and maximal visible coordinates
-    local x_min = 0 + 3
+    local x_min = 0 + 4
     local x_max = bb:getWidth() - 4
     local y_min = 0 + 3
-    local y_max = bb:getHeight() - 15
+    local y_max = bb:getHeight() - 3 - 12
     
     -- Render extremes on screen
     RenderText:renderUtf8Text(bb, 150, 100, Font:getFace("ffont", 22), "x_min = "..x_min, true)
     RenderText:renderUtf8Text(bb, 500, 100, Font:getFace("ffont", 22), "x_max = "..x_max, true)
     RenderText:renderUtf8Text(bb, 100, 150, Font:getFace("ffont", 22), "y_min = "..y_min, true)
     RenderText:renderUtf8Text(bb, 100, 300, Font:getFace("ffont", 22), "y_max = "..y_max, true)
+    RenderText:renderUtf8Text(bb, 100, 500, Font:getFace("ffont", 26), "Visible screen size :  "..(x_max-x_min).."x"..(y_max-y_min), true)
     
     -- Three parallel lines at the top
     bb:paintRect(x_min,y_min, x_max, 1 , 10)
@@ -102,7 +111,12 @@ function TestVisible:paintTo(bb)
     bb:paintRect(x_max,y_min, 1, y_max , 10)
     bb:paintRect(x_max - 3,y_min, 1, y_max, 10)
     bb:paintRect(x_max - 6,y_min, 1, y_max, 10)
-    
+   
+    --Two lines spaces 600 pixels
+    bb:paintRect(100,600, 1, 250 , 10)
+    bb:paintRect(700,600, 1, 250 , 10)
+    RenderText:renderUtf8Text(bb, 150, 670, Font:getFace("ffont", 26), "Measure inches per 600 pixels", true)
+    RenderText:renderUtf8Text(bb, 150, 770, Font:getFace("ffont", 22), "Kobo Aura: 600 pixels/ 2.82 \" = "..(600/2.82).." dpi", true)
 end
 
 -----------------------------------------------------


### PR DESCRIPTION
The visible screen of the Kobo Aura is smaller due to the black bezel that limits the visible area. This commit fixes this. The minibar is now inside the visible screen area.

`wtest.lua` is updated. Extra requires and paths are added. Also the function `TestVisible:paintTo(bb)` is updated to check the visibility and dpi.

In `uimanager.lua` the functions `offsetX()` and `offsetY()` are introduced to add an offset to `widget.x` and `widget.y`. The offsets for non-Kobo Aura devices remains zero.

In `screen.lua` the functions `getWidth()` and `getHeight` are changed to allow hardcoding the dimensions of the visible screen. Non-Kobo Aura devices are not affected.

Limitations:
- Full screen refresh uses the new screen dimensions. Artifacts drawn outside the visible screen remain forever. These remainders are due to change of rotation mode. 
