### PR TITLE
E-ink optimization setting should be correctly set after restart.

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -53,7 +53,7 @@ function Device:init()
     end
 
     local is_eink = G_reader_settings:readSetting("eink")
-    self.screen.eink = (is_eink == nill) or is_eink
+    self.screen.eink = (is_eink == nil) or is_eink
 
     DEBUG("initializing for device", self.model)
     DEBUG("framebuffer resolution:", self.screen:getSize())

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -52,6 +52,9 @@ function Device:init()
         error("screen/framebuffer must be implemented")
     end
 
+    local is_eink = G_reader_settings:readSetting("eink")
+    self.screen.eink = (is_eink == nill) or is_eink
+
     DEBUG("initializing for device", self.model)
     DEBUG("framebuffer resolution:", self.screen:getSize())
 

--- a/frontend/ui/screen.lua
+++ b/frontend/ui/screen.lua
@@ -1,8 +1,0 @@
--- compatibility wrapper
-local Screen = require("device").screen
-
--- set eink flag for this screen
-local is_eink = G_reader_settings:readSetting("eink")
-Screen.eink = (is_eink == nil) and true or is_eink
-
-return Screen

--- a/spec/unit/eink_optimization_spec.lua
+++ b/spec/unit/eink_optimization_spec.lua
@@ -1,0 +1,8 @@
+require("commonrequire")
+
+describe("eink optimization setting", function()
+    it("should be correctly loaded", function()
+        G_reader_settings:saveSetting("eink", true)
+        assert.Equals(require("device").screen.eink, true)
+    end)
+end)


### PR DESCRIPTION
frontend/ui/screen.lua is not required by any other components, so it's initializing function won't be called. Move its logic into frontend/device/generic/device.lua.