### PR TITLE
Removing metadata file instead of purging .sdr folder

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -161,10 +161,10 @@ function FileManager:init()
                 },
                 {
                     text = _("Purge .sdr"),
-                    enabled = DocSettings:hasSidecarDir(util.realpath(file)),
+                    enabled = DocSettings:hasSidecarFile(util.realpath(file)),
                     callback = function()
                         local full_path = util.realpath(file)
-                        util.purgeDir(DocSettings:getSidecarDir(full_path))
+                        os.remove(DocSettings:getSidecarFile(full_path))
                         self:refreshPath()
                         -- also remove from history if present
                         local readhistory = require("readhistory")

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -29,13 +29,17 @@ end
 
 function DocSettings:getSidecarFile(doc_path)
     if doc_path == nil or doc_path == '' then return '' end
-    return self:getSidecarDir(doc_path) .. "/metadata." .. doc_path:match(".*%.(.+)") .. ".lua"
+    -- If the file does not have a suffix or we are working on a directory, we
+    -- should ignore the suffix part in metadata file path.
+    local suffix = doc_path:match(".*%.(.+)")
+    if suffix == nil then
+        suffix = ''
+    end
+    return self:getSidecarDir(doc_path) .. "/metadata." .. suffix .. ".lua"
 end
 
 function DocSettings:hasSidecarFile(doc_path)
-    local file = self:getSidecarFile(doc_path)
-    if file == nil or file == '' then return false end
-    return lfs.attributes(file, "mode") == "file"
+    return lfs.attributes(self:getSidecarFile(doc_path), "mode") == "file"
 end
 
 function DocSettings:getHistoryPath(fullpath)

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -32,12 +32,10 @@ function DocSettings:getSidecarFile(doc_path)
     return self:getSidecarDir(doc_path) .. "/metadata." .. doc_path:match(".*%.(.+)") .. ".lua"
 end
 
-function DocSettings:hasSidecarDir(doc_path)
-    -- We may be called with items from FileManager, which may not be a document
-    if lfs.attributes(doc_path, "mode") == "directory" then
-        return false
-    end
-    return lfs.attributes(self:getSidecarDir(doc_path), "mode") == "directory"
+function DocSettings:hasSidecarFile(doc_path)
+    local file = self:getSidecarFile(doc_path)
+    if file == nil or file == '' then return false end
+    return lfs.attributes(file, "mode") == "file"
 end
 
 function DocSettings:getHistoryPath(fullpath)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -144,7 +144,7 @@ function FileChooser:genItemTableFromPath(path)
             path = full_path
         }
         if show_file_in_bold ~= false then
-            file_item.bold = DocSettings:hasSidecarDir(full_path)
+            file_item.bold = DocSettings:hasSidecarFile(full_path)
             if show_file_in_bold ~= "opened" then
                 file_item.bold = not file_item.bold
             end


### PR DESCRIPTION
.sdr folder is shared between kindle stock reader and kobo; it's also shared by files with only different suffixes, so we definitely should not purge it. Instead, removing metadata.{suffix}.lua is a safer choice.

Meanwhile, sidecar dir is generated by kindle stock reader automatically, even without opening the book, so DocSetting:hasSidecarDir() should be replace by DocSetting:hasSidecarFile() to decide the display style in file manager.