### PR TITLE
Change message after import

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -170,7 +170,7 @@ Please wait…
                 UIManager:close(info)
                 UIManager:forceRePaint()
                 UIManager:show(InfoMessage:new{
-                    text =T(_("Conversion completed.\nImported %1 books to database."),nr_book), timeout = 4 })
+                    text =T(_("Conversion completed.\nImported %1 books to database.\nTap to continue."),nr_book) })
             else
                 self:createDB(conn)
             end


### PR DESCRIPTION
See comment: https://github.com/koreader/koreader/issues/3185#issuecomment-328300123

> Maybe if there's a wait for people to tap screen, maybe someone would like to know how many books were imported?