### PR TITLE
Avoid warning on input timeout on the emulator

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -578,7 +578,10 @@ function Input:waitEvent(timeout_us)
         end
 
         -- ev does contain an error message:
-        if ev == "Waiting for input failed: timeout\n" then
+        local timeout_err_msg = "Waiting for input failed: timeout\n"
+        -- ev may not be equal to timeout_err_msg, but it may ends with it
+        -- ("./ffi/SDL2_0.lua:110: Waiting for input failed: timeout" on the emulator)
+        if ev and ev.sub and ev:sub(-timeout_err_msg:len()) == timeout_err_msg then
             -- don't report an error on timeout
             ev = nil
             break


### PR DESCRIPTION
Avoid these warning on the emulator output:
```
08/19/17-14:42:22 WARN  got error waiting for events: ./ffi/SDL2_0.lua:110: Waiting for input failed: timeout
08/19/17-14:42:22 WARN  got error waiting for events: ./ffi/SDL2_0.lua:110: Waiting for input failed: timeout
08/19/17-14:42:25 WARN  got error waiting for events: ./ffi/SDL2_0.lua:110: Waiting for input failed: timeout
08/19/17-14:42:27 WARN  got error waiting for events: ./ffi/SDL2_0.lua:110: Waiting for input failed: timeout
```
They happen when something scheduled get us out of waitForInput (which may be useful to know on the emulator), but they ought to be ignored by the code - they were just not ignored because the error message with SDL had some prefix. So, we just replace equality check with some kind of _endswith_.