### PR TITLE
Fix Linux build docs to mention luarocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,17 @@ Building Prerequisites
 These instructions for how to get and compile the source are intended for a Linux
 OS. Windows users are suggested to develop in a [Linux VM][linux-vm] or use Wubi.
 
-To get and compile the source you must have `patch`, `wget`, `unzip`, `git`, `autoconf`,
-`subversion` and `cmake` installed, as well as a version of `autoconf` greater than 2.64.
-You also need `nasm` and of course a compiler like `gcc` or `clang`. If you want to
-cross-compile for other architectures, you need a proper cross-compile toolchain.
-Your GCC should be at least of version 4.7 for both native and cross compiling.
+To get and compile the source you must have `patch`, `wget`, `unzip`, `git`,
+`subversion`, `cmake` and `luarocks` installed, as well as a version of `autoconf`
+greater than 2.64. You also need `nasm` and of course a compiler like `gcc`
+or `clang`. If you want to cross-compile for other architectures, you need a proper
+cross-compile toolchain. Your GCC should be at least of version 4.7 for both native
+and cross compiling.
 
 Users of Debian and Ubuntu can install the required packages using:
 ```
 sudo apt-get install build-essential libtool gcc-multilib libffi-dev \
-patch wget unzip git autoconf subversion cmake nasm libsdl1.2-dev
+patch wget unzip git autoconf subversion cmake nasm libsdl1.2-dev luarocks
 ```
 
 Cross compile toolchains are available for Ubuntu users through these commands:


### PR DESCRIPTION
The list of Linux build dependencies needs to include `luarocks`,
since the current master doesn't build without it:

    /bin/bash: line 2: luarocks: command not found
    make[1]: *** [build/x86_64-linux-gnu/rocks/lib/luarocks/rocks/lua-spore/0.3.1-1/lua-spore-0.3.1-1.rockspec] Error 127
    make[1]: Leaving directory `~/koreader/base'
    make: *** [base/build/x86_64-linux-gnu/luajit] Error 2

This PR fixes the docs (and removes a redundant mention
of `autoconf` from the list as well.)