### PR TITLE
fix mupdf rendering caused by FONTDIR env var

### DIFF
--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -78,7 +78,10 @@ function Font:getFace(font, size)
 end
 
 function Font:_readList(target, dir)
-    for f in lfs.dir(dir) do
+    -- lfs.dir non-exsitent directory will give error, weird!
+    local ok, iter, dir_obj = pcall(lfs.dir, dir)
+    if not ok then return end
+    for f in iter, dir_obj do
         if lfs.attributes(dir.."/"..f, "mode") == "directory" and f ~= "." and f ~= ".." then
             self:_readList(target, dir.."/"..f)
         else
@@ -95,7 +98,7 @@ function Font:getFontList()
     local fontlist = {}
     self:_readList(fontlist, self.fontdir)
     -- multiple path should be joined with semicolon in FONTDIR env variable
-    for dir in string.gmatch(os.getenv("FONTDIR") or "", "([^;]+)") do
+    for dir in string.gmatch(os.getenv("EXT_FONT_DIR") or "", "([^;]+)") do
         self:_readList(fontlist, dir)
     end
     table.sort(fontlist)

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -115,8 +115,8 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# export font directory
-export FONTDIR="/mnt/us/fonts"
+# export external font directory
+export EXT_FONT_DIR="/mnt/us/fonts"
 
 logmsg "Setting up IPTables rules . . ."
 # accept input ports for zsync plugin

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -21,8 +21,8 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# export font directory
-export FONTDIR="/mnt/onboard/fonts"
+# export external font directory
+export EXT_FONT_DIR="/mnt/onboard/fonts"
 
 # fast and dirty way of check if we are called from nickel
 # through fmon, or from another launcher (KSM or advboot)

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -21,8 +21,8 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# export font directory
-export FONTDIR="/mnt/ext1/fonts"
+# export external font directory
+export EXT_FONT_DIR="/mnt/ext1/fonts"
 
 if [ `echo $@ | wc -c` -eq 1 ]; then
     args="/mnt/ext1/"


### PR DESCRIPTION
It turns out that one of our mupdf patch reads the FONTDIR env var
and uses it in a totally different way so we will use another env var
EXT_FONT_DIR to define external font directory for different platforms.

This is a hot fix. 