### PR TITLE
OPDS: Fixed Wifi prompt and enabled removing default catalogs.

### DIFF
--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -9,37 +9,13 @@ local Blitbuffer = require("ffi/blitbuffer")
 local ReaderUI = require("apps/reader/readerui")
 local ConfirmBox = require("ui/widget/confirmbox")
 local T = require("ffi/util").template
-
 local OPDSCatalog = InputContainer:extend{
     title = _("OPDS Catalog"),
-    opds_servers = {
-        {
-            title = "Project Gutenberg",
-            subtitle = "Free ebooks since 1971.",
-            url = "http://m.gutenberg.org/ebooks.opds/?format=opds",
-        },
-        {
-            title = "Feedbooks",
-            subtitle = "",
-            url = "http://www.feedbooks.com/publicdomain/catalog.atom",
-        },
-        {
-            title = "ManyBooks",
-            subtitle = "Online Catalog for Manybooks.net",
-            url = "http://manybooks.net/opds/index.php",
-        },
-        {
-            title = "Internet Archive",
-            subtitle = "Internet Archive Catalog",
-            url = "http://bookserver.archive.org/catalog/",
-        },
-    },
     onExit = function() end,
 }
 
 function OPDSCatalog:init()
     local opds_browser = OPDSBrowser:new{
-        opds_servers = self.opds_servers,
         title = self.title,
         show_parent = self,
         is_popout = false,

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -353,7 +353,7 @@ end
 function OPDSBrowser:getCatalog(feed_url)
     local ok, catalog = pcall(self.parseFeed, self, feed_url)
     -- prompt users to turn on Wifi if network is unreachable
-    if not ok and catalog and catalog:find("Network is unreachable") then
+    if not ok and catalog and (catalog:find("Network is unreachable") or catalog:find("host or service not provided")) then
         NetworkMgr:promptWifiOn()
         return
     elseif not ok and catalog then

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -58,7 +58,29 @@ local OPDSBrowser = Menu:extend{
 }
 
 function OPDSBrowser:init()
-    self.item_table = self:genItemTableFromRoot(self.opds_servers)
+    local servers = G_reader_settings:readSetting("opds_servers")
+    if not servers then -- If there are no saved servers, add some defaults
+        servers = {
+          {
+            title = "Project Gutenberg",
+            url = "http://m.gutenberg.org/ebooks.opds/?format=opds",
+          },
+          {
+             title = "Feedbooks",
+             url = "http://www.feedbooks.com/publicdomain/catalog.atom",
+          },
+          {
+             title = "ManyBooks",
+             url = "http://manybooks.net/opds/index.php",
+          },
+          {
+             title = "Internet Archive",
+             url = "http://bookserver.archive.org/catalog/",
+          },
+        }
+        G_reader_settings:saveSetting("opds_servers", servers)
+    end
+    self.item_table = self:genItemTableFromRoot()
     Menu.init(self) -- call parent's init()
 end
 
@@ -168,13 +190,6 @@ end
 
 function OPDSBrowser:genItemTableFromRoot()
     local item_table = {}
-    for _, server in ipairs(self.opds_servers) do
-        table.insert(item_table, {
-            text = server.title,
-            content = server.subtitle,
-            url = server.url,
-        })
-    end
     local added_servers = G_reader_settings:readSetting("opds_servers") or {}
     for _, server in ipairs(added_servers) do
         table.insert(item_table, {


### PR DESCRIPTION
I removed the special nature of the default OPDS catalogs (Project Gutenberg, for example) where they could not be removed or edited and fixed a bug where non-calibre OPDS catalogs would not prompt the user to enable Wifi upon the failure of the device to connect to the internet. Instead, it threw a generic error message.