### PR TITLE
Prevent problem with git clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "koreader-base"]
 	path = base
-	url = git://github.com/koreader/koreader-base.git
+	url = https://github.com/koreader/koreader-base.git
 [submodule "platform/android/luajit-launcher"]
 	path = platform/android/luajit-launcher
 	url = https://github.com/koreader/android-luajit-launcher.git


### PR DESCRIPTION
We should use https://github.com/koreader/... instead of git://github.com/koreader/... to prevent such problems: https://stackoverflow.com/questions/16298986/unable-to-connect-to-github-com-for-cloning
I have today similar problem.