### PR TITLE
Gesture to show only config menu

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -69,7 +69,7 @@ FOLLOW_LINK_TIMEOUT = 0.5
 -- w: width of tap zone in proportion of screen width
 -- h: height of tap zone in proportion of screen height
 DTAP_ZONE_MENU = {x = 1/8, y = 0, w = 3/4, h = 1/8}
-DTAP_ZONE_CONFIG = {x = 0, y = 0, w = 0, h = 0}
+DTAP_ZONE_CONFIG = {x = 1/8, y = 7/8, w = 3/4, h = 1/8}
 DTAP_ZONE_MINIBAR = {x = 0, y = 15/16, w = 1, h = 1/16}
 DTAP_ZONE_FORWARD = {x = 1/4, y = 0, w = 3/4, h = 1}
 DTAP_ZONE_BACKWARD = {x = 0, y = 0, w = 1/4, h = 1}

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -1,10 +1,8 @@
 local ConfigDialog = require("ui/widget/configdialog")
-local InputContainer = require("ui/widget/container/inputcontainer")
 local Device = require("device")
-local GestureRange = require("ui/gesturerange")
-local Geom = require("ui/geometry")
-local Screen = require("device").screen
 local Event = require("ui/event")
+local Geom = require("ui/geometry")
+local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 
@@ -25,19 +23,28 @@ function ReaderConfig:init()
 end
 
 function ReaderConfig:initGesListener()
-    self.ges_events = {
-        TapShowConfigMenu = {
-            GestureRange:new{
-                ges = "tap",
-                range = Geom:new{
-                    x = Screen:getWidth()*DTAP_ZONE_CONFIG.x,
-                    y = Screen:getHeight()*DTAP_ZONE_CONFIG.y,
-                    w = Screen:getWidth()*DTAP_ZONE_CONFIG.w,
-                    h = Screen:getHeight()*DTAP_ZONE_CONFIG.h,
-                }
-            }
-        }
-    }
+    self.ui:registerTouchZones({
+        {
+            id = "readerconfigmenu_tap",
+            ges = "tap",
+            screen_zone = {
+                ratio_x = DTAP_ZONE_CONFIG.x, ratio_y = DTAP_ZONE_CONFIG.y,
+                ratio_w = DTAP_ZONE_CONFIG.w, ratio_h = DTAP_ZONE_CONFIG.h,
+            },
+            overrides = { 'tap_forward', 'tap_backward', },
+            handler = function() return self:onTapShowConfigMenu() end,
+        },
+        {
+            id = "readerconfigmenu_swipe",
+            ges = "swipe",
+            screen_zone = {
+                ratio_x = DTAP_ZONE_CONFIG.x, ratio_y = DTAP_ZONE_CONFIG.y,
+                ratio_w = DTAP_ZONE_CONFIG.w, ratio_h = DTAP_ZONE_CONFIG.h,
+            },
+            overrides = { "rolling_swipe", "paging_swipe", },
+            handler = function(ges) return self:onSwipeShowConfigMenu(ges) end,
+        },
+    })
 end
 
 function ReaderConfig:onShowConfigMenu()
@@ -60,6 +67,13 @@ end
 function ReaderConfig:onTapShowConfigMenu()
     self:onShowConfigMenu()
     return true
+end
+
+function ReaderConfig:onSwipeShowConfigMenu(ges)
+    if ges.direction == "north" then
+        self:onShowConfigMenu()
+        return true
+    end
 end
 
 function ReaderConfig:onSetDimensions(dimen)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -233,7 +233,7 @@ function ReaderFooter:setupTouchZones()
             screen_zone = footer_screen_zone,
             handler = function(ges) return self:onTapFooter(ges) end,
             overrides = {
-                'tap_forward', 'tap_backward',
+                'tap_forward', 'tap_backward', 'readerconfigmenu_tap',
             },
         },
         {

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -29,7 +29,7 @@ function ReaderHighlight:setupTouchZones()
             screen_zone = {
                 ratio_x = 0, ratio_y = 0, ratio_w = 1, ratio_h = 1,
             },
-            overrides = { 'tap_forward', 'tap_backward', },
+            overrides = { 'tap_forward', 'tap_backward', 'readermenu_tap', 'readerconfigmenu_tap', },
             handler = function(ges) return self:onTap(nil, ges) end
         },
         {

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -279,6 +279,9 @@ function ReaderMenu:onSwipeShowMenu(ges)
         self.ui:handleEvent(Event:new("ShowConfigMenu"))
         self.ui:handleEvent(Event:new("ShowReaderMenu"))
         return true
+    elseif ges.direction == "north" then
+        self.ui:handleEvent(Event:new("ShowConfigMenu"))
+        return true
     end
 end
 

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -279,9 +279,6 @@ function ReaderMenu:onSwipeShowMenu(ges)
         self.ui:handleEvent(Event:new("ShowConfigMenu"))
         self.ui:handleEvent(Event:new("ShowReaderMenu"))
         return true
-    elseif ges.direction == "north" then
-        self.ui:handleEvent(Event:new("ShowConfigMenu"))
-        return true
     end
 end
 


### PR DESCRIPTION
In some cases config menu is hidden by reader menu. 

![screenshot 2017-08-04 12-47-10](https://user-images.githubusercontent.com/22982594/28967918-dc4560da-791d-11e7-9aec-ba808169f6aa.jpg)

Useful should be gesture to show only config menu. I implemented it
When we swipe from down to up in menu zone we get config menu.

![screenshot 2017-08-04 14-08-28](https://user-images.githubusercontent.com/22982594/28968058-76fe6176-791e-11e7-979f-ef600c6f53a8.jpg)
