### PR TITLE
strip generic punctuation (U+2000 - U+206F) in lookup word

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -18,9 +18,9 @@ end
 function ReaderDictionary:stardictLookup(word, box)
     DEBUG("lookup word:", word, box)
     if word then
-        -- strip punctuation characters around selected word
-        word = string.gsub(word, "^%p+", '')
-        word = string.gsub(word, "%p+$", '')
+        -- strip ASCII punctuation characters around selected word
+        -- and strip any generic punctuation (U+2000 - U+206F) in the word
+        word = word:gsub("\226[\128-\131][\128-\191]",''):gsub("^%p+",''):gsub("%p+$",'')
         DEBUG("stripped word:", word)
         -- escape quotes and other funny characters in word
         local std_out = io.popen("./sdcv --utf8-input --utf8-output -nj "..("%q"):format(word), "r")


### PR DESCRIPTION
This should fix #921.
