### PR TITLE
wait for background thread before free()ing koptcontext

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -23,6 +23,7 @@ local ContextCacheItem = CacheItem:new{}
 
 function ContextCacheItem:onFree()
     if self.kctx.free then
+        KoptInterface:waitForContext(self.kctx)
         DEBUG("free koptcontext", self.kctx)
         self.kctx:free()
     end


### PR DESCRIPTION
This should prevent freeing resources that are actually in use in
a background thread. See #1224 for a manifestation of that bug.
