### PR TITLE
Restore WIFI state when koreader starts

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -10,9 +10,15 @@ local _ = require("gettext")
 
 local NetworkMgr = {}
 
-function NetworkMgr:init()
+function NetworkMgr:readNWSettings()
     self.nw_settings = LuaSettings:open(DataStorage:getSettingsDir().."/network.lua")
+end
+
+function NetworkMgr:init()
     self.wifi_was_on = G_reader_settings:isTrue("wifi_was_on")
+    if self.wifi_was_on and G_reader_settings:nilOrTrue("auto_restore_wifi") then
+        self:restoreWifiAsync()
+    end
 end
 
 -- Following methods are Device specific which need to be initialized in
@@ -174,7 +180,7 @@ function NetworkMgr:showNetworkMenu(complete_callback)
 end
 
 function NetworkMgr:saveNetwork(setting)
-    if not self.nw_settings then self:init() end
+    if not self.nw_settings then self:readNWSettings() end
     self.nw_settings:saveSetting(setting.ssid, {
         ssid = setting.ssid,
         password = setting.password,
@@ -184,13 +190,13 @@ function NetworkMgr:saveNetwork(setting)
 end
 
 function NetworkMgr:deleteNetwork(setting)
-    if not self.nw_settings then self:init() end
+    if not self.nw_settings then self:readNWSettings() end
     self.nw_settings:delSetting(setting.ssid)
     self.nw_settings:flush()
 end
 
 function NetworkMgr:getAllSavedNetworks()
-    if not self.nw_settings then self:init() end
+    if not self.nw_settings then self:readNWSettings() end
     return self.nw_settings
 end
 
@@ -204,5 +210,6 @@ if NETWORK_PROXY then
 end
 
 Device:initNetworkManager(NetworkMgr)
+NetworkMgr:init()
 
 return NetworkMgr

--- a/spec/unit/network_manager_spec.lua
+++ b/spec/unit/network_manager_spec.lua
@@ -48,6 +48,7 @@ describe("network_manager module", function()
     end)
 
     it("should restore wifi in init if wifi was on", function()
+        package.loaded["ui/network/manager"] = nil
         clearState()
         G_reader_settings:saveSetting("wifi_was_on", true)
         local network_manager = require("ui/network/manager")
@@ -58,6 +59,7 @@ describe("network_manager module", function()
     end)
 
     it("should not restore wifi in init if wifi was off", function()
+        package.loaded["ui/network/manager"] = nil
         clearState()
         G_reader_settings:saveSetting("wifi_was_on", false)
         local network_manager = require("ui/network/manager")
@@ -65,5 +67,10 @@ describe("network_manager module", function()
         assert.is.same(turn_off_wifi_called, 0)
         assert.is.same(obtain_ip_called, 0)
         assert.is.same(release_ip_called, 0)
+    end)
+
+    teardown(function()
+        function Device:initNetworkManager() end
+        package.loaded["ui/network/manager"] = nil
     end)
 end)

--- a/spec/unit/network_manager_spec.lua
+++ b/spec/unit/network_manager_spec.lua
@@ -1,0 +1,69 @@
+describe("network_manager module", function()
+    local Device
+    local turn_on_wifi_called
+    local turn_off_wifi_called
+    local obtain_ip_called
+    local release_ip_called
+
+    local function clearState()
+        turn_on_wifi_called = 0
+        turn_off_wifi_called = 0
+        obtain_ip_called = 0
+        release_ip_called = 0
+    end
+
+    setup(function()
+        require("commonrequire")
+        Device = require("device")
+        function Device:initNetworkManager(NetworkMgr)
+            function NetworkMgr:turnOnWifi(callback)
+                turn_on_wifi_called = turn_on_wifi_called + 1
+                if callback then
+                    callback()
+                end
+            end
+            function NetworkMgr:turnOffWifi(callback)
+                turn_off_wifi_called = turn_off_wifi_called + 1
+                if callback then
+                    callback()
+                end
+            end
+            function NetworkMgr:obtainIP(callback)
+                obtain_ip_called = obtain_ip_called + 1
+                if callback then
+                    callback()
+                end
+            end
+            function NetworkMgr:releaseIP(callback)
+                release_ip_called = release_ip_called + 1
+                if callback then
+                    callback()
+                end
+            end
+            function NetworkMgr:restoreWifiAsync()
+                self:turnOnWifi()
+                self:obtainIP()
+            end
+        end
+    end)
+
+    it("should restore wifi in init if wifi was on", function()
+        clearState()
+        G_reader_settings:saveSetting("wifi_was_on", true)
+        local network_manager = require("ui/network/manager")
+        assert.is.same(turn_on_wifi_called, 1)
+        assert.is.same(turn_off_wifi_called, 0)
+        assert.is.same(obtain_ip_called, 1)
+        assert.is.same(release_ip_called, 0)
+    end)
+
+    it("should not restore wifi in init if wifi was off", function()
+        clearState()
+        G_reader_settings:saveSetting("wifi_was_on", false)
+        local network_manager = require("ui/network/manager")
+        assert.is.same(turn_on_wifi_called, 0)
+        assert.is.same(turn_off_wifi_called, 0)
+        assert.is.same(obtain_ip_called, 0)
+        assert.is.same(release_ip_called, 0)
+    end)
+end)


### PR DESCRIPTION
Seems I forgot this function in last PR.
This change should ensure koreader can automatically enable WIFI and obtain IP when it starts.