### PR TITLE
imagewidget fix

### DIFF
--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -87,7 +87,7 @@ function ImageWidget:_render()
         error("cannot render image")
     end
     local native_w, native_h = self._bb:getWidth(), self._bb:getHeight()
-    local w, h
+    local w, h = self.width, self.height
     if self.autoscale then
         local dpi_scale = Screen:getDPI() / 167
         -- rounding off to power of 2 to avoid alias with pow(2, floor(log(x)/log(2))


### PR DESCRIPTION
bring back the old behavior: when width and height are set and all the
zooming options are false, zoom the image to that size. The last commit
to Imagewidget.lua caused it ignores the set width and height and use
the image's original size instead when no zoom option is set. This
caused #1979. Although #1979 can be fixed by setting autostretch=true,
but I think it's good to fix here.