### PR TITLE
ReaderFooter (lang): "Show toc markers" to "Show chapter markers"

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -310,11 +310,11 @@ end
 
 local option_titles = {
     all_at_once = _("Show all at once"),
-    toc_markers = _("Show table of content markers"),
+    toc_markers = _("Show chapter markers"),
     auto_refresh_time = _("Auto refresh time"),
     page_progress = _("Current page"),
     time = _("Current time"),
-    pages_left = _("Pages left in this chapter"),
+    pages_left = _("Pages left in chapter"),
     battery = _("Battery status"),
     percentage = _("Progress percentage"),
     book_time_to_read = _("Book time to read"),

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -194,7 +194,7 @@ describe("Readerfooter module", function()
         assert.are.same('=> 1', footer.footer_text.text)
 
         -- disable page left, battery should follow
-        tapFooterMenu(fake_menu, "Pages left in this chapter")
+        tapFooterMenu(fake_menu, "Pages left in chapter")
         assert.are.same('B:0%', footer.footer_text.text)
 
         -- disable battery, percentage should follow
@@ -495,7 +495,7 @@ describe("Readerfooter module", function()
         assert.are.same('1 / 2 | => 1', footer.footer_text.text)
 
         -- remove mode from footer text
-        tapFooterMenu(fake_menu, "Pages left in this chapter")
+        tapFooterMenu(fake_menu, "Pages left in chapter")
         assert.are.same('1 / 2', footer.footer_text.text)
 
         -- add mode to footer text


### PR DESCRIPTION
I think it sounds more natural as chapter than as table of content, which is an implementation detail (i.e., the chapter markers are shown based on what's in the TOC).

Also removed redundant "this" from "Remaining pages in this chapter"