### PR TITLE
add network settings in reader menu

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -4,6 +4,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local GestureRange = require("ui/gesturerange")
+local NetworkMgr = require("ui/networkmgr")
 local OTAManager = require("ui/otamanager")
 local UIManager = require("ui/uimanager")
 local Device = require("device")
@@ -97,6 +98,13 @@ function ReaderMenu:setUpdateItemTable()
             require("ui/elements/screen_eink_opt_menu_table"),
             UIManager:getRefreshMenuTable(),
         },
+    })
+    table.insert(self.tab_item_table.setting, {
+        text = _("Network settings"),
+        sub_item_table = {
+            NetworkMgr:getWifiMenuTable(),
+            NetworkMgr:getProxyMenuTable(),
+        }
     })
     table.insert(self.tab_item_table.setting, {
         text = _("Night mode"),

--- a/frontend/ui/networkmgr.lua
+++ b/frontend/ui/networkmgr.lua
@@ -1,3 +1,4 @@
+local InfoMessage = require("ui/widget/infomessage")
 local ConfirmBox = require("ui/widget/confirmbox")
 local UIManager = require("ui/uimanager")
 local Device = require("device")
@@ -83,10 +84,72 @@ function NetworkMgr:getWifiStatus()
     return false
 end
 
+function NetworkMgr:setHTTPProxy(proxy)
+    local http = require("socket.http")
+    http.PROXY = proxy
+    if proxy then
+        G_reader_settings:saveSetting("http_proxy", proxy)
+        G_reader_settings:saveSetting("http_proxy_enabled", true)
+    else
+        G_reader_settings:saveSetting("http_proxy_enabled", false)
+    end
+end
+
+function NetworkMgr:getWifiMenuTable()
+    return {
+        text = _("Wifi connection"),
+        enabled_func = function() return Device:isKindle() or Device:isKobo() end,
+        checked_func = function() return NetworkMgr:getWifiStatus() end,
+        callback = function()
+            if NetworkMgr:getWifiStatus() then
+                NetworkMgr:promptWifiOff()
+            else
+                NetworkMgr:promptWifiOn()
+            end
+        end
+    }
+end
+
+function NetworkMgr:getProxyMenuTable()
+    local proxy_enabled = function()
+        return G_reader_settings:readSetting("http_proxy_enabled")
+    end
+    local proxy = function()
+        return G_reader_settings:readSetting("http_proxy")
+    end
+    return {
+        text_func = function()
+            return _("HTTP proxy ") .. (proxy_enabled() and proxy() or "")
+        end,
+        checked_func = function() return proxy_enabled() end,
+        callback = function()
+            if not proxy_enabled() and proxy() then
+                NetworkMgr:setHTTPProxy(proxy())
+            elseif proxy_enabled() then
+                NetworkMgr:setHTTPProxy(nil)
+            end
+            if not proxy() then
+                UIManager:show(InfoMessage:new{
+                    text = _("Tips:\nlong press on this menu entry to configure HTTP proxy."),
+                })
+            end
+        end,
+        hold_input = {
+            title = _("input proxy address"),
+            type = "text",
+            hint = proxy() or "",
+            callback = function(input)
+                if input ~= "" then
+                    NetworkMgr:setHTTPProxy(input)
+                end
+            end,
+        }
+    }
+end
+
 -- set network proxy if global variable NETWORK_PROXY is defined
 if NETWORK_PROXY then
-    local http = require("socket.http")
-    http.PROXY = NETWORK_PROXY
+    NetworkMgr:setHTTPProxy(NETWORK_PROXY)
 end
 
 return NetworkMgr

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -20,7 +20,6 @@ local Geom = require("ui/geometry")
 local Font = require("ui/font")
 local DEBUG = require("dbg")
 local _ = require("gettext")
-local NetworkMgr = require("ui/networkmgr")
 local Blitbuffer = require("ffi/blitbuffer")
 
 --[[
@@ -322,23 +321,9 @@ function TouchMenu:init()
         text = "",
         face = self.fface,
     }
-    if Device:isKindle() or Device:isKobo() then
-        self.net_info = Button:new{
-            icon = "resources/icons/appbar.wifi.png",
-            callback = function() self:netToggle() end,
-            bordersize = 0,
-            show_parent = self,
-        }
-        self.net_info.label_widget.dim = not NetworkMgr:getWifiStatus()
-        self.device_info = HorizontalGroup:new{
-            self.time_info,
-            self.net_info,
-        }
-    else
-        self.device_info = HorizontalGroup:new{
-            self.time_info,
-        }
-    end
+    self.device_info = HorizontalGroup:new{
+        self.time_info,
+    }
     local footer_width = self.width - self.padding*2 - self.bordersize*2
     self.footer = HorizontalGroup:new{
         LeftContainer:new{
@@ -454,14 +439,6 @@ function TouchMenu:updateItems()
     -- FIXME: this is a dirty hack to clear previous menus
     -- refert to issue #664
     UIManager.repaint_all = true
-end
-
-function TouchMenu:netToggle()
-    if NetworkMgr:getWifiStatus() == true then
-        NetworkMgr:promptWifiOff()
-    else
-        NetworkMgr:promptWifiOn()
-    end
 end
 
 function TouchMenu:switchMenuTab(tab_num)


### PR DESCRIPTION
and remove the wifi toggler on the footer of each menu page,
so that network status is only checked (currently with the stdout of ip cmd)
when navigating to the "Network settings" submenu instead of checking
on each menu popup.
