### PR TITLE
Show vertical marker at target position when following a link

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1,4 +1,6 @@
+local Blitbuffer = require("ffi/blitbuffer")
 local Device = require("device")
+local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Event = require("ui/event")
 local ReaderPanning = require("apps/reader/modules/readerpanning")
@@ -393,6 +395,23 @@ end
 function ReaderRolling:onGotoXPointer(xp)
     self:_gotoXPointer(xp)
     self.xpointer = xp
+    -- Show a mark on left side of screen to give a visual feedback
+    -- of where xpointer target is (removed after 1 second)
+    if string.sub(xp, 1, 1) == "#" then -- only for links, not page top fragment identifier
+        local doc_y = self.ui.document:getPosFromXPointer(xp)
+        local top_y = self.ui.document:getCurrentPos()
+        local doc_margins = self.ui.document._document:getPageMargins()
+        local screen_y = doc_y - top_y + doc_margins["top"]
+        local marker_w = math.max(doc_margins["left"] - Screen:scaleBySize(5), Screen:scaleBySize(5))
+        local marker_h = math.ceil(self.ui.font.font_size * 2) -- 2 * font_size looks nice with normal text and headers
+        UIManager:scheduleIn(0.5, function()
+            Screen.bb:paintRect(0, screen_y, marker_w, marker_h, Blitbuffer.COLOR_BLACK)
+            Screen["refreshPartial"](Screen, 0, screen_y, marker_w, marker_h)
+            UIManager:scheduleIn(1, function()
+                UIManager:setDirty(self.view.dialog, "partial", Geom:new({x=0, y=screen_y, w=marker_w, h=marker_h}))
+            end)
+        end)
+    end
     return true
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -403,7 +403,7 @@ function ReaderRolling:onGotoXPointer(xp)
         local doc_margins = self.ui.document._document:getPageMargins()
         local screen_y = doc_y - top_y + doc_margins["top"]
         local marker_w = math.max(doc_margins["left"] - Screen:scaleBySize(5), Screen:scaleBySize(5))
-        local marker_h = math.ceil(self.ui.font.font_size * 2) -- 2 * font_size looks nice with normal text and headers
+        local marker_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0)
         UIManager:scheduleIn(0.5, function()
             Screen.bb:paintRect(0, screen_y, marker_w, marker_h, Blitbuffer.COLOR_BLACK)
             Screen["refreshPartial"](Screen, 0, screen_y, marker_w, marker_h)


### PR DESCRIPTION
When following an internal link (ie: to footnotes), this will show for 1 second a vertical marker where the link target is.
<kbd>![link_target_marker](https://user-images.githubusercontent.com/24273478/30252418-a8738d82-9672-11e7-9d7e-6da0327a369c.png)</kbd>

I think it helps a lot, your eyes just jump to where the footnore is, no need to remember and look for the footnote number.
Only works with readerrolling/crengine, as for pdf, we only get the target page, not the precise xpointer that allows us to get the vertical position.
I would also have liked to have that when back from link, to again see where we were before jumping to link, but that's more complicated.
Dunno if some people may dislike it and if it should be made an option in the Links submenu.
~~Also, for some reason i don't get, the marker height (font_size * 2) looks a lot more fitting on my kobo (screenshot) than on the emulator (edit: may be it needs a ScaleBySize ?)~~