### PR TITLE
Some History fixes and enhancements

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -146,28 +146,9 @@ function FileManager:init()
                             text = util.template(_("Purge .sdr to reset settings for this document?\n\n%1"), self.file_dialog.title),
                             ok_text = _("Purge"),
                             ok_callback = function()
-                                local file_abs_path = util.realpath(file)
-                                if file_abs_path then
-                                    local autoremove_deleted_items_from_history = G_reader_settings:readSetting("autoremove_deleted_items_from_history") or false
-                                    os.remove(DocSettings:getSidecarFile(file_abs_path))
-                                    -- also remove backup, otherwise it will be used if we re-open this document
-                                    -- (it also allows for the sidecar folder to be empty and removed)
-                                    os.remove(DocSettings:getSidecarFile(file_abs_path)..".old")
-                                    -- If the sidecar folder is empty, os.remove() can
-                                    -- delete it. Otherwise, the following statement has no
-                                    -- effect.
-                                    os.remove(DocSettings:getSidecarDir(file_abs_path))
-                                    self:refreshPath()
-                                    -- also delete from history and update lastfile to top item in
-                                    -- history if autoremove_deleted_items_from_history is enabled
-                                    if autoremove_deleted_items_from_history then
-                                        local readhistory = require("readhistory")
-                                        readhistory:removeItemByPath(file_abs_path)
-                                        if G_reader_settings:readSetting("lastfile") == file_abs_path then
-                                            G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
-                                        end
-                                    end
-                                end
+                                filemanagerutil.purgeSettings(file)
+                                filemanagerutil.removeFileFromHistoryIfWanted(file)
+                                self:refreshPath()
                                 UIManager:close(self.file_dialog)
                             end,
                         })
@@ -186,26 +167,14 @@ function FileManager:init()
                     text = _("Delete"),
                     callback = function()
                         local ConfirmBox = require("ui/widget/confirmbox")
-                        UIManager:close(self.file_dialog)
                         UIManager:show(ConfirmBox:new{
                             text = _("Are you sure that you want to delete this file?\n") .. file .. ("\n") .. _("If you delete a file, it is permanently lost."),
                             ok_text = _("Delete"),
                             ok_callback = function()
-                                local autoremove_deleted_items_from_history = G_reader_settings:readSetting("autoremove_deleted_items_from_history") or false
-                                local file_abs_path = util.realpath(file)
                                 deleteFile(file)
-                                -- also delete from history and update lastfile to top item in
-                                -- history if autoremove_deleted_items_from_history is enabled
-                                if autoremove_deleted_items_from_history then
-                                    if file_abs_path then
-                                        local readhistory = require("readhistory")
-                                        readhistory:removeItemByPath(file_abs_path)
-                                        if G_reader_settings:readSetting("lastfile") == file_abs_path then
-                                            G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
-                                        end
-                                    end
-                                end
+                                filemanagerutil.removeFileFromHistoryIfWanted(file)
                                 self:refreshPath()
+                                UIManager:close(self.file_dialog)
                             end,
                         })
                     end,

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -3,6 +3,8 @@ This module contains miscellaneous helper functions for FileManager
 ]]
 
 local Device = require("device")
+local DocSettings = require("docsettings")
+local util = require("ffi/util")
 
 local filemanagerutil = {}
 
@@ -29,6 +31,32 @@ function filemanagerutil.abbreviate(path)
         end
     end
     return path
+end
+
+-- Purge doc settings in sidecar directory,
+function filemanagerutil.purgeSettings(file)
+    local file_abs_path = util.realpath(file)
+    if file_abs_path then
+        os.remove(DocSettings:getSidecarFile(file_abs_path))
+        -- Also remove backup, otherwise it will be used if we re-open this document
+        -- (it also allows for the sidecar folder to be empty and removed)
+        os.remove(DocSettings:getSidecarFile(file_abs_path)..".old")
+        -- If the sidecar folder is empty, os.remove() can delete it.
+        -- Otherwise, the following statement has no effect.
+        os.remove(DocSettings:getSidecarDir(file_abs_path))
+    end
+end
+
+-- Remove from history and update lastfile to top item in history
+-- if autoremove_deleted_items_from_history is enabled
+function filemanagerutil.removeFileFromHistoryIfWanted(file)
+    if G_reader_settings:readSetting("autoremove_deleted_items_from_history") then
+        local readhistory = require("readhistory")
+        readhistory:removeItemByPath(file)
+        if G_reader_settings:readSetting("lastfile") == file then
+            G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
+        end
+    end
 end
 
 return filemanagerutil

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -209,6 +209,7 @@ function MenuItem:init()
                 text = self.text,
                 face = self.face,
                 bold = self.bold,
+                fgcolor = self.dim and Blitbuffer.COLOR_GREY or nil,
             }
         }
     }
@@ -219,6 +220,7 @@ function MenuItem:init()
             text = mandatory,
             face = self.info_face,
             bold = self.bold,
+            fgcolor = self.dim and Blitbuffer.COLOR_GREY or nil,
         }
     }
 
@@ -651,6 +653,7 @@ function Menu:updateItems(select_number)
                 text = getMenuText(self.item_table[i]),
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
+                dim = self.item_table[i].dim,
                 face = self.cface,
                 dimen = self.item_dimen:new(),
                 shortcut = item_shortcut,

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -326,22 +326,23 @@ function CoverMenu:onHistoryMenuHold(item)
         return true
     end
 
-    -- Remember some of this original ButtonDialog properties
+    -- Remember some of this original ButtonDialogTitle properties
+    local orig_title = self.histfile_dialog.title
+    local orig_title_align = self.histfile_dialog.title_align
     local orig_buttons = self.histfile_dialog.buttons
     -- Close original ButtonDialog (it has not yet been painted
     -- on screen, so we won't see it)
     UIManager:close(self.histfile_dialog)
 
     -- Replace Book information callback to use directly our bookinfo
-    orig_buttons[2][1].callback = function()
+    orig_buttons[2][2].callback = function()
         FileManagerBookInfo:show(file, bookinfo)
         UIManager:close(self.histfile_dialog)
     end
-    -- Re-organise buttons to make them more coherent with those we're going to add
-    -- Move up "Clear history of deleted items" and down "Book information", so
-    -- it's now similar to File browser's onFileHold
-    -- (The original organisation is fine in classic mode)
-    orig_buttons[2], orig_buttons[4] = orig_buttons[4], orig_buttons[2]
+
+    -- Remove last button ("Clear history of deleted files"), we'll
+    -- add it back after our buttons
+    local last_button = table.remove(orig_buttons)
 
     -- Add some new buttons to original buttons set
     table.insert(orig_buttons, {
@@ -412,10 +413,15 @@ function CoverMenu:onHistoryMenuHold(item)
             end,
         },
     })
+    table.insert(orig_buttons, {}) -- separator
+    -- Put back "Clear history of deleted files"
+    table.insert(orig_buttons, last_button)
 
     -- Create the new ButtonDialog, and let UIManager show it
-    local ButtonDialog = require("ui/widget/buttondialog")
-    self.histfile_dialog = ButtonDialog:new{
+    local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+    self.histfile_dialog = ButtonDialogTitle:new{
+        title = orig_title,
+        title_align = orig_title_align,
         buttons = orig_buttons,
     }
     UIManager:show(self.histfile_dialog)

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -513,8 +513,8 @@ local function _FileManagerHistory_updateItemTable(self)
         hist_menu._do_hint_opened = BookInfoManager:getSetting("history_hint_opened")
     end
 
-    -- We do now the single thing done in FileManagerHistory:updateItemTable():
-    hist_menu:switchItemTable(self.hist_menu_title, require("readhistory").hist)
+    -- And do now what the original does
+    _FileManagerHistory_updateItemTable_orig(self)
 end
 
 function CoverBrowser:setupHistoryDisplayMode(display_mode)


### PR DESCRIPTION
Seen https://www.mobileread.com/forums/showthread.php?t=290611 , and I'm not sure we need a "Purge all books in history" feature. But we should at least be able to purge or delete from History (currently, when I want to do that, i have to: open the book, switch to File browser to get in that book directory, browse the directory to find the book, delete it, go back to History, repeat for the next book).

So, I just wanted to add "Purge .sdr" and "Delete" to the onHold buttons of History... and it lead me to having to do much more:

- Made the onHold buttons table similar to the one of File browser (use ButtonDialogTitle with the full filename as title, instead of a truncated one), just cause it's prettier, and for consistency.
- Added "Purge .sdr" and "Delete" to these buttons.
- Moved the purgeSettings and removeFileFromHistoryIfWanted logic into filemanagerutil functions, now that they are used in 2 places.
- Stay on the same page when manipulating history items (previously, we were always put back on first page).
- Really keep deleted files in history (unless setting says otherwise). Previously, these were always removed on startup, because of kept logic that was duplicated in clearMissing(), so it was applied even if `autoremove_deleted_items_from_history` was false (*).
- Show deleted items in grey or dimmed in classic History and all CoverBrowser display modes.

(There were many combinations to check, and I may have missed a few, so this may introduce some new bugs.)

(*): we disccused this some months ago, about whether History should keep deleted files, which was chosen as to be the default, with a setting `autoremove_deleted_items_from_history` to change this behaviour.
But since then, and even with the apparent clearMissing() fix, they were still removed.
I thought about making that `autoremove_deleted_items_from_history` true as default (because that's what people are accustomed to), but then, they wouldn't see the grey/dim stuff I just added :)

