### PR TITLE
Minor fixes

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -74,7 +74,8 @@ function BasePowerD:getCapacity()
 end
 
 function BasePowerD:refreshCapacity()
-    self:getCapacityHW()
+    -- We want our next getCapacity call to actually pull up to date info instead of a cached value ;)
+    self.capacity_pulled_count = self.capacity_cached_count
 end
 
 function BasePowerD:isCharging()

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -381,6 +381,8 @@ function TouchMenu:init()
     }
 
     self.bar:switchToTab(self.last_index or 1)
+    -- Make sure we always show an up to date battery status when first opening the menu...
+    Device:getPowerDevice():refreshCapacity()
     self:updateItems()
 end
 

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -261,8 +261,14 @@ if [ "${STOP_FRAMEWORK}" == "no" -a "${INIT_TYPE}" == "upstart" ] ; then
 		#lipc-set-prop com.lab126.pillow disableEnablePillow enable
 		logmsg "Restoring the status bar . . ."
 		lipc-set-prop com.lab126.pillow interrogatePillow '{"pillowId": "default_status_bar", "function": "nativeBridge.showMe();"}'
-		# Poke the search bar too, so that we get a proper refresh ;)
-		lipc-set-prop com.lab126.pillow interrogatePillow '{"pillowId": "search_bar", "function": "nativeBridge.hideMe(); nativeBridge.showMe();"}'
+		# And now we want to poke something to refresh the UI...
+		if [ "$(printf "%.3s" $(grep '^Kindle 5' /etc/prettyversion.txt 2>&1 | sed -n -r 's/^(Kindle)([[:blank:]]*)([[:digit:].]*)(.*?)$/\3/p' | tr -d '.'))" -ge "565" ] ; then
+			# FIXME: The old search_bar method doesn't seem to work anymore since FW 5.6.5... Get at least the homescreen back. We're still missing the men :/.
+			lipc-set-prop com.lab126.appmgrd start app://com.lab126.booklet.home
+		else
+			# Poke the search bar too, so that we get a proper refresh ;)
+			lipc-set-prop com.lab126.pillow interrogatePillow '{"pillowId": "search_bar", "function": "nativeBridge.hideMe(); nativeBridge.showMe();"}'
+		fi
 	fi
 fi
 

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -41,7 +41,8 @@ if [ "${INIT_TYPE}" == "upstart" ] ; then
 fi
 
 # Keep track of what we do with pillow...
-PILLOW_DISABLED="no"
+PILLOW_HARD_DISABLED="no"
+PILLOW_SOFT_DISABLED="no"
 
 # Keep track of if we were started through KUAL
 FROM_KUAL="no"


### PR DESCRIPTION
Fix the battery status polling cache invalidation. And use it to make sure the battery status shown in the top menu is always fresh (re #1656).

Update the startup script on Kindles to properly handle the status bar on FW 5.6.5 when starting via KUAL with the framework running. (Our previous method doesn't work properly anymore).