### PR TITLE
Option to make password visible when entering

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -220,6 +220,11 @@ function InputDialog:setInputText(text)
     self._input_widget:setText(text)
 end
 
+function InputDialog:changeTextType(type)
+    self._input_widget.text_type = type
+    self._input_widget:setText(self._input_widget:getText())
+end
+
 function InputDialog:onShow()
     UIManager:setDirty(self, function()
         return "ui", self.dialog_frame.dimen

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -63,6 +63,7 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local UIManager = require("ui/uimanager")
 local Screen = require("device").screen
+local _ = require("gettext")
 
 local InputDialog = InputContainer:new{
     title = "",
@@ -155,7 +156,7 @@ function InputDialog:init()
     if self.show_password_toggle and is_password_type then
         local button_switch = {
             {
-                text = "Show password",
+                text = _("Show password"),
                 callback = function()
                     if self._input_widget.text_type == "text" then
                         self._input_widget.text_type = "password"

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -72,7 +72,7 @@ local InputDialog = InputContainer:new{
     buttons = nil,
     input_type = nil,
     enter_callback = nil,
-    show_toggle = nil,
+    show_password_toggle = true,
 
     width = nil,
 
@@ -148,19 +148,21 @@ function InputDialog:init()
         scroll = false,
         parent = self,
     }
-
-    if self.show_toggle then
+    local is_password_type = false
+    if self._input_widget.text_type == "password" then
+        is_password_type = true
+    end
+    if self.show_password_toggle and is_password_type then
         local button_switch = {
             {
-                text = ("Switch visible"),
+                text = "Show password",
                 callback = function()
                     if self._input_widget.text_type == "text" then
                         self._input_widget.text_type = "password"
-                        self:changeTextType("password")
                     else
                         self._input_widget.text_type = "text"
-                        self:changeTextType("text")
                     end
+                    self._input_widget:setText(self._input_widget:getText())
                 end,
             },
         }
@@ -236,11 +238,6 @@ end
 
 function InputDialog:setInputText(text)
     self._input_widget:setText(text)
-end
-
-function InputDialog:changeTextType(type)
-    self._input_widget.text_type = type
-    self._input_widget:setText(self._input_widget:getText())
 end
 
 function InputDialog:onShow()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -72,6 +72,7 @@ local InputDialog = InputContainer:new{
     buttons = nil,
     input_type = nil,
     enter_callback = nil,
+    show_toggle = nil,
 
     width = nil,
 
@@ -148,6 +149,23 @@ function InputDialog:init()
         parent = self,
     }
 
+    if self.show_toggle then
+        local button_switch = {
+            {
+                text = ("Switch visible"),
+                callback = function()
+                    if self._input_widget.text_type == "text" then
+                        self._input_widget.text_type = "password"
+                        self:changeTextType("password")
+                    else
+                        self._input_widget.text_type = "text"
+                        self:changeTextType("text")
+                    end
+                end,
+            },
+        }
+        table.insert(self.buttons[1], button_switch[1])
+    end
     self.button_table = ButtonTable:new{
         width = self.width,
         button_font_face = "cfont",

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -314,25 +314,13 @@ function NetworkItem:onAddNetwork()
         input_hint = "password",
         input_type = "text",
         text_type = "password",
+        show_toggle = true,
         buttons = {
             {
                 {
                     text = _("Cancel"),
                     callback = function()
                         UIManager:close(password_input)
-                    end,
-                },
-                {
-                    text = ("Switch visible"),
-                    callback = function()
-                        if password_input.text_type == "text" then
-                            password_input.text_type = "password"
-                            password_input:changeTextType("password")
-
-                        else
-                            password_input.text_type = "text"
-                            password_input:changeTextType("text")
-                        end
                     end,
                 },
                 {

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -314,7 +314,6 @@ function NetworkItem:onAddNetwork()
         input_hint = "password",
         input_type = "text",
         text_type = "password",
-        show_toggle = true,
         buttons = {
             {
                 {

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -323,6 +323,19 @@ function NetworkItem:onAddNetwork()
                     end,
                 },
                 {
+                    text = ("Switch visible"),
+                    callback = function()
+                        if password_input.text_type == "text" then
+                            password_input.text_type = "password"
+                            password_input:changeTextType("password")
+
+                        else
+                            password_input.text_type = "text"
+                            password_input:changeTextType("text")
+                        end
+                    end,
+                },
+                {
                     text = _("Connect"),
                     is_enter_default = true,
                     callback = function()


### PR DESCRIPTION
Reference: #2882 
It's now possible to visible password when entering (connect to the wifi). After click in "Swich visible" you can show/hide password. 

![screenshot 2017-08-01 17-27-32](https://user-images.githubusercontent.com/22982594/28834377-5bca93b8-76e2-11e7-8409-a8dd3f0fdff8.jpg)

![screenshot 2017-08-01 17-28-34](https://user-images.githubusercontent.com/22982594/28834382-60c8a24c-76e2-11e7-9b6f-33e8b40b1cca.jpg)

I have no way of checking (on the emulator and the Kindle there is no option to add a wifi network), so ask to see if it works.

