### PR TITLE
Fix crash on Swipe to follow links with DJVU documents

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -225,7 +225,7 @@ function ReaderLink:onGoToFirstLink(ges)
             return
         end
         local links = self.ui.document:getPageLinks(pos.page)
-        if #links == 0 then
+        if not links or #links == 0 then
             return
         end
         -- DEBUG("PDF Page links : ", links)
@@ -254,7 +254,7 @@ function ReaderLink:onGoToFirstLink(ges)
         end
     else
         local links = self.ui.document:getPageLinks()
-        if #links == 0 then
+        if not links or #links == 0 then
             return
         end
         -- DEBUG("CRE Page links : ", links)


### PR DESCRIPTION
`self.ui.document:getPageLinks()` (being not supported) returns nil for djvu (unlike pdf or cre where a possibly empty table is returned).