### PR TITLE
disable jit on some modules on android

### DIFF
--- a/frontend/cache.lua
+++ b/frontend/cache.lua
@@ -6,6 +6,10 @@ local lfs = require("libs/libkoreader-lfs")
 local DataStorage = require("datastorage")
 local DEBUG = require("dbg")
 
+if require("device"):isAndroid() then
+    require("jit").off(true, true)
+end
+
 local function calcFreeMem()
     local meminfo = io.open("/proc/meminfo", "r")
     local freemem = 0

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -8,6 +8,10 @@ local CacheItem = require("cacheitem")
 local BlitBuffer = require("ffi/blitbuffer")
 local DEBUG = require("dbg")
 
+if require("device"):isAndroid() then
+    require("jit").off(true, true)
+end
+
 --[[
 @TODO: all these functions should probably be methods on Face objects
 ]]--

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -5,6 +5,10 @@ local Geom = require("ui/geometry")
 local Event = require("ui/event")
 local _ = require("gettext")
 
+if require("device"):isAndroid() then
+    require("jit").off(true, true)
+end
+
 --[[
 an InputContainer is an WidgetContainer that handles input events
 

--- a/frontend/ui/widget/container/widgetcontainer.lua
+++ b/frontend/ui/widget/container/widgetcontainer.lua
@@ -1,6 +1,10 @@
 local Geom = require("ui/geometry")
 local Widget = require("ui/widget/widget")
 
+if require("device"):isAndroid() then
+    require("jit").off(true, true)
+end
+
 --[[
 WidgetContainer is a container for another Widget
 --]]


### PR DESCRIPTION
to make koreader on Android  more stable

and with these opt params:
```
require("jit.opt").start("sizemcode=64","maxmcode=64", "hotloop=10000")
```

The strategy here is that we only use precious mcode memory (jitting)
on deep loops like the several blitting methods in blitbuffer.lua and
the pixel-copying methods in mupdf.lua. So that a small amount of mcode
memory (64KB) allocated when koreader is launched in the android.lua
is enough for the program and it won't need to jit other parts of lua
code and thus won't allocate mcode memory any more which by our
observation will be harder and harder as we run koreader and cause 
random freeze on some Android devices.

This PR relies on koreader/android-luajit-launcher#40.