### PR TITLE
Added PicDocument:getCoverPageImage() and :getProps()

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -107,14 +107,7 @@ function BookInfo:show(file, book_props)
             -- for all others than crengine, we seem to get an accurate nb of pages
             pages = document:getPageCount()
         end
-        -- via pcall because picdocument:getProps() always fails (we could
-        -- check document.is_pic, but this way, we'll catch any other error)
-        local ok, props = pcall(document.getProps, document)
-        if ok then
-            book_props = props
-        else
-            book_props = {}
-        end
+        book_props = document:getProps()
         book_props.pages = pages
         DocumentRegistry:closeDocument(file)
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -352,12 +352,7 @@ function ReaderUI:init()
     -- Now that document is loaded, store book metadata in settings
     -- (so that filemanager can use it from sideCar file to display
     -- Book information).
-    -- via pcall because picdocument:getProps() may fail
-    local ok, doc_props = pcall(self.document.getProps, self.document)
-    if not ok then
-        doc_props = {}
-    end
-    self.doc_settings:saveSetting("doc_props", doc_props)
+    self.doc_settings:saveSetting("doc_props", self.document:getProps())
 
     -- After initialisation notify that document is loaded and rendered
     -- CREngine only reports correct page count after rendering is done

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -26,6 +26,28 @@ function PicDocument:getUsedBBox(pageno)
     return { x0 = 0, y0 = 0, x1 = self._document.width, y1 = self._document.height }
 end
 
+function PicDocument:getProps()
+    local _, _, docname = self.file:find(".*/(.*)")
+    docname = docname or self.file
+    return {
+        title = docname:match("(.*)%."),
+    }
+end
+
+function PicDocument:getCoverPageImage()
+    local f = io.open(self.file, "rb")
+    if f then
+        local data = f:read("*all")
+        f:close()
+        local Mupdf = require("ffi/mupdf")
+        local ok, image = pcall(Mupdf.renderImage, data, data:len())
+        if ok then
+            return image
+        end
+    end
+    return nil
+end
+
 function PicDocument:register(registry)
     registry:addProvider("jpeg", "image/jpeg", self)
     registry:addProvider("jpg", "image/jpeg", self)

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -373,18 +373,16 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
             local pages = document:getPageCount()
             dbrow.pages = pages
         end
-        -- via pcall because picdocument:getProps() always fails (we could
-        -- check document.is_pic, but this way, we'll catch any other error)
-        local ok, props = pcall(document.getProps, document)
-        if ok then
+        local props = document:getProps()
+        if next(props) then -- there's at least one item
             dbrow.has_meta = 'Y'
-            if props.title and props.title ~= "" then dbrow.title = props.title end
-            if props.authors and props.authors ~= "" then dbrow.authors = props.authors end
-            if props.series and props.series ~= "" then dbrow.series = props.series end
-            if props.language and props.language ~= "" then dbrow.language = props.language end
-            if props.keywords and props.keywords ~= "" then dbrow.keywords = props.keywords end
-            if props.description and props.description ~= "" then dbrow.description = props.description end
         end
+        if props.title and props.title ~= "" then dbrow.title = props.title end
+        if props.authors and props.authors ~= "" then dbrow.authors = props.authors end
+        if props.series and props.series ~= "" then dbrow.series = props.series end
+        if props.language and props.language ~= "" then dbrow.language = props.language end
+        if props.keywords and props.keywords ~= "" then dbrow.keywords = props.keywords end
+        if props.description and props.description ~= "" then dbrow.description = props.description end
         if cover_specs then
             local spec_sizetag = cover_specs.sizetag
             local spec_max_cover_w = cover_specs.max_cover_w


### PR DESCRIPTION
So an image file can have a cover in coverbrowser's display.
It also allows for an alternative viewer (ImageViewer widget) when holding on file / View full size cover.