### PR TITLE
Some small fixes related to pdf / kopt reading

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -316,7 +316,7 @@ function GestureDetector:handleDoubleTap(tev)
         timev = tev.timev,
     }
 
-    if self.last_taps[slot] ~= nil and
+    if not self.input.disable_double_tap and self.last_taps[slot] ~= nil and
     self:isDoubleTap(self.last_taps[slot], cur_tap) then
         -- it is a double tap
         self:clearState(slot)

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -180,6 +180,11 @@ function KoptInterface:getSemiAutoBBox(doc, pageno)
         auto_bbox.x1 = auto_bbox.x1 + bbox.x0
         auto_bbox.y1 = auto_bbox.y1 + bbox.y0
         logger.dbg("Semi-auto detected bbox", auto_bbox)
+        local native_size = Document.getNativePageDimensions(doc, pageno)
+        if (auto_bbox.x1 - auto_bbox.x0)/native_size.w < 0.1 and (auto_bbox.y1 - auto_bbox.y0)/native_size.h < 0.1 then
+            logger.dbg("Semi-auto detected bbox too small, using manual bbox")
+            auto_bbox = bbox
+        end
         page:close()
         Cache:insert(hash, CacheItem:new{ semiautobbox = auto_bbox })
         kc:free()


### PR DESCRIPTION
See commit texts.

About the disable double tap stuff, I tried first to just not go thru the deadline/setTimeout stuff if disable_double_tap is true, but there are some strange side effects (in readerhighlight) i didnt fully understand, so it's just easier and safer to just not do the isDoubleTap check.
#1594 is not obvious to reproduce, i think it needs quick taping and some intensive processing for page display (kopt semi auto crop + dewatermark) so that the setTimeout has less chance to happen before next Tap processing.