### PR TITLE
fix crash when highlighting text in EPUB documents

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -223,7 +223,7 @@ function ReaderView:getScreenPageArea(page)
             return area
         end
     else
-        return self.dimen:copy()
+        return self.dimen
     end
 end
 


### PR DESCRIPTION
Since the new Screen:getSize modthod returns a regular table
instead of a Geom which is set to the dimen field of readerview,
there is no copy method in the dimen field. And we don't need to
copy dimen any more since the result won't be modified. Even the
screen page area somehow needs to be modified, the caller of this
function should make a copy of that variable by itself.
