### PR TITLE
Add an ignore_power_sleepcover setting to ignore Kobo power_sleepcover keycode

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -86,12 +86,15 @@ function Kobo:init()
     self.input = require("device/input"):new{
         device = self,
         event_map = {
-            [59] = "Power_SleepCover",
             [90] = "Light",
             [102] = "Home",
             [116] = "Power",
         }
     }
+
+    if not G_reader_settings:readSetting("ignore_power_sleepcover") then
+        self.input.event_map[59] = "Power_SleepCover"
+    end
 
     Generic.init(self)
 


### PR DESCRIPTION
This issue is discussing @ #1981, the change simply ignore Power_Sleepcover keycode if 'ignore_power_sleepcover' setting has been enabled.