### PR TITLE
Support handling usb hotplug event in kobo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ dist-clean: clean
 	$(MAKE) -C $(KOR_BASE) dist-clean
 	$(MAKE) -C doc clean
 
+ZIP_EXCLUDE=-x "*.swp" -x "*.swo" -x "*.orig" -x "*.un~"
 # Don't bundle launchpad on touch devices..
 ifeq ($(TARGET), kindle-legacy)
 KINDLE_LEGACY_LAUNCHER:=launchpad
@@ -164,7 +165,8 @@ kindleupdate: all
 			../koreader-$(DIST)-$(MACHINE)-$(VERSION).zip \
 			extensions koreader $(KINDLE_LEGACY_LAUNCHER) \
 			-x "koreader/resources/fonts/*" "koreader/ota/*" \
-			"koreader/resources/icons/src/*" "koreader/spec/*"
+			"koreader/resources/icons/src/*" "koreader/spec/*" \
+			$(ZIP_EXCLUDE)
 	# generate kindleupdate package index file
 	zipinfo -1 koreader-$(DIST)-$(MACHINE)-$(VERSION).zip > \
 		$(INSTALL_DIR)/koreader/ota/package.index
@@ -196,7 +198,8 @@ koboupdate: all
 		zip -9 -r \
 			../koreader-kobo-$(MACHINE)-$(VERSION).zip \
 			koreader -x "koreader/resources/fonts/*" \
-			"koreader/resources/icons/src/*" "koreader/spec/*"
+			"koreader/resources/icons/src/*" "koreader/spec/*" \
+			$(ZIP_EXCLUDE)
 	# generate koboupdate package index file
 	zipinfo -1 koreader-kobo-$(MACHINE)-$(VERSION).zip > \
 		$(INSTALL_DIR)/koreader/ota/package.index
@@ -228,7 +231,8 @@ pbupdate: all
 		zip -9 -r \
 			../koreader-pocketbook-$(MACHINE)-$(VERSION).zip \
 			applications -x "applications/koreader/resources/fonts/*" \
-			"applications/koreader/resources/icons/src/*" "applications/koreader/spec/*"
+			"applications/koreader/resources/icons/src/*" "applications/koreader/spec/*" \
+			$(ZIP_EXCLUDE)
 	# generate koboupdate package index file
 	zipinfo -1 koreader-pocketbook-$(MACHINE)-$(VERSION).zip > \
 		$(INSTALL_DIR)/applications/koreader/ota/package.index
@@ -264,7 +268,8 @@ utupdate: all
 		zip -9 -r \
 			../koreader-$(DIST)-$(MACHINE)-$(VERSION).zip \
 			koreader -x "koreader/resources/fonts/*" "koreader/ota/*" \
-			"koreader/resources/icons/src/*" "koreader/spec/*"
+			"koreader/resources/icons/src/*" "koreader/spec/*" \
+			$(ZIP_EXCLUDE)
 
 	# generate update package index file
 	zipinfo -1 koreader-$(DIST)-$(MACHINE)-$(VERSION).zip > \
@@ -293,7 +298,8 @@ androidupdate: all
 	cd $(INSTALL_DIR)/koreader && \
 		zip -9 -r \
 			../../koreader-android-$(MACHINE)-$(VERSION).zip \
-			* -x "resources/fonts/*" "resources/icons/src/*" "spec/*"
+			* -x "resources/fonts/*" "resources/icons/src/*" "spec/*" \
+			$(ZIP_EXCLUDE)
 	# generate android update package index file
 	zipinfo -1 koreader-android-$(MACHINE)-$(VERSION).zip > \
 		$(INSTALL_DIR)/koreader/ota/package.index

--- a/frontend/dbg.lua
+++ b/frontend/dbg.lua
@@ -2,6 +2,7 @@ local dump = require("dump")
 local isAndroid, android = pcall(require, "android")
 
 local Dbg = {
+    -- set to nil so first debug:turnOff call won't be skipped
     is_on = nil,
     is_verbose = nil,
     ev_log = nil,

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -1,5 +1,4 @@
 local Event = require("ui/event")
-local util = require("ffi/util")
 local DEBUG = require("dbg")
 
 local function yes() return true end
@@ -83,40 +82,6 @@ function Device:getPowerDevice()
     return self.powerd
 end
 
--- ONLY used for Kindle devices
-function Device:intoScreenSaver()
-    local UIManager = require("ui/uimanager")
-    if self.charging_mode == false and self.screen_saver_mode == false then
-        self.screen:saveCurrentBB()
-        self.screen_saver_mode = true
-        -- On FW >= 5.7.2, we sigstop awesome, but we need it to show stuff...
-        if os.getenv("AWESOME_STOPPED") == "yes" then
-            os.execute("killall -cont awesome")
-        end
-    end
-    UIManager:broadcastEvent(Event:new("FlushSettings"))
-end
-
--- ONLY used for Kindle devices
-function Device:outofScreenSaver()
-    if self.screen_saver_mode == true and self.charging_mode == false then
-        -- On FW >= 5.7.2, put awesome to sleep again...
-        if os.getenv("AWESOME_STOPPED") == "yes" then
-            os.execute("killall -stop awesome")
-        end
-        -- wait for native system update screen before we recover saved
-        -- Blitbuffer.
-        util.usleep(1500000)
-        self.screen:restoreFromSavedBB()
-        self:resume()
-        if self:needsScreenRefreshAfterResume() then
-            self.screen:refreshFull()
-        end
-        self.powerd:refreshCapacity()
-    end
-    self.screen_saver_mode = false
-end
-
 function Device:rescheduleSuspend()
     local UIManager = require("ui/uimanager")
     UIManager:unschedule(self.suspend)
@@ -179,6 +144,12 @@ function Device:onPowerEvent(ev)
     end
 end
 
+-- Hardware specific method to handle usb plug in event
+function Device:usbPlugIn() end
+
+-- Hardware specific method to handle usb plug out event
+function Device:usbPlugOut() end
+
 -- Hardware specific method to suspend the device
 function Device:suspend() end
 
@@ -188,37 +159,8 @@ function Device:resume() end
 -- Hardware specific method to power off the device
 function Device:powerOff() end
 
-function Device:usbPlugIn()
-    if self.charging_mode == false and self.screen_saver_mode == false then
-        self.screen:saveCurrentBB()
-        -- On FW >= 5.7.2, we sigstop awesome, but we need it to show stuff...
-        if os.getenv("AWESOME_STOPPED") == "yes" then
-            os.execute("killall -cont awesome")
-        end
-    end
-    self.charging_mode = true
-end
-
-function Device:usbPlugOut()
-    if self.charging_mode == true and self.screen_saver_mode == false then
-        -- On FW >= 5.7.2, put awesome to sleep again...
-        if os.getenv("AWESOME_STOPPED") == "yes" then
-            os.execute("killall -stop awesome")
-        end
-        -- Same as when going out of screensaver, wait for the native system
-        util.usleep(1500000)
-        self.screen:restoreFromSavedBB()
-        self.screen:refreshFull()
-        self.powerd:refreshCapacity()
-    end
-
-    --@TODO signal filemanager for file changes  13.06 2012 (houqp)
-    self.charging_mode = false
-end
-
 -- Hardware specific method to initialize network manager module
-function Device:initNetworkManager()
-end
+function Device:initNetworkManager() end
 
 --[[
 prepare for application shutdown

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -130,7 +130,6 @@ function Kobo:init()
                     return "Light"
                 end
             end,
-            -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status
             [102] = "Home",
             [116] = "Power",
         }
@@ -141,6 +140,9 @@ function Kobo:init()
     -- event2 is for MMA7660 sensor (3-Axis Orientation/Motion Detection)
     self.input.open("/dev/input/event0") -- Light button and sleep slider
     self.input.open("/dev/input/event1")
+    -- fake_events is only used for usb plug event so far
+    -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status
+    self.input.open("fake_events")
 
     if not self.needsTouchScreenProbe() then
         self:initEventAdjustHooks()

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -24,7 +24,9 @@ function WpaSupplicant:getNetworkList()
     for _,network in ipairs(list) do
         network.signal_quality = network:getSignalQuality()
         local saved_nw = saved_networks:readSetting(network.ssid)
-        if saved_nw and saved_nw.flags == network.flags then
+        if saved_nw then
+            -- TODO: verify saved_nw.flags == network.flags? This will break if user changed the
+            -- network setting from [WPA-PSK-TKIP+CCMP][WPS][ESS] to [WPA-PSK-TKIP+CCMP][ESS]
             network.password = saved_nw.password
         end
         -- TODO: also verify bssid if it is not set to any

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -108,12 +108,12 @@ function UIManager:init()
         self.event_handlers["Light"] = function()
             Device:getPowerDevice():toggleFrontlight()
         end
-        self.event_handlers["USBPlugIn"] = function()
+        self.event_handlers["Charging"] = function()
             if Device.screen_saver_mode then
                 self.event_handlers["Suspend"]()
             end
         end
-        self.event_handlers["USBPlugOut"] = self.event_handlers["USBPlugIn"]
+        self.event_handlers["NotCharging"] = self.event_handlers["Charging"]
         self.event_handlers["__default__"] = function(input_event)
             if Device.screen_saver_mode then
                 -- Suspension in Kobo can be interrupted by screen updates. We

--- a/reader.lua
+++ b/reader.lua
@@ -77,7 +77,8 @@ end
 
 -- should check DEBUG option in arg and turn on DEBUG before loading other
 -- modules, otherwise DEBUG in some modules may not be printed.
-local DEBUG = require("dbg")
+local dbg = require("dbg")
+if G_reader_settings:readSetting("debug") then dbg:turnOn() end
 
 local Profiler = nil
 local ARGV = arg
@@ -95,9 +96,9 @@ while argidx <= #ARGV do
     if arg == "-h" then
         return showusage()
     elseif arg == "-d" then
-        DEBUG:turnOn()
+        dbg:turnOn()
     elseif arg == "-v" then
-        DEBUG:setVerbose(true)
+        dbg:setVerbose(true)
     elseif arg == "-p" then
         Profiler = require("jit.p")
         Profiler.start("la")

--- a/reader.lua
+++ b/reader.lua
@@ -1,5 +1,5 @@
 #!./luajit
-print(string.format([[
+io.stdout:write(string.format([[
 ---------------------------------------------
                 launching...
   _  _____  ____                _
@@ -10,6 +10,7 @@ print(string.format([[
 
  [*] Current time: %s
 ]], os.date("%x-%X")))
+io.stdout:flush()
 
 
 -- load default settings


### PR DESCRIPTION
This PR depends on https://github.com/koreader/koreader-base/pull/462.

Now plugging in/out usb cable should not corrupt the device suspend state anymore.
