### PR TITLE
Fix the viewport on Kobo Aura (phoenix).

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -53,8 +53,8 @@ local KoboPhoenix = Kobo:new{
     hasFrontlight = yes,
     touch_phoenix_protocol = true,
     display_dpi = 212.8,
-    -- bezel:
-    viewport = Geom:new{x=0, y=0, w=752, h=1012},
+    -- the bezel covers 12 pixels at the bottom:
+    viewport = Geom:new{x=0, y=0, w=758, h=1012},
 }
 
 function Kobo:init()


### PR DESCRIPTION
On my Aura, the right edge of the viewport seems slightly off. Experiments show that w=758 works best (can be seen by the top menu frame). That actually makes sense, because 758 is the full witdh of the screen, meaning that the bezel only covers 12 pixels at the bottom.

@WS64 and other Aura owners, please test. :)
