### PR TITLE
Fix battery status on legacy Kindles

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -79,6 +79,10 @@ local KindlePaperWhite3 = Kindle:new{
 
 function Kindle2:init()
     self.screen = require("ffi/framebuffer_einkfb"):new{device = self, debug = DEBUG}
+    self.powerd = require("device/kindle/powerd"):new{
+        device = self,
+        is_charging_file = "/sys/devices/platform/charger/charging",
+    }
     self.input = require("device/input"):new{
         device = self,
         event_map = require("device/kindle/event_map_keyboard"),
@@ -90,6 +94,10 @@ end
 
 function KindleDXG:init()
     self.screen = require("ffi/framebuffer_einkfb"):new{device = self, debug = DEBUG}
+    self.powerd = require("device/kindle/powerd"):new{
+        device = self,
+        is_charging_file = "/sys/devices/platform/charger/charging",
+    }
     self.input = require("device/input"):new{
         device = self,
         event_map = require("device/kindle/event_map_keyboard"),
@@ -101,6 +109,11 @@ end
 
 function Kindle3:init()
     self.screen = require("ffi/framebuffer_einkfb"):new{device = self, debug = DEBUG}
+    self.powerd = require("device/kindle/powerd"):new{
+        device = self,
+        batt_capacity_file = "/sys/devices/system/luigi_battery/luigi_battery0/battery_capacity",
+        is_charging_file = "/sys/devices/platform/fsl-usb2-udc/charging",
+    }
     self.input = require("device/input"):new{
         device = self,
         event_map = require("device/kindle/event_map_keyboard"),

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -112,6 +112,11 @@ end
 
 function Kindle4:init()
     self.screen = require("ffi/framebuffer_einkfb"):new{device = self, debug = DEBUG}
+    self.powerd = require("device/kindle/powerd"):new{
+        device = self,
+        batt_capacity_file = "/sys/devices/system/yoshi_battery/yoshi_battery0/battery_capacity",
+        is_charging_file = "/sys/devices/platform/fsl-usb2-udc/charging",
+    }
     self.input = require("device/input"):new{
         device = self,
         event_map = require("device/kindle/event_map_kindle4"),

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -11,8 +11,8 @@ local KindlePowerD = BasePowerD:new{
 }
 
 function KindlePowerD:init()
-    local lipc = require("liblipclua")
-    if lipc then
+    local haslipc, lipc = pcall(require, "liblipclua")
+    if haslipc and lipc then
         self.lipc_handle = lipc.init("com.github.koreader.kindlepowerd")
     end
     if self.device.hasFrontlight() then

--- a/frontend/ui/networkmgr.lua
+++ b/frontend/ui/networkmgr.lua
@@ -8,9 +8,9 @@ local _ = require("gettext")
 local NetworkMgr = {}
 
 local function kindleEnableWifi(toggle)
-    local lipc = require("liblipclua")
+    local haslipc, lipc = pcall(require, "liblipclua")
     local lipc_handle = nil
-    if lipc then
+    if haslipc and lipc then
         lipc_handle = lipc.init("com.github.koreader.networkmgr")
     end
     if lipc_handle then


### PR DESCRIPTION
... at least starting from the K3.

On older devices, we'd need to parse gasgauge-info's output.