### PR TITLE
Kill fmon before start koreader for kobos

### DIFF
--- a/kobo/koreader.sh
+++ b/kobo/koreader.sh
@@ -11,8 +11,7 @@ export TESSDATA_PREFIX="data"
 export STARDICT_DATA_DIR="data/dict"
 
 # exit from nickel
-killall nickel
-killall hindenburg
+killall nickel hindenburg fmon
 
 # finally call the launcher
 ./reader.lua /mnt/onboard 2> crash.log


### PR DESCRIPTION
We don't need fmon while koreader is running. Also nickel.sh starts fmon again after koreader exit and we want to make sure that just one instance of fmon is running.
