### PR TITLE
FileSearcher: also show directory results

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -42,6 +42,7 @@ function FileSearcher:readDir()
                 local attributes = lfs.attributes(fullpath)
                 if attributes.mode == "directory" and f ~= "." and f~=".." then
                     table.insert(new_dirs, fullpath)
+                    table.insert(self.files, {name = f, path = fullpath, attr = attributes})
                 elseif attributes.mode == "file" and DocumentRegistry:getProvider(fullpath) then
                     table.insert(self.files, {name = f, path = fullpath, attr = attributes})
                 end
@@ -52,6 +53,7 @@ function FileSearcher:readDir()
 end
 
 function FileSearcher:setSearchResults()
+    local FileManager = require("apps/filemanager/filemanager")
     local ReaderUI = require("apps/reader/readerui")
     local keywords = self.search_value
     --DEBUG("self.files", self.files)
@@ -62,12 +64,21 @@ function FileSearcher:setSearchResults()
         for __,f in pairs(self.files) do
         DEBUG("f", f)
             if string.find(string.lower(f.name), string.lower(keywords)) then
-                f.text = f.name
-                f.name = nil
-                f.callback = function()
-                    ReaderUI:showReader(f.path)
+                if f.attr.mode == "directory" then
+                    f.text = f.name.."/"
+                    f.name = nil
+                    f.callback = function()
+                        FileManager:showFiles(f.path)
+                    end
+                    table.insert(self.results, f)
+                else
+                    f.text = f.name
+                    f.name = nil
+                    f.callback = function()
+                        ReaderUI:showReader(f.path)
+                    end
+                    table.insert(self.results, f)
                 end
-                table.insert(self.results, f)
             end
         end
     end


### PR DESCRIPTION
Fixes #2177 

## Search for `epub2`
![screenshot_2017-02-25_15-28-37](https://cloud.githubusercontent.com/assets/202757/23331889/2c8dd810-fb6f-11e6-8c14-2c6d39717a17.png)

## Results before
![screenshot_2017-02-25_15-29-03](https://cloud.githubusercontent.com/assets/202757/23331891/2c8ec2de-fb6f-11e6-8ff3-7a5d30c1d57f.png)

## Results after
![screenshot_2017-02-25_15-28-23](https://cloud.githubusercontent.com/assets/202757/23331890/2c8e6226-fb6f-11e6-97b3-8b2a69c3c0c5.png)

## As part of result list for `epub`
![screenshot_2017-02-25_15-30-33](https://cloud.githubusercontent.com/assets/202757/23331906/63f18a68-fb6f-11e6-966a-9d495afdbcd0.png)
