### PR TITLE
Fix crash when taping on toggleswitch left or bottom borders

### DIFF
--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -142,7 +142,7 @@ end
 function ToggleSwitch:calculatePosition(gev)
     local x = (gev.pos.x - self.dimen.x) / self.dimen.w * self.n_pos
     local y = (gev.pos.y - self.dimen.y) / self.dimen.h * self.row_count
-    return math.ceil(x) + math.floor(y) * self.n_pos
+    return math.max(1, math.ceil(x)) + math.min(self.row_count-1, math.floor(y)) * self.n_pos
 end
 
 function ToggleSwitch:onTapSelect(arg, gev)


### PR DESCRIPTION
Taping on left or bottom borders of the toggles (bottom menu) was causing a crash (easier to reproduce with mouse clicks on the emulator :)
The crash was caused later, when we got for example 5 as position when the toggle has only 3 values.