### PR TITLE
Skim to widget (New Go to page/location widget )

### DIFF
--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -3,7 +3,7 @@ local InputDialog = require("ui/widget/inputdialog")
 local UIManager = require("ui/uimanager")
 local Event = require("ui/event")
 local _ = require("gettext")
-local SkimToWidget = require("ui/widget/skimtowidget")
+local SkimToWidget = require("frontend/apps/reader/skimtowidget")
 
 local ReaderGoto = InputContainer:new{
     goto_menu_title = _("Go to"),
@@ -64,15 +64,13 @@ function ReaderGoto:onShowGotoDialog()
                 },
                 goto_btn,
                 {
-                    text = _("Skim"),
+                    text = _("Skim mode"),
                     enabled = true,
                     callback = function()
                         self:close()
                         self.skimto = SkimToWidget:new{
                             document = self.document,
-                            callback_goto_page = function(page)
-                                self.ui:handleEvent(Event:new("GotoPage", page ))
-                            end,
+                            ui = self.ui,
                             callback_switch_to_goto = function()
                                 UIManager:close(self.skimto)
                                 self:onShowGotoDialog()
@@ -93,9 +91,7 @@ end
 function ReaderGoto:onShowSkimtoDialog()
     self.skimto = SkimToWidget:new{
         document = self.document,
-        callback_goto_page = function(page)
-            self.ui:handleEvent(Event:new("GotoPage", page ))
-        end,
+        ui = self.ui,
         callback_switch_to_goto = function()
             UIManager:close(self.skimto)
             self:onShowGotoDialog()

--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -3,9 +3,11 @@ local InputDialog = require("ui/widget/inputdialog")
 local UIManager = require("ui/uimanager")
 local Event = require("ui/event")
 local _ = require("gettext")
+local SkimToWidget = require("ui/widget/skimtowidget")
 
 local ReaderGoto = InputContainer:new{
     goto_menu_title = _("Go to"),
+    skim_menu_title = _("Skim to"),
 }
 
 function ReaderGoto:init()
@@ -18,6 +20,12 @@ function ReaderGoto:addToMainMenu(tab_item_table)
         text = self.goto_menu_title,
         callback = function()
             self:onShowGotoDialog()
+        end,
+    })
+    table.insert(tab_item_table.navi, {
+        text = self.skim_menu_title,
+        callback = function()
+            self:onShowSkimtoDialog()
         end,
     })
 end
@@ -55,12 +63,45 @@ function ReaderGoto:onShowGotoDialog()
                     end,
                 },
                 goto_btn,
+                {
+                    text = _("Skim"),
+                    enabled = true,
+                    callback = function()
+                        self:close()
+                        self.skimto = SkimToWidget:new{
+                            document = self.document,
+                            callback_goto_page = function(page)
+                                self.ui:handleEvent(Event:new("GotoPage", page ))
+                            end,
+                            callback_switch_to_goto = function()
+                                UIManager:close(self.skimto)
+                                self:onShowGotoDialog()
+                            end,
+                        }
+                        UIManager:show(self.skimto)
+
+                    end,
+                },
             },
         },
         input_type = "number",
     }
     self.goto_dialog:onShowKeyboard()
     UIManager:show(self.goto_dialog)
+end
+
+function ReaderGoto:onShowSkimtoDialog()
+    self.skimto = SkimToWidget:new{
+        document = self.document,
+        callback_goto_page = function(page)
+            self.ui:handleEvent(Event:new("GotoPage", page ))
+        end,
+        callback_switch_to_goto = function()
+            UIManager:close(self.skimto)
+            self:onShowGotoDialog()
+        end,
+    }
+    UIManager:show(self.skimto)
 end
 
 function ReaderGoto:close()

--- a/frontend/apps/reader/skimtowidget.lua
+++ b/frontend/apps/reader/skimtowidget.lua
@@ -19,6 +19,7 @@ local Blitbuffer = require("ffi/blitbuffer")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local ProgressWidget = require("ui/widget/progresswidget")
 local VerticalSpan = require("ui/widget/verticalspan")
+local Event = require("ui/event")
 
 local SkimToWidget = InputContainer:new{
     title_face = Font:getFace("tfont", 22),
@@ -39,7 +40,7 @@ function SkimToWidget:init()
     end
     if Device:isTouchDevice() then
         self.ges_events = {
-            TapCloseGT = {
+            TapProgress = {
                 GestureRange:new{
                     ges = "tap",
                     range = Geom:new{
@@ -51,26 +52,15 @@ function SkimToWidget:init()
             },
          }
     end
-    local curr_page
     if self.document.info.has_pages then
         self.dialog_title = _("Go to Page")
-        curr_page = self.ui.paging.current_page
+        self.curr_page = self.ui.paging.current_page
     else
         self.dialog_title = _("Go to Location")
-        curr_page = self.document:getCurrentPage()
+        self.curr_page = self.document:getCurrentPage()
     end
     self.page_count = self.document:getPageCount()
-    self:update(curr_page)
-end
 
-function SkimToWidget:update(curr_page)
-    if curr_page <= 0 then
-        curr_page = 1
-    end
-    if curr_page > self.page_count then
-        curr_page = self.page_count
-    end
-    -- header
     self.skimto_title = FrameContainer:new{
         padding = Screen:scaleBySize(5),
         margin = Screen:scaleBySize(2),
@@ -89,7 +79,7 @@ function SkimToWidget:update(curr_page)
     local progress_bar = ProgressWidget:new{
         width = self.screen_width * 0.9,
         height = Screen:scaleBySize(30),
-        percentage = curr_page / self.page_count,
+        percentage = self.curr_page / self.page_count,
         ticks = nil,
         last = nil,
     }
@@ -104,7 +94,7 @@ function SkimToWidget:update(curr_page)
         self.skimto_container
     }
 
-    local skimto_line = LineWidget:new{
+    self.skimto_line = LineWidget:new{
         dimen = Geom:new{
             w = self.width,
             h = Screen:scaleBySize(2),
@@ -118,7 +108,7 @@ function SkimToWidget:update(curr_page)
         self.skimto_title,
         CloseButton:new{ window = self, },
     }
-    local button_minus = Button:new{
+    self.button_minus = Button:new{
         text = "-1",
         bordersize = 2,
         margin = 2,
@@ -127,11 +117,12 @@ function SkimToWidget:update(curr_page)
         width = self.screen_width * 0.16,
         show_parent = self,
         callback = function()
-            self.callback_goto_page(curr_page - 1)
-            self:update(curr_page - 1)
+            self.curr_page = self.curr_page - 1
+            self.ui:handleEvent(Event:new("GotoPage", self.curr_page))
+            self:update()
         end,
     }
-    local button_minus_ten = Button:new{
+    self.button_minus_ten = Button:new{
         text = "-10",
         bordersize = 2,
         margin = 2,
@@ -140,11 +131,12 @@ function SkimToWidget:update(curr_page)
         width = self.screen_width * 0.16,
         show_parent = self,
         callback = function()
-            self.callback_goto_page(curr_page - 10)
-            self:update(curr_page - 10)
+            self.curr_page = self.curr_page - 10
+            self.ui:handleEvent(Event:new("GotoPage", self.curr_page))
+            self:update()
         end,
     }
-    local button_plus = Button:new{
+    self.button_plus = Button:new{
         text = "+1",
         bordersize = 2,
         margin = 2,
@@ -153,11 +145,12 @@ function SkimToWidget:update(curr_page)
         width = self.screen_width * 0.16,
         show_parent = self,
         callback = function()
-            self.callback_goto_page(curr_page + 1)
-            self:update(curr_page + 1)
+            self.curr_page = self.curr_page + 1
+            self.ui:handleEvent(Event:new("GotoPage", self.curr_page))
+            self:update()
         end,
     }
-    local button_plus_ten = Button:new{
+    self.button_plus_ten = Button:new{
         text = "+10",
         bordersize = 2,
         margin = 2,
@@ -166,12 +159,13 @@ function SkimToWidget:update(curr_page)
         width = self.screen_width * 0.16,
         show_parent = self,
         callback = function()
-            self.callback_goto_page(curr_page + 10)
-            self:update(curr_page + 10)
+            self.curr_page = self.curr_page + 10
+            self.ui:handleEvent(Event:new("GotoPage", self.curr_page))
+            self:update()
         end,
     }
     local current_page_text = Button:new{
-        text = curr_page,
+        text = self.curr_page,
         bordersize = 0,
         margin = 2,
         radius = 0,
@@ -183,22 +177,20 @@ function SkimToWidget:update(curr_page)
         end,
     }
 
-
     local button_group_up = HorizontalGroup:new{ align = "center" }
     local button_table_up = HorizontalGroup:new{
         align = "center",
-        button_minus,
-        button_minus_ten,
+        self.button_minus,
+        self.button_minus_ten,
         current_page_text,
-        button_plus_ten,
-        button_plus,
+        self.button_plus_ten,
+        self.button_plus,
     }
     local vertical_group_control= VerticalGroup:new{ align = "center" }
     local padding_span = VerticalSpan:new{ width = self.screen_height * 0.01 }
     table.insert(button_group_up, button_table_up)
     table.insert(vertical_group_control,button_group_up)
     table.insert(vertical_group_control,padding_span)
-
 
     self.skimto_frame = FrameContainer:new{
         radius = 5,
@@ -209,10 +201,99 @@ function SkimToWidget:update(curr_page)
         VerticalGroup:new{
             align = "center",
             self.skimto_bar,
-            skimto_line,
+            self.skimto_line,
             CenterContainer:new{
                 dimen = Geom:new{
-                    w = skimto_line:getSize().w,
+                    w = self.skimto_line:getSize().w,
+                    h = self.skimto_progress:getSize().h,
+                },
+                self.skimto_progress,
+            },
+            vertical_group_control
+        }
+    }
+    self[1] = WidgetContainer:new{
+        align = "center",
+        dimen =Geom:new{
+            x = 0, y = 0,
+            w = self.screen_width,
+            h = self.screen_height,
+        },
+        FrameContainer:new{
+            bordersize = 0,
+            padding = Screen:scaleBySize(5),
+            self.skimto_frame,
+        }
+    }
+end
+
+function SkimToWidget:update()
+    self.skimto_container:clear()
+    UIManager:setDirty("all", "ui")
+    if self.curr_page <= 0 then
+        self.curr_page = 1
+    end
+    if self.curr_page > self.page_count then
+        self.curr_page = self.page_count
+    end
+    local progress_bar = ProgressWidget:new{
+        width = self.screen_width * 0.9,
+        height = Screen:scaleBySize(30),
+        percentage = self.curr_page / self.page_count,
+        ticks = nil,
+        last = nil,
+    }
+    local vertical_group = VerticalGroup:new{ align = "center" }
+    table.insert(vertical_group, progress_bar)
+    table.insert(self.skimto_container, vertical_group)
+
+    self.skimto_progress = FrameContainer:new{
+        padding = Screen:scaleBySize(2),
+        margin = Screen:scaleBySize(2),
+        bordersize = 0,
+        self.skimto_container
+    }
+    local current_page_text = Button:new{
+        text = self.curr_page,
+        bordersize = 0,
+        margin = 2,
+        radius = 0,
+        enabled = true,
+        width = self.screen_width * 0.2,
+        show_parent = self,
+        callback = function()
+            self.callback_switch_to_goto()
+        end,
+    }
+
+    local button_group_up = HorizontalGroup:new{ align = "center" }
+    local button_table_up = HorizontalGroup:new{
+        align = "center",
+        self.button_minus,
+        self.button_minus_ten,
+        current_page_text,
+        self.button_plus_ten,
+        self.button_plus,
+    }
+    local vertical_group_control= VerticalGroup:new{ align = "center" }
+    local padding_span = VerticalSpan:new{ width = self.screen_height * 0.01 }
+    table.insert(button_group_up, button_table_up)
+    table.insert(vertical_group_control,button_group_up)
+    table.insert(vertical_group_control,padding_span)
+
+    self.skimto_frame = FrameContainer:new{
+        radius = 5,
+        bordersize = 3,
+        padding = 0,
+        margin = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        VerticalGroup:new{
+            align = "center",
+            self.skimto_bar,
+            self.skimto_line,
+            CenterContainer:new{
+                dimen = Geom:new{
+                    w = self.skimto_line:getSize().w,
                     h = self.skimto_progress:getSize().h,
                 },
                 self.skimto_progress,
@@ -254,17 +335,16 @@ function SkimToWidget:onAnyKeyPressed()
     return true
 end
 
-function SkimToWidget:onTapCloseGT(arg, ges_ev)
-    if not ges_ev.pos:notIntersectWith(self.skimto_progress.dimen) then
+function SkimToWidget:onTapProgress(arg, ges_ev)
+    if ges_ev.pos:intersectWith(self.skimto_progress.dimen) then
         local width = self.screen_width * 0.89
         local pos = ges_ev.pos.x - width * 0.05 - 3
         local perc = pos / width
         local page = math.floor(perc * self.page_count)
-        self.skimto_container:clear()
-        UIManager:setDirty("all", "ui")
-        self.callback_goto_page(page)
-        self:update(page)
-    elseif ges_ev.pos:notIntersectWith(self.skimto_frame.dimen) then
+        self.ui:handleEvent(Event:new("GotoPage", page ))
+        self.curr_page = page
+        self:update()
+    else
         self:onClose()
     end
     return true

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -1,0 +1,278 @@
+local InputContainer = require("ui/widget/container/inputcontainer")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local OverlapGroup = require("ui/widget/overlapgroup")
+local CloseButton = require("ui/widget/closebutton")
+local TextWidget = require("ui/widget/textwidget")
+local LineWidget = require("ui/widget/linewidget")
+local GestureRange = require("ui/gesturerange")
+local Button = require("ui/widget/button")
+local UIManager = require("ui/uimanager")
+local Screen = require("device").screen
+local Device = require("device")
+local Geom = require("ui/geometry")
+local Font = require("ui/font")
+local _ = require("gettext")
+local Blitbuffer = require("ffi/blitbuffer")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local ProgressWidget = require("ui/widget/progresswidget")
+local VerticalSpan = require("ui/widget/verticalspan")
+
+local SkimToWidget = InputContainer:new{
+    title_face = Font:getFace("tfont", 22),
+    width = nil,
+    height = nil,
+}
+
+function SkimToWidget:init()
+    self.medium_font_face = Font:getFace("ffont", 20)
+    self.screen_width = Screen:getSize().w
+    self.screen_height = Screen:getSize().h
+    self.span = math.ceil(self.screen_height * 0.01)
+    self.width = self.screen_width * 0.95
+    if Device:hasKeys() then
+        self.key_events = {
+            Close = { {"Back"}, doc = "close skimto page" }
+        }
+    end
+    if Device:isTouchDevice() then
+        self.ges_events = {
+            TapCloseGT = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = Geom:new{
+                        x = 0, y = 0,
+                        w = self.screen_width,
+                        h = self.screen_height,
+                    }
+                },
+            },
+         }
+    end
+    local curr_page
+    if self.document.info.has_pages then
+        self.dialog_title = _("Go to Page")
+        curr_page = self.ui.paging.current_page
+    else
+        self.dialog_title = _("Go to Location")
+        curr_page = self.document:getCurrentPage()
+    end
+    self.page_count = self.document:getPageCount()
+    self:update(curr_page)
+end
+
+function SkimToWidget:update(curr_page)
+    if curr_page <= 0 then
+        curr_page = 1
+    end
+    if curr_page > self.page_count then
+        curr_page = self.page_count
+    end
+    -- header
+    self.skimto_title = FrameContainer:new{
+        padding = Screen:scaleBySize(5),
+        margin = Screen:scaleBySize(2),
+        bordersize = 0,
+        TextWidget:new{
+            text = self.dialog_title,
+            face = self.title_face,
+            bold = true,
+            width = self.screen_width * 0.95,
+        },
+    }
+
+    self.skimto_container = CenterContainer:new{
+        dimen = Geom:new{ w = self.screen_width * 0.95, h = self.screen_height * 0.075 },
+    }
+    local progress_bar = ProgressWidget:new{
+        width = self.screen_width * 0.9,
+        height = Screen:scaleBySize(30),
+        percentage = curr_page / self.page_count,
+        ticks = nil,
+        last = nil,
+    }
+    local vertical_group = VerticalGroup:new{ align = "center" }
+    table.insert(vertical_group, progress_bar)
+    table.insert(self.skimto_container, vertical_group)
+
+    self.skimto_progress = FrameContainer:new{
+        padding = Screen:scaleBySize(2),
+        margin = Screen:scaleBySize(2),
+        bordersize = 0,
+        self.skimto_container
+    }
+
+    local skimto_line = LineWidget:new{
+        dimen = Geom:new{
+            w = self.width,
+            h = Screen:scaleBySize(2),
+        }
+    }
+    self.skimto_bar = OverlapGroup:new{
+        dimen = {
+            w = self.width,
+            h = self.skimto_title:getSize().h
+        },
+        self.skimto_title,
+        CloseButton:new{ window = self, },
+    }
+    local button_minus = Button:new{
+        text = "-1",
+        bordersize = 2,
+        margin = 2,
+        radius = 0,
+        enabled = true,
+        width = self.screen_width * 0.16,
+        show_parent = self,
+        callback = function()
+            self.callback_goto_page(curr_page - 1)
+            self:update(curr_page - 1)
+        end,
+    }
+    local button_minus_ten = Button:new{
+        text = "-10",
+        bordersize = 2,
+        margin = 2,
+        radius = 0,
+        enabled = true,
+        width = self.screen_width * 0.16,
+        show_parent = self,
+        callback = function()
+            self.callback_goto_page(curr_page - 10)
+            self:update(curr_page - 10)
+        end,
+    }
+    local button_plus = Button:new{
+        text = "+1",
+        bordersize = 2,
+        margin = 2,
+        radius = 0,
+        enabled = true,
+        width = self.screen_width * 0.16,
+        show_parent = self,
+        callback = function()
+            self.callback_goto_page(curr_page + 1)
+            self:update(curr_page + 1)
+        end,
+    }
+    local button_plus_ten = Button:new{
+        text = "+10",
+        bordersize = 2,
+        margin = 2,
+        radius = 0,
+        enabled = true,
+        width = self.screen_width * 0.16,
+        show_parent = self,
+        callback = function()
+            self.callback_goto_page(curr_page + 10)
+            self:update(curr_page + 10)
+        end,
+    }
+    local current_page_text = Button:new{
+        text = curr_page,
+        bordersize = 0,
+        margin = 2,
+        radius = 0,
+        enabled = true,
+        width = self.screen_width * 0.2,
+        show_parent = self,
+        callback = function()
+            self.callback_switch_to_goto()
+        end,
+    }
+
+
+    local button_group_up = HorizontalGroup:new{ align = "center" }
+    local button_table_up = HorizontalGroup:new{
+        align = "center",
+        button_minus,
+        button_minus_ten,
+        current_page_text,
+        button_plus_ten,
+        button_plus,
+    }
+    local vertical_group_control= VerticalGroup:new{ align = "center" }
+    local padding_span = VerticalSpan:new{ width = self.screen_height * 0.01 }
+    table.insert(button_group_up, button_table_up)
+    table.insert(vertical_group_control,button_group_up)
+    table.insert(vertical_group_control,padding_span)
+
+
+    self.skimto_frame = FrameContainer:new{
+        radius = 5,
+        bordersize = 3,
+        padding = 0,
+        margin = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        VerticalGroup:new{
+            align = "center",
+            self.skimto_bar,
+            skimto_line,
+            CenterContainer:new{
+                dimen = Geom:new{
+                    w = skimto_line:getSize().w,
+                    h = self.skimto_progress:getSize().h,
+                },
+                self.skimto_progress,
+            },
+            vertical_group_control
+        }
+    }
+    self[1] = WidgetContainer:new{
+        align = "center",
+        dimen =Geom:new{
+            x = 0, y = 0,
+            w = self.screen_width,
+            h = self.screen_height,
+        },
+        FrameContainer:new{
+            bordersize = 0,
+            padding = Screen:scaleBySize(5),
+            self.skimto_frame,
+        }
+    }
+end
+
+function SkimToWidget:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "partial", self.skimto_frame.dimen
+    end)
+    return true
+end
+
+function SkimToWidget:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self.skimto_frame.dimen
+    end)
+    return true
+end
+
+function SkimToWidget:onAnyKeyPressed()
+    UIManager:close(self)
+    return true
+end
+
+function SkimToWidget:onTapCloseGT(arg, ges_ev)
+    if not ges_ev.pos:notIntersectWith(self.skimto_progress.dimen) then
+        local width = self.screen_width * 0.89
+        local pos = ges_ev.pos.x - width * 0.05 - 3
+        local perc = pos / width
+        local page = math.floor(perc * self.page_count)
+        self.skimto_container:clear()
+        UIManager:setDirty("all", "ui")
+        self.callback_goto_page(page)
+        self:update(page)
+    elseif ges_ev.pos:notIntersectWith(self.skimto_frame.dimen) then
+        self:onClose()
+    end
+    return true
+end
+
+function SkimToWidget:onClose()
+    UIManager:close(self)
+    return true
+end
+
+return SkimToWidget


### PR DESCRIPTION
close #2444 
Discussion: #2444 
In sum:
- Add new menu item "Skim to"
- Left old widget "Go to"

![1](https://cloud.githubusercontent.com/assets/22982594/21503288/a0533bac-cc56-11e6-88a2-4209ff2828d5.png)

- In the "old" widget has been added new button "Skim" to switch to new skim widget.

![2](https://cloud.githubusercontent.com/assets/22982594/21503319/e8f1ebe2-cc56-11e6-8223-2ba439789b91.png)

- From "skim widget" we can switch to "go to widget" clicking on the page number (button) between -10 and +10.

![3](https://cloud.githubusercontent.com/assets/22982594/21503347/1778a9ba-cc57-11e6-9432-29783f37f699.png)


