### PR TITLE
get rid of plugin name "calibre companion"

### DIFF
--- a/plugins/calibrecompanion.koplugin/main.lua
+++ b/plugins/calibrecompanion.koplugin/main.lua
@@ -81,7 +81,7 @@ end
 
 function CalibreCompanion:addToMainMenu(tab_item_table)
     table.insert(tab_item_table.plugins, {
-        text = _("Calibre Companion"),
+        text = _("Calibre wireless connection"),
         sub_item_table = {
             {
                 text_func = function()


### PR DESCRIPTION
It's called "calibre wireless connection" now.

The author of the Calibre Companion Android App wrote to me an email saying that we cannot use their production name here. I totally agree with him and change our plugin with another name.
