### PR TITLE
Remove invalid UTF8 chars from FTP (cloud storage) and sort order of requires

### DIFF
--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -1,12 +1,14 @@
-local FtpApi = require("frontend/apps/cloudstorage/ftpapi")
 local ConfirmBox = require("ui/widget/confirmbox")
+local FtpApi = require("frontend/apps/cloudstorage/ftpapi")
 local InfoMessage = require("ui/widget/infomessage")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
+local ReaderUI = require("apps/reader/readerui")
+local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 local T = require("ffi/util").template
-local ReaderUI = require("apps/reader/readerui")
-local Screen = require("device").screen
+
+
 
 local Ftp = {
 }
@@ -33,6 +35,8 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
     local url = generateUrl(address, user, pass) .. item.url
     local response = FtpApi:downloadFile(url)
     if response ~= nil then
+        local util = require("util")
+        path = util.fixUtf8(path, "_")
         local file = io.open(path, "w")
         file:write(response)
         file:close()

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -5,10 +5,9 @@ local MultiInputDialog = require("ui/widget/multiinputdialog")
 local ReaderUI = require("apps/reader/readerui")
 local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
+local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
-
-
 
 local Ftp = {
 }
@@ -35,7 +34,6 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
     local url = generateUrl(address, user, pass) .. item.url
     local response = FtpApi:downloadFile(url)
     if response ~= nil then
-        local util = require("util")
         path = util.fixUtf8(path, "_")
         local file = io.open(path, "w")
         file:write(response)

--- a/frontend/apps/cloudstorage/ftpapi.lua
+++ b/frontend/apps/cloudstorage/ftpapi.lua
@@ -1,7 +1,7 @@
+local DocumentRegistry = require("document/documentregistry")
 local ftp = require("socket.ftp")
 local ltn12 = require("ltn12")
 local url = require("socket.url")
-local DocumentRegistry = require("document/documentregistry")
 
 local FtpApi = {
 }


### PR DESCRIPTION
Sort order of requires in ftp.lua and ftpapi.lua.