### PR TITLE
Patch for wikipedia language

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -5,7 +5,7 @@ local DEBUG = require("dbg")
 local _ = require("gettext")
 
 -- Wikipedia as a special dictionary
-local ReaderWikipedia = ReaderDictionary:extend{
+local ReaderWikipedia = ReaderDictionary:extend {
     -- identify itself
     wiki = true,
     no_page = _("No wiki page found."),
@@ -17,16 +17,16 @@ function ReaderWikipedia:init()
 end
 
 function ReaderWikipedia:onLookupWikipedia(word, box)
-    local lang_reader = G_reader_settings:readSetting("language")
     -- set language from book properties
-    if self.view.document:getProps().language ~= nil then
-        lang = self.view.document:getProps().language
+    lang = self.view.document:getProps().language
+    if lang == nil then
         -- or set laguage from KOReader settings
-    elseif lang_reader ~= nil then
-        lang = lang_reader
-    else  --use detect language of the text
-        local ok, lang = pcall(Translator.detect, Translator, word)
-        if not ok then return end
+        lang_reader = G_reader_settings:readSetting("language")
+        if lang == nil then
+            -- or detect language
+            local ok, lang = pcall(Translator.detect, Translator, word)
+            if not ok then return end
+        end
     end
     -- convert "zh-CN" and "zh-TW" to "zh"
     lang = lang:match("(.*)-") or lang

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -17,9 +17,17 @@ function ReaderWikipedia:init()
 end
 
 function ReaderWikipedia:onLookupWikipedia(word, box)
-    -- detect language of the text
-    local ok, lang = pcall(Translator.detect, Translator, word)
-    if not ok then return end
+    local lang_reader = G_reader_settings:readSetting("language")
+    -- set language from book properties
+    if self.view.document:getProps().language ~= nil then
+        lang = self.view.document:getProps().language
+        -- or set laguage from KOReader settings
+    elseif lang_reader ~= nil then
+        lang = lang_reader
+    else  --use detect language of the text
+        local ok, lang = pcall(Translator.detect, Translator, word)
+        if not ok then return end
+    end
     -- convert "zh-CN" and "zh-TW" to "zh"
     lang = lang:match("(.*)-") or lang
     -- strip punctuation characters around selected word

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -5,7 +5,7 @@ local DEBUG = require("dbg")
 local _ = require("gettext")
 
 -- Wikipedia as a special dictionary
-local ReaderWikipedia = ReaderDictionary:extend {
+local ReaderWikipedia = ReaderDictionary:extend{
     -- identify itself
     wiki = true,
     no_page = _("No wiki page found."),
@@ -18,14 +18,15 @@ end
 
 function ReaderWikipedia:onLookupWikipedia(word, box)
     -- set language from book properties
-    lang = self.view.document:getProps().language
+    local lang = self.view.document:getProps().language
     if lang == nil then
         -- or set laguage from KOReader settings
-        lang_reader = G_reader_settings:readSetting("language")
+        lang = G_reader_settings:readSetting("language")
         if lang == nil then
             -- or detect language
-            local ok, lang = pcall(Translator.detect, Translator, word)
-            if not ok then return end
+            local ok_translator
+            ok_translator, lang = pcall(Translator.detect, Translator, word)
+            if not ok_translator then return end
         end
     end
     -- convert "zh-CN" and "zh-TW" to "zh"
@@ -36,8 +37,7 @@ function ReaderWikipedia:onLookupWikipedia(word, box)
     -- seems lower case phrase has higher hit rate
     word = string.lower(word)
     local results = {}
-    local pages
-    ok, pages = pcall(Wikipedia.wikintro, Wikipedia, word, lang)
+    local ok, pages = pcall(Wikipedia.wikintro, Wikipedia, word, lang)
     if ok and pages then
         for pageid, page in pairs(pages) do
             local result = {

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -33,9 +33,24 @@ function Wikipedia:loadPage(text, lang, intro, plain)
     local http = require('socket.http')
     local https = require('ssl.https')
     local ltn12 = require('ltn12')
-
+    local _ = require("gettext")
+    local DataStorage = require("datastorage")
+    local DocSettings = require("docsettings")
+    --read language from current book
+    local lastfile = G_reader_settings:readSetting("lastfile")
+    local book_stats = DocSettings:open(lastfile):readSetting('stats')
+    G_reader_settings = require("luasettings"):open(
+        DataStorage:getDataDir().."/settings.reader.lua")
+    local lang_locale = G_reader_settings:readSetting("language")
     local request, sink = {}, {}
     local query = ""
+    -- set language from book properties
+    if book_stats.language ~= nil then
+        lang = book_stats.language
+        -- or set laguage from KOReader settings
+    elseif lang_locale ~= nil then
+        lang = lang_locale
+    end
     self.wiki_params.exintro = intro and "" or nil
     self.wiki_params.explaintext = plain and "" or nil
     for k,v in pairs(self.wiki_params) do

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -33,24 +33,9 @@ function Wikipedia:loadPage(text, lang, intro, plain)
     local http = require('socket.http')
     local https = require('ssl.https')
     local ltn12 = require('ltn12')
-    local _ = require("gettext")
-    local DataStorage = require("datastorage")
-    local DocSettings = require("docsettings")
-    --read language from current book
-    local lastfile = G_reader_settings:readSetting("lastfile")
-    local book_stats = DocSettings:open(lastfile):readSetting('stats')
-    G_reader_settings = require("luasettings"):open(
-        DataStorage:getDataDir().."/settings.reader.lua")
-    local lang_locale = G_reader_settings:readSetting("language")
+
     local request, sink = {}, {}
     local query = ""
-    -- set language from book properties
-    if book_stats.language ~= nil then
-        lang = book_stats.language
-        -- or set laguage from KOReader settings
-    elseif lang_locale ~= nil then
-        lang = lang_locale
-    end
     self.wiki_params.exintro = intro and "" or nil
     self.wiki_params.explaintext = plain and "" or nil
     for k,v in pairs(self.wiki_params) do


### PR DESCRIPTION
This patch fix https://github.com/koreader/koreader/issues/1844.
Language wikipedia search is set based on current document language or (if document language doesn't set) on Koreader settings.
Tested on KPW3 and emulator on Polish, English and German.