### PR TITLE
KOSync plugin should repect onNetworkConnected and onFlushSettings events

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -80,11 +80,20 @@ function NetworkMgr:getWifiMenuTable()
         enabled_func = function() return Device:isKindle() or Device:isKobo() end,
         checked_func = function() return NetworkMgr:getWifiStatus() end,
         callback = function(menu)
+            local wifi_status = NetworkMgr:getWifiStatus()
             local complete_callback = function()
                 -- notify touch menu to update item check state
                 menu:updateItems()
+                local Event = require("ui/event")
+                -- if wifi was on, this callback will only be executed when the network has been
+                -- disconnected.
+                if wifi_status then
+                    UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
+                else
+                    UIManager:broadcastEvent(Event:new("NetworkConnected"))
+                end
             end
-            if NetworkMgr:getWifiStatus() then
+            if wifi_status then
                 NetworkMgr:promptWifiOff(complete_callback)
             else
                 NetworkMgr:promptWifiOn(complete_callback)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -36,7 +36,7 @@ function UIManager:init()
             self:sendEvent(input_event)
         end,
         SaveState = function()
-            self:sendEvent(Event:new("FlushSettings"))
+            self:broadcastEvent(Event:new("FlushSettings"))
         end,
         Power = function(input_event)
             Device:onPowerEvent(input_event)

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -601,13 +601,25 @@ function KOSync:_onResume()
     UIManager:scheduleIn(1, function() self:getProgress() end)
 end
 
+function KOSync:_onFlushSettings()
+    self:updateProgress()
+end
+
+function KOSync:_onNetworkConnected()
+    self:_onResume()
+end
+
 function KOSync:registerEvents()
     if self.kosync_auto_sync then
         self.onPageUpdate = self._onPageUpdate
         self.onResume = self._onResume
+        self.onFlushSettings = self._onFlushSettings
+        self.onNetworkConnected = self._onNetworkConnected
     else
         self.onPageUpdate = nil
         self.onResume = nil
+        self.onFlushSettings = nil
+        self.onNetworkConnected = nil
     end
 end
 


### PR DESCRIPTION
This change ensures KOSync plugin can automatically push and pull progress on related events.
onNetworkConnected / onNetworkDisconnected are two new events. But,
1. Since we do not block network restoring process when device resumes, the onNetworkConnected event cannot be raised on kobo correctly.
2. On android or kindle, we do not actively control the network. The onNetworkConnected event also cannot be raised correctly.
But this issue does not block KOSync plugin from listening to the event to get progress, which should be an expected behavior.