### PR TITLE
[fix] revert removing tap gestures to show menus

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -54,6 +54,15 @@ function FileManagerMenu:initGesListener()
 
     self:registerTouchZones({
         {
+            id = "filemanager_tap",
+            ges = "tap",
+            screen_zone = {
+                ratio_x = DTAP_ZONE_MENU.x, ratio_y = DTAP_ZONE_MENU.y,
+                ratio_w = DTAP_ZONE_MENU.w, ratio_h = DTAP_ZONE_MENU.h,
+            },
+            handler = function(ges) return self:onTapShowMenu(ges) end,
+        },
+        {
             id = "filemanager_swipe",
             ges = "swipe",
             screen_zone = {
@@ -367,6 +376,11 @@ function FileManagerMenu:onCloseFileManagerMenu()
     local last_tab_index = self.menu_container[1].last_index
     G_reader_settings:saveSetting("filemanagermenu_tab_index", last_tab_index)
     UIManager:close(self.menu_container)
+    return true
+end
+
+function FileManagerMenu:onTapShowMenu(ges)
+    self:onShowMenu()
     return true
 end
 

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -84,6 +84,15 @@ function ReaderMenu:onReaderReady()
 
     self.ui:registerTouchZones({
         {
+            id = "readermenu_tap",
+            ges = "tap",
+            screen_zone = {
+                ratio_x = DTAP_ZONE_MENU.x, ratio_y = DTAP_ZONE_MENU.y,
+                ratio_w = DTAP_ZONE_MENU.w, ratio_h = DTAP_ZONE_MENU.h,
+            },
+            handler = function(ges) return self:onTapShowMenu(ges) end,
+        },
+        {
             id = "readermenu_swipe",
             ges = "swipe",
             screen_zone = {
@@ -283,6 +292,11 @@ function ReaderMenu:onSwipeShowMenu(ges)
         self.ui:handleEvent(Event:new("ShowReaderMenu"))
         return true
     end
+end
+
+function ReaderMenu:onTapShowMenu()
+    self.ui:handleEvent(Event:new("ShowConfigMenu"))
+    self.ui:handleEvent(Event:new("ShowReaderMenu"))
 end
 
 function ReaderMenu:onTapCloseMenu()


### PR DESCRIPTION
as the tap gesture on the upper part (mostly) of the screen is
a conventional design to show menus in almost all ereaders as well as
some mobile phone apps. While users not farmilar with the Android world
have no experience with swipe down to show menus that's why we need a
quick start guide for this feature. And experienced Koreader users
probably will turn pages by mistake each time they want to popup the menus.

The solution here is adding back the tap gestures as they were and keep
the new swipe to show menu feature as a supplementary function when
link's tap area blocks menu's tap area.