### PR TITLE
fix a case when "ip r" command fails

### DIFF
--- a/frontend/ui/networkmgr.lua
+++ b/frontend/ui/networkmgr.lua
@@ -74,10 +74,12 @@ end
 
 function NetworkMgr:getWifiStatus()
     local default_string = io.popen("ip r | grep default")
+    if not default_string then return false end
     local result = default_string:read()
+    default_string:close()
     if result ~= nil then
         local gateway = string.match(result,"%d+.%d+.%d+.%d+")
-        if os.execute("ping -q -c1 "..gateway) == 0 then
+        if gateway and os.execute("ping -q -c1 "..gateway) == 0 then
             return true
       end -- ping to gateway
     end -- test for empty string


### PR DESCRIPTION
our network manager script isn't the beauty of the code base.
However, this fixes a case where it would crash the reader when an
external command fails.

fixes #1279.
