### PR TITLE
Prompt users to turn on Wifi in Cloud Storage and OPDS Browser

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -101,6 +101,11 @@ end
 
 function CloudStorage:openCloudServer(url)
     local tbl
+    local NetworkMgr = require("ui/network/manager")
+    if not NetworkMgr:isOnline() then
+        NetworkMgr:promptWifiOn()
+        return
+    end
     if self.type == "dropbox" then
         tbl = DropBox:run(url, self.password)
     elseif self.type == "ftp" then

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -353,9 +353,7 @@ end
 
 function OPDSBrowser:getCatalog(feed_url)
     local ok, catalog = pcall(self.parseFeed, self, feed_url)
-    -- prompt users to turn on Wifi if network is unreachable
-    if not ok and catalog and (catalog:find("Network is unreachable") or catalog:find("host or service not provided")) then
-        NetworkMgr:promptWifiOn()
+    if not ok and catalog and not NetworkMgr:isOnline() then
         return
     elseif not ok and catalog then
         logger.warn("cannot get catalog info from", feed_url, catalog)

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -354,6 +354,7 @@ end
 function OPDSBrowser:getCatalog(feed_url)
     local ok, catalog = pcall(self.parseFeed, self, feed_url)
     if not ok and catalog and not NetworkMgr:isOnline() then
+        NetworkMgr:promptWifiOn()
         return
     elseif not ok and catalog then
         logger.warn("cannot get catalog info from", feed_url, catalog)


### PR DESCRIPTION
https://github.com/koreader/koreader/issues/2555#issuecomment-283987684

> I think that there are at least two other cases where the gray out option or the asking for enabling WiFi option should be implemented: OPDS catalog and CLoud storage.