### PR TITLE
fix mcode allocation failure on Android

### DIFF
--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -5,8 +5,6 @@ local ffi = require("ffi")
 ffi.cdef[[
     char *getenv(const char *name);
     int putenv(const char *envvar);
-    void *mmap(void *addr, size_t length, int prot, int flags, int fd, size_t offset);
-    int munmap(void *addr, size_t length);
 ]]
 
 -- check uri of the intent that starts this application
@@ -30,23 +28,6 @@ local file = A.jni:context(A.app.activity.vm, function(JNI)
     end
 end)
 A.LOGI("intent file path " .. (file or ""))
-
--- reservation enough mmap slots for mcode allocation
-local reserved_slots = {}
-for i = 1, 32 do
-  local len = 0x80000 + i*0x2000
-  local p = ffi.C.mmap(nil, len, 0x3, 0x22, -1, 0)
-  A.LOGI("mmapped " ..  tostring(p))
-  table.insert(reserved_slots, {p = p, len = len})
-end
--- free the reservation immediately
-for _, slot in ipairs(reserved_slots) do
-  local res = ffi.C.munmap(slot.p, slot.len)
-  A.LOGI("munmap " .. tostring(slot.p) .. " " .. res)
-end
--- and allocate a large mcode segment, hopefully it will success.
-require("jit.opt").start("sizemcode=512","maxmcode=512")
-for i=1,100 do end  -- Force allocation of one large segment
 
 -- run koreader patch before koreader startup
 pcall(function() dofile("/sdcard/koreader/patch.lua") end)


### PR DESCRIPTION
This workaround makes a reservation of mmap slots that are hopefully
near the address of `mcode_alloc_at`. Then it unmaps those slots and
lets luajit allocate a large slot for mcode.

This PR relies on the merge of https://github.com/koreader/android-luajit-launcher/pull/33.