### PR TITLE
Fix: Lost last document position in scroll mode

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -162,7 +162,9 @@ end
 
 function ReaderRolling:onReaderReady()
     self:setupTouchZones()
-    self.setupXpointer()
+    self.ui:registerPostReadyCallback(function()
+        self.setupXpointer()
+    end)
 end
 
 function ReaderRolling:setupTouchZones()


### PR DESCRIPTION
In scroll mode (epub) document was always reopen on first page. It should fix it.