### PR TITLE
Changes to calibre companion

### DIFF
--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -27,7 +27,7 @@ local order = {
         -- end common settings
     },
     tools = {
-        "calibre_wireless_connection",
+        "calibre_companion",
         "evernote",
         "keep_alive",
         "frontlight_gesture_controller",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -49,7 +49,7 @@ local order = {
     },
     tools = {
         "read_timer",
-        "calibre_wireless_connection",
+        "calibre_companion",
         "evernote",
         "keep_alive",
         "frontlight_gesture_controller",

--- a/plugins/calibrecompanion.koplugin/main.lua
+++ b/plugins/calibrecompanion.koplugin/main.lua
@@ -85,9 +85,11 @@ function CalibreCompanion:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text_func = function()
-                    return not self.calibre_socket
-                        and _("Connect")
-                        or _("Disconnect")
+                  if self.calibre_socket then
+                    return _("Disconnect")
+                  else
+                    return _("Connect")
+                  end
                 end,
                 callback = function()
                     if not self.calibre_socket then

--- a/plugins/calibrecompanion.koplugin/main.lua
+++ b/plugins/calibrecompanion.koplugin/main.lua
@@ -99,6 +99,12 @@ function CalibreCompanion:addToMainMenu(menu_items)
                     end
                 end
             },
+            {
+              text = _("Set inbox directory"),
+              callback = function()
+                CalibreCompanion:setInboxDir()
+                end
+            }
         }
     }
 end
@@ -131,7 +137,9 @@ function CalibreCompanion:setInboxDir(host, port)
         onConfirm = function(inbox)
             DEBUG("set inbox directory", inbox)
             G_reader_settings:saveSetting("inbox_dir", inbox)
-            calibre_device:initCalibreMQ(host, port)
+            if host and port then
+              calibre_device:initCalibreMQ(host, port)
+            end
         end,
     }:chooseDir()
 end

--- a/plugins/calibrecompanion.koplugin/main.lua
+++ b/plugins/calibrecompanion.koplugin/main.lua
@@ -80,8 +80,8 @@ function CalibreCompanion:find_calibre_server()
 end
 
 function CalibreCompanion:addToMainMenu(menu_items)
-    menu_items.calibre_wireless_connection = {
-        text = _("calibre wireless connection"),
+    menu_items.calibre_companion = {
+        text = _("calibre companion"),
         sub_item_table = {
             {
                 text_func = function()


### PR DESCRIPTION
Summary of changes
- Renamed all instances of calibre_wireless_connection to calibre_companion
- Added option to change inbox directory

note that the files that have already been imported from calibre are not moved, nor are any changes made to the database, if this is even necessary? (I have not looked into this yet). Could someone point me to where I would need to make those changes? 

![](https://i.imgur.com/odMGMud.png)