### PR TITLE
Don't try to set the value of fm_screen_mode

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -330,7 +330,6 @@ end
 
 function FileManager:onClose()
     DEBUG("close filemanager")
-    G_reader_settings:saveSetting("fm_screen_mode", Screen:getScreenMode())
     UIManager:close(self)
     if self.onExit then
         self:onExit()


### PR DESCRIPTION
I'm not sure what the original intention was, but in practice, the user experience regarding the way this setting is saved is horrible: it seems to change randomly and once the orientation is changed from portrait to landscape, the only way to fix it is to edit `settings.reader.lua`.