### PR TITLE
Set hyphenation dict fallback with Hold

### DIFF
--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -2,6 +2,7 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
 local JSON = require("json")
 local InfoMessage = require("ui/widget/infomessage")
+local ConfirmBox = require("ui/widget/confirmbox")
 local T = require("ffi/util").template
 local _ = require("gettext")
 local util = require("util")
@@ -30,6 +31,14 @@ function ReaderHyphenation:init()
                     })
                     self.ui.document:setHyphDictionary(v.filename)
                     self.ui.toc:onUpdateToc()
+                end,
+                hold_callback = function()
+                    UIManager:show(ConfirmBox:new{
+                        text = T( _("Set fallback hyphenation to %1?"), v.name),
+                        ok_callback = function()
+                            G_reader_settings:saveSetting("hyph_alg_fallback", v.filename)
+                        end,
+                    })
                 end,
                 checked_func = function()
                     return v.filename == self.hyph_alg
@@ -94,6 +103,9 @@ function ReaderHyphenation:onPreRenderDocument(config)
     local hyph_alg = config:readSetting("hyph_alg")
     if not hyph_alg then
         hyph_alg = self:getDictForLanguage(self.ui.document:getProps().language)
+    end
+    if not hyph_alg then
+        hyph_alg = G_reader_settings:readSetting("hyph_alg_fallback")
     end
     if hyph_alg then
         self.ui.document:setHyphDictionary(hyph_alg)

--- a/plugins/perceptionexpander.koplugin/main.lua
+++ b/plugins/perceptionexpander.koplugin/main.lua
@@ -189,11 +189,6 @@ function PerceptionExpander:addToMainMenu(tab_item_table)
     })
 end
 
--- in case when screensaver starts
-function PerceptionExpander:onSaveSettings()
-    self:saveSettings()
-end
-
 function PerceptionExpander:onPageUpdate(pageno)
     if not self.is_enabled then
         return


### PR DESCRIPTION
Most settings allow for choosing a default with Hold. Hyphenation didnt have that.
We could choose to make the hold item the default (overriding the document languages' one), instead of a fallback, but some people may not like that.
This fallback will help in that one doesnt have to select a non-english one each time for .txt and likes.

Also removed unnecessary PerceptionExpander:onSaveSettings().