### PR TITLE
Can't display the doc name in Statistics page

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -453,6 +453,10 @@ end
 function ReaderStatistics:getTotalStats()
     local total_stats = {}
     if not self:isDocless() then
+        -- empty title
+        if self.data.title == "" then
+            self.data.title = self.document.file:match("^.+/(.+)$")
+        end
         total_stats = {
             {
                 self.data.title,
@@ -481,6 +485,10 @@ function ReaderStatistics:getStatisticsFromHistory(total_stats)
     local total_books_time = 0
     for _, v in pairs(ReadHistory.hist) do
         local book_stats = DocSettings:open(v.file):readSetting('stats')
+        -- empty title
+        if book_stats and book_stats.title == "" then
+            book_stats.title = v.file:match("^.+/(.+)$")
+        end
         if book_stats and book_stats.total_time_in_sec > 0
             and book_stats.title ~= self.data.title then
             titles[book_stats.title] = true


### PR DESCRIPTION
close #2503 
Fix: #2503 (Statistics can't display the DOC name)