### PR TITLE
Small visual fixes to Menu

### DIFF
--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -75,7 +75,8 @@ function MultiConfirmBox:init()
     local content = HorizontalGroup:new{
         align = "center",
         ImageWidget:new{
-            file = "resources/info-i.png"
+            file = "resources/info-i.png",
+            scale_for_dpi = true,
         },
         HorizontalSpan:new{ width = Size.span.horizontal_default },
         TextBoxWidget:new{


### PR DESCRIPTION
Rationalize horizontal construction of Menu items (TOC, Bookmarks, Classic file views) for more even padding.
Align "x" close button diagonaly with top right border and title.
Also add forgotten scale_for_dpi to MultiConfirmBox
Solves items 1 & 2 of #3265.

The 'x' looks also a bit misaligned in TextViewer and KeyValuePage titles. I'll try to do the same to them if there is no negative feeback about this one (and when I see how it does on android).