### PR TITLE
TouchMenu: keep file/exit button on the right

### DIFF
--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -203,7 +203,7 @@ function TouchMenuBar:init()
         local icon_sep = LineWidget:new{
             style = k == 1 and "solid" or "none",
             dimen = Geom:new{
-                w = Screen:scaleBySize(2),
+                w = icon_sep_width,
                 h = self.height,
             }
         }
@@ -219,6 +219,18 @@ function TouchMenuBar:init()
             for i, sep in ipairs(self.icon_seps) do
                 local current_icon = i == k - 1 or i == k
                 self.icon_seps[i].style = current_icon and "solid" or "none"
+
+                -- if this is the before last seperator then extend it to put the last icon on the right
+                if i == #self.icon_seps - 1 then
+                    self.icon_seps[i].dimen = Geom:new{
+                        -- self.width is the screen width
+                        -- content_width is the width of the icons
+                        -- (math.min(spacing_width, Screen:scaleBySize(20)) * #self.icons *2) is the combined width of spacing/separators
+                        -- icon_sep_width is the standard icon separator width
+                        w = self.width - content_width - (math.min(spacing_width, Screen:scaleBySize(20)) * #self.icons *2) + icon_sep_width,
+                        h = self.height,
+                    }
+                end
             end
             self.menu:switchMenuTab(k)
         end


### PR DESCRIPTION
References #2555.

Before:
![screenshot_2017-02-24_16-29-57](https://cloud.githubusercontent.com/assets/202757/23309337/9f4ddd9e-faae-11e6-948c-0a2871737cfd.png)

After:
![screenshot_2017-02-24_16-30-27](https://cloud.githubusercontent.com/assets/202757/23309343/a4adcdc6-faae-11e6-8e71-78d482754590.png)
![screenshot_2017-02-24_16-30-47](https://cloud.githubusercontent.com/assets/202757/23309344/a4cd1e42-faae-11e6-80b6-fe360113cac0.png)