### PR TITLE
(chore) Remove storage statistics menu order leftovers

### DIFF
--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -33,7 +33,6 @@ local order = {
         "frontlight_gesture_controller",
         "statistics",
         "battery_statistics",
-        "storage_stat",
         "cloud_storage",
         "read_timer",
         "news_downloader",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -55,7 +55,6 @@ local order = {
         "frontlight_gesture_controller",
         "statistics",
         "battery_statistics",
-        "storage_stat",
         "synchronize_time",
         "progress_sync",
         "zsync",


### PR DESCRIPTION
Fixes #2921. Leftover from #2764.