### PR TITLE
fix(readerrolling): crash with legacy last_per config in page mode

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -8,4 +8,4 @@ make all
 retry_cmd 6 make testfront
 set +o pipefail
 luajit $(which luacheck) --no-color -q frontend | tee ./luacheck.out
-test $(grep Total ./luacheck.out | awk '{print $2}') -le 63
+test $(grep Total ./luacheck.out | awk '{print $2}') -le 59

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,7 @@
 unused_args = false
 std = "luajit"
+-- ignore implicit self
+self = false
 
 globals = {
     "G_reader_settings",

--- a/Makefile
+++ b/Makefile
@@ -340,9 +340,12 @@ po:
 	$(MAKE) -i -C l10n bootstrap pull
 
 static-check:
-	@if which luacheck > /dev/null; then luacheck -q frontend; else \
-		echo "[!] luacheck not found. "\
-		"you can install it with 'luarocks install luacheck'"; fi
+	@if which luacheck > /dev/null; then \
+			luacheck -q frontend; \
+		else \
+			echo "[!] luacheck not found. "\
+			"you can install it with 'luarocks install luacheck'"; \
+		fi
 
 doc:
 	make -C doc

--- a/frontend/dbg.lua
+++ b/frontend/dbg.lua
@@ -2,7 +2,7 @@ local dump = require("dump")
 local isAndroid, android = pcall(require, "android")
 
 local Dbg = {
-    is_on = false,
+    is_on = nil,
     ev_log = nil,
 }
 
@@ -25,15 +25,38 @@ local function LvDEBUG(lv, ...)
     end
 end
 
-function Dbg_mt.__call(dbg, ...)
-    if dbg.is_on then LvDEBUG(math.huge, ...) end
-end
-
 function Dbg:turnOn()
+    if self.is_on == true then return end
     self.is_on = true
+
+    Dbg_mt.__call = function(dbg, ...) LvDEBUG(math.huge, ...) end
+    Dbg.guard = function(_, module, method, pre_guard, post_guard)
+        local old_method = module[method]
+        module[method] = function(...)
+            if pre_guard then
+                pre_guard(...)
+            end
+            local values = {old_method(...)}
+            if post_guard then
+                post_guard(...)
+            end
+            return unpack(values)
+        end
+    end
 
     -- create or clear ev log file
     self.ev_log = io.open("ev.log", "w")
+end
+
+function Dbg:turnOff()
+    if self.is_on == false then return end
+    self.is_on = false
+    function Dbg_mt.__call() end
+    function Dbg.guard() end
+    if self.ev_log then
+        io.close(self.ev_log)
+        self.ev_log = nil
+    end
 end
 
 function Dbg:logEv(ev)
@@ -51,4 +74,5 @@ end
 
 setmetatable(Dbg, Dbg_mt)
 
+Dbg:turnOff()
 return Dbg

--- a/spec/unit/commonrequire.lua
+++ b/spec/unit/commonrequire.lua
@@ -21,8 +21,7 @@ local Input = require("device").input
 Input.dummy = true
 
 -- turn on debug
-local DEBUG = require("dbg")
---DEBUG:turnOn()
+--require("dbg"):turnOn()
 
 function assertAlmostEquals(expected, actual, margin)
     if type(actual) ~= 'number' or type(expected) ~= 'number'

--- a/spec/unit/dbg_spec.lua
+++ b/spec/unit/dbg_spec.lua
@@ -1,0 +1,65 @@
+describe("Dbg module", function()
+    local dbg
+    setup(function()
+        package.path = "?.lua;common/?.lua;rocks/share/lua/5.1/?.lua;frontend/?.lua;" .. package.path
+        dbg = require("dbg")
+    end)
+
+    it("setup mt.__call and guard after tunrnOn is called", function()
+        local old_call = getmetatable(dbg).__call
+        local old_guard = dbg.guard
+        dbg:turnOn()
+        assert.is_not.same(old_call, getmetatable(dbg).__call)
+        assert.is_not.same(old_guard, dbg.guard)
+    end)
+
+    it("should call pre_gard callback", function()
+        local called = false
+        local foo = {}
+        function foo:bar() end
+        assert.is.falsy(called)
+
+        dbg:turnOff()
+        assert.is.falsy(called)
+
+        dbg:turnOn()
+        dbg:guard(foo, 'bar', function() called = true end)
+        foo:bar()
+        assert.is.truthy(called)
+    end)
+
+    it("should call post_gard callback", function()
+        local called = false
+        local foo = {}
+        function foo:bar() end
+        assert.is.falsy(called)
+
+        dbg:turnOff()
+        assert.is.falsy(called)
+
+        dbg:turnOn()
+        dbg:guard(foo, 'bar', nil, function() called = true end)
+        foo:bar()
+        assert.is.truthy(called)
+    end)
+
+    it("should return all values returned by the guarded function", function()
+        local called = false, re
+        local foo = {}
+        function foo:bar() return 1 end
+        assert.is.falsy(called)
+
+        dbg:turnOn()
+        dbg:guard(foo, 'bar', function() called = true end)
+        re = {foo:bar()}
+        assert.is.truthy(called)
+        assert.is.same(re, {1})
+
+        called = false
+        function foo:bar() return 1, 2, 3 end
+        dbg:guard(foo, 'bar', function() called = true end)
+        assert.is.falsy(called)
+        re = {foo:bar()}
+        assert.is.same(re, {1, 2, 3})
+    end)
+end)

--- a/spec/unit/font_spec.lua
+++ b/spec/unit/font_spec.lua
@@ -1,10 +1,11 @@
-require("commonrequire")
-local DEBUG = require("dbg")
-local Font = require("ui/font")
-
 describe("Font module", function()
-    local f = nil
+    local Font
+    setup(function()
+        require("commonrequire")
+        Font = require("ui/font")
+    end)
     it("should get face", function()
+        local f
         f = Font:getFace('cfont', 18)
         assert.are_not.equals(f.ftface, nil)
         f = Font:getFace('tfont', 16)

--- a/spec/unit/readerbookmark_spec.lua
+++ b/spec/unit/readerbookmark_spec.lua
@@ -1,4 +1,4 @@
-describe("ReaderBookmark module #ok", function()
+describe("ReaderBookmark module", function()
     local DocumentRegistry, ReaderUI, UIManager, Screen, Geom, DEBUG, DocSettings
     local sample_epub, sample_pdf
 

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -1,11 +1,13 @@
-require("commonrequire")
-local util = require("ffi/util")
-local UIManager = require("ui/uimanager")
-local DEBUG = require("dbg")
-DEBUG:turnOn()
-
 describe("UIManager spec", function()
+    local Device, UIManager, util
     local noop = function() end
+
+    setup(function()
+        require("commonrequire")
+        util = require("ffi/util")
+        UIManager = require("ui/uimanager")
+        Device = require("device")
+    end)
 
     it("should consume due tasks", function()
         local now = { util.gettime() }
@@ -160,5 +162,33 @@ describe("UIManager spec", function()
         UIManager:nextTick(function() UIManager:nextTick(noop) end)
         UIManager:_checkTasks()
         assert.is_true(UIManager._task_queue_dirty)
+    end)
+
+    it("should setup auto suspend on kobo", function()
+        local old_reset_timer = UIManager._resetAutoSuspendTimer
+        local noop = old_reset_timer
+        assert.falsy(UIManager._startAutoSuspend)
+        assert.falsy(UIManager._stopAutoSuspend)
+        assert.truthy(old_reset_timer)
+        G_reader_settings:saveSetting("auto_suspend_timeout_seconds", 3600)
+
+        UIManager:quit()
+        -- should skip on non-kobo devices
+        UIManager:_initAutoSuspend()
+        assert.is.same(noop, UIManager._startAutoSuspend)
+        assert.is.same(noop, UIManager._stopAutoSuspend)
+        assert.truthy(old_reset_timer)
+        assert.is.same(#UIManager._task_queue, 0)
+        -- now test kobo devices
+        local old_is_kobo = Device.isKobo
+        Device.isKobo = function() return true end
+        UIManager:_initAutoSuspend()
+        assert.truthy(UIManager._startAutoSuspend)
+        assert.truthy(UIManager._stopAutoSuspend)
+        assert.is_not.same(UIManager._resetAutoSuspendTimer, old_reset_timer)
+        assert.is.same(#UIManager._task_queue, 1)
+        assert.is.same(UIManager._task_queue[1].action,
+                       UIManager.auto_suspend_action)
+        Device.isKobo = old_is_kobo
     end)
 end)


### PR DESCRIPTION
* fixed a bug in legacy reader config initialization
* added `dbg:guard()` function to disable critical asserts in non-debug mode
* refactor autospend a bit to make the code mostly self contained. that way it's easier for us to move it into its own module in the future if needed. also got rid of some if check at runtime.