### PR TITLE
ReaderUI: return to filemanager instead of quitting if no document

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -3,7 +3,6 @@ local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Screensaver = require("ui/screensaver")
-local QuickStart = require("ui/quickstart")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local dbg = require("dbg")
@@ -43,18 +42,7 @@ function ReaderMenu:init()
             callback = function()
                 self:onTapCloseMenu()
                 self.ui:onClose()
-                local lastdir
-                local last_file = G_reader_settings:readSetting("lastfile")
-                -- ignore quickstart guide as last_file so we can go back to home dir
-                if last_file and last_file ~= QuickStart.quickstart_filename then
-                    lastdir = last_file:match("(.*)/")
-                end
-                local FileManager = require("apps/filemanager/filemanager")
-                if FileManager.instance then
-                    FileManager.instance:reinit(lastdir)
-                else
-                    FileManager:showFiles(lastdir)
-                end
+                self.ui:showFileManager()
             end,
         },
         main = {


### PR DESCRIPTION
This affects #2335, at least for documents covered by `validDjvuFile()` (see https://github.com/koreader/koreader/blob/76cef07c079e979de6aac6b540c9cc2b672b6f57/frontend/document/djvudocument.lua#L15-L23). However, that's only with regard to `touch invalid.djvu` and should not affect whatever happened in the OP.