### PR TITLE
force paint open file info before loading document

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -521,6 +521,10 @@ function UIManager:_repaint()
     self.refresh_counted = false
 end
 
+function UIManager:forceRePaint()
+    self:_repaint()
+end
+
 function UIManager:setInputTimeout(timeout)
     self.INPUT_TIMEOUT = timeout or 200*1000
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -198,8 +198,8 @@ function UIManager:schedule(time, action)
                     break
                 end
             else
-                -- for fairness, it's better to make p+1 is strictly less than p
-                -- might want to revisit here in the future
+                -- for fairness, it's better to make p+1 is strictly less than
+                -- p might want to revisit here in the future
                 break
             end
         until e < s

--- a/kodev
+++ b/kodev
@@ -4,7 +4,7 @@ CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function assert_ret_zero {
     if [ $1 -ne 0 ]; then
-        if [ ! -z $2 ]; then
+        if [ ! -z "$2" ]; then
             echo $2
         fi
         exit 1

--- a/spec/unit/readersearch_spec.lua
+++ b/spec/unit/readersearch_spec.lua
@@ -93,6 +93,7 @@ describe("Readersearch module", function()
             assert.are.equal(13, count)
         end)
     end)
+
     describe("search API for PDF documents", function()
         local doc, search, paging
         setup(function()


### PR DESCRIPTION
See commit message for more info. I remember someone reported this issue before, but I can't find the ticket anymore. I am able to reproduce the bug in my K3.