### PR TITLE
Update kobolight plugin to support kindle

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -46,6 +46,7 @@ function Kindle:usbPlugIn()
 end
 
 function Kindle:intoScreenSaver()
+    self.powerd:beforeSuspend()
     if self.charging_mode == false and self.screen_saver_mode == false then
         self.screen:saveCurrentBB()
         self.screen_saver_mode = true
@@ -74,6 +75,7 @@ function Kindle:outofScreenSaver()
         self.powerd:refreshCapacity()
     end
     self.screen_saver_mode = false
+    self.powerd:afterResume()
 end
 
 function Kindle:usbPlugOut()

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -8,6 +8,8 @@ local KindlePowerD = BasePowerD:new{
     battCapacity = nil,
     is_charging = nil,
     lipc_handle = nil,
+
+    is_fl_on = false,
 }
 
 function KindlePowerD:init()
@@ -21,6 +23,7 @@ function KindlePowerD:init()
         else
             self.fl_intensity = self:read_int_file(self.fl_intensity_file)
         end
+        self.is_fl_on = (self.fl_intensity > 0)
     end
 end
 
@@ -29,9 +32,11 @@ function KindlePowerD:toggleFrontlight()
     if sysint == 0 then
         -- NOTE: We want to bypass setIntensity's shenanigans and simply restore the light as-is
         self:setIntensityHW()
+        self.is_fl_on = true
     else
         -- NOTE: We want to really kill the light, so do it manually (asking lipc to set it to 0 would in fact set it to 1)...
         os.execute("echo -n 0 > " .. self.fl_intensity_file)
+        self.is_fl_on = false
     end
 end
 

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -73,16 +73,13 @@ function KindlePowerD:__gc()
 end
 
 function KindlePowerD:_turnOffFL()
+    -- NOTE: We want to really kill the light, so do it manually (asking lipc to set it to 0 would in fact set it to 1)...
     os.execute("echo -n 0 > " .. self.fl_intensity_file)
     self.is_fl_on = false
 end
 
 function KindlePowerD:_readFLIntensity()
-    if self.lipc_handle ~= nil then
-        return self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
-    else
-        return self:read_int_file(self.fl_intensity_file)
-    end
+    return self:read_int_file(self.fl_intensity_file)
 end
 
 function KindlePowerD:_set_fl_on()

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -18,7 +18,13 @@ function KindlePowerD:init()
         self.lipc_handle = lipc.init("com.github.koreader.kindlepowerd")
     end
     if self.device.hasFrontlight() then
-        self.fl_intensity = self:_readFLIntensity()
+        -- Kindle stock software does not use intensity file directly, so we need to read from its
+        -- lipc property first.
+        if self.lipc_handle ~= nil then
+            self.fl_intensity = self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
+        else
+            self.fl_intensity = self:_readFLIntensity()
+        end
         self:_set_fl_on()
     end
 end

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -18,34 +18,33 @@ function KindlePowerD:init()
         self.lipc_handle = lipc.init("com.github.koreader.kindlepowerd")
     end
     if self.device.hasFrontlight() then
-        if self.lipc_handle ~= nil then
-            self.fl_intensity = self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
-        else
-            self.fl_intensity = self:read_int_file(self.fl_intensity_file)
-        end
-        self.is_fl_on = (self.fl_intensity > 0)
+        self.fl_intensity = self:_readFLIntensity()
+        self:_set_fl_on()
     end
 end
 
 function KindlePowerD:toggleFrontlight()
-    local sysint = self:read_int_file(self.fl_intensity_file)
-    if sysint == 0 then
-        -- NOTE: We want to bypass setIntensity's shenanigans and simply restore the light as-is
+    if not self.device.hasFrontlight() then
+        return
+    end
+
+    if self:_readFLIntensity() == 0 then
         self:setIntensityHW()
-        self.is_fl_on = true
     else
-        -- NOTE: We want to really kill the light, so do it manually (asking lipc to set it to 0 would in fact set it to 1)...
-        os.execute("echo -n 0 > " .. self.fl_intensity_file)
-        self.is_fl_on = false
+        self:_turnOffFL()
     end
 end
 
 function KindlePowerD:setIntensityHW()
-    if self.lipc_handle ~= nil then
+    if self.lipc_handle ~= nil and self.fl_intensity > 0 then
+        -- NOTE: We want to bypass setIntensity's shenanigans and simply restore the light as-is
         self.lipc_handle:set_int_property("com.lab126.powerd", "flIntensity", self.fl_intensity)
     else
+        -- NOTE: when fl_intensity is 0, We want to really kill the light, so do it manually
+        -- (asking lipc to set it to 0 would in fact set it to 1)...
         os.execute("echo -n ".. self.fl_intensity .." > " .. self.fl_intensity_file)
     end
+    self:_set_fl_on()
 end
 
 function KindlePowerD:getCapacityHW()
@@ -70,6 +69,36 @@ function KindlePowerD:__gc()
     if self.lipc_handle then
         self.lipc_handle:close()
         self.lipc_handle = nil
+    end
+end
+
+function KindlePowerD:_turnOffFL()
+    os.execute("echo -n 0 > " .. self.fl_intensity_file)
+    self.is_fl_on = false
+end
+
+function KindlePowerD:_readFLIntensity()
+    if self.lipc_handle ~= nil then
+        return self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
+    else
+        return self:read_int_file(self.fl_intensity_file)
+    end
+end
+
+function KindlePowerD:_set_fl_on()
+    self.is_fl_on = (self.fl_intensity > 0)
+end
+
+function KindlePowerD:afterResume()
+    if not self.device.hasFrontlight() then
+        return
+    end
+    if self.is_fl_on then
+        -- Kindle stock software should turn on the front light automatically. The follow statement
+        -- ensure the consistency of intensity.
+        self:setIntensityHW()
+    else
+        self:_turnOffFL()
     end
 end
 

--- a/plugins/kobolight.koplugin/main.lua
+++ b/plugins/kobolight.koplugin/main.lua
@@ -1,6 +1,6 @@
 local Device = require("device")
 
-if not (Device:isKobo() and Device:hasFrontlight()) then
+if not ((Device:isKindle() or Device:isKobo()) and Device:hasFrontlight()) then
     return { disabled = true, }
 end
 
@@ -72,6 +72,12 @@ end
 function KoboLight:resetLayout()
     local new_screen_height = Screen:getHeight()
     self.gestureScale = new_screen_height * swipe_touch_zone_ratio.h * 0.8
+    local powerd = Device:getPowerDevice()
+    local scale = (powerd.fl_max - powerd.fl_min) / 20
+    for i = 1, #self.steps, 1
+    do
+        self.steps[i] = math.floor(self.steps[i] * scale)
+    end
 end
 
 function KoboLight:onShowIntensity()

--- a/plugins/kobolight.koplugin/main.lua
+++ b/plugins/kobolight.koplugin/main.lua
@@ -17,21 +17,16 @@ local swipe_touch_zone_ratio = { x = 0, y = 1/8, w = 1/10, h = 7/8, }
 
 local KoboLight = WidgetContainer:new{
     name = 'kobolight',
-    steps = { 0, 0.01, 0.01, 0.01, 1, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10, },
+    steps = { 0.1, 0.1, 0.2, 0.4, 0.7, 1.1, 1.6, 2.2, 2.9, 3.7, 4.6, 5.6, 6.7, 7.9, 9.2, 10.6, },
     gestureScale = nil,  -- initialized in self:resetLayout()
 }
 
 function KoboLight:init()
     local powerd = Device:getPowerDevice()
-    local scale = (powerd.fl_max - powerd.fl_min) / 20
+    local scale = (powerd.fl_max - powerd.fl_min) / 2 / 10.6
     for i = 1, #self.steps, 1
     do
-        self.steps[i] = self.steps[i] * scale
-        if self.steps[i] > 0 and self.steps[i] < 1 then
-            self.steps[i] = 1
-        else
-            self.steps[i] = math.floor(self.steps[i])
-        end
+        self.steps[i] = math.ceil(self.steps[i] * scale)
     end
 end
 

--- a/plugins/kobolight.koplugin/main.lua
+++ b/plugins/kobolight.koplugin/main.lua
@@ -17,9 +17,23 @@ local swipe_touch_zone_ratio = { x = 0, y = 1/8, w = 1/10, h = 7/8, }
 
 local KoboLight = WidgetContainer:new{
     name = 'kobolight',
-    steps = { 0, 1, 1, 1, 1, 2, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10, },
+    steps = { 0, 0.01, 0.01, 0.01, 1, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10, },
     gestureScale = nil,  -- initialized in self:resetLayout()
 }
+
+function KoboLight:init()
+    local powerd = Device:getPowerDevice()
+    local scale = (powerd.fl_max - powerd.fl_min) / 20
+    for i = 1, #self.steps, 1
+    do
+        self.steps[i] = self.steps[i] * scale
+        if self.steps[i] > 0 and self.steps[i] < 1 then
+            self.steps[i] = 1
+        else
+            self.steps[i] = math.floor(self.steps[i])
+        end
+    end
+end
 
 function KoboLight:onReaderReady()
     self:setupTouchZones()
@@ -72,12 +86,6 @@ end
 function KoboLight:resetLayout()
     local new_screen_height = Screen:getHeight()
     self.gestureScale = new_screen_height * swipe_touch_zone_ratio.h * 0.8
-    local powerd = Device:getPowerDevice()
-    local scale = (powerd.fl_max - powerd.fl_min) / 20
-    for i = 1, #self.steps, 1
-    do
-        self.steps[i] = math.floor(self.steps[i] * scale)
-    end
 end
 
 function KoboLight:onShowIntensity()


### PR DESCRIPTION
The kobolight plugin is more useful on Kindle, which does not have a hardware front light toggle. So I changed frontend/device/kindle/powerd to support kobolight.

Meanwhile, this change modifies the steps in kobolight.koplugin, the original gesture level seems too small, and it should respect fl_min / fl_max. (Front light intensity on Kobo Aura HD has 100 levels, i.e. you need to swipe up 10 times to fully turn on the light.) If the behavior is expected, though I do not really think so, I am happy to remove it.
This change also modifies frontend/device/kindle/device, 0 is not a valid value for kindle front light intensity. Once the front light is fully turned off in KOReader, it turned back on again after resume. So we need to manually handle it in powerd:afterResume().