### PR TITLE
Avoid settings double save when leaving Reader

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -547,7 +547,11 @@ end
 
 function ReaderUI:onClose()
     logger.dbg("closing reader")
-    self:saveSettings()
+    -- if self.dialog is us, we'll have our onFlushSettings() called
+    -- by UIManager:close() below, so avoid double save
+    if self.dialog ~= self then
+        self:saveSettings()
+    end
     if self.document ~= nil then
         logger.dbg("closing document")
         self:notifyCloseDocument()


### PR DESCRIPTION
See https://github.com/koreader/koreader/pull/3093#issuecomment-323595972

It allows keeping the original metadata.lua.old backup a little bit longer, instead of having them both be the same because of this double save when leaving reader.
I have this change for a few days, and I haven't noticed once I lost the page I was on, so it should be ok :)