### PR TITLE
Update networkmgr.lua

### DIFF
--- a/frontend/ui/networkmgr.lua
+++ b/frontend/ui/networkmgr.lua
@@ -28,7 +28,7 @@ local function koboEnableWifi(toggle)
         os.execute("wlarm_le -i eth0 up")
         os.execute("pidof wpa_supplicant >/dev/null || wpa_supplicant -s -i eth0 -c /etc/wpa_supplicant/wpa_supplicant.conf -C /var/run/wpa_supplicant -B")
         os.execute("sleep 1")
-        os.execute("sbin/udhcpc -S -i eth0 -s /etc/udhcpc.d/default.script -t15 -T10 -A3 -b -q >/dev/null 2>&1 &")
+        os.execute("/sbin/udhcpc -S -i eth0 -s /etc/udhcpc.d/default.script -t15 -T10 -A3 -b -q >/dev/null 2>&1 &")
     else
         os.execute("killall udhcpc wpa_supplicant 2>/dev/null")
         os.execute("wlarm_le -i eth0 down")

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -37,6 +37,27 @@ else
     args=$@
 fi
 
+# check whether PLATFORM has a value assigned by rcS
+# PLATFORM is used in koreader for the path to the WiFi drivers
+if [ -n "$PLATFORM" ]; then 
+  PLATFORM=freescale
+  if [ `dd if=/dev/mmcblk0 bs=512 skip=1024 count=1 | grep -c "HW CONFIG"` == 1 ]; then
+    CPU=`ntx_hwconfig -s -p /dev/mmcblk0 CPU`
+    PLATFORM=$CPU-ntx
+  fi
+
+  if [ $PLATFORM == freescale ]; then
+    if [ ! -s /lib/firmware/imx/epdc_E60_V220.fw ]; then
+      mkdir -p /lib/firmware/imx
+      dd if=/dev/mmcblk0 bs=512K skip=10 count=1 | zcat > /lib/firmware/imx/epdc_E60_V220.fw
+      sync
+    fi
+  elif [ ! -e /etc/u-boot/$PLATFORM/u-boot.mmc ]; then
+    PLATFORM=ntx508
+  fi
+fi
+# end of value check of PLATFORM
+
 ./reader.lua $args 2> crash.log
 
 if [ $from_nickel -ne 0 ]; then

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -55,6 +55,7 @@ if [ -n "$PLATFORM" ]; then
   elif [ ! -e /etc/u-boot/$PLATFORM/u-boot.mmc ]; then
     PLATFORM=ntx508
   fi
+  export PLATFORM
 fi
 # end of value check of PLATFORM
 


### PR DESCRIPTION
Change from the commands from `wifi.sh` to those from `wifi_enable_dhcp.sh` from Tshering's Start Menu. See Issue #939. Should resolve hanging of Kobo Aura H2O.