### PR TITLE
Add Nickle.frontLightState, save and restore frontlight toggle state when koreader starts

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -47,10 +47,13 @@ function BasePowerD:read_str_file(file)
     end
 end
 
-function BasePowerD:setIntensity(intensity)
+function BasePowerD:normalizeIntensity(intensity)
     intensity = intensity < self.fl_min and self.fl_min or intensity
-    intensity = intensity > self.fl_max and self.fl_max or intensity
-    self.flIntensity = intensity
+    return intensity > self.fl_max and self.fl_max or intensity
+end
+
+function BasePowerD:setIntensity(intensity)
+    self.flIntensity = self:normalizeIntensity(intensity)
     self:setIntensityHW()
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -12,7 +12,8 @@ local MILLION = 1000000
 -- there is only one instance of this
 local UIManager = {
     -- trigger a full refresh when counter reaches FULL_REFRESH_COUNT
-    FULL_REFRESH_COUNT = G_reader_settings:readSetting("full_refresh_count") or DRCOUNTMAX,
+    FULL_REFRESH_COUNT =
+        G_reader_settings:readSetting("full_refresh_count") or DRCOUNTMAX,
     refresh_count = 0,
 
     event_handlers = nil,
@@ -63,17 +64,24 @@ function UIManager:init()
         local kobo_light_on_start = tonumber(KOBO_LIGHT_ON_START)
         if kobo_light_on_start then
             local new_intensity
-            if kobo_light_on_start >= 0 then
+            local new_state
+            if kobo_light_on_start > 0 then
                 new_intensity = math.min(kobo_light_on_start, 100)
+                new_state = true
+            elseif kobo_light_on_start == 0 then
+                new_state = false
             elseif kobo_light_on_start == -2 then
                 local NickelConf = require("device/kobo/nickel_conf")
-                new_intensity = NickelConf.frontLightLevel:get()
+                new_intensity = NickelConf.frontLightLevel.get()
+                new_state = NickelConf.frontLightState:get()
             end
             if new_intensity then
                 -- Since this kobo-specific, we save here and let the code pick
                 -- it up later from the reader settings.
-                G_reader_settings:saveSetting("frontlight_intensity", new_intensity)
+                G_reader_settings:saveSetting(
+                    "frontlight_intensity", new_intensity)
             end
+            G_reader_settings:saveSetting("frontlight_state", new_state)
         end
     elseif Device:isKindle() then
         self.event_handlers["IntoSS"] = function()

--- a/reader.lua
+++ b/reader.lua
@@ -6,8 +6,12 @@ local DataStorage = require("datastorage")
 pcall(dofile, DataStorage:getDataDir() .. "/defaults.persistent.lua")
 
 -- set search path for 'require()'
-package.path = "common/?.lua;rocks/share/lua/5.1/?.lua;frontend/?.lua;" .. package.path
-package.cpath = "common/?.so;common/?.dll;/usr/lib/lua/?.so;rocks/lib/lua/5.1/?.so;" .. package.cpath
+package.path =
+    "common/?.lua;rocks/share/lua/5.1/?.lua;frontend/?.lua;" ..
+    package.path
+package.cpath =
+    "common/?.so;common/?.dll;/usr/lib/lua/?.so;rocks/lib/lua/5.1/?.so;" ..
+    package.cpath
 
 -- set search path for 'ffi.load()'
 local ffi = require("ffi")
@@ -117,8 +121,12 @@ if Device:isKobo() then
     local powerd = Device:getPowerDevice()
     if powerd and powerd.restore_settings then
         local intensity = G_reader_settings:readSetting("frontlight_intensity")
-        intensity = intensity or powerd.flIntensity
-        powerd:setIntensity(intensity)
+        powerd.flIntensity = intensity or powerd.flIntensity
+        local state = G_reader_settings:readSetting("frontlight_state")
+        if state then
+            -- Default state is off
+            powerd:toggleFrontlight()
+        end
     end
     if Device:getCodeName() == "trilogy" then
         require("utils/kobo_touch_probe")
@@ -132,8 +140,8 @@ if ARGV[argidx] and ARGV[argidx] ~= "" then
     elseif open_last and last_file then
         file = last_file
     end
-    -- if file is given in command line argument or open last document is set true
-    -- the given file or the last file is opened in the reader
+    -- if file is given in command line argument or open last document is set
+    -- true, the given file or the last file is opened in the reader
     if file then
         local ReaderUI = require("apps/reader/readerui")
         ReaderUI:showReader(file)
@@ -141,7 +149,8 @@ if ARGV[argidx] and ARGV[argidx] ~= "" then
     -- the filemanger will show the files in that path
     else
         local FileManager = require("apps/filemanager/filemanager")
-        local home_dir = G_reader_settings:readSetting("home_dir") or ARGV[argidx]
+        local home_dir =
+            G_reader_settings:readSetting("home_dir") or ARGV[argidx]
         FileManager:showFiles(home_dir)
     end
     UIManager:run()
@@ -154,7 +163,8 @@ else
 end
 
 local function exitReader()
-    local ReaderActivityIndicator = require("apps/reader/modules/readeractivityindicator")
+    local ReaderActivityIndicator =
+        require("apps/reader/modules/readeractivityindicator")
 
     G_reader_settings:close()
 

--- a/spec/unit/nickel_conf_spec.lua
+++ b/spec/unit/nickel_conf_spec.lua
@@ -12,6 +12,7 @@ describe("Nickel configuation module", function()
 foo=bar
 [PowerOptions]
 FrontLightLevel=55
+FrontLightState=true
 [YetAnotherThing]
 bar=baz
 ]])
@@ -19,6 +20,46 @@ bar=baz
 
             NickelConf._set_kobo_conf_path(fn)
             assert.Equals(NickelConf.frontLightLevel.get(), 55)
+            assert.Equals(NickelConf.frontLightState.get(), true)
+
+            os.remove(fn)
+        end)
+
+        it("should also read value", function()
+            local fn = os.tmpname()
+            local fd = io.open(fn, "w")
+            fd:write([[
+[OtherThing]
+foo=bar
+[PowerOptions]
+FrontLightLevel=30
+FrontLightState=false
+[YetAnotherThing]
+bar=baz
+]])
+            fd:close()
+
+            NickelConf._set_kobo_conf_path(fn)
+            assert.Equals(NickelConf.frontLightLevel.get(), 30)
+            assert.Equals(NickelConf.frontLightState.get(), false)
+
+            os.remove(fn)
+        end)
+
+        it("should have default value", function()
+            local fn = os.tmpname()
+            local fd = io.open(fn, "w")
+            fd:write([[
+[OtherThing]
+foo=bar
+[YetAnotherThing]
+bar=baz
+]])
+            fd:close()
+
+            NickelConf._set_kobo_conf_path(fn)
+            assert.Equals(NickelConf.frontLightLevel.get(), 20)
+            assert.Equals(NickelConf.frontLightState.get(), false)
 
             os.remove(fn)
         end)
@@ -34,6 +75,7 @@ FrontLightLevel=6
 
             NickelConf._set_kobo_conf_path(fn)
             NickelConf.frontLightLevel.set(100)
+            NickelConf.frontLightState.set(true)
 
             fd = io.open(fn, "r")
             assert.Equals(fd:read("*a"), [[
@@ -41,6 +83,7 @@ FrontLightLevel=6
 FrontLightLevel=6
 [PowerOptions]
 FrontLightLevel=100
+FrontLightState=true
 ]])
             fd:close()
             os.remove(fn)
@@ -50,11 +93,13 @@ FrontLightLevel=100
             fd:close()
 
             NickelConf.frontLightLevel.set(20)
+            NickelConf.frontLightState.set(false)
 
             fd = io.open(fn, "r")
             assert.Equals(fd:read("*a"), [[
 [PowerOptions]
 FrontLightLevel=20
+FrontLightState=false
 ]])
             fd:close()
             os.remove(fn)
@@ -68,6 +113,7 @@ FrontLightLevel=20
 foo=bar
 [PowerOptions]
 FrontLightLevel=6
+FrontLightState=false
 [YetAnotherThing]
 bar=baz
 ]])
@@ -75,6 +121,7 @@ bar=baz
 
             NickelConf._set_kobo_conf_path(fn)
             NickelConf.frontLightLevel.set(100)
+            NickelConf.frontLightState.set(true)
 
             fd = io.open(fn, "r")
             assert.Equals(fd:read("*a"), [[
@@ -82,6 +129,7 @@ bar=baz
 foo=bar
 [PowerOptions]
 FrontLightLevel=100
+FrontLightState=true
 [YetAnotherThing]
 bar=baz
 ]])
@@ -102,12 +150,14 @@ bar=baz
 
             NickelConf._set_kobo_conf_path(fn)
             NickelConf.frontLightLevel.set(1)
+            NickelConf.frontLightState.set(true)
 
             fd = io.open(fn, "r")
             assert.Equals(fd:read("*a"), [[
 [PowerOptions]
 foo=bar
 FrontLightLevel=1
+FrontLightState=true
 [OtherThing]
 bar=baz
 ]])
@@ -122,11 +172,13 @@ bar=baz
 
             NickelConf._set_kobo_conf_path(fn)
             NickelConf.frontLightLevel.set(15)
+            NickelConf.frontLightState.set(false)
 
             fd = io.open(fn, "r")
             assert.Equals([[
 [PowerOptions]
 FrontLightLevel=15
+FrontLightState=false
 ]],
                           fd:read("*a"))
             fd:close()


### PR DESCRIPTION
Currently koreader front light level is syncing with Nickle, but leaks front light state configuration. So this change is to,
1. Read / write FrontLightState in Nickle config.
2. Add a frontlight_state in G_reader_settings (for kobo only).
3. Add a flState (boolean) in kobo/powerd, to control the hardware toggle activity.
4. Change the fl_min of kobo from 0 to 1 (set front light level to 0 will confuse users, since the hardware toggle won't take any effect).

After this change, we can remove most of the functions and state variables (isOn, savedBrightness, etc) in koreader-base/ffi/kobolight.lua (only setBrightness is using)

Please kindly let me know if you think this PR needs to be squashed.