### PR TITLE
OPDS catalog: improve download dialog (#2445)

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -1,5 +1,6 @@
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local ButtonDialog = require("ui/widget/buttondialog")
+local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local InfoMessage = require("ui/widget/infomessage")
 local LoginDialog = require("ui/widget/logindialog")
 local OPDSParser = require("ui/opdsparser")
@@ -9,7 +10,7 @@ local CacheItem = require("cacheitem")
 local Menu = require("ui/widget/menu")
 local Screen = require("device").screen
 local url = require('socket.url')
-local util = require("ffi/util")
+local T = require("ffi/util").template
 local Cache = require("cache")
 local logger = require("logger")
 local _ = require("gettext")
@@ -359,7 +360,7 @@ function OPDSBrowser:getCatalog(feed_url)
     elseif not ok and catalog then
         logger.warn("cannot get catalog info from", feed_url, catalog)
         UIManager:show(InfoMessage:new{
-            text = util.template(
+            text = T(
                 _("Cannot get catalog info from %1"),
                 (feed_url or "")
             ),
@@ -482,10 +483,14 @@ function OPDSBrowser:appendCatalog(item_table_url)
     return true
 end
 
+function OPDSBrowser.getCurrentDownloadDir()
+    local lastdir = G_reader_settings:readSetting("lastdir")
+    return G_reader_settings:readSetting("download_dir") or lastdir
+end
+
 function OPDSBrowser:downloadFile(item, format, remote_url)
     -- download to user selected directory or last opened dir
-    local lastdir = G_reader_settings:readSetting("lastdir")
-    local download_dir = G_reader_settings:readSetting("download_dir") or lastdir
+    local download_dir = self.getCurrentDownloadDir()
     local utl = require("frontend/util")
     local file_system = utl.getFilesystemType(download_dir)
     if file_system == "vfat" or file_system == "fuse.fsp" then
@@ -520,6 +525,13 @@ function OPDSBrowser:downloadFile(item, format, remote_url)
     end
 end
 
+function OPDSBrowser:createNewDownloadDialog(path, buttons)
+    self.download_dialog = ButtonDialogTitle:new{
+        title = T(_("Download directory:\n%1\n\nDownload file type:"), path),
+        buttons = buttons
+    }
+end
+
 function OPDSBrowser:showDownloads(item)
     local acquisitions = item.acquisitions
     local downloadsperline = 2
@@ -534,7 +546,8 @@ function OPDSBrowser:showDownloads(item)
             if acquisition then
                 local format = self.formats[acquisition.type]
                 if format then
-                    button.text = format
+                    -- append DOWNWARDS BLACK ARROW ⬇ U+2B07 to format
+                    button.text = format .. "\xE2\xAC\x87"
                     button.callback = function()
                         UIManager:scheduleIn(1, function()
                             self:downloadFile(item, format, acquisition.href)
@@ -547,10 +560,13 @@ function OPDSBrowser:showDownloads(item)
                     end
                     table.insert(line, button)
                 end
+            elseif #acquisitions > downloadsperline then
+                table.insert(line, {text=""})
             end
         end
         table.insert(buttons, line)
     end
+    table.insert(buttons, {})
     -- set download directory button
     table.insert(buttons, {
         {
@@ -561,15 +577,18 @@ function OPDSBrowser:showDownloads(item)
                     onConfirm = function(path)
                         logger.dbg("set download directory to", path)
                         G_reader_settings:saveSetting("download_dir", path)
+                        UIManager:nextTick(function()
+                            UIManager:close(self.download_dialog)
+                            self:createNewDownloadDialog(path, buttons)
+                            UIManager:show(self.download_dialog)
+                        end)
                     end,
                 }:chooseDir()
             end,
         }
     })
 
-    self.download_dialog = ButtonDialog:new{
-        buttons = buttons
-    }
+    self:createNewDownloadDialog(self.getCurrentDownloadDir(), buttons)
     UIManager:show(self.download_dialog)
 end
 


### PR DESCRIPTION
* Add action clarification to format download dialog

The format download dialog now has a title reflecting where a format will be downloaded with a prefix making it clear that choosing a format will download it.