### PR TITLE
[UX] Smaller borders

### DIFF
--- a/frontend/ui/size.lua
+++ b/frontend/ui/size.lua
@@ -30,10 +30,10 @@ local Screen = require("device").screen
 
 local Size = {
     border = {
-        default = Screen:scaleBySize(2),
-        thin = Screen:scaleBySize(1),
-        button = Screen:scaleBySize(2),
-        window = Screen:scaleBySize(2),
+        default = Screen:scaleBySize(1),
+        thin = Screen:scaleBySize(0.5),
+        button = Screen:scaleBySize(1.5),
+        window = Screen:scaleBySize(1.5),
     },
     margin = {
         default = Screen:scaleBySize(5),


### PR DESCRIPTION
For years they've been smaller on higher DPI devices and likely very few people realized it was technically a bug. These values round up on lower DPI and smaller screen devices.

References https://github.com/koreader/koreader/issues/3265

![screenshot_2017-09-28_10-33-28](https://user-images.githubusercontent.com/202757/30956792-a8f23528-a438-11e7-8b49-d797ed8188c1.png)
![screenshot_2017-09-28_10-33-44](https://user-images.githubusercontent.com/202757/30956793-a8f2e446-a438-11e7-8499-436bfd20f1a0.png)
![screenshot_2017-09-28_10-34-01](https://user-images.githubusercontent.com/202757/30956794-a914be54-a438-11e7-9350-afee6da46c85.png)
