### PR TITLE
Reduce memory leaks when switching credocuments

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -9,6 +9,9 @@ local ffi = require("ffi")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
+-- engine can be initialized only once, on first document opened
+local engine_initialized = false
+
 local CreDocument = Document:new{
     -- this is defined in kpvcrlib/crengine/crengine/include/lvdocview.h
     SCROLL_VIEW_MODE = 0,
@@ -16,7 +19,6 @@ local CreDocument = Document:new{
 
     _document = false,
     _loaded = false,
-    engine_initilized = false,
 
     line_space_percent = 100,
     default_font = G_reader_settings:readSetting("cre_font") or "Noto Serif",
@@ -47,7 +49,7 @@ function CreDocument:cacheInit()
 end
 
 function CreDocument:engineInit()
-    if not self.engine_initilized then
+    if not engine_initialized then
         require "libs/libkoreader-cre"
         -- initialize cache
         self:cacheInit()
@@ -66,7 +68,7 @@ function CreDocument:engineInit()
             end
         end
 
-        self.engine_initilized = true
+        engine_initialized = true
     end
 end
 

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -28,6 +28,11 @@ function DocumentRegistry:getProvider(file)
 end
 
 function DocumentRegistry:openDocument(file)
+    -- force a GC, so that any previous document used memory can be reused
+    -- immediately by this new document without having to wait for the
+    -- next regular gc. The second call may help reclaming more memory.
+    collectgarbage()
+    collectgarbage()
     if not self.registry[file] then
         local provider = self:getProvider(file)
         if provider ~= nil then


### PR DESCRIPTION
CRE cache, hyphdict and fonts can be initialized only once when first credocument is opened. Previously, they were recreated for each document, and as previous instances were probably not free'd, this caused memory leaks.
Can be tested by opening some epub, and re-opening this same epub from History.
Before, mem usage went like: 14 > 30 > 38 > 48 > 57 > 66.
With this: 14 > 17 > 18 > 20 > 22 > 24.

The 2 collectgarbage() may not be necessary (the engineInit stuff is the one that has that effect), but I got the feeling of an sligthly better, and sometimes a memory decrease with them - but that may be placebo. I can remove them if they look too hacky.