### PR TITLE
Kobo Aura H2O: fix bezel.

### DIFF
--- a/frontend/ui/device/screen.lua
+++ b/frontend/ui/device/screen.lua
@@ -44,19 +44,7 @@ local Screen = {
 
 function Screen:init()
     self.bb = self.fb.bb
-    if self.device:getModel() ~= 'Kobo_phoenix' then
-        function Screen:getSize()
-            return Screen:getSizeBB()
-        end
-        function Screen:getWidth()
-            return Screen:getWidthBB()
-        end
-        function Screen:getHeight()
-            return Screen:getHeightBB()
-        end
-        function self:offsetX() return 0 end
-        function self:offsetY() return 0 end
-    else
+    if self.device:getModel() == 'Kobo_phoenix' then
         function Screen:getSize()
             return Screen:getSizePhoenix()
         end
@@ -80,6 +68,38 @@ function Screen:init()
         function self:offsetY()
             return 1
         end
+    elseif self.device:getModel() == 'Kobo_dahlia' then
+        function Screen:getSize()
+            return Screen:getSizePhoenix()
+        end
+        function Screen:getWidth()
+            return Screen:getWidthDahlia()
+        end
+        function Screen:getHeight()
+            return Screen:getHeightDahlia()
+        end
+        function self:offsetX()
+            return 0
+        end
+        function self:offsetY()
+            if Screen.cur_rotation_mode == 0 or Screen.cur_rotation_mode == 3 then
+                return 10
+            else
+                return 0
+            end
+        end
+    else
+        function Screen:getSize()
+            return Screen:getSizeBB()
+        end
+        function Screen:getWidth()
+            return Screen:getWidthBB()
+        end
+        function Screen:getHeight()
+            return Screen:getHeightBB()
+        end
+        function self:offsetX() return 0 end
+        function self:offsetY() return 0 end
     end
     self.blitbuffer_rotation_mode = self.bb:getRotation()
     -- asking the framebuffer for orientation is error prone,
@@ -121,6 +141,12 @@ function Screen:getWidthBB()
     return self.bb:getWidth()
 end
 
+function Screen:getWidthDahlia()
+    if self.cur_rotation_mode == 0 then return 1080
+    else return 1430
+    end
+end
+
 function Screen:getWidthPhoenix()
     if self.cur_rotation_mode == 0 then return 752
     else return 1012
@@ -129,6 +155,12 @@ end
 
 function Screen:getHeightBB()
     return self.bb:getHeight()
+end
+
+function Screen:getHeightDahlia()
+    if self.cur_rotation_mode == 0 then return 1430
+    else return 1080
+    end
 end
 
 function Screen:getHeightPhoenix()


### PR DESCRIPTION
The Kobo Aura H2O has only 1430x1080 visible pixels. The top 10 pixels are unfortunately hidden by the bezel. This commit makes KOReader display as intended.

A few general remarks:
- `getSizePhoenix` should probably be renamed to something more generic like `getSizeHardcoded` for clarity.
- I wrote `if Screen.cur_rotation_mode == 0 or Screen.cur_rotation_mode == 3` only because that's equivalent to the Phoenix code I modified. I saw no GUI way to get more than 2 types of rotation, so rotation_mode 3 remains untested.
- Surprisingly, no offSetX was required to obtain a correct display in landscape mode. On the contrary, adding it messed things up.
- The code would suggest that line 127 needs to be replaced by `if (self.device:getModel() == 'Kobo_phoenix' or self.device:getModel() == 'Kobo_dahlia') and refresh_type == 1 then` but I could only spot any differences with a few ghost lines while I was testing. Once I was done testing all possible offset values so they were correct, it seemed to make no difference one way or the other. That is, there were no odd artifacts on the screen when I left it out, so I left it out.
