### PR TITLE
Fix: crash when incorrect value in input page number

### DIFF
--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -295,7 +295,7 @@ function KeyValuePage:init()
             end,
             callback = function(input)
                 local page = tonumber(input)
-                if page >= 1 and page <= self.pages then
+                if page and page >= 1 and page <= self.pages then
                     self:goToPage(page)
                 end
             end,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -445,7 +445,7 @@ function Menu:init()
             end,
             callback = function(input)
                 local page = tonumber(input)
-                if page >= 1 and page <= self.page_num then
+                if page and page >= 1 and page <= self.page_num then
                     self:onGotoPage(page)
                 end
             end,


### PR DESCRIPTION
Fix crash when input non number value (or empty) in "Input page number" (Filemanager or KeyValuePage -> long press on page 1 of xx -> input non number value eg. "aaaa")