### PR TITLE
Day of week and months can now be translated

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -284,4 +284,49 @@ function util.getMenuText(item)
     return text
 end
 
+function util.translateDayOfWeek(day_of_week)
+    local _ = require("gettext")
+    if day_of_week == "Monday" then return _("Monday")
+        elseif day_of_week == "Tuesday" then return _("Tuesday")
+        elseif day_of_week == "Wednesday" then return _("Wednesday")
+        elseif day_of_week == "Thursday" then return _("Thursday")
+        elseif day_of_week == "Friday" then return _("Friday")
+        elseif day_of_week == "Saturday" then return _("Saturday")
+        elseif day_of_week == "Sunday" then return _("Sunday")
+    end
+    return
+end
+
+function util.translateShortDayOfWeek(day_of_week)
+    local _ = require("gettext")
+    if day_of_week == "Mon" then return _("Monday")
+    elseif day_of_week == "Tue" then return _("Tue")
+    elseif day_of_week == "Wed" then return _("Wed")
+    elseif day_of_week == "Thu" then return _("Thu")
+    elseif day_of_week == "Fri" then return _("Fri")
+    elseif day_of_week == "Sat" then return _("Sat")
+    elseif day_of_week == "Sun" then return _("Sun")
+    end
+    return
+end
+
+
+function util.translateMonth(month)
+    local _ = require("gettext")
+    if month == "January" then return _("January")
+        elseif month == "February" then return _("February")
+        elseif month == "March" then return _("March")
+        elseif month == "April" then return _("April")
+        elseif month == "May" then return _("May")
+        elseif month == "June" then return _("June")
+        elseif month == "July" then return _("July")
+        elseif month == "August" then return _("August")
+        elseif month == "September" then return _("September")
+        elseif month == "October" then return _("October")
+        elseif month == "November" then return _("November")
+        elseif month == "December" then return _("December")
+    end
+    return
+end
+
 return util

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -284,49 +284,4 @@ function util.getMenuText(item)
     return text
 end
 
-function util.translateDayOfWeek(day_of_week)
-    local _ = require("gettext")
-    if day_of_week == "Monday" then return _("Monday")
-        elseif day_of_week == "Tuesday" then return _("Tuesday")
-        elseif day_of_week == "Wednesday" then return _("Wednesday")
-        elseif day_of_week == "Thursday" then return _("Thursday")
-        elseif day_of_week == "Friday" then return _("Friday")
-        elseif day_of_week == "Saturday" then return _("Saturday")
-        elseif day_of_week == "Sunday" then return _("Sunday")
-    end
-    return
-end
-
-function util.translateShortDayOfWeek(day_of_week)
-    local _ = require("gettext")
-    if day_of_week == "Mon" then return _("Mon")
-    elseif day_of_week == "Tue" then return _("Tue")
-    elseif day_of_week == "Wed" then return _("Wed")
-    elseif day_of_week == "Thu" then return _("Thu")
-    elseif day_of_week == "Fri" then return _("Fri")
-    elseif day_of_week == "Sat" then return _("Sat")
-    elseif day_of_week == "Sun" then return _("Sun")
-    end
-    return
-end
-
-
-function util.translateMonth(month)
-    local _ = require("gettext")
-    if month == "January" then return _("January")
-        elseif month == "February" then return _("February")
-        elseif month == "March" then return _("March")
-        elseif month == "April" then return _("April")
-        elseif month == "May" then return _("May")
-        elseif month == "June" then return _("June")
-        elseif month == "July" then return _("July")
-        elseif month == "August" then return _("August")
-        elseif month == "September" then return _("September")
-        elseif month == "October" then return _("October")
-        elseif month == "November" then return _("November")
-        elseif month == "December" then return _("December")
-    end
-    return
-end
-
 return util

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -299,7 +299,7 @@ end
 
 function util.translateShortDayOfWeek(day_of_week)
     local _ = require("gettext")
-    if day_of_week == "Mon" then return _("Monday")
+    if day_of_week == "Mon" then return _("Mon")
     elseif day_of_week == "Tue" then return _("Tue")
     elseif day_of_week == "Wed" then return _("Wed")
     elseif day_of_week == "Thu" then return _("Thu")

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -353,6 +353,9 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype)
     local one_day = 24 * 3600 -- one day in seconds
     local avg_time_per_page
     local period = now_stamp - ((sdays -1) * one_day) - from_begin_day
+    local week_translate = _("Week")
+    local month_translate
+    local short_day_of_week
     for _, v in pairs(ReadHistory.hist) do
         local book_stats = DocSettings:open(v.file):readSetting('stats')
         if book_stats ~= nil then
@@ -376,13 +379,16 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype)
             table.sort(sorted_performance_in_pages)
             for i, n in pairs(sorted_performance_in_pages) do
                 if ptype == "daily_weekday" then
-                    date_text = os.date("%Y-%m-%d (%a)", n)
+                    short_day_of_week = util.translateShortDayOfWeek(os.date("%a", n))
+                    date_text = os.date("%Y-%m-%d ", n) .. "(" .. short_day_of_week .. ")"
                 elseif ptype == "daily" then
                     date_text = os.date("%Y-%m-%d" , n)
                 elseif ptype == "weekly" then
-                    date_text = os.date("%Y Week %W" , n)
+                    date_text = os.date("%Y ".. week_translate .. " %W" , n)
                 elseif ptype == "monthly" then
-                    date_text = os.date("%B %Y" , n)
+                    month_translate = util.translateMonth(os.date("%B" , n))
+                    date_text = os.date(" %Y" , n)
+                    date_text = month_translate .. date_text
                 else
                     date_text = os.date("%Y-%m-%d" , n)
                 end  --if ptype

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -344,6 +344,29 @@ end
 --          weekly - show weekly
 --          monthly - show monthly
 function ReaderStatistics:getDatesFromAll(sdays, ptype)
+    local shortDayOfWeekTranslation = {
+        ["Mon"] = _("Mon"),
+        ["Tue"] = _("Tue"),
+        ["Wed"] = _("Wed"),
+        ["Thu"] = _("Thu"),
+        ["Fri"] = _("Fri"),
+        ["Sat"] = _("Sat"),
+        ["Sun"] = _("Sun"),
+    }
+    local monthTranslation = {
+        ["January"] = _("January"),
+        ["February"] = _("February"),
+        ["March"] = _("March"),
+        ["April"] = _("April"),
+        ["May"] = _("May"),
+        ["June"] = _("June"),
+        ["July"] = _("July"),
+        ["August"] = _("August"),
+        ["September"] = _("September"),
+        ["October"] = _("October"),
+        ["November"] = _("November"),
+        ["December"] = _("December"),
+    }
     local dates = {}
     local sorted_performance_in_pages
     local diff
@@ -355,7 +378,6 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype)
     local period = now_stamp - ((sdays -1) * one_day) - from_begin_day
     local week_translate = _("Week")
     local month_translate
-    local short_day_of_week
     for _, v in pairs(ReadHistory.hist) do
         local book_stats = DocSettings:open(v.file):readSetting('stats')
         if book_stats ~= nil then
@@ -379,14 +401,15 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype)
             table.sort(sorted_performance_in_pages)
             for i, n in pairs(sorted_performance_in_pages) do
                 if ptype == "daily_weekday" then
-                    short_day_of_week = util.translateShortDayOfWeek(os.date("%a", n))
-                    date_text = os.date("%Y-%m-%d ", n) .. "(" .. short_day_of_week .. ")"
+                    date_text = string.format("%s (%s)",
+                        os.date("%Y-%m-%d ", n),
+                        shortDayOfWeekTranslation[os.date("%a", n)])
                 elseif ptype == "daily" then
                     date_text = os.date("%Y-%m-%d" , n)
                 elseif ptype == "weekly" then
                     date_text = os.date("%Y ".. week_translate .. " %W" , n)
                 elseif ptype == "monthly" then
-                    month_translate = util.translateMonth(os.date("%B" , n))
+                    month_translate = monthTranslation[os.date("%B" , n)]
                     date_text = os.date(" %Y" , n)
                     date_text = month_translate .. date_text
                 else

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -40,6 +40,31 @@ local ReaderStatistics = Widget:extend{
     },
 }
 
+local shortDayOfWeekTranslation = {
+    ["Mon"] = _("Mon"),
+    ["Tue"] = _("Tue"),
+    ["Wed"] = _("Wed"),
+    ["Thu"] = _("Thu"),
+    ["Fri"] = _("Fri"),
+    ["Sat"] = _("Sat"),
+    ["Sun"] = _("Sun"),
+}
+
+local monthTranslation = {
+    ["January"] = _("January"),
+    ["February"] = _("February"),
+    ["March"] = _("March"),
+    ["April"] = _("April"),
+    ["May"] = _("May"),
+    ["June"] = _("June"),
+    ["July"] = _("July"),
+    ["August"] = _("August"),
+    ["September"] = _("September"),
+    ["October"] = _("October"),
+    ["November"] = _("November"),
+    ["December"] = _("December"),
+}
+
 function ReaderStatistics:isDocless()
     return self.ui == nil or self.ui.document == nil
 end
@@ -344,29 +369,6 @@ end
 --          weekly - show weekly
 --          monthly - show monthly
 function ReaderStatistics:getDatesFromAll(sdays, ptype)
-    local shortDayOfWeekTranslation = {
-        ["Mon"] = _("Mon"),
-        ["Tue"] = _("Tue"),
-        ["Wed"] = _("Wed"),
-        ["Thu"] = _("Thu"),
-        ["Fri"] = _("Fri"),
-        ["Sat"] = _("Sat"),
-        ["Sun"] = _("Sun"),
-    }
-    local monthTranslation = {
-        ["January"] = _("January"),
-        ["February"] = _("February"),
-        ["March"] = _("March"),
-        ["April"] = _("April"),
-        ["May"] = _("May"),
-        ["June"] = _("June"),
-        ["July"] = _("July"),
-        ["August"] = _("August"),
-        ["September"] = _("September"),
-        ["October"] = _("October"),
-        ["November"] = _("November"),
-        ["December"] = _("December"),
-    }
     local dates = {}
     local sorted_performance_in_pages
     local diff
@@ -376,9 +378,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype)
     local one_day = 24 * 3600 -- one day in seconds
     local avg_time_per_page
     local period = now_stamp - ((sdays -1) * one_day) - from_begin_day
-    local week_translate = _("Week")
-    local month_translate
-    for _, v in pairs(ReadHistory.hist) do
+    for __, v in pairs(ReadHistory.hist) do
         local book_stats = DocSettings:open(v.file):readSetting('stats')
         if book_stats ~= nil then
             -- if current reading book
@@ -402,18 +402,16 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype)
             for i, n in pairs(sorted_performance_in_pages) do
                 if ptype == "daily_weekday" then
                     date_text = string.format("%s (%s)",
-                        os.date("%Y-%m-%d ", n),
+                        os.date("%Y-%m-%d", n),
                         shortDayOfWeekTranslation[os.date("%a", n)])
                 elseif ptype == "daily" then
-                    date_text = os.date("%Y-%m-%d" , n)
+                    date_text = os.date("%Y-%m-%d", n)
                 elseif ptype == "weekly" then
-                    date_text = os.date("%Y ".. week_translate .. " %W" , n)
+                    date_text = T(_("%1 Week %2"), os.date("%Y "), os.date(" %W", n))
                 elseif ptype == "monthly" then
-                    month_translate = monthTranslation[os.date("%B" , n)]
-                    date_text = os.date(" %Y" , n)
-                    date_text = month_translate .. date_text
+                    date_text = monthTranslation[os.date("%B", n)] .. os.date(" %Y", n)
                 else
-                    date_text = os.date("%Y-%m-%d" , n)
+                    date_text = os.date("%Y-%m-%d", n)
                 end  --if ptype
                 if not dates[date_text] then
                     dates[date_text] = {

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -164,11 +164,20 @@ function ReaderProgress:genDoubleHeader(title_left, title_right)
 end
 
 function ReaderProgress:genWeekStats(stats_day)
+    local dayOfWeekTranslation = {
+        ["Monday"] = _("Monday"),
+        ["Tuesday"] = _("Tuesday"),
+        ["Wednesday"] = _("Wednesday"),
+        ["Thursday"] = _("Thursday"),
+        ["Friday"] = _("Fri"),
+        ["Saturday"] = _("Saturday"),
+        ["Sunday"] = _("Sunday"),
+    }
     local second_in_day = 86400
     local date_format
     local date_format_show
-    local day_of_week
     local select_day_time
+    local diff_time
     local now_time = os.time()
     local height = Screen:scaleBySize(60)
     local statistics_container = CenterContainer:new{
@@ -206,9 +215,8 @@ function ReaderProgress:genWeekStats(stats_day)
         else
             select_day_time = 0
         end
-        day_of_week = os.date("%A" , now_time - second_in_day * (i - 1))
-        date_format_show = os.date(" (%d.%m)" , now_time - second_in_day * (i - 1))
-        date_format_show = util.translateDayOfWeek(day_of_week) .. date_format_show
+        diff_time = now_time - second_in_day * (i - 1)
+        date_format_show = dayOfWeekTranslation[os.date("%A" , diff_time)] .. os.date(" (%d.%m)" , diff_time)
         local total_group = HorizontalGroup:new{
             align = "center",
             padding = 2,

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -167,6 +167,7 @@ function ReaderProgress:genWeekStats(stats_day)
     local second_in_day = 86400
     local date_format
     local date_format_show
+    local day_of_week
     local select_day_time
     local now_time = os.time()
     local height = Screen:scaleBySize(60)
@@ -205,7 +206,9 @@ function ReaderProgress:genWeekStats(stats_day)
         else
             select_day_time = 0
         end
-        date_format_show = os.date("%A (%d.%m)" , now_time - second_in_day * (i - 1))
+        day_of_week = os.date("%A" , now_time - second_in_day * (i - 1))
+        date_format_show = os.date(" (%d.%m)" , now_time - second_in_day * (i - 1))
+        date_format_show = util.translateDayOfWeek(day_of_week) .. date_format_show
         local total_group = HorizontalGroup:new{
             align = "center",
             padding = 2,

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -26,6 +26,26 @@ local ReaderProgress = InputContainer:new{
     padding = Screen:scaleBySize(15),
 }
 
+local dayOfWeekTranslation = {
+    ["Monday"] = _("Monday"),
+    ["Tuesday"] = _("Tuesday"),
+    ["Wednesday"] = _("Wednesday"),
+    ["Thursday"] = _("Thursday"),
+    ["Friday"] = _("Friday"),
+    ["Saturday"] = _("Saturday"),
+    ["Sunday"] = _("Sunday"),
+}
+
+local shortDayOfWeekTranslation = {
+    ["Mon"] = _("Mon"),
+    ["Tue"] = _("Tue"),
+    ["Wed"] = _("Wed"),
+    ["Thu"] = _("Thu"),
+    ["Fri"] = _("Fri"),
+    ["Sat"] = _("Sat"),
+    ["Sun"] = _("Sun"),
+}
+
 function ReaderProgress:init()
     self.small_font_face = Font:getFace("ffont", 15)
     self.medium_font_face = Font:getFace("ffont", 20)
@@ -58,7 +78,10 @@ end
 function ReaderProgress:getTodayStats(dates)
     local today_time = 0
     local today_pages = 0
-    local today = os.date("%Y-%m-%d (%a)" , os.time())
+    local now_time = os.time()
+    local today = string.format("%s (%s)",
+        os.date("%Y-%m-%d", now_time),
+        shortDayOfWeekTranslation[os.date("%a", now_time)])
     if dates[today] ~= nil then
         today_time = dates[today].read
         today_pages = dates[today].count
@@ -164,15 +187,6 @@ function ReaderProgress:genDoubleHeader(title_left, title_right)
 end
 
 function ReaderProgress:genWeekStats(stats_day)
-    local dayOfWeekTranslation = {
-        ["Monday"] = _("Monday"),
-        ["Tuesday"] = _("Tuesday"),
-        ["Wednesday"] = _("Wednesday"),
-        ["Thursday"] = _("Thursday"),
-        ["Friday"] = _("Fri"),
-        ["Saturday"] = _("Saturday"),
-        ["Sunday"] = _("Sunday"),
-    }
     local second_in_day = 86400
     local date_format
     local date_format_show
@@ -209,14 +223,16 @@ function ReaderProgress:genWeekStats(stats_day)
     }
 
     for i = 1, stats_day , 1 do
-        date_format = os.date("%Y-%m-%d (%a)" , now_time - second_in_day * (i -1))
+        diff_time = now_time - second_in_day * (i - 1)
+        date_format = string.format("%s (%s)",
+            os.date("%Y-%m-%d", diff_time),
+            shortDayOfWeekTranslation[os.date("%a", diff_time)])
         if self.dates[date_format] ~= nil then
             select_day_time = self.dates[date_format].read
         else
             select_day_time = 0
         end
-        diff_time = now_time - second_in_day * (i - 1)
-        date_format_show = dayOfWeekTranslation[os.date("%A" , diff_time)] .. os.date(" (%d.%m)" , diff_time)
+        date_format_show = dayOfWeekTranslation[os.date("%A", diff_time)] .. os.date(" (%d.%m)", diff_time)
         local total_group = HorizontalGroup:new{
             align = "center",
             padding = 2,


### PR DESCRIPTION
In statistics plugin day of the week and months can now be translated.
Of course name of days and months must be translated in selected language with Transifex. 
e.g. in English
![zrzut2](https://cloud.githubusercontent.com/assets/22982594/23078833/8f83b8ca-f54a-11e6-9fcb-203bee6edb93.jpg)

e.g. in Polish
![zrzut1](https://cloud.githubusercontent.com/assets/22982594/23078824/895e2c64-f54a-11e6-966c-9a1c99d49004.jpg)


