### PR TITLE
[statistics] Fix onPosUpdate and save stats when closing document

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1569,7 +1569,9 @@ function ReaderStatistics:deleteBook(id_book)
 end
 
 function ReaderStatistics:onPosUpdate(pos, pageno)
-    self:onPageUpdate(pageno)
+    if self.curr_page ~= pageno then
+        self:onPageUpdate(pageno)
+    end
 end
 
 function ReaderStatistics:onPageUpdate(pageno)
@@ -1626,6 +1628,7 @@ end
 function ReaderStatistics:onCloseDocument()
     if not self:isDocless() and self.is_enabled then
         self.ui.doc_settings:saveSetting("stats", self.data)
+        self:insertDB(self.id_curr_book)
     end
 end
 
@@ -1649,7 +1652,6 @@ function ReaderStatistics:onSaveSettings()
     self:saveSettings()
     if not self:isDocless() then
         self.ui.doc_settings:saveSetting("stats", self.data)
-        self:insertDB(self.id_curr_book)
     end
 end
 


### PR DESCRIPTION
Previously we didn't write stats to DB on document exit :( 
Now should be fine.