### PR TITLE
Wrap text in TextViewer

### DIFF
--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -80,11 +80,12 @@ function TextViewer:init()
         }
     end
 
+    local closeb = CloseButton:new{ window = self, }
     local title_text = TextBoxWidget:new{
         text = self.title,
         face = self.title_face,
         bold = true,
-        width = self.width * 0.9,
+        width = self.width - 2*self.title_padding - 2*self.title_margin - closeb:getSize().w,
     }
     local titlew = FrameContainer:new{
         padding = self.title_padding,
@@ -104,7 +105,7 @@ function TextViewer:init()
             h = titlew:getSize().h
         },
         titlew,
-        CloseButton:new{ window = self, },
+        closeb,
     }
 
     local separator = LineWidget:new{

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -14,7 +14,7 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local ScrollTextWidget = require("ui/widget/scrolltextwidget")
-local TextWidget = require("ui/widget/textwidget")
+local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -80,11 +80,11 @@ function TextViewer:init()
         }
     end
 
-    local title_text = TextWidget:new{
+    local title_text = TextBoxWidget:new{
         text = self.title,
         face = self.title_face,
         bold = true,
-        width = self.width - 2*self.title_padding - 2*self.title_margin,
+        width = self.width * 0.9,
     }
     local titlew = FrameContainer:new{
         padding = self.title_padding,


### PR DESCRIPTION
Minor fix.
Wrap text in title TextViewer widget.

Before:
![screenshot 2017-07-30 17-32-16](https://user-images.githubusercontent.com/22982594/28754838-df8ba9f8-754d-11e7-906a-4b1040374dfc.jpg)

After:

![screenshot 2017-07-30 17-28-14](https://user-images.githubusercontent.com/22982594/28754840-e6af2e76-754d-11e7-9ad0-e015125d187f.jpg)

