### PR TITLE
Read bookmarks without having to view ebook page (#1395)

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1,4 +1,3 @@
-local ButtonDialog = require("ui/widget/buttondialog")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
 local Event = require("ui/event")
@@ -7,6 +6,7 @@ local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Menu = require("ui/widget/menu")
+local TextViewer = require("ui/widget/textviewer")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
@@ -207,22 +207,31 @@ function ReaderBookmark:onShowBookmark()
     end
 
     function bm_menu:onMenuHold(item)
-        self.remove_bookmark_dialog = ButtonDialog:new{
-            buttons = {
+        self.textviewer = TextViewer:new{
+            title = _("Bookmark details"),
+            text = item.notes,
+            width = self.textviewer_width,
+            height = self.textviewer_height,
+            buttons_table = {
                 {
+                    {
+                        text = _("Close"),
+                        callback = function()
+                            UIManager:close(self.textviewer)
+                        end,
+                    },
                     {
                         text = _("Remove this bookmark"),
                         callback = function()
                             bookmark:removeHightligit(item)
                             bm_menu:switchItemTable(nil, bookmark.bookmarks, -1)
-                            UIManager:close(self.remove_bookmark_dialog)
+                            UIManager:close(self.textviewer)
                         end,
                     },
                 },
-            },
+            }
         }
-
-        UIManager:show(self.remove_bookmark_dialog)
+        UIManager:show(self.textviewer)
         return true
     end
 

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -27,6 +27,7 @@ local TextViewer = InputContainer:new{
     text = nil,
     width = nil,
     height = nil,
+    buttons_table = nil,
 
     title_face = Font:getFace("x_smalltfont"),
     text_face = Font:getFace("x_smallinfofont"),
@@ -115,16 +116,21 @@ function TextViewer:init()
         }
     }
 
-    local buttons = {
-        {
+    local buttons
+    if self.buttons_table == nil then
+        buttons = {
             {
-                text = _("Close"),
-                callback = function()
-                    UIManager:close(self)
-                end,
+                {
+                    text = _("Close"),
+                    callback = function()
+                        UIManager:close(self)
+                    end,
+                },
             },
-        },
-    }
+        }
+    else
+        buttons = self.buttons_table
+    end
     local button_table = ButtonTable:new{
         width = self.width - self.button_padding,
         button_font_face = "cfont",


### PR DESCRIPTION
Close #1395
Now it's available to read bookmarks without having to view ebook page. 
When we long press on selected bookmark:

![screenshot 2017-07-30 21-04-42](https://user-images.githubusercontent.com/22982594/28789543-1c8f1bae-7626-11e7-89d9-6f3d4ad6b5bf.jpg)

we get detailed window with all highlighted text. We can also remove selected bookmark.

![screenshot 2017-07-30 21-05-24](https://user-images.githubusercontent.com/22982594/28789609-467e95c0-7626-11e7-9b6b-e962ea8c1362.jpg)

