### PR TITLE
credocument reader optimisation (avoid multiple TOC builds)

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -94,6 +94,8 @@ function ReaderRolling:init()
     table.insert(self.ui.postInitCallback, function()
         self.doc_height = self.ui.document.info.doc_height
         self.old_doc_height = self.doc_height
+        self.ui.document:_readMetadata()
+        self.old_page = self.ui.document.info.number_of_pages
     end)
     self.ui.menu:registerToMainMenu(self)
 end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -746,9 +746,11 @@ function ReaderView:onMarginUpdate()
 end
 
 function ReaderView:onSetViewMode(new_mode)
-    self.view_mode = new_mode
-    self.ui.document:setViewMode(new_mode)
-    self.ui:handleEvent(Event:new("ChangeViewMode"))
+    if new_mode ~= self.view_mode then
+        self.view_mode = new_mode
+        self.ui.document:setViewMode(new_mode)
+        self.ui:handleEvent(Event:new("ChangeViewMode"))
+    end
     return true
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -96,9 +96,9 @@ function CreDocument:init()
     -- @TODO check the default view_mode to a global user configurable
     -- variable  22.12 2012 (houqp)
     local ok
-    ok, self._document = pcall(cre.newDocView,
-        Screen:getWidth(), Screen:getHeight(), self.PAGE_VIEW_MODE
-    )
+    ok, self._document = pcall(cre.newDocView, Screen:getWidth(), Screen:getHeight(),
+        DCREREADER_VIEW_MODE == "scroll" and self.SCROLL_VIEW_MODE or self.PAGE_VIEW_MODE
+    ) -- this mode must be the same as the default one set as ReaderView.view_mode
     if not ok then
         error(self._document)  -- will contain error message
     end


### PR DESCRIPTION
Avoid unnecessary work in `ReaderView:onSetViewMode() `and `ReaderRolling:updatePos() `that would result in TOC being reset and rebuilt (which can take time on books with huge TOC) during reader setup.
See https://github.com/koreader/koreader/issues/3261#issuecomment-333560902.
(IT works fine in my tests and it looks simple enough, but given the heavy use of indirections in readerui/readerview setup - postSomethingCallback, events propagated to all widgets... - it's hard to foresee side effects...)
credocument.lua updated just to logically use `DCREREADER_VIEW_MODE `(and to mention the value must be the same as in readerview) , which defaults to `page`, even if we know that `scroll` mode currently crashes.