### PR TITLE
Force kobo to suspend

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -59,7 +59,20 @@ function UIManager:init()
         -- resume.
         self:_initAutoSuspend()
         self.event_handlers["Suspend"] = function()
-            self:_stopAutoSuspend()
+            if self._stopAutoSuspend then
+                -- TODO(Hzj-jie): Why _stopAutoSuspend could be nil in test cases.
+                --[[
+                frontend/ui/uimanager.lua:62: attempt to call method _stopAutoSuspend (a nil value)
+
+                stack traceback:
+                frontend/ui/uimanager.lua:62: in function Suspend
+                frontend/ui/uimanager.lua:119: in function __default__
+                frontend/ui/uimanager.lua:662: in function handleInput
+                frontend/ui/uimanager.lua:707: in function run
+                spec/front/unit/readerui_spec.lua:32: in function <spec/front/unit/readerui_spec.lua:28>
+                --]]
+                self:_stopAutoSuspend()
+            end
             self:broadcastEvent(Event:new("Suspend"))
             Device:onPowerEvent("Suspend")
         end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -116,7 +116,7 @@ function UIManager:init()
                 -- Suspension in Kobo can be interrupted by screen updates. We
                 -- ignore user touch input here so screen udpate won't be
                 -- triggered in suspend mode
-                return
+                self.event_handlers["Suspend"]()
             else
                 self:sendEvent(input_event)
             end


### PR DESCRIPTION
With the BatteryStats plugin, I found my Kobo Aura HD resumes unexpectedly.

Without this change, the device resumed randomly. Though I had not used it, it waked up for 4170 minutes.
![reader_2017-mar-25_155421](https://cloud.githubusercontent.com/assets/1188462/24438894/7d38419e-13ff-11e7-8792-361e03d3e37a.png)

With this change, the device had not resumed randomly anymore. (Technically speaking, it still randomly resumed, but got suspended immediately. I will add a system stats plugin later to track the issue.)
Day 1,
![reader_2017-mar-27_222715](https://cloud.githubusercontent.com/assets/1188462/24438896/7d3f83aa-13ff-11e7-81f0-a87df9393396.png)
![reader_2017-mar-27_223507](https://cloud.githubusercontent.com/assets/1188462/24438895/7d3d481a-13ff-11e7-9442-0263ea55e021.png)
Day 2,
![reader_2017-mar-28_212830](https://cloud.githubusercontent.com/assets/1188462/24438893/7d322fca-13ff-11e7-9161-148baba96999.png)
