### PR TITLE
Change menu entry to "Show advanced options for PDFs"

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -77,7 +77,7 @@ table.insert(common_settings, {
 })
 table.insert(common_settings, Language:getLangMenuTable())
 table.insert(common_settings, {
-    text = _("Show advanced options"),
+    text = _("Show advanced options for PDFs"),
     checked_func = function() return G_reader_settings:readSetting("show_advanced") end,
     callback = function()
         local show_advanced = G_reader_settings:readSetting("show_advanced") or false


### PR DESCRIPTION
Imho the "Show advanced options" menu entry should be filled with content, so advanced options like "Developer options", "Keep alive" and others could be visible only when "Show advanced options" is ticked. Until that is implemented, if it ever is, this tiny PR could be useful.
The menu entry "Show advanced options" is only used to show some options when opening PDFs (is it used too when opening Djvu?), so changing its name makes the menu entry more explanatory. Other possible names could be "Show advanced PDF options" or "Show advanced options for PDF files".