### PR TITLE
"File to remove" DEBUG message was empty

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -241,8 +241,8 @@ end
 
 function FileManager:deleteFile(file)
     local InfoMessage = require("ui/widget/infomessage")
-    local rm = util.execute("/bin/rm", "-r", util.realpath(file))
     DEBUG("File to remove", util.realpath(file))
+    local rm = util.execute("/bin/rm", "-r", util.realpath(file))
     DEBUG("rm status", rm)
     if rm == 0 then
         UIManager:show(InfoMessage:new{


### PR DESCRIPTION
You can't get the full file path of a file that no longer exists, obviously.
