### PR TITLE
register opened document in documentregistry

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -17,6 +17,7 @@ local CreDocument = Document:new{
     PAGE_VIEW_MODE = 1,
 
     _document = false,
+    _loaded = false,
     engine_initilized = false,
 
     line_space_percent = 100,
@@ -120,9 +121,16 @@ function CreDocument:init()
     self.info.configurable = true
 end
 
+function CreDocument:loadDocument()
+    if not self._loaded then
+        self._document:loadDocument(self.file)
+        self._loaded = true
+    end
+end
+
 function CreDocument:render()
     -- load document before rendering
-    self._document:loadDocument(self.file)
+    self:loadDocument()
     self._document:renderDocument()
     if not self.info.has_pages then
         self.info.doc_height = self._document:getFullHeight()
@@ -139,7 +147,7 @@ end
 
 function CreDocument:getCoverPageImage()
     -- don't need to render document in order to get cover image
-    self._document:loadDocument(self.file)
+    self:loadDocument()
     local data, size = self._document:getCoverPageImageData()
     if data and size then
         local image = Image:fromData(data, size)

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -81,7 +81,8 @@ end
 
 -- this might be overridden by a document implementation
 function Document:close()
-    if self.is_open then
+    local DocumentRegistry = require("document/documentregistry")
+    if self.is_open and DocumentRegistry:closeDocument(self.file) == 0 then
         self.is_open = false
         self._document:close()
     end


### PR DESCRIPTION
so that when calling getCoverPageImage in screensaver mode
the document won't be opened again. This should avoid a lot of
problem such as messing up style and options described in #863.

This should fix #863.
