### PR TITLE
Lang: two tiny strings

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -74,7 +74,7 @@ end
 
 local highlight_style = {
     lighten = _("Lighten"),
-    underscore = _("Underscore"),
+    underscore = _("Underline"),
     invert = _("Invert"),
 }
 

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -193,7 +193,7 @@ end
 
 function ReaderStatistics:addToMainMenu(menu_items)
     menu_items.statistics = {
-        text = _("Statistics"),
+        text = _("Reading statistics"),
         sub_item_table = {
             self:getStatisticEnabledMenuItem(),
             {


### PR DESCRIPTION
* ReaderHighlight: underscore to underline. Although underscore means to
emphasize by underlining, the emphasis lies on the, ahem, emphasis. Besides
which, it's mostly AmE and less well understood worldwide (although in this
particular context it should probably cause no trouble).

* Statistics plugin: menu item text to "reading statistics" to make it clear
which statistics we're talking about. Fixes #2744.