### PR TITLE
Change a logger.warn() back to .dbg() as it used to be

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -633,7 +633,7 @@ function UIManager:_repaint()
     -- we should have at least one refresh if we did repaint.  If we don't, we
     -- add one now and log a warning if we are debugging
     if dirty and #self._refresh_stack == 0 then
-        logger.warn("no refresh got enqueued. Will do a partial full screen refresh, which might be inefficient")
+        logger.dbg("no refresh got enqueued. Will do a partial full screen refresh, which might be inefficient")
         self:_refresh("partial")
     end
 


### PR DESCRIPTION
Seen sometimes in the crash.log on my kobo:
09/08/17-15:45:03 WARN  no refresh got enqueued. Will do a partial full screen refresh, which might be inefficient
It's logged when, for example, closing a KeyValuePage widget, getting out of screensaver, may be a few others.

It used to be a debug, as it's just some info for developers that they may have forgotten to use a setDirty when widget is closed, and houpq made it a log.warn() when rewritting all the old debug code:
https://github.com/koreader/koreader/commit/f95ad00b9#diff-df44ce4f2932b4d7c52ce1bd4d511defL571

Just some info that KeyValuePage may need to have:
```
function KeyValuePage:onCloseWidget()
    UIManager:setDirty(nil, "partial")
end
```
But it's exactly what uimanager does when a widget does not do it explicitely, so, it's fine for KeyValuePage, which is full screen, to not have it.

