### PR TITLE
Fix kobo fl_min and frontlightwidget

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -5,9 +5,7 @@ local batt_state_folder =
         "/sys/devices/platform/pmic_battery.1/power_supply/mc13892_bat/"
 
 local KoboPowerD = BasePowerD:new{
-    -- Do not actively set front light to 0, it may confuse users -- pressing
-    -- hardware button won't take any effect.
-    fl_min = 1, fl_max = 100,
+    fl_min = 0, fl_max = 100,
     fl = nil,
 
     batt_capacity_file = batt_state_folder .. "capacity",


### PR DESCRIPTION
Been inclined to have a look at frontlightwidget after reading some issues, after i suggesting the fl_min=0 fix (https://github.com/koreader/koreader/issues/3103 https://github.com/koreader/koreader/issues/2970#issuecomment-324973222).
I don't use that widget, and I just fixed what was obvious to me, and for it to somehow behave like the 1st-time user I was would expect :) But maybe I changed some of the original expected behaviour. @robert00s , could you please review this and tell me if you're fine with it? And may be if it works as fine on Kindle (looks like most issues are reported on Kobo, but some should happen on Kindle too).

`fl_min=0` for all other devices, and I see no reason for it to be different on Kobo, and it solves the _1% acting as Off_ bug.
The assumption it should be 1 so that toggling is managed another way is not/no more implemented by current code:
https://github.com/koreader/koreader/blob/efac2721bf40ca17a5e04c9983e86cb28927e8bc/frontend/device/generic/powerd.lua#L38-L39


About frontlightwidget.lua, the main ideas around things I changed are:

- `Min` sets light to 1 (the minimal not-Off light level). Toggle can be used to set it off.
- Setting/reaching 0 does toggle: so, when using `-1` and reaching 0, the previous not-Off level was 1, so `Toggle` puts it back to 1 (when toggling/untoggling, light is restored to previous not-Off level).

Seen no issue after that with the footer frontlight indicator.