### PR TITLE
Bring back the two KOBO variables for the light

### DIFF
--- a/frontend/ui/device.lua
+++ b/frontend/ui/device.lua
@@ -229,6 +229,7 @@ end
 
 function Device:Suspend()
     if self:isKobo() then
+        if KOBO_LIGHT_OFF_ON_SUSPEND then self:getPowerDevice():setIntensity(0) end
         os.execute("./suspend.sh")
     end
 end
@@ -236,20 +237,16 @@ end
 function Device:Resume()
     if self:isKobo() then
         os.execute("echo 0 > /sys/power/state-extended")
-    end
-    self.screen:refresh(1)
-    local powerd = self:getPowerDevice()
-    if powerd.fl ~= nil then
-        powerd.fl:restore()
-    end
-    -- FIXME: this conflicts with powerd.fl:restore
-    --[[
-    if KOBO_LIGHT_ON_START and tonumber(KOBO_LIGHT_ON_START) > -1 then
+        local powerd = self:getPowerDevice()
         if powerd then
-            powerd:setIntensity(math.max(math.min(KOBO_LIGHT_ON_START,100),0))
+            if KOBO_LIGHT_ON_START and tonumber(KOBO_LIGHT_ON_START) > -1 then
+                powerd:setIntensity(math.max(math.min(KOBO_LIGHT_ON_START,100),0))
+            elseif powerd.fl ~= nil then
+                powerd.fl:restore()
+            end
         end
     end
-    --]]
+    self.screen:refresh(1)
     self.screen_saver_mode = false
 end
 


### PR DESCRIPTION
This should close #856.
Although still closed I will check this one back with someone from the German forum, I hope this also closes #822, but there might be still some problems with the light-bug introduced in Kobo's firmware 3.5. But since 822 is already in the state closed we can leave things as they are for now and I will reopen 822 if necessary.
