### PR TITLE
add option to turn off e-ink optimization

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -94,6 +94,7 @@ function ReaderMenu:setUpdateItemTable()
         text = _("Screen settings"),
         sub_item_table = {
             require("ui/elements/screen_dpi_menu_table"),
+            require("ui/elements/screen_eink_opt_menu_table"),
             UIManager:getRefreshMenuTable(),
         },
     })

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -103,7 +103,7 @@ function ReaderPaging:initGesListener()
                     w = Screen:getWidth(),
                     h = Screen:getHeight(),
                 },
-                rate = 4.0,
+                rate = Screen.eink and 4.0 or nil,
             }
         },
         PanRelease = {

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -139,7 +139,7 @@ function ReaderRolling:initGesListener()
                     w = Screen:getWidth(),
                     h = Screen:getHeight(),
                 },
-                rate = 4.0,
+                rate = Screen.eink and 4.0 or nil,
             }
         },
         DoubleTapForward = {

--- a/frontend/apps/reader/modules/readerrotation.lua
+++ b/frontend/apps/reader/modules/readerrotation.lua
@@ -35,7 +35,7 @@ function ReaderRotation:init()
                         w = Screen:getWidth(),
                         h = Screen:getHeight(),
                     },
-                    rate = 0.3
+                    rate = 0.3,
                 }
             },
         }

--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -1,0 +1,14 @@
+local _ = require("gettext")
+local Screen = require("device").screen
+
+local eink = G_reader_settings:readSetting("eink")
+Screen.eink = (eink == nil) and true or eink
+
+return {
+    text = _("E-ink optimization"),
+    checked_func = function() return Screen.eink end,
+    callback = function()
+        Screen.eink = not Screen.eink
+        G_reader_settings:saveSetting("eink", Screen.eink)
+    end,
+}


### PR DESCRIPTION
which currently just sets free the limitation of panning gestures
emitting rate.
This should fix #1039 when unchecking the "E-ink optimization" in screen
settings.
