### PR TITLE
Minor: Reader Frontlight modification

### DIFF
--- a/frontend/apps/reader/modules/readerfrontlight.lua
+++ b/frontend/apps/reader/modules/readerfrontlight.lua
@@ -52,7 +52,14 @@ function ReaderFrontLight:onAdjust(arg, ges)
             new_intensity = powerd.fl_intensity - delta_int
         end
         if new_intensity ~= nil then
+            -- when new_intensity <=0, toggle light off
+            if new_intensity <= 0 then
+                powerd:toggleFrontlight()
+            end
             powerd:setIntensity(new_intensity)
+            if self.view.footer_visible and self.view.footer.settings.frontlight then
+                self.view.footer:updateFooter()
+            end
         end
     end
     return true
@@ -61,8 +68,14 @@ end
 function ReaderFrontLight:onShowIntensity()
     local powerd = Device:getPowerDevice()
     if powerd.fl_intensity ~= nil then
+        local new_text
+        if powerd.fl_intensity == 0 then
+            new_text = _("Frontlight is off.")
+        else
+            new_text = T(_("Frontlight intensity is set to %1."), powerd.fl_intensity)
+        end
         UIManager:show(Notification:new{
-            text = T(_("Frontlight intensity is set to %1."), powerd.fl_intensity),
+            text = new_text,
             timeout = 1.0,
         })
     end


### PR DESCRIPTION
Close #1903 
- add refresh footer after two finger frontlight change
- change info when frontlight is off from `Frontlight intensity is set to 0` to `Frontlight is off` like in KoboLight plugin
- #1903 was resolved earlier