### PR TITLE
Mount SD card as RW on kobo, but ignore errors

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -80,8 +80,12 @@ if [ ! -n "${PLATFORM}" ] ; then
 fi
 # end of value check of PLATFORM
 
-# Remount SD to RW, ignore errors since we may not have sd card
-mount -o remount,rw /mnt/sd || true
+grep ' /mnt/sd ' /proc/mounts | grep 'ro'
+# Remount SD to RW if it's RO
+if [ $? -eq 0 ]
+then
+    mount -o remount,rw /mnt/sd
+fi
 
 ./reader.lua "${args}" 2> crash.log
 

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -80,6 +80,9 @@ if [ ! -n "${PLATFORM}" ] ; then
 fi
 # end of value check of PLATFORM
 
+# Remount SD to RW, ignore errors since we may not have sd card
+mount -o remount,rw /mnt/sd || true
+
 ./reader.lua "${args}" 2> crash.log
 
 if [ "${from_nickel}" == "true" ] ; then


### PR DESCRIPTION
This change is to mount sd card as RW on kobo devices. Currently we are using sdr doc config, which needs write permission to the location where the original books store. But by default, sd card on kobo is mounted as RO, so the sdr doc config won't be written.