### PR TITLE
Add a bunch of OTA mirrors...

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -14,6 +14,9 @@ local ota_dir = DataStorage:getDataDir() .. "/ota/"
 local OTAManager = {
     ota_servers = {
         "http://vislab.bjmu.edu.cn:80/apps/koreader/ota/",
+        "http://koreader-eu.ak-team.com:80/",
+        "http://koreader-af.ak-team.com:80/",
+        "http://koreader-na.ak-team.com:80/",
         "http://koreader.ak-team.com:80/",
         "http://hal9k.ifsc.usp.br:80/koreader/",
     },


### PR DESCRIPTION
With much better peerings & bandwidth than my fallback.
-eu is in Central Europe
-af is in Western Europe
-na is in North America

----

Now that OVH's Cloud Storage solution is out of beta, we can do that!
(We previously could only access those over HTTPS, which zsync doesn't support).

Should be preferred over my 'old' mirror which is a simple dedicated server, and has much less throughput ;).

Note that I only upload to -eu, the rest is handled by OpenStack's background replication (EU -> AF -> NA).