### PR TITLE
Revert "on finish of pan gesture when scrolling, do partial refresh"

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -344,8 +344,8 @@ function ReaderPaging:onPanRelease(arg, ges)
         end
     else
         self.last_pan_relative_y = 0
-        -- trigger partial refresh
-        UIManager:setDirty(nil, "partial")
+        -- trigger full refresh
+        UIManager:setDirty(nil, "full")
     end
 end
 


### PR DESCRIPTION
This reverts commit c4a990316272dc7ab5aa4a718af33170ed9fb55a.

Actually, a full refresh is needed to clean the clutter after fast
refresh.

Might fix #1305
