### PR TITLE
Update ImageWidget to support more stretch settings, and enable screensaver on kobo

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -178,7 +178,7 @@ KOBO_LIGHT_ON_START = -2           -- -1, -2 or 0-100. -1 leaves light as it
                                    -- sets light on start/wake up
 KOBO_SYNC_BRIGHTNESS_WITH_NICKEL = true  -- Save brightness set in KOreader
                                          -- with nickel's 'Kobo eReader.conf'
-KOBO_SCREEN_SAVER = ""             -- image or directory with pictures or "-"
+KOBO_SCREEN_SAVER = ""             -- image or directory with pictures or empty
 KOBO_SCREEN_SAVER_LAST_BOOK = true -- get screensaver from last book if possible
 
 -- Network proxy settings

--- a/defaults.lua
+++ b/defaults.lua
@@ -178,8 +178,6 @@ KOBO_LIGHT_ON_START = -2           -- -1, -2 or 0-100. -1 leaves light as it
                                    -- sets light on start/wake up
 KOBO_SYNC_BRIGHTNESS_WITH_NICKEL = true  -- Save brightness set in KOreader
                                          -- with nickel's 'Kobo eReader.conf'
-KOBO_SCREEN_SAVER = ""             -- image or directory with pictures or empty
-KOBO_SCREEN_SAVER_LAST_BOOK = true -- get screensaver from last book if possible
 
 -- Network proxy settings
 -- proxy url should be a string in the format of "http://localhost:3128"

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -79,6 +79,9 @@ local KoboAlyssum = Kobo:new{
 }
 
 function Kobo:init()
+    -- Default screensaver folder
+    KOBO_SCREEN_SAVER = "/mnt/onboard/screensaver"
+
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = dbg}
     self.powerd = require("device/kobo/powerd"):new{device = self}
     self.input = require("device/input"):new{

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -15,6 +15,8 @@ local Kobo = Generic:new{
     touch_mirrored_x = true,
     -- enforce protrait mode on Kobos:
     isAlwaysPortrait = yes,
+    -- the internal storage mount point users can write to
+    internal_storage_mount_point = "/mnt/onboard/"
 }
 
 -- TODO: hasKeys for some devices?
@@ -79,9 +81,6 @@ local KoboAlyssum = Kobo:new{
 }
 
 function Kobo:init()
-    -- Default screensaver folder
-    KOBO_SCREEN_SAVER = "/mnt/onboard/screensaver"
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = dbg}
     self.powerd = require("device/kobo/powerd"):new{device = self}
     self.input = require("device/input"):new{

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -1,6 +1,7 @@
 local DocumentRegistry = require("document/documentregistry")
 local UIManager = require("ui/uimanager")
-local Screen = require("device").screen
+local Device = require("device")
+local Screen = Device.screen
 local DocSettings = require("docsettings")
 local DEBUG = require("dbg")
 local _ = require("gettext")
@@ -84,7 +85,9 @@ function Screensaver:show()
     DEBUG("show screensaver")
     local InfoMessage = require("ui/widget/infomessage")
     -- first check book cover image
-    if KOBO_SCREEN_SAVER_LAST_BOOK then
+    screen_saver_last_book =
+        G_reader_settings:readSetting("use_lastfile_as_screensaver")
+    if screen_saver_last_book == nil or screen_saver_last_book then
         local lastfile = G_reader_settings:readSetting("lastfile")
         if lastfile then
             local data = DocSettings:open(lastfile)
@@ -96,8 +99,15 @@ function Screensaver:show()
     end
     -- then screensaver directory or file image
     if not self.suspend_msg then
-        if type(KOBO_SCREEN_SAVER) == "string" then
-            local file = KOBO_SCREEN_SAVER
+        local screen_saver_folder =
+            G_reader_settings:readSetting("screensaver_folder")
+        if screen_saver_folder == nil
+        and Device.internal_storage_mount_point ~= nil then
+            screen_saver_folder =
+                Device.internal_storage_mount_point .. "screensaver"
+        end
+        if screen_saver_folder then
+            local file = screen_saver_folder
             if lfs.attributes(file, "mode") == "directory" then
                 self.suspend_msg = getRandomImage(file)
             else

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -9,8 +9,8 @@ local _ = require("gettext")
 local Screensaver = {
 }
 
-local function createWidgetFromImage(imageWidget)
-    if imageWidget then
+local function createWidgetFromImage(image_widget)
+    if image_widget then
         local AlphaContainer = require("ui/widget/container/alphacontainer")
         local CenterContainer = require("ui/widget/container/centercontainer")
         return AlphaContainer:new{
@@ -19,7 +19,7 @@ local function createWidgetFromImage(imageWidget)
             width = Screen:getWidth(),
             CenterContainer:new{
                 dimen = Screen:getSize(),
-                imageWidget,
+                image_widget,
             }
         }
     end

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -47,13 +47,6 @@ local ImageWidget = Widget:new{
     -- size vertically and horizontally, without impact original aspect ratio.
     -- But overflow part will be ignored.
     overflow = false,
-    -- when nostretch is set to true, image won't be stretched.
-    nostretch = false,
-    -- when centering is set to true, image will be placed in the middle of the
-    -- widget. This setting takes effect only with overflow, autostretch and
-    -- nostretch. i.e. only when the image size is not consistent with widget
-    -- size.
-    centering = false,
     _bb = nil
 }
 
@@ -100,25 +93,25 @@ function ImageWidget:_render()
         -- rounding off to power of 2 to avoid alias with pow(2, floor(log(x)/log(2))
         local scale = math.pow(2, math.max(0, math.floor(math.log(dpi_scale)/0.69)))
         w, h = scale * native_w, scale * native_h
-    elseif self.autostretch then
-        local ratio = native_w / self.width / native_h * self.height
-        if ratio < 1 then
-            h = self.height
-            w = self.width * ratio
-        else
-            h = self.height * ratio
-            w = self.width
-        end
-    elseif self.nostretch then
-        w, h = native_w, native_h
-    elseif self.overflow then
-        local ratio = native_w / self.width / native_h * self.height
-        if ratio < 1 then
-            h = self.height / ratio
-            w = self.width
-        else
-            h = self.height
-            w = self.width / ratio
+    elseif self.width and self.height then
+        if self.autostretch then
+            local ratio = native_w / self.width / native_h * self.height
+            if ratio < 1 then
+                h = self.height
+                w = self.width * ratio
+            else
+                h = self.height * ratio
+                w = self.width
+            end
+        elseif self.overflow then
+            local ratio = native_w / self.width / native_h * self.height
+            if ratio < 1 then
+                h = self.height / ratio
+                w = self.width
+            else
+                h = self.height
+                w = self.width / ratio
+            end
         end
     end
     if (w and w ~= native_w) or (h and h ~= native_h) then
@@ -145,10 +138,6 @@ function ImageWidget:paintTo(bb, x, y)
         w = size.w,
         h = size.h
     }
-    if self.centering then
-        x = x - (size.w - self.width) / 2
-        y = y - (size.h - self.height) / 2
-    end
     if self.alpha == true then
         bb:alphablitFrom(self._bb, x, y, 0, 0, size.w, size.h)
     else

--- a/reader.lua
+++ b/reader.lua
@@ -97,7 +97,12 @@ local UIManager = require("ui/uimanager")
 local Device = require("device")
 local Font = require("ui/font")
 
--- read some global reader setting here:
+-- change some global default values according to the device types
+if Device:isKobo() then
+    KOBO_SCREEN_SAVER = "/mnt/onboard/screensaver"
+end
+
+-- read some global reader settings here:
 -- font
 local fontmap = G_reader_settings:readSetting("fontmap")
 if fontmap ~= nil then

--- a/reader.lua
+++ b/reader.lua
@@ -97,11 +97,6 @@ local UIManager = require("ui/uimanager")
 local Device = require("device")
 local Font = require("ui/font")
 
--- change some global default values according to the device types
-if Device:isKobo() then
-    KOBO_SCREEN_SAVER = "/mnt/onboard/screensaver"
-end
-
 -- read some global reader settings here:
 -- font
 local fontmap = G_reader_settings:readSetting("fontmap")

--- a/reader.lua
+++ b/reader.lua
@@ -97,7 +97,7 @@ local UIManager = require("ui/uimanager")
 local Device = require("device")
 local Font = require("ui/font")
 
--- read some global reader settings here:
+-- read some global reader setting here:
 -- font
 local fontmap = G_reader_settings:readSetting("fontmap")
 if fontmap ~= nil then


### PR DESCRIPTION
This issue has been discussed @ #1968 .

Also, current ImageWidget does not provide enough stretch strategies to better present a screen saver.
I have tried several combinations, and finally decide to use overflow + centering, considering users may use screensaver to hide what they are reading, so stretch the image to cover entire screen but respect original aspect ratio should be a good choice.