### PR TITLE
Revert "smaller viewport for Kobo H2O (bezel overlaps bottom)"

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -41,7 +41,7 @@ local KoboDahlia = Kobo:new{
     touch_phoenix_protocol = true,
     display_dpi = 265,
     -- bezel:
-    viewport = Geom:new{x=0, y=10, w=1080, h=1420},
+    viewport = Geom:new{x=0, y=10, w=1080, h=1430},
 }
 
 -- Kobo Aura HD:


### PR DESCRIPTION
This reverts commit fc36d6db371a79e9500eea426a4f4d11ec9dbafb.
Sorry, the bug description was misleading. The problem is rather that the font became too large, so it reaches over the (imaginary) baseline. See here: https://github.com/hwhw/koreader/commit/fc36d6db371a79e9500eea426a4f4d11ec9dbafb#commitcomment-8752241
