### PR TITLE
fix #2219

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -349,11 +349,12 @@ function KindleOasis:init()
         }
     }
 
-    local lipc = require("liblipclua")
-    if lipc then
+    local haslipc, lipc = pcall(require, "liblipclua")
+    if haslipc and lipc then
         local lipc_handle = lipc.init("com.github.koreader.screen")
         if lipc_handle then
-            local orientation_code = lipc_handle:get_string_property("com.lab126.winmgr", "accelerometer")
+            local orientation_code = lipc_handle:get_string_property(
+                "com.lab126.winmgr", "accelerometer")
             local rotation_mode = 0
             if orientation_code then
                 if orientation_code == "V" then
@@ -376,8 +377,9 @@ function KindleOasis:init()
         end
     end
 
-
     Kindle.init(self)
+
+    self.input:registerEventAdjustHook(self.input.adjustKindleOasisOrientation)
 
     self.input.open(self.touch_dev)
     self.input.open("/dev/input/by-path/platform-gpiokey.0-event")


### PR DESCRIPTION
The ABS_PRESSURE ABS code is also detected on some KOBO devices
if ABS_PRESSURE events are feeded to handle orientation those devices
will have a unresponsive screen as described in #2219.

This patch registers an event adjustment handler for Kindle Oasis to
adjust the ABS_PRESSURE code to ABS_OASIS_ORIENTATION so that
it won't affect event handling on other devices.