### PR TITLE
Remove "Set default Fine Tuning"

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -577,6 +577,10 @@ function ConfigDialog:onConfigChoose(values, name, event, args, events, position
 end
 
 function ConfigDialog:onMakeDefault(name, name_text, values, labels, position)
+    if name == "font_fine_tune" then
+        return
+    end
+
     UIManager:show(ConfirmBox:new{
         text = T(
             _("Set default %1 to %2?"),


### PR DESCRIPTION
Close: #2879
Should remove illogical  "Set default Fine Tuning to increase" or "Set default Fine Tuning to decrease" when long pressing on "increase" or "decrease"