### PR TITLE
Return correct result from koreader.sh

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -115,6 +115,7 @@ fi
 cat crash.log 2> /dev/null | tail -c 100000000 > crash.log.new
 mv -f crash.log.new crash.log
 ./reader.lua "${args}" >> crash.log 2>&1
+RESULT=$?
 
 if [ "${FROM_NICKEL}" = "true" ] ; then
 	if [ "${FROM_KFMON}" != "true" ] ; then
@@ -139,4 +140,4 @@ else
 	fi
 fi
 
-return 0
+return ${RESULT}


### PR DESCRIPTION
This is a trivial change to return correct result from koreader.sh.

koreader on my kobo aura hd randomly crashes, so I prefer to have a while loop to ensure it can be restarted automatically. But I also do not want koreader to restart if I actively click on close button. So this change returns reader.lua result from koreader.sh, a wrapper script can use this value to decide whether restart or not.