### PR TITLE
Remove rounded corners from fullscren History

### DIFF
--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -127,6 +127,7 @@ function FileManagerHistory:onShowHist()
         width = Screen:getWidth(),
         height = Screen:getHeight(),
         is_borderless = true,
+        is_popout = false,
         onMenuHold = self.onMenuHold,
         _manager = self,
     }


### PR DESCRIPTION
Prevent visibility of readers's footer edges.