### PR TITLE
kodev: add --graph option for rudimentary memory use tracking

### DIFF
--- a/kodev
+++ b/kodev
@@ -17,6 +17,64 @@ function check_submodules() {
     fi
 }
 
+# Takes two arguments:
+# $1 arguments to pass to pgrep
+# $2 process name to pgrep for
+function gnuplot_wrapper() {
+    # inspired by https://gist.github.com/nicolasazrak/32d68ed6c845a095f75f037ecc2f0436
+    trap capture_ctrl_c INT
+    TEMP_DIR=$(mktemp --directory /tmp/tmp.koreaderXXX)
+    LOG="$TEMP_DIR/memory.log"
+    SCRIPT_PNG="$TEMP_DIR/script_png.p"
+    SCRIPT_SHOW="$TEMP_DIR/script_show.p"
+    IMAGE_PNG="$TEMP_DIR/graph.png"
+
+    echo "Memory plot output to $TEMP_DIR"
+
+    cat >"$SCRIPT_PNG" <<EOL
+set term pngcairo size 1600,1200
+set output "$IMAGE_PNG"
+set ylabel "RSS"
+set y2label "VSZ"
+set ytics nomirror
+set y2tics nomirror in
+set yrange [0:*]
+set y2range [0:*]
+plot "$LOG" using 3 with lines axes x1y1 title "RSS", "$LOG" using 2 with lines axes x1y2 title "VSZ"
+EOL
+
+    cat >"$SCRIPT_SHOW" <<EOL
+set term wxt noraise
+set ylabel "RSS"
+set y2label "VSZ"
+set ytics nomirror
+set y2tics nomirror in
+set yrange [0:*]
+set y2range [0:*]
+plot "$LOG" using 3 with lines axes x1y1 title "RSS", "$LOG" using 2 with lines axes x1y2 title "VSZ"
+pause 1
+reread
+EOL
+
+    function capture_ctrl_c() {
+        kill "$LOOP_PID"
+        kill "$GNUPLOT_PID"
+        gnuplot "$SCRIPT_PNG"
+        exit
+    }
+
+    # initialize at 0 so gnuplot has something to show
+    echo "0 0 0" >"${LOG}"
+    while true; do
+        # shellcheck disable=SC2086
+        ps -p "$(pgrep --delimiter ' ' $1 "$2")" -o pid=,vsz=,rss= >>"${LOG}"
+        sleep 1
+    done &
+    LOOP_PID=$!
+    gnuplot "$SCRIPT_SHOW" &
+    GNUPLOT_PID=$!
+}
+
 function setup_env() {
     files=$(ls -d ./koreader-emulator-*/koreader)
     assert_ret_zero $? "Emulator not found, please build it first."
@@ -288,8 +346,7 @@ function kodev-wbuilder() {
     echo "[*] Running wbuilder.lua..."
     pushd "${EMU_DIR}" && {
         EMULATE_READER_W=540 EMULATE_READER_H=720 ./luajit ./tools/wbuilder.lua
-    } || exit
-    popd
+    } && popd || exit
 }
 
 function kodev-run() {
@@ -304,6 +361,7 @@ OPTIONS:
     --disable-touch          use this if you want to simulate keyboard only devices
     -s=FOO --simulate=FOO    simulate dimension and other specs for a given device model
                              supported model: kobo-aura-one, kindle3
+    --graph                  graph memory use (requires gnuplot)
     "
     screen_width=540
     screen_height=720
@@ -316,6 +374,9 @@ OPTIONS:
                 ;;
             --no-build)
                 no_build=true
+                ;;
+            --graph)
+                graph_memory=true
                 ;;
             -w | --screen-width)
                 screen_width=${VALUE}
@@ -364,6 +425,10 @@ OPTIONS:
         exit 1
     fi
 
+    if [ ${graph_memory} ]; then
+        gnuplot_wrapper "--parent $$" "reader.lua"
+    fi
+
     echo "[*] Running KOReader with arguments: $*..."
     pushd "${EMU_DIR}" && {
         if [ $# -lt 1 ]; then
@@ -379,8 +444,11 @@ OPTIONS:
                 ./reader.lua -d "$args"
             RETURN_VALUE=$?
         done
-    } || exit
-    popd
+    } && popd || exit
+
+    if [ ${graph_memory} ]; then
+        capture_ctrl_c
+    fi
 }
 
 function kodev-test() {
@@ -397,6 +465,9 @@ OPTIONS:
         PARAM=$(echo "$1" | awk -F= '{print $1}')
         VALUE=$(echo "$1" | awk -F= '{print $2}')
         case $PARAM in
+            --graph)
+                graph_memory=true
+                ;;
             --tags)
                 opts="--tags=${VALUE}"
                 ;;
@@ -425,6 +496,7 @@ OPTIONS:
 
     check_submodules && make
     setup_env
+
     make "${EMU_DIR}/.busted"
     pushd "${EMU_DIR}" && {
         test_path="./spec/$1/unit"
@@ -440,8 +512,7 @@ OPTIONS:
             --lazy \
             -o "./spec/$1/unit/verbose_print" \
             --exclude-tags=notest "${test_path}"
-    } || exit
-    popd
+    } && popd || exit
 }
 
 function kodev-cov() {
@@ -504,8 +575,7 @@ OPTIONS:
                 +$((LUACOV_REPORT_SUMMARY - 1)) \
                 luacov.report.out
         fi
-    } || exit
-    popd
+    } && popd || exit
 }
 
 function kodev-log() {
@@ -599,8 +669,7 @@ case $1 in
         kodev-build
         pushd "${EMU_DIR}" && {
             ./luajit -i setupkoenv.lua
-        } || exit
-        popd
+        } && popd || exit
         ;;
     log)
         shift 1


### PR DESCRIPTION
Usage:
`./kodev run --graph`

You get fun little graphs like this while running:
![screenshot_2017-09-12_13-12-02](https://user-images.githubusercontent.com/202757/30323067-0e9d076a-97bc-11e7-8443-58c3c01b7447.png)

And a PNG for sharing afterward:
![graph](https://user-images.githubusercontent.com/202757/30323081-1a8df034-97bc-11e7-9b19-65155124f7cc.png)

Edit: for reference (as the default plots aren't great looking), also see http://www.gnuplotting.org/attractive-plots/