### PR TITLE
Add a setting to disable save document

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -465,18 +465,23 @@ end
 function ReaderUI:notifyCloseDocument()
     self:handleEvent(Event:new("CloseDocument"))
     if self.document:isEdited() then
-        UIManager:show(ConfirmBox:new{
-            text = _("Do you want to save this document?"),
-            ok_text = _("Yes"),
-            cancel_text = _("No"),
-            ok_callback = function()
-                self:closeDocument()
-            end,
-            cancel_callback = function()
-                self.document:discardChange()
-                self:closeDocument()
-            end,
-        })
+        if G_reader_settings:readSetting("disable_save_document") then
+            self.document:discardChange()
+            self:closeDocument()
+        else
+            UIManager:show(ConfirmBox:new{
+                text = _("Do you want to save this document?"),
+                ok_text = _("Yes"),
+                cancel_text = _("No"),
+                ok_callback = function()
+                    self:closeDocument()
+                end,
+                cancel_callback = function()
+                    self.document:discardChange()
+                    self:closeDocument()
+                end,
+            })
+        end
     else
         self:closeDocument()
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -465,7 +465,10 @@ end
 function ReaderUI:notifyCloseDocument()
     self:handleEvent(Event:new("CloseDocument"))
     if self.document:isEdited() then
-        if G_reader_settings:readSetting("disable_save_document") then
+        local setting = G_reader_settings:readSetting("save_document")
+        if setting == "always" then
+            self:closeDocument()
+        elseif setting == "disable" then
             self.document:discardChange()
             self:closeDocument()
         else

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -43,6 +43,41 @@ table.insert(common_settings, {
         require("ui/elements/refresh_menu_table"),
     },
 })
+table.insert(common_settings, {
+    text = _("Save Document"),
+    sub_item_table = {
+        {
+            text = _("Prompt"),
+            checked_func = function()
+                local setting = G_reader_settings:readSetting("save_document")
+                return setting == "prompt" or setting == nil
+            end,
+            callback = function()
+                G_reader_settings:delSetting("save_document")
+            end,
+        },
+        {
+            text = _("Always"),
+            checked_func = function()
+                return G_reader_settings:readSetting("save_document")
+                           == "always"
+            end,
+            callback = function()
+                G_reader_settings:saveSetting("save_document", "always")
+            end,
+        },
+        {
+            text = _("Disable"),
+            checked_func = function()
+                return G_reader_settings:readSetting("save_document")
+                           == "disable"
+            end,
+            callback = function()
+                G_reader_settings:saveSetting("save_document", "disable")
+            end,
+        },
+    },
+})
 table.insert(common_settings, Language:getLangMenuTable())
 table.insert(common_settings, {
     text = _("Show advanced options"),


### PR DESCRIPTION
This is a small change to add a hidden setting to disable save document feature.

I am considering whether we should add an individual 'control panel' like module.