### PR TITLE
Dictionary settings and Wikipedia settings menu items

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -36,17 +36,31 @@ function ReaderDictionary:addToMainMenu(menu_items)
             end,
         },
     }
-    menu_items.disable_fuzzy_search = {
-        text = _("Disable dictionary fuzzy search"),
-        checked_func = function()
-            return self.disable_fuzzy_search == true
-        end,
-        callback = function()
-            self.disable_fuzzy_search = not self.disable_fuzzy_search
-        end,
-        hold_callback = function()
-            self:makeDisableFuzzyDefault(self.disable_fuzzy_search)
-        end,
+    menu_items.dictionary_settings = {
+        text = _("Dictionary settings"),
+        sub_item_table = {
+            {
+                text = _("Disable dictionary fuzzy search"),
+                checked_func = function()
+                    return self.disable_fuzzy_search == true
+                end,
+                callback = function()
+                    self.disable_fuzzy_search = not self.disable_fuzzy_search
+                end,
+                hold_callback = function()
+                    self:makeDisableFuzzyDefault(self.disable_fuzzy_search)
+                end,
+            },
+            { -- setting used by dictquicklookup
+                text = _("Justify text"),
+                checked_func = function()
+                    return G_reader_settings:nilOrTrue("dict_justify")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrTrue("dict_justify")
+                end,
+            }
+        }
     }
 end
 

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -53,9 +53,10 @@ local order = {
     },
     search = {
         "dictionary_lookup",
-        "disable_fuzzy_search",
+        "dictionary_settings",
         "----------------------------",
         "wikipedia_lookup",
+        "wikipedia_settings",
         "----------------------------",
         "find_book_in_calibre_catalog",
         "find_file",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -70,9 +70,10 @@ local order = {
     },
     search = {
         "dictionary_lookup",
-        "disable_fuzzy_search",
+        "dictionary_settings",
         "----------------------------",
         "wikipedia_lookup",
+        "wikipedia_settings",
         "----------------------------",
         "goodreads",
         "----------------------------",

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -43,8 +43,6 @@ local DictQuickLookup = InputContainer:new{
     height = nil,
     -- box of highlighted word, quick lookup window tries to not hide the word
     word_box = nil,
-    -- allow for disabling justification
-    dict_justify = G_reader_settings:nilOrTrue("dict_justify"),
 
     title_padding = Screen:scaleBySize(5),
     title_margin = Screen:scaleBySize(2),
@@ -243,7 +241,8 @@ function DictQuickLookup:update()
             -- get a bit more height for definition as wiki has one less button raw
             height = self.is_fullpage and self.height*0.75 or self.height*0.7,
             dialog = self,
-            justified = self.dict_justify,
+            -- allow for disabling justification
+            justified = G_reader_settings:nilOrTrue("dict_justify"),
         },
     }
     -- Different sets of buttons if fullpage or not
@@ -266,9 +265,8 @@ function DictQuickLookup:update()
                         local filename = cleaned_lookupword .. "."..string.upper(lang)..".epub"
                         -- Find a directory to save file into
                         local dir = G_reader_settings:readSetting("wikipedia_save_dir")
-                        if not dir then dir = G_reader_settings:readSetting("download_dir") end -- OPDS dir
                         if not dir then dir = G_reader_settings:readSetting("home_dir") end
-                        if not dir then dir = G_reader_settings:readSetting("lastdir") end
+                        if not dir then dir = require("apps/filemanager/filemanagerutil").getDefaultDir() end
                         if not dir then
                             UIManager:show(InfoMessage:new{
                                 text = _("No directory to save the page to could be found."),


### PR DESCRIPTION
Added 2 submenus, and some settings menu items I was too lazy to add some months ago.
`Dictionary settings `: moved `Disable dictionary fuzzy search` in it, and added `Justify definitions' text` (we may add later some other items like list dictionary, dictionary management and ordering...)
`Wikipedia settings `: added `Set Wikipedia languages` (free input of language codes separated by space) and `Set Wikipedia 'Save as EPUB' directory`.

Should I remove `download_dir` (directory configured for OPDS downloads) from the candidates for `Save as EPUB`, so candidates starts with `home_dir` or `getDefaultDir()` ?