### PR TITLE
Remove run twice onPageUpdate() when document is opening

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -153,6 +153,7 @@ end
 function ReaderRolling:onReaderReady()
     self:setupTouchZones()
     self.setupXpointer()
+    self.old_page = 0
 end
 
 function ReaderRolling:setupTouchZones()
@@ -446,6 +447,9 @@ function ReaderRolling:updatePos()
     local new_height = self.ui.document.info.doc_height
     local new_page = self.ui.document.info.number_of_pages
     if self.old_doc_height ~= new_height or self.old_page ~= new_page then
+        if self.old_page > 0 then
+            self:_gotoXPointer(self.xpointer)
+        end
         self.old_doc_height = new_height
         self.old_page = new_page
         self.ui:handleEvent(Event:new("UpdateToc"))
@@ -459,9 +463,12 @@ end
 function ReaderRolling:onChangeViewMode()
     self.ui.document:_readMetadata()
     self.old_doc_height = self.ui.document.info.doc_height
+    local old_page = self.old_page
     self.old_page = self.ui.document.info.number_of_pages
     self.ui:handleEvent(Event:new("UpdateToc"))
-    if self.xpointer == nil then
+    if self.xpointer and old_page > 0 then
+        self:_gotoXPointer(self.xpointer)
+    elseif self.xpointer == nil then
         table.insert(self.ui.postInitCallback, function()
             self:_gotoXPointer(self.xpointer)
         end)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1,13 +1,12 @@
-local InputContainer = require("ui/widget/container/inputcontainer")
-local ReaderPanning = require("apps/reader/modules/readerpanning")
-local Screen = require("device").screen
 local Device = require("device")
-local Input = require("device").input
+local InputContainer = require("ui/widget/container/inputcontainer")
 local Event = require("ui/event")
+local ReaderPanning = require("apps/reader/modules/readerpanning")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
-
+local Input = require("device").input
+local Screen = require("device").screen
 
 --[[
     Rolling is just like paging in page-based documents except that
@@ -447,7 +446,6 @@ function ReaderRolling:updatePos()
     local new_height = self.ui.document.info.doc_height
     local new_page = self.ui.document.info.number_of_pages
     if self.old_doc_height ~= new_height or self.old_page ~= new_page then
-        self:_gotoXPointer(self.xpointer)
         self.old_doc_height = new_height
         self.old_page = new_page
         self.ui:handleEvent(Event:new("UpdateToc"))
@@ -463,9 +461,7 @@ function ReaderRolling:onChangeViewMode()
     self.old_doc_height = self.ui.document.info.doc_height
     self.old_page = self.ui.document.info.number_of_pages
     self.ui:handleEvent(Event:new("UpdateToc"))
-    if self.xpointer then
-        self:_gotoXPointer(self.xpointer)
-    else
+    if self.xpointer == nil then
         table.insert(self.ui.postInitCallback, function()
             self:_gotoXPointer(self.xpointer)
         end)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -5,8 +5,8 @@ local ReaderPanning = require("apps/reader/modules/readerpanning")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
-local Input = require("device").input
-local Screen = require("device").screen
+local Input = Device.input
+local Screen = Device.screen
 
 --[[
     Rolling is just like paging in page-based documents except that

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -92,7 +92,6 @@ function ReaderRolling:init()
     table.insert(self.ui.postInitCallback, function()
         self.doc_height = self.ui.document.info.doc_height
         self.old_doc_height = self.doc_height
-        self.old_page = self.ui.document.info.number_of_pages
     end)
     self.ui.menu:registerToMainMenu(self)
 end
@@ -153,7 +152,6 @@ end
 function ReaderRolling:onReaderReady()
     self:setupTouchZones()
     self.setupXpointer()
-    self.old_page = 0
 end
 
 function ReaderRolling:setupTouchZones()
@@ -447,7 +445,7 @@ function ReaderRolling:updatePos()
     local new_height = self.ui.document.info.doc_height
     local new_page = self.ui.document.info.number_of_pages
     if self.old_doc_height ~= new_height or self.old_page ~= new_page then
-        if self.old_page > 0 then
+        if self.old_page then
             self:_gotoXPointer(self.xpointer)
         end
         self.old_doc_height = new_height
@@ -466,7 +464,7 @@ function ReaderRolling:onChangeViewMode()
     local old_page = self.old_page
     self.old_page = self.ui.document.info.number_of_pages
     self.ui:handleEvent(Event:new("UpdateToc"))
-    if self.xpointer and old_page > 0 then
+    if self.xpointer and old_page then
         self:_gotoXPointer(self.xpointer)
     elseif self.xpointer == nil then
         table.insert(self.ui.postInitCallback, function()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -265,7 +265,11 @@ end
 
 function ReaderRolling:getLastPercent()
     if self.view.view_mode == "page" then
-        return self.current_page / self.old_page
+        if self.old_page then
+            return self.current_page / self.old_page
+        else
+            return nil
+        end
     else
         -- FIXME: the calculated percent is not accurate in "scroll" mode.
         return self.ui.document:getPosFromXPointer(


### PR DESCRIPTION
Close #2836 
Should fix problem: `onPageUpdate()` methods runs twice on book open.