### PR TITLE
timesync: fix ntpd sync after RTC reset

### DIFF
--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -4,7 +4,7 @@ local Device = require("device")
 local command
 -- TODO(hzj-jie): Does pocketbook provide ntpdate?
 if Device:isKobo() then
-    command = "ntpd -q -n -p pool.ntp.org"
+    command = "ntpd -q -n -g -p pool.ntp.org"
 elseif Device:isKindle() or Device:isPocketBook() then
     command = "ntpdate pool.ntp.org"
 else


### PR DESCRIPTION
When the battery is fully drained in Kobo devices, the RTC is
reset. After such an occurence, synchronisation via ntpd failed
because ntpd refuses to change the system time if the offset
exceeds a threshold (1000s by default).