### PR TITLE
OPDS: fix parsing entry titles on ManyBooks (and possible other sites)

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -421,8 +421,8 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                 if type(entry.title) == "string" then
                     title = entry.title
                 elseif type(entry.title) == "table" then
-                    if entry.title.type == "text/xhtml" then
-                        title = entry.title.div or title
+                    if type(entry.title.type) == "string" and entry.title.div ~= "" then
+                        title = entry.title.div
                     end
                 end
                 if title == "Unknown" then


### PR DESCRIPTION
The current code expects entry titles in OPDS feeds to be either plain text or XHTML nodes with a `type="text/xhtml"` atrribute. Some feeds may have titles with `type="xhtml"` or `type="html"` instead.

For example, the feed at http://manybooks.net/opds/titles.php contains:

```
<title type="xhtml">
    <div xmlns="http://www.w3.org/1999/xhtml">Z</div>
</title>
```

Koreader does not know how to deal with this and displays "Unknown" instead.

This PR removes the type check altogether and just uses the contents of the `div` node as the entry title, if available.