### PR TITLE
add support of screen brightness settings for Android

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -11,6 +11,7 @@ local Device = Generic:new{
     hasKeys = yes,
     hasDPad = no,
     isAndroid = yes,
+    hasFrontlight = yes,
     firmware_rev = "none",
     display_dpi = ffi.C.AConfiguration_getDensity(android.app.config),
 }

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -1,6 +1,9 @@
 local BasePowerD = require("device/generic/powerd")
+local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
+    fl_min = 0, fl_max = 25,
+    fl_intensity = 10,
     batt_capacity_file = "/sys/class/power_supply/battery/capacity",
     is_charging_file = "/sys/class/power_supply/battery/charging_enabled",
     battCapacity = nil,
@@ -11,16 +14,17 @@ function AndroidPowerD:init()
 end
 
 function AndroidPowerD:setIntensityHW()
+    android.setScreenBrightness(math.floor(255 * self.fl_intensity / 25))
 end
 
 function AndroidPowerD:getCapacityHW()
-    self.battCapacity = self:read_int_file(self.batt_capacity_file)
+    self.battCapacity = android.getBatteryLevel()
     return self.battCapacity
 end
 
 function AndroidPowerD:isChargingHW()
-    self.is_charging = self:read_int_file(self.is_charging_file)
-    return self.is_charging == 1
+    self.is_charging = android.isCharging()
+    return self.is_charging
 end
 
 return AndroidPowerD

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,3 +1,5 @@
+local DEBUG = require("dbg")
+
 local BasePowerD = {
     fl_min = 0,          -- min frontlight intensity
     fl_max = 10,         -- max frontlight intensity
@@ -59,6 +61,7 @@ end
 function BasePowerD:setIntensity(intensity)
     if intensity == self.fl_intensity then return end
     self.fl_intensity = self:normalizeIntensity(intensity)
+    DEBUG("set light intensity", self.fl_intensity)
     self:setIntensityHW()
 end
 

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -37,9 +37,11 @@ local function update()
     local update_file = io.open(new_update, "r")
     if update_file ~= nil then
         io.close(update_file)
+        A.showProgress()
         if os.execute("tar xf " .. new_update) == 0 then
             os.execute("mv " .. new_update .. " " .. installed)
         end
+        A.dismissProgress()
     end
 
 end


### PR DESCRIPTION
and use standrad Android API to query battery level and charging status
This should fix #2025, fix #1759 and fix #1415.

And now Android adb log shall be filtered by `adb logcat | grep -i koreader`.