### PR TITLE
Fix: Zsync -> Share this document crashes

### DIFF
--- a/plugins/zsync.koplugin/main.lua
+++ b/plugins/zsync.koplugin/main.lua
@@ -38,6 +38,11 @@ function ZSync:addToMainMenu(menu_items)
                     return self.filemq_client == nil
                 end,
                 callback = function()
+                    local NetworkMgr = require("ui/network/manager")
+                    if not NetworkMgr:isOnline() then
+                        NetworkMgr:promptWifiOn()
+                        return
+                    end
                     if not self.filemq_server then
                         self:publish()
                     else


### PR DESCRIPTION
Close: #2638 
"Zsync" -> "Share this document" crashes koreader if not connected to wifi

After this fix when koreader is offline after "Zsync" -> "Share this document" we are asked to enable wifi.