### PR TITLE
Automatically choose the hyphenation dictionary based on the document language

### DIFF
--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -3,6 +3,7 @@ local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
 local T = require("ffi/util").template
 local _ = require("gettext")
+local util = require("util")
 
 local ReaderHyphenation = InputContainer:new{
     hyph_menu_title = _("Hyphenation"),
@@ -10,29 +11,86 @@ local ReaderHyphenation = InputContainer:new{
 }
 
 function ReaderHyphenation:init()
+    local lang_data_file = assert(io.open("./data/hyph/languages.json"), "r")
+    lang_data = json.decode(lang_data_file:read("*all"))
+
+    self.lang_table = {}
     self.hyph_table = {}
     self.hyph_alg = cre.getSelectedHyphDict()
-    for k,v in ipairs(cre.getHyphDictList()) do
+    for k,v in ipairs(lang_data) do
         table.insert(self.hyph_table, {
-            text = v,
+            text = v.name,
             callback = function()
-                self.hyph_alg = v
+                self.hyph_alg = v.filename
                 UIManager:show(InfoMessage:new{
-                    text = T( _("Changed hyphenation to %1."), v),
+                    text = T( _("Changed hyphenation to %1."), v.name),
                 })
-                self.ui.document:setHyphDictionary(v)
+                self.ui.document:setHyphDictionary(v.filename)
                 self.ui.toc:onUpdateToc()
             end,
             checked_func = function()
-                return v == self.hyph_alg
+                return v.filename == self.hyph_alg
             end
         })
+
+        self.lang_table[v.language] = v.filename
+        if v.aliases then
+            for i,alias in ipairs(v.aliases) do
+                self.lang_table[alias] = v.filename
+            end
+        end
     end
     self.ui.menu:registerToMainMenu(self)
 end
 
-function ReaderHyphenation:onReadSettings(config)
+function ReaderHyphenation:parseLanguageTag(lang_tag)
+    -- Parse an RFC 5646 language tag, like "en-US" or "en".
+    -- https://tools.ietf.org/html/rfc5646
+
+    -- We are only interested in the language and region parts.
+    local language = nil
+    local region = nil
+
+    for part in util.gsplit(lang_tag, "-", false) do
+        if not language then
+            language = string.lower(part)
+        elseif string.len(part) == 2 and not string.match(part, "[^%a]") then
+            region = string.upper(part)
+        end
+    end
+    return language, region
+end
+
+function ReaderHyphenation:getDictForLanguage(lang_tag)
+    -- EPUB language is an RFC 5646 language tag.
+    -- http://www.idpf.org/epub/301/spec/epub-publications.html#sec-opf-dclanguage
+    --
+    -- FB2 language is a two-letter language code
+    -- (which is also a valid RFC 5646 language tag).
+    -- http://fictionbook.org/index.php/%D0%AD%D0%BB%D0%B5%D0%BC%D0%B5%D0%BD%D1%82_lang (in Russian)
+
+    local language, region = self:parseLanguageTag(lang_tag)
+    if not language then
+        return
+    end
+
+    local dict
+    if region then
+        dict = self.lang_table[language .. '-' .. region]
+    end
+    if not dict then
+        dict = self.lang_table[language]
+    end
+    return dict
+end
+function ReaderHyphenation:onPreRenderDocument(config)
+    -- This is called after the document has been loaded
+    -- so we can use the document language.
+
     local hyph_alg = config:readSetting("hyph_alg")
+    if not hyph_alg then
+        hyph_alg = self:getDictForLanguage(self.ui.document:getProps().language)
+    end
     if hyph_alg then
         self.ui.document:setHyphDictionary(hyph_alg)
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -257,6 +257,12 @@ function ReaderUI:init()
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
+            self.document:loadDocument()
+
+            -- read additional settings after the document has been loaded
+            -- (but not rendered yet)
+            self:handleEvent(Event:new("PreRenderDocument", self.doc_settings))
+
             self.document:render()
         end)
         -- typeset controller


### PR DESCRIPTION
All EPUB and FB2 documents have a language specified in their metadata so we can choose the hyphenation dictionary automatically, without having to choose it manually for each document.

I've added a JSON index file to the crengine source tree (koreader/crengine#24). It is used for mapping language tags, like `en` or `ru-RU`, to hyphenation dictionaries, like `English_US_hyphen_(Alan).pdb`.

I've also had to add a new event, `ReadSettingsLate` alongside the usual `ReadSettings`. The reason for that is that `ReadSettings` is fired *before* the document is loaded and parsed, but the hyphenation manager needs to access the document metadata for choosing the right hyphenation dictionary when reading settings. The new `ReadSettingsLate` event is fired *after* the document has been read and parsed (but before the document is actually rendered).

Depends on koreader/koreader-base#369 and koreader/crengine#24