### PR TITLE
disable Turbo on Android

### DIFF
--- a/frontend/httpclient.lua
+++ b/frontend/httpclient.lua
@@ -17,7 +17,7 @@ function HTTPClient:request(request, response_callback)
     request.connect_timeout = 10
     request.request_timeout = 20
     UIManager:initLooper()
-    UIManager:handleTask(function()
+    UIManager.looper:add_callback(function()
         -- avoid endless waiting for input
         UIManager.INPUT_TIMEOUT = self.INPUT_TIMEOUT
         self.input_timeouts = self.input_timeouts + 1

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -23,6 +23,9 @@ local file = A.jni:context(A.app.activity.vm, function(JNI)
 end)
 A.LOGI("intent file path " .. (file or ""))
 
+-- run koreader patch before koreader startup
+pcall(function() dofile("/sdcard/koreader/patch.lua") end)
+
 -- create fake command-line arguments
 arg = {"-d", file or "/sdcard"}
 dofile(A.dir.."/reader.lua")


### PR DESCRIPTION
mcode force allocation on Android is now optional

Anyone who encounters random freeze of koreader for Android
is encouraged to enable this by adding a file at
"/sdcard/koreader/patch.lua" with the content of:
```
require("jit.opt").start("sizemcode=256","maxmcode=256")
for i=1,100 do end  -- Force allocation of one large segment
```
The sizemcode and maxmcode could be adjusted from 128 to 512 to
make koreader best fit on your Android device.

This is a workaround to fix #1456.