### PR TITLE
Migrate Goodreads to https

### DIFF
--- a/plugins/goodreads.koplugin/goodreadsapi.lua
+++ b/plugins/goodreads.koplugin/goodreadsapi.lua
@@ -4,7 +4,6 @@ local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local url = require('socket.url')
 local socket = require('socket')
-local http = require('socket.http')
 local https = require('ssl.https')
 local ltn12 = require('ltn12')
 local _ = require("gettext")
@@ -26,7 +25,7 @@ local function genSearchURL(text_search, userApi, search_type, npage)
         text_search = string.gsub (text_search, " ", "+")
     end
     return (string.format(
-        "http://www.goodreads.com/search?q=%s&search[field]=%s&format=xml&key=%s&page=%s",
+        "https://www.goodreads.com/search?q=%s&search[field]=%s&format=xml&key=%s&page=%s",
         text_search,
         search_type,
         userApi,
@@ -48,10 +47,9 @@ function GoodreadsApi:fetchXml(s_url)
     request['url'] = s_url
     request['method'] = 'GET'
     request['sink'] = ltn12.sink.table(sink)
-    http.TIMEOUT = 5
     https.TIMEOUT = 5
-    local httpRequest = parsed.scheme == 'http' and http.request or https.request
-    local headers = socket.skip(1, httpRequest(request))
+    local httpsRequest = parsed.scheme == 'https' and https.request
+    local headers = socket.skip(1, httpsRequest(request))
     if headers == nil then
         return nil
     end

--- a/plugins/goodreads.koplugin/goodreadsbook.lua
+++ b/plugins/goodreads.koplugin/goodreadsbook.lua
@@ -20,6 +20,7 @@ local Screen = require("device").screen
 local ScrollTextWidget = require("ui/widget/scrolltextwidget")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
+local https = require('ssl.https')
 local T = require("ffi/util").template
 local _ = require("gettext")
 
@@ -192,8 +193,7 @@ function GoodreadsBook:genBookInfoGroup()
         HorizontalSpan:new{ width =  split_span_width }
     }
     -- thumbnail
-    local http = require("socket.http")
-    local body = http.request(self.dates.image)
+    local body = https.request(self.dates.image)
     local image = false
     if body then image = Pic.openJPGDocumentFromMem(body) end
     if image then


### PR DESCRIPTION
See: https://www.goodreads.com/topic/show/18944471-announcement---migrating-all-api-endpoint-to-https
```

To better protect user privacy and security, we will be enabling HTTP to HTTPS redirection for all requests to goodreads.com on December 4th.

To prevent your applications from breaking, please do one of the following before December 4th:
Make sure your applications support HTTPS redirects
Update your applications to make only HTTPS requests
```