### PR TITLE
Leave both readerconfig and readermenu open on wifi toggle

### DIFF
--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -460,7 +460,6 @@ function TouchMenu:netToggle()
     else
         NetworkMgr:promptWifiOn()
     end
-    self:closeMenu()
 end
 
 function TouchMenu:switchMenuTab(tab_num)


### PR DESCRIPTION
Previously, pressing the wifi icon would close only the readermenu and leave readerconfig open. This change leaves both open so that the prompt acts more like a popup.
