### PR TITLE
FileBrowser: change page to show last file or previous subdir

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -317,7 +317,7 @@ function FileManager:init()
     self:handleEvent(Event:new("SetDimensions", self.dimen))
 end
 
-function FileManager:reinit(path)
+function FileManager:reinit(path, focused_file)
     self.dimen = Screen:getSize()
     -- backup the root path and path items
     self.root_path = path or self.file_chooser.path
@@ -329,6 +329,9 @@ function FileManager:reinit(path)
     self:init()
     self.file_chooser.path_items = path_items_backup
     self:onRefresh()
+    if focused_file then
+        self.file_chooser:changePageToPath(focused_file)
+    end
 end
 
 function FileManager:toggleHiddenFiles()
@@ -547,7 +550,7 @@ function FileManager:getStartWithMenuTable()
     }
 end
 
-function FileManager:showFiles(path)
+function FileManager:showFiles(path, focused_file)
     path = path or G_reader_settings:readSetting("lastdir") or filemanagerutil.getDefaultDir()
     G_reader_settings:saveSetting("lastdir", path)
     restoreScreenMode()
@@ -558,6 +561,9 @@ function FileManager:showFiles(path)
             self.instance = nil
         end
     }
+    if focused_file then
+        file_manager.file_chooser:changePageToPath(focused_file)
+    end
     UIManager:show(file_manager)
     self.instance = file_manager
 end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -365,16 +365,16 @@ end
 function ReaderUI:showFileManager()
     local FileManager = require("apps/filemanager/filemanager")
     local QuickStart = require("ui/quickstart")
-    local lastdir
+    local last_dir
     local last_file = G_reader_settings:readSetting("lastfile")
     -- ignore quickstart guide as last_file so we can go back to home dir
     if last_file and last_file ~= QuickStart.quickstart_filename then
-        lastdir = last_file:match("(.*)/")
+        last_dir = last_file:match("(.*)/")
     end
     if FileManager.instance then
-        FileManager.instance:reinit(lastdir)
+        FileManager.instance:reinit(last_dir, last_file)
     else
-        FileManager:showFiles(lastdir)
+        FileManager:showFiles(last_dir, last_file)
     end
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -175,7 +175,8 @@ function FileChooser:genItemTableFromPath(path)
         table.insert(item_table, {
             text = dir.name == ".." and  "⬆ ../" or dir.name.."/",
             mandatory = istr,
-            path = subdir_path
+            path = subdir_path,
+            is_go_up = dir.name == ".."
         })
     end
 
@@ -230,11 +231,27 @@ function FileChooser:refreshPath()
     self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path])
 end
 
-function FileChooser:changeToPath(path)
+function FileChooser:changeToPath(path, focused_path)
     path = util.realpath(path)
     self.path = path
     self:refreshPath()
+    if focused_path then
+        self:changePageToPath(focused_path)
+    end
     self:onPathChanged(path)
+end
+
+function FileChooser:changePageToPath(path)
+    if not path then return end
+    for num, item in ipairs(self.item_table) do
+        if item.path == path then
+            local page = math.floor((num-1) / self.perpage) + 1
+            if page ~= self.page then
+                self:onGotoPage(page)
+            end
+            break
+        end
+    end
 end
 
 function FileChooser:toggleHiddenFiles()
@@ -258,7 +275,7 @@ function FileChooser:onMenuSelect(item)
     if lfs.attributes(item.path, "mode") == "file" then
         self:onFileSelect(item.path)
     else
-        self:changeToPath(item.path)
+        self:changeToPath(item.path, item.is_go_up and self.path)
     end
     return true
 end


### PR DESCRIPTION
When going from reader to filemanager, we are in the directory containing the last_file. With this, we will also be on the page showing this last_file.
When in filemanager and going up (".."), we will also be on the page containing the directory we came from (I think this was what the OP of https://www.mobileread.com/forums/showthread.php?t=290695 wanted).

Previously, we were either on page 1 (when we haven't yet browsed that directory in this koreader session), or on the page we were when we last visited this directory.
In most cases, this will be the same page, except in the following:
when "Start with: last file", and opening File browser for the first time: we were previously always on page 1
when opening files from History, and going to File browser: we were previously always on page 1, or on the last visited page which may have nothing to do with the file we were reading.

It may be surprising in some cases with what one was used to, so dunno if that should make it, but it seems logical.