### PR TITLE
Fix startup scripts.

### DIFF
--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -208,7 +208,7 @@ fi
 ./reader.lua "$@" 2> crash.log
 
 # clean up our own process tree in case the reader crashed (if needed, to avoid flooding KUAL's log)
-if pkill -0 reader.lua ; then
+if pidof reader.lua > /dev/null 2>&1 ; then
 	logmsg "Sending a SIGTERM to stray KOreader processes . . ."
 	killall -TERM reader.lua
 fi

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -89,7 +89,7 @@ else
 	# if we were called from advboot then we must reboot to go to the menu
 	# NOTE: This is actually achieved by checking if KSM is running:
 	#       This might lead to false-positives if you use neither KSM nor advboot to launch KOReader *without nickel running*.
-	if ! pidof ksmhome.sh > /dev/null 2>&1 ; then
+	if ! pgrep -f ksmhome.sh > /dev/null 2>&1 ; then
 		reboot
 	fi
 fi


### PR DESCRIPTION
Thanks to @Markismus's questions, I realized that some of what I thought
was true, wasn't.

First, pkill is a terrible idea to check for interpreted scripts.
Second, pidof is also potentially not that great for interpreted
scripts, because it'll only work when said script is called via a shebang, and one that is
following the Linux syntax at that.
We don't have the full pidof version from procps with the -x flag to paper over that,
so use pgrep -f instead.

cf.
https://github.com/NiLuJe/koreader/commit/a736a571d221993c410da36bdcd8a1a2bde3f0fa#commitcomment-10948910
for the gory details.