### PR TITLE
Avoid recalculation of partial_md5_checksum at each opening

### DIFF
--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -124,10 +124,10 @@ function Document:fastDigest(docsettings)
     if not self.file then return end
     local file = io.open(self.file, 'rb')
     if file then
-        local own_docsettings = false
+        local tmp_docsettings = false
         if not docsettings then -- if not provided, open/create it
             docsettings = require("docsettings"):open(self.file)
-            own_docsettings = true
+            tmp_docsettings = true
         end
         local result = docsettings:readSetting("partial_md5_checksum")
         if not result then
@@ -148,7 +148,7 @@ function Document:fastDigest(docsettings)
             result = m:sum()
             docsettings:saveSetting("partial_md5_checksum", result)
         end
-        if own_docsettings then
+        if tmp_docsettings then
             docsettings:close()
         end
         file:close()

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -82,7 +82,7 @@ function KOSync:onReaderReady()
     -- Make sure checksum has been calculated at the very first time a document has been opened, to
     -- avoid document saving feature to impact the checksum, and eventually impact the document
     -- identity in the progress sync feature.
-    self.view.document:fastDigest()
+    self.view.document:fastDigest(self.ui.doc_settings)
 end
 
 function KOSync:addToMainMenu(menu_items)


### PR DESCRIPTION
This is done by/for kosync plugin at each opening, because the docsettings was re-opened and saved for this, but later overwritten by the current koreader docsettings - so it was redone each time. This correctly adds this partial_md5_checksum to the current koreader docsettings, which will be saved on document closing - so it will not be redone next time.
Note: this partial_md5_checksum is not (yet) used by anything, but it will be there when kosync wants to use it.
Quick fix for #3132 (to avoid writting a metadata.lua at each opening, that will anyway be overwritten when closing document).