### PR TITLE
Option to choose gesture to open menu

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -47,6 +47,10 @@ function FileManagerMenu:init()
             ShowMenu = { { "Menu" }, doc = "show menu" },
         }
     end
+    self.activation_menu = G_reader_settings:readSetting("activate_menu")
+    if self.activation_menu == nil then
+        self.activation_menu = "swipe_tap"
+    end
 end
 
 function FileManagerMenu:initGesListener()
@@ -380,12 +384,14 @@ function FileManagerMenu:onCloseFileManagerMenu()
 end
 
 function FileManagerMenu:onTapShowMenu(ges)
-    self:onShowMenu()
-    return true
+    if self.activation_menu ~= "swipe" then
+        self:onShowMenu()
+        return true
+    end
 end
 
 function FileManagerMenu:onSwipeShowMenu(ges)
-    if ges.direction == "south" then
+    if self.activation_menu ~= "tap" and ges.direction == "south" then
         self:onShowMenu()
         return true
     end

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -20,6 +20,10 @@ function ReaderConfig:init()
     if Device:isTouchDevice() then
         self:initGesListener()
     end
+    self.activation_menu = G_reader_settings:readSetting("activate_menu")
+    if self.activation_menu == nil then
+        self.activation_menu = "swipe_tap"
+    end
 end
 
 function ReaderConfig:initGesListener()
@@ -65,12 +69,14 @@ function ReaderConfig:onShowConfigMenu()
 end
 
 function ReaderConfig:onTapShowConfigMenu()
-    self:onShowConfigMenu()
-    return true
+    if self.activation_menu ~= "swipe" then
+        self:onShowConfigMenu()
+        return true
+    end
 end
 
 function ReaderConfig:onSwipeShowConfigMenu(ges)
-    if ges.direction == "north" then
+    if self.activation_menu ~= "tap" and ges.direction == "north" then
         self:onShowConfigMenu()
         return true
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -62,6 +62,10 @@ function ReaderMenu:init()
             self.key_events.ShowReaderMenu = { { "Menu" }, doc = "show menu", }
         end
     end
+    self.activation_menu = G_reader_settings:readSetting("activate_menu")
+    if self.activation_menu == nil then
+        self.activation_menu = "swipe_tap"
+    end
 end
 
 function ReaderMenu:onReaderReady()
@@ -275,7 +279,7 @@ function ReaderMenu:onCloseReaderMenu()
 end
 
 function ReaderMenu:onSwipeShowMenu(ges)
-    if ges.direction == "south" then
+    if self.activation_menu ~= "tap" and ges.direction == "south" then
         self.ui:handleEvent(Event:new("ShowConfigMenu"))
         self.ui:handleEvent(Event:new("ShowReaderMenu"))
         return true
@@ -283,9 +287,11 @@ function ReaderMenu:onSwipeShowMenu(ges)
 end
 
 function ReaderMenu:onTapShowMenu()
-    self.ui:handleEvent(Event:new("ShowConfigMenu"))
-    self.ui:handleEvent(Event:new("ShowReaderMenu"))
-    return true
+    if self.activation_menu ~= "swipe" then
+        self.ui:handleEvent(Event:new("ShowConfigMenu"))
+        self.ui:handleEvent(Event:new("ShowReaderMenu"))
+        return true
+    end
 end
 
 function ReaderMenu:onTapCloseMenu()

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -39,6 +39,7 @@ common_settings.screen = {
         require("ui/elements/screen_disable_double_tap_table"),
         require("ui/elements/refresh_menu_table"),
         require("ui/elements/flash_keyboard"),
+        require("ui/elements/menu_activate"),
     },
 }
 common_settings.save_document = {

--- a/frontend/ui/elements/menu_activate.lua
+++ b/frontend/ui/elements/menu_activate.lua
@@ -1,0 +1,61 @@
+local InfoMessage = require("ui/widget/infomessage")
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+
+local function activateMenu() return G_reader_settings:readSetting("activate_menu") end
+
+
+return {
+    text = _("Activate menu"),
+    sub_item_table = {
+        {
+            text = _("Swipe and tap"),
+            checked_func = function()
+                local activate_menu = activateMenu()
+                if activate_menu == nil or activate_menu == "swipe_tap" then
+                    return true
+                else
+                    return false
+                end
+            end,
+            callback = function()
+                G_reader_settings:saveSetting("activate_menu", "swipe_tap")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
+            end
+        },
+        {
+            text = _("Only swipe"),
+            checked_func = function()
+                if activateMenu() == "swipe" then
+                    return true
+                else
+                    return false
+                end
+            end,
+            callback = function()
+                G_reader_settings:saveSetting("activate_menu", "swipe")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
+            end
+        },
+        {
+            text = _("Only tap"),
+            checked_func = function()
+                if activateMenu() == "tap" then
+                    return true
+                else
+                    return false
+                end
+            end,
+            callback = function()
+                G_reader_settings:saveSetting("activate_menu", "tap")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
+            end
+        },
+    }
+}


### PR DESCRIPTION
After this patch we can choose way to open reader menu and config menu.
Go to config > Screen > Activate menu :
+ Swipe and tap (default value) - activate of the menu by swipe and tap
+ Only swipe - activate of the menu by swipe (tap doesn't start menu)
+ Only tap - activate of the menu by tap (swipe doesn't start menu)

![screenshot 2017-08-08 18-24-46](https://user-images.githubusercontent.com/22982594/29083132-fc1730bc-7c67-11e7-90fe-b715721dd8fb.jpg)

![screenshot 2017-08-08 18-25-35](https://user-images.githubusercontent.com/22982594/29083150-01298e1a-7c68-11e7-92ca-670196770385.jpg)

