### PR TITLE
Fix util.secondsToClock

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -81,12 +81,16 @@ function util.secondsToClock(seconds, withoutSeconds)
         end
     else
         local round = withoutSeconds and require("optmath").round or math.floor
-        local hours = string.format("%02.f", math.floor(seconds / 3600));
-        local mins = string.format("%02.f", round(seconds / 60 - (hours * 60)));
+        local hours = string.format("%02.f", math.floor(seconds / 3600))
+        local mins = string.format("%02.f", round(seconds / 60 - (hours * 60)))
+        if mins == "60" then
+            mins = string.format("%02.f", 0)
+            hours = string.format("%02.f", hours + 1)
+        end
         if withoutSeconds then
             return hours .. ":" .. mins
         end
-        local secs = string.format("%02.f", math.floor(seconds - hours * 3600 - mins * 60));
+        local secs = string.format("%02.f", math.floor(seconds - hours * 3600 - mins * 60))
         return hours .. ":" .. mins .. ":" .. secs
     end
 end

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -75,9 +75,9 @@ function util.secondsToClock(seconds, withoutSeconds)
     seconds = tonumber(seconds)
     if seconds == 0 or seconds ~= seconds then
         if withoutSeconds then
-            return "00:00";
+            return "00:00"
         else
-            return "00:00:00";
+            return "00:00:00"
         end
     else
         local round = withoutSeconds and require("optmath").round or math.floor

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -329,6 +329,14 @@ describe("util module", function()
                             util.secondsToClock(110, true))
             assert.is_equal("00:02",
                             util.secondsToClock(120, true))
+            assert.is_equal("01:00",
+                            util.secondsToClock(3600, true))
+            assert.is_equal("01:00",
+                            util.secondsToClock(3599, true))
+            assert.is_equal("01:00",
+                            util.secondsToClock(3570, true))
+            assert.is_equal("00:59",
+                            util.secondsToClock(3569, true))
         end)
         it("should convert seconds to 00:00:00 format", function()
             assert.is_equal("00:00:00",


### PR DESCRIPTION
util.secondsToClock(3599, true)) shows 0:60.
This commit fix it.