### PR TITLE
libc6-dev-i386 is required to build kobo / kindle version on amd64 system

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Users of Debian and Ubuntu can install the required packages using:
 ```
 sudo apt-get install build-essential git patch wget unzip \
 gettext autoconf cmake libtool nasm luarocks \
-libssl-dev libffi-dev libsdl2-dev linux-libc-dev:i386
+libssl-dev libffi-dev libsdl2-dev libc6-dev-i386 linux-libc-dev:i386
 ```
 Note that the `linux-libc-dev:i386` package is only necessary for x86_64 machines.
 


### PR DESCRIPTION
I have encountered the issue to build kobo version (kindle should also be impacted) on one of my newly installed amd64 ubuntu box recently. Error message is
/usr/include/features.h|374|fatal error: sys/cdefs.h: No such file or directory|
After google around, this seems like a very common issue for cross platform compiling. Installing libc6-dev-i386 should resolve the issue.