### PR TITLE
WiFi manager bugfix: delete the cached psk when changing the password

### DIFF
--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -255,6 +255,7 @@ function NetworkItem:saveAndConnectToNetwork(password_input)
     else
         if new_passwd ~= self.info.password then
             self.info.password = new_passwd
+            self.info.psk = nil
             NetworkMgr:saveNetwork(self.info)
         end
         self:connect()


### PR DESCRIPTION
Previously, the cached psk, which is derived from the password and
passed to wpa_supplicant, was not updated when changing the password.