### PR TITLE
fix 'opening file' dialog not centered in landscape

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -338,7 +338,7 @@ function ReaderUI:showReader(file)
     end
     UIManager:show(InfoMessage:new{
         text = T( _("Opening file '%1'."), file),
-        timeout = 0.1,
+        timeout = 0.0,
     })
     UIManager:nextTick(function()
         DEBUG("creating coroutine for showing reader")


### PR DESCRIPTION
by setting the timeout to 0.0 seconds so that when the screen
is turned to landscape the dialog is already closed.

Before this patch the 'Opening file' dialog could be this:
![screenshot from 2016-04-23 23 07 52](https://cloud.githubusercontent.com/assets/751535/14762272/edb3c784-09a8-11e6-84b7-5866f5f9b120.png)

