### PR TITLE
Update koreader.sh; fixes #2791

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -12,7 +12,7 @@ NEWUPDATE="${KOREADER_DIR}/ota/koreader.updated.tar"
 INSTALLED="${KOREADER_DIR}/ota/koreader.installed.tar"
 if [ -f "${NEWUPDATE}" ]; then
     # TODO: any graphic indication for the updating progress?
-    ./tar xf "${NEWUPDATE}" --strip-components=1 && mv "${NEWUPDATE}" "${INSTALLED}"
+    ./tar xf "${NEWUPDATE}" --strip-components=1 --no-same-permissions --no-same-owner && mv "${NEWUPDATE}" "${INSTALLED}"
 fi
 
 # load our own shared libraries if possible


### PR DESCRIPTION
tar fails to apply permissions on fat32 filesystem. thus mv doesn't get executed and consequently OTA package gets applied on every launch. Fixes #2791 