### PR TITLE
UX and language fixes

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -1,16 +1,16 @@
-local UIManager = require("ui/uimanager")
-local Screen = require("device").screen
-local _ = require("gettext")
-local Menu = require("ui/widget/menu")
-local InfoMessage = require("ui/widget/infomessage")
 local ButtonDialog = require("ui/widget/buttondialog")
-local DropBox = require("frontend/apps/cloudstorage/dropbox")
-local LuaSettings = require("luasettings")
-local DataStorage = require("datastorage")
-local Ftp = require("frontend/apps/cloudstorage/ftp")
-local ConfirmBox = require("ui/widget/confirmbox")
-local lfs = require("libs/libkoreader-lfs")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+local ConfirmBox = require("ui/widget/confirmbox")
+local DataStorage = require("datastorage")
+local DropBox = require("frontend/apps/cloudstorage/dropbox")
+local InfoMessage = require("ui/widget/infomessage")
+local Ftp = require("frontend/apps/cloudstorage/ftp")
+local Menu = require("ui/widget/menu")
+local LuaSettings = require("luasettings")
+local Screen = require("device").screen
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+local lfs = require("libs/libkoreader-lfs")
 
 local CloudStorage = Menu:extend{
     cloud_servers = {
@@ -181,7 +181,7 @@ function CloudStorage:cloudFile(item, path)
                         end)
                         UIManager:close(self.download_dialog)
                         UIManager:show(InfoMessage:new{
-                            text = _("Downloading may take several minutes..."),
+                            text = _("Downloading may take several minutes…"),
                             timeout = 1,
                         })
                     elseif self.type == "ftp" then
@@ -193,7 +193,7 @@ function CloudStorage:cloudFile(item, path)
                         end)
                         UIManager:close(self.download_dialog)
                         UIManager:show(InfoMessage:new{
-                            text = _("Downloading may take several minutes..."),
+                            text = _("Downloading may take several minutes…"),
                             timeout = 1,
                         })
                     end

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -1,13 +1,13 @@
-local InfoMessage = require("ui/widget/infomessage")
 local ConfirmBox = require("ui/widget/confirmbox")
-local NetworkMgr = require("ui/network/manager")
-local lfs = require("libs/libkoreader-lfs")
 local DataStorage = require("datastorage")
-local UIManager = require("ui/uimanager")
 local Device = require("device")
+local InfoMessage = require("ui/widget/infomessage")
+local NetworkMgr = require("ui/network/manager")
+local UIManager = require("ui/uimanager")
+local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
-local T = require("ffi/util").template
 local _ = require("gettext")
+local T = require("ffi/util").template
 
 local ota_dir = DataStorage:getDataDir() .. "/ota/"
 
@@ -131,7 +131,7 @@ function OTAManager:fetchAndProcessUpdate()
     local ota_version, local_version = OTAManager:checkUpdate()
     if ota_version == 0 then
         UIManager:show(InfoMessage:new{
-            text = _("Your KOReader is up to date."),
+            text = _("KOReader is up to date."),
         })
     elseif ota_version == nil then
         local channel = ota_channels[OTAManager:getOTAChannel()]

--- a/plugins/keepalive.koplugin/main.lua
+++ b/plugins/keepalive.koplugin/main.lua
@@ -1,4 +1,3 @@
-
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local UIManager = require("ui/uimanager")
@@ -15,14 +14,14 @@ local enable
 
 local function showConfirmBox()
     UIManager:show(ConfirmBox:new{
-        text = _("The system won't sleep when this message is showing.\nPress \"Stay alive\" if you prefer to keep system on even after closing this notification. *It will drain the battery.*\n\nIf for any reasons KOReader died before \"Close\" is pressed, please start and close KeepAlive plugin again to ensure settings are reset."),
-        ok_text = _("Close"),
-        ok_callback = function()
+        text = _("The system won't sleep while this message is showing.\n\nPress \"Stay alive\" if you prefer to keep the system on even after closing this notification. *This will drain the battery*.\n\nIf KOReader terminates before \"Close\" is pressed, please start and close the KeepAlive plugin again to ensure settings are reset."),
+        cancel_text = _("Close"),
+        cancel_callback = function()
             disable()
             menuItem.checked =false
         end,
-        cancel_text = _("Stay alive"),
-        cancel_callback = function()
+        ok_text = _("Stay alive"),
+        ok_callback = function()
             menuItem.checked = true
         end,
     })


### PR DESCRIPTION
* lang: changed `...` in CloudStorage to real ellipses
* chore: reordered requires in CloudStorage per coding style
* UX: switched "Close" and "Stay alive" in KeepAlive per UX style
* lang: improved message in CloudStorage
* chore: reordered requires in OTAManager per coding style
* lang: removed "your" from "Your KOReader is up to date" in OTAManager