### PR TITLE
CreDocument: disable fancy formatting by default

### DIFF
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -50,6 +50,11 @@ function ReaderTypeset:onReadSettings(config)
     self.floating_punctuation = config:readSetting("floating_punctuation") or
         G_reader_settings:readSetting("floating_punctuation") or 1
     self:toggleFloatingPunctuation(self.floating_punctuation)
+
+    -- default to disable txt formatting as it does more harm than good
+    self.txt_preformatted = config:readSetting("txt_preformatted") or
+        G_reader_settings:readSetting("txt_preformatted") or 1
+    self:toggleTxtPreFormatted(self.txt_preformatted)
 end
 
 function ReaderTypeset:onSaveSettings()
@@ -137,6 +142,11 @@ function ReaderTypeset:toggleFloatingPunctuation(toggle)
         toggle = 0
     end
     self.ui.document:setFloatingPunctuation(toggle)
+    self.ui:handleEvent(Event:new("UpdatePos"))
+end
+
+function ReaderTypeset:toggleTxtPreFormatted(toggle)
+    self.ui.document:setTxtPreFormatted(toggle)
     self.ui:handleEvent(Event:new("UpdatePos"))
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -427,6 +427,13 @@ function CreDocument:setFloatingPunctuation(enabled)
     self._document:setIntProperty("crengine.style.floating.punctuation.enabled", enabled)
 end
 
+function CreDocument:setTxtPreFormatted(enabled)
+    logger.dbg("CreDocument: set txt preformatted", enabled)
+    self._document:setIntProperty("crengine.file.txt.preformatted", enabled)
+    -- monospace is really kind of ugly for this...
+    self._document:setStringProperty("styles.pre.font-face", "font-family: \"" .. self.default_font .. "\"")
+end
+
 function CreDocument:getVisiblePageCount()
     return self._document:getVisiblePageCount()
 end
@@ -458,8 +465,8 @@ function CreDocument:findText(pattern, origin, reverse, caseInsensitive)
 end
 
 function CreDocument:register(registry)
-    registry:addProvider("txt", "application/txt", self)
-    registry:addProvider("log", "application/txt", self)
+    registry:addProvider("txt", "text/plain", self)
+    registry:addProvider("log", "text/plain", self)
     registry:addProvider("txt.zip", "application/zip", self)
     registry:addProvider("log.zip", "application/zip", self)
     registry:addProvider("epub", "application/epub", self)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1,13 +1,13 @@
-local CreOptions = require("ui/data/creoptions")
-local Document = require("document/document")
 local Blitbuffer = require("ffi/blitbuffer")
-local lfs = require("libs/libkoreader-lfs")
+local CreOptions = require("ui/data/creoptions")
 local DataStorage = require("datastorage")
+local Document = require("document/document")
+local Font = require("ui/font")
 local Geom = require("ui/geometry")
 local Screen = require("device").screen
-local Font = require("ui/font")
-local logger = require("logger")
 local ffi = require("ffi")
+local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
 
 local CreDocument = Document:new{
     -- this is defined in kpvcrlib/crengine/crengine/include/lvdocview.h
@@ -430,8 +430,6 @@ end
 function CreDocument:setTxtPreFormatted(enabled)
     logger.dbg("CreDocument: set txt preformatted", enabled)
     self._document:setIntProperty("crengine.file.txt.preformatted", enabled)
-    -- monospace is really kind of ugly for this...
-    self._document:setStringProperty("styles.pre.font-face", "font-family: \"" .. self.default_font .. "\"")
 end
 
 function CreDocument:getVisiblePageCount()


### PR DESCRIPTION
It does significantly more harm than good. It can be reenabled with a `txt_preformatted` setting. Fixes #1607.

## Before
![screenshot_2017-04-01_16-35-19](https://cloud.githubusercontent.com/assets/202757/24579639/5e602c1c-16f9-11e7-8fd2-974c5e82f3b4.png)

## After
![screenshot_2017-04-01_16-33-42](https://cloud.githubusercontent.com/assets/202757/24579638/5e5bca82-16f9-11e7-889b-421eddd23bbb.png)

(Screenshots made with the file from #2422.)