### PR TITLE
Bump base/crengine for SVG images support

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -10,7 +10,10 @@ echo "pwd: $(pwd)"
 ls
 
 # toss submodules if there are any changes
-if [ "$(git status --ignore-submodules=dirty --porcelain)" ]; then
+# if [ "$(git status --ignore-submodules=dirty --porcelain)" ]; then
+# "--ignore-submodules=dirty", removed temporarily, as it did not notice as
+# expected that base was updated and kept using old cached base
+if [ "$(git status --porcelain)" ]; then
     # what changed?
     git status
     # purge and reinit submodules


### PR DESCRIPTION
Parsing and rasterisation provided by nanosvg (some svg tags like text, span and images are not supported).
Only svg images included as files in the .epub are supported (embedded svg tags in html are not).
Holding on svg image shows it 4x zoomed in ImageViewer.
Closes #2668 (with the above limitations)