### PR TITLE
Fix: truncateTextByWidth() should respect kerning and bold

### DIFF
--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -241,7 +241,7 @@ end
 
 local ellipsis, space = "…", " "
 local ellipsis_width, space_width
-function RenderText:truncateTextByWidth(text, face, max_width, prepend_space)
+function RenderText:truncateTextByWidth(text, face, max_width, kerning, bold, prepend_space)
     if not ellipsis_width then
         ellipsis_width = self:sizeUtf8Text(0, max_width, face, ellipsis).x
     end
@@ -249,7 +249,7 @@ function RenderText:truncateTextByWidth(text, face, max_width, prepend_space)
         space_width = self:sizeUtf8Text(0, max_width, face, space).x
     end
     local new_txt_width = max_width - ellipsis_width - space_width
-    local sub_txt = self:getSubTextByWidth(text, face, new_txt_width)
+    local sub_txt = self:getSubTextByWidth(text, face, new_txt_width, kerning, bold)
     if prepend_space then
         return space.. sub_txt .. ellipsis
     else

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -241,7 +241,7 @@ end
 
 local ellipsis, space = "…", " "
 local ellipsis_width, space_width
-function RenderText:truncateTextByWidth(text, face, max_width, prepend_space, kerning, bold)
+function RenderText:truncateTextByWidth(text, face, max_width, kerning, bold, prepend_space)
     if not ellipsis_width then
         ellipsis_width = self:sizeUtf8Text(0, max_width, face, ellipsis).x
     end

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -241,7 +241,7 @@ end
 
 local ellipsis, space = "…", " "
 local ellipsis_width, space_width
-function RenderText:truncateTextByWidth(text, face, max_width, kerning, bold, prepend_space)
+function RenderText:truncateTextByWidth(text, face, max_width, prepend_space, kerning, bold)
     if not ellipsis_width then
         ellipsis_width = self:sizeUtf8Text(0, max_width, face, ellipsis).x
     end

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -155,7 +155,8 @@ function KeyValueItem:init()
                 self.show_value = self.value
             else
                 key_w = key_w_rendered + space_w_rendered
-                self.show_value = RenderText:truncateTextByWidth(self.value, self.cface, frame_internal_width - key_w_rendered, true)
+                self.show_value = RenderText:truncateTextByWidth(self.value, self.cface, frame_internal_width - key_w_rendered,
+                    false, false, true)
                 self.show_key = self.key
             end
             -- allow for displaying the non-truncated texts with Hold


### PR DESCRIPTION
It is not useful at this time, but it will be used by me in the future.