### PR TITLE
Statistics: Add percentage completed to Statistics plugin

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -310,6 +310,7 @@ function ReaderStatistics:getCurrentStat()
         { _("Total days"), total_days },
         { _("Average time per page"), util.secondsToClock(avg_time_per_page, false) },
         { _("Read pages/Total pages"), read_pages .. "/" .. self.data.pages },
+        { _("Percentage completed"), math.floor(read_pages / self.data.pages * 100 + 0.5) .. "%" }, -- adding 0.5 rounds to nearest integer with math.floor
     }
 end
 


### PR DESCRIPTION
Makes percentage completed easily accessible through the statistics plugin. It has always been accessible through the status bar, but not through the statistics menu. I found myself wanting to know this information without using it on the status bar and figured others might feel the same way.