### PR TITLE
InputContainer: add cancel_text and ok_text

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1,14 +1,14 @@
-local InputContainer = require("ui/widget/container/inputcontainer")
-local DictQuickLookup = require("ui/widget/dictquicklookup")
-local InfoMessage = require("ui/widget/infomessage")
 local DataStorage = require("datastorage")
-local UIManager = require("ui/uimanager")
-local Screen = require("device").screen
 local Device = require("device")
+local DictQuickLookup = require("ui/widget/dictquicklookup")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local InfoMessage = require("ui/widget/infomessage")
 local JSON = require("json")
+local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local util  = require("util")
 local _ = require("gettext")
+local Screen = Device.screen
 local T = require("ffi/util").template
 
 local ReaderDictionary = InputContainer:new{
@@ -28,6 +28,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
         text = _("Dictionary lookup"),
         tap_input = {
             title = _("Enter a word to look up"),
+            ok_text = _("Search dictionary"),
             type = "text",
             callback = function(input)
                 self:onLookupWord(input)

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -1,5 +1,5 @@
-local InputContainer = require("ui/widget/container/inputcontainer")
 local ButtonDialog = require("ui/widget/buttondialog")
+local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
@@ -18,6 +18,7 @@ function ReaderSearch:addToMainMenu(menu_items)
         text = _("Fulltext search"),
         tap_input = {
             title = _("Input text to search for"),
+            ok_text = _("Search all text"),
             type = "text",
             callback = function(input)
                 self:onShowSearchDialog(input)

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -1,12 +1,12 @@
+local InputDialog = require("ui/widget/inputdialog")
+local NetworkMgr = require("ui/network/manager")
 local ReaderDictionary = require("apps/reader/modules/readerdictionary")
 local Translator = require("ui/translator")
 local Wikipedia = require("ui/wikipedia")
+local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
 local T = require("ffi/util").template
-local NetworkMgr = require("ui/network/manager")
-local InputDialog = require("ui/widget/inputdialog")
-local UIManager = require("ui/uimanager")
 
 -- Wikipedia as a special dictionary
 local ReaderWikipedia = ReaderDictionary:extend{
@@ -34,7 +34,7 @@ function ReaderWikipedia:lookupInput()
                     end,
                 },
                 {
-                    text = _("OK"),
+                    text = _("Search Wikipedia"),
                     is_enter_default = true,
                     callback = function()
                         UIManager:close(self.input_dialog)

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1,30 +1,30 @@
-local UnderlineContainer = require("ui/widget/container/underlinecontainer")
-local InputContainer = require("ui/widget/container/inputcontainer")
-local CenterContainer = require("ui/widget/container/centercontainer")
-local RightContainer = require("ui/widget/container/rightcontainer")
-local FrameContainer = require("ui/widget/container/framecontainer")
-local BottomContainer = require("ui/widget/container/bottomcontainer")
-local HorizontalSpan = require("ui/widget/horizontalspan")
-local HorizontalGroup = require("ui/widget/horizontalgroup")
-local VerticalSpan = require("ui/widget/verticalspan")
-local VerticalGroup = require("ui/widget/verticalgroup")
-local FixedTextWidget = require("ui/widget/fixedtextwidget")
-local ToggleSwitch = require("ui/widget/toggleswitch")
-local ConfirmBox = require("ui/widget/confirmbox")
-local ImageWidget = require("ui/widget/imagewidget")
-local TextWidget = require("ui/widget/textwidget")
-local IconButton = require("ui/widget/iconbutton")
-local GestureRange = require("ui/gesturerange")
 local Blitbuffer = require("ffi/blitbuffer")
-local UIManager = require("ui/uimanager")
-local Geom = require("ui/geometry")
-local Screen = require("device").screen
-local Event = require("ui/event")
+local BottomContainer = require("ui/widget/container/bottomcontainer")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
+local Event = require("ui/event")
+local FixedTextWidget = require("ui/widget/fixedtextwidget")
 local Font = require("ui/font")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local HorizontalSpan = require("ui/widget/horizontalspan")
+local IconButton = require("ui/widget/iconbutton")
+local ImageWidget = require("ui/widget/imagewidget")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local RightContainer = require("ui/widget/container/rightcontainer")
+local TextWidget = require("ui/widget/textwidget")
+local ToggleSwitch = require("ui/widget/toggleswitch")
+local UIManager = require("ui/uimanager")
+local UnderlineContainer = require("ui/widget/container/underlinecontainer")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
 local logger = require("logger")
-local T = require("ffi/util").template
 local _ = require("gettext")
+local Screen = Device.screen
+local T = require("ffi/util").template
 
 local OptionTextItem = InputContainer:new{}
 function OptionTextItem:init()
@@ -583,6 +583,7 @@ function ConfigDialog:onMakeDefault(name, name_text, values, labels, position)
             (name_text or ""),
             labels[position]
         ),
+        ok_text = T(_("Set default")),
         ok_callback = function()
             name = self.config_options.prefix.."_"..name
             G_reader_settings:saveSetting(name, values[position])

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -24,14 +24,14 @@ and to store that table as a configuration setting.
 
 ]]
 
-local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local DepGraph = require("depgraph")
+local Event = require("ui/event")
+local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local UIManager = require("ui/uimanager")
-local Screen = require("device").screen
-local DepGraph = require("depgraph")
-local Geom = require("ui/geometry")
-local Event = require("ui/event")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
+local Screen = require("device").screen
 
 if require("device"):isAndroid() then
     require("jit").off(true, true)
@@ -220,13 +220,13 @@ function InputContainer:onInput(input)
         buttons = {
             {
                 {
-                    text = _("Cancel"),
+                    text = input.cancel_text or _("Cancel"),
                     callback = function()
                         self:closeInputDialog()
                     end,
                 },
                 {
-                    text = _("OK"),
+                    text = input.ok_text or _("OK"),
                     is_enter_default = true,
                     callback = function()
                         input.callback(self.input_dialog:getInputText())


### PR DESCRIPTION
Makes it easier to comply with UX style.

* Change "OK" to "Search dictionary" in Dictionary lookup to comply with UX style
* Change "OK" to "Search all text" in Fulltext search to comply with UX style

Tacked on but highly related:

* change "OK" to "Search Wikipedia" in Wikipedia lookup to comply with UX style
* change "OK" to "Set default" in ConfigDialog to comply with UX style

Chore:

* fixed up order of requires