### PR TITLE
Make the powered off state customizable

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -1,5 +1,6 @@
 local Event = require("ui/event")
 local DEBUG = require("dbg")
+local _ = require("gettext")
 
 local function yes() return true end
 local function no() return false end
@@ -137,7 +138,7 @@ function Device:onPowerEvent(ev)
         -- always suspend in portrait mode
         self.orig_rotation_mode = self.screen:getRotationMode()
         self.screen:setRotationMode(0)
-        require("ui/screensaver"):show()
+        require("ui/screensaver"):show("suspend", _("Sleeping"))
         self.screen:refreshFull()
         self.screen_saver_mode = true
         UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend)


### PR DESCRIPTION
This changes the behavior of the powered off transition phase for the Kobo devices: instead of displaying a confirmation dialog, a screensaver is used after a 2 seconds press delay.

Users can specify separate directories/files/messages for the powered off and sleeping states through the `path` and `message` attributes of the `{poweroff,suspend}_screensaver` settings.

Fixes #2327 and closes #2306.