### PR TITLE
Add characters in menu items to indicate sub menus

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -649,7 +649,7 @@ function Menu:updateItems(select_number)
                 show_parent = self.show_parent,
                 state = self.item_table[i].state,
                 state_size = self.state_size or {},
-                text = ((self.item_table[i].sub_item_table ~= nil) and "+ " or "") .. self.item_table[i].text,
+                text = self.item_table[i].text .. ((self.item_table[i].sub_item_table ~= nil) and " >" or ""),
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 face = self.cface,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -649,7 +649,7 @@ function Menu:updateItems(select_number)
                 show_parent = self.show_parent,
                 state = self.item_table[i].state,
                 state_size = self.state_size or {},
-                text = self.item_table[i].text .. ((self.item_table[i].sub_item_table ~= nil) and " +" or ""),
+                text = ((self.item_table[i].sub_item_table ~= nil) and "+ " or "") .. self.item_table[i].text,
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 face = self.cface,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -649,7 +649,7 @@ function Menu:updateItems(select_number)
                 show_parent = self.show_parent,
                 state = self.item_table[i].state,
                 state_size = self.state_size or {},
-                text = self.item_table[i].text .. ((self.item_table[i].sub_item_table ~= nil) and " >" or ""),
+                text = self.item_table[i].text .. ((self.item_table[i].sub_item_table ~= nil) and " \226\150\185" or ""),
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 face = self.cface,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -27,6 +27,7 @@ local util = require("ffi/util")
 local logger = require("logger")
 local Blitbuffer = require("ffi/blitbuffer")
 local _ = require("gettext")
+local getMenuText = require("util").getMenuText
 
 --[[
 Widget that displays a shortcut icon for menu item
@@ -649,7 +650,7 @@ function Menu:updateItems(select_number)
                 show_parent = self.show_parent,
                 state = self.item_table[i].state,
                 state_size = self.state_size or {},
-                text = self.item_table[i].text .. ((self.item_table[i].sub_item_table ~= nil) and " \226\150\185" or ""),
+                text = getMenuText(self.item_table[i]),
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 face = self.cface,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -169,8 +169,7 @@ function MenuItem:init()
 
     local state_button_width = self.state_size.w or 0
     local my_text = self.text and ""..self.text or ""
-    local w = RenderText:sizeUtf8Text(0, self.dimen.w, self.face,
-                    ""..my_text, true, self.bold).x
+    local w = RenderText:sizeUtf8Text(0, self.dimen.w, self.face, my_text, true, self.bold).x
     if w + mandatory_w + state_button_width >= self.content_width then
         if Device:hasKeyboard() then
             self.active_key_events.ShowItemDetail = {
@@ -599,7 +598,7 @@ function Menu:init()
     if self.path_items then
         self:refreshPath()
     else
-        self:updateItems(1)
+        self:updateItems()
     end
 end
 
@@ -650,7 +649,7 @@ function Menu:updateItems(select_number)
                 show_parent = self.show_parent,
                 state = self.item_table[i].state,
                 state_size = self.state_size or {},
-                text = self.item_table[i].text,
+                text = self.item_table[i].text .. ((self.item_table[i].sub_item_table ~= nil) and " +" or ""),
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 face = self.cface,
@@ -727,7 +726,7 @@ function Menu:swithItemTable(new_title, new_item_table, itemnumber)
     end
 
     self.item_table = new_item_table
-    self:updateItems(1)
+    self:updateItems()
 end
 
 function Menu:onSelectByShortCut(_, keyevent)
@@ -803,7 +802,7 @@ function Menu:onNextPage()
     end
     if self.page < self.page_num then
         self.page = self.page + 1
-        self:updateItems(1)
+        self:updateItems()
     elseif self.page == self.page_num then
         -- on the last page, we check if we're on the last item
         local end_position = #self.item_table % self.perpage
@@ -814,7 +813,7 @@ function Menu:onNextPage()
             self:updateItems(end_position)
         end
         self.page = 1
-        self:updateItems(1)
+        self:updateItems()
     end
     return true
 end
@@ -825,25 +824,25 @@ function Menu:onPrevPage()
     elseif self.page == 1 then
         self.page = self.page_num
     end
-    self:updateItems(1)
+    self:updateItems()
     return true
 end
 
 function Menu:onFirstPage()
     self.page = 1
-    self:updateItems(1)
+    self:updateItems()
     return true
 end
 
 function Menu:onLastPage()
     self.page = self.page_num
-    self:updateItems(1)
+    self:updateItems()
     return true
 end
 
 function Menu:onGotoPage(page)
     self.page = page
-    self:updateItems(1)
+    self:updateItems()
     return true
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -78,7 +78,7 @@ function TouchMenuItem:init()
                 item_checked and checked_widget or unchecked_widget
             },
             TextWidget:new{
-                text = (self.item.text or self.item.text_func()) .. ((self.item.sub_item_table == nil) and "" or " +"),
+                text = ((self.item.sub_item_table == nil) and "" or "+ ") .. (self.item.text or self.item.text_func()),
                 fgcolor = item_enabled ~= false and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GREY,
                 face = self.face,
             },

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -20,6 +20,7 @@ local Font = require("ui/font")
 local util = require("ffi/util")
 local _ = require("gettext")
 local Blitbuffer = require("ffi/blitbuffer")
+local getMenuText = require("util").getMenuText
 
 --[[
 TouchMenuItem widget
@@ -78,7 +79,7 @@ function TouchMenuItem:init()
                 item_checked and checked_widget or unchecked_widget
             },
             TextWidget:new{
-                text = (self.item.text or self.item.text_func()) .. ((self.item.sub_item_table == nil) and "" or " \226\150\185"),
+                text = getMenuText(self.item),
                 fgcolor = item_enabled ~= false and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GREY,
                 face = self.face,
             },

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -78,7 +78,7 @@ function TouchMenuItem:init()
                 item_checked and checked_widget or unchecked_widget
             },
             TextWidget:new{
-                text = self.item.text or self.item.text_func(),
+                text = (self.item.text or self.item.text_func()) .. ((self.item.sub_item_table == nil) and "" or " +"),
                 fgcolor = item_enabled ~= false and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GREY,
                 face = self.face,
             },

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -78,7 +78,7 @@ function TouchMenuItem:init()
                 item_checked and checked_widget or unchecked_widget
             },
             TextWidget:new{
-                text = (self.item.text or self.item.text_func()) .. ((self.item.sub_item_table == nil) and "" or " >"),
+                text = (self.item.text or self.item.text_func()) .. ((self.item.sub_item_table == nil) and "" or " \226\150\185"),
                 fgcolor = item_enabled ~= false and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GREY,
                 face = self.face,
             },

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -78,7 +78,7 @@ function TouchMenuItem:init()
                 item_checked and checked_widget or unchecked_widget
             },
             TextWidget:new{
-                text = ((self.item.sub_item_table == nil) and "" or "+ ") .. (self.item.text or self.item.text_func()),
+                text = (self.item.text or self.item.text_func()) .. ((self.item.sub_item_table == nil) and "" or " >"),
                 fgcolor = item_enabled ~= false and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GREY,
                 face = self.face,
             },

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -266,4 +266,17 @@ function util.splitFileNameSuffix(file)
     return string.gsub(file, "(.*)%.(.*)", "%1"), string.gsub(file, ".*%.", "")
 end
 
+function util.getMenuText(item)
+    local text
+    if item.text_func then
+        text = item.text_func()
+    else
+        text = item.text
+    end
+    if item.sub_item_table ~= nil then
+        text = text .. " \226\150\182"
+    end
+    return text
+end
+
 return util

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -274,7 +274,7 @@ function util.getMenuText(item)
         text = item.text
     end
     if item.sub_item_table ~= nil then
-        text = text .. " \226\150\182"
+        text = text .. " \226\150\184"
     end
     return text
 end


### PR DESCRIPTION
I think this may be a common issue in KOReader. For some unfamiliar features, I always need to try the menu items before actually understanding their meanings. A very basic issue is, I cannot quite tell whether the menu item is an action or contains sub items.

So this change adds a + before menu items with sub menu.

Indeed there are several options, say, preposing a +, as this solution; postposing a >, more like Microsoft style; postposing a +, the first design, etc. Feel free to vote or suggest your preference.