### PR TITLE
Fix: Footer hides text

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -16,7 +16,6 @@ local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
 
-
 local MODE = {
     off = 0,
     page_progress = 1,
@@ -195,6 +194,10 @@ function ReaderFooter:init()
     self[1] = self.footer_positioner
 
     self.mode = G_reader_settings:readSetting("reader_footer_mode") or self.mode
+    if self.has_no_mode then
+        self.mode = MODE.off
+        self:resetLayout()
+    end
     if self.settings.all_at_once then
         self.view.footer_visible = (self.mode ~= MODE.off)
         self:updateFooterTextGenerator()
@@ -368,6 +371,14 @@ function ReaderFooter:addToMainMenu(menu_items)
                         self.has_no_mode = false
                         break
                     end
+                end
+                -- refresh margins position
+                if self.has_no_mode then
+                    self.ui:handleEvent(Event:new("SetPageMargins", self.view.document.configurable.page_margins))
+                    self.mode = MODE.off
+                elseif prev_has_no_mode then
+                    self.ui:handleEvent(Event:new("SetPageMargins", self.view.document.configurable.page_margins))
+                    G_reader_settings:saveSetting("reader_footer_mode", first_enabled_mode_num)
                 end
                 if callback then
                     should_update = callback(self)
@@ -603,6 +614,9 @@ function ReaderFooter:onExitFlippingMode()
 end
 
 function ReaderFooter:onTapFooter(ges)
+    if self.has_no_mode then
+        return
+    end
     if self.view.flipping_visible then
         local pos = ges.pos
         local dimen = self.progress_bar.dimen

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -196,6 +196,7 @@ function ReaderFooter:init()
     self.mode = G_reader_settings:readSetting("reader_footer_mode") or self.mode
     if self.has_no_mode then
         self.mode = MODE.off
+        self.view.footer_visible = false
         self:resetLayout()
     end
     if self.settings.all_at_once then
@@ -204,7 +205,6 @@ function ReaderFooter:init()
     else
         self:applyFooterMode()
     end
-
     if self.settings.auto_refresh_time then
         self:setupAutoRefreshTime()
     end
@@ -375,6 +375,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 -- refresh margins position
                 if self.has_no_mode then
                     self.ui:handleEvent(Event:new("SetPageMargins", self.view.document.configurable.page_margins))
+                    self.genFooterText = footerTextGeneratorMap.empty
                     self.mode = MODE.off
                 elseif prev_has_no_mode then
                     self.ui:handleEvent(Event:new("SetPageMargins", self.view.document.configurable.page_margins))

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -1,11 +1,11 @@
-local InputContainer = require("ui/widget/container/inputcontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
-local lfs = require("libs/libkoreader-lfs")
-local UIManager = require("ui/uimanager")
-local Screen = require("device").screen
 local Event = require("ui/event")
-local T = require("ffi/util").template
+local InputContainer = require("ui/widget/container/inputcontainer")
+local UIManager = require("ui/uimanager")
+local lfs = require("libs/libkoreader-lfs")
 local _ = require("gettext")
+local Screen = require("device").screen
+local T = require("ffi/util").template
 
 local ReaderTypeset = InputContainer:new{
     css_menu_title = _("Set render style"),
@@ -196,7 +196,12 @@ function ReaderTypeset:onSetPageMargins(margins)
     local left = Screen:scaleBySize(margins[1])
     local top = Screen:scaleBySize(margins[2])
     local right = Screen:scaleBySize(margins[3])
-    local bottom = Screen:scaleBySize(margins[4])
+    local bottom
+    if self.view.footer.has_no_mode then
+        bottom = Screen:scaleBySize(margins[4])
+    else
+        bottom = Screen:scaleBySize(margins[4] + DMINIBAR_HEIGHT)
+    end
     self.ui.document:setPageMargins(left, top, right, bottom)
     self.ui:handleEvent(Event:new("UpdatePos"))
     return true

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -595,7 +595,7 @@ describe("Readerfooter module", function()
         local footer = readerui.view.footer
 
         assert.truthy(footer.has_no_mode)
-        assert.truthy(readerui.view.footer_visible)
+        assert.falsy(readerui.view.footer_visible)
         assert.is.same(21, footer:getHeight())
     end)
 

--- a/spec/unit/readerhighlight_spec.lua
+++ b/spec/unit/readerhighlight_spec.lua
@@ -99,9 +99,9 @@ describe("Readerhighlight module", function()
         end)
         it("should response on tap gesture", function()
             tap_highlight_text(readerui,
-                               Geom:new{ x = 26, y = 374 },
-                               Geom:new{ x = 484, y = 574 },
-                               Geom:new{ x = 331, y = 474 })
+                               Geom:new{ x = 151, y = 120  },
+                               Geom:new{ x = 290, y = 301 },
+                               Geom:new{ x = 200, y = 268 })
             Screen:shot("screenshots/reader_tap_highlight_text_epub.png")
         end)
     end)


### PR DESCRIPTION
Close: #2257 
This patch should resolve issue #2257 (Footer hides text)
`Sometimes, depending on an epub style, some text is hidden by the progress bar (the mini one at the bottom).`