### PR TITLE
calibre 'series' metadata fixes

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -121,7 +121,11 @@ function BookInfo:show(file, book_props)
     table.insert(kv_pairs, { _("Authors:"), authors })
 
     local series = book_props.series
-    if series == "" or series == nil then series = _("N/A") end
+    if series == "" or series == nil then
+        series = _("N/A")
+    else -- Shorten calibre series decimal number (#4.0 => #4)
+        series = series:gsub("(#%d+)%.0$", "%1")
+    end
     table.insert(kv_pairs, { _("Series:"), series })
 
     local pages = book_props.pages

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -392,6 +392,8 @@ function ListMenuItem:update()
             -- add Series metadata if requested
             if bookinfo.series then
                 if BookInfoManager:getSetting("append_series_to_title") then
+                    -- Shorten calibre series decimal number (#4.0 => #4)
+                    bookinfo.series = bookinfo.series:gsub("(#%d+)%.0$", "%1")
                     if title then
                         title = title .. " - " .. bookinfo.series
                     else
@@ -399,6 +401,7 @@ function ListMenuItem:update()
                     end
                 end
                 if BookInfoManager:getSetting("append_series_to_authors") then
+                    bookinfo.series = bookinfo.series:gsub("(#%d+)%.0$", "%1")
                     if authors then
                         authors = authors .. " - " .. bookinfo.series
                     else

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -481,6 +481,8 @@ function MosaicMenuItem:update()
                 -- add Series metadata if requested
                 if bookinfo.series then
                     if BookInfoManager:getSetting("append_series_to_title") then
+                        -- Shorten calibre series decimal number (#4.0 => #4)
+                        bookinfo.series = bookinfo.series:gsub("(#%d+)%.0$", "%1")
                         if bookinfo.title then
                             bookinfo.title = bookinfo.title .. " - " .. bookinfo.series
                         else
@@ -488,6 +490,7 @@ function MosaicMenuItem:update()
                         end
                     end
                     if BookInfoManager:getSetting("append_series_to_authors") then
+                        bookinfo.series = bookinfo.series:gsub("(#%d+)%.0$", "%1")
                         if bookinfo.authors then
                             bookinfo.authors = bookinfo.authors .. " - " .. bookinfo.series
                         else


### PR DESCRIPTION
Decode XML entities in series metadata and display decimal in series number if any.
See https://github.com/koreader/koreader/issues/3347#issuecomment-336268606. Closes #3347.