### PR TITLE
Book information: refactored and additional features

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -59,29 +59,33 @@ function BookInfo:show(file, book_props)
     -- book_props may be provided if caller already has them available
     -- but it may lack 'pages', that we may get from sidecar file
     if not book_props or not book_props.pages then
-        local doc_settings = DocSettings:open(file)
-        if doc_settings then
-            if not book_props then
-                -- Files opened after 20170701 have a 'doc_props' setting with
-                -- complete metadata and 'doc_pages' with accurate nb of pages
-                book_props = doc_settings:readSetting('doc_props')
-            end
-            if not book_props then
-                -- File last opened before 20170701 may have a 'stats' setting
-                -- with partial metadata, or empty metadata if statistics plugin
-                -- was not enabled when book was read (we can guess that from
-                -- the fact that stats.page = 0)
-                local stats = doc_settings:readSetting('stats')
-                if stats and stats.pages ~= 0 then
-                    -- Let's use them as is (which was what was done before), even if
-                    -- incomplete, to avoid expensive book opening
-                    book_props = stats
+        -- check there is actually a sidecar file before calling DocSettings:open()
+        -- that would create an empty sidecar directory
+        if DocSettings:hasSidecarFile(file) then
+            local doc_settings = DocSettings:open(file)
+            if doc_settings then
+                if not book_props then
+                    -- Files opened after 20170701 have a 'doc_props' setting with
+                    -- complete metadata and 'doc_pages' with accurate nb of pages
+                    book_props = doc_settings:readSetting('doc_props')
                 end
-            end
-            -- Files opened after 20170701 have an accurate 'doc_pages' setting
-            local doc_pages = doc_settings:readSetting('doc_pages')
-            if doc_pages and book_props then
-                book_props.pages = doc_pages
+                if not book_props then
+                    -- File last opened before 20170701 may have a 'stats' setting
+                    -- with partial metadata, or empty metadata if statistics plugin
+                    -- was not enabled when book was read (we can guess that from
+                    -- the fact that stats.page = 0)
+                    local stats = doc_settings:readSetting('stats')
+                    if stats and stats.pages ~= 0 then
+                        -- Let's use them as is (which was what was done before), even if
+                        -- incomplete, to avoid expensive book opening
+                        book_props = stats
+                    end
+                end
+                -- Files opened after 20170701 have an accurate 'doc_pages' setting
+                local doc_pages = doc_settings:readSetting('doc_pages')
+                if doc_pages and book_props then
+                    book_props.pages = doc_pages
+                end
             end
         end
     end

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -1,0 +1,183 @@
+--[[--
+This module provides a way to display book information (filename and book metadata)
+]]
+
+local DocSettings = require("docsettings")
+local DocumentRegistry = require("document/documentregistry")
+local ImageViewer = require("ui/widget/imageviewer")
+local InfoMessage = require("ui/widget/infomessage")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local KeyValuePage = require("ui/widget/keyvaluepage")
+local UIManager = require("ui/uimanager")
+local filemanagerutil = require("apps/filemanager/filemanagerutil")
+local lfs = require("libs/libkoreader-lfs")
+local util = require("util")
+local _ = require("gettext")
+
+local BookInfo = InputContainer:extend{
+    bookinfo_menu_title = _("Book information"),
+}
+
+function BookInfo:init()
+    if self.ui then -- only for Reader menu
+        self.ui.menu:registerToMainMenu(self)
+    end
+end
+
+function BookInfo:addToMainMenu(menu_items)
+    menu_items.book_info = {
+        text = self.bookinfo_menu_title,
+        callback = function()
+            -- Get them directly from ReaderUI's doc_settings
+            local doc_props = self.ui.doc_settings:readSetting("doc_props")
+            -- Make a copy, so we don't add "pages" to the original doc_props
+            -- that will be saved at some point by ReaderUI.
+            local book_props = {}
+            for k, v in pairs(doc_props) do
+                book_props[k] = v
+            end
+            book_props.pages = self.ui.doc_settings:readSetting("doc_pages")
+            self:show(self.document.file, book_props)
+        end,
+    }
+end
+
+function BookInfo:isSupported(file)
+    return lfs.attributes(file, "mode") == "file"
+end
+
+function BookInfo:show(file, book_props)
+    local kv_pairs = {}
+
+    local directory, filename = util.splitFilePathName(file)
+    local filename_without_suffix, filetype = util.splitFileNameSuffix(filename) -- luacheck: no unused
+    table.insert(kv_pairs, { _("Filename:"), filename })
+    table.insert(kv_pairs, { _("Format:"), filetype:upper() })
+    table.insert(kv_pairs, { _("Directory:"), filemanagerutil.abbreviate(directory) })
+    table.insert(kv_pairs, "----")
+
+    -- book_props may be provided if caller already has them available
+    -- but it may lack 'pages', that we may get from sidecar file
+    if not book_props or not book_props.pages then
+        local doc_settings = DocSettings:open(file)
+        if doc_settings then
+            if not book_props then
+                -- Files opened after 20170701 have a 'doc_props' setting with
+                -- complete metadata and 'doc_pages' with accurate nb of pages
+                book_props = doc_settings:readSetting('doc_props')
+            end
+            if not book_props then
+                -- File last opened before 20170701 may have a 'stats' setting
+                -- with partial metadata, or empty metadata if statistics plugin
+                -- was not enabled when book was read (we can guess that from
+                -- the fact that stats.page = 0)
+                local stats = doc_settings:readSetting('stats')
+                if stats and stats.pages ~= 0 then
+                    -- Let's use them as is (which was what was done before), even if
+                    -- incomplete, to avoid expensive book opening
+                    book_props = stats
+                end
+            end
+            -- Files opened after 20170701 have an accurate 'doc_pages' setting
+            local doc_pages = doc_settings:readSetting('doc_pages')
+            if doc_pages and book_props then
+                book_props.pages = doc_pages
+            end
+        end
+    end
+
+    -- If still no book_props (book never opened or empty 'stats'), open the
+    -- document to get them
+    if not book_props then
+        local pages
+        local document = DocumentRegistry:openDocument(file)
+        if document.loadDocument then -- needed for crengine
+            document:loadDocument()
+            -- document:render()
+            -- It would be needed to get nb of pages, but the nb obtained
+            -- by simply calling here document:getPageCount() is wrong,
+            -- often 2 to 3 times the nb of pages we see when opening
+            -- the document (may be some other cre settings should be applied
+            -- before calling render() ?)
+        else
+            -- for all others than crengine, we seem to get an accurate nb of pages
+            pages = document:getPageCount()
+        end
+        -- via pcall because picdocument:getProps() always fails (we could
+        -- check document.is_pic, but this way, we'll catch any other error)
+        local ok, props = pcall(document.getProps, document)
+        if ok then
+            book_props = props
+        else
+            book_props = {}
+        end
+        book_props.pages = pages
+        DocumentRegistry:closeDocument(file)
+    end
+
+    local title = book_props.title
+    if title == "" or title == nil then title = _("N/A") end
+    table.insert(kv_pairs, { _("Title:"), title })
+
+    local authors = book_props.authors
+    if authors == "" or authors == nil then authors = _("N/A") end
+    table.insert(kv_pairs, { _("Authors:"), authors })
+
+    local series = book_props.series
+    if series == "" or series == nil then series = _("N/A") end
+    table.insert(kv_pairs, { _("Series:"), series })
+
+    local pages = book_props.pages
+    if pages == "" or pages == nil then pages = _("N/A") end
+    table.insert(kv_pairs, { _("Pages:"), pages })
+
+    local language = book_props.language
+    if language == "" or language == nil then language = _("N/A") end
+    table.insert(kv_pairs, { _("Language:"), language })
+
+    local keywords = book_props.keywords
+    if keywords == "" or keywords == nil then keywords = _("N/A") end
+    table.insert(kv_pairs, { _("Keywords:"), keywords })
+
+    local description = book_props.description
+    if description == "" or description == nil then
+        description = _("N/A")
+    else
+        -- Description may (often in EPUB, but not always) or may not (rarely
+        -- in PDF) be HTML.
+        description = util.htmlToPlainTextIfHtml(book_props.description)
+    end
+    table.insert(kv_pairs, { _("Description:"), description })
+
+    -- Cover image
+    local viewCoverImage = function()
+        local widget
+        local document = DocumentRegistry:openDocument(file)
+        if document then
+            local cover_bb = document:getCoverPageImage()
+            if cover_bb then
+                widget = ImageViewer:new{
+                    image = cover_bb,
+                    with_title_bar = false,
+                    fullscreen = true,
+                }
+            end
+            DocumentRegistry:closeDocument(file)
+        end
+        if not widget then
+            widget = InfoMessage:new{
+                text = _("No cover image available"),
+            }
+        end
+        UIManager:show(widget)
+    end
+    table.insert(kv_pairs, { _("Cover image:"), _("Tap to display"), callback=viewCoverImage })
+
+    local widget = KeyValuePage:new{
+        title = _("Book information"),
+        kv_pairs = kv_pairs,
+    }
+    UIManager:show(widget)
+end
+
+return BookInfo

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -1,10 +1,8 @@
 local ButtonDialog = require("ui/widget/buttondialog")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local DocSettings = require("docsettings")
+local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local Font = require("ui/font")
-local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local KeyValuePage = require("ui/widget/keyvaluepage")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
 local RenderText = require("ui/rendertext")
@@ -39,48 +37,6 @@ function FileManagerHistory:onSetDimensions(dimen)
     self.dimen = dimen
 end
 
-function FileManagerHistory:buildBookInformationTable(book_props)
-    if book_props == nil then
-        return false
-    end
-
-    if book_props.authors == "" or book_props.authors == nil then
-        book_props.authors = _("N/A")
-    end
-
-    if book_props.title == "" or book_props.title == nil then
-        book_props.title = _("N/A")
-    end
-
-    if book_props.series == "" or book_props.series == nil then
-        book_props.series = _("N/A")
-    end
-
-    if book_props.pages == "" or book_props.pages == nil then
-        book_props.pages = _("N/A")
-    end
-
-    if book_props.language == "" or book_props.language == nil then
-        book_props.language = _("N/A")
-    end
-
-    return {
-        { _("Title:"), book_props.title },
-        { _("Authors:"), book_props.authors },
-        { _("Series:"), book_props.series },
-        { _("Pages:"), book_props.pages },
-        { _("Language:"), string.upper(book_props.language) },
-    }
-end
-
-function FileManagerHistory:bookInformation(file)
-    local file_mode = lfs.attributes(file, "mode")
-    if file_mode ~= "file" then return false end
-    local book_stats = DocSettings:open(file):readSetting('stats')
-    if book_stats == nil then return false end
-    return self:buildBookInformationTable(book_stats)
-end
-
 function FileManagerHistory:onMenuHold(item)
     local font_size = Font:getFace("tfont")
     local text_remove_hist = _("Remove \"%1\" from history")
@@ -113,18 +69,9 @@ function FileManagerHistory:onMenuHold(item)
             {
                 {
                     text = _("Book information"),
+                    enabled = FileManagerBookInfo:isSupported(item.file),
                     callback = function()
-                        local book_info_metadata = FileManagerHistory:bookInformation(item.file)
-                        if  book_info_metadata then
-                            UIManager:show(KeyValuePage:new{
-                                title = _("Book information"),
-                                kv_pairs = book_info_metadata,
-                            })
-                        else
-                            UIManager:show(InfoMessage:new{
-                                text = _("Cannot fetch information for a selected book"),
-                            })
-                        end
+                        FileManagerBookInfo:show(item.file)
                         UIManager:close(self.histfile_dialog)
                     end,
                  },

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -1,0 +1,34 @@
+--[[--
+This module contains miscellaneous helper functions for FileManager
+]]
+
+local Device = require("device")
+
+local filemanagerutil = {}
+
+function filemanagerutil.getDefaultDir()
+    if Device:isKindle() then
+        return "/mnt/us/documents"
+    elseif Device:isKobo() then
+        return "/mnt/onboard"
+    elseif Device:isAndroid() then
+        return "/sdcard"
+    else
+        return "."
+    end
+end
+
+function filemanagerutil.abbreviate(path)
+    local home_dir_name = G_reader_settings:readSetting("home_dir_display_name")
+    if home_dir_name ~= nil then
+        local home_dir = G_reader_settings:readSetting("home_dir") or filemanagerutil.getDefaultDir()
+        local len = home_dir:len()
+        local start = path:sub(1, len)
+        if start == home_dir then
+            return home_dir_name .. path:sub(len+1)
+        end
+    end
+    return path
+end
+
+return filemanagerutil

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -546,6 +546,7 @@ end
 function ReaderFooter:onPageUpdate(pageno)
     self.pageno = pageno
     self.pages = self.view.document:getPageCount()
+    self.ui.doc_settings:saveSetting("doc_pages", self.pages) -- for Book information
     self:updateFooterPage()
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -10,6 +10,7 @@ local Device = require("device")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
 local Event = require("ui/event")
+local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local FileManagerHistory = require("apps/filemanager/filemanagerhistory")
 local Geom = require("ui/geometry")
 local InfoMessage = require("ui/widget/infomessage")
@@ -315,6 +316,12 @@ function ReaderUI:init()
     -- history view
     self:registerModule("history", FileManagerHistory:new{
         dialog = self.dialog,
+        ui = self,
+    })
+    -- book info
+    self:registerModule("bookinfo", FileManagerBookInfo:new{
+        dialog = self.dialog,
+        document = self.document,
         ui = self,
     })
     -- koreader plugins

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -342,6 +342,16 @@ function ReaderUI:init()
     end
     self.postInitCallback = nil
 
+    -- Now that document is loaded, store book metadata in settings
+    -- (so that filemanager can use it from sideCar file to display
+    -- Book information).
+    -- via pcall because picdocument:getProps() may fail
+    local ok, doc_props = pcall(self.document.getProps, self.document)
+    if not ok then
+        doc_props = {}
+    end
+    self.doc_settings:saveSetting("doc_props", doc_props)
+
     -- After initialisation notify that document is loaded and rendered
     -- CREngine only reports correct page count after rendering is done
     -- Need the same event for PDF document

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -174,6 +174,8 @@ function PdfDocument:getProps()
     props.authors = props.author
     props.series = ""
     props.language = ""
+    props.keywords = props.keywords
+    props.description = props.subject
     return props
 end
 

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -81,6 +81,7 @@ local order = {
     main = {
         "history",
         "book_status",
+        "book_info",
         "----------------------------",
         "ota_update", --[[ if Device:isKindle() or Device:isKobo() or
                            Device:isPocketBook() or Device:isAndroid() ]]--

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -1,0 +1,238 @@
+--[[
+Display some text in scrollable view
+]]
+local Blitbuffer = require("ffi/blitbuffer")
+local ButtonTable = require("ui/widget/buttontable")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local CloseButton = require("ui/widget/closebutton")
+local Device = require("device")
+local Geom = require("ui/geometry")
+local Font = require("ui/font")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local GestureRange = require("ui/gesturerange")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local LineWidget = require("ui/widget/linewidget")
+local OverlapGroup = require("ui/widget/overlapgroup")
+local ScrollTextWidget = require("ui/widget/scrolltextwidget")
+local TextWidget = require("ui/widget/textwidget")
+local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local logger = require("logger")
+local _ = require("gettext")
+local Screen = Device.screen
+
+local TextViewer = InputContainer:new{
+    title = nil,
+    text = nil,
+    width = nil,
+    height = nil,
+
+    title_face = Font:getFace("x_smalltfont"),
+    text_face = Font:getFace("x_smallinfofont"),
+    title_padding = Screen:scaleBySize(5),
+    title_margin = Screen:scaleBySize(2),
+    text_padding = Screen:scaleBySize(10),
+    text_margin = Screen:scaleBySize(2),
+    button_padding = Screen:scaleBySize(14),
+}
+
+function TextViewer:init()
+    local orig_dimen = self.frame and self.frame.dimen or Geom:new{}
+    -- calculate window dimension
+    self.align = "center"
+    self.region = Geom:new{
+        x = 0, y = 0,
+        w = Screen:getWidth(),
+        h = Screen:getHeight(),
+    }
+    self.width = self.width or Screen:getWidth() - Screen:scaleBySize(30)
+    self.height = self.height or Screen:getHeight() - Screen:scaleBySize(30)
+
+    if Device:hasKeys() then
+        self.key_events = {
+            Close = { {"Back"}, doc = "close text viewer" }
+        }
+    end
+
+    if Device:isTouchDevice() then
+        self.ges_events = {
+            TapClose = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = Geom:new{
+                        x = 0, y = 0,
+                        w = Screen:getWidth(),
+                        h = Screen:getHeight(),
+                    }
+                },
+            },
+            Swipe = {
+                GestureRange:new{
+                    ges = "swipe",
+                    range = Geom:new{
+                        x = 0, y = 0,
+                        w = Screen:getWidth(),
+                        h = Screen:getHeight(),
+                    }
+                },
+            },
+        }
+    end
+
+    local title_text = TextWidget:new{
+        text = self.title,
+        face = self.title_face,
+        bold = true,
+        width = self.width - 2*self.title_padding - 2*self.title_margin,
+    }
+    local titlew = FrameContainer:new{
+        padding = self.title_padding,
+        margin = self.title_margin,
+        bordersize = 0,
+        CenterContainer:new{
+            dimen = Geom:new{
+                w = self.width,
+                h = title_text:getSize().h,
+            },
+            title_text
+        }
+    }
+    titlew = OverlapGroup:new{
+        dimen = {
+            w = self.width,
+            h = titlew:getSize().h
+        },
+        titlew,
+        CloseButton:new{ window = self, },
+    }
+
+    local separator = LineWidget:new{
+        dimen = Geom:new{
+            w = self.width,
+            h = Screen:scaleBySize(2),
+        }
+    }
+
+    local buttons = {
+        {
+            {
+                text = _("Close"),
+                callback = function()
+                    UIManager:close(self)
+                end,
+            },
+        },
+    }
+    local button_table = ButtonTable:new{
+        width = self.width - self.button_padding,
+        button_font_face = "cfont",
+        button_font_size = 20,
+        buttons = buttons,
+        zero_sep = true,
+        show_parent = self,
+    }
+
+    local textw_height = self.height - titlew:getSize().h - separator:getSize().h - button_table:getSize().h
+
+    self.scroll_text_w = ScrollTextWidget:new{
+            text = self.text,
+            face = self.text_face,
+            width = self.width - 2*self.text_padding - 2*self.text_margin,
+            height = textw_height - 2*self.text_padding -2*self.text_margin,
+            dialog = self,
+            justified = true,
+    }
+    local textw = FrameContainer:new{
+        padding = self.text_padding,
+        margin = self.text_margin,
+        bordersize = 0,
+        self.scroll_text_w
+    }
+
+    self.frame = FrameContainer:new{
+        radius = 8,
+        bordersize = 3,
+        padding = 0,
+        margin = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        VerticalGroup:new{
+            align = "left",
+            titlew,
+            separator,
+            CenterContainer:new{
+                dimen = Geom:new{
+                    w = self.width,
+                    h = textw:getSize().h,
+                },
+                textw,
+            },
+            CenterContainer:new{
+                dimen = Geom:new{
+                    w = self.width,
+                    h = button_table:getSize().h,
+                },
+                button_table,
+            }
+        }
+    }
+    self[1] = WidgetContainer:new{
+        align = self.align,
+        dimen = self.region,
+        self.frame,
+    }
+    UIManager:setDirty("all", function()
+        local update_region = self.frame.dimen:combine(orig_dimen)
+        logger.dbg("update region", update_region)
+        return "partial", update_region
+    end)
+end
+
+function TextViewer:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "partial", self.frame.dimen
+    end)
+    return true
+end
+
+function TextViewer:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self.frame.dimen
+    end)
+    return true
+end
+
+function TextViewer:onAnyKeyPressed()
+    UIManager:close(self)
+    return true
+end
+
+function TextViewer:onTapClose(arg, ges_ev)
+    if ges_ev.pos:notIntersectWith(self.frame.dimen) then
+        self:onClose()
+    end
+    return true
+end
+
+function TextViewer:onClose()
+    UIManager:close(self)
+    return true
+end
+
+function TextViewer:onSwipe(arg, ges)
+    if ges.direction == "west" then
+        self.scroll_text_w:scrollText(1)
+        return true
+    elseif ges.direction == "east" then
+        self.scroll_text_w:scrollText(-1)
+        return true
+    else
+        -- trigger full refresh
+        UIManager:setDirty(nil, "full")
+        -- a long diagonal swipe may also be used for taking a screenshot,
+        -- so let it propagate
+        return false
+    end
+end
+
+return TextViewer

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -283,4 +283,17 @@ describe("util module", function()
         assert.are_same(util.splitToArray("100  abc   def ghi200  ", " ", false),
                         {"100", "abc", "def", "ghi200"})
     end)
+
+    it("should guess it is not HTML and let is as is", function()
+        local s = "if (i < 0 && j < 0) j = i&amp;"
+        assert.is_equal(util.htmlToPlainTextIfHtml(s), s)
+    end)
+    it("should guess it is HTML and convert it to text", function()
+        assert.is_equal(util.htmlToPlainTextIfHtml("<div> <br> Making <b>unit&nbsp;tests</b> is <i class='notreally'>fun &amp; n&#xE9;c&#233;ssaire</i><br/> </div>"),
+                    "Making unit tests is fun & nécéssaire")
+    end)
+    it("should guess it is double encoded HTML and convert it to text", function()
+        assert.is_equal(util.htmlToPlainTextIfHtml("Deux parties.&lt;br&gt;Prologue.Désespérée, elle le tue...&lt;br&gt;Première partie. Sur la route &amp;amp; dans la nuit"),
+                    "Deux parties.\nPrologue.Désespérée, elle le tue...\nPremière partie. Sur la route & dans la nuit")
+    end)
 end)


### PR DESCRIPTION
See discussion in #2986 and individual commit detailed messages:
- TextViewer widget, used when onHold on truncated item in KeyValuePage
- Store book metadata and nb of pages in new settings
- Book information: refactored and additional features

(not sure why github displays `\x`C2`\x`A0 in red, they work and I had added a lot in wikipedia.lua, where they are displayed in red too)