### PR TITLE
CircleCI cache fix

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -13,7 +13,7 @@ ls
 # if [ "$(git status --ignore-submodules=dirty --porcelain)" ]; then
 # "--ignore-submodules=dirty", removed temporarily, as it did not notice as
 # expected that base was updated and kept using old cached base
-if [ "$(git status --porcelain)" ]; then
+if [ "$(git status --ignore-submodules=dirty --porcelain)" ]; then
     # what changed?
     git status
     # purge and reinit submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,16 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps
-            - build
+            # binary dependencies require {{ arch }} because there are different CPUs in use on the servers
+            - deps-{{ arch }}-{{ checksum ".ci/install.sh" }}
+      # need to init some stuff first or git will complain when sticking in base cache
+      - run: git submodule init base && git submodule update base && pushd base && git submodule init && git submodule update && popd
+      # we can't use command output directly for cache check so we write it to git-rev-base
+      - run: pushd base && git_rev_base=$(git describe HEAD) && popd && echo $git_rev_base && echo $git_rev_base >git-rev-base
+      - restore_cache:
+          keys:
+            - build-{{ arch }}-{{ checksum "git-rev-base" }}
       - run: echo 'export PATH=${HOME}/bin:${PATH}' >> $BASH_ENV
-
       - run:
           name: setup
           command: .ci/before_install.sh
@@ -41,12 +47,12 @@ jobs:
           name: clean up cache
           command: rm -frv ./base/build/*/{spec,cache/*}
       - save_cache:
-          key: build
+          key: build-{{ arch }}-{{ checksum "git-rev-base" }}
           paths:
             - "/home/ko/.ccache"
             - "base"
       - save_cache:
-          key: deps
+          key: deps-{{ arch }}-{{ checksum ".ci/install.sh" }}
           paths:
             - "/home/ko/bin"
             - "/home/ko/.luarocks"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ install/
 spec/unit/data
 doc/html
 git-rev
+git-rev-base
 emu
 luacov.stats.out
 trace-out.txt


### PR DESCRIPTION
* Update luarocks/shellcheck/shfmt check based on `deps-{{ arch }}-{{ checksum ".ci/install.sh" }}`
* We generate a git-rev-base to check whether we can trust the cache
  with `build-{{ arch }}-{{ checksum "git-rev-base" }}`

Binary dependencies require `{{ arch }}` because there are different CPUs used on the servers.
More information here: https://discuss.circleci.com/t/use-the-arch-cache-template-key-if-you-rely-on-cached-compiled-binary-dependencies/16129