### PR TITLE
add datastorage module to handle data directory on various platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ANDROID_LAUNCHER_DIR:=$(ANDROID_DIR)/luajit-launcher
 WIN32_DIR=$(PLATFORM_DIR)/win32
 
 # files to link from main directory
-INSTALL_FILES=reader.lua frontend resources defaults.lua l10n \
+INSTALL_FILES=reader.lua frontend resources defaults.lua datastorage.lua l10n \
 		git-rev README.md COPYING
 
 # for gettext

--- a/datastorage.lua
+++ b/datastorage.lua
@@ -1,0 +1,14 @@
+-- need low-level mechnism to detect android to avoid recursive dependency
+local isAndroid = pcall(require, "android")
+
+local DataStorage = {}
+
+function DataStorage:getDataDir()
+    if isAndroid then
+        return "/sdcard/koreader/"
+    else
+        return "./"
+    end
+end
+
+return DataStorage

--- a/frontend/apps/filemanager/filemanagersetdefaults.lua
+++ b/frontend/apps/filemanager/filemanagersetdefaults.lua
@@ -1,10 +1,11 @@
 local InfoMessage = require("ui/widget/infomessage")
-local UIManager = require("ui/uimanager")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local CenterContainer = require("ui/widget/container/centercontainer")
+local DataStorage = require("datastorage")
+local UIManager = require("ui/uimanager")
 local Screen = require("device").screen
 local Menu = require("ui/widget/menu")
 local Font = require("ui/font")
@@ -319,16 +320,16 @@ function SetDefaults:SaveSettings()
         file:close()
     end
 
-    local filename = "defaults.persistent.lua"
+    local persistent_filename = DataStorage:getDataDir() .. "/defaults.persistent.lua"
     local file
-    if io.open(filename,"r") == nil then
-        file = io.open(filename, "w")
+    if io.open(persistent_filename,"r") == nil then
+        file = io.open(persistent_filename, "w")
         file:write("-- For configuration changes that persists between (nightly) releases\n")
         file:close()
     end
 
     local dpl = {}
-    fileread("defaults.persistent.lua",dpl)
+    fileread(persistent_filename, dpl)
     local dl = {}
     fileread("defaults.lua",dl)
     self.results = {}
@@ -355,12 +356,16 @@ function SetDefaults:SaveSettings()
         end
     end
 
-    file = io.open("defaults.persistent.lua", "w")
-    for i = 1,#dpl do
-        file:write(dpl[i] .. "\n")
+    file = io.open(persistent_filename, "w")
+    if file then
+        for i = 1,#dpl do
+            file:write(dpl[i] .. "\n")
+        end
+        file:close()
+        UIManager:show(InfoMessage:new{
+            text = _("Default settings were saved successfully!"),
+        })
     end
-    file:close()
-    UIManager:show(InfoMessage:new{text = _("Default settings were saved successfully!")})
     settings_changed = false
 end
 return SetDefaults

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -359,10 +359,9 @@ function ReaderHighlight:onHoldRelease()
                         end,
                     },
                     {
-                        text = _("More"),
-                        enabled = false,
+                        text = _("Dictionary"),
                         callback = function()
-                            self:moreAction()
+                            self:onHighlightDictLookup()
                             self:onClose()
                         end,
                     },
@@ -484,6 +483,15 @@ function ReaderHighlight:onHighlightSearch()
     if self.selected_text then
         local text = require("util").stripePunctuations(self.selected_text.text)
         self.ui:handleEvent(Event:new("ShowSearchDialog", text))
+    end
+end
+
+function ReaderHighlight:onHighlightDictLookup()
+    DEBUG("dictionary lookup highlight")
+    self:highlightFromHoldPos()
+    if self.selected_text then
+        local text = require("util").stripePunctuations(self.selected_text.text)
+        self.ui:handleEvent(Event:new("LookupWord", text))
     end
 end
 

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -1,6 +1,7 @@
 local lfs = require("libs/libkoreader-lfs")
 local DocSettings = {}
 local dump = require("dump")
+local DataStorage = require("datastorage")
 
 function DocSettings:getHistoryPath(fullpath)
     return "./history/[" .. fullpath:gsub("(.*/)([^/]+)","%1] %2"):gsub("/","#") .. ".lua"
@@ -26,7 +27,7 @@ function DocSettings:open(docfile)
     local sidecar_path = nil
     if docfile == ".reader" then
         -- we handle reader setting as special case
-        history_path = "settings.reader.lua"
+        history_path = DataStorage:getDataDir() .. "/settings.reader.lua"
     else
         if lfs.attributes("./history", "mode") ~= "directory" then
             lfs.mkdir("history")

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1,6 +1,7 @@
 local TileCacheItem = require("document/tilecacheitem")
 local KOPTContext = require("ffi/koptcontext")
 local Document = require("document/document")
+local DataStorage = require("datastorage")
 local CacheItem = require("cacheitem")
 local Screen = require("device").screen
 local Geom = require("ui/geometry")
@@ -11,7 +12,7 @@ local util = require("ffi/util")
 
 local KoptInterface = {
     ocrengine = "ocrengine",
-    tessocr_data = "data",
+    tessocr_data = DataStorage:getDataDir() .. "/data",
     ocr_lang = "eng",
     ocr_type = 3, -- default 0, for more accuracy use 3
     last_context_size = nil,

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -1,6 +1,12 @@
 local A = require("android")
 A.dl.library_path = A.dl.library_path .. ":" .. A.dir .. "/libs"
 
+local ffi = require("ffi")
+ffi.cdef[[
+    char *getenv(const char *name);
+    int putenv(const char *envvar);
+]]
+
 -- check uri of the intent that starts this application
 local file = A.jni:context(A.app.activity.vm, function(JNI)
     local uri = JNI:callObjectMethod(
@@ -28,6 +34,9 @@ pcall(function() dofile("/sdcard/koreader/patch.lua") end)
 
 -- set proper permission for sdcv
 A.execute("chmod", "755", "./sdcv")
+
+-- set TESSDATA_PREFIX env var
+ffi.C.putenv("TESSDATA_PREFIX=/sdcard/koreader/data")
 
 -- create fake command-line arguments
 arg = {"-d", file or "/sdcard"}

--- a/reader.lua
+++ b/reader.lua
@@ -2,7 +2,8 @@
 
 -- load default settings
 require "defaults"
-pcall(dofile, "defaults.persistent.lua")
+local DataStorage = require("datastorage")
+pcall(dofile, DataStorage:getDataDir() .. "/defaults.persistent.lua")
 
 -- set search path for 'require()'
 package.path = "common/?.lua;rocks/share/lua/5.1/?.lua;frontend/?.lua;" .. package.path


### PR DESCRIPTION
On kindle, kobo and pocketbook the data directory is the current
running directory but on Android the app is installed in system
defined location and users may have no access to that location.
The same circumstances should be true for the upcoming Koreader for
Ubuntu touch, so the data directory (in which tessdata, dictionaries,
global settings, persistant defaults and probably history data are
stored) could be stored in another place.

This PR also fix #1537 and fix #1476.