### PR TITLE
Refresh filemanager after exit from OPDS browser

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -73,6 +73,9 @@ local FileManager = InputContainer:extend{
 
 function FileManager:init()
     self.show_parent = self.show_parent or self
+    self.callback_refresh = function()
+        self:onRefresh()
+    end
 
     self.path_text = TextWidget:new{
         face = Font:getFace("infofont", 18),

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -73,9 +73,6 @@ local FileManager = InputContainer:extend{
 
 function FileManager:init()
     self.show_parent = self.show_parent or self
-    self.callback_refresh = function()
-        self:onRefresh()
-    end
 
     self.path_text = TextWidget:new{
         face = Font:getFace("infofont", 18),

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -188,13 +188,14 @@ function FileManagerMenu:setUpdateItemTable()
     table.insert(self.tab_item_table.tools, {
         text = _("OPDS catalog"),
         callback = function()
-            local FileManager = require("apps/filemanager/filemanager")
             local OPDSCatalog = require("apps/opdscatalog/opdscatalog")
-            function OPDSCatalog:onExit()
-                FileManager:onRefresh()
-            end
-            OPDSCatalog:showCatalog()
-        end,
+            local callback_filemanager_refresh = function() self.ui.callback_refresh() end
+                function OPDSCatalog:onClose()
+                    callback_filemanager_refresh()
+                    UIManager:close(self)
+                end
+                OPDSCatalog:showCatalog()
+            end,
     })
 
     -- search tab

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -189,13 +189,13 @@ function FileManagerMenu:setUpdateItemTable()
         text = _("OPDS catalog"),
         callback = function()
             local OPDSCatalog = require("apps/opdscatalog/opdscatalog")
-            local callback_filemanager_refresh = function() self.ui.callback_refresh() end
-                function OPDSCatalog:onClose()
-                    callback_filemanager_refresh()
-                    UIManager:close(self)
-                end
-                OPDSCatalog:showCatalog()
-            end,
+            local filemanagerRefresh = function() self.ui:onRefresh() end
+            function OPDSCatalog:onClose()
+                filemanagerRefresh()
+                UIManager:close(self)
+            end
+            OPDSCatalog:showCatalog()
+        end,
     })
 
     -- search tab


### PR DESCRIPTION
After exit from OPDS browser we should refresh filemanager. 
Without that we have not seen newly downloaded book in the current folder.