### PR TITLE
fix strcoll() workaround

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -155,6 +155,12 @@ DDICT_FONT_SIZE = 20
 -- e.g. 2 changes the sensitivity by 1/2, 3 by 1/3 etc.
 FRONTLIGHT_SENSITIVITY_DECREASE = 2
 
+-- Normally, Koreader will present file lists sorted in case insensitive manner
+-- when presenting an alphatically sorted list. So the Order is "A, b, C, d".
+-- You can switch to a case sensitive sort ("A", "C", "b", "d") by disabling
+-- insensitive sort
+DALPHA_SORT_CASE_INSENSITIVE = true
+
 -- Set a path to a folder that is filled by Calibre (must contain the file metadata.calibre)
 -- e.g.
 -- "/mnt/sd/.hidden" for Kobo with files in ".hidden" on the SD card

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -73,8 +73,14 @@ function FileChooser:genItemTableFromPath(path)
     local sorting = nil
     local reverse = self.reverse_collate
     if self.collate == "strcoll" then
-        sorting = function(a, b)
-            return self.strcoll(a.name, b.name) == not reverse
+        if DALPHA_SORT_CASE_INSENSITIVE then
+            sorting = function(a, b)
+                return self.strcoll(string.lower(a.name), string.lower(b.name)) == not reverse
+            end
+        else
+            sorting = function(a, b)
+                return self.strcoll(a.name, b.name) == not reverse
+            end
         end
     elseif self.collate == "access" then
         sorting = function(a, b)


### PR DESCRIPTION
The strcoll() workaround we had in place for Kobo devices was (or has
become) ineffective. We had set self.strcoll to nil on Kobo devices -
but this was the instance variable. Setting it to nil effectively makes
the instance variable vanish, so when trying to access it later, it
was not there and got looked up via the metatable - which had the original
reference. Setting it to nil had no effect whatsoever.

We simplify that approach and set the replacement function where before we
had set this to nil.

This is a partial fix for issue #1183 (and explains a comment in issue #686
which says that the old fix did not work).

Second patch fixes the case-sensitivity issue.
