### PR TITLE
max_width in buttontable - prevent overlong text

### DIFF
--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -1,12 +1,12 @@
-local HorizontalGroup = require("ui/widget/horizontalgroup")
-local VerticalGroup = require("ui/widget/verticalgroup")
-local VerticalSpan = require("ui/widget/verticalspan")
-local FocusManager = require("ui/widget/focusmanager")
-local LineWidget = require("ui/widget/linewidget")
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
-local Geom = require("ui/geometry")
 local Device = require("device")
+local FocusManager = require("ui/widget/focusmanager")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local LineWidget = require("ui/widget/linewidget")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
+local Geom = require("ui/geometry")
 local Screen = Device.screen
 
 local ButtonTable = FocusManager:new{
@@ -46,6 +46,7 @@ function ButtonTable:init()
                 enabled = btn_entry.enabled,
                 callback = btn_entry.callback,
                 width = (self.width - sizer_space)/column_cnt,
+                max_width = (self.width - sizer_space)/column_cnt - self.sep_width - self.padding,
                 bordersize = 0,
                 margin = 0,
                 padding = 0,

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -46,7 +46,7 @@ function ButtonTable:init()
                 enabled = btn_entry.enabled,
                 callback = btn_entry.callback,
                 width = (self.width - sizer_space)/column_cnt,
-                max_width = (self.width - sizer_space)/column_cnt - self.sep_width - self.padding,
+                max_width = (self.width - sizer_space)/column_cnt - 2*self.sep_width - 2*self.padding,
                 bordersize = 0,
                 margin = 0,
                 padding = 0,


### PR DESCRIPTION
This patch should prevent something like that:

![screenshot 2017-08-29 17-29-26](https://user-images.githubusercontent.com/22982594/29830517-c7995c30-8ce2-11e7-81dd-3069430f1843.jpg)
