### PR TITLE
OPDS: ignore links with unknown rel values, treat empty rel as rel="subsection"

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -332,7 +332,7 @@ function OPDSBrowser:genItemTableFromURL(item_url, base_url)
                 item.acquisitions = {}
                 if entry.link then
                     for i, link in ipairs(entry.link) do
-                        if link.type:find(self.catalog_type) then
+                        if link.type:find(self.catalog_type) and (not link.rel or link.rel == 'subsection') then
                             item.url = build_href(link.href)
                         end
                         if link.rel and link.rel:match(self.acquisition_rel) then


### PR DESCRIPTION
Fixes #943 and hopefully does not break #1259 this time. @Frenzie, please test. :)
