### PR TITLE
fix kobo touch probe

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -26,10 +26,10 @@ DRENDER_MODE = 0 -- 0 is COLOUR
 DGLOBAL_CACHE_SIZE_MINIMUM = 1024*1024*10
 
 -- proportion of system free memory used as global cache
-DGLOBAL_CACHE_FREE_PROPORTION = 0.2
+DGLOBAL_CACHE_FREE_PROPORTION = 0.4
 
 -- maximum cache size
-DGLOBAL_CACHE_SIZE_MAXIMUM = 1024*1024*30
+DGLOBAL_CACHE_SIZE_MAXIMUM = 1024*1024*60
 
 -- background colour in non scroll mode: 8 = gray, 0 = white, 15 = black
 DBACKGROUND_COLOR = 0

--- a/utils/kobo_touch_probe.lua
+++ b/utils/kobo_touch_probe.lua
@@ -91,7 +91,7 @@ if KOBO_TOUCH_MIRRORED == nil then
         UIManager:show(TouchProbe:new{})
         UIManager:run()
     -- otherwise, we will use probed result
-    else
-        KOBO_TOUCH_MIRRORED = switch_xy
+    elseif switch_xy then
+        Input:registerEventAdjustHook(Input.adjustTouchSwitchXY)
     end
 end


### PR DESCRIPTION
The KOBO_TOUCH_MIRRORED is only used when init input device,
after the initialization setting it will have no effect on the
event adjust hook.