### PR TITLE
Prefer sdr folder to history folder

### DIFF
--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -56,9 +56,9 @@ function DocSettings:open(docfile)
         sidecar_file = sidecar_path,
         data = {}
     }
-    local ok, stored = pcall(dofile, new.history_file or "")
+    local ok, stored = pcall(dofile, new.sidecar_file or "")
     if not ok then
-        ok, stored = pcall(dofile, new.sidecar_file or "")
+        ok, stored = pcall(dofile, new.history_file or "")
         if not ok then
             -- try legacy conf path, for backward compatibility. this also
             -- takes care of reader legacy setting


### PR DESCRIPTION
This change resolves issue #1962, and also this is the first step to migrate old history folder to sdr docsettings.