### PR TITLE
Fix crash when holding on unsupported image

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -162,8 +162,15 @@ function CreDocument:getImageFromPosition(pos)
         local Mupdf = require("ffi/mupdf")
         -- wrapped with pcall so we always free(data)
         local ok, image = pcall(Mupdf.renderImage, data, size)
-        ffi.C.free(data) -- need that explicite clean
         logger.dbg("Mupdf.renderImage", ok, image)
+        if not ok and string.find(image, "could not load image data: unknown image file format") then
+            -- in that case, mupdf seems to have already freed data (see mupdf/source/fitz/image.c:494),
+            -- as doing outselves ffi.C.free(data) would result in a crash with :
+            -- *** Error in `./luajit': double free or corruption (!prev): 0x0000000000e48a40 ***
+            logger.warn("Mupdf says 'unknown image file format', assuming mupdf has already freed image data")
+        else
+            ffi.C.free(data) -- need that explicite clean
+        end
         if ok then
             return image
         end


### PR DESCRIPTION
When holding on an SVG image (unsupported by MuPDF,  but displayed as a small empty squere by crengine), KOReader would crash with:
`*** Error in ./luajit: double free or corruption (!prev): 0x0000000000e48a40 ***`
when freeing image data from LUA with `ffi.C.free(data)` .
It seems that for some errors, MuPDF does itself free() the data provided.
As I'm not sure if we can know from lua/ffi if a pointer has already been freed (the `data` cdata structure has the same pointer value before and after the error), the easiest fix is to catch that error message and not do the ffi.C.free(data) in that case.
Better a small memory leak if it's not really freed, than a crash.
