### PR TITLE
Update 'lastfile' if autoremove_deleted_items_from_history

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -158,9 +158,14 @@ function FileManager:init()
                                     -- effect.
                                     os.remove(DocSettings:getSidecarDir(file_abs_path))
                                     self:refreshPath()
-                                    -- also delete from history if autoremove_deleted_items_from_history is enabled
+                                    -- also delete from history and update lastfile to top item in
+                                    -- history if autoremove_deleted_items_from_history is enabled
                                     if autoremove_deleted_items_from_history then
-                                        require("readhistory"):removeItemByPath(file_abs_path)
+                                        local readhistory = require("readhistory")
+                                        readhistory:removeItemByPath(file_abs_path)
+                                        if G_reader_settings:readSetting("lastfile") == file_abs_path then
+                                            G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
+                                        end
                                     end
                                 end
                                 UIManager:close(self.file_dialog)
@@ -189,10 +194,15 @@ function FileManager:init()
                                 local autoremove_deleted_items_from_history = G_reader_settings:readSetting("autoremove_deleted_items_from_history") or false
                                 local file_abs_path = util.realpath(file)
                                 deleteFile(file)
-                                -- also delete from history if autoremove_deleted_items_from_history is enabled
+                                -- also delete from history and update lastfile to top item in
+                                -- history if autoremove_deleted_items_from_history is enabled
                                 if autoremove_deleted_items_from_history then
                                     if file_abs_path then
-                                        require("readhistory"):removeItemByPath(file_abs_path)
+                                        local readhistory = require("readhistory")
+                                        readhistory:removeItemByPath(file_abs_path)
+                                        if G_reader_settings:readSetting("lastfile") == file_abs_path then
+                                            G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
+                                        end
                                     end
                                 end
                                 self:refreshPath()


### PR DESCRIPTION
For people who set autoremove_deleted_items_from_history to true, file is removed from history when Deleted or 'Purge .sdr'. This also updates lastfile to the new top in history if needed.
Closes #2547.
See https://github.com/koreader/koreader/issues/2547#issuecomment-291009619 and https://github.com/koreader/koreader/pull/2583#issuecomment-282509524 for the autoremove_deleted_items_from_history setting context.