### PR TITLE
.gitignore: add linux-i686 emulator to excluded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ koreader-kindle-arm-linux-gnueabi
 koreader-kobo-arm-linux-gnueabihf*
 koreader-kobo-arm-kobo-linux-gnueabi*
 koreader-emulator-i686-w64-mingw32
+koreader-emulator-i686-linux-gnu
 koreader-emulator-x86_64-linux-gnu
 koreader-emulator-x86_64-pc-linux-gnu
 koreader-emulator-x86_64-apple-darwin*


### PR DESCRIPTION
for 32bits machines