### PR TITLE
[fix] util.isEmptyDir() crashes on non-existent dir

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -288,7 +288,10 @@ end
 ---- @treturn bool
 function util.isEmptyDir(path)
     local lfs = require("libs/libkoreader-lfs")
-    for filename in lfs.dir(path) do
+    -- lfs.dir will crash rather than return nil if directory doesn't exist O_o
+    local ok, iter, dir_obj = pcall(lfs.dir, path)
+    if not ok then return end
+    for filename in iter, dir_obj do
         if filename ~= '.' and filename ~= '..' then
             return false
         end

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -1,7 +1,8 @@
 describe("util module", function()
-    local util
+    local DataStorage, util
     setup(function()
         require("commonrequire")
+        DataStorage = require("datastorage")
         util = require("util")
     end)
 
@@ -295,5 +296,17 @@ describe("util module", function()
     it("should guess it is double encoded HTML and convert it to text", function()
         assert.is_equal(util.htmlToPlainTextIfHtml("Deux parties.&lt;br&gt;Prologue.Désespérée, elle le tue...&lt;br&gt;Première partie. Sur la route &amp;amp; dans la nuit"),
                     "Deux parties.\nPrologue.Désespérée, elle le tue...\nPremière partie. Sur la route & dans la nuit")
+    end)
+    it("should return true on empty dir", function()
+        assert.is_equal(util.isEmptyDir(DataStorage:getDataDir() .. "/data/dict"), -- should be empty during unit tests
+                    true)
+    end)
+    it("should return false on non-empty dir", function()
+        assert.is_equal(util.isEmptyDir(DataStorage:getDataDir()), -- should contain subdirectories
+                    false)
+    end)
+    it("should return nil on non-existent dir", function()
+        assert.is_equal(util.isEmptyDir("/this/is/just/some/nonsense/really/this/should/not/exist"),
+                    nil)
     end)
 end)


### PR DESCRIPTION
lfs.dir will crash rather than return nil if directory doesn't exist

Proper fix for 9f5e44670183d046054f87b4820bf5d1b35b3b12 which is nothing but a workaround. However, I do think creating more of those data dirs automatically is more user-friendly because otherwise Android users will have to look it up or guess.