### PR TITLE
Fix refresh in rotated (landscape) mode when using viewport

### DIFF
--- a/frontend/device/screen.lua
+++ b/frontend/device/screen.lua
@@ -148,6 +148,9 @@ end
 
 function Screen:setRotationMode(mode)
     self.bb:rotateAbsolute(-90 * (mode - self.native_rotation_mode - self.blitbuffer_rotation_mode))
+    if self.viewport then
+        self.fb.bb:setRotation(self.bb:getRotation())
+    end
     self.cur_rotation_mode = mode
 end
 


### PR DESCRIPTION
Rotation wasn't applied to the underlying framebuffer's blitbuffer,
so refresh coordinates were cut off the wrong way.

Should fix #1119 (at least the screen corruption)
