### PR TITLE
readercopt(fix): set view mode after reader is ready

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -1,17 +1,16 @@
 local EventListener = require("ui/widget/eventlistener")
-local Event = require("ui/event")
 
 local ReaderCoptListener = EventListener:new{}
 
 function ReaderCoptListener:onReadSettings(config)
     local view_mode = config:readSetting("copt_view_mode")
     if view_mode == 0 then
-        table.insert(self.ui.postInitCallback, function()
-            self.ui:handleEvent(Event:new("SetViewMode", "page"))
+        self.ui:registerPostReadyCallback(function()
+            self.view:onSetViewMode("page")
         end)
     elseif view_mode == 1 then
-        table.insert(self.ui.postInitCallback, function()
-            self.ui:handleEvent(Event:new("SetViewMode", "scroll"))
+        self.ui:registerPostReadyCallback(function()
+            self.view:onSetViewMode("scroll")
         end)
     end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -72,6 +72,7 @@ local ReaderUI = InputContainer:new{
     password = nil,
 
     postInitCallback = nil,
+    postReaderCallback = nil,
 }
 
 function ReaderUI:registerModule(name, ui_module, always_active)
@@ -84,8 +85,13 @@ function ReaderUI:registerPostInitCallback(callback)
     table.insert(self.postInitCallback, callback)
 end
 
+function ReaderUI:registerPostReadyCallback(callback)
+    table.insert(self.postReaderCallback, callback)
+end
+
 function ReaderUI:init()
     self.postInitCallback = {}
+    self.postReaderCallback = {}
     -- if we are not the top level dialog ourselves, it must be given in the table
     if not self.dialog then
         self.dialog = self
@@ -324,11 +330,17 @@ function ReaderUI:init()
     for _,v in ipairs(self.postInitCallback) do
         v()
     end
+    self.postInitCallback = nil
 
     -- After initialisation notify that document is loaded and rendered
     -- CREngine only reports correct page count after rendering is done
     -- Need the same event for PDF document
     self:handleEvent(Event:new("ReaderReady", self.doc_settings))
+
+    for _,v in ipairs(self.postReaderCallback) do
+        v()
+    end
+    self.postReaderCallback = nil
 end
 
 function ReaderUI:showReader(file)


### PR DESCRIPTION
Otherwise readerrolling will try to jump to a nil xpointer.

fix https://github.com/koreader/koreader/issues/2635.