### PR TITLE
[kobo]: add reboot and poweroff menu actions

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -161,6 +161,9 @@ function Device:resume() end
 -- Hardware specific method to power off the device
 function Device:powerOff() end
 
+-- Hardware specific method to reboot the device
+function Device:reboot() end
+
 -- Hardware specific method to initialize network manager module
 function Device:initNetworkManager() end
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -517,6 +517,10 @@ function Kobo:powerOff()
     os.execute("poweroff")
 end
 
+function Kobo:reboot()
+    os.execute("reboot")
+end
+
 -------------- device probe ------------
 
 local codename = Kobo:getCodeName()

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -53,13 +53,13 @@ if Device:isKobo() then
     common_info.reboot = {
         text = _("Reboot the device"),
         callback = function()
-            UIManager:scheduleIn(0, UIManager.reboot_action)
+            UIManager:nextTick(UIManager.reboot_action)
         end
     }
     common_info.poweroff = {
         text = _("Power off"),
         callback = function()
-            UIManager:scheduleIn(0, UIManager.poweroff_action)
+            UIManager:nextTick(UIManager.poweroff_action)
         end
     }
 end

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -49,5 +49,19 @@ common_info.report_bug = {
         })
     end
 }
+if Device:isKobo() then
+    common_info.reboot = {
+        text = _("Reboot the device"),
+        callback = function()
+            UIManager:scheduleIn(0, UIManager.reboot_action)
+        end
+    }
+    common_info.poweroff = {
+        text = _("Power off"),
+        callback = function()
+            UIManager:scheduleIn(0, UIManager.poweroff_action)
+        end
+    }
+end
 
 return common_info

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -57,10 +57,14 @@ local order = {
         "history",
         "open_last_document",
         "----------------------------",
-        "ota_update", -- if Device:isKindle() or Device:isKobo() or Device:isPocketBook() or Device:isAndroid()
+        "ota_update", --[[ if Device:isKindle() or Device:isKobo() or
+                           Device:isPocketBook() or Device:isAndroid() ]]--
         "version",
         "help",
         "system_statistics",
+        "----------------------------",
+        "poweroff", -- if Device:isKobo()
+        "reboot",   -- if Device:isKobo()
         "----------------------------",
         "exit",
     },

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -75,10 +75,14 @@ local order = {
         "history",
         "book_status",
         "----------------------------",
-        "ota_update", -- if Device:isKindle() or Device:isKobo() or Device:isPocketBook() or Device:isAndroid()
+        "ota_update", --[[ if Device:isKindle() or Device:isKobo() or
+                           Device:isPocketBook() or Device:isAndroid() ]]--
         "version",
         "help",
         "system_statistics",
+        "----------------------------",
+        "poweroff", -- if Device:isKobo()
+        "reboot",   -- if Device:isKobo()
         "----------------------------",
         "exit",
     },

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -57,6 +57,16 @@ function UIManager:init()
             Device:powerOff()
         end)
     end
+    self.reboot_action = function()
+        self._entered_poweroff_stage = true;
+        Screen:setRotationMode(0)
+        require("ui/screensaver"):show("reboot", _("Rebooting..."))
+        Screen:refreshFull()
+        UIManager:nextTick(function()
+            self:broadcastEvent(Event:new("Close"))
+            Device:reboot()
+        end)
+    end
     if Device:isKobo() then
         -- We do not want auto suspend procedure to waste battery during
         -- suspend. So let's unschedule it when suspending, and restart it after


### PR DESCRIPTION
a new PR with suggestions from #2873. I close the old one

Not sure yet if those menu items should go in common_info_menu_table.lua or in another place. Feel free to give me your points. This is my first commit in lua code :+1: 

This should fix #2868 and #2588