### PR TITLE
Travis: `git fetch --unshallow` for version number 

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -10,3 +10,8 @@ ln -s "$(which gcc-4.8)" bin/cc
 ln -s "$(which gcc-4.8)" bin/gcc
 ln -s "$(which c++-4.8)" bin/c++
 ln -s "$(which g++-4.8)" bin/g++
+
+# Travis only makes a shallow clone of --depth=50. KOReader is small enough that
+# we can just grab it all. This is necessary to generate the version number,
+# without which some tests will fail.
+git fetch --unshallow


### PR DESCRIPTION
Travis only makes a shallow clone of --depth=50. KOReader is small enough that we can just grab it all. This is necessary to generate the version number, without which some tests will fail.

I'm not entirely sure why something like `git fetch origin master tags/v2015.11` doesn't do the trick, but it doesn't matter much.