### PR TITLE
Screensaver option on Kindle devices

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -152,6 +152,20 @@ function FileManagerMenu:setUpdateItemTable()
                 },
             }
         }
+    elseif Device.isKindle() then
+        self.menu_items.screensaver = {
+            text = _("Screensaver"),
+            sub_item_table = {
+                {
+                    text = _("Enable cover screensaver"),
+                    checked_func = function() return G_reader_settings:readSetting("kindle_screensaver") end,
+                    callback = function()
+                        local show_advanced = G_reader_settings:readSetting("kindle_screensaver") or false
+                        G_reader_settings:saveSetting("kindle_screensaver", not show_advanced)
+                    end
+                }
+            }
+        }
     end
     -- insert common settings
     for id, common_setting in pairs(require("ui/elements/common_settings_menu_table")) do

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -96,7 +96,7 @@ function FileManagerMenu:setUpdateItemTable()
             G_reader_settings:flush()
         end
     }
-    if Device.isKobo() then
+    if Device.isKobo() or Device.isKindle() then
         self.menu_items.screensaver = {
             text = _("Screensaver"),
             sub_item_table = {
@@ -150,20 +150,6 @@ function FileManagerMenu:setUpdateItemTable()
                         UIManager:show(ss_folder_path_input)
                     end,
                 },
-            }
-        }
-    elseif Device.isKindle() then
-        self.menu_items.screensaver = {
-            text = _("Screensaver"),
-            sub_item_table = {
-                {
-                    text = _("Enable cover screensaver"),
-                    checked_func = function() return G_reader_settings:readSetting("kindle_screensaver") end,
-                    callback = function()
-                        local show_advanced = G_reader_settings:readSetting("kindle_screensaver") or false
-                        G_reader_settings:saveSetting("kindle_screensaver", not show_advanced)
-                    end
-                }
             }
         }
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -146,9 +146,6 @@ function ReaderMenu:setUpdateItemTable()
             }
         }
     elseif Device:isKindle() and Screensaver:isUsingBookCover() then
-        local kindle_screensaver = function()
-            return  not (G_reader_settings:readSetting("kindle_screensaver") or false)
-        end
         self.menu_items.screensaver = {
             text = _("Screensaver"),
             sub_item_table = {

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -145,6 +145,23 @@ function ReaderMenu:setUpdateItemTable()
                 }
             }
         }
+    elseif Device:isKindle() and Screensaver:isUsingBookCover() then
+        local kindle_screensaver = function()
+            return  not (G_reader_settings:readSetting("kindle_screensaver") or false)
+        end
+        self.menu_items.screensaver = {
+            text = _("Screensaver"),
+            sub_item_table = {
+                {
+                    text = _("Enable cover screensaver"),
+                    checked_func = function() return G_reader_settings:readSetting("kindle_screensaver") end,
+                    callback = function()
+                        local show_advanced = G_reader_settings:readSetting("kindle_screensaver") or false
+                        G_reader_settings:saveSetting("kindle_screensaver", not show_advanced)
+                    end
+                }
+            }
+        }
     end
 
     -- main menu tab

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -145,22 +145,27 @@ function ReaderMenu:setUpdateItemTable()
                 }
             }
         }
-    elseif Device:isKindle() and Screensaver:isUsingBookCover() then
+    elseif Device:isKindle() then
         self.menu_items.screensaver = {
             text = _("Screensaver"),
             sub_item_table = {
                 {
-                    text = _("Enable cover screensaver"),
-                    checked_func = function() return G_reader_settings:readSetting("kindle_screensaver") end,
+                    text = _("Use book's cover as screensaver"),
+                    checked_func = Screensaver.isUsingBookCover,
                     callback = function()
-                        local show_advanced = G_reader_settings:readSetting("kindle_screensaver") or false
-                        G_reader_settings:saveSetting("kindle_screensaver", not show_advanced)
+                        if Screensaver:isUsingBookCover() then
+                            G_reader_settings:saveSetting(
+                                "use_lastfile_as_screensaver", false)
+                        else
+                            G_reader_settings:delSetting(
+                                "use_lastfile_as_screensaver")
+                        end
+                        G_reader_settings:flush()
                     end
                 }
             }
         }
     end
-
     -- main menu tab
     -- insert common info
     for id, common_setting in pairs(require("ui/elements/common_info_menu_table")) do

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -46,8 +46,8 @@ function Kindle:usbPlugIn()
 end
 
 function Kindle:intoScreenSaver()
-    if G_reader_settings:readSetting("kindle_screensaver") then
-        require("ui/screensaver"):show("suspend", "")
+    if require("ui/screensaver").isUsingBookCover then
+        require("ui/screensaver"):show("suspend")
     end
     self.powerd:beforeSuspend()
     if self.charging_mode == false and self.screen_saver_mode == false then
@@ -67,7 +67,7 @@ function Kindle:outofScreenSaver()
         if os.getenv("AWESOME_STOPPED") == "yes" then
             os.execute("killall -stop awesome")
         end
-        if G_reader_settings:readSetting("kindle_screensaver") then
+        if require("ui/screensaver").isUsingBookCover then
             require("ui/screensaver"):close()
         end
         -- wait for native system update screen before we recover saved

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -46,6 +46,9 @@ function Kindle:usbPlugIn()
 end
 
 function Kindle:intoScreenSaver()
+    if G_reader_settings:readSetting("kindle_screensaver") then
+        require("ui/screensaver"):show("suspend", "")
+    end
     self.powerd:beforeSuspend()
     if self.charging_mode == false and self.screen_saver_mode == false then
         self.screen:saveCurrentBB()
@@ -63,6 +66,9 @@ function Kindle:outofScreenSaver()
         -- On FW >= 5.7.2, put awesome to sleep again...
         if os.getenv("AWESOME_STOPPED") == "yes" then
             os.execute("killall -stop awesome")
+        end
+        if G_reader_settings:readSetting("kindle_screensaver") then
+            require("ui/screensaver"):close()
         end
         -- wait for native system update screen before we recover saved
         -- Blitbuffer.

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -129,8 +129,10 @@ function Screensaver:show(kind, default_msg)
     -- fallback to message box
     if not self.left_msg then
         local msg = screensaver_settings.message or default_msg
-        self.left_msg = InfoMessage:new{ text = msg }
-        UIManager:show(self.left_msg)
+        if msg then
+            self.left_msg = InfoMessage:new{ text = msg }
+            UIManager:show(self.left_msg)
+        end
     else
         -- refresh whole screen for other types
         UIManager:show(self.left_msg, "full")


### PR DESCRIPTION
Add screensaver on Kindle devices.
Defaults screensaver is disabled. We can enable it by select Menu -> Screensaver -> Enable cover screensaver
![1](https://cloud.githubusercontent.com/assets/22982594/24812768/c140266c-1bcb-11e7-849f-3f472714f81a.jpg)
![2](https://cloud.githubusercontent.com/assets/22982594/24812774/c4e78148-1bcb-11e7-9b8c-83396f7d9d46.jpg)

Tested on KPW3 with special offers and KPW2.
