### PR TITLE
Force refresh when kindle is out of screensaver or usb is unpluged.

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1,6 +1,6 @@
 local Generic = require("device/generic/device")
-local util = require("ffi/util")
 local logger = require("logger")
+local util = require("ffi/util")
 
 local function yes() return true end
 local function no() return false end  -- luacheck: ignore
@@ -69,7 +69,6 @@ end
 
 function Kindle:usbPlugIn()
     if self.charging_mode == false and self.screen_saver_mode == false then
-        self.screen:saveCurrentBB()
         -- On FW >= 5.7.2, we sigstop awesome, but we need it to show stuff...
         if os.getenv("AWESOME_STOPPED") == "yes" then
             os.execute("killall -cont awesome")
@@ -85,7 +84,6 @@ function Kindle:intoScreenSaver()
     end
     self.powerd:beforeSuspend()
     if self.charging_mode == false and self.screen_saver_mode == false then
-        self.screen:saveCurrentBB()
         self.screen_saver_mode = true
         -- On FW >= 5.7.2, we sigstop awesome, but we need it to show stuff...
         if os.getenv("AWESOME_STOPPED") == "yes" then
@@ -104,14 +102,8 @@ function Kindle:outofScreenSaver()
         if self:supportsScreensaver() and Screensaver.isUsingBookCover() then
             Screensaver:close()
         end
-        -- wait for native system update screen before we recover saved
-        -- Blitbuffer.
-        util.usleep(1500000)
-        self.screen:restoreFromSavedBB()
-        self:resume()
-        if self:needsScreenRefreshAfterResume() then
-            self.screen:refreshFull()
-        end
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
     end
     self.screen_saver_mode = false
     self.powerd:afterResume()
@@ -123,10 +115,8 @@ function Kindle:usbPlugOut()
         if os.getenv("AWESOME_STOPPED") == "yes" then
             os.execute("killall -stop awesome")
         end
-        -- Same as when going out of screensaver, wait for the native system
-        util.usleep(1500000)
-        self.screen:restoreFromSavedBB()
-        self.screen:refreshFull()
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
     end
 
     --@TODO signal filemanager for file changes  13.06 2012 (houqp)

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1,6 +1,5 @@
 local Generic = require("device/generic/device")
 local logger = require("logger")
-local util = require("ffi/util")
 
 local function yes() return true end
 local function no() return false end  -- luacheck: ignore


### PR DESCRIPTION
Comparing to the existing sleep 1.5 / saveCurrentBB and restoreCurrentBB solution, this looks simple, fast and reliable.
I cannot tell whether this change works fine on devices without special offer, can anyone have a shot?