### PR TITLE
WIP Synchronise frontlight level with nickel config

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -173,7 +173,11 @@ SEARCH_SERIES = true
 SEARCH_PATH = true
 
 -- Light parameter for Kobo
-KOBO_LIGHT_ON_START = -1           -- -1 or 0-100. -1 leaves light as it is, other sets light on start/wake up
+KOBO_LIGHT_ON_START = -2           -- -1, -2 or 0-100. -1 leaves light as it
+                                   -- is, -2 uses 'Kobo eReader.conf', other
+                                   -- sets light on start/wake up
+KOBO_SYNC_BRIGHTNESS_WITH_NICKEL = true  -- Save brightness set in KOreader
+                                         -- with nickel's 'Kobo eReader.conf'
 KOBO_SCREEN_SAVER = ""             -- image or directory with pictures or "-"
 KOBO_SCREEN_SAVER_LAST_BOOK = true -- get screensaver from last book if possible
 

--- a/frontend/apps/reader/modules/readerfrontlight.lua
+++ b/frontend/apps/reader/modules/readerfrontlight.lua
@@ -46,10 +46,14 @@ function ReaderFrontLight:onAdjust(arg, ges)
         DEBUG("step = ", step)
         local delta_int = self.steps[step] or self.steps[#self.steps]
         DEBUG("delta_int = ", delta_int)
+        local new_intensity
         if ges.direction == "north" then
-            powerd:setIntensity(powerd.flIntensity + delta_int)
+            new_intensity = powerd.flIntensity + delta_int
         elseif ges.direction == "south" then
-            powerd:setIntensity(powerd.flIntensity - delta_int)
+            new_intensity = powerd.flIntensity - delta_int
+        end
+        if new_intensity ~= nil then
+            powerd:setIntensity(new_intensity)
         end
     end
     return true
@@ -121,7 +125,6 @@ end
 
 function ReaderFrontLight:close()
     self.fl_dialog:onClose()
-    G_reader_settings:saveSetting("frontlight_intensity", Device:getPowerDevice().flIntensity)
     UIManager:close(self.fl_dialog)
 end
 

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -20,7 +20,6 @@ end
 function BasePowerD:init() end
 function BasePowerD:toggleFrontlight() end
 function BasePowerD:setIntensityHW() end
-function BasePowerD:setIntensitySW() end
 function BasePowerD:getCapacityHW() return "0" end
 function BasePowerD:isChargingHW() end
 function BasePowerD:suspendHW() end
@@ -54,14 +53,6 @@ function BasePowerD:setIntensity(intensity)
     self.flIntensity = intensity
     self:setIntensityHW()
 end
-
-function BasePowerD:setIntensityWithoutHW(intensity)
-    intensity = intensity < self.fl_min and self.fl_min or intensity
-    intensity = intensity > self.fl_max and self.fl_max or intensity
-    self.flIntensity = intensity
-    self:setIntensitySW()
-end
-
 
 function BasePowerD:getCapacity()
     if self.capacity_pulled_count == self.capacity_cached_count then

--- a/frontend/device/kobo/nickel_conf.lua
+++ b/frontend/device/kobo/nickel_conf.lua
@@ -1,0 +1,70 @@
+--[[
+    Access and modify values in 'Kobo eReader.conf' used by Nickel.
+    Only PowerOptions:FrontLightLevel is currently supported .
+]]
+
+local NickelConf = {}
+NickelConf.frontLightLevel = {}
+
+local kobo_conf_path = '/mnt/onboard/.kobo/Kobo/Kobo eReader.conf'
+local re_BrightnessValue = "[0-9]+"
+local re_FrontLightLevel = "^FrontLightLevel%s*=%s*(" .. re_BrightnessValue .. ")%s*$"
+local re_PowerOptionsSection = "^%[PowerOptions%]%s*"
+local re_AnySection = "^%[.*%]%s*"
+
+function NickelConf.frontLightLevel.get()
+    local correct_section = false
+    local kobo_conf = assert(io.open(kobo_conf_path, "r"))
+    for line in kobo_conf:lines() do
+        if string.match(line, re_AnySection) then
+            correct_section = false
+            if string.match(line, re_PowerOptionsSection) then
+                correct_section = true
+            end
+        end
+        if correct_section then
+            new_intensity = string.match(line, re_FrontLightLevel)
+            if new_intensity then
+                new_intensity = tonumber(new_intensity)
+                break
+            end
+        end
+    end
+    kobo_conf:close()
+    return new_intensity
+end
+
+function NickelConf.frontLightLevel.set(new_intensity)
+	assert(new_intensity >= 0 and new_intensity <= 100,
+		"Wrong brightness value given!")
+
+    local lines = {}
+    local correct_section = false
+    local kobo_conf = assert(io.open(kobo_conf_path, "r"))
+    for line in kobo_conf:lines() do
+        if string.match(line, re_AnySection) then
+            correct_section = false
+            if string.match(line, re_PowerOptionsSection) then
+                correct_section = true
+            end
+        end
+        old_intensity = string.match(line, re_FrontLightLevel)
+        if correct_section and old_intensity then
+            lines[#lines + 1] = string.gsub(line, re_BrightnessValue, new_intensity, 1)
+            remaining_file = kobo_conf:read("*a")
+            break
+        else
+            lines[#lines + 1] = line
+        end
+    end
+    kobo_conf:close()
+
+    kobo_conf = assert(io.open(kobo_conf_path, "w"))
+    for i, line in ipairs(lines) do
+      kobo_conf:write(line, "\n")
+    end
+    kobo_conf:write(remaining_file)
+    kobo_conf:close()
+end
+
+return NickelConf

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -1,4 +1,5 @@
 local BasePowerD = require("device/generic/powerd")
+local NickelConf = require("device/kobo/nickel_conf")
 
 local KoboPowerD = BasePowerD:new{
     fl_min = 0, fl_max = 100,
@@ -29,15 +30,11 @@ end
 function KoboPowerD:setIntensityHW()
     if self.fl ~= nil then
         self.fl:setBrightness(self.flIntensity)
+        if KOBO_SYNC_BRIGHTNESS_WITH_NICKEL then
+            NickelConf.frontLightLevel.set(self.flIntensity)
+        end
     end
 end
-
-function KoboPowerD:setIntensitySW()
-    if self.fl ~= nil then
-        self.fl:restoreBrightness(self.flIntensity)
-    end
-end
-
 
 function KoboPowerD:getCapacityHW()
     self.battCapacity = self:read_int_file(self.batt_capacity_file)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -6,6 +6,7 @@ local Geom = require("ui/geometry")
 local util = require("ffi/util")
 local DEBUG = require("dbg")
 local _ = require("gettext")
+local NickelConf = require("device/kobo/nickel_conf")
 
 local MILLION = 1000000
 
@@ -60,8 +61,18 @@ function UIManager:init()
                 self:sendEvent(input_event)
             end
         end
-        if KOBO_LIGHT_ON_START and tonumber(KOBO_LIGHT_ON_START) > -1 then
-            Device:getPowerDevice():setIntensity( math.max( math.min(KOBO_LIGHT_ON_START,100) ,0) )
+        local kobo_light_on_start = tonumber(KOBO_LIGHT_ON_START)
+        if kobo_light_on_start then
+            if kobo_light_on_start >= 0 then
+                new_intensity = math.min(kobo_light_on_start, 100)
+            elseif kobo_light_on_start == -2 then
+                new_intensity = NickelConf.frontLightLevel:get()
+            end
+            if new_intensity then
+                -- Since this kobo-specific, we save here and let the code pick
+                -- it up later from the reader settings.
+                G_reader_settings:saveSetting("frontlight_intensity", new_intensity)
+            end
         end
     elseif Device:isKindle() then
         self.event_handlers["IntoSS"] = function()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -6,7 +6,6 @@ local Geom = require("ui/geometry")
 local util = require("ffi/util")
 local DEBUG = require("dbg")
 local _ = require("gettext")
-local NickelConf = require("device/kobo/nickel_conf")
 
 local MILLION = 1000000
 
@@ -63,9 +62,11 @@ function UIManager:init()
         end
         local kobo_light_on_start = tonumber(KOBO_LIGHT_ON_START)
         if kobo_light_on_start then
+            local new_intensity
             if kobo_light_on_start >= 0 then
                 new_intensity = math.min(kobo_light_on_start, 100)
             elseif kobo_light_on_start == -2 then
+                local NickelConf = require("device/kobo/nickel_conf")
                 new_intensity = NickelConf.frontLightLevel:get()
             end
             if new_intensity then

--- a/reader.lua
+++ b/reader.lua
@@ -118,8 +118,7 @@ if Device:isKobo() then
     if powerd and powerd.restore_settings then
         local intensity = G_reader_settings:readSetting("frontlight_intensity")
         intensity = intensity or powerd.flIntensity
-        powerd:setIntensityWithoutHW(intensity)
-        -- powerd:setIntensity(intensity)
+        powerd:setIntensity(intensity)
     end
     if Device:getCodeName() == "trilogy" then
         require("utils/kobo_touch_probe")


### PR DESCRIPTION
A few points about this patch:

* Because I consider nickel an optional external entity I tried to keep it away from core logic. For this reason I [load its value into `settings.reader.lua`](https://github.com/koreader/koreader/compare/master...dset0x:frontlight-sync?expand=1#diff-df44ce4f2932b4d7c52ce1bd4d511defR74) and let the rest of koreader's boot process read _that_ as it's always been doing.

* At the moment, KSM resets the brightness setting when switching from koreader to nickel and vice-versa. I have patches that fix that and once I've cleaned them up I will push them in KSM's way.

---

Issues that make this a WIP for now:

* Currently set to crash when `/mnt/onboard/.kobo/Kobo/Kobo eReader.conf` is missing, but I'll fix once I have the chance.

* The ini parser is very naive, but I could not find a lua library that works with nickel's configuration without breaking it. I'm open to suggestions to making it more robust.