### PR TITLE
Language: prevent spaces from disappearing in localizations with util.template

### DIFF
--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -10,6 +10,7 @@ local Screen = require("device").screen
 local util = require("ffi/util")
 local Font = require("ui/font")
 local DEBUG = require("dbg")
+local T = require("ffi/util").template
 local _ = require("gettext")
 
 local calibre = "metadata.calibre"
@@ -517,10 +518,10 @@ function Search:showresults()
         self.results = {}
         local i = 1
         while i <= self.count do
-            local dummy = _("Title: ")  .. (self.data[i][self.title] or "-") .. "\n \n" ..
-                          _("Author(s):") .. " " .. (self.data[i][self.authors2] or "-") .. "\n \n" ..
-                          _("Tags:") .. " " .. (self.data[i][self.tags2] or "-") .. "\n \n" ..
-                          _("Series:") .. " " .. (self.data[i][self.series] or "-")
+            local dummy = T(_("Title: %1"), (self.data[i][self.title] or "-")) .. "\n \n" ..
+                          T(_("Author(s): %1"), (self.data[i][self.authors2] or "-")) .. "\n \n" ..
+                          T(_("Tags: %1"), (self.data[i][self.tags2] or "-")) .. "\n \n" ..
+                          T(_("Series: %1"), (self.data[i][self.series] or "-"))
             if self.data[i][self.series] ~= "-" then
                 dummy = dummy .. " (" .. tostring(self.data[i][self.series_index]):gsub(".0$","") .. ")"
             end

--- a/frontend/ui/networkmgr.lua
+++ b/frontend/ui/networkmgr.lua
@@ -3,8 +3,8 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local UIManager = require("ui/uimanager")
 local Device = require("device")
 local DEBUG = require("dbg")
+local T = require("ffi/util").template
 local _ = require("gettext")
-
 local NetworkMgr = {}
 
 local function kindleEnableWifi(toggle)
@@ -121,7 +121,7 @@ function NetworkMgr:getProxyMenuTable()
     end
     return {
         text_func = function()
-            return _("HTTP proxy ") .. (proxy_enabled() and proxy() or "")
+            return T(_("HTTP proxy %1"), (proxy_enabled() and proxy() or ""))
         end,
         checked_func = function() return proxy_enabled() end,
         callback = function()

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -7,8 +7,8 @@ local UIManager = require("ui/uimanager")
 local Screen = require("device").screen
 local Event = require("ui/event")
 local DEBUG = require("dbg")
+local T = require("ffi/util").template
 local _ = require("gettext")
-
 local slt2 = require('slt2')
 local MyClipping = require("clip")
 
@@ -346,15 +346,21 @@ function EvernoteExporter:exportClippings(clippings)
         if all_count == 1 then
             msg = _("Exported notes from book:") .. "\n" .. export_title
         else
-            msg = _("Exported notes from book:") .. "\n" .. export_title
-            msg = msg .. "\n" .. _("and ") .. all_count-1 .. _(" others.")
+            msg = T(
+                _("Exported notes from book:\n%1\nand %2 others."),
+                export_title,
+                all_count-1
+            )
         end
     elseif error_count > 0 then
         if all_count == 1 then
             msg = _("An error occurred while trying to export notes from book:") .. "\n" .. error_title
         else
-            msg = _("Multiple errors occurred while trying to export notes from book:") .. "\n" .. error_title
-            msg = msg .. "\n" .. _("and ") .. error_count-1 .. _(" others.")
+            msg = T(
+                _("Multiple errors occurred while trying to export notes from book:\n%1\nand %2 others."),
+                error_title,
+                error_count-1
+            )
         end
     end
     UIManager:show(InfoMessage:new{ text = msg })


### PR DESCRIPTION
Fixes #1276 

As far as I've been able to find this is every last one of them.
