### PR TITLE
Fix potential crash when clearing hold highlight

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -110,7 +110,23 @@ function ReaderHighlight:genHighlightDrawerMenu()
     }
 end
 
-function ReaderHighlight:clear()
+function ReaderHighlight:getClearTag()
+    -- Returns a tag, that can be provided on delayed call to clear(tag)
+    -- to ensure current highlight has not already been cleared, and that
+    -- we are not going to clear a new highlight
+    self.clear_tag = TimeVal.now() -- can act as a unique tag
+    return self.clear_tag
+end
+
+function ReaderHighlight:clear(clear_tag)
+    if clear_tag then -- should be provided by delayed call to clear()
+        if clear_tag ~= self.clear_tag then
+            -- if tag is no more valid, highlight has already been
+            -- cleared since this tag was given
+            return
+        end
+    end
+    self.clear_tag = nil -- invalidate tag
     if self.ui.document.info.has_pages then
         self.view.highlight.temp = {}
     else
@@ -223,6 +239,7 @@ end
 function ReaderHighlight:onHold(arg, ges)
     -- disable hold gesture if highlighting is disabled
     if self.view.highlight.disabled then return true end
+    self:clear() -- clear previous highlight (delayed clear may not have done it yet)
     self.hold_pos = self.view:screenToPageTransform(ges.pos)
     logger.dbg("hold position in page", self.hold_pos)
     if not self.hold_pos then

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -110,23 +110,23 @@ function ReaderHighlight:genHighlightDrawerMenu()
     }
 end
 
-function ReaderHighlight:getClearTag()
-    -- Returns a tag, that can be provided on delayed call to clear(tag)
-    -- to ensure current highlight has not already been cleared, and that
-    -- we are not going to clear a new highlight
-    self.clear_tag = TimeVal.now() -- can act as a unique tag
-    return self.clear_tag
+-- Returns a unique id, that can be provided on delayed call to :clear(id)
+-- to ensure current highlight has not already been cleared, and that we
+-- are not going to clear a new highlight
+function ReaderHighlight:getClearId()
+    self.clear_id = TimeVal.now() -- can act as a unique id
+    return self.clear_id
 end
 
-function ReaderHighlight:clear(clear_tag)
-    if clear_tag then -- should be provided by delayed call to clear()
-        if clear_tag ~= self.clear_tag then
-            -- if tag is no more valid, highlight has already been
-            -- cleared since this tag was given
+function ReaderHighlight:clear(clear_id)
+    if clear_id then -- should be provided by delayed call to clear()
+        if clear_id ~= self.clear_id then
+            -- if clear_id is no more valid, highlight has already been
+            -- cleared since this clear_id was given
             return
         end
     end
-    self.clear_tag = nil -- invalidate tag
+    self.clear_id = nil -- invalidate id
     if self.ui.document.info.has_pages then
         self.view.highlight.temp = {}
     else

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -613,8 +613,9 @@ function DictQuickLookup:onClose()
     if self.highlight then
         -- delay unhighlight of selection, so we can see where we stopped when
         -- back from our journey into dictionary or wikipedia
+        local clear_tag = self.highlight:getClearTag()
         UIManager:scheduleIn(0.5, function()
-            self.highlight:clear()
+            self.highlight:clear(clear_tag)
         end)
     end
     return true
@@ -626,8 +627,9 @@ function DictQuickLookup:onHoldClose(no_clear)
         local window = self.window_list[i]
         -- if one holds a highlight, let's clear it like in onClose()
         if window.highlight and not no_clear then
-            UIManager:scheduleIn(1, function()
-                window.highlight:clear()
+            local clear_tag = window.highlight:getClearTag()
+            UIManager:scheduleIn(0.5, function()
+                window.highlight:clear(clear_tag)
             end)
         end
         UIManager:close(window)

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -613,9 +613,9 @@ function DictQuickLookup:onClose()
     if self.highlight then
         -- delay unhighlight of selection, so we can see where we stopped when
         -- back from our journey into dictionary or wikipedia
-        local clear_tag = self.highlight:getClearTag()
+        local clear_id = self.highlight:getClearId()
         UIManager:scheduleIn(0.5, function()
-            self.highlight:clear(clear_tag)
+            self.highlight:clear(clear_id)
         end)
     end
     return true
@@ -627,9 +627,9 @@ function DictQuickLookup:onHoldClose(no_clear)
         local window = self.window_list[i]
         -- if one holds a highlight, let's clear it like in onClose()
         if window.highlight and not no_clear then
-            local clear_tag = window.highlight:getClearTag()
+            local clear_id = window.highlight:getClearId()
             UIManager:scheduleIn(0.5, function()
-                window.highlight:clear(clear_tag)
+                window.highlight:clear(clear_id)
             end)
         end
         UIManager:close(window)


### PR DESCRIPTION
Finally understood the occasional crashes I got (which are less likely to happen now that the delayed selection clear() when leaving dictionary has been decreased from 1 to 0.5 second, but well, better ensure that).
A delayed clear() could reset hold_pos while a onHold/onHoldPan/onHoldRelease is in progress, resulting in hold_pos becoming nil and a crash:
```
./luajit: frontend/apps/reader/modules/readerhighlight.lua:310: attempt to index field 'hold_pos' (a nil value)
stack traceback:
    frontend/apps/reader/modules/readerhighlight.lua:310: in function 'lookup'
```
Can easily be reproduced by increasing the 0.5 to 2.5, and doing a new Hold after closing a dict window.