### PR TITLE
a way to set fallback font and fix a crash when character is not in droidsansfallback

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -210,13 +210,14 @@ end
 function ReaderFont:makeDefault(face)
     if face then
         UIManager:show(MultiConfirmBox:new{
-            text = T( _("Set default or fallback font to %1?"), face),
-            choise1_text = ("Default"),
-            choise1_callback = function()
+            text = T( _([[Set %1 to be the default or the fallback font? ]] 
+                      ..[[The fallback font is used on characters not in active font.]]), face),
+            choice1_text = ("Default"),
+            choice1_callback = function()
                 G_reader_settings:saveSetting("cre_font", face)
             end,
-            choise2_text = ("Fallback"),
-            choise2_callback = function()
+            choice2_text = ("Fallback"),
+            choice2_callback = function()
                 G_reader_settings:saveSetting("fallback_font", face)
             end,
         })

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -210,8 +210,8 @@ end
 function ReaderFont:makeDefault(face)
     if face then
         UIManager:show(MultiConfirmBox:new{
-            text = T( _([[Set %1 to be the default or the fallback font? ]] 
-                      ..[[The fallback font is used on characters not in active font.]]), face),
+            text = T( _([[Set %1 as default or fallback font? The fallback font ]] 
+                      ..[[displays characters not found in the active font.]]), face),
             choice1_text = ("Default"),
             choice1_callback = function()
                 G_reader_settings:saveSetting("cre_font", face)

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -211,11 +211,11 @@ function ReaderFont:makeDefault(face)
     if face then
         UIManager:show(MultiConfirmBox:new{
             text = T( _("Set default or fallback font to %1?"), face),
-            choise1_text = ("default"),
+            choise1_text = ("Default"),
             choise1_callback = function()
                 G_reader_settings:saveSetting("cre_font", face)
             end,
-            choise2_text = ("fallback"),
+            choise2_text = ("Fallback"),
             choise2_callback = function()
                 G_reader_settings:saveSetting("fallback_font", face)
             end,

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -1,7 +1,7 @@
 local InputContainer = require("ui/widget/container/inputcontainer")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Notification = require("ui/widget/notification")
-local ConfirmBox = require("ui/widget/confirmbox")
+local MultiConfirmBox = require("ui/widget/multiconfirmbox")
 local Menu = require("ui/widget/menu")
 local Device = require("device")
 local Screen = require("device").screen
@@ -209,10 +209,15 @@ end
 
 function ReaderFont:makeDefault(face)
     if face then
-        UIManager:show(ConfirmBox:new{
-            text = T( _("Set default font to %1?"), face),
-            ok_callback = function()
+        UIManager:show(MultiConfirmBox:new{
+            text = T( _("Set default or fallback font to %1?"), face),
+            choise1_text = ("default"),
+            choise1_callback = function()
                 G_reader_settings:saveSetting("cre_font", face)
+            end,
+            choise2_text = ("fallback"),
+            choise2_callback = function()
+                G_reader_settings:saveSetting("fallback_font", face)
             end,
         })
     end

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -75,10 +75,13 @@ function RenderText:getGlyph(face, charcode, bold)
         for index, font in pairs(Font.fallbacks) do
             -- use original size before scaling by screen DPI
             local fb_face = Font:getFace(font, face.orig_size)
-            if fb_face.ftface:checkGlyph(charcode) ~= 0 then
-                rendered_glyph = fb_face.ftface:renderGlyph(charcode, bold)
-                --DEBUG("fallback to font", font)
-                break
+            if fb_face ~= nil then
+            -- for some characters it cannot find in Fallbacks, it will crash here
+                if fb_face.ftface:checkGlyph(charcode) ~= 0 then
+                    rendered_glyph = fb_face.ftface:renderGlyph(charcode, bold)
+                    --DEBUG("fallback to font", font)
+                    break
+                end 
             end
         end
     end

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -1,0 +1,132 @@
+local InputContainer = require("ui/widget/container/inputcontainer")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local ImageWidget = require("ui/widget/imagewidget")
+local TextBoxWidget = require("ui/widget/textboxwidget")
+local HorizontalSpan = require("ui/widget/horizontalspan")
+local ButtonTable = require("ui/widget/buttontable")
+local GestureRange = require("ui/gesturerange")
+local UIManager = require("ui/uimanager")
+local Device = require("device")
+local Geom = require("ui/geometry")
+local Input = require("device").input
+local Screen = require("device").screen
+local Font = require("ui/font")
+local DEBUG = require("dbg")
+local _ = require("gettext")
+local Blitbuffer = require("ffi/blitbuffer")
+
+-- screen
+
+--[[
+Widget that shows a message and Choise1/Choise2/Cancel buttons
+]]
+local MultiConfirmBox = InputContainer:new{
+    modal = true,
+    text = _("no text"),
+    face = Font:getFace("infofont", 25),
+    choise1_text = _("Choise1"),
+    choise2_text = _("Choise2"),
+    cancel_text = _("Cancel"),
+    choise1_callback = function() end,
+    choise2_callback = function() end,
+    cancel_callback = function() end,
+    margin = 5,
+    padding = 5,
+}
+
+function MultiConfirmBox:init()
+    local content = HorizontalGroup:new{
+        align = "center",
+        ImageWidget:new{
+            file = "resources/info-i.png"
+        },
+        HorizontalSpan:new{ width = 10 },
+        TextBoxWidget:new{
+            text = self.text,
+            face = self.face,
+            width = Screen:getWidth()*2/3,
+        }
+    }
+
+    local button_table = ButtonTable:new{
+        width = content:getSize().w,
+        button_font_face = "cfont",
+        button_font_size = 20,
+        buttons = {
+            {
+                {
+                    text = self.cancel_text,
+                    callback = function()
+                        self.cancel_callback()
+                        UIManager:close(self)
+                    end,
+                },
+                {
+                    text = self.choise1_text,
+                    callback = function()
+                        self.choise1_callback()
+                        UIManager:close(self)
+                    end,
+                },
+                {
+                    text = self.choise2_text,
+                    callback = function()
+                        self.choise2_callback()
+                        UIManager:close(self)
+                    end,
+                },
+            },
+        },
+        zero_sep = true,
+        show_parent = self,
+    }
+
+    self[1] = CenterContainer:new{
+        dimen = Screen:getSize(),
+        FrameContainer:new{
+            background = Blitbuffer.COLOR_WHITE,
+            margin = self.margin,
+            padding = self.padding,
+            VerticalGroup:new{
+                align = "left",
+                content,
+                button_table,
+            }
+        }
+    }
+end
+
+function MultiConfirmBox:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self[1][1].dimen
+    end)
+end
+
+function MultiConfirmBox:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "partial", self[1][1].dimen
+    end)
+end
+
+function MultiConfirmBox:onClose()
+    UIManager:close(self)
+    return true
+end
+
+function MultiConfirmBox:onSelect()
+    DEBUG("selected:", self.selected.x)
+    if self.selected.x == 1 then
+        self:choise1_callback()
+    elseif self.selected.x == 2 then
+        self:choise2_callback()
+    elseif self.selected.x == 0 then
+        self:cancle_callback()
+    end
+    UIManager:close(self)
+    return true
+end
+
+return MultiConfirmBox

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -21,17 +21,17 @@ local Blitbuffer = require("ffi/blitbuffer")
 -- screen
 
 --[[
-Widget that shows a message and Choise1/Choise2/Cancel buttons
+Widget that shows a message and choice1/choice2/Cancel buttons
 ]]
 local MultiConfirmBox = InputContainer:new{
     modal = true,
     text = _("no text"),
     face = Font:getFace("infofont", 25),
-    choise1_text = _("Choise1"),
-    choise2_text = _("Choise2"),
+    choice1_text = _("Choice1"),
+    choice2_text = _("Choice2"),
     cancel_text = _("Cancel"),
-    choise1_callback = function() end,
-    choise2_callback = function() end,
+    choice1_callback = function() end,
+    choice2_callback = function() end,
     cancel_callback = function() end,
     margin = 5,
     padding = 5,
@@ -65,16 +65,16 @@ function MultiConfirmBox:init()
                     end,
                 },
                 {
-                    text = self.choise1_text,
+                    text = self.choice1_text,
                     callback = function()
-                        self.choise1_callback()
+                        self.choice1_callback()
                         UIManager:close(self)
                     end,
                 },
                 {
-                    text = self.choise2_text,
+                    text = self.choice2_text,
                     callback = function()
-                        self.choise2_callback()
+                        self.choice2_callback()
                         UIManager:close(self)
                     end,
                 },
@@ -119,9 +119,9 @@ end
 function MultiConfirmBox:onSelect()
     DEBUG("selected:", self.selected.x)
     if self.selected.x == 1 then
-        self:choise1_callback()
+        self:choice1_callback()
     elseif self.selected.x == 2 then
-        self:choise2_callback()
+        self:choice2_callback()
     elseif self.selected.x == 0 then
         self:cancle_callback()
     end


### PR DESCRIPTION
*add a button to confirmbox, now it has three buttons, i call it multiconfirmbox.
**when long tap font list ,it will show a box with three buttons. one for set default font, one for set fallback font,one for cancel.
*when the character is out of the range of Droid sans fallback, crengine will display '?'. this can be fixed by set a doc font  or fallback font which contains this character. But when I chose the character to lookup in dictionary, koreader will crash. The reason is that koreader has a fixed fallback font list in /ui/font.lua.  this patch only prevent it crash, it will display a box instead. 
