### PR TITLE
Slightly refector device & powerd component, remove some magic code

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -22,8 +22,12 @@ function BasePowerD:toggleFrontlight() end
 function BasePowerD:setIntensityHW() end
 function BasePowerD:getCapacityHW() return "0" end
 function BasePowerD:isChargingHW() end
-function BasePowerD:suspendHW() end
-function BasePowerD:wakeUpHW() end
+-- Anything needs to be done before do a real hardware suspend. Such as turn off
+-- front light.
+function BasePowerD:beforeSuspend() end
+-- Anything needs to be done after do a real hardware resume. Such as resume
+-- front light state.
+function BasePowerD:afterResume() end
 
 function BasePowerD:read_int_file(file)
     local fd =  io.open(file, "r")
@@ -68,20 +72,13 @@ function BasePowerD:getCapacity()
 end
 
 function BasePowerD:refreshCapacity()
-    -- We want our next getCapacity call to actually pull up to date info instead of a cached value ;)
+    -- We want our next getCapacity call to actually pull up to date info
+    -- instead of a cached value ;)
     self.capacity_pulled_count = self.capacity_cached_count
 end
 
 function BasePowerD:isCharging()
     return self:isChargingHW()
-end
-
-function BasePowerD:suspend()
-    return self:suspendHW()
-end
-
-function BasePowerD:wakeUp()
-    return self:wakeUpHW()
 end
 
 return BasePowerD

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -143,15 +143,6 @@ end
 
 function Kobo:resume()
     os.execute("echo 0 > /sys/power/state-extended")
-    if self.powerd then
-        if KOBO_LIGHT_ON_START and tonumber(KOBO_LIGHT_ON_START) > -1 then
-            self.powerd:setIntensity(math.max(math.min(KOBO_LIGHT_ON_START,100),0))
-        elseif self.powerd.fl ~= nil then
-            self.powerd.fl:restore()
-        end
-    end
-
-    Generic.resume(self)
 end
 
 -------------- device probe ------------
@@ -175,6 +166,3 @@ elseif codename == "alyssum" then
 else
     error("unrecognized Kobo model "..codename)
 end
-
-
-

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -60,4 +60,22 @@ function KoboPowerD:isChargingHW()
     return self.is_charging
 end
 
+-- Turn off front light before suspend.
+function KoboPowerD:beforeSuspend()
+    if self.flState then
+        assert(self.fl ~= nil)
+        self.fl:setBrightness(0)
+    end
+end
+
+-- Restore front light state after resume.
+function KoboPowerD:afterResume()
+    if KOBO_LIGHT_ON_START and tonumber(KOBO_LIGHT_ON_START) > -1 then
+        self:setIntensity(math.min(KOBO_LIGHT_ON_START, 100))
+    elseif self.flState then
+        assert(self.fl ~= nil)
+        self.fl:setBrightness(self.flIntensity)
+    end
+end
+
 return KoboPowerD


### PR DESCRIPTION
Logic to turn off Kobo front light when suspending device is too magic. So this change is a slight refector of device & powerd component. After this change, we can remove almost all variables in koreader-base/ffi/kobolight.lua.
Please refer to https://github.com/Hzj-jie/koreader-base for koreader-base change. Comparing is @ https://github.com/koreader/koreader-base/compare/master...Hzj-jie:master