### PR TITLE
Revert "(chore) Remove storage statistics menu order leftovers"

### DIFF
--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -33,6 +33,7 @@ local order = {
         "frontlight_gesture_controller",
         "statistics",
         "battery_statistics",
+        "storage_stat",
         "cloud_storage",
         "read_timer",
         "news_downloader",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -55,6 +55,7 @@ local order = {
         "frontlight_gesture_controller",
         "statistics",
         "battery_statistics",
+        "storage_stat",
         "synchronize_time",
         "progress_sync",
         "zsync",


### PR DESCRIPTION
Reverts koreader/koreader#2922

Wrt #2926 I figure it's better to keep this where it was.