### PR TITLE
Workaround to support new kobo firmwares (+4.0) without needing KSM8

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -114,8 +114,19 @@ fi
 # we keep maximum 500K worth of crash log
 cat crash.log 2> /dev/null | tail -c 500000 > crash.log.new
 mv -f crash.log.new crash.log
+
+# TODO: add support for 32bit framebuffer in koreader. This is a workaround
+# to run koreader in 16bpp. Useful since FW 4.0
+FB_BPP=$(cat /sys/class/graphics/fb0/bits_per_pixel)
+[ "$FB_BPP" -gt 16 ] && /usr/sbin/fbset -depth 16
+# fix rotation issues on Kobo Aura HD (dragon) and Kobo Aura H2O (dahlia)
+case "$PRODUCT" in "dragon" | "dahlia" ) cat /sys/class/graphics/fb0/rotate > /sys/class/graphics/fb0/rotate ;; esac
+
 ./reader.lua "${args}" >> crash.log 2>&1
 RESULT=$?
+
+# back to default depth in framebuffer.
+[ "$FB_BPP" -gt 16 ] && /usr/sbin/fbset -depth "$FB_BPP"
 
 if [ "${FROM_NICKEL}" = "true" ] ; then
 	if [ "${FROM_KFMON}" != "true" ] ; then

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -139,7 +139,7 @@ if [ "${FROM_NICKEL}" = "true" ] ; then
 		else
 			# By default, if we were called from KFMon, just reboot, because there might be a chance Nickel will get its panties in a serious twist on restore for one reason or another...
 			# And at best, we'd still restart with slightly broken suspend behavior anyway...
-			reboot
+			/sbin/reboot
 		fi
 	fi
 else
@@ -147,7 +147,7 @@ else
 	# NOTE: This is actually achieved by checking if KSM or a KSM-related script is running:
 	#       This might lead to false-positives if you use neither KSM nor advboot to launch KOReader *without nickel running*.
 	if ! pgrep -f kbmenu > /dev/null 2>&1 ; then
-		reboot
+		/sbin/reboot
 	fi
 fi
 


### PR DESCRIPTION
Waiting for #2502. Until now only KSM8 supports new firmware and this is because it uses its own version of koreader.sh.

This forces depth to 16bpp before running koreader.  It was suggested by baskerville on #2542
It also handles weird rotations that I've found on a Kobo Aura HD. AFAIK the same rotation bug happens on Kobo Aura H20 too.
Useful to run koreader from shell, fmon, kfmon...