### PR TITLE
Make the geometry of the minibar user-configurable

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -127,7 +127,12 @@ DMINIBAR_PAGES = true
 DMINIBAR_NEXT_CHAPTER = true
 DMINIBAR_BATTERY = true
 
-DMINIBAR_PROGRESS_MARKER = true
+DMINIBAR_PROGRESS_MARKER = true -- Black notch for each TOC entry
+DMINIBAR_TOC_MARKER_WIDTH = 2   -- Looses usefulness > 3
+
+DMINIBAR_HEIGHT = 7             -- Should be smaller than DMINIBAR_CONTAINER_HEIGHT
+DMINIBAR_CONTAINER_HEIGHT = 14  -- Larger means more padding at the bottom, at the risk of eating into the last line
+
 
 -- gesture detector defaults
 DGESDETECT_DISABLE_DOUBLE_TAP = true

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -24,8 +24,8 @@ local ReaderFooter = InputContainer:new{
     progress_text = nil,
     text_font_face = "ffont",
     text_font_size = 14,
-    bar_height = Screen:scaleByDPI(7),
-    height = Screen:scaleByDPI(19),
+    bar_height = Screen:scaleByDPI(DMINIBAR_HEIGHT),
+    height = Screen:scaleByDPI(DMINIBAR_CONTAINER_HEIGHT),
     padding = Screen:scaleByDPI(10),
 }
 

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -11,6 +11,7 @@ local ProgressWidget = Widget:new{
     margin_v = 1,
     radius = 2,
     bordersize = 1,
+    toc_marker_width = DMINIBAR_TOC_MARKER_WIDTH,
     bordercolor = 15,
     bgcolor = 0,
     rectcolor = 10,
@@ -28,7 +29,7 @@ function ProgressWidget:paintTo(bb, x, y)
     self.dimen = Geom:new{
         x = x, y = y,
         w = my_size.w,
-        h = my_size.h 
+        h = my_size.h
     }
     bb:paintRoundedRect(x, y, my_size.w, my_size.h, self.bgcolor, self.radius)
     bb:paintBorder(x, y, my_size.w, my_size.h,
@@ -41,7 +42,7 @@ function ProgressWidget:paintTo(bb, x, y)
             for i=1, #self.TOC do
                 v = self.TOC[i]
                 bb:paintRect(x+(my_size.w-2*self.margin_h)*(v.page/self.last), y+self.margin_v+self.bordersize,
-                    2,(my_size.h-2*(self.margin_v+self.bordersize)), self.bordercolor)
+                    self.toc_marker_width,(my_size.h-2*(self.margin_v+self.bordersize)), self.bordercolor)
             end
         end
     end


### PR DESCRIPTION
As well as the width of the toc notches
Lower the default value of the container size a bit to avoid eating into
the last line on small borders setup (I checked on 167 & 212 DPI
devices, Feel free to revert to the previous value (19) if that causes
trouble).

---

Following the recent discussions in the Kobo thread ;).
