### PR TITLE
Popup goto dialog only when holding on visible status bar and various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ env:
     - EMULATE_READER=1 USE_NO_CCACHE=1
 
 before_install:
-    - sudo apt-get update
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq g++-4.8
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
 
 install:
     # nasm for building libpng

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ KOReader
 
 KOReader is a document viewer application, originally created for Kindle
 e-ink readers. It currently runs on Kindle 5 (Touch), Kindle Paperwhite,
-Kobo, PocketBook 840 and Android (2.3+) devices. Developers can also run Koreader emulator
+Kobo, PocketBook and Android (2.3+) devices. Developers can also run Koreader emulator
 for development purpose on desktop PC with Linux or Windows operating system.
 
 Main features for users

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -351,6 +351,7 @@ function ReaderFooter:onTapFooter(arg, ges)
 end
 
 function ReaderFooter:onHoldFooter(arg, ges)
+    if self.mode == 0 then return end
     self.ui:handleEvent(Event:new("ShowGotoDialog"))
     return true
 end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -7,6 +7,7 @@ local function yes() return true end
 
 local Device = Generic:new{
     model = "Android",
+    hasKeys = yes,
     isAndroid = yes,
     firmware_rev = "none",
     display_dpi = ffi.C.AConfiguration_getDensity(android.app.config),

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -620,7 +620,9 @@ function KoptInterface:getNativeOCRWord(doc, pageno, rect)
         kc:setZoom(30/rect.h)
         local page = doc._document:openPage(pageno)
         page:getPagePix(kc)
+        --kc:exportSrcPNGFile({rect}, nil, "ocr-word.png")
         local word_w, word_h = kc:getPageDim()
+        --DEBUG(word_w, word_h)
         local ok, word = pcall(
             kc.getTOCRWord, kc, "src",
             0, 0, word_w, word_h,


### PR DESCRIPTION
This should also fix #1350 by temporarily dismissing minibar.

And now we are independent from system libstdc++ library, tested with all tool-chains currently available on my machine:
```
koreader $ readelf -d koreader-x86_64-linux-gnu/koreader/libs/*|grep stdc++|wc -l
0
koreader $ readelf -d koreader-x86_64-pc-linux-gnu/koreader/libs/*|grep stdc++|wc -l
0
koreader $ readelf -d koreader-arm-linux-gnueabi/koreader/libs/*|grep stdc++|wc -l
0
koreader $ readelf -d koreader-arm-obreey-linux-gnueabi/koreader/libs/*|grep stdc++|wc -l
0
koreader $ readelf -d koreader-arm-linux-androideabi/koreader/libs/*|grep stdc++|wc -l
0
```
This should fix #1469 and #480.