### PR TITLE
Added util.getFormattedSize()

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -52,7 +52,9 @@ function BookInfo:show(file, book_props)
     local directory, filename = util.splitFilePathName(file)
     local filename_without_suffix, filetype = util.splitFileNameSuffix(filename) -- luacheck: no unused
     local file_size = lfs.attributes(file, "size") or 0
-    local size = util.getFriendlySize(file_size)
+    local size_f = util.getFriendlySize(file_size)
+    local size_b = util.getFormattedSize(file_size)
+    local size = string.format("%s (%s bytes)", size_f, size_b)
     table.insert(kv_pairs, { _("Filename:"), filename })
     table.insert(kv_pairs, { _("Format:"), filetype:upper() })
     table.insert(kv_pairs, { _("Size:"), size })

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -369,6 +369,16 @@ function util.getFriendlySize(size)
     return s
 end
 
+--- Gets formatted size as string (1273334 => "1,273,334")
+---- @int size (bytes)
+---- @treturn string
+function util.getFormattedSize(size)
+    local s = tostring(size)
+    s = s:reverse():gsub("(%d%d%d)", "%1,")
+    s = s:reverse():gsub("^,", "")
+    return s
+end
+
 --- Adds > to touch menu items with a submenu
 function util.getMenuText(item)
     local text


### PR DESCRIPTION
https://github.com/koreader/koreader/pull/3381#issuecomment-338246490

![capture](https://user-images.githubusercontent.com/24273478/31832601-e15e7fca-b5c7-11e7-99f8-34653ba612be.PNG)

(In french, we would use a space instead of a comma, and `octets` instead of `bytes`, but I'm perfectly fine with it as is.)
If there's a need for internationalisation:
https://ux.stackexchange.com/questions/23667/is-using-a-comma-as-a-number-separator-a-cultural-thing