### PR TITLE
Avoid multiple refreshes when opening credocuments

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -97,6 +97,9 @@ function ReaderRolling:init()
         self.ui.document:_readMetadata()
         self.old_page = self.ui.document.info.number_of_pages
     end)
+    table.insert(self.ui.postReaderCallback, function()
+        self:updatePos()
+    end)
     self.ui.menu:registerToMainMenu(self)
 end
 
@@ -466,6 +469,12 @@ end
     Note that xpointer should not be changed.
 --]]
 function ReaderRolling:onUpdatePos()
+    if self.ui.postReaderCallback ~= nil then -- ReaderUI:init() not yet done
+        -- Don't schedule any updatePos as long as ReaderUI:init() is
+        -- not finished (one will be called in the ui.postReaderCallback
+        -- we have set above) to avoid multiple refreshs.
+        return true
+    end
     UIManager:scheduleIn(0.1, function () self:updatePos() end)
     return true
 end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -472,7 +472,7 @@ function ReaderRolling:onUpdatePos()
     if self.ui.postReaderCallback ~= nil then -- ReaderUI:init() not yet done
         -- Don't schedule any updatePos as long as ReaderUI:init() is
         -- not finished (one will be called in the ui.postReaderCallback
-        -- we have set above) to avoid multiple refreshs.
+        -- we have set above) to avoid multiple refreshes.
         return true
     end
     UIManager:scheduleIn(0.1, function () self:updatePos() end)


### PR DESCRIPTION
Was only noticable on Kindle (which uses REAGL as partial refresh) where a flash occurs (on kobo, the second refresh, with the same content, is not noticed).
On the emulator, we saw at end of opening with readerrolling 2 log lines like
```
10/04/17-21:54:08 DEBUG refresh on physical rectangle 0 0 600 610
10/04/17-21:54:08 DEBUG refresh on physical rectangle 0 0 600 610
```
We have only one with PDF/readerpaging.

Should resolves the 3rd item in #3230. @robert00s : can you confirm (and that you don't notice any side effects) ? (I verified it by enabling REAGL on kobo - Kindle is the real test).

