### PR TITLE
fixed script to support OSX bash 3.x

### DIFF
--- a/kodev
+++ b/kodev
@@ -78,7 +78,7 @@ ${SUPPORTED_TARGETS}"
         kindle-legacy)
             make TARGET=kindle-legacy; assert_ret_zero $? ;;
         android)
-            [[ -v NDK ]] || export NDK="${CURDIR}/base/toolchain/android-ndk-r12b"
+            [[ -n ${NDK+x} ]] || export NDK="${CURDIR}/base/toolchain/android-ndk-r12b"
             [ -e ${CURDIR}/base/toolchain/android-toolchain/bin/arm-linux-androideabi-gcc ] || { \
                 { [ -e ${NDK} ] || make -C ${CURDIR}/base/toolchain android-ndk; }; \
                 make android-toolchain; assert_ret_zero $?; \


### PR DESCRIPTION
OSX's version of bash (3.x) does not support the new -v conditional operator. 
The problematic line in the script was modified to support bash 3.x.