### PR TITLE
Fix: Cloud Storage not working on Kobo Aura ONE

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -10,6 +10,7 @@ local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
 local lfs = require("libs/libkoreader-lfs")
 local _ = require("gettext")
+local Screen = require("device").screen
 
 local CloudStorage = Menu:extend{
     cloud_servers = {
@@ -32,6 +33,8 @@ function CloudStorage:init()
     self.title = "Cloud Storage"
     self.show_parent = self
     self.item_table = self:genItemTableFromRoot()
+    self.width = Screen:getWidth()
+    self.height = Screen:getHeight()
     Menu.init(self)
 end
 

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -3,11 +3,10 @@ local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local DropBox = require("apps/cloudstorage/dropbox")
-local InfoMessage = require("ui/widget/infomessage")
 local Ftp = require("apps/cloudstorage/ftp")
-local Menu = require("ui/widget/menu")
+local InfoMessage = require("ui/widget/infomessage")
 local LuaSettings = require("luasettings")
-local Screen = require("device").screen
+local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
 local lfs = require("libs/libkoreader-lfs")
 local _ = require("gettext")
@@ -21,8 +20,6 @@ local CloudStorage = Menu:extend{
             editable = false,
         },
     },
-    width = Screen:getWidth(),
-    height = Screen:getHeight(),
     no_title = false,
     show_parent = nil,
     is_popout = false,

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -1,11 +1,11 @@
-local url = require('socket.url')
-local socket = require('socket')
+local DocumentRegistry = require("document/documentregistry")
+local JSON = require("json")
 local http = require('socket.http')
 local https = require('ssl.https')
 local ltn12 = require('ltn12')
+local socket = require('socket')
+local url = require('socket.url')
 local _ = require("gettext")
-local JSON = require("json")
-local DocumentRegistry = require("document/documentregistry")
 
 local DropBoxApi = {
 }
@@ -95,7 +95,7 @@ function DropBoxApi:listFolder(path, token)
     local dropbox_file = {}
     local tag, text
     local ls_dropbox = self:fetchListFolders(path, token)
-    if ls_dropbox == nil or ls_dropbox.entreis == nil then return false end
+    if ls_dropbox == nil or ls_dropbox.entries == nil then return false end
     for _, files in ipairs(ls_dropbox.entries) do
         text = files.name
         tag = files[".tag"]

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -95,7 +95,7 @@ function DropBoxApi:listFolder(path, token)
     local dropbox_file = {}
     local tag, text
     local ls_dropbox = self:fetchListFolders(path, token)
-    if ls_dropbox == nil then return false end
+    if ls_dropbox == nil or ls_dropbox.entreis == nil then return false end
     for _, files in ipairs(ls_dropbox.entries) do
         text = files.name
         tag = files[".tag"]

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -230,10 +230,7 @@ function FileManagerMenu:setUpdateItemTable()
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),
         callback = function()
-            local cloud_storage = CloudStorage:new{
-                width = Screen:getWidth(),
-                height = Screen:getHeight(),
-            }
+            local cloud_storage = CloudStorage:new{}
             UIManager:show(cloud_storage)
             local filemanagerRefresh = function() self.ui:onRefresh() end
             function cloud_storage:onClose()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -230,7 +230,10 @@ function FileManagerMenu:setUpdateItemTable()
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),
         callback = function()
-            local cloud_storage = CloudStorage:new{}
+            local cloud_storage = CloudStorage:new{
+                width = Screen:getWidth(),
+                height = Screen:getHeight(),
+            }
             UIManager:show(cloud_storage)
             local filemanagerRefresh = function() self.ui:onRefresh() end
             function cloud_storage:onClose()


### PR DESCRIPTION
Should fix: #3074 

    Cloud storage opens in landscape mode when display is in portrait mode.
    If return is pressed when in root, koreader crashes.

