### PR TITLE
dict/wiki text justification + language rotation fix

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -11,7 +11,6 @@ local ReaderWikipedia = ReaderDictionary:extend{
     is_wiki = true,
     wiki_languages = {},
     no_page = _("No wiki page found."),
-    lookup_msg = _("Searching Wikipedia for:\n%1")
 }
 
 function ReaderWikipedia:init()
@@ -87,6 +86,13 @@ function ReaderWikipedia:onLookupWikipedia(word, box, get_fullpage)
     logger.dbg("stripped word:", word)
     if word == "" then
         return
+    end
+
+    -- Fix lookup message to include lang
+    if get_fullpage then
+        self.lookup_msg = T(_("Getting Wikipedia %2 page:\n%1"), "%1", lang:upper())
+    else
+        self.lookup_msg = T(_("Searching Wikipedia %2 for:\n%1"), "%1", lang:upper())
     end
     self:onLookupStarted(word)
     local results = {}

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -192,8 +192,9 @@ end
 -- @bool[opt=false] bold whether the text should be measured as bold
 -- @tparam[opt=BlitBuffer.COLOR_BLACK] BlitBuffer.COLOR fgcolor foreground color
 -- @int[opt=nil] width maximum rendering width
+-- @tparam[opt] table char_pads array of integers, nb of pixels to add, one for each utf8 char in text
 -- @return int width of rendered bitmap
-function RenderText:renderUtf8Text(dest_bb, x, baseline, face, text, kerning, bold, fgcolor, width)
+function RenderText:renderUtf8Text(dest_bb, x, baseline, face, text, kerning, bold, fgcolor, width, char_pads)
     if not text then
         logger.warn("renderUtf8Text called without text");
         return 0
@@ -211,6 +212,7 @@ function RenderText:renderUtf8Text(dest_bb, x, baseline, face, text, kerning, bo
     if width and width < text_width then
         text_width = width
     end
+    local char_idx = 0
     for _, charcode, uchar in utf8Chars(text) do
         if pen_x < text_width then
             local glyph = self:getGlyph(face, charcode, bold)
@@ -227,6 +229,11 @@ function RenderText:renderUtf8Text(dest_bb, x, baseline, face, text, kerning, bo
             pen_x = pen_x + glyph.ax
             prevcharcode = charcode
         end -- if pen_x < text_width
+        if char_pads then
+            char_idx = char_idx + 1
+            pen_x = pen_x + char_pads[char_idx] -- or 0
+            -- will fail if we didnt count the same number of chars, we'll see
+        end
     end
 
     return pen_x

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -42,6 +42,8 @@ local DictQuickLookup = InputContainer:new{
     height = nil,
     -- box of highlighted word, quick lookup window tries to not hide the word
     word_box = nil,
+    -- allow for disabling justification
+    dict_justify = G_reader_settings:nilOrTrue("dict_justify"),
 
     title_padding = Screen:scaleBySize(5),
     title_margin = Screen:scaleBySize(2),
@@ -231,6 +233,7 @@ function DictQuickLookup:update()
             -- get a bit more height for definition as wiki has one less button raw
             height = self.is_fullpage and self.height*0.75 or self.height*0.7,
             dialog = self,
+            justified = self.dict_justify,
         },
     }
     -- Different sets of buttons if fullpage or not

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -19,12 +19,13 @@ local ScrollTextWidget = InputContainer:new{
     charlist = nil,
     charpos = nil,
     editable = false,
+    justified = false,
     face = nil,
     fgcolor = Blitbuffer.COLOR_BLACK,
     width = 400,
     height = 20,
     scroll_bar_width = Screen:scaleBySize(6),
-    text_scroll_span = Screen:scaleBySize(6),
+    text_scroll_span = Screen:scaleBySize(12),
     dialog = nil,
 }
 
@@ -34,6 +35,7 @@ function ScrollTextWidget:init()
         charlist = self.charlist,
         charpos = self.charpos,
         editable = self.editable,
+        justified = self.justified,
         face = self.face,
         fgcolor = self.fgcolor,
         width = self.width - self.scroll_bar_width - self.text_scroll_span,


### PR DESCRIPTION
**Text justification of definitions:**
This is prettier (and helps distinguish paragraphs), but can be disabled for those who don't like it by adding `["dict_justify"] = false` to `settings.reader.lua`.
This could be used in any textboxwidget or scrolltextwidget with optional `justified=true` attribute.
The idea is just to add some pixels to spaces (or first chars if no space in line) to fill width.
I first did all the stuff in `RenderText:renderUtf8Text()`, before realizing i needed the padding info in `textboxwidget.lua` for hold position accuracy. So I ended up passing some optional `char_pads` table to `RenderText:renderUtf8Text()`.
I don't know what is the right syntax to mention it in the `RenderText:renderUtf8Text()` doc string.
I also increased `text_scroll_span` from 6 to 12 for esthetics : with text justification, it was obvious it wasn't enough and margin wasnt balanced on left and right sides.

**Wikipedia language button and rotation fix**

While doing nested lookups and rotating wikipedia languages, when back from nested lookups, the button state was not synced with current `self.wiki_languages` table. So we keep a copy of its original state, and use it to sync back `self.wiki_languages` when needed.

Also: 
More informative lookup message (langage used, search or full page)
Allow for screen refresh with diagonal swipe (like in readerpaging).


