### PR TITLE
Update footer when refreshing screen with diagonal swipe

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -524,6 +524,10 @@ function ReaderFooter:onPosUpdate(pos)
     self:updateFooterPos()
 end
 
+function ReaderFooter:onUpdateFooter()
+    self:updateFooter()
+end
+
 -- recalculate footer sizes when document page count is updated
 -- see documentation for more info about this event.
 ReaderFooter.onUpdatePos = ReaderFooter.updateFooter

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -367,6 +367,8 @@ function ReaderPaging:onSwipe(_, ges)
             self:onPagingRel(-1)
         end
     else
+        -- update footer (time & battery)
+        self.view.footer:updateFooter()
         -- trigger full refresh
         UIManager:setDirty(nil, "full")
     end
@@ -849,6 +851,9 @@ end
 -- wrapper for bounds checking
 function ReaderPaging:_gotoPage(number, orig_mode)
     if number == self.current_page or not number then
+        -- update footer even if we stay on the same page (like when
+        -- viewing the bottom part of a page from a top part view)
+        self.view.footer:updateFooter()
         return true
     end
     if number > self.number_of_pages or number < 1 then

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -302,6 +302,11 @@ function ReaderRolling:onSwipe(_, ges)
         else
             self:onGotoViewRel(-1)
         end
+    else
+        -- update footer (time & battery)
+        self.view.footer:updateFooter()
+        -- trigger full refresh
+        UIManager:setDirty(nil, "full")
     end
 end
 

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -627,6 +627,8 @@ function DictQuickLookup:onSwipe(arg, ges)
     elseif ges.direction == "east" then
         self:changeToPrevDict()
     else
+        -- update footer (time & battery)
+        UIManager:broadcastEvent(Event:new("UpdateFooter"))
         -- trigger full refresh
         UIManager:setDirty(nil, "full")
     end


### PR DESCRIPTION
And added diagonal swipe support (which was there in readerpaging) to readerrolling, as requested in #2655.