### PR TITLE
[fix] stop propagation of tap events when triggering reader menu

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -259,9 +259,10 @@ end
 
 function ReaderDictionary:onReadSettings(config)
     self.default_dictionary = config:readSetting("default_dictionary")
-    self.disable_fuzzy_search = config:readSetting("disable_fuzzy_search") or
-                    G_reader_settings:readSetting("disable_fuzzy_search") or
-                    false
+    self.disable_fuzzy_search = config:readSetting("disable_fuzzy_search")
+    if self.disable_fuzzy_search == nil then
+        self.disable_fuzzy_search = G_reader_settings:isTrue("disable_fuzzy_search")
+    end
 end
 
 function ReaderDictionary:onSaveSettings()

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -130,7 +130,6 @@ function ReaderDictionary:stardictLookup(word, box)
     if word == "" then
         return
     end
-    self:onLookupStarted(word)
     local final_results = {}
     local seen_results = {}
     -- Allow for two sdcv calls : one in the classic data/dict, and
@@ -153,7 +152,6 @@ function ReaderDictionary:stardictLookup(word, box)
                 definition = _([[No dictionaries installed. Please search for "Dictionary support" in the KOReader Wiki to get more information about installing new dictionaries.]]),
             }
         }
-        self:onLookupDone()
         self:showDict(word, final_results, box)
         return
     end
@@ -198,7 +196,6 @@ function ReaderDictionary:stardictLookup(word, box)
             }
         }
     end
-    self:onLookupDone()
     self:showDict(word, tidyMarkup(final_results), box)
 end
 

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -5,11 +5,11 @@ local DictQuickLookup = require("ui/widget/dictquicklookup")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local JSON = require("json")
-local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local util  = require("util")
 local _ = require("gettext")
+local Screen = Device.screen
 local T = require("ffi/util").template
 
 local ReaderDictionary = InputContainer:new{
@@ -120,14 +120,14 @@ function ReaderDictionary:cleanSelection(text)
     return text
 end
 
-function ReaderDictionary:onLookupInfoStarted(word)
+function ReaderDictionary:showLookupInfo(word)
     local text = T(self.lookup_msg, word)
     self.lookup_progress_msg = InfoMessage:new{text=text}
     UIManager:show(self.lookup_progress_msg)
     UIManager:forceRePaint()
 end
 
-function ReaderDictionary:onLookupInfoDone()
+function ReaderDictionary:dismissLookupInfo()
     if self.lookup_progress_msg then
         UIManager:close(self.lookup_progress_msg)
         UIManager:forceRePaint()
@@ -144,7 +144,7 @@ function ReaderDictionary:stardictLookup(word, box)
         return
     end
     if not self.disable_fuzzy_search then
-        self:onLookupInfoStarted(word)
+        self:showLookupInfo(word)
     end
     local final_results = {}
     local seen_results = {}
@@ -217,7 +217,7 @@ function ReaderDictionary:stardictLookup(word, box)
 end
 
 function ReaderDictionary:showDict(word, results, box)
-    self:onLookupInfoDone()
+    self:dismissLookupInfo()
     if results and results[1] then
         logger.dbg("showing quick lookup window", word, results)
         self.dict_window = DictQuickLookup:new{

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -118,7 +118,7 @@ function ReaderHighlight:clear()
     if self.hold_pos then
         self.hold_pos = nil
         self.selected_text = nil
-        UIManager:setDirty(self.dialog, "partial")
+        UIManager:setDirty(self.dialog, "ui")
         return true
     end
 end
@@ -255,7 +255,7 @@ function ReaderHighlight:onHold(arg, ges)
             table.insert(boxes, self.selected_word.sbox)
             self.view.highlight.temp[self.hold_pos.page] = boxes
         end
-        UIManager:setDirty(self.dialog, "partial")
+        UIManager:setDirty(self.dialog, "ui")
         -- TODO: only mark word?
         -- Unfortunately, CREngine does not return good coordinates
         -- UIManager:setDirty(self.dialog, "partial", self.selected_word.sbox)

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -297,6 +297,7 @@ end
 function ReaderMenu:onTapShowMenu()
     self.ui:handleEvent(Event:new("ShowConfigMenu"))
     self.ui:handleEvent(Event:new("ShowReaderMenu"))
+    return true
 end
 
 function ReaderMenu:onTapCloseMenu()

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -137,7 +137,7 @@ function ReaderWikipedia:onLookupWikipedia(word, box, get_fullpage, forced_lang)
     else
         self.lookup_msg = T(_("Searching Wikipedia %2 for:\n%1"), "%1", lang:upper())
     end
-    self:onLookupStarted(word)
+    self:onLookupInfoStarted(word)
     local results = {}
     local ok, pages
     if get_fullpage then
@@ -193,7 +193,6 @@ function ReaderWikipedia:onLookupWikipedia(word, box, get_fullpage, forced_lang)
         }
         logger.dbg("dummy result table:", word, results)
     end
-    self:onLookupDone()
     self:showDict(word, results, box)
 end
 

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -137,7 +137,7 @@ function ReaderWikipedia:onLookupWikipedia(word, box, get_fullpage, forced_lang)
     else
         self.lookup_msg = T(_("Searching Wikipedia %2 for:\n%1"), "%1", lang:upper())
     end
-    self:onLookupInfoStarted(word)
+    self:showLookupInfo(word)
     local results = {}
     local ok, pages
     if get_fullpage then

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -32,6 +32,7 @@ local order = {
     },
     setting = {
         "read_from_right_to_left",
+        "disable_fuzzy_search",
         -- common settings
         -- those that don't exist will simply be skipped during menu gen
         "frontlight", -- if Device:hasFrontlight()


### PR DESCRIPTION
And also get rid of unnecessary screen refreshes on Kindle Voyage.
The "progress" window for dict lookup is also eliminated as most of the time dict lookup is an instant process, and the "progress" window is preserved for wikipedia lookup as it may take longer time to show the result window.