### PR TITLE
[UX] Smaller menu icons

### DIFF
--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -14,6 +14,8 @@ local IconButton = InputContainer:new{
     dimen = nil,
     -- show_parent is used for UIManager:setDirty, so we can trigger repaint
     show_parent = nil,
+    width = nil,
+    height = nil,
     scale_for_dpi = true,
     horizontal_padding = 0,
     callback = function() end,
@@ -23,6 +25,8 @@ function IconButton:init()
     self.image = ImageWidget:new{
         file = self.icon_file,
         scale_for_dpi = self.scale_for_dpi,
+        width = self.width,
+        height = self.height,
     }
 
     self.show_parent = self.show_parent or self

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -162,12 +162,13 @@ function TouchMenuBar:init()
     local icon_sep_width = Size.span.vertical_default
     local icons_sep_width = icon_sep_width * (#self.icons + 1)
     -- we assume all icons are of the same width
-    local tmp_ib = IconButton:new{icon_file = self.icons[1]}
+    local icon_width = Screen:scaleBySize(40)
+    local icon_height = icon_width
     -- content_width is the width of all the icon images
-    local content_width = tmp_ib:getSize().w * #self.icons + icons_sep_width
+    local content_width = icon_width * #self.icons + icons_sep_width
     local spacing_width = (self.width - content_width)/(#self.icons*2)
-    local icon_padding = math.min(spacing_width, Screen:scaleBySize(20))
-    self.height = tmp_ib:getSize().h + Screen:scaleBySize(10)
+    local icon_padding = math.min(spacing_width, Size.span.horizontal_default)
+    self.height = icon_height + Size.span.vertical_large
     self.show_parent = self.show_parent or self
     self.bar_icon_group = HorizontalGroup:new{}
     -- build up image widget for menu icon bar
@@ -187,6 +188,9 @@ function TouchMenuBar:init()
         local ib = IconButton:new{
             show_parent = self.show_parent,
             icon_file = v,
+            width = icon_width,
+            height = icon_height,
+            scale_for_dpi = false,
             callback = nil,
             horizontal_padding = icon_padding,
         }

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -167,7 +167,7 @@ function TouchMenuBar:init()
     -- content_width is the width of all the icon images
     local content_width = icon_width * #self.icons + icons_sep_width
     local spacing_width = (self.width - content_width)/(#self.icons*2)
-    local icon_padding = math.min(spacing_width, Size.span.horizontal_default)
+    local icon_padding = math.min(spacing_width, Screen:scaleBySize(16))
     self.height = icon_height + Size.span.vertical_large
     self.show_parent = self.show_parent or self
     self.bar_icon_group = HorizontalGroup:new{}


### PR DESCRIPTION
This is to get discussion started but it does reflect my input.

### Small screen before/after

![screenshot_2017-09-23_20-57-43](https://user-images.githubusercontent.com/202757/30776164-09a9faf8-a0a2-11e7-8858-c709d2063f3b.png)
![screenshot_2017-09-23_21-44-27](https://user-images.githubusercontent.com/202757/30776537-64657cb4-a0a8-11e7-8e2e-ad6bde9db14e.png)


### Kobo Aura One before/after

![screenshot_2017-09-23_20-58-39](https://user-images.githubusercontent.com/202757/30776168-09b97c58-a0a2-11e7-8c7a-a48ed3e270a1.png)
![screenshot_2017-09-23_21-42-52](https://user-images.githubusercontent.com/202757/30776528-3f31602a-a0a8-11e7-9b7e-20d3bf76665d.png)

Edited to add screenshots after @poire-z's comment.
