### PR TITLE
get rid of query filed of baseurl when building href

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -299,6 +299,8 @@ function OPDSBrowser:genItemTableFromURL(item_url, base_url)
                 return base_url .. "/" .. href
             elseif item_url then
                 local parsed = url.parse(item_url)
+                -- get rid of query field of base url
+                parsed.query = nil
                 -- update item url with href parts(mostly path and query)
                 for k, v in pairs(url.parse(href) or {}) do
                     if k == "path" then


### PR DESCRIPTION
otherwise there will be "?offset=90" query in downloading href
for calibre opds server which doesn't accept the url

This should fix #950.
