### PR TITLE
Fix hyphenation words with unicode character in texboxwidget

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -138,7 +138,7 @@ end
 
 -- Test whether a string could be separated by a char for multi-line rendering
 function util.isSplitable(c)
-    return c == " " or c == '-'
+    return c == " " or string.match(c, "%p") ~= nil
 end
 
 return util

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -138,7 +138,7 @@ end
 
 -- Test whether a string could be separated by a char for multi-line rendering
 function util.isSplitable(c)
-    return #c > 1 or c == " " or string.match(c, "%p") ~= nil
+    return c == " " or c == '-'
 end
 
 return util

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -76,4 +76,34 @@ describe("util module", function()
         local words = util.splitToWords("BBC纪录片")
         assert.are_same(words, {"BBC", "纪", "录", "片"})
     end)
+
+    it("should split text to line - unicode", function()
+        local text = "Pójdźże, chmurność glück schließen Štěstí neštěstí. Uñas gavilán"
+        local word = ""
+        local table_of_words = {}
+        local c
+        local table_chars = util.splitToChars(text)
+        for i = 1, #table_chars  do
+            c = table_chars[i]
+            word = word .. c
+            if util.isSplitable(c) then
+                table.insert(table_of_words, word)
+                word = ""
+            end
+            if i == #table_chars then table.insert(table_of_words, word) end
+        end
+        assert.are_same(table_of_words, {
+            "Pójdźże,",
+            " ",
+            "chmurność ",
+            "glück ",
+            "schließen ",
+            "Štěstí ",
+            "neštěstí.",
+            " ",
+            "Uñas ",
+            "gavilán",
+        })
+    end)
+
 end)


### PR DESCRIPTION
In textboxwidget words with unicode characters are incorect hyphenation.
This patch fix it.
e.g.
Polish:
![hyph1](https://cloud.githubusercontent.com/assets/22982594/20446192/c283a6c2-add8-11e6-97ae-02f97a715e9d.png)

German:
![hyph2](https://cloud.githubusercontent.com/assets/22982594/20446206/d548409c-add8-11e6-86e9-b36f3e9d14f0.png)


