### PR TITLE
Various fixes

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -213,6 +213,14 @@ function FileManagerMenu:setUpdateItemTable()
                                 purgeDir(cachedir)
                             end
                             lfs.mkdir(cachedir)
+                            -- Also remove from Cache objet references to
+                            -- the cache files we just deleted
+                            local Cache = require("cache")
+                            Cache.cached = {}
+                            local InfoMessage = require("ui/widget/infomessage")
+                            UIManager:show(InfoMessage:new{
+                                text = _("Caches cleared. Please exit and restart KOReader."),
+                            })
                         end,
                     })
                 end,

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -150,22 +150,24 @@ end
 -- specific punctuation : e.g. "word :" or "word )"
 -- (In french, there is a space before a colon, and it better
 -- not be wrapped there.)
--- Includes U+00BB >> (right double angle quotation mark) and
--- U+201D '' (right double quotation mark)
-local non_splitable_space_tailers = ":;,.!?)]}$%-=/<>»”"
+local non_splitable_space_tailers = ":;,.!?)]}$%=-+*/|<>»”"
+-- Same if a space has some specific other punctuation before it
+local non_splitable_space_leaders = "([{$=-+*/|<>«“"
 
 -- Test whether a string could be separated by this char for multi-line rendering
--- Optional next char may be provided to help make the decision
-function util.isSplitable(c, next_c)
+-- Optional next or prev chars may be provided to help make the decision
+function util.isSplitable(c, next_c, prev_c)
     if util.isCJKChar(c) then
         -- a CJKChar is a word in itself, and so is splitable
         return true
     elseif c == " " then
         -- we only split on a space (so punctuation sticks to prev word)
-        -- if next_c is provided, we can make a better decision
+        -- if next_c or prev_c is provided, we can make a better decision
         if next_c and non_splitable_space_tailers:find(next_c, 1, true) then
-            -- this space is followed by some punctuation that is better
-            -- kept with us along previous word
+            -- this space is followed by some punctuation that is better kept with us
+            return false
+        elseif prev_c and non_splitable_space_leaders:find(prev_c, 1, true) then
+            -- this space is lead by some punctuation that is better kept with us
             return false
         else
             -- we can split on this space

--- a/platform/kobo/disable-wifi.sh
+++ b/platform/kobo/disable-wifi.sh
@@ -7,6 +7,13 @@ killall udhcpc default.script wpa_supplicant 2>/dev/null
 wlarm_le -i eth0 down
 ifconfig eth0 down
 
-rmmod -r dhd
-sleep 1 # sleeping a bit here may avoid system getting hung
-rmmod -r sdio_wifi_pwr
+# Some sleep in between may avoid system getting hung
+# (we test if a module is actually loaded to avoid unneeded sleeps)
+if lsmod | grep -q dhd ; then
+    usleep 200000
+    rmmod -r dhd
+fi
+if lsmod | grep -q sdio_wifi_pwr ; then
+    usleep 200000
+    rmmod -r sdio_wifi_pwr
+fi

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -157,5 +157,38 @@ describe("util module", function()
         })
     end)
 
+    it("should split text to line with next_c and prev_c - unicode", function()
+        local text = "Ce test : 1) est « très simple » ; 2 ) simple comme ( 2/2 ) > 50 % ? ok."
+        local word = ""
+        local table_of_words = {}
+        local c
+        local table_chars = util.splitToChars(text)
+        for i = 1, #table_chars  do
+            c = table_chars[i]
+            next_c = i < #table_chars and table_chars[i+1] or nil
+            prev_c = i > 1 and table_chars[i-1] or nil
+            word = word .. c
+            if util.isSplitable(c, next_c, prev_c) then
+                table.insert(table_of_words, word)
+                word = ""
+            end
+            if i == #table_chars then table.insert(table_of_words, word) end
+        end
+        assert.are_same(table_of_words, {
+            "Ce ",
+            "test : ",
+            "1) ",
+            "est ",
+            "« très ",
+            "simple » ; ",
+            "2 ) ",
+            "simple ",
+            "comme ",
+            "( 2/2 ) > 50 % ? ",
+            "ok."
+        })
+    end)
+
+
 
 end)


### PR DESCRIPTION
As discussed in some issues some days ago:
- `disable-wifi.sh `: reduced sleep time (1 second was noticable when exiting koreader) : 2x200ms is enough for my device to not crash, and should be less noticable to those who dont need it.
- clear reader's cache: also clear in-memory cache (I think it's quite simple, and less risky than exiting reader without flushing settings). I thought about adding `Cache.cached={} `in its `Cache:clear() `method, but this method is used by unit tests that expect `cached `to not be reset between calls to `clear()`. So, yes, i access some unexposed object attribute from outside, but we're in "developer options" :) If you prefer I add an other method for that, let me know.

About textboxwidget merged yesterday: I wasn't proud of my unit test results, and I thought i may also pass previous char to isSplitable, and it indeed gives better wrapping.