### PR TITLE
Get the ticks of lower <hx> first, not of higher

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -65,8 +65,10 @@ function ReaderFooter:init()
     if self.ui.toc and DMINIBAR_PROGRESS_MARKER then
         local max_level = self.ui.toc:getMaxDepth()
         for i = 1, max_level do
-            ticks = self.ui.toc:getTocTicks(i)
-            if #ticks < self.max_ticks then break end
+            ticks_backup = self.ui.toc:getTocTicks(i)
+            if i == 1 then ticks = ticks_backup end
+            if #ticks_backup >= self.max_ticks then break end
+            ticks = ticks_backup
         end
     end
     self.progress_bar = ProgressWidget:new{


### PR DESCRIPTION
In my opinion the logic was wrong.
Imagine to have a book with 20 h3s. Each of the h32 has 10-20 h4s (all in all for sure more than 50), and some of these h4 also have some h5s.
With the old logic you would see the h5s only since the h4s are too much.
But the h3s are way more important than the h5s, so the counter should start at the beginning.

I am unsure though if the for-loop should start with 1 or if we know somehow already that h3 is the smallest?
