### PR TITLE
Avoid some full refreshes on Kindle

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -105,6 +105,7 @@ end
 
 function ReaderConfig:onCloseCallback()
     self.last_panel_index = self.config_dialog.panel_index
+    self.config_dialog = nil
     self.ui:handleEvent(Event:new("RestoreHinting"))
 end
 

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -466,7 +466,7 @@ function DictQuickLookup:update()
     UIManager:setDirty("all", function()
         local update_region = self.dict_frame.dimen:combine(orig_dimen)
         logger.dbg("update dict region", update_region)
-        return "partial", update_region
+        return "ui", update_region
     end)
 end
 

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -143,7 +143,7 @@ end
 
 function InfoMessage:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "partial", self[1][1].dimen
+        return "ui", self[1][1].dimen
     end)
     return true
 end


### PR DESCRIPTION
"partial" refresh causes a full (without black flash) refresh on Kindle (which uses REAGL mode for partial refresh). This causes a full redraw of widgets, which is a bit distracting with some of them:
- dictquicklookup: when showing next definition
- infomessage: when displaying a new one (Wikipedia Save as epub)

Also fix bottom menu, that even when closed, would still register bottom area as dirty: this would cause top menu navigation to cause a full partial refresh, only noticable on Kindle.

See #3230 for details about these. Closes #3230