### PR TITLE
Put disable_fuzzy_search in search menu

### DIFF
--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -51,6 +51,8 @@ local order = {
     },
     search = {
         "dictionary_lookup",
+        "disable_fuzzy_search",
+        "----------------------------",
         "wikipedia_lookup",
         "----------------------------",
         "find_book_in_calibre_catalog",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -32,7 +32,6 @@ local order = {
     },
     setting = {
         "read_from_right_to_left",
-        "disable_fuzzy_search",
         -- common settings
         -- those that don't exist will simply be skipped during menu gen
         "frontlight", -- if Device:hasFrontlight()
@@ -70,6 +69,8 @@ local order = {
     },
     search = {
         "dictionary_lookup",
+        "disable_fuzzy_search",
+        "----------------------------",
         "wikipedia_lookup",
         "----------------------------",
         "goodreads",


### PR DESCRIPTION
Since "disable_fuzzy_search" is for dictionary search only, putting it into "search" menu should be more proper.