### PR TITLE
Fix fetching new pages in the OPDS browser

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -375,6 +375,9 @@ function OPDSBrowser:updateCatalog(url, baseurl)
     if #menu_table > 0 then
         --DEBUG("menu table", menu_table)
         self:swithItemTable(nil, menu_table)
+        if self.page_num <= 1 then
+            self:onNext()
+        end
         return true
     end
 end


### PR DESCRIPTION
OPDS browser tries to fetch new pages from the server when the user opens the last page. This doesn't work if the server returns less than one pageful of items - in this case there is no new page for user to open and trigger the update. This patch is trying to fix that.
