### PR TITLE
don't share info field in document

### DIFF
--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -15,29 +15,6 @@ local Document = {
     -- file name
     file = nil,
 
-    info = {
-        -- whether the document is pageable
-        has_pages = false,
-        -- whether words can be provided
-        has_words = false,
-        -- whether hyperlinks can be provided
-        has_hyperlinks = false,
-        -- whether (native to format) annotations can be provided
-        has_annotations = false,
-
-        -- whether pages can be rotated
-        is_rotatable = false,
-
-        number_of_pages = 0,
-        -- if not pageable, length of the document in pixels
-        doc_height = 0,
-
-        -- other metadata
-        title = "",
-        author = "",
-        date = ""
-    },
-
     links = {},
 
     GAMMA_NO_GAMMA = 1.0,
@@ -68,6 +45,28 @@ end
 -- base document initialization should be called on each document init
 function Document:_init()
     self.configurable = Configurable:new()
+    self.info = {
+        -- whether the document is pageable
+        has_pages = false,
+        -- whether words can be provided
+        has_words = false,
+        -- whether hyperlinks can be provided
+        has_hyperlinks = false,
+        -- whether (native to format) annotations can be provided
+        has_annotations = false,
+
+        -- whether pages can be rotated
+        is_rotatable = false,
+
+        number_of_pages = 0,
+        -- if not pageable, length of the document in pixels
+        doc_height = 0,
+
+        -- other metadata
+        title = "",
+        author = "",
+        date = ""
+    }
 end
 
 -- override this method to open a document


### PR DESCRIPTION
We may have multiple documents opened simultaneously, such as in
screensaver mode the current document is opened twice, it's better
to keep seperate info table for each document.

This should fix #858. When a credocument is opened for screensaver to
get the cover page, the total pages info is set to 1(strangely enough),
before this fix this total pages is shared with the reading document
so the progress bar will get a progress percentage well beyond 100% and
rendering the progress bar out of the boundering box as shown in #858.
