### PR TITLE
Support history as default view for filemanager

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -483,6 +483,37 @@ function FileManager:getSortingMenuTable()
     }
 end
 
+function FileManager:getStartWithMenuTable()
+    local start_with_setting = G_reader_settings:readSetting("start_with") or "filemanager"
+    local start_withs = {
+        filemanager = _("Start with file browser"),
+        history = _("Start with history"),
+        last = _("Start with last file"),
+    }
+    local set_sw_table = function(start_with)
+        return {
+            text = start_withs[start_with],
+            checked_func = function()
+                return start_with_setting == start_with
+            end,
+            callback = function()
+                start_with_setting = start_with
+                G_reader_settings:saveSetting("start_with", start_with)
+            end,
+        }
+    end
+    return {
+        text_func = function()
+            return start_withs[start_with_setting]
+        end,
+        sub_item_table = {
+            set_sw_table("filemanager"),
+            set_sw_table("history"),
+            set_sw_table("last"),
+        }
+    }
+end
+
 function FileManager:showFiles(path)
     path = path or G_reader_settings:readSetting("lastdir") or filemanagerutil.getDefaultDir()
     G_reader_settings:saveSetting("lastdir", path)

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -468,7 +468,7 @@ function FileManager:getSortingMenuTable()
     return {
         text_func = function()
             return util.template(
-                _("Sort by %1"),
+                _("Sort by: %1"),
                 collates[fm.file_chooser.collate][1]
             )
         end,
@@ -486,13 +486,13 @@ end
 function FileManager:getStartWithMenuTable()
     local start_with_setting = G_reader_settings:readSetting("start_with") or "filemanager"
     local start_withs = {
-        filemanager = _("Start with file browser"),
-        history = _("Start with history"),
-        last = _("Start with last file"),
+        filemanager = {_("file browser"), _("Start with file browser")},
+        history = {_("history"), _("Start with history")},
+        last = {_("last file"), _("Start with last file")},
     }
     local set_sw_table = function(start_with)
         return {
-            text = start_withs[start_with],
+            text = start_withs[start_with][2],
             checked_func = function()
                 return start_with_setting == start_with
             end,
@@ -504,7 +504,10 @@ function FileManager:getStartWithMenuTable()
     end
     return {
         text_func = function()
-            return start_withs[start_with_setting]
+            return util.template(
+                _("Start with: %1"),
+                start_withs[start_with_setting][1]
+            )
         end,
         sub_item_table = {
             set_sw_table("filemanager"),

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -100,8 +100,9 @@ function FileManagerHistory:onShowHist()
 
     self.hist_menu = Menu:new{
         ui = self.ui,
-        width = Screen:getWidth()-50,
-        height = Screen:getHeight()-50,
+        width = Screen:getWidth(),
+        height = Screen:getHeight(),
+        is_borderless = true,
         show_parent = menu_container,
         onMenuHold = self.onMenuHold,
         _manager = self,

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -95,20 +95,7 @@ function FileManagerMenu:setUpdateItemTable()
         checked_func = function() return self.ui.file_chooser.reverse_collate end,
         callback = function() self.ui:toggleReverseCollate() end
     }
-    self.menu_items.start_with_last_opened_file = {
-        text = _("Start with last opened file"),
-        checked_func = function() return
-            G_reader_settings:readSetting("open_last")
-        end,
-        enabled_func = function() return
-            G_reader_settings:readSetting("lastfile") ~= nil
-        end,
-        callback = function()
-            local open_last = G_reader_settings:readSetting("open_last") or false
-            G_reader_settings:saveSetting("open_last", not open_last)
-            G_reader_settings:flush()
-        end
-    }
+    self.menu_items.start_with = self.ui:getStartWithMenuTable()
     if Device:supportsScreensaver() then
         self.menu_items.screensaver = {
             text = _("Screensaver"),

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -11,7 +11,7 @@ local order = {
         "sort_by",
         "reverse_sorting",
         "----------------------------",
-        "start_with_last_opened_file",
+        "start_with",
         "screensaver",
         "----------------------------",
         -- common settings

--- a/reader.lua
+++ b/reader.lua
@@ -122,8 +122,9 @@ if fontmap ~= nil then
 end
 -- last file
 local last_file = G_reader_settings:readSetting("lastfile")
+local start_with = G_reader_settings:readSetting("start_with")
 -- load last opened file
-local open_last = G_reader_settings:readSetting("open_last")
+local open_last = start_with == "last"
 if open_last and last_file and lfs.attributes(last_file, "mode") ~= "file" then
     UIManager:show(retryLastFile())
     last_file = nil
@@ -165,6 +166,14 @@ if ARGV[argidx] and ARGV[argidx] ~= "" then
         UIManager:nextTick(function()
             FileManager:showFiles(home_dir)
         end)
+        -- always open history on top of filemanager so closing history
+        -- doesn't result in exit
+        if start_with == "history" then
+            local FileManagerHistory = require("apps/filemanager/filemanagerhistory")
+            UIManager:nextTick(function()
+                FileManagerHistory:onShowHist(last_file)
+            end)
+        end
     end
     exit_code = UIManager:run()
 elseif last_file then


### PR DESCRIPTION
Fixes #2774

* make history view borderless
* add new menu for what to start with

# Before
![screenshot_2017-08-08_12-02-33](https://user-images.githubusercontent.com/202757/29067041-7e904952-7c31-11e7-9e6d-65ce7bca3904.png)

![screenshot_2017-08-08_12-15-21](https://user-images.githubusercontent.com/202757/29067524-460256be-7c33-11e7-87d5-a7acedf2c9d6.png)


# After
![screenshot_2017-08-08_12-01-37](https://user-images.githubusercontent.com/202757/29067015-632cd860-7c31-11e7-80c1-b285370b67be.png)

![screenshot_2017-08-08_12-01-45](https://user-images.githubusercontent.com/202757/29067017-6330fb70-7c31-11e7-8dd6-0fa0e2bf34e4.png)

![screenshot_2017-08-08_12-01-51](https://user-images.githubusercontent.com/202757/29067016-6330e18a-7c31-11e7-92e2-cbd1bb5e9610.png)

# Take note

I didn't bother to implement the "feature" that you couldn't toggle this setting unless you opened a document first. Comments welcome @ersi @KenMaltby

![screenshot_2017-08-08_12-03-40](https://user-images.githubusercontent.com/202757/29067081-a125a6d8-7c31-11e7-84f6-1591a3ab4fd8.png)
