### PR TITLE
[lang] OPDSCatalog ConfirmBox ok_text/cancel_text

### DIFF
--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -27,6 +27,8 @@ function OPDSCatalog:init()
             UIManager:show(ConfirmBox:new{
                 text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"),
                     downloaded_file),
+                ok_text = _("Read"),
+                cancel_text = _("Don't read"),
                 ok_callback = function()
                     self:onClose()
                     ReaderUI:showReader(downloaded_file)

--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -27,8 +27,8 @@ function OPDSCatalog:init()
             UIManager:show(ConfirmBox:new{
                 text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"),
                     downloaded_file),
-                ok_text = _("Read"),
-                cancel_text = _("Don't read"),
+                ok_text = _("Read now"),
+                cancel_text = _("Read later"),
                 ok_callback = function()
                     self:onClose()
                     ReaderUI:showReader(downloaded_file)


### PR DESCRIPTION
I noticed this dialog was undescriptive. I'm not entirely sure what to go for instead of Cancel/OK though.

<kbd>Don't read</kbd>/<kbd>Read</kbd>

or

<kbd>Read later</kbd>/<kbd>Read now</kbd>