### PR TITLE
update instructions for install fmon on kobos

### DIFF
--- a/kobo/fmon/README.txt
+++ b/kobo/fmon/README.txt
@@ -1,15 +1,14 @@
 Installation instructions for Kobo:
 
 
-Newer installation based on Start Menu
+Newer installation based on Start Menu:
 - Install "Start Menu" (http://www.mobileread.com/forums/showthread.php?t=233259)
 - Extract the koreader folder of the zip into the ".kobo" directory (both KoboRoot.tgz and the koreader.png file are only needed for the older installation based on Filemonitor. See below.). 
 
 Select koreader from the Start Menu to start.
 
 
-Older installation based on Filemonitor (Please refer to [this post](http://www.mobileread.com/forums/showthread.php?t=216960).)
-
+Older installation based on Filemonitor:
 - Put the image included in the zip (called "koreader.png") in the main folder of your kobo and disconnect it from your computer. Open the image on the reader, go back to the home and then, just to be extra-safe, reboot it.
 - Install "Files Monitor" (http://www.mobileread.com/forums/showthread.php?t=218283).
 - Extract the remaining content of the zip into the ".kobo" directory (both KoboRoot.tgz and the koreader folder). 


### PR DESCRIPTION
If a user install fmon first and then extract  all the contents of the zip  (the koreader folder and KoboRoot.tgz under .kobo/ and koreader.png in main folder) together, we reach some CRITICAL condition:

1 koboroot.tgz triggers an update BEFORE indexing koreader.png in the database
2 the update triggers a reboot which launchs fmon with the koreader script associated to koreader.png
3 nickel find a new valid file and start indexing, this trigger koreader.sh (file koreader.png was opened)
4 koreader.sh kills nickel, the koreader.png image is not indexed. 
5 at koreader exit we launch nickel again, but we back to 3

When we reach this critical condition:
- the reader will boot directly to koreader
- the reader will start koreader again at koreader exit

I think is a good idea to copy the image first, even before install fmon, And just follow next steps if we are able to find koreader.png in kobo library.

Any thoughts?
