### PR TITLE
Update kosync plugin

### DIFF
--- a/frontend/random.lua
+++ b/frontend/random.lua
@@ -1,0 +1,33 @@
+-- A set of functions to extend math.random and math.randomseed.
+
+local random = {}
+
+-- Use current time as seed to randomlize.
+function random.seed()
+    math.randomseed(os.time())
+end
+
+random.seed()
+
+-- Return a UUID (v4, random).
+function random.uuid(with_dash)
+    local array = {}
+    for i = 1, 16 do
+        table.insert(array, math.random(256) - 1)
+    end
+    -- The 13th character should be 4.
+    array[7] = bit.band(array[7], 79)
+    array[7] = bit.bor(array[7], 64)
+    -- The 17th character should be 8 / 9 / a / b.
+    array[9] = bit.band(array[9], 191)
+    array[9] = bit.bor(array[9], 128)
+    if with_dash then
+        return string.format("%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+                             unpack(array))
+    else
+        return string.format("%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+                             unpack(array))
+    end
+end
+
+return random

--- a/plugins/kosync.koplugin/KOSyncClient.lua
+++ b/plugins/kosync.koplugin/KOSyncClient.lua
@@ -93,8 +93,15 @@ function KOSyncClient:authorize(username, password)
     end
 end
 
-function KOSyncClient:update_progress(username, password,
-        document, progress, percentage, device, callback)
+function KOSyncClient:update_progress(
+        username,
+        password,
+        document,
+        progress,
+        percentage,
+        device,
+        device_id,
+        callback)
     self.client:reset_middlewares()
     self.client:enable('Format.JSON')
     self.client:enable("GinClient")
@@ -109,6 +116,7 @@ function KOSyncClient:update_progress(username, password,
                 progress = progress,
                 percentage = percentage,
                 device = device,
+                device_id = device_id,
             })
         end)
         if ok then
@@ -123,8 +131,11 @@ function KOSyncClient:update_progress(username, password,
     if UIManager.looper then UIManager:setInputTimeout() end
 end
 
-function KOSyncClient:get_progress(username, password,
-        document, callback)
+function KOSyncClient:get_progress(
+        username,
+        password,
+        document,
+        callback)
     self.client:reset_middlewares()
     self.client:enable('Format.JSON')
     self.client:enable("GinClient")

--- a/plugins/kosync.koplugin/api.json
+++ b/plugins/kosync.koplugin/api.json
@@ -28,12 +28,14 @@
                 "progress",
                 "percentage",
                 "device",
+                "device_id",
             ],
             "payload" : [
                 "document",
                 "progress",
                 "percentage",
                 "device",
+                "device_id",
             ],
             "expected_status" : [200, 202, 401]
         },

--- a/reader.lua
+++ b/reader.lua
@@ -96,6 +96,11 @@ local lfs = require("libs/libkoreader-lfs")
 local UIManager = require("ui/uimanager")
 local Device = require("device")
 local Font = require("ui/font")
+local random = require("random")
+
+if not G_reader_settings:readSetting("device_id") then
+    G_reader_settings:saveSetting("device_id", random.uuid())
+end
 
 -- read some global reader setting here:
 -- font

--- a/spec/unit/random_spec.lua
+++ b/spec/unit/random_spec.lua
@@ -1,0 +1,33 @@
+describe("random package tests", function()
+    local random
+
+    local function is_magic_char(c)
+        return c == "8" or c == "9" or c == "A" or c == "B"
+    end
+
+    setup(function()
+        random = require("frontend/random")
+    end)
+
+    it("should generate uuid without dash", function()
+        for i = 1, 10000 do
+            local uuid = random.uuid()
+            assert.Equals(uuid:len(), 32)
+            assert.Equals(uuid:sub(13, 13), "4")
+            assert.is_true(is_magic_char(uuid:sub(17, 17)))
+        end
+    end)
+
+    it("should generate uuid with dash", function()
+        for i = 1, 10000 do
+            local uuid = random.uuid(true)
+            assert.Equals(uuid:len(), 36)
+            assert.Equals(uuid:sub(9, 9), "-")
+            assert.Equals(uuid:sub(14, 14), "-")
+            assert.Equals(uuid:sub(19, 19), "-")
+            assert.Equals(uuid:sub(24, 24), "-")
+            assert.Equals(uuid:sub(15, 15), "4")
+            assert.is_true(is_magic_char(uuid:sub(20, 20)))
+        end
+    end)
+end)


### PR DESCRIPTION
HouQP and I are discussing the details about whisper sync feature in issue https://github.com/koreader/koreader/issues/2179. Some of the changes to koreader client can be made in advance to the conclusion of discussion.

1. MD5 hash of a document should be calculated at the very first time a book has been opened. This change can avoid any document saving feature to impact this value. The MD5 hash is the only key to identity a file in kosync plugin.
2. Create a device id in kosync plugin to identity a device, and kosync plugin won't sync progress from a same device. I have considered to put the device id into a more common place, i.e. G_reader_settings. But I finally decide to leave it in kosync plugin, because of the complexity of the key. We always send the device_id in http requests, and since the device attaches to a single user, comparing to a UUID, a very simple model + int solution can distinct the device with very limited payload.
3. Separate 'Sync now' into 'pull' and 'push' in manual sync mode. This change can avoid to implicitly push current process to the server.
4. Round percentage to avoid to trigger sync with very small differences. Currently I am rounding the number to 0.00001, we can definitely change it later.
5. Never sync from same device. By using model + device_id to identity a device, we can avoid to synchronize progress from and to a same device.
6. Always output result if users actively click 'push' or 'pull' menu items. This is important, as users may not understand what happened, if server error, or progress is ignored.