### PR TITLE
Fix showing footer on Kindle with Special Offers screensaver

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -625,6 +625,16 @@ end
 
 function ReaderFooter:onResume()
     self:updateFooter()
+    if self.settings.auto_refresh_time then
+        self:setupAutoRefreshTime()
+    end
+end
+
+function ReaderFooter:onSuspend()
+    if self.settings.auto_refresh_time then
+        UIManager:unschedule(self.autoRefreshTime)
+        self.onCloseDocument = nil
+    end
 end
 
 return ReaderFooter


### PR DESCRIPTION
Device: Kindle Paperwhite with Special Offers (with ads)
Auto refresh time is enabled (Status bar -> Auto refresh time)
When device is going sleep ads is showing from Amazon. Up to 1 minute footer is showing:
![_img1](https://cloud.githubusercontent.com/assets/22982594/24672985/ea8775b8-1976-11e7-9ab9-81159982cb60.jpg)

This patch should fix it (remove footer from screen with ads).
