### PR TITLE
Kobo Aura ONE: no viewport adjustments needed

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -59,7 +59,6 @@ local KoboDaylight = Kobo:new{
     touch_probe_ev_epoch_time = true,
     touch_phoenix_protocol = true,
     display_dpi = 300,
-    viewport = Geom:new{x=4, y=3, w=1396, h=1866},
 }
 
 -- Kobo Aura H2O:


### PR DESCRIPTION
Test image:
https://cloud.githubusercontent.com/assets/159419/20651651/5e344d1c-b4e9-11e6-8450-6fb165c792db.png

Fixes #2372.