### PR TITLE
Add removed item name in "Remove this item from history" and fix wrong items deleted issue.

### DIFF
--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -4,6 +4,7 @@ local ButtonDialog = require("ui/widget/buttondialog")
 local UIManager = require("ui/uimanager")
 local Menu = require("ui/widget/menu")
 local Screen = require("device").screen
+local util = require("ffi/util")
 local _ = require("gettext")
 
 local FileManagerHistory = InputContainer:extend{
@@ -38,7 +39,8 @@ function FileManagerHistory:onMenuHold(item)
         buttons = {
             {
                 {
-                    text = _("Remove this item from history"),
+                    text = util.template(_("Remove \"%1\" from history"),
+                                         item.text),
                     callback = function()
                         require("readhistory"):removeItem(item)
                         self._manager:updateItemTable()

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -25,16 +25,21 @@ function DocSettings:getHistoryPath(fullpath)
 end
 
 function DocSettings:getPathFromHistory(hist_name)
+    if hist_name == nil or hist_name == '' then return nil end
     -- 1. select everything included in brackets
     local s = string.match(hist_name,"%b[]")
+    if s == nil or s == '' then return nil end
     -- 2. crop the bracket-sign from both sides
     -- 3. and finally replace decorative signs '#' to dir-char '/'
     return string.gsub(string.sub(s,2,-3),"#","/")
 end
 
 function DocSettings:getNameFromHistory(hist_name)
+    if hist_name == nil or hist_name == '' then return nil end
+    hist_name = string.match(hist_name, "%b[]")
+    if hist_name == nil or hist_name == '' then return nil end
     -- at first, search for path length
-    local s = string.len(string.match(hist_name,"%b[]"))
+    local s = string.len(hist_name)
     -- and return the rest of string without 4 last characters (".lua")
     return string.sub(hist_name, s+2, -5)
 end

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -84,10 +84,16 @@ function ReadHistory:_readLegacyHistory()
     for f in lfs.dir(history_dir) do
         local path = joinPath(history_dir, f)
         if lfs.attributes(path, "mode") == "file" then
-            local file = joinPath(DocSettings:getPathFromHistory(f),
-                                  DocSettings:getNameFromHistory(f))
-            table.insert(self.hist,
-                         buildEntry(lfs.attributes(path, "modification"), file))
+            path = DocSettings:getPathFromHistory(f)
+            if path ~= nil and path ~= "" then
+                local file = DocSettings:getNameFromHistory(f)
+                if file ~= nil and file ~= "" then
+                    table.insert(
+                        self.hist,
+                        buildEntry(lfs.attributes(path, "modification"),
+                                   joinPath(path, file)))
+                end
+            end
         end
     end
 end

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -22,6 +22,13 @@ local function buildEntry(input_time, input_file)
     }
 end
 
+function ReadHistory:_indexing(start)
+    -- TODO(Hzj_jie): Use binary search to find an item when deleting it.
+    for i = start, #self.hist, 1 do
+        self.hist[i].index = i
+    end
+end
+
 function ReadHistory:_sort()
     for i = #self.hist, 1, -1 do
         if lfs.attributes(self.hist[i].file, "mode") ~= "file" then
@@ -40,10 +47,7 @@ function ReadHistory:_sort()
         end
     end
     table.sort(self.hist, function(v1, v2) return v1.time > v2.time end)
-    -- TODO(zijiehe): Use binary search to find an item when deleting it.
-    for i = 1, #self.hist, 1 do
-        self.hist[i].index = i
-    end
+    self:_indexing(1)
 end
 
 -- Reduces total count in hist list to a reasonable number by removing last
@@ -108,6 +112,7 @@ end
 function ReadHistory:removeItem(item)
     table.remove(self.hist, item.index)
     os.remove(DocSettings:getHistoryPath(item.file))
+    self:_indexing(item.index)
     self:_flush()
 end
 


### PR DESCRIPTION
This change is to fix #2162.
This change adds item text in the button, and fixes several potential crashes. (A bad file name in history folder can crash DocSettings class.)
This change also fixes a wrong items deleted issue. i.e. index of ReadHistory.hist has not been updated after removing items.