### PR TITLE
Issue #1688 - FR: Would you like to read the downloaded book for OPDS

### DIFF
--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -6,6 +6,7 @@ local Screen = require("device").screen
 local DEBUG = require("dbg")
 local _ = require("gettext")
 local Blitbuffer = require("ffi/blitbuffer")
+local ReaderUI = require("apps/reader/readerui")
 
 local OPDSCatalog = InputContainer:extend{
     title = _("OPDS Catalog"),
@@ -42,6 +43,7 @@ function OPDSCatalog:init()
         is_popout = false,
         is_borderless = true,
         has_close_button = true,
+        downloaded_file = nil,
         close_callback = function() return self:onClose() end,
     }
 
@@ -79,6 +81,10 @@ function OPDSCatalog:onClose()
     DEBUG("close OPDS catalog")
     UIManager:close(self)
     if self.onExit then
+        if self[1][1].downloaded_file ~= nil then
+            ReaderUI:showReader(self[1][1].downloaded_file)
+            self[1][1].filePath = nil
+        end
         self:onExit()
     end
     return true

--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -7,6 +7,8 @@ local DEBUG = require("dbg")
 local _ = require("gettext")
 local Blitbuffer = require("ffi/blitbuffer")
 local ReaderUI = require("apps/reader/readerui")
+local ConfirmBox = require("ui/widget/confirmbox")
+local T = require("ffi/util").template
 
 local OPDSCatalog = InputContainer:extend{
     title = _("OPDS Catalog"),
@@ -45,6 +47,16 @@ function OPDSCatalog:init()
         has_close_button = true,
         downloaded_file = nil,
         close_callback = function() return self:onClose() end,
+        file_downloaded_callback = function(downloaded_file)
+            UIManager:show(ConfirmBox:new{
+                text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"),
+                    downloaded_file),
+                ok_callback = function()
+                    self:onClose()
+                    ReaderUI:showReader(downloaded_file)
+                end
+            })
+        end,
     }
 
     self[1] = FrameContainer:new{
@@ -81,10 +93,6 @@ function OPDSCatalog:onClose()
     DEBUG("close OPDS catalog")
     UIManager:close(self)
     if self.onExit then
-        if self[1][1].downloaded_file ~= nil then
-            ReaderUI:showReader(self[1][1].downloaded_file)
-            self[1][1].filePath = nil
-        end
         self:onExit()
     end
     return true

--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -45,7 +45,6 @@ function OPDSCatalog:init()
         is_popout = false,
         is_borderless = true,
         has_close_button = true,
-        downloaded_file = nil,
         close_callback = function() return self:onClose() end,
         file_downloaded_callback = function(downloaded_file)
             UIManager:show(ConfirmBox:new{

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -13,15 +13,12 @@ local util = require("ffi/util")
 local Cache = require("cache")
 local DEBUG = require("dbg")
 local _ = require("gettext")
-local T = require("ffi/util").template
 
 local socket = require('socket')
 local http = require('socket.http')
 local https = require('ssl.https')
 local ltn12 = require('ltn12')
 local mime = require('mime')
-local ConfirmBox = require("ui/widget/confirmbox")
-
 
 local CatalogCacheItem = CacheItem:new{
     size = 1024,  -- fixed size for catalog item
@@ -464,16 +461,6 @@ function OPDSBrowser:appendCatalog(item_table_url)
     return true
 end
 
-function OPDSBrowser:openBook(path_file_downloaded)
-    UIManager:show(ConfirmBox:new{
-        text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"), path_file_downloaded),
-        ok_callback = function()
-            self.downloaded_file = path_file_downloaded
-            self.show_parent:onClose()
-        end
-    })
-end
-
 function OPDSBrowser:downloadFile(item, format, remote_url)
     -- download to user selected directory or last opened dir
     local lastdir = G_reader_settings:readSetting("lastdir")
@@ -492,7 +479,9 @@ function OPDSBrowser:downloadFile(item, format, remote_url)
 
     if c == 200 then
         DEBUG("file downloaded to", local_path)
-        self:openBook(local_path)
+        if self.file_downloaded_callback then
+            self.file_downloaded_callback(local_path)
+        end
     else
         DEBUG("response", {r, c, h})
         UIManager:show(InfoMessage:new{

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -21,7 +21,7 @@ local https = require('ssl.https')
 local ltn12 = require('ltn12')
 local mime = require('mime')
 local ConfirmBox = require("ui/widget/confirmbox")
-local ReaderUI = require("apps/reader/readerui")
+
 
 local CatalogCacheItem = CacheItem:new{
     size = 1024,  -- fixed size for catalog item
@@ -468,7 +468,8 @@ function OPDSBrowser:openBook(path_file_downloaded)
     UIManager:show(ConfirmBox:new{
         text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"), path_file_downloaded),
         ok_callback = function()
-            ReaderUI:showReader(path_file_downloaded)
+            self.downloaded_file = path_file_downloaded
+            self.show_parent:onClose()
         end
     })
 end

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -464,11 +464,11 @@ function OPDSBrowser:appendCatalog(item_table_url)
     return true
 end
 
-function OPDSBrowser:openBook(file_downloaded)
+function OPDSBrowser:openBook(path_file_downloaded)
     UIManager:show(ConfirmBox:new{
-        text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"), file_downloaded),
+        text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"), path_file_downloaded),
         ok_callback = function()
-            ReaderUI:showReader(file_downloaded)
+            ReaderUI:showReader(path_file_downloaded)
         end
     })
 end


### PR DESCRIPTION
I wonder that before opening the downloaded file close widget "opds catalog". Is it possible in function OPDSBrowser:openBook? What do you think? When you close the book and return to the "file manager" we see opds catalog widget.