### PR TITLE
Always release ip before obtaining a new one

### DIFF
--- a/platform/kobo/obtain-ip.sh
+++ b/platform/kobo/obtain-ip.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+./release-ip.sh
+
 # Use udhcpc to obtain IP.
 env -u LD_LIBRARY_PATH udhcpc -S -i eth0 -s /etc/udhcpc.d/default.script -t15 -T10 -A3 -b -q


### PR DESCRIPTION
I recently found on Kobo, KOReader always gets a new IP each time it starts. Though this is not a serious issue, I would prefer to fix it in this simple way.