### PR TITLE
Allow for colored rendering

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -57,6 +57,10 @@ function Device:init()
         error("screen/framebuffer must be implemented")
     end
 
+    self.screen.isColorEnabled = function()
+        return G_reader_settings:has("color_rendering") and G_reader_settings:isTrue("color_rendering") or self.screen.color
+    end
+
     local is_eink = G_reader_settings:readSetting("eink")
     self.screen.eink = (is_eink == nil) or is_eink
 

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -58,7 +58,8 @@ function Device:init()
     end
 
     self.screen.isColorEnabled = function()
-        return G_reader_settings:has("color_rendering") and G_reader_settings:isTrue("color_rendering") or self.screen.color
+        if G_reader_settings:has("color_rendering") then return G_reader_settings:isTrue("color_rendering") end
+        return self.screen.color
     end
 
     local is_eink = G_reader_settings:readSetting("eink")

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -26,6 +26,7 @@ local CreDocument = Document:new{
     fallback_font = G_reader_settings:readSetting("fallback_font") or "Noto Sans CJK SC",
     default_css = "./data/cr3.css",
     options = CreOptions,
+    color = G_reader_settings:isTrue("color_rendering"),
 }
 
 -- NuPogodi, 20.05.12: inspect the zipfile content
@@ -240,9 +241,13 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
         self.buffer = nil
     end
     if not self.buffer then
-        self.buffer = Blitbuffer.new(rect.w, rect.h)
+        -- If we use TYPE_BBRGB32 (and LVColorDrawBuf drawBuf(..., 32) in cre.cpp),
+        -- we get inverted Red and Blue in the blitbuffer (could be that 
+        -- crengine/src/lvdrawbuf.cpp treats our 32bits not as RGBA).
+        -- But it is all fine if we use TYPE_BBRGB16.
+        self.buffer = Blitbuffer.new(rect.w, rect.h, self.color and Blitbuffer.TYPE_BBRGB16 or nil)
     end
-    self._document:drawCurrentPage(self.buffer)
+    self._document:drawCurrentPage(self.buffer, self.color)
     target:blitFrom(self.buffer, x, y, 0, 0, rect.w, rect.h)
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -242,7 +242,7 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
     end
     if not self.buffer then
         -- If we use TYPE_BBRGB32 (and LVColorDrawBuf drawBuf(..., 32) in cre.cpp),
-        -- we get inverted Red and Blue in the blitbuffer (could be that 
+        -- we get inverted Red and Blue in the blitbuffer (could be that
         -- crengine/src/lvdrawbuf.cpp treats our 32bits not as RGBA).
         -- But it is all fine if we use TYPE_BBRGB16.
         self.buffer = Blitbuffer.new(rect.w, rect.h, self.color and Blitbuffer.TYPE_BBRGB16 or nil)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -26,7 +26,6 @@ local CreDocument = Document:new{
     fallback_font = G_reader_settings:readSetting("fallback_font") or "Noto Sans CJK SC",
     default_css = "./data/cr3.css",
     options = CreOptions,
-    color = G_reader_settings:isTrue("color_rendering"),
 }
 
 -- NuPogodi, 20.05.12: inspect the zipfile content
@@ -240,14 +239,15 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
         self.buffer:free()
         self.buffer = nil
     end
+    local color = Screen:isColorEnabled()
     if not self.buffer then
         -- If we use TYPE_BBRGB32 (and LVColorDrawBuf drawBuf(..., 32) in cre.cpp),
         -- we get inverted Red and Blue in the blitbuffer (could be that
         -- crengine/src/lvdrawbuf.cpp treats our 32bits not as RGBA).
         -- But it is all fine if we use TYPE_BBRGB16.
-        self.buffer = Blitbuffer.new(rect.w, rect.h, self.color and Blitbuffer.TYPE_BBRGB16 or nil)
+        self.buffer = Blitbuffer.new(rect.w, rect.h, color and Blitbuffer.TYPE_BBRGB16 or nil)
     end
-    self._document:drawCurrentPage(self.buffer, self.color)
+    self._document:drawCurrentPage(self.buffer, color)
     target:blitFrom(self.buffer, x, y, 0, 0, rect.w, rect.h)
 end
 

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -1,6 +1,6 @@
-local KoptOptions = require("ui/data/koptoptions")
 local Document = require("document/document")
 local DrawContext = require("ffi/drawcontext")
+local KoptOptions = require("ui/data/koptoptions")
 
 local DjvuDocument = Document:new{
     _document = false,
@@ -10,7 +10,7 @@ local DjvuDocument = Document:new{
     dc_null = DrawContext.new(),
     options = KoptOptions,
     koptinterface = nil,
-    color = false,
+    is_color_capable = false,
 }
 
 -- check DjVu magic string to validate

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -10,6 +10,7 @@ local DjvuDocument = Document:new{
     dc_null = DrawContext.new(),
     options = KoptOptions,
     koptinterface = nil,
+    color = false,
 }
 
 -- check DjVu magic string to validate

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -31,6 +31,9 @@ local Document = {
 
     -- flag to show that the document is edited and needs to write back to disk
     is_edited = false,
+
+    -- whether to use colored or greyscale blitbuffers
+    color = G_reader_settings:isTrue("color_rendering"),
 }
 
 function Document:new(from_o)
@@ -303,7 +306,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode)
         size = size.w * size.h + 64, -- estimation
         excerpt = size,
         pageno = pageno,
-        bb = Blitbuffer.new(size.w, size.h)
+        bb = Blitbuffer.new(size.w, size.h, self.color and Blitbuffer.TYPE_BBRGB32 or nil)
     }
 
     -- create a draw context

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -1,12 +1,13 @@
-local TileCacheItem = require("document/tilecacheitem")
-local DrawContext = require("ffi/drawcontext")
-local Configurable = require("configurable")
 local Blitbuffer = require("ffi/blitbuffer")
-local lfs = require("libs/libkoreader-lfs")
+local Cache = require("cache")
 local CacheItem = require("cacheitem")
+local Configurable = require("configurable")
+local DrawContext = require("ffi/drawcontext")
 local Geom = require("ui/geometry")
 local Math = require("optmath")
-local Cache = require("cache")
+local Screen = require("device").screen
+local TileCacheItem = require("document/tilecacheitem")
+local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 --[[
@@ -32,8 +33,9 @@ local Document = {
     -- flag to show that the document is edited and needs to write back to disk
     is_edited = false,
 
-    -- whether to use colored or greyscale blitbuffers
-    color = G_reader_settings:isTrue("color_rendering"),
+    -- whether this document can be rendered in color
+    is_color_capable = true,
+
 }
 
 function Document:new(from_o)
@@ -301,12 +303,16 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode)
     end
 
     -- prepare cache item with contained blitbuffer
+    local bbtype = nil -- use Blitbuffer default greyscale type
+    if self.is_color_capable and Screen:isColorEnabled() then
+        bbtype = Blitbuffer.TYPE_BBRGB32
+    end
     tile = TileCacheItem:new{
         persistent = true,
         size = size.w * size.h + 64, -- estimation
         excerpt = size,
         pageno = pageno,
-        bb = Blitbuffer.new(size.w, size.h, self.color and Blitbuffer.TYPE_BBRGB32 or nil)
+        bb = Blitbuffer.new(size.w, size.h, bbtype)
     }
 
     -- create a draw context

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -1,8 +1,9 @@
 local Cache = require("cache")
 local CacheItem = require("cacheitem")
-local KoptOptions = require("ui/data/koptoptions")
 local Document = require("document/document")
 local DrawContext = require("ffi/drawcontext")
+local KoptOptions = require("ui/data/koptoptions")
+local Screen = require("device").screen
 local logger = require("logger")
 local util = require("util")
 
@@ -16,7 +17,7 @@ local PdfDocument = Document:new{
 
 function PdfDocument:init()
     local pdf = require("ffi/mupdf")
-    pdf.color = G_reader_settings:isTrue("color_rendering")
+    pdf.color = Screen:isColorEnabled()
     self.koptinterface = require("document/koptinterface")
     self.configurable:loadDefaults(self.options)
     local ok

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -16,6 +16,7 @@ local PdfDocument = Document:new{
 
 function PdfDocument:init()
     local pdf = require("ffi/mupdf")
+    pdf.color = G_reader_settings:isTrue("color_rendering")
     self.koptinterface = require("document/koptinterface")
     self.configurable:loadDefaults(self.options)
     local ok

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -10,6 +10,7 @@ local PicDocument = Document:new{
 
 function PicDocument:init()
     if not pic then pic = require("ffi/pic") end
+    pic.color = G_reader_settings:isTrue("color_rendering")
     local ok
     ok, self._document = pcall(pic.openDocument, self.file)
     if not ok then

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -1,5 +1,6 @@
 local Document = require("document/document")
 local DrawContext = require("ffi/drawcontext")
+local Screen = require("device").screen
 local pic = nil
 
 local PicDocument = Document:new{
@@ -10,7 +11,7 @@ local PicDocument = Document:new{
 
 function PicDocument:init()
     if not pic then pic = require("ffi/pic") end
-    pic.color = G_reader_settings:isTrue("color_rendering")
+    pic.color = Screen:isColorEnabled()
     local ok
     ok, self._document = pcall(pic.openDocument, self.file)
     if not ok then


### PR DESCRIPTION
Support for colored rendering is already there for most engines/formats (CRE, PDF, Images). It just needs a few fixes, and enabling it. (Only reflowed PDF and DJVU are still greyscale).
Needs to manually add setting: `"color_rendering" = true` (any better name for this setting?)
It will use 4 times more memory for blitbuffers (32bits RGB vs 8bits greyscale), so, even if a platform supports colors, it should be togglable thru a menu item.
Will need a base bump for https://github.com/koreader/koreader-base/pull/524.
Only observable for now with the emulator, but I guess some tweaks on the android side could make it colorful too.

edit:
- if this is going to be togglable thru menu, we'll need to clear tile cache (otherwise, cached grey pages would still be used once color is enabled).
- seems enabling color screws rendering of djvu (djvu3spec.djvu): there's hardcoded in djvu.c `ddjvu_format_create(DDJVU_FORMAT_GREY8` - which may not go well when we give it a 32bits blitbuffer...