### PR TITLE
Fix footer, stats, TOC position with cre in scroll mode

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -568,9 +568,14 @@ function ReaderFooter:onPageUpdate(pageno)
     self:updateFooterPage()
 end
 
-function ReaderFooter:onPosUpdate(pos)
+function ReaderFooter:onPosUpdate(pos, pageno)
     self.position = pos
     self.doc_height = self.view.document.info.doc_height
+    if pageno then
+        self.pageno = pageno
+        self.pages = self.view.document:getPageCount()
+        self.ui.doc_settings:saveSetting("doc_pages", self.pages) -- for Book information
+    end
     self:updateFooterPos()
 end
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -72,6 +72,10 @@ function ReaderToc:onPageUpdate(pageno)
     self.pageno = pageno
 end
 
+function ReaderToc:onPosUpdate(pos, pageno)
+    self.pageno = pageno
+end
+
 function ReaderToc:fillToc()
     if self.toc and #self.toc > 0 then return end
     self.toc = self.ui.document:getToc()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1568,6 +1568,10 @@ function ReaderStatistics:deleteBook(id_book)
     conn:close()
 end
 
+function ReaderStatistics:onPageUpdate(pos, pageno)
+    self:onPageUpdate(pageno)
+end
+
 function ReaderStatistics:onPageUpdate(pageno)
     if self:isDocless() or not self.is_enabled then
         return


### PR DESCRIPTION
This gives the page position to these modules even in scroll mode. Closes #3282

Also, in readerrolling: don't query battery/charging status when crengine does not need it (used only when it shows its top progress bar).