### PR TITLE
issue error directly when doc is malformated

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -76,7 +76,6 @@ function CreDocument:init()
     self:engineInit()
     self.configurable:loadDefaults(self.options)
 
-    local ok
     local file_type = string.lower(string.match(self.file, ".+%.([^.]+)"))
     if file_type == "zip" then
         -- NuPogodi, 20.05.12: read the content of zip-file
@@ -95,12 +94,12 @@ function CreDocument:init()
 
     -- @TODO check the default view_mode to a global user configurable
     -- variable  22.12 2012 (houqp)
+    local ok
     ok, self._document = pcall(cre.newDocView,
         Screen:getWidth(), Screen:getHeight(), self.PAGE_VIEW_MODE
     )
     if not ok then
-        self.error_message = self._document -- will contain error message
-        return
+        error(self._document)  -- will contain error message
     end
 
     -- adjust font sizes according to screen dpi

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -30,15 +30,13 @@ function DjvuDocument:init()
     self.koptinterface = require("document/koptinterface")
     self.configurable:loadDefaults(self.options)
     if not validDjvuFile(self.file) then
-        self.error_message = "Not a valid DjVu file"
-        return
+        error("Not a valid DjVu file")
     end
 
     local ok
     ok, self._document = pcall(djvu.openDocument, self.file, self.djvulibre_cache_size)
     if not ok then
-        self.error_message = self._document -- will contain error message
-        return
+        error(self._document)  -- will contain error message
     end
     self.is_open = true
     self.info.has_pages = true

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -24,7 +24,6 @@ local Document = {
 
     -- flag to show whether the document was opened successfully
     is_open = false,
-    error_message = nil,
 
     -- flag to show that the document needs to be unlocked by a password
     is_locked = false,

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -1,3 +1,5 @@
+local DEBUG = require("dbg")
+
 --[[
 This is a registry for document providers
 ]]--
@@ -24,15 +26,22 @@ function DocumentRegistry:openDocument(file)
     if not self.registry[file] then
         local provider = self:getProvider(file)
         if provider ~= nil then
-            self.registry[file] = {
-                doc = provider:new{file = file},
-                refs = 1,
-            }
+            local ok, doc = pcall(provider.new, provider, {file = file})
+            if ok then
+                self.registry[file] = {
+                    doc = doc,
+                    refs = 1,
+                }
+            else
+                DEBUG("cannot open document", file, doc)
+            end
         end
     else
         self.registry[file].refs = self.registry[file].refs + 1
     end
-    return self.registry[file].doc
+    if self.registry[file] then
+        return self.registry[file].doc
+    end
 end
 
 function DocumentRegistry:closeDocument(file)

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -56,8 +56,7 @@ function PdfDocument:init()
     local ok
     ok, self._document = pcall(pdf.openDocument, self.file, self.mupdf_cache_size)
     if not ok then
-        self.error_message = self._document -- will contain error message
-        return
+        error(self._document)  -- will contain error message
     end
     self.is_open = true
     self.info.has_pages = true
@@ -66,6 +65,9 @@ function PdfDocument:init()
         self.is_locked = true
     else
         self:_readMetadata()
+    end
+    if not (self.info.number_of_pages > 0) then
+        error("No page found in PDF file")
     end
 end
 

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -11,8 +11,7 @@ function PicDocument:init()
     if not pic then pic = require("ffi/pic") end
     ok, self._document = pcall(pic.openDocument, self.file)
     if not ok then
-        self.error_message = "failed to open jpeg image"
-        return
+        error("Failed to open jpeg image")
     end
 
     self.info.has_pages = true


### PR DESCRIPTION
This should popup a message saying "No reader engine for this file"
instead of a crash when document file is malformated.

This should fix #868.
