### PR TITLE
fix Droid Sans Fallback not registered to crengine

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -22,7 +22,7 @@ local CreDocument = Document:new{
     line_space_percent = 100,
     default_font = G_reader_settings:readSetting("cre_font") or "Noto Serif",
     header_font = G_reader_settings:readSetting("header_font") or "Noto Sans",
-    fallback_font = G_reader_settings:readSetting("fallback_font") or "Droid Sans Fallback",
+    fallback_font = G_reader_settings:readSetting("fallback_font") or "Droid Sans Fallback H",
     default_css = "./data/cr3.css",
     options = CreOptions,
 }

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -83,7 +83,8 @@ function Font:_readList(target, dir, effective_dir)
             self:_readList(target, dir.."/"..f, effective_dir..f.."/")
         else
             local file_type = string.lower(string.match(f, ".+%.([^.]+)") or "")
-            if file_type == "ttf" or file_type == "cff" or file_type == "otf" then
+            if file_type == "ttf" or file_type == "ttc"
+                or file_type == "cff" or file_type == "otf" then
                 table.insert(target, effective_dir..f)
             end
         end


### PR DESCRIPTION
Mupdf 1.5 ships with "DroidSansFallback.ttc" instead of the "DroidSansFallback.ttf". The new ttc file has two fonts, the original "Droid Sans Fallback H" and a vertical variant "Droid Sans Fallback V". This patch fixes registering ttc files and makes "Droid Sans Fallback H" the fallback font for crengine.
