### PR TITLE
[UX] Add exit menu

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -266,6 +266,12 @@ function FileManagerMenu:setUpdateItemTable()
     for id, common_setting in pairs(require("ui/elements/common_info_menu_table")) do
         self.menu_items[id] = common_setting
     end
+    self.menu_items.exit_menu = {
+        text = _("Exit"),
+        hold_callback = function()
+            self:exitOrRestart()
+        end,
+    }
     self.menu_items.exit = {
         text = _("Exit"),
         callback = function()

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -184,13 +184,18 @@ function ReaderMenu:setUpdateItemTable()
         self.menu_items[id] = common_setting
     end
 
+    self.menu_items.exit_menu = {
+        text = _("Exit"),
+        hold_callback = function()
+            self:exitOrRestart()
+        end,
+    }
     self.menu_items.exit = {
         text = _("Exit"),
         callback = function()
             self:exitOrRestart()
         end,
     }
-
     self.menu_items.restart_koreader = {
         text = _("Restart KOReader"),
         callback = function()

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -53,9 +53,7 @@ common_info.report_bug = {
         })
     end
 }
-common_info.exit_menu = {
-    text = _("Exit"),
-}
+
 if Device:isKindle() or Device:isKobo() then
     common_info.sleep = {
         text = _("Sleep"),

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -52,6 +52,17 @@ common_info.report_bug = {
         })
     end
 }
+common_info.exit_menu = {
+    text = _("Exit"),
+}
+if Device:isKindle() or Device:isKobo() then
+    common_info.sleep = {
+        text = _("Sleep"),
+        callback = function()
+            UIManager:suspend()
+        end,
+    }
+end
 if Device:isKobo() then
     common_info.reboot = {
         text = _("Reboot the device"),

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -1,3 +1,4 @@
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
@@ -67,13 +68,25 @@ if Device:isKobo() then
     common_info.reboot = {
         text = _("Reboot the device"),
         callback = function()
-            UIManager:nextTick(UIManager.reboot_action)
+            UIManager:show(ConfirmBox:new{
+                text = _("Are you sure you want to reboot the device?"),
+                ok_text = _("Reboot"),
+                ok_callback = function()
+                    UIManager:nextTick(UIManager.reboot_action)
+                end,
+            })
         end
     }
     common_info.poweroff = {
         text = _("Power off"),
         callback = function()
-            UIManager:nextTick(UIManager.poweroff_action)
+            UIManager:show(ConfirmBox:new{
+                text = _("Are you sure you want to power off the device?"),
+                ok_text = _("Power off"),
+                ok_callback = function()
+                    UIManager:nextTick(UIManager.poweroff_action)
+                end,
+            })
         end
     }
 end

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -68,17 +68,14 @@ local order = {
         "history",
         "open_last_document",
         "----------------------------",
+        "system_statistics",
+        "----------------------------",
         "ota_update", --[[ if Device:isKindle() or Device:isKobo() or
                            Device:isPocketBook() or Device:isAndroid() ]]--
         "version",
         "help",
-        "system_statistics",
         "----------------------------",
-        "restart_koreader",
-        "poweroff", -- if Device:isKobo()
-        "reboot",   -- if Device:isKobo()
-        "----------------------------",
-        "exit",
+        "exit_menu",
     },
     help = {
         "quickstart_guide",
@@ -87,6 +84,15 @@ local order = {
         "----------------------------",
         "about",
     },
+    exit_menu = {
+        "restart_koreader",
+        "----------------------------",
+        "sleep", -- if Device:isKindle() or Device:isKobo()
+        "poweroff", -- if Device:isKobo()
+        "reboot",   -- if Device:isKobo()
+        "----------------------------",
+        "exit",
+    }
 }
 
 return order

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -85,17 +85,14 @@ local order = {
         "book_status",
         "book_info",
         "----------------------------",
+        "system_statistics",
+        "----------------------------",
         "ota_update", --[[ if Device:isKindle() or Device:isKobo() or
                            Device:isPocketBook() or Device:isAndroid() ]]--
         "version",
         "help",
-        "system_statistics",
         "----------------------------",
-        "restart_koreader",
-        "poweroff", -- if Device:isKobo()
-        "reboot",   -- if Device:isKobo()
-        "----------------------------",
-        "exit",
+        "exit_menu",
     },
     help = {
         "quickstart_guide",
@@ -104,6 +101,15 @@ local order = {
         "----------------------------",
         "about",
     },
+    exit_menu = {
+        "restart_koreader",
+        "----------------------------",
+        "sleep", -- if Device:isKindle() or Device:isKobo()
+        "poweroff", -- if Device:isKobo()
+        "reboot",   -- if Device:isKobo()
+        "----------------------------",
+        "exit",
+    }
 }
 
 return order

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -121,6 +121,7 @@ function MenuSorter:sort(item_table, order)
                     changed = true
                     local sub_menu_content = menu_table[sub_menu]
                     sub_menu_position.text = sub_menu_content.text
+                    sub_menu_position.hold_callback = sub_menu_content.hold_callback
                     sub_menu_position.sub_item_table = sub_menu_content
                     -- remove reference from top level output
                     menu_table[sub_menu] = nil


### PR DESCRIPTION
* fixes #2898 (prevents accidentally triggering reboot or poweroff)
* increases clarity by preventing second page
* add "sleep" menu entry

## Before

![screenshot_2017-09-03_10-26-37](https://user-images.githubusercontent.com/202757/30001584-6958cc4c-9092-11e7-84b8-84bdce0b6951.png)


## After

![screenshot_2017-09-03_10-20-03](https://user-images.githubusercontent.com/202757/30001541-7cc78030-9091-11e7-825b-1fad6cd995bd.png)

![2017-09-03 10 16 10](https://user-images.githubusercontent.com/202757/30001539-7ca94d7c-9091-11e7-9b7f-bf5e4db2216c.jpg)

@a-kohout Do you think this is sufficient or should I still add confirmation boxes to the restart and shutdown actions seeing how they're more "destructive" than a mere accidental "sleep" or "exit".