### PR TITLE
don't use tar.gz file extension for OTA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ kindleupdate: all
 		koreader/ota/package.index
 	# make gzip kindleupdate for zsync OTA update
 	cd $(INSTALL_DIR) && \
-		tar czafh ../koreader-kindle-$(MACHINE)-$(VERSION).tar.gz \
+		tar czafh ../koreader-kindle-$(MACHINE)-$(VERSION).targz \
 		-T koreader/ota/package.index --no-recursion
 
 koboupdate: all
@@ -182,7 +182,7 @@ koboupdate: all
 		koreader/ota/package.index KoboRoot.tgz koreader.png README_kobo.txt
 	# make gzip koboupdate for zsync OTA update
 	cd $(INSTALL_DIR) && \
-		tar czafh ../koreader-kobo-$(MACHINE)-$(VERSION).tar.gz \
+		tar czafh ../koreader-kobo-$(MACHINE)-$(VERSION).targz \
 		-T koreader/ota/package.index --no-recursion
 
 pbupdate: all
@@ -218,7 +218,7 @@ pbupdate: all
 		applications/koreader/ota/package.index system
 	# make gzip pbupdate for zsync OTA update
 	cd $(INSTALL_DIR)/applications && \
-		tar czafh ../../koreader-pocketbook-$(MACHINE)-$(VERSION).tar.gz \
+		tar czafh ../../koreader-pocketbook-$(MACHINE)-$(VERSION).targz \
 		-T koreader/ota/package.index --no-recursion
 
 androidupdate: all


### PR DESCRIPTION
because ISP may cache gz files and confuse zsync protocol
When I wget the gz file it's redirected to a ISP cached file and zsync
will fail.
```
~ $ wget http://vislab.bjmu.edu.cn/apps/koreader/ota/koreader-kindle-arm-linux-gnueabi-v2014.11-348-gddc3619.tar.gz
--2015-09-26 10:55:54--
http://vislab.bjmu.edu.cn/apps/koreader/ota/koreader-kindle-arm-linux-gnueabi-v2014.11-348-gddc3619.tar.gz
Resolving vislab.bjmu.edu.cn (vislab.bjmu.edu.cn)... 202.112.180.24
Connecting to vislab.bjmu.edu.cn
(vislab.bjmu.edu.cn)|202.112.180.24|:80... connected.
HTTP request sent, awaiting response... 302 Found
Location:
http://202.112.191.194/file/gz/2cd4eae05d961f8afe9ad99fb20288d4e735fbf4/vislab.bjmu.edu.cn/apps/koreader/ota/koreader-kindle-arm-linux-gnueabi-v2014.11-348-gddc3619.tar.gz
[following]
--2015-09-26 10:55:55--
http://202.112.191.194/file/gz/2cd4eae05d961f8afe9ad99fb20288d4e735fbf4/vislab.bjmu.edu.cn/apps/koreader/ota/koreader-kindle-arm-linux-gnueabi-v2014.11-348-gddc3619.tar.gz
```