### PR TITLE
restore wifi icon/toggler using global wifi status variable

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -10,6 +10,7 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local ButtonDialog = require("ui/widget/buttondialog")
 local lfs = require("libs/libkoreader-lfs")
 local UIManager = require("ui/uimanager")
+local NetworkMgr = require("ui/networkmgr")
 local Font = require("ui/font")
 local Screen = require("device").screen
 local Geom = require("ui/geometry")
@@ -153,6 +154,7 @@ function FileManager:init()
     end
 
     self:handleEvent(Event:new("SetDimensions", self.dimen))
+    G_wifi_status = NetworkMgr:getWifiStatus()
 end
 
 function FileManager:toggleHiddenFiles()

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -5,6 +5,7 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local lfs = require("libs/libkoreader-lfs")
 local DocSettings = require("docsettings")
 local UIManager = require("ui/uimanager")
+local NetworkMgr = require("ui/networkmgr")
 local Geom = require("ui/geometry")
 local Device = require("device")
 local Screen = require("device").screen
@@ -307,6 +308,7 @@ function ReaderUI:init()
     for _,v in ipairs(self.postInitCallback) do
         v()
     end
+    G_wifi_status = NetworkMgr:getWifiStatus()
 end
 
 function ReaderUI:showReader(file)

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -97,6 +97,7 @@ function Device:onPowerEvent(ev)
         self.screen:setRotationMode(0)
         Screensaver:show()
         self:prepareSuspend()
+        G_wifi_status = false
         UIManager:scheduleIn(10, self.Suspend)
     elseif (ev == "Power" or ev == "Resume") and self.screen_saver_mode then
         DEBUG("Resuming...")

--- a/frontend/ui/networkmgr.lua
+++ b/frontend/ui/networkmgr.lua
@@ -44,6 +44,7 @@ function NetworkMgr:turnOnWifi()
     elseif Device:isKobo() then
         koboEnableWifi(1)
     end
+    G_wifi_status = true
 end
 
 function NetworkMgr:turnOffWifi()
@@ -52,6 +53,7 @@ function NetworkMgr:turnOffWifi()
     elseif Device:isKobo() then
         koboEnableWifi(0)
     end
+    G_wifi_status = false
 end
 
 function NetworkMgr:promptWifiOn()
@@ -101,7 +103,7 @@ function NetworkMgr:getWifiMenuTable()
     return {
         text = _("Wifi connection"),
         enabled_func = function() return Device:isKindle() or Device:isKobo() end,
-        checked_func = function() return NetworkMgr:getWifiStatus() end,
+        checked_func = function() G_wifi_status = NetworkMgr:getWifiStatus() return G_wifi_status end,
         callback = function()
             if NetworkMgr:getWifiStatus() then
                 NetworkMgr:promptWifiOff()

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -14,6 +14,7 @@ local IconButton = require("ui/widget/iconbutton")
 local GestureRange = require("ui/gesturerange")
 local Button = require("ui/widget/button")
 local UIManager = require("ui/uimanager")
+local NetworkMgr = require("ui/networkmgr")
 local Device = require("device")
 local Screen = require("device").screen
 local Geom = require("ui/geometry")
@@ -344,9 +345,23 @@ function TouchMenu:init()
         text = "",
         face = self.fface,
     }
-    self.device_info = HorizontalGroup:new{
-        self.time_info,
-    }
+    if Device:isKindle() or Device:isKobo() then
+        self.net_info = Button:new{
+            icon = "resources/icons/appbar.wifi.png",
+            callback = function() self:netToggle() end,
+            bordersize = 0,
+            show_parent = self,
+         }
+         self.net_info.label_widget.dim = not G_wifi_status
+         self.device_info = HorizontalGroup:new{
+             self.time_info,
+             self.net_info,
+         }
+    else
+         self.device_info = HorizontalGroup:new{
+            self.time_info,
+         }
+    end
     local up_button = IconButton:new{
         icon_file = "resources/icons/appbar.chevron.up.png",
         show_parent = self.show_parent,
@@ -472,6 +487,14 @@ function TouchMenu:updateItems()
             or self.dimen
         return "partial", refresh_dimen
     end)
+end
+
+function TouchMenu:netToggle()
+    if G_wifi_status == true then
+        NetworkMgr:promptWifiOff()
+    else
+        NetworkMgr:promptWifiOn()
+    end
 end
 
 function TouchMenu:switchMenuTab(tab_num)


### PR DESCRIPTION
Restore wifi icon/toggler to touch menu - uses global wifi status variable rather than call to ping each time menu is refreshed.