### PR TITLE
Fix long filename text in history textbox

### DIFF
--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -16,24 +16,6 @@ local FileManagerHistory = InputContainer:extend{
     hist_menu_title = _("History"),
 }
 
-local ellipsis, space = "…", " "
-local ellipsis_width, space_width
-local function truncateTextByWidth(text, face, max_width, prepend_space)
-    if not ellipsis_width then
-        ellipsis_width = RenderText:sizeUtf8Text(0, max_width, face, ellipsis).x
-    end
-    if not space_width then
-        space_width = RenderText:sizeUtf8Text(0, max_width, face, space).x
-    end
-    local new_txt_width = max_width - ellipsis_width - space_width
-    local sub_txt = RenderText:getSubTextByWidth(text, face, new_txt_width)
-    if prepend_space then
-        return space.. sub_txt .. ellipsis
-    else
-        return sub_txt .. ellipsis .. space
-    end
-end
-
 function FileManagerHistory:init()
     self.ui.menu:registerToMainMenu(self)
 end
@@ -101,7 +83,7 @@ end
 
 function FileManagerHistory:onMenuHold(item)
     local font_size = Font:getFace("tfont")
-    local text_remove_hist = T(_("Remove \"%1\" from history"))
+    local text_remove_hist = _("Remove \"%1\" from history")
     local text_remove_without_item = util.template(text_remove_hist, "")
     local text_remove_hist_width = (RenderText:sizeUtf8Text(
         0, self.width, font_size, text_remove_without_item).x )
@@ -110,11 +92,11 @@ function FileManagerHistory:onMenuHold(item)
 
     local item_trun
     if self.width < text_remove_hist_width + text_item_width then
-        item_trun = truncateTextByWidth(item.text, font_size, 1.2 * self.width - text_remove_hist_width)
+        item_trun = RenderText:truncateTextByWidth(item.text, font_size, 1.2 * self.width - text_remove_hist_width)
     else
         item_trun = item.text
     end
-    local text_remove = util.template(text_remove_hist, item_trun)
+    local text_remove = T(text_remove_hist, item_trun)
 
     self.histfile_dialog = ButtonDialog:new{
         buttons = {

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -4,7 +4,6 @@ local ButtonDialog = require("ui/widget/buttondialog")
 local UIManager = require("ui/uimanager")
 local Menu = require("ui/widget/menu")
 local Screen = require("device").screen
-local util = require("ffi/util")
 local _ = require("gettext")
 local KeyValuePage = require("ui/widget/keyvaluepage")
 local DocSettings = require("docsettings")

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -84,7 +84,7 @@ end
 function FileManagerHistory:onMenuHold(item)
     local font_size = Font:getFace("tfont")
     local text_remove_hist = _("Remove \"%1\" from history")
-    local text_remove_without_item = util.template(text_remove_hist, "")
+    local text_remove_without_item = T(text_remove_hist, "")
     local text_remove_hist_width = (RenderText:sizeUtf8Text(
         0, self.width, font_size, text_remove_without_item).x )
     local text_item_width = (RenderText:sizeUtf8Text(

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -233,4 +233,22 @@ function RenderText:renderUtf8Text(dest_bb, x, baseline, face, text, kerning, bo
     return pen_x
 end
 
+local ellipsis, space = "…", " "
+local ellipsis_width, space_width
+function RenderText:truncateTextByWidth(text, face, max_width, prepend_space)
+    if not ellipsis_width then
+        ellipsis_width = RenderText:sizeUtf8Text(0, max_width, face, ellipsis).x
+    end
+    if not space_width then
+        space_width = RenderText:sizeUtf8Text(0, max_width, face, space).x
+    end
+    local new_txt_width = max_width - ellipsis_width - space_width
+    local sub_txt = RenderText:getSubTextByWidth(text, face, new_txt_width)
+    if prepend_space then
+        return space.. sub_txt .. ellipsis
+    else
+        return sub_txt .. ellipsis .. space
+    end
+end
+
 return RenderText

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -237,13 +237,13 @@ local ellipsis, space = "…", " "
 local ellipsis_width, space_width
 function RenderText:truncateTextByWidth(text, face, max_width, prepend_space)
     if not ellipsis_width then
-        ellipsis_width = RenderText:sizeUtf8Text(0, max_width, face, ellipsis).x
+        ellipsis_width = self:sizeUtf8Text(0, max_width, face, ellipsis).x
     end
     if not space_width then
-        space_width = RenderText:sizeUtf8Text(0, max_width, face, space).x
+        space_width = self:sizeUtf8Text(0, max_width, face, space).x
     end
     local new_txt_width = max_width - ellipsis_width - space_width
-    local sub_txt = RenderText:getSubTextByWidth(text, face, new_txt_width)
+    local sub_txt = self:getSubTextByWidth(text, face, new_txt_width)
     if prepend_space then
         return space.. sub_txt .. ellipsis
     else

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -38,26 +38,6 @@ local Font = require("ui/font")
 local Device = require("device")
 local Screen = Device.screen
 
-
-local ellipsis, space = "…", "  "
-local ellipsis_width, space_width
-local function truncateTextByWidth(text, face, max_width, prepend_space)
-    if not ellipsis_width then
-        ellipsis_width = RenderText:sizeUtf8Text(0, max_width, face, ellipsis).x
-    end
-    if not space_width then
-        space_width = RenderText:sizeUtf8Text(0, max_width, face, space).x
-    end
-    local new_txt_width = max_width - ellipsis_width - space_width
-    local sub_txt = RenderText:getSubTextByWidth(text, face, new_txt_width)
-    if prepend_space then
-        return space.. sub_txt .. ellipsis
-    else
-        return sub_txt .. ellipsis .. space
-    end
-end
-
-
 local KeyValueTitle = VerticalGroup:new{
     kv_page = nil,
     title = "",
@@ -72,7 +52,7 @@ function KeyValueTitle:init()
                                 0, self.width, self.tface, self.title).x
     local show_title_txt
     if self.width < (title_txt_width + btn_width) then
-        show_title_txt = truncateTextByWidth(
+        show_title_txt = RenderText:truncateTextByWidth(
                             self.title, self.tface, self.width-btn_width)
     else
         show_title_txt = self.title
@@ -155,10 +135,10 @@ function KeyValueItem:init()
     if key_w + value_w > self.width then
         -- truncate key or value so they fits in one row
         if key_w >= value_w then
-            self.show_key = truncateTextByWidth(self.key, self.cface, self.width-value_w)
+            self.show_key = RenderText:truncateTextByWidth(self.key, self.cface, self.width-value_w)
             self.show_value = self.value
         else
-            self.show_value = truncateTextByWidth(self.value, self.cface, self.width-key_w, true)
+            self.show_value = RenderText:truncateTextByWidth(self.value, self.cface, self.width-key_w, true)
             self.show_key = self.key
         end
     else


### PR DESCRIPTION
In history window when we long press on item we get menu. When filename is long the text go outside menu like that:
![reader_2016-nov-07_180118](https://cloud.githubusercontent.com/assets/22982594/20067763/c321145e-a516-11e6-9b94-d4401f792486.png)

After this fix we have truncated text on long filename:
![reader_2016-nov-07_175946](https://cloud.githubusercontent.com/assets/22982594/20067752/bb1a325e-a516-11e6-8323-eea4cf3f744d.png)




 