### PR TITLE
[UX] Allow following links though hold/highlight dialog

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -194,9 +194,9 @@ If you'd like to change the order in which dictionaries are queried (and their r
     }
 end
 
-function ReaderDictionary:onLookupWord(word, box, highlight)
+function ReaderDictionary:onLookupWord(word, box, highlight, link)
     self.highlight = highlight
-    self:stardictLookup(word, box)
+    self:stardictLookup(word, box, link)
     return true
 end
 
@@ -317,7 +317,7 @@ function ReaderDictionary:dismissLookupInfo()
     self.lookup_progress_msg = nil
 end
 
-function ReaderDictionary:stardictLookup(word, box)
+function ReaderDictionary:stardictLookup(word, box, link)
     logger.dbg("lookup word:", word, box)
     -- escape quotes and other funny characters in word
     word = self:cleanSelection(word)
@@ -402,10 +402,10 @@ function ReaderDictionary:stardictLookup(word, box)
             }
         }
     end
-    self:showDict(word, tidyMarkup(final_results), box)
+    self:showDict(word, tidyMarkup(final_results), box, link)
 end
 
-function ReaderDictionary:showDict(word, results, box)
+function ReaderDictionary:showDict(word, results, box, link)
     self:dismissLookupInfo()
     if results and results[1] then
         logger.dbg("showing quick lookup window", word, results)
@@ -416,6 +416,8 @@ function ReaderDictionary:showDict(word, results, box)
             dialog = self.dialog,
             -- original lookup word
             word = word,
+            -- selected link, if any
+            selected_link = link,
             results = results,
             dictionary = self.default_dictionary,
             width = Screen:getWidth() - Screen:scaleBySize(80),

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -252,9 +252,10 @@ function ReaderHighlight:onHold(arg, ges)
         logger.dbg("selected word:", word)
         logger.dbg(self.hold_pos)
         self.selected_word = word
-        local link = self.ui.document:getLinkFromPosition(self.hold_pos)
-        if string.find(link, "#") == 1 then
-            ReaderLink.ui = self.ui
+        ReaderLink.ui = self.ui
+        ReaderLink.view = self.view
+        local link = ReaderLink:getLinkFromGes(ges)
+        if link and string.find(link, "#") == 1 then
             logger.dbg("link:", link)
             self.selected_link = link
         else

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -250,16 +250,14 @@ function ReaderHighlight:onHold(arg, ges)
     local ok, word = pcall(self.ui.document.getWordFromPosition, self.ui.document, self.hold_pos)
     if ok and word then
         logger.dbg("selected word:", word)
-        logger.dbg(self.hold_pos)
         self.selected_word = word
         ReaderLink.ui = self.ui
         ReaderLink.view = self.view
         local link = ReaderLink:getLinkFromGes(ges)
-        if link and string.find(link, "#") == 1 then
+        self.selected_link = nil
+        if link then
             logger.dbg("link:", link)
             self.selected_link = link
-        else
-            self.selected_link = nil
         end
         if self.ui.document.info.has_pages then
             local boxes = {}

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -77,18 +77,21 @@ function ReaderLink:addToMainMenu(menu_items)
         text = _("Links"),
         sub_item_table = {
             {
+                text = _("Go back to previous location"),
+                enabled_func = function() return #self.location_stack > 0 end,
+                callback = function() self:onGoBackLink() end,
+                separator = true,
+            },
+            {
                 text = _("Tap to follow links"),
                 checked_func = isTapToFollowLinksOn,
                 callback = function()
                     G_reader_settings:saveSetting("tap_to_follow_links",
                         not isTapToFollowLinksOn())
-                end
+                end,
+                separator = true,
             },
-            {
-                text = _("Go back"),
-                enabled_func = function() return #self.location_stack > 0 end,
-                callback = function() self:onGoBackLink() end,
-            },
+
             {
                 text = _("Swipe to go back"),
                 checked_func = isSwipeToGoBackEnabled,

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -78,9 +78,7 @@ function ReaderLink:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Tap to follow links"),
-                checked_func = function()
-                    return isTapToFollowLinksOn()
-                end,
+                checked_func = isTapToFollowLinksOn,
                 callback = function()
                     G_reader_settings:saveSetting("tap_to_follow_links",
                         not isTapToFollowLinksOn())
@@ -92,7 +90,7 @@ function ReaderLink:addToMainMenu(menu_items)
                 callback = function() self:onGoBackLink() end,
             },
             {
-                text = _("Swipe left to go back"),
+                text = _("Swipe to go back"),
                 checked_func = isSwipeToGoBackEnabled,
                 callback = function()
                     G_reader_settings:saveSetting("swipe_to_go_back",
@@ -100,7 +98,7 @@ function ReaderLink:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Swipe right to follow first link"),
+                text = _("Swipe to follow first link"),
                 checked_func = isSwipeToFollowFirstLinkEnabled,
                 callback = function()
                     G_reader_settings:saveSetting("swipe_to_follow_first_link",

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1,3 +1,7 @@
+--[[
+ReaderLink is an abstraction for document-specific link interfaces.
+]]--
+
 local Device = require("device")
 local Event = require("ui/event")
 local Geom = require("ui/geometry")
@@ -55,7 +59,7 @@ function ReaderLink:initGesListener()
     end
 end
 
-local function isTapToFollowLinkOn()
+local function isTapToFollowLinksOn()
     return not G_reader_settings:isFalse("tap_to_follow_links")
 end
 
@@ -75,11 +79,11 @@ function ReaderLink:addToMainMenu(menu_items)
             {
                 text = _("Tap to follow links"),
                 checked_func = function()
-                    return isTapToFollowLinkOn()
+                    return isTapToFollowLinksOn()
                 end,
                 callback = function()
                     G_reader_settings:saveSetting("tap_to_follow_links",
-                        not isTapToFollowLinkOn())
+                        not isTapToFollowLinksOn())
                 end
             },
             {
@@ -88,7 +92,7 @@ function ReaderLink:addToMainMenu(menu_items)
                 callback = function() self:onGoBackLink() end,
             },
             {
-                text = _("Swipe to go back"),
+                text = _("Swipe left to go back"),
                 checked_func = isSwipeToGoBackEnabled,
                 callback = function()
                     G_reader_settings:saveSetting("swipe_to_go_back",
@@ -96,7 +100,7 @@ function ReaderLink:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Swipe to follow first link"),
+                text = _("Swipe right to follow first link"),
                 checked_func = isSwipeToFollowFirstLinkEnabled,
                 callback = function()
                     G_reader_settings:saveSetting("swipe_to_follow_first_link",
@@ -157,7 +161,7 @@ function ReaderLink:onSetDimensions(dimen)
 end
 
 function ReaderLink:onTap(_, ges)
-    if not isTapToFollowLinkOn() then return end
+    if not isTapToFollowLinksOn() then return end
     local link, lbox, pos = self:getLinkFromGes(ges)
     if link then
         self:showLinkBox(link, lbox, pos)
@@ -219,6 +223,7 @@ function ReaderLink:onGotoLink(link)
     return true
 end
 
+--- Goes back to previous location.
 function ReaderLink:onGoBackLink()
     local saved_location = table.remove(self.location_stack)
     if saved_location then
@@ -239,6 +244,7 @@ function ReaderLink:onSwipe(_, ges)
     end
 end
 
+--- Goes to first link on page.
 function ReaderLink:onGoToFirstLink(ges)
     local firstlink = nil
     if self.ui.document.info.has_pages then

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -14,6 +14,7 @@ local InputDialog = require("ui/widget/inputdialog")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local OverlapGroup = require("ui/widget/overlapgroup")
+local ReaderLink = require("apps/reader/modules/readerlink")
 local ScrollTextWidget = require("ui/widget/scrolltextwidget")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
@@ -367,12 +368,17 @@ function DictQuickLookup:update()
                 {
                     -- if more than one language, enable it and display "current lang > next lang"
                     -- otherwise, just display current lang
-                    text = self.is_wiki and ( #self.wiki_languages > 1 and self.wiki_languages[1].." > "..self.wiki_languages[2] or self.wiki_languages[1] ) or "-",
-                    enabled = self.is_wiki and #self.wiki_languages > 1,
+                    text = self.is_wiki and ( #self.wiki_languages > 1 and self.wiki_languages[1].." > "..self.wiki_languages[2] or self.wiki_languages[1] ) or "Follow Link",
+                    enabled = (self.is_wiki and #self.wiki_languages > 1) or self.selected_link ~= nil,
                     callback = function()
-                        self:resyncWikiLanguages(true) -- rotate & resync them
-                        UIManager:close(self)
-                        self:lookupWikipedia()
+                        if self.is_wiki then
+                            self:resyncWikiLanguages(true) -- rotate & resync them
+                            UIManager:close(self)
+                            self:lookupWikipedia()
+                        else
+                            UIManager:close(self)
+                            ReaderLink:onGotoLink(self.selected_link)
+                        end
                     end,
                 },
                 {


### PR DESCRIPTION
I realized I've got too many ideas just sitting around on my hard drive. The idea behind this one is that you can disable "follow links" on single tap yet still follow links.

### Before

<img src=https://user-images.githubusercontent.com/202757/30210272-49b630c4-949c-11e7-8ee4-2bc03dc38700.png width=30%> <img src=https://user-images.githubusercontent.com/202757/30210286-52a585d6-949c-11e7-9f70-cf8baf4d8b54.png width=30%>

### After

<img src=https://user-images.githubusercontent.com/202757/30210283-52a03388-949c-11e7-95d5-7a9162298bae.png width=30%> <img src=https://user-images.githubusercontent.com/202757/30210284-52a0e6f2-949c-11e7-9466-a5b8fcfa7850.png width=30%>

Of course if you just hold on some regular text it's disabled.

<img src=https://user-images.githubusercontent.com/202757/30210390-cbb4f5b0-949c-11e7-9e97-b89a56ffdb14.png width=30%>


It actually takes you to one page prior to where the chapter actually starts, but that's not caused by this change.
<img src=https://user-images.githubusercontent.com/202757/30210285-52a24ee8-949c-11e7-9d08-ff17db167186.png width=30%> <img src=https://user-images.githubusercontent.com/202757/30210287-52a69304-949c-11e7-986b-baf5cba34670.png width=30%>

