### PR TITLE
CoverBrowser: avoid crash when indexing some cre documents

### DIFF
--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -373,6 +373,9 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
     local document = DocumentRegistry:openDocument(filepath)
     if document then
         if document.loadDocument then -- needed for crengine
+            -- Setting a default font before loading document
+            -- actually do prevent some crashes
+            document:setFontFace(document.default_font)
             document:loadDocument()
             -- Not needed for getting props:
             -- document:render()


### PR DESCRIPTION
It wouldn't extract info from a book, but that book opened without problem for reading.
That book css contains a font-family applied to body (that doesn't look strange!):
```
@font-face {
 font-family: "MinionPro-Regular";
 font-style: normal;
 font-weight: normal;
 src: url(fonts/MinionPro-Regular.otf);
}
body {
        margin-right: 20pt;
        margin-left: 15pt;
        font-family: "MinionPro-Regular";
        font-style: normal;
        font-weight: normal;
}

```
It looks like crengine is trying to reach parent->font, which may be wasn't defined and could be the default font the reader set.
Removing that body.font-family from the css, or adding a default font before loading document, avoid the crash. So let's do that.