### PR TITLE
Removed a bunch of "successfully" and replaced one ellipsis.

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -149,7 +149,7 @@ DDICT_FONT_SIZE = 20
 -- e.g. 2 changes the sensitivity by 1/2, 3 by 1/3 etc.
 FRONTLIGHT_SENSITIVITY_DECREASE = 2
 
--- Normally, Koreader will present file lists sorted in case insensitive manner
+-- Normally, KOReader will present file lists sorted in case insensitive manner
 -- when presenting an alphatically sorted list. So the Order is "A, b, C, d".
 -- You can switch to a case sensitive sort ("A", "C", "b", "d") by disabling
 -- insensitive sort

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -322,7 +322,7 @@ function FileManager:deleteFile(file)
             os.remove(legacy_history_file)
         end
         UIManager:show(InfoMessage:new{
-            text = util.template(_("Successfully deleted %1"), file),
+            text = util.template(_("Deleted %1"), file),
             timeout = 2,
         })
     else
@@ -350,7 +350,7 @@ function FileManager:renameFile(file)
                 end
                 if move_history then
                     UIManager:show(InfoMessage:new{
-                        text = util.template(_("Successfully renamed from %1 to %2"), file, dest),
+                        text = util.template(_("Renamed from %1 to %2"), file, dest),
                         timeout = 2,
                     })
                 else

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -85,7 +85,7 @@ end
 
 function DocSettings:flush()
     -- write serialized version of the data table into
-    --  i) history directory in root directory of koreader
+    --  i) history directory in root directory of KOReader
     -- ii) sidecar directory in the same directory of the document
     if not self.history_file and not self.sidecar_file then
         return

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -100,14 +100,14 @@ function Document:discardChange()
 end
 
 -- calculate partial digest of the document
--- since only PDF documents could be modified by koreader by appending data
+-- since only PDF documents could be modified by KOReader by appending data
 -- at the end of the files when highlighting, we use a non-even sampling
 -- algorithm which samples with larger weight at file head and much smaller
 -- weight at file tail, thus reduces the probability that appended data may change
 -- the digest value.
 -- Note that if PDF file size is around 1024, 4096, 16384, 65536, 262144
 -- 1048576, 4194304, 16777216, 67108864, 268435456 or 1073741824, appending data
--- by highlighting in koreader may change the digest value.
+-- by highlighting in KOReader may change the digest value.
 function Document:fastDigest()
     local md5 = require("ffi/MD5")
     local lshift = bit.lshift

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -476,9 +476,9 @@ function OPDSBrowser:downloadFile(item, format, remote_url)
     }
 
     if c == 200 then
-        DEBUG("file downloaded successfully to", local_path)
+        DEBUG("file downloaded to", local_path)
         UIManager:show(InfoMessage:new{
-            text = _("File successfully saved to:\n") .. local_path,
+            text = _("File saved to:\n") .. local_path,
             timeout = 3,
         })
     else
@@ -511,7 +511,7 @@ function OPDSBrowser:showDownloads(item)
                         end)
                         UIManager:close(self.download_dialog)
                         UIManager:show(InfoMessage:new{
-                            text = _("Downloading may take several minutes..."),
+                            text = _("Downloading may take several minutes…"),
                             timeout = 3,
                         })
                     end

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -212,7 +212,7 @@ function EvernoteExporter:doLogin(username, password)
         self.evernote_token = token
         self.notebook_guid = guid
         UIManager:show(InfoMessage:new{
-            text = _("Logged in to Evernote successfully."),
+            text = _("Logged in to Evernote."),
         })
     end
 

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -177,7 +177,7 @@ function KOSync:doRegister(username, password)
             self.kosync_username = username
             self.kosync_userkey = userkey
             UIManager:show(InfoMessage:new{
-                text = _("Registered to KOReader server successfully."),
+                text = _("Registered to KOReader server."),
             })
         else
             UIManager:show(InfoMessage:new{
@@ -207,7 +207,7 @@ function KOSync:doLogin(username, password)
             self.kosync_username = username
             self.kosync_userkey = userkey
             UIManager:show(InfoMessage:new{
-                text = _("Logged in to KOReader server successfully."),
+                text = _("Logged in to KOReader server."),
             })
         else
             UIManager:show(InfoMessage:new{

--- a/reader.lua
+++ b/reader.lua
@@ -128,10 +128,10 @@ if Device:isKobo() then
                 -- default powerd.is_fl_on is false, turn it on
                 powerd:toggleFrontlight()
             else
-                -- the light can still be turned on manually outside of koreader
-                -- or nickel. so we always set the intensity to 0 here to keep it
+                -- the light can still be turned on manually outside of KOReader
+                -- or Nickel. so we always set the intensity to 0 here to keep it
                 -- in sync with powerd.is_fl_on (false by default)
-                -- NOTE: we cant use setIntensity method here because for kobo the
+                -- NOTE: we cant use setIntensity method here because for Kobo the
                 -- min intensity is 1 :(
                 powerd.fl:setBrightness(0)
             end

--- a/spec/unit/filemanager_spec.lua
+++ b/spec/unit/filemanager_spec.lua
@@ -55,7 +55,7 @@ describe("FileManager module", function()
         assert.is_not_nil(lfs.attributes(tmp_history))
 
         UIManager.show = function(self, w)
-            assert.Equals(w.text, "Successfully deleted "..tmp_fn)
+            assert.Equals(w.text, "Deleted "..tmp_fn)
         end
         filemanager:deleteFile(tmp_fn)
         UIManager.show = old_show
@@ -90,7 +90,7 @@ describe("FileManager module", function()
         assert.is_not_nil(lfs.attributes(tmp_history))
 
         UIManager.show = function(self, w)
-            assert.Equals(w.text, "Successfully deleted "..tmp_fn)
+            assert.Equals(w.text, "Deleted "..tmp_fn)
         end
         filemanager:deleteFile(tmp_fn)
         UIManager.show = old_show

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -14,12 +14,12 @@ describe("util module", function()
     end)
 
     it("should split string with patterns", function()
-        local sentence = "Hello world, welcome to KoReader!"
+        local sentence = "Hello world, welcome to KOReader!"
         local words = {}
         for word in util.gsplit(sentence, "%s+", false) do
             table.insert(words, word)
         end
-        assert.are_same(words, {"Hello", "world,", "welcome", "to", "KoReader!"})
+        assert.are_same(words, {"Hello", "world,", "welcome", "to", "KOReader!"})
     end)
 
     it("should split command line arguments with quotation", function()


### PR DESCRIPTION
If we're saying "successfully" is redundant as per #1972 we'd better be thorough.

I realized I should also check for deviant spellings of KOReader, but they don't really seem to occur. I changed a couple of comments to prevent false positives though.

Edit: oh yeah, if someone wants to double check, I searched with commands like
```
grep -R --include="*.lua" 'KoReader' .
```