### PR TITLE
CoverBrowser: Speed up switch from Reader to FileBrowser

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -96,6 +96,7 @@ function FileManager:init()
     local file_chooser = FileChooser:new{
         -- remeber to adjust the height when new item is added to the group
         path = self.root_path,
+        focused_path = self.focused_file,
         collate = G_reader_settings:readSetting("collate") or "strcoll",
         show_parent = self.show_parent,
         show_hidden = show_hidden,
@@ -112,6 +113,7 @@ function FileManager:init()
         close_callback = function() return self:onClose() end,
     }
     self.file_chooser = file_chooser
+    self.focused_file = nil -- use it only once
 
     function file_chooser:onPathChanged(path)  -- luacheck: ignore
         FileManager.instance.path_text:setText(filemanagerutil.abbreviate(path))
@@ -326,12 +328,13 @@ function FileManager:reinit(path, focused_file)
         path_items_backup[k] = v
     end
     -- reinit filemanager
+    self.focused_file = focused_file
     self:init()
     self.file_chooser.path_items = path_items_backup
-    self:onRefresh()
-    if focused_file then
-        self.file_chooser:changePageToPath(focused_file)
-    end
+    -- self:init() has already done file_chooser:refreshPath(), so this one
+    -- looks like not necessary (cheap with classic mode, less cheap with
+    -- CoverBrowser plugin's cover image renderings)
+    -- self:onRefresh()
 end
 
 function FileManager:toggleHiddenFiles()
@@ -557,13 +560,11 @@ function FileManager:showFiles(path, focused_file)
     local file_manager = FileManager:new{
         dimen = Screen:getSize(),
         root_path = path,
+        focused_file = focused_file,
         onExit = function()
             self.instance = nil
         end
     }
-    if focused_file then
-        file_manager.file_chooser:changePageToPath(focused_file)
-    end
     UIManager:show(file_manager)
     self.instance = file_manager
 end

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -222,16 +222,24 @@ function FileChooser:updateItems(select_number)
 end
 
 function FileChooser:refreshPath()
-    self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path])
+    local itemmatch = nil
+    if self.focused_path then
+        itemmatch = {path = self.focused_path}
+        -- We use focused_path only once, but remember it
+        -- for CoverBrower to re-apply it on startup if needed
+        self.prev_focused_path = self.focused_path
+        self.focused_path = nil
+    end
+    self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path], itemmatch)
 end
 
 function FileChooser:changeToPath(path, focused_path)
     path = util.realpath(path)
     self.path = path
-    self:refreshPath()
     if focused_path then
-        self:changePageToPath(focused_path)
+        self.focused_path = focused_path
     end
+    self:refreshPath()
     self:onPathChanged(path)
 end
 

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -179,7 +179,7 @@ function ImageWidget:_render()
     if self._bb then -- already rendered
         return
     end
-    logger.dbg("ImageWidget: _render'ing")
+    logger.dbg("ImageWidget: _render'ing", self.file and self.file or "data", self.width, self.height)
     if self.image then
         self:_loadimage()
     elseif self.file then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -411,6 +411,8 @@ function Menu:_recalculateDimen()
     -- header and footer should approximately take up space of 2 items
     self.perpage = math.floor(self.dimen.h / self.item_dimen.h) - (self.no_title and 1 or 2)
     self.page_num = math.ceil(#self.item_table / self.perpage)
+    -- fix current page if out of range
+    if self.page_num > 0 and self.page > self.page_num then self.page = self.page_num end
 end
 
 function Menu:init()
@@ -740,8 +742,12 @@ end
     3. itemnumber is negative number
         the page number is not changed, used when item_table is appended with
         new entries
+
+    alternatively, itemmatch may be provided as a {key = value} table,
+    and the page number will be the page containing the first item for
+    which item.key = value
 --]]
-function Menu:switchItemTable(new_title, new_item_table, itemnumber)
+function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch)
     if self.menu_title and new_title then
         self.menu_title.text = new_title
     end
@@ -750,6 +756,16 @@ function Menu:switchItemTable(new_title, new_item_table, itemnumber)
         self.page = 1
     elseif itemnumber >= 0 then
         self.page = math.ceil(itemnumber / self.perpage)
+    end
+
+    if type(itemmatch) == "table" then
+        local key, value = next(itemmatch)
+        for num, item in ipairs(new_item_table) do
+            if item[key] == value then
+                self.page = math.floor((num-1) / self.perpage) + 1
+                break
+            end
+        end
     end
 
     -- make sure current page is in right page range

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -672,6 +672,8 @@ function MosaicMenu:_recalculateDimen()
     end
     self.perpage = self.nb_rows * self.nb_cols
     self.page_num = math.ceil(#self.item_table / self.perpage)
+    -- fix current page if out of range
+    if self.page_num > 0 and self.page > self.page_num then self.page = self.page_num end
 
     -- Find out available height from other UI elements made in Menu
     self.others_height = 0


### PR DESCRIPTION
I noticed since #3351 that it took 2 to 3 seconds to switch from Reader to FileBrowser.
Thought it would be some docsettings save or crecache stuff, but no: it was actually CoverBrowser doing many renderings, and in mosaic mode with 9 thumbnails, it was actually doing 3x9 = 27 renderings...
One additional time because of #3351 and its simple way of doing what it does.
One other unneeded time because I didnt thought much about the plugin initialization when I did it, and it could be optimized in a few ways.
See individual commit messages.
I haven't tested this as long as I did the first time :), but it seems ok, hope I haven't broken anything.

(The long diff in covermenu.lua is just indentation for wrap into `UIManager:nextTick(function()...` )