### PR TITLE
Prevent crash on exit in scroll mode

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -140,6 +140,8 @@ function ReaderRolling:onReadSettings(config)
     self.inverse_reading_order = config:readSetting("inverse_reading_order") or false
 end
 
+-- in scroll mode percent_finished must be save before close document
+-- we cannot do it in onSaveSettings() because getLastPercent() uses self.ui.document
 function ReaderRolling:onCloseDocument()
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
 end
@@ -148,6 +150,9 @@ function ReaderRolling:onSaveSettings()
     -- remove last_percent config since its deprecated
     self.ui.doc_settings:saveSetting("last_percent", nil)
     self.ui.doc_settings:saveSetting("last_xpointer", self.xpointer)
+    -- in scrolling mode, the document may already be closed,
+    -- so we have to check the condition to avoid crash function self:getLastPercent()
+    -- that uses self.ui.document
     if self.ui.document then
         self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
     end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -148,6 +148,9 @@ function ReaderRolling:onSaveSettings()
     -- remove last_percent config since its deprecated
     self.ui.doc_settings:saveSetting("last_percent", nil)
     self.ui.doc_settings:saveSetting("last_xpointer", self.xpointer)
+    if self.ui.document then
+        self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
+    end
     self.ui.doc_settings:saveSetting("show_overlap_enable", self.show_overlap_enable)
     self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
 end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -141,15 +141,15 @@ function ReaderRolling:onReadSettings(config)
 end
 
 function ReaderRolling:onCloseDocument()
-    -- remove last_percent config since its deprecated
-    self.ui.doc_settings:saveSetting("last_percent", nil)
-    self.ui.doc_settings:saveSetting("last_xpointer", self.xpointer)
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
-    self.ui.doc_settings:saveSetting("show_overlap_enable", self.show_overlap_enable)
-    self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
 end
 
 function ReaderRolling:onSaveSettings()
+    -- remove last_percent config since its deprecated
+    self.ui.doc_settings:saveSetting("last_percent", nil)
+    self.ui.doc_settings:saveSetting("last_xpointer", self.xpointer)
+    self.ui.doc_settings:saveSetting("show_overlap_enable", self.show_overlap_enable)
+    self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
 end
 
 function ReaderRolling:onReaderReady()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -140,13 +140,16 @@ function ReaderRolling:onReadSettings(config)
     self.inverse_reading_order = config:readSetting("inverse_reading_order") or false
 end
 
-function ReaderRolling:onSaveSettings()
+function ReaderRolling:onCloseDocument()
     -- remove last_percent config since its deprecated
     self.ui.doc_settings:saveSetting("last_percent", nil)
     self.ui.doc_settings:saveSetting("last_xpointer", self.xpointer)
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
     self.ui.doc_settings:saveSetting("show_overlap_enable", self.show_overlap_enable)
     self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
+end
+
+function ReaderRolling:onSaveSettings()
 end
 
 function ReaderRolling:onReaderReady()


### PR DESCRIPTION
Fix that problem:
Open epub -> change to scroll mode -> exit than we have in crash log
```
./luajit: frontend/apps/reader/modules/readerrolling.lua:275: attempt to index field 'document' (a nil value)
stack traceback:
	frontend/apps/reader/modules/readerrolling.lua:275: in function 'getLastPercent'
	frontend/apps/reader/modules/readerrolling.lua:147: in function 'handleEvent'
	frontend/ui/widget/container/widgetcontainer.lua:87: in function 'propagateEvent'
	frontend/ui/widget/container/widgetcontainer.lua:105: in function 'handleEvent'
	frontend/apps/reader/readerui.lua:506: in function 'saveSettings'
	frontend/apps/reader/readerui.lua:512: in function 'handleEvent'
	frontend/ui/uimanager.lua:226: in function 'close'
	frontend/apps/reader/readerui.lua:559: in function 'onClose'
	frontend/apps/reader/modules/readermenu.lua:223: in function 'action'
	frontend/ui/uimanager.lua:516: in function '_checkTasks'
	frontend/ui/uimanager.lua:667: in function 'handleInput'
	frontend/ui/uimanager.lua:763: in function 'run'
	./reader.lua:178: in main chunk
	[C]: at 0x00404960
```
Settings are write to late. Document is already closed.