### PR TITLE
ImageViewer widget, better handling of external links, fix some blitbuffer memory leaks

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -224,7 +224,7 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
     return true
 end
 
-function ReaderHighlight:onHold(_, ges)
+function ReaderHighlight:onHold(arg, ges)
     -- disable hold gesture if highlighting is disabled
     if self.view.highlight.disabled then return true end
     self.hold_pos = self.view:screenToPageTransform(ges.pos)
@@ -234,6 +234,23 @@ function ReaderHighlight:onHold(_, ges)
         return true
     end
 
+    -- check if we were holding on an image
+    local image = self.ui.document:getImageFromPosition(self.hold_pos)
+    if image then
+        logger.dbg("hold on image")
+        local ImageViewer = require("ui/widget/imageviewer")
+        local imgviewer = ImageViewer:new{
+            image = image,
+            -- title_text = _("Document embedded image"),
+            -- No title, more room for image
+            with_title_bar = false,
+            fullscreen = true,
+        }
+        UIManager:show(imgviewer)
+        return true
+    end
+
+    -- otherwise, we must be holding on text
     local ok, word = pcall(self.ui.document.getWordFromPosition, self.ui.document, self.hold_pos)
     if ok and word then
         logger.dbg("selected word:", word)

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -5,8 +5,10 @@ local UIManager = require("ui/uimanager")
 local Geom = require("ui/geometry")
 local Screen = require("device").screen
 local Device = require("device")
+local logger = require("logger")
 local Event = require("ui/event")
 local _ = require("gettext")
+local T = require("ffi/util").template
 
 local ReaderLink = InputContainer:new{
     location_stack = {}
@@ -141,13 +143,57 @@ function ReaderLink:onTap(_, ges)
 end
 
 function ReaderLink:onGotoLink(link)
+    logger.dbg("onGotoLink:", link)
     if self.ui.document.info.has_pages then
-        table.insert(self.location_stack, self.ui.paging:getBookLocation())
-        self.ui:handleEvent(Event:new("GotoPage", link.page + 1))
+        -- internal pdf links have a "page" attribute, while external ones have an "uri" attribute
+        if link.page then -- Internal link
+            logger.dbg("Internal link:", link)
+            table.insert(self.location_stack, self.ui.paging:getBookLocation())
+            self.ui:handleEvent(Event:new("GotoPage", link.page + 1))
+            return true
+        end
+        link = link.uri -- external link
     else
-        table.insert(self.location_stack, self.ui.rolling:getBookLocation())
-        self.ui:handleEvent(Event:new("GotoXPointer", link))
+        -- For crengine, internal links may look like :
+        --   #_doc_fragment_0_Organisation (link from anchor)
+        --   /body/DocFragment/body/ul[2]/li[5]/text()[3].16 (xpointer from full-text search)
+        -- If the XPointer does not exist (or is a full url), we will jump to page 1
+        -- Best to check that this link exists in document with the following,
+        -- which accepts both of the above legitimate xpointer as input.
+        if self.ui.document:isXPointerInDocument(link) then
+            logger.dbg("Internal link:", link)
+            table.insert(self.location_stack, self.ui.rolling:getBookLocation())
+            self.ui:handleEvent(Event:new("GotoXPointer", link))
+            return true
+        end
     end
+    logger.dbg("External link:", link)
+    -- Check if it is a wikipedia link
+    local wiki_lang, wiki_page = link:match([[https?://([^%.]+).wikipedia.org/wiki/([^/]+)]])
+    if wiki_lang and wiki_page then
+        logger.dbg("Wikipedia link:", wiki_lang, wiki_page)
+        -- Ask for user confirmation before launching lookup (on a
+        -- wikipedia page saved as epub, full of wikipedia links, it's
+        -- too easy to click on links when wanting to change page...)
+        local ConfirmBox = require("ui/widget/confirmbox")
+        UIManager:show(ConfirmBox:new{
+            text = T(_("Would you like to read this Wikipedia %1 full page?\n\n%2\n"), wiki_lang:upper(), wiki_page:gsub("_", " ")),
+            cancel_on_tap_outside = true,
+            ok_callback = function()
+                UIManager:nextTick(function()
+                    self.ui:handleEvent(Event:new("LookupWikipedia", wiki_page, false, true, wiki_lang))
+                end)
+            end
+        })
+    else
+        -- local Notification = require("ui/widget/notification")
+        local InfoMessage = require("ui/widget/infomessage")
+        UIManager:show(InfoMessage:new{
+            text = T(_("Invalid or external link:\n%1"), link),
+            timeout = 1.0,
+        })
+    end
+    -- don't propagate, user will notice and tap elsewhere if he wants to change page
     return true
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -148,8 +148,23 @@ function CreDocument:getCoverPageImage()
     if data and size then
         local Mupdf = require("ffi/mupdf")
         local ok, image = pcall(Mupdf.renderImage, data, size)
+        ffi.C.free(data)
         if ok then
-            ffi.C.free(data)
+            return image
+        end
+    end
+end
+
+function CreDocument:getImageFromPosition(pos)
+    local data, size = self._document:getImageDataFromPosition(pos.x, pos.y)
+    if data and size then
+        logger.dbg("CreDocument: got image data from position", data, size)
+        local Mupdf = require("ffi/mupdf")
+        -- wrapped with pcall so we always free(data)
+        local ok, image = pcall(Mupdf.renderImage, data, size)
+        ffi.C.free(data) -- need that explicite clean
+        logger.dbg("Mupdf.renderImage", ok, image)
+        if ok then
             return image
         end
     end
@@ -248,6 +263,10 @@ end
 
 function CreDocument:getXPointer()
     return self._document:getXPointer()
+end
+
+function CreDocument:isXPointerInDocument(xp)
+    return self._document:isXPointerInDocument(xp)
 end
 
 function CreDocument:getPosFromXPointer(xp)

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -244,6 +244,10 @@ function Document:getLinkFromPosition(pageno, pos)
     return nil
 end
 
+function Document:getImageFromPosition(pos)
+    return nil
+end
+
 function Document:getTextBoxes(pageno)
     return nil
 end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -30,6 +30,7 @@ local function createWidgetFromFile(file)
         return createWidgetFromImage(
                    ImageWidget:new{
                        file = file,
+                       file_do_cache = false,
                        height = Screen:getHeight(),
                        width = Screen:getWidth(),
                        autostretch = true,

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -22,6 +22,8 @@ local ImageWidget = require("ui/widget/imagewidget")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local HorizontalSpan = require("ui/widget/horizontalspan")
 local ButtonTable = require("ui/widget/buttontable")
+local GestureRange = require("ui/gesturerange")
+local Geom = require("ui/geometry")
 local UIManager = require("ui/uimanager")
 local Device = require("device")
 local Screen = Device.screen
@@ -44,6 +46,23 @@ local ConfirmBox = InputContainer:new{
 }
 
 function ConfirmBox:init()
+    if Device:isTouchDevice() then
+        self.ges_events.TapClose = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    x = 0, y = 0,
+                    w = Screen:getWidth(),
+                    h = Screen:getHeight(),
+                }
+            }
+        }
+    end
+    if Device:hasKeys() then
+        self.key_events = {
+            Close = { {"Back"}, doc = "cancel" }
+        }
+    end
     local content = HorizontalGroup:new{
         align = "center",
         ImageWidget:new{
@@ -110,8 +129,18 @@ function ConfirmBox:onCloseWidget()
 end
 
 function ConfirmBox:onClose()
+    -- Call cancel_callback, parent may expect a choice
+    self.cancel_callback()
     UIManager:close(self)
     return true
+end
+
+function ConfirmBox:onTapClose(arg, ges)
+    if ges.pos:notIntersectWith(self[1][1].dimen) then
+        self:onClose()
+        return true
+    end
+    return false
 end
 
 function ConfirmBox:onSelect()

--- a/frontend/ui/widget/container/alphacontainer.lua
+++ b/frontend/ui/widget/container/alphacontainer.lua
@@ -29,6 +29,9 @@ function AlphaContainer:paintTo(bb, x, y)
     or private_bb:getWidth() ~= contentSize.w
     or private_bb:getHeight() ~= contentSize.h
     then
+        if private_bb then
+            private_bb:free() -- free the one we're going to replace
+        end
         -- create private blitbuffer for our child widget to paint to
         private_bb = BlitBuffer.new(contentSize.w, contentSize.h, bb:getType())
         self.private_bb = private_bb
@@ -38,6 +41,9 @@ function AlphaContainer:paintTo(bb, x, y)
         or self.background_bb:getWidth() ~= contentSize.w
         or self.background_bb:getHeight() ~= contentSize.h
         then
+            if self.background_bb then
+                self.background_bb:free() -- free the one we're going to replace
+            end
             self.background_bb = BlitBuffer.new(contentSize.w, contentSize.h, bb:getType())
         end
         self.background_bb:blitFrom(bb, 0, 0, x, y)
@@ -50,5 +56,17 @@ function AlphaContainer:paintTo(bb, x, y)
     -- blit the private blitbuffer to our parent blitbuffer
     bb:addblitFrom(private_bb, x, y, nil, nil, nil, nil, self.alpha)
 end
+
+function AlphaContainer:onCloseWidget()
+    if self.private_bb then
+        self.private_bb:free()
+        self.private_bb = nil
+    end
+    if self.background_bb then
+        self.background_bb:free()
+        self.background_bb = nil
+    end
+end
+
 
 return AlphaContainer

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -1,0 +1,310 @@
+local InputContainer = require("ui/widget/container/inputcontainer")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local OverlapGroup = require("ui/widget/overlapgroup")
+local CloseButton = require("ui/widget/closebutton")
+local ButtonTable = require("ui/widget/buttontable")
+local TextWidget = require("ui/widget/textwidget")
+local LineWidget = require("ui/widget/linewidget")
+local ImageWidget = require("ui/widget/imagewidget")
+local GestureRange = require("ui/gesturerange")
+local UIManager = require("ui/uimanager")
+local Screen = require("device").screen
+local Device = require("device")
+local Geom = require("ui/geometry")
+local Font = require("ui/font")
+local logger = require("logger")
+local _ = require("gettext")
+local Blitbuffer = require("ffi/blitbuffer")
+
+--[[
+Display image with some simple manipulation options
+]]
+local ImageViewer = InputContainer:new{
+    -- Allow for providing same different input types as ImageWidget :
+    -- a path to a file
+    file = nil,
+    -- or an already made BlitBuffer (ie: made by Mupdf.renderImageFile())
+    image = nil,
+    -- whether provided BlitBuffer should be free(), normally true
+    -- unless our caller wants to reuse it's provided image
+    image_disposable = true,
+
+    fullscreen = false, -- false will add some padding around widget (so footer can be visible)
+    with_title_bar = true,
+    title_text = _("Viewing image"), -- default title text
+
+    width = nil,
+    height = nil,
+    stretched = true, -- start with image stretched (Best fit)
+    rotated = false,
+    -- we use this global setting for rotation angle to have the same angle as reader
+    rotation_angle = DLANDSCAPE_CLOCKWISE_ROTATION and 90 or 270,
+
+    title_face = Font:getFace("tfont", 22),
+    title_padding = Screen:scaleBySize(5),
+    title_margin = Screen:scaleBySize(2),
+    image_padding = Screen:scaleBySize(2),
+    button_padding = Screen:scaleBySize(14),
+
+    -- Reference to current ImageWidget instance, for cleaning
+    _image_wg = nil,
+}
+
+function ImageViewer:init()
+    if Device:hasKeys() then
+        self.key_events = {
+            Close = { {"Back"}, doc = "close viewer" }
+        }
+    end
+    if Device:isTouchDevice() then
+        self.ges_events = {
+            Tap = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = Geom:new{
+                        x = 0, y = 0,
+                        w = Screen:getWidth(),
+                        h = Screen:getHeight(),
+                    }
+                },
+            },
+            Swipe = {
+                GestureRange:new{
+                    ges = "swipe",
+                    range = Geom:new{
+                        x = 0, y = 0,
+                        w = Screen:getWidth(),
+                        h = Screen:getHeight(),
+                    }
+                },
+            },
+        }
+    end
+    self:update()
+end
+
+function ImageViewer:_clean_image_wg()
+    -- To be called before re-using / not needing self._image_wg
+    -- otherwise ressources used by its blitbuffer won't be freed
+    if self._image_wg then
+        logger.dbg("ImageViewer:_clean_image_wg()")
+        self._image_wg:free()
+        self._image_wg = nil
+    end
+end
+
+function ImageViewer:update()
+    self:_clean_image_wg() -- clean previous if any
+    local orig_dimen = self.main_frame and self.main_frame.dimen or Geom:new{}
+    self.align = "center"
+    self.region = Geom:new{
+        x = 0, y = 0,
+        w = Screen:getWidth(),
+        h = Screen:getHeight(),
+    }
+    if self.fullscreen then
+        self.height = Screen:getHeight()
+        self.width = Screen:getWidth()
+    else
+        self.height = Screen:getHeight() - Screen:scaleBySize(40)
+        self.width = Screen:getWidth() - Screen:scaleBySize(40)
+    end
+
+    local buttons = {
+        {
+            {
+                text = self.stretched and _("Original size") or _("Best fit"),
+                callback = function()
+                    self.stretched = not self.stretched and true or false
+                    self:update()
+                end,
+            },
+            {
+                text = self.rotated and _("No rotation") or _("Rotate"),
+                callback = function()
+                    self.rotated = not self.rotated and true or false
+                    self:update()
+                end,
+            },
+            {
+                text = _("Close"),
+                callback = function()
+                    UIManager:close(self)
+                end,
+            },
+        },
+    }
+    local button_table = ButtonTable:new{
+        width = self.width,
+        button_font_face = "cfont",
+        button_font_size = 20,
+        buttons = buttons,
+        zero_sep = true,
+        show_parent = self,
+    }
+    local button_container = CenterContainer:new{
+        dimen = Geom:new{
+            w = self.width,
+            h = button_table:getSize().h,
+        },
+        button_table,
+    }
+
+    -- height available to our image
+    local img_container_h = self.height - button_table:getSize().h
+
+    local title_bar, title_sep
+    if self.with_title_bar then
+        local title_text = FrameContainer:new{
+            padding = self.title_padding,
+            margin = self.title_margin,
+            bordersize = 0,
+            TextWidget:new{
+                text = self.title_text,
+                face = self.title_face,
+                bold = true,
+                width = self.width,
+            }
+        }
+        title_bar = OverlapGroup:new{
+            dimen = {
+                w = self.width,
+                h = title_text:getSize().h
+            },
+            title_text,
+            CloseButton:new{ window = self, },
+        }
+        title_sep = LineWidget:new{
+            dimen = Geom:new{
+                w = self.width,
+                h = Screen:scaleBySize(2),
+            }
+        }
+        -- adjust height available to our image
+        img_container_h = img_container_h - title_bar:getSize().h - title_sep:getSize().h
+    end
+
+    local max_image_h = img_container_h - self.image_padding*2
+    local max_image_w = self.width - self.image_padding*2
+
+    -- Do a first rendering without our h/w to get native image size and see if it needs to be reduced
+    self._image_wg = ImageWidget:new{
+        file = self.file,
+        image = self.image,
+        image_disposable = false, -- we may re-use self.image
+        alpha = true,
+        pre_rotate = self.rotated and self.rotation_angle or 0,
+    }
+    local imwg_size = self._image_wg:getSize()
+    if self.stretched or imwg_size.w > max_image_w or imwg_size.h > max_image_h then
+        -- 2nd rendering if it needs to be stretched to fit our size
+        self:_clean_image_wg() -- clean previous ImageWidget._bb
+        self._image_wg = ImageWidget:new{
+            file = self.file,
+            image = self.image,
+            image_disposable = false, -- we may re-use self.image
+            alpha = true,
+            width = max_image_w,
+            height = max_image_h,
+            autostretch = true,
+            pre_rotate = self.rotated and self.rotation_angle or 0,
+        }
+    end
+
+    local image_container = CenterContainer:new{
+        dimen = Geom:new{
+            w = self.width,
+            h = img_container_h,
+        },
+        self._image_wg,
+    }
+
+    local frame_elements
+    if self.with_title_bar then
+        frame_elements = VerticalGroup:new{
+            align = "left",
+            title_bar,
+            title_sep,
+            image_container,
+            button_container,
+        }
+    else
+        frame_elements = VerticalGroup:new{
+            align = "left",
+            image_container,
+            button_container,
+        }
+    end
+    self.main_frame = FrameContainer:new{
+        radius = not self.fullscreen and 8 or nil,
+        bordersize = 3,
+        padding = 0,
+        margin = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        frame_elements,
+    }
+    self[1] = WidgetContainer:new{
+        align = self.align,
+        dimen = self.region,
+        FrameContainer:new{
+            bordersize = 0,
+            padding = Screen:scaleBySize(5),
+            self.main_frame,
+        }
+    }
+    UIManager:setDirty("all", function()
+        local update_region = self.main_frame.dimen:combine(orig_dimen)
+        logger.dbg("update image region", update_region)
+        return "partial", update_region
+    end)
+end
+
+function ImageViewer:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self.main_frame.dimen
+    end)
+    return true
+end
+
+function ImageViewer:onTap(arg, ges)
+    if ges.pos:notIntersectWith(self.main_frame.dimen) then
+        self:onClose()
+        return true
+    end
+    return true
+end
+
+function ImageViewer:onSwipe(arg, ges)
+    -- trigger full refresh
+    UIManager:setDirty(nil, "full")
+    return true
+end
+
+function ImageViewer:onClose()
+    UIManager:close(self)
+    return true
+end
+
+function ImageViewer:onAnyKeyPressed()
+    self:onClose()
+    return true
+end
+
+function ImageViewer:onCloseWidget()
+    -- clean all our BlitBuffer objects when UIManager:close() was called
+    self:_clean_image_wg()
+    if self.image and self.image_disposable and self.image.free then
+        logger.dbg("ImageViewer:free(self.image)")
+        self.image:free()
+        self.image = nil
+    end
+    UIManager:setDirty(nil, function()
+        return "partial", self.main_frame.dimen
+    end)
+    return true
+end
+
+return ImageViewer


### PR DESCRIPTION
Details in the commits' comments.
(All in one PR, cause they all depends on https://github.com/koreader/koreader-base/pull/470 - dunno about the base bumps needed for this to be linked to the cre.cpp mods, tell me if i need to do something more).

I did all these for a better experience with a wikipedia page "save as epub" feature, which produces a epub with thumbnail images and wikipedia links in the html. Here's one example, if one needs an epub with images (photos, maps) to check this PR: [Battle of Stalingrad.EN.zip](https://github.com/koreader/koreader/files/706922/Battle.of.Stalingrad.EN.zip)
(You'll tell me if there's some interest for that, or if it's a gadget.)

Btw, on the emulator, colored images (thumbnails in the wikipedia page) appears B&W for crengine, but with this ImageViewer making use of mupdf, they appear in colors, but the color are strange (orange is blue, blue is orange). They look fine on our B&W readers.

Forgotten in my comments:
`credocument:getCoverPageImage()` : fixed `ffi.C.free(data)` not happening in case of faliure of renderImage.
imagewidget: fixed calculation of w/h for autostrech of landscape images (hardly noticable with screensaver images which are most often portrait).