### PR TITLE
fix #1142 by adding 'show page overlap' option for EPUB doc

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -136,15 +136,20 @@ function ReaderPaging:onSaveSettings()
 end
 
 function ReaderPaging:addToMainMenu(tab_item_table)
-    if self.ui.document.info.has_pages then
-        table.insert(tab_item_table.typeset, {
-            text = _("Show page overlap"),
-            checked_func = function() return self.show_overlap_enable end,
-            callback = function()
-                self.show_overlap_enable = not self.show_overlap_enable
+    table.insert(tab_item_table.typeset, {
+        text = _("Show page overlap"),
+        enabled_func = function()
+            return not self.view.page_scroll and self.zoom_mode ~= "page"
+                    and not self.zoom_mode:find("height")
+        end,
+        checked_func = function() return self.show_overlap_enable end,
+        callback = function()
+            self.show_overlap_enable = not self.show_overlap_enable
+            if not self.show_overlap_enable then
+                self.view:resetDimArea()
             end
-        })
-    end
+        end
+    })
 end
 
 --[[

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -54,7 +54,7 @@ local ReaderView = OverlapGroup:new{
     -- dimen for current viewing page
     page_area = Geom:new{},
     -- dimen for area to dim
-    dim_area = Geom:new{w = 0, h = 0},
+    dim_area = nil,
     -- has footer
     footer_visible = nil,
     -- has dogear
@@ -69,7 +69,13 @@ local ReaderView = OverlapGroup:new{
 function ReaderView:init()
     -- fix recalculate from close document pageno
     self.state.page = nil
+    -- fix inherited dim_area for following opened documents
+    self:resetDimArea()
     self:resetLayout()
+end
+
+function ReaderView:resetDimArea()
+    self.dim_area = Geom:new{w = 0, h = 0}
 end
 
 function ReaderView:resetLayout()


### PR DESCRIPTION
And 'show page overlap' option is disabled in "page" mode for EPUBs,
and in fit to page/*height zoom mode for PDFs.
