### PR TITLE
Update with suggestions from KSM's author Tshering

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -39,7 +39,7 @@ fi
 
 # check whether PLATFORM has a value assigned by rcS
 # PLATFORM is used in koreader for the path to the WiFi drivers
-if [ -n "$PLATFORM" ]; then 
+if [ ! -n "$PLATFORM" ]; then 
   PLATFORM=freescale
   if [ `dd if=/dev/mmcblk0 bs=512 skip=1024 count=1 | grep -c "HW CONFIG"` == 1 ]; then
     CPU=`ntx_hwconfig -s -p /dev/mmcblk0 CPU`
@@ -66,7 +66,7 @@ if [ $from_nickel -ne 0 ]; then
     ./nickel.sh
 else
     # if we were called from advboot then we must reboot to go to the menu
-    if [ -d /mnt/onboard/.kobo/advboot ]; then
+   if [ "$(pidof ksmhome.sh | wc -w)" -lt "1" ]; then
         reboot
     fi
 fi


### PR DESCRIPTION
After forum discussion with Tshering. (see http://www.mobileread.com/forums/showthread.php?p=3090057#post3090057 , ) he made these suggestions: 

"Since we are already talking about the koreader.sh, could you consider changing
```sh
if [ -n "$PLATFORM" ]; then
```
to
```sh
if [ ! -n "${PLATFORM}" ]; then
```
or similar. Currently the whole block after that line is useless, since it is only execute, if PLATFORM is already defined.


And maybe you could replace
```sh
    # if we were called from advboot then we must reboot to go to the menu
    if [ -d /mnt/onboard/.kobo/advboot ]; then
        reboot
    fi
```
by something like
```sh
    if [ "$(pidof ksmhome.sh | wc -w)" -lt "1" ]; then
        reboot
    fi
```
The old script reboots the device if /mnt/onboard/.kobo/advboot exists, even if advboot is not active. "