### PR TITLE
Fix: Can't long-press lookup word inside bookmark tap zone

### DIFF
--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -1,11 +1,11 @@
+local Device = require("device")
+local Event = require("ui/event")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local ImageWidget = require("ui/widget/imagewidget")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local RightContainer = require("ui/widget/container/rightcontainer")
-local ImageWidget = require("ui/widget/imagewidget")
-local GestureRange = require("ui/gesturerange")
-local Device = require("device")
-local Geom = require("ui/geometry")
 local Screen = require("device").screen
-local Event = require("ui/event")
 
 local ReaderDogear = InputContainer:new{}
 
@@ -40,29 +40,13 @@ function ReaderDogear:resetLayout()
                         h = new_screen_height*DTAP_ZONE_BOOKMARK.h
                     }
                 }
-            },
-            Hold = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = Geom:new{
-                        x = new_screen_width*DTAP_ZONE_BOOKMARK.x,
-                        y = new_screen_height*DTAP_ZONE_BOOKMARK.y,
-                        w = new_screen_width*DTAP_ZONE_BOOKMARK.w,
-                        h = new_screen_height*DTAP_ZONE_BOOKMARK.h
-                    }
-                }
             }
-        }
+         }
     end
 end
 
 function ReaderDogear:onTap()
     self.ui:handleEvent(Event:new("ToggleBookmark"))
-    return true
-end
-
-function ReaderDogear:onHold()
-    self.ui:handleEvent(Event:new("ToggleBookmarkFlipping"))
     return true
 end
 

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -41,7 +41,7 @@ function ReaderDogear:resetLayout()
                     }
                 }
             }
-         }
+        }
     end
 end
 


### PR DESCRIPTION
Close: #2636 
This patch should fix problem: Can't long-press lookup word inside bookmark tap zone.

```
Can't long-press lookup word inside bookmark tap zone.
This happens with short words, small fonts and very narrow margins.
```