### PR TITLE
Remove BatteryStat:initCurrentState()

### DIFF
--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -108,20 +108,16 @@ function BatteryStat:init()
     -- the unaccumulated values.
     self.charging_state = State:new(self.settings:readSetting("charging_state"))
     self.awake_state = State:new(self.settings:readSetting("awake_state"))
-    self:initCurrentState()
+    -- Whether the device was suspending before current timestamp.
+    self.was_suspending = false
+    -- Whether the device was charging before current timestamp.
+    self.was_charging = PowerD:isCharging()
 
     if self.debugging then
         self.debugOutput = self._debugOutput
     else
         self.debugOutput = function() end
     end
-end
-
-function BatteryStat:initCurrentState()
-    -- Whether the device was suspending before current timestamp.
-    self.was_suspending = false
-    -- Whether the device was charging before current timestamp.
-    self.was_charging = PowerD:isCharging()
 end
 
 function BatteryStat:onFlushSettings()
@@ -197,7 +193,6 @@ function BatteryStat:onNotCharging()
 end
 
 function BatteryStat:showStatistics()
-    self:initCurrentState()
     self:accumulate()
     local kv_pairs = self:dump()
     table.insert(kv_pairs, "----------")


### PR DESCRIPTION
This function is not really needed: the state should always be updated by the events.
But we do have trouble that the events won't be fired on Kindle when sleeping, which makes the analysis inaccurate.