### PR TITLE
Kobo: remove useless error messages from ntx_hwconfig

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -80,7 +80,7 @@ fi
 
 # check whether PLATFORM & PRODUCT have a value assigned by rcS
 if [ ! -n "${PRODUCT}" ] ; then
-	PRODUCT="$(/bin/kobo_config.sh)"
+	PRODUCT="$(/bin/kobo_config.sh 2>/dev/null)"
 	[ "${PRODUCT}" != "trilogy" ] && PREFIX="${PRODUCT}-"
 	export PRODUCT
 fi
@@ -89,7 +89,7 @@ fi
 if [ ! -n "${PLATFORM}" ] ; then
 	PLATFORM="freescale"
 	if dd if="/dev/mmcblk0" bs=512 skip=1024 count=1 | grep -q "HW CONFIG" ; then
-		CPU="$(ntx_hwconfig -s -p /dev/mmcblk0 CPU)"
+		CPU="$(ntx_hwconfig -s -p /dev/mmcblk0 CPU 2>/dev/null)"
 		PLATFORM="${CPU}-ntx"
 	fi
 


### PR DESCRIPTION
ntx_hwconfig is a tool present in all kobo devices. It reads part of the firmware in the first MBs of the internal card. Variables stored in the "hwconfig" are used by uboot, the kernel itself, some kernel drivers and from userspace. The source code of both uboot and linux contains hooks to read some values and send them to the coproccesor.

Because of FW upgrades the binary: ntx_hwconfig is upgraded but the "hwconfig" storage area is not. So all those warnings "config too old, please upgrade" spammed by koreader came from here and there isn't any simple way to fix it" ( hexadecimal editor != simple way )

kobo_config.sh is a wrapper to ntx_hwconfig BTW

So, its SAFE to avoid those messages