### PR TITLE
[fix] MenuSorter: ignore separator as first item

### DIFF
--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -86,7 +86,10 @@ function MenuSorter:sort(item_table, order)
                 if v then
                     if v.id == separator_id then
                         new_index = new_index - 1
-                        menu_table[order_id][new_index].separator = true
+                        -- ignore separator if the menu starts with it
+                        if new_index > 0 then
+                            menu_table[order_id][new_index].separator = true
+                        end
                     else
                         -- fix the index
                         menu_table[order_id][new_index] = tmp_menu_table[i]

--- a/spec/unit/menusorter_spec.lua
+++ b/spec/unit/menusorter_spec.lua
@@ -124,6 +124,28 @@ describe("MenuSorter module", function()
         assert.is_true(test_menu[1][2].separator == true)
         assert.is_true(test_menu[1][3].id == "third2")
     end)
+    it("should ignore separator as first item", function()
+        local menu_items = {
+            ["KOMenu:menu_buttons"] = {},
+            first = {},
+            second = {},
+            third1 = {},
+            third2 = {},
+        }
+        local order = {
+            ["KOMenu:menu_buttons"] = {"first",},
+            first = {"----------------------------", "second", "third1", "----------------------------", "third2"},
+        }
+
+        local test_menu = MenuSorter:sort(menu_items, order)
+
+        assert.is_true(test_menu[1].id == "first")
+        assert.is_true(test_menu[1][1].id == "second")
+        assert.is_nil(test_menu[1][1].separator)
+        assert.is_true(test_menu[1][2].id == "third1")
+        assert.is_true(test_menu[1][2].separator == true)
+        assert.is_true(test_menu[1][3].id == "third2")
+    end)
     it("should compress menus when items from order are missing", function()
         local menu_items = {
             ["KOMenu:menu_buttons"] = {},


### PR DESCRIPTION
See https://github.com/koreader/koreader/pull/3107#issuecomment-323581851