### PR TITLE
News downloader settings menu entry

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -69,7 +69,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Help"),
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_("News downloader can be configured in the feeds config file:\n%1\n\nIt downloads news items to:\n%2.\n\nTo set you own news sources edit foregoing feeds config file. Items download limit can be set there."),
+                        text = T(_("Plugin obtains RSS and Atom news entries and stores them to:\n%2.\nEach entry is a separate html file, that can be browsed by KOReader file manager."),
                                  feed_config_path,
                                  news_download_dir_path)
                     })

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -57,6 +57,15 @@ function NewsDownloader:addToMainMenu(menu_items)
                 callback = function() self:setCustomDownloadDirectory() end,
             },
             {
+                text = _("Settings"),
+                callback = function()
+                    UIManager:show(InfoMessage:new{
+                        text = T(_("To change feed (Atom/RSS) sources please manually edit configuration file:\n%1"),
+                                 feed_config_path)
+                    })
+                end,
+            },
+            {
                 text = _("Help"),
                 callback = function()
                     UIManager:show(InfoMessage:new{

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -69,7 +69,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Help"),
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_("News Downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
+                        text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
                                  news_download_dir_path)
                     })
                 end,

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -60,7 +60,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Settings"),
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_("To change feed (Atom/RSS) sources please manually edit configuration file:\n%1"),
+                        text = T(_("To change feed (Atom/RSS) sources please manually edit configuration file:\n%1\n\nIt's very simple, contains comments and sample configuration."),
                                  feed_config_path)
                     })
                 end,

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -69,8 +69,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Help"),
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_("Plugin obtains RSS and Atom news entries and stores them to:\n%2.\nEach entry is a separate html file, that can be browsed by KOReader file manager."),
-                                 feed_config_path,
+                        text = T(_("Plugin downloads RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
                                  news_download_dir_path)
                     })
                 end,

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -60,7 +60,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Settings"),
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_("To change feed (Atom/RSS) sources please manually edit configuration file:\n%1\n\nIt's very simple, contains comments and sample configuration."),
+                        text = T(_("To change feed (Atom/RSS) sources please manually edit the configuration file:\n%1\n\nIt is very simple and contains comments as well as sample configuration."),
                                  feed_config_path)
                     })
                 end,
@@ -69,7 +69,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Help"),
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_("Plugin downloads RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
+                        text = T(_("News Downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
                                  news_download_dir_path)
                     })
                 end,


### PR DESCRIPTION
After reinstallation Koreader I looked for "Settings" in NewsDownloader to change feed sources but there's no such menu entry.

I think it's not clear howto set own feed sources (especially for new users).
And should be explicitly shown.

To make it better visible I decided to add new menu entry with text info.
Maybe one day I'll try to add UI to handle that...

But for now I think this will do the work, better than "manual".