### PR TITLE
Use getCapacityHW() to ensure latest battery capacity can be retrieved

### DIFF
--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -18,7 +18,7 @@ function State:new(o)
     setmetatable(o, self)
     self.__index = self
     if o.percentage == nil or o.timestamp == nil then
-        o.percentage = PowerD:getCapacity()
+        o.percentage = PowerD:getCapacityHW()
         o.timestamp = os.time()
     end
     return o


### PR DESCRIPTION
I believe the battery of my Kobo may die soon or later, the capacity may suddenly change *after* I unplug the usb charger. But it's still reasonable for BatteryStats plugin to get hardware battery capacity instead of a cached version.
Indeed I cannot quite tell why getCapacity() needs to cache the result at all.