### PR TITLE
Disable the network asynchronously to avoid blocking the UI

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -124,11 +124,6 @@ function Device:onPowerEvent(ev)
     -- else we we not in screensaver mode
     elseif ev == "Power" or ev == "Suspend" then
         self.powerd:beforeSuspend()
-        local network_manager = require("ui/network/manager")
-        if network_manager.wifi_was_on then
-            network_manager:releaseIP()
-            network_manager:turnOffWifi()
-        end
         local UIManager = require("ui/uimanager")
         -- flushing settings first in case the screensaver takes too long time
         -- that flushing has no chance to run
@@ -140,7 +135,14 @@ function Device:onPowerEvent(ev)
         require("ui/screensaver"):show("suspend", _("Sleeping"))
         self.screen:refreshFull()
         self.screen_saver_mode = true
-        UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend)
+        UIManager:scheduleIn(0.1, function()
+          local network_manager = require("ui/network/manager")
+          if network_manager.wifi_was_on then
+              network_manager:releaseIP()
+              network_manager:turnOffWifi()
+          end
+          UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend)
+        end)
     end
 end
 


### PR DESCRIPTION
Noticeable latency between toggling the power switch and the device
showing the screensaver has been tracked down to the two network
manager calls. This change allows the screen to be updated first.
Note that unloading the open source brcmfmac driver used on okreader
is slower than unloading the proprietary driver shipped by Kobo,
making this delay even more noticeable.

self.suspend() is scheduled after the network manager calls to avoid
race conditions.