### PR TITLE
Fix crash with keyboard navigation of onHold buttontables

### DIFF
--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -27,6 +27,7 @@ local ButtonTable = FocusManager:new{
 }
 
 function ButtonTable:init()
+    self.selected = { x = 1, y = 1 }
     self.buttons_layout = {}
     self.container = VerticalGroup:new{ width = self.width }
     table.insert(self, self.container)

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -73,8 +73,15 @@ function FocusManager:onFocusMove(args)
             end
         else
             self.selected.y = self.selected.y + dy
+            if #self.layout[self.selected.y] == 0 then -- horizontal separator
+                self.selected.y = self.selected.y + dy -- skip it
+            end
         end
         self.selected.x = self.selected.x + dx
+        if self.selected.x > #self.layout[self.selected.y] then
+            -- smaller nb of items on new row than on prev row
+            self.selected.x = #self.layout[self.selected.y]
+        end
 
         if self.layout[self.selected.y][self.selected.x] ~= current_item
         or not self.layout[self.selected.y][self.selected.x].is_inactive then


### PR DESCRIPTION
Using keyboard arrow keys on the emulator to select buttons in the OnHold button tables (in History or File Browser) crashes when encountering a separator or when the number of buttons in a row changes.