### PR TITLE
PDF free zoom mode revisit

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -136,9 +136,6 @@ DMINIBAR_HEIGHT = 7             -- Should be smaller than DMINIBAR_CONTAINER_HEI
 DMINIBAR_CONTAINER_HEIGHT = 14  -- Larger means more padding at the bottom, at the risk of eating into the last line
 DMINIBAR_FONT_SIZE = 14
 
--- gesture detector defaults
-DGESDETECT_DISABLE_DOUBLE_TAP = true
-
 -- change this to any numerical value if you want to antomatically save settings when turning pages
 DAUTO_SAVE_PAGING_COUNT = nil
 

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -267,30 +267,24 @@ function ReaderPaging:onToggleBookmarkFlipping()
 end
 
 function ReaderPaging:enterFlippingMode()
-    self.ui:handleEvent(Event:new("EnterFlippingMode"))
     self.orig_reflow_mode = self.view.document.configurable.text_wrap
     self.orig_scroll_mode = self.view.page_scroll
     self.orig_zoom_mode = self.view.zoom_mode
     DEBUG("store zoom mode", self.orig_zoom_mode)
-    self.DGESDETECT_DISABLE_DOUBLE_TAP = DGESDETECT_DISABLE_DOUBLE_TAP
-
     self.view.document.configurable.text_wrap = 0
     self.view.page_scroll = self.flipping_scroll_mode
     Input.disable_double_tap = false
-    DGESDETECT_DISABLE_DOUBLE_TAP = false
-    self.ui:handleEvent(Event:new("SetZoomMode", self.flipping_zoom_mode))
+    self.ui:handleEvent(Event:new("EnterFlippingMode", self.flipping_zoom_mode))
 end
 
 function ReaderPaging:exitFlippingMode()
-    self.ui:handleEvent(Event:new("ExitFlippingMode"))
     self.view.document.configurable.text_wrap = self.orig_reflow_mode
     self.view.page_scroll = self.orig_scroll_mode
-    DGESDETECT_DISABLE_DOUBLE_TAP = self.DGESDETECT_DISABLE_DOUBLE_TAP
-    Input.disable_double_tap = DGESDETECT_DISABLE_DOUBLE_TAP
+    Input.disable_double_tap = true
     self.flipping_zoom_mode = self.view.zoom_mode
     self.flipping_scroll_mode = self.view.page_scroll
     DEBUG("restore zoom mode", self.orig_zoom_mode)
-    self.ui:handleEvent(Event:new("SetZoomMode", self.orig_zoom_mode))
+    self.ui:handleEvent(Event:new("ExitFlippingMode", self.orig_zoom_mode))
 end
 
 function ReaderPaging:updateOriginalPage(page)

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -88,7 +88,7 @@ local Input = {
     },
 
     timer_callbacks = {},
-    disable_double_tap = DGESDETECT_DISABLE_DOUBLE_TAP,
+    disable_double_tap = true,
 
     -- keyboard state:
     modifiers = {

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -69,8 +69,8 @@ function DjvuDocument:getOCRText(pageno, tboxes)
     return self.koptinterface:getOCRText(self, pageno, tboxes)
 end
 
-function DjvuDocument:getPageRegions(pageno)
-    return self.koptinterface:getPageRegions(self, pageno)
+function DjvuDocument:getPageBlock(pageno, x, y)
+    return self.koptinterface:getPageBlock(self, pageno, x, y)
 end
 
 function DjvuDocument:getUsedBBox(pageno)

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -77,8 +77,8 @@ function PdfDocument:getOCRText(pageno, tboxes)
     return self.koptinterface:getOCRText(self, pageno, tboxes)
 end
 
-function PdfDocument:getPageRegions(pageno)
-    return self.koptinterface:getPageRegions(self, pageno)
+function PdfDocument:getPageBlock(pageno, x, y)
+    return self.koptinterface:getPageBlock(self, pageno, x, y)
 end
 
 function PdfDocument:getUsedBBox(pageno)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -181,8 +181,6 @@ function UIManager:close(widget, refreshtype, refreshregion)
         return
     end
     dbg("close widget", widget.id)
-    -- TODO: Why do we the following?
-    Input.disable_double_tap = DGESDETECT_DISABLE_DOUBLE_TAP
     local dirty = false
     for i = #self._window_stack, 1, -1 do
         if self._window_stack[i].widget == widget then

--- a/spec/unit/defaults_spec.lua
+++ b/spec/unit/defaults_spec.lua
@@ -8,8 +8,8 @@ describe("defaults module", function()
 
     it("should load all defaults from defaults.lua", function()
         Defaults:init()
-        assert.is_same(#Defaults.defaults_name, 78)
-        assert.is_same(Defaults.defaults_name[29], 'DHINTCOUNT')
+        assert.is_same(#Defaults.defaults_name, 77)
+        assert.is_same(Defaults.defaults_name[28], 'DHINTCOUNT')
     end)
 
     it("should save changes to defaults.persistent.lua", function()
@@ -19,14 +19,14 @@ describe("defaults module", function()
         -- not in persistent but checked in defaults
         Defaults.changed[14] = true
         Defaults.changed[19] = true
-        Defaults.changed[29] = true
-        Defaults.changed[64] = true
-        Defaults.changed[78] = true
+        Defaults.changed[28] = true
+        Defaults.changed[63] = true
+        Defaults.changed[77] = true
         Defaults:SaveSettings()
-        assert.is_same(#Defaults.defaults_name, 78)
-        assert.is_same(Defaults.defaults_name[29], 'DHINTCOUNT')
-        assert.is_same(Defaults.defaults_name[78], 'SEARCH_TITLE')
-        assert.is_same(Defaults.defaults_name[64], 'DTAP_ZONE_MENU')
+        assert.is_same(#Defaults.defaults_name, 77)
+        assert.is_same(Defaults.defaults_name[28], 'DHINTCOUNT')
+        assert.is_same(Defaults.defaults_name[77], 'SEARCH_TITLE')
+        assert.is_same(Defaults.defaults_name[63], 'DTAP_ZONE_MENU')
         assert.is_same(Defaults.defaults_name[19], 'DCREREADER_VIEW_MODE')
         assert.is_same(Defaults.defaults_name[14],
                        'DCREREADER_CONFIG_MARGIN_SIZES_LARGE')
@@ -54,10 +54,10 @@ DTAP_ZONE_MENU = {
 
         -- in persistent
         Defaults:init()
-        Defaults.changed[29] = true
-        Defaults.defaults_value[29] = 2
-        Defaults.changed[64] = true
-        Defaults.defaults_value[64] = {
+        Defaults.changed[28] = true
+        Defaults.defaults_value[28] = 2
+        Defaults.changed[63] = true
+        Defaults.defaults_value[63] = {
             y = 10,
             x = 10.125,
             h = 20.25,
@@ -107,8 +107,8 @@ DHINTCOUNT = 2
 
         -- in persistent
         Defaults:init()
-        Defaults.changed[29] = true
-        Defaults.defaults_value[29] = 1
+        Defaults.changed[28] = true
+        Defaults.defaults_value[28] = 1
         Defaults:SaveSettings()
         fd = io.open(persistent_filename)
         assert.Equals(


### PR DESCRIPTION
This should implement feature request of zoom mode for multi-columns page in #501.
This PR depends on koreader/koreader-base#435.

How to use?

1. 
Tap the top left corner of a PDF/Djvu page to get into the flipping
mode

1. 
Double-tap on text block will zoom in to that column

1. 
Double-tap on any area will zoom out to an overview of the page

1. 
repeat step 2 to focus to another page block

How does it work? 

1. 
We first find the mask of text blocks in the page.
![screenshot from 2016-06-15 01 44 26](https://cloud.githubusercontent.com/assets/751535/16054105/4b6829d8-329e-11e6-9d5f-78d7030dd334.png)

1. 
Then we intersect page boxes with user tap to form a page block.
![screenshot from 2016-06-15 01 44 30](https://cloud.githubusercontent.com/assets/751535/16054114/54760c0c-329e-11e6-82ee-6c7f32223be2.png)

1. 
Finally we zoom the page to the page block and center current view to
that block.
![screenshot from 2016-06-15 01 44 20](https://cloud.githubusercontent.com/assets/751535/16054117/5ca17452-329e-11e6-8d42-46ac93e33961.png)
