### PR TITLE
Button and TextWidget: added max_width attribute

### DIFF
--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -26,6 +26,7 @@ local Button = InputContainer:new{
     radius = 15,
     padding = 2,
     width = nil,
+    max_width = nil,
     text_font_face = "cfont",
     text_font_size = 20,
     text_font_bold = true,
@@ -35,6 +36,7 @@ function Button:init()
     if self.text then
         self.label_widget = TextWidget:new{
             text = self.text,
+            max_width = self.max_width and self.max_width - 2*self.padding - 2*self.margin - 2*self.bordersize or nil,
             fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GREY,
             bold = self.text_font_bold,
             face = Font:getFace(self.text_font_face, self.text_font_size)

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -225,6 +225,7 @@ function DictQuickLookup:update()
         padding = lookup_word_padding,
         margin = lookup_word_margin,
         bordersize = 0,
+        max_width = self.width,
         text = self.displayword,
         text_font_face = "tfont",
         text_font_size = lookup_word_font_size,

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -23,6 +23,7 @@ local TextWidget = Widget:new{
     face = nil,
     bold = nil,
     fgcolor = Blitbuffer.COLOR_BLACK,
+    max_width = nil,
     _bb = nil,
     _length = 0,
     _height = 0,
@@ -37,7 +38,7 @@ local TextWidget = Widget:new{
 --end
 
 function TextWidget:updateSize()
-    local tsize = RenderText:sizeUtf8Text(0, Screen:getWidth(), self.face, self.text, true, self.bold)
+    local tsize = RenderText:sizeUtf8Text(0, self.max_width and self.max_width or Screen:getWidth(), self.face, self.text, true, self.bold)
     if not tsize then
         self._length = 0
     else
@@ -70,7 +71,7 @@ function TextWidget:paintTo(bb, x, y)
     --bb:blitFrom(self._bb, x, y, 0, 0, self._length, self._bb:getHeight())
     --@TODO Don't use kerning for monospaced fonts.    (houqp)
     RenderText:renderUtf8Text(bb, x, y+self._height*0.7, self.face, self.text, true, self.bold,
-                self.fgcolor, self.width)
+                self.fgcolor, self.max_width and self.max_width or self.width)
 end
 
 function TextWidget:free()


### PR DESCRIPTION
Simple way to ensure overlong text is truncated. Used by dictquicklookup to truncate long titles.
Closes #3099.
See https://github.com/koreader/koreader/issues/3099#issuecomment-323515768