### PR TITLE
Allow for toggling color rendering

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -219,6 +219,10 @@ function ReaderPaging:addToMainMenu(menu_items)
     }
 end
 
+function ReaderPaging:onColorRenderingUpdate()
+    self.ui.document:updateColorRendering()
+end
+
 --[[
 Set reading position on certain page
 Page position is a fractional number ranging from 0 to 1, indicating the read

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -530,6 +530,10 @@ function ReaderRolling:onChangeScreenMode(mode)
     self:onUpdatePos()
 end
 
+function ReaderRolling:onColorRenderingUpdate()
+    self.ui.document:updateColorRendering()
+end
+
 --[[
     PosUpdate event is used to signal other widgets that pos has been changed.
 --]]

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -14,6 +14,7 @@ local Device = Generic:new{
     hasFrontlight = yes,
     firmware_rev = "none",
     display_dpi = android.lib.AConfiguration_getDensity(android.app.config),
+    hasColorScreen = yes,
 }
 
 function Device:init()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -24,6 +24,7 @@ local Device = {
     isTouchDevice = no,
     hasFrontlight = no,
     needsTouchScreenProbe = no,
+    hasColorScreen = no,
 
     -- use these only as a last resort. We should abstract the functionality
     -- and have device dependent implementations in the corresponting
@@ -57,9 +58,10 @@ function Device:init()
         error("screen/framebuffer must be implemented")
     end
 
+    self.screen.isColorScreen = self.hasColorScreen
     self.screen.isColorEnabled = function()
         if G_reader_settings:has("color_rendering") then return G_reader_settings:isTrue("color_rendering") end
-        return self.screen.color
+        return self.screen.isColorScreen()
     end
 
     local is_eink = G_reader_settings:readSetting("eink")

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -14,6 +14,7 @@ local Device = Generic:new{
     hasFrontlight = yes,
     isTouchDevice = yes,
     needsScreenRefreshAfterResume = no,
+    hasColorScreen = yes,
 }
 
 if os.getenv("DISABLE_TOUCH") == "1" then

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -24,6 +24,7 @@ local function validDjvuFile(filename)
 end
 
 function DjvuDocument:init()
+    self:updateColorRendering()
     local djvu = require("libs/libkoreader-djvu")
     self.koptinterface = require("document/koptinterface")
     self.configurable:loadDefaults(self.options)

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -10,8 +10,10 @@ local PicDocument = Document:new{
 }
 
 function PicDocument:init()
+    self:updateColorRendering()
     if not pic then pic = require("ffi/pic") end
-    pic.color = Screen:isColorEnabled()
+    -- pic.color needs to be true before opening document to allow toggling color
+    pic.color = Screen.isColorScreen()
     local ok
     ok, self._document = pcall(pic.openDocument, self.file)
     if not ok then

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -107,13 +107,19 @@ common_settings.screen = {
     text = _("Screen"),
     sub_item_table = {
         require("ui/elements/screen_dpi_menu_table"),
-        require("ui/elements/screen_eink_opt_menu_table"),
-        require("ui/elements/screen_disable_double_tap_table"),
         require("ui/elements/refresh_menu_table"),
-        require("ui/elements/flash_keyboard"),
+        require("ui/elements/screen_eink_opt_menu_table"),
         require("ui/elements/menu_activate"),
+        require("ui/elements/screen_disable_double_tap_table"),
+        require("ui/elements/flash_keyboard"),
     },
 }
+if Screen.isColorScreen() then
+    table.insert(common_settings.screen.sub_item_table, 4, require("ui/elements/screen_color_menu_table"))
+    common_settings.screen.sub_item_table[4].separator = true
+else
+    common_settings.screen.sub_item_table[3].separator = true
+end
 if Device:isAndroid() then
     table.insert(common_settings.screen.sub_item_table, require("ui/elements/screen_fullscreen_menu_table"))
 end

--- a/frontend/ui/elements/screen_color_menu_table.lua
+++ b/frontend/ui/elements/screen_color_menu_table.lua
@@ -1,0 +1,14 @@
+local Event = require("ui/event")
+local Screen = require("device").screen
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+
+return {
+    text = _("Color rendering"),
+    enabled_func = Screen.isColorScreen,
+    checked_func = Screen.isColorEnabled,
+    callback = function()
+        G_reader_settings:flipNilOrTrue("color_rendering")
+        UIManager:broadcastEvent(Event:new("ColorRenderingUpdate"))
+    end
+}


### PR DESCRIPTION
New menu item in Screen submenu (and screen submenu a bit re-ordered).
hasColorScreen enabled for SDL device.
I could have either required a restart (and clear all caches, but I didn't want to bother with that), or deal with each document type so it supports toggling color rendering, which is what I did.
Follow-up of #3276