### PR TITLE
Fix: Backspace will delete the character before the one on the left 

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -299,6 +299,8 @@ function TextBoxWidget:moveCursor(x, y)
         local w_prev = w - self.char_width_list[offset].width - self.char_width_list[offset].pad
         if x - w_prev < w - x then -- the previous one is more closer
             w = w_prev
+        else
+            offset = offset + 1
         end
     end
     self:free()


### PR DESCRIPTION
Close: #2074 