### PR TITLE
Fix wifi for Aura One

### DIFF
--- a/frontend/dbg.lua
+++ b/frontend/dbg.lua
@@ -48,6 +48,7 @@ function Dbg:turnOn()
         end
     end
 
+    -- TODO: close ev.log fd for children
     -- create or clear ev log file
     self.ev_log = io.open("ev.log", "w")
 end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -594,7 +594,8 @@ function Input:waitEvent(timeout_us)
     if ok and ev then
         if DEBUG.is_on and ev then
             DEBUG:logEv(ev)
-            logger.dbg("ev", ev)
+            logger.dbg(string.format("input event => type: %d, code: %d, value: %d, time: %d.%d",
+                                     ev.type, ev.code, ev.value, ev.time.sec, ev.time.usec))
         end
         self:eventAdjustHook(ev)
         if ev.type == EV_KEY then

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -196,9 +196,11 @@ end
 
 function NetworkMgr:saveNetwork(setting)
     if not self.nw_settings then self:readNWSettings() end
+
     self.nw_settings:saveSetting(setting.ssid, {
         ssid = setting.ssid,
         password = setting.password,
+        psk = setting.psk,
         flags = setting.flags,
     })
     self.nw_settings:flush()

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -49,8 +49,16 @@ function WpaSupplicant:authenticateNetwork(network)
     nw_id, err = wcli:addNetwork()
     if err then return false, err end
 
-    wcli:setNetwork(nw_id, "ssid", network.ssid)
-    wcli:setNetwork(nw_id, "psk", network.password)
+    local re = wcli:setNetwork(nw_id, "ssid", network.ssid)
+    if re == 'FAIL' then
+        wcli:removeNetwork(nw_id)
+        return false, _("Failed to set network SSID.")
+    end
+    re = wcli:setNetwork(nw_id, "psk", network.password)
+    if re == 'FAIL' then
+        wcli:removeNetwork(nw_id)
+        return false, _("Failed to set network password.")
+    end
     wcli:enableNetworkByID(nw_id)
 
     wcli:attach()
@@ -58,7 +66,7 @@ function WpaSupplicant:authenticateNetwork(network)
     local failure_cnt = 0
     local max_retry = 30
     local info = InfoMessage:new{text = _("Authenticating…")}
-    local re, msg
+    local msg
     UIManager:show(info)
     UIManager:forceRePaint()
     while cnt < max_retry do

--- a/platform/kobo/disable-wifi.sh
+++ b/platform/kobo/disable-wifi.sh
@@ -9,9 +9,9 @@ ifconfig eth0 down
 
 # Some sleep in between may avoid system getting hung
 # (we test if a module is actually loaded to avoid unneeded sleeps)
-if lsmod | grep -q dhd ; then
+if lsmod | grep -q $WIFI_MODULE ; then
     usleep 200000
-    rmmod -r dhd
+    rmmod -r $WIFI_MODULE
 fi
 if lsmod | grep -q sdio_wifi_pwr ; then
     usleep 200000

--- a/platform/kobo/enable-wifi.sh
+++ b/platform/kobo/enable-wifi.sh
@@ -12,4 +12,4 @@ wlarm_le -i eth0 up
 
 pidof wpa_supplicant >/dev/null || \
     env -u LD_LIBRARY_PATH \
-    wpa_supplicant -s -ieth0 -O /var/run/wpa_supplicant -c/etc/wpa_supplicant/wpa_supplicant.conf -B
+    wpa_supplicant -D wext -s -ieth0 -O /var/run/wpa_supplicant -c/etc/wpa_supplicant/wpa_supplicant.conf -B

--- a/platform/kobo/enable-wifi.sh
+++ b/platform/kobo/enable-wifi.sh
@@ -3,7 +3,8 @@
 # Load wifi modules and enable wifi.
 
 lsmod | grep -q sdio_wifi_pwr || insmod /drivers/$PLATFORM/wifi/sdio_wifi_pwr.ko
-lsmod | grep -q dhd || insmod /drivers/$PLATFORM/wifi/dhd.ko
+# WIFI_MODULE_PATH = /drivers/$PLATFORM/wifi/$WIFI_MODULE.ko
+lsmod | grep -q $WIFI_MODULE || insmod $WIFI_MODULE_PATH
 sleep 1
 
 ifconfig eth0 up


### PR DESCRIPTION
Aura One uses 8189fs instead of dhd module. Depends on https://github.com/koreader/koreader-base/pull/476.