### PR TITLE
Preserve hyphenation settings when changing font face

### DIFF
--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -32,7 +32,7 @@ function ReaderHyphenation:init()
                     text = _("Change Hyphenation to ")..v,
                 })
                 self:_changeSel(k)
-                cre.setHyphDictionary(v)
+                self.ui.document:setHyphDictionary(v)
                 self.ui.toc:onUpdateToc()
             end
         })
@@ -43,7 +43,7 @@ end
 function ReaderHyphenation:onReadSettings(config)
     local hyph_alg = config:readSetting("hyph_alg")
     if hyph_alg then
-        cre.setHyphDictionary(hyph_alg)
+        self.ui.document:setHyphDictionary(hyph_alg)
     end
     self.hyph_alg = cre.getSelectedHyphDict()
     for k,v in ipairs(self.hyph_table) do

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -313,6 +313,13 @@ function CreDocument:setFontFace(new_font_face)
     end
 end
 
+function CreDocument:setHyphDictionary(new_hyph_dictionary)
+    if new_hyph_dictionary then
+        DEBUG("CreDocument: set hyphenation dictionary", new_hyph_dictionary)
+        self._document:setStringProperty("crengine.hyphenation.directory", new_hyph_dictionary)
+    end
+end
+
 function CreDocument:clearSelection()
     DEBUG("clear selection")
     self._document:clearSelection()


### PR DESCRIPTION
Changing font face currently resets the hyphenation dictonary to the default.

This problem is similar to #569.  `cre.setHyphDictionary()` does not modify document properties, and the next call to `set*Property()` reverts the change. Using `setStringProperty()` instead of `cre.setHyphDictionary()` fixes it.
