### PR TITLE
Screensaver repair

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -67,15 +67,13 @@ function Screensaver:show()
                    file = file .. "/"
                 end
                 self.suspend_msg = self:getRandomImage(file)
-            else
-                if lfs.attributes(file, "mode") == "file" then
-                    local ImageWidget = require("ui/widget/imagewidget")
-                    self.suspend_msg = ImageWidget:new{
-                        file = file,
-                        width = Screen:getWidth(),
-                        height = Screen:getHeight(),
-                    }
-                end
+            elseif lfs.attributes(file, "mode") == "file" then
+                local ImageWidget = require("ui/widget/imagewidget")
+                self.suspend_msg = ImageWidget:new{
+                    file = file,
+                    width = Screen:getWidth(),
+                    height = Screen:getHeight(),
+                }
             end
         end
     end


### PR DESCRIPTION
Single picture as screensaver was not displayed anymore after the last update.
Actually no screensaver (only the "suspended message") was shown when the settings were set to book cover but the book did not have any.
Additionally only the directory screensaver was still implemented, but not the fixed file.
