### PR TITLE
(minor, lang) improve text clarity for downloadmgr dialogs

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -202,7 +202,7 @@ function CloudStorage:cloudFile(item, path)
         },
         {
             {
-                text = _("Set download directory"),
+                text = _("Choose download directory by long-pressing"),
                 callback = function()
                     require("ui/downloadmgr"):new{
                         title = _("Choose download directory"),

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -571,7 +571,7 @@ function OPDSBrowser:showDownloads(item)
     -- set download directory button
     table.insert(buttons, {
         {
-            text = gettext("Set download directory"),
+            text = gettext("Choose download directory by long-pressing"),
             callback = function()
                 require("ui/downloadmgr"):new{
                     title = gettext("Choose download directory"),

--- a/plugins/calibrecompanion.koplugin/main.lua
+++ b/plugins/calibrecompanion.koplugin/main.lua
@@ -125,7 +125,7 @@ end
 function CalibreCompanion:setInboxDir(host, port)
     local calibre_device = self
     require("ui/downloadmgr"):new{
-        title = _("Choose inbox"),
+        title = _("Choose inbox by long-pressing"),
         onConfirm = function(inbox)
             DEBUG("set inbox directory", inbox)
             G_reader_settings:saveSetting("inbox_dir", inbox)

--- a/plugins/zsync.koplugin/main.lua
+++ b/plugins/zsync.koplugin/main.lua
@@ -223,7 +223,7 @@ function ZSync:subscribe()
     self.received = {}
     local zsync = self
     require("ui/downloadmgr"):new{
-        title = _("Choose inbox"),
+        title = _("Choose inbox by long-pressing"),
         onConfirm = function(inbox)
             G_reader_settings:saveSetting("inbox_dir", inbox)
             zsync:onChooseInbox(inbox)


### PR DESCRIPTION
It's not necessarily clear that you need to long-press, see https://www.mobileread.com/forums/showpost.php?p=3520376&postcount=7