### PR TITLE
Allow for disabling flashing of menu, icons and buttons 

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -111,6 +111,7 @@ common_settings.screen = {
         require("ui/elements/screen_eink_opt_menu_table"),
         require("ui/elements/menu_activate"),
         require("ui/elements/screen_disable_double_tap_table"),
+        require("ui/elements/flash_ui"),
         require("ui/elements/flash_keyboard"),
     },
 }

--- a/frontend/ui/elements/flash_ui.lua
+++ b/frontend/ui/elements/flash_ui.lua
@@ -1,7 +1,7 @@
 local _ = require("gettext")
 
 return {
-    text = _("Flash UI elements"),
+    text = _("Flash buttons and menu items"),
     checked_func = function()
         return G_reader_settings:nilOrTrue("flash_ui")
     end,

--- a/frontend/ui/elements/flash_ui.lua
+++ b/frontend/ui/elements/flash_ui.lua
@@ -1,0 +1,11 @@
+local _ = require("gettext")
+
+return {
+    text = _("Flash UI elements"),
+    checked_func = function()
+        return G_reader_settings:nilOrTrue("flash_ui")
+    end,
+    callback = function()
+        G_reader_settings:flipNilOrTrue("flash_ui")
+    end,
+}

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -188,19 +188,23 @@ end
 
 function Button:onTapSelectButton()
     if self.enabled and self.callback then
-        UIManager:scheduleIn(0.0, function()
-            self[1].invert = true
-            UIManager:setDirty(self.show_parent, function()
-                return "ui", self[1].dimen
-            end)
-        end)
-        UIManager:scheduleIn(0.1, function()
+        if G_reader_settings:isFalse("flash_ui") then
             self.callback()
-            self[1].invert = false
-            UIManager:setDirty(self.show_parent, function()
-                return "ui", self[1].dimen
+        else
+            UIManager:scheduleIn(0.0, function()
+                self[1].invert = true
+                UIManager:setDirty(self.show_parent, function()
+                    return "ui", self[1].dimen
+                end)
             end)
-        end)
+            UIManager:scheduleIn(0.1, function()
+                self.callback()
+                self[1].invert = false
+                UIManager:setDirty(self.show_parent, function()
+                    return "ui", self[1].dimen
+                end)
+            end)
+        end
     elseif self.tap_input then
         self:onInput(self.tap_input)
     elseif type(self.tap_input_func) == "function" then

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -88,19 +88,23 @@ end
 
 function CheckButton:onTapCheckButton()
     if self.enabled and self.callback then
-        UIManager:scheduleIn(0.0, function()
-            self.invert = true
-            UIManager:setDirty(self.show_parent, function()
-                return "ui", self.dimen
-            end)
-        end)
-        UIManager:scheduleIn(0.1, function()
+        if G_reader_settings:isFalse("flash_ui") then
             self.callback()
-            self.invert = false
-            UIManager:setDirty(self.show_parent, function()
-                return "ui", self.dimen
+        else
+            UIManager:scheduleIn(0.0, function()
+                self.invert = true
+                UIManager:setDirty(self.show_parent, function()
+                    return "ui", self.dimen
+                end)
             end)
-        end)
+            UIManager:scheduleIn(0.1, function()
+                self.callback()
+                self.invert = false
+                UIManager:setDirty(self.show_parent, function()
+                    return "ui", self.dimen
+                end)
+            end)
+        end
     elseif self.tap_input then
         self:onInput(self.tap_input)
     elseif type(self.tap_input_func) == "function" then

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -92,20 +92,24 @@ function IconButton:initGesListener()
 end
 
 function IconButton:onTapIconButton()
-    UIManager:scheduleIn(0.0, function()
-        self.image.invert = true
-        UIManager:setDirty(self.show_parent, function()
-            return "ui", self[1].dimen
-        end)
-    end)
-    -- make sure button reacts before doing callback
-    UIManager:scheduleIn(0.1, function()
+    if G_reader_settings:isFalse("flash_ui") then
         self.callback()
-        self.image.invert = false
-        UIManager:setDirty(self.show_parent, function()
-            return "ui", self[1].dimen
+    else
+        UIManager:scheduleIn(0.0, function()
+            self.image.invert = true
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self[1].dimen
+            end)
         end)
-    end)
+        -- make sure button reacts before doing callback
+        UIManager:scheduleIn(0.1, function()
+            self.callback()
+            self.image.invert = false
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self[1].dimen
+            end)
+        end)
+    end
     return true
 end
 

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -211,17 +211,21 @@ end
 
 function KeyValueItem:onTap()
     if self.callback then
-        self[1].invert = true
-        UIManager:setDirty(self.show_parent, function()
-            return "ui", self[1].dimen
-        end)
-        UIManager:scheduleIn(0.1, function()
+        if G_reader_settings:isFalse("flash_ui") then
             self.callback()
-            self[1].invert = false
+        else
+            self[1].invert = true
             UIManager:setDirty(self.show_parent, function()
                 return "ui", self[1].dimen
             end)
-        end)
+            UIManager:scheduleIn(0.1, function()
+                self.callback()
+                self[1].invert = false
+                UIManager:setDirty(self.show_parent, function()
+                    return "ui", self[1].dimen
+                end)
+            end)
+        end
     end
     return true
 end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -295,35 +295,47 @@ end
 
 function MenuItem:onTapSelect(arg, ges)
     local pos = self:getGesPosition(ges)
-    self[1].invert = true
-    local refreshfunc = function()
-        return "ui", self[1].dimen
-    end
-    UIManager:setDirty(self.show_parent, refreshfunc)
-    UIManager:scheduleIn(0.1, function()
-        self[1].invert = false
-        UIManager:setDirty(self.show_parent, refreshfunc)
+    if G_reader_settings:isFalse("flash_ui") then
         logger.dbg("creating coroutine for menu select")
         local co = coroutine.create(function()
             self.menu:onMenuSelect(self.table, pos)
         end)
         coroutine.resume(co)
-    end)
+    else
+        self[1].invert = true
+        local refreshfunc = function()
+            return "ui", self[1].dimen
+        end
+        UIManager:setDirty(self.show_parent, refreshfunc)
+        UIManager:scheduleIn(0.1, function()
+            self[1].invert = false
+            UIManager:setDirty(self.show_parent, refreshfunc)
+            logger.dbg("creating coroutine for menu select")
+            local co = coroutine.create(function()
+                self.menu:onMenuSelect(self.table, pos)
+            end)
+            coroutine.resume(co)
+        end)
+    end
     return true
 end
 
 function MenuItem:onHoldSelect(arg, ges)
     local pos = self:getGesPosition(ges)
-    self[1].invert = true
-    local refreshfunc = function()
-        return "ui", self[1].dimen
-    end
-    UIManager:setDirty(self.show_parent, refreshfunc)
-    UIManager:scheduleIn(0.1, function()
-        self[1].invert = false
-        UIManager:setDirty(self.show_parent, refreshfunc)
+    if G_reader_settings:isFalse("flash_ui") then
         self.menu:onMenuHold(self.table, pos)
-    end)
+    else
+        self[1].invert = true
+        local refreshfunc = function()
+            return "ui", self[1].dimen
+        end
+        UIManager:setDirty(self.show_parent, refreshfunc)
+        UIManager:scheduleIn(0.1, function()
+            self[1].invert = false
+            UIManager:setDirty(self.show_parent, refreshfunc)
+            self.menu:onMenuHold(self.table, pos)
+        end)
+    end
     return true
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -107,18 +107,22 @@ function TouchMenuItem:onTapSelect(arg, ges)
     end
     if enabled == false then return end
 
-    self.item_frame.invert = true
-    UIManager:setDirty(self.show_parent, function()
-        return "ui", self.dimen
-    end)
-    -- yield to main UI loop to invert item
-    UIManager:scheduleIn(0.1, function()
+    if G_reader_settings:isFalse("flash_ui") then
         self.menu:onMenuSelect(self.item)
-        self.item_frame.invert = false
+    else
+        self.item_frame.invert = true
         UIManager:setDirty(self.show_parent, function()
             return "ui", self.dimen
         end)
-    end)
+        -- yield to main UI loop to invert item
+        UIManager:scheduleIn(0.1, function()
+            self.menu:onMenuSelect(self.item)
+            self.item_frame.invert = false
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self.dimen
+            end)
+        end)
+    end
     return true
 end
 
@@ -129,21 +133,25 @@ function TouchMenuItem:onHoldSelect(arg, ges)
     end
     if enabled == false then return end
 
-    UIManager:scheduleIn(0.0, function()
-        self.item_frame.invert = true
-        UIManager:setDirty(self.show_parent, function()
-            return "ui", self.dimen
-        end)
-    end)
-    UIManager:scheduleIn(0.1, function()
+    if G_reader_settings:isFalse("flash_ui") then
         self.menu:onMenuHold(self.item)
-    end)
-    UIManager:scheduleIn(0.5, function()
-        self.item_frame.invert = false
-        UIManager:setDirty(self.show_parent, function()
-            return "ui", self.dimen
+    else
+        UIManager:scheduleIn(0.0, function()
+            self.item_frame.invert = true
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self.dimen
+            end)
         end)
-    end)
+        UIManager:scheduleIn(0.1, function()
+            self.menu:onMenuHold(self.item)
+        end)
+        UIManager:scheduleIn(0.5, function()
+            self.item_frame.invert = false
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self.dimen
+            end)
+        end)
+    end
     return true
 end
 


### PR DESCRIPTION
May give a feeling of more responsiveness (real or just a feeling, I'm not sure).
Thought it would solve the "papercut glitches" (see #3130) when there's lots of refresh going on (like when changing fonts), but it does not (and may be accentuates them in some cases).
But it's nice to have I think (it also speeds up working with the emulator with X11 forwarded over slow ssh link).
Alternate wording for the menu checkboxed item ?
`Flash UI elements` ? `UI Feedback` ? `UI animations` ?