### PR TITLE
Option to disable show bottom menu on top menu activation

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -66,6 +66,7 @@ function ReaderMenu:init()
     if self.activation_menu == nil then
         self.activation_menu = "swipe_tap"
     end
+    self.show_bottom_menu = G_reader_settings:readSetting("show_bottom_menu") ~= false
 end
 
 function ReaderMenu:onReaderReady()
@@ -305,7 +306,9 @@ end
 
 function ReaderMenu:onSwipeShowMenu(ges)
     if self.activation_menu ~= "tap" and ges.direction == "south" then
-        self.ui:handleEvent(Event:new("ShowConfigMenu"))
+        if self.show_bottom_menu then
+            self.ui:handleEvent(Event:new("ShowConfigMenu"))
+        end
         self.ui:handleEvent(Event:new("ShowReaderMenu"))
         return true
     end
@@ -313,7 +316,9 @@ end
 
 function ReaderMenu:onTapShowMenu()
     if self.activation_menu ~= "swipe" then
-        self.ui:handleEvent(Event:new("ShowConfigMenu"))
+        if self.show_bottom_menu then
+            self.ui:handleEvent(Event:new("ShowConfigMenu"))
+        end
         self.ui:handleEvent(Event:new("ShowReaderMenu"))
         return true
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -66,7 +66,6 @@ function ReaderMenu:init()
     if self.activation_menu == nil then
         self.activation_menu = "swipe_tap"
     end
-    self.show_bottom_menu = G_reader_settings:readSetting("show_bottom_menu") ~= false
 end
 
 function ReaderMenu:onReaderReady()
@@ -306,7 +305,7 @@ end
 
 function ReaderMenu:onSwipeShowMenu(ges)
     if self.activation_menu ~= "tap" and ges.direction == "south" then
-        if self.show_bottom_menu then
+        if G_reader_settings:nilOrTrue("show_bottom_menu") then
             self.ui:handleEvent(Event:new("ShowConfigMenu"))
         end
         self.ui:handleEvent(Event:new("ShowReaderMenu"))
@@ -316,7 +315,7 @@ end
 
 function ReaderMenu:onTapShowMenu()
     if self.activation_menu ~= "swipe" then
-        if self.show_bottom_menu then
+        if G_reader_settings:nilOrTrue("show_bottom_menu") then
             self.ui:handleEvent(Event:new("ShowConfigMenu"))
         end
         self.ui:handleEvent(Event:new("ShowReaderMenu"))

--- a/frontend/ui/elements/menu_activate.lua
+++ b/frontend/ui/elements/menu_activate.lua
@@ -4,7 +4,6 @@ local _ = require("gettext")
 
 local function activateMenu() return G_reader_settings:readSetting("activate_menu") end
 
-
 return {
     text = _("Activate menu"),
     sub_item_table = {
@@ -55,7 +54,21 @@ return {
                 UIManager:show(InfoMessage:new{
                     text = _("This will take effect on next restart."),
                 })
-            end
+            end,
+            separator = true,
+        },
+        {
+            text = _("Show bottom menu"),
+            checked_func = function()
+                return G_reader_settings:readSetting("show_bottom_menu") ~= false
+            end,
+            callback = function()
+                local disabled = G_reader_settings:readSetting("show_bottom_menu") ~= false
+                G_reader_settings:saveSetting("show_bottom_menu", not disabled)
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
+            end,
         },
     }
 }

--- a/frontend/ui/elements/menu_activate.lua
+++ b/frontend/ui/elements/menu_activate.lua
@@ -58,7 +58,7 @@ return {
             separator = true,
         },
         {
-            text = _("Show bottom menu"),
+            text = _("Auto-show bottom menu"),
             checked_func = function()
                 return G_reader_settings:nilOrTrue("show_bottom_menu")
             end,

--- a/frontend/ui/elements/menu_activate.lua
+++ b/frontend/ui/elements/menu_activate.lua
@@ -60,14 +60,10 @@ return {
         {
             text = _("Show bottom menu"),
             checked_func = function()
-                return G_reader_settings:readSetting("show_bottom_menu") ~= false
+                return G_reader_settings:nilOrTrue("show_bottom_menu")
             end,
             callback = function()
-                local disabled = G_reader_settings:readSetting("show_bottom_menu") ~= false
-                G_reader_settings:saveSetting("show_bottom_menu", not disabled)
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                G_reader_settings:flipNilOrTrue("show_bottom_menu")
             end,
         },
     }


### PR DESCRIPTION
I added an option to disable show bottom menu every time when top menu (main) is opened.
Setting -> Screen -> Activate menu -> Show bottom menu 
![screenshot 2017-10-07 18-08-41](https://user-images.githubusercontent.com/22982594/31309708-f910be22-ab8a-11e7-8be2-ccc3048e9126.jpg)
