### PR TITLE
Remove powerd:refreshCapacity()

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -112,7 +112,6 @@ function Device:onPowerEvent(ev)
                     UIManager:scheduleIn(1, function() self.screen:refreshFull() end)
                 end
                 self.screen_saver_mode = false
-                self.powerd:refreshCapacity()
                 self.powerd:afterResume()
             end
         elseif ev == "Suspend" then

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -72,12 +72,6 @@ function BasePowerD:getCapacity()
     return self.battCapacity
 end
 
-function BasePowerD:refreshCapacity()
-    -- We want our next getCapacity call to actually pull up to date info
-    -- instead of a cached value ;)
-    self.last_capacity_pull_time = 0
-end
-
 function BasePowerD:isCharging()
     return self:isChargingHW()
 end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -72,7 +72,6 @@ function Kindle:outofScreenSaver()
         if self:needsScreenRefreshAfterResume() then
             self.screen:refreshFull()
         end
-        self.powerd:refreshCapacity()
     end
     self.screen_saver_mode = false
     self.powerd:afterResume()
@@ -88,7 +87,6 @@ function Kindle:usbPlugOut()
         util.usleep(1500000)
         self.screen:restoreFromSavedBB()
         self.screen:refreshFull()
-        self.powerd:refreshCapacity()
     end
 
     --@TODO signal filemanager for file changes  13.06 2012 (houqp)

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -394,8 +394,6 @@ function TouchMenu:init()
         }
     }
     self.footer_top_margin = VerticalSpan:new{width = Screen:scaleBySize(2)}
-    -- Make sure we always show an up to date battery status when first opening the menu...
-    Device:getPowerDevice():refreshCapacity()
     self.bar:switchToTab(self.last_index or 1)
 end
 


### PR DESCRIPTION
Battery capacity is now refreshed every 60 seconds, so we do not need to actively call refreshCapacity() anymore.