### PR TITLE
remove too verbose information that is utterly untranslatable

### DIFF
--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -514,15 +514,7 @@ function Search:find(option)
             self:browse(option,1)
         end
     else
-        if option == "find" then
-            dummy = _("No match for") .. " " .. self.search_value
-        else
-            dummy = _("No") .. " " .. option .. " " .. _("found")
-            if string.len(self.search_value) > 0 then
-                dummy = dummy .. " " .. _("matching") .. " " .. self.search_value
-            end
-            dummy = dummy .. "!"
-        end
+        dummy = _("No match for") .. " " .. self.search_value
         UIManager:show(InfoMessage:new{text = dummy})
     end
 end


### PR DESCRIPTION
I would suggest when creating a translate string you'd better keep
as much words together as you can other than trying to call the
`_` function on each word which may cause the final
translation in some languages unreadable.
For example, no matter how we translate the single words, the Chinese
translation of

```
_("No ") .. some_thing .. _("found ") .. _("matching") .. other_thing
```

will be nonsense.
Better way would be:

```
some_thing .. " is not found matching" .. other_thing
```
