### PR TITLE
Fullscreen android - resize window after toggle fulscreen

### DIFF
--- a/frontend/ui/elements/screen_fullscreen_menu_table.lua
+++ b/frontend/ui/elements/screen_fullscreen_menu_table.lua
@@ -1,4 +1,5 @@
 local isAndroid, android = pcall(require, "android")
+local Geom = require("ui/geometry")
 local logger = require("logger")
 local _ = require("gettext")
 

--- a/frontend/ui/elements/screen_fullscreen_menu_table.lua
+++ b/frontend/ui/elements/screen_fullscreen_menu_table.lua
@@ -26,7 +26,6 @@ return {
         logger.dbg("screen_fullscreen_menu_table.lua: Screen height: ", screen_height)
 
         local new_height = screen_height - status_bar_height
-        logger.dbg("screen_fullscreen_menu_table.lua: Setting viewport to {x= 0, y=" .. status_bar_height ..", w=" .. screen_width .. ", h=" .. new_height .. "}")
         local viewport = Geom:new{x=0, y= status_bar_height, w=screen_width, h= new_height}
         android.screen:setViewport(viewport)
 

--- a/frontend/ui/elements/screen_fullscreen_menu_table.lua
+++ b/frontend/ui/elements/screen_fullscreen_menu_table.lua
@@ -2,6 +2,7 @@ local isAndroid, android = pcall(require, "android")
 local Geom = require("ui/geometry")
 local logger = require("logger")
 local _ = require("gettext")
+local Screen = require("device").screen
 
 if not isAndroid then return end
 
@@ -26,8 +27,8 @@ return {
         logger.dbg("screen_fullscreen_menu_table.lua: Screen height: ", screen_height)
 
         local new_height = screen_height - status_bar_height
-        local viewport = Geom:new{x=0, y= status_bar_height, w=screen_width, h= new_height}
-        android.screen:setViewport(viewport)
+        local viewport = Geom:new{x=0, y=status_bar_height, w=screen_width, h=new_height}
+        Screen:setViewport(viewport)
 
         G_reader_settings:saveSetting("disabled_fullscreen", enabled_fullscreen)
     end,

--- a/frontend/ui/elements/screen_fullscreen_menu_table.lua
+++ b/frontend/ui/elements/screen_fullscreen_menu_table.lua
@@ -24,6 +24,11 @@ return {
         local screen_height = android.getScreenHeight()
         logger.dbg("screen_fullscreen_menu_table.lua: Screen height: ", screen_height)
 
+        local new_height = screen_height - status_bar_height
+        logger.dbg("screen_fullscreen_menu_table.lua: Setting viewport to {x= 0, y=" .. status_bar_height ..", w=" .. screen_width .. ", h=" .. new_height .. "}")
+        local viewport = Geom:new{x=0, y= status_bar_height, w=screen_width, h= new_height}
+        android.screen:setViewport(viewport)
+
         G_reader_settings:saveSetting("disabled_fullscreen", enabled_fullscreen)
     end,
 }


### PR DESCRIPTION
As now vieport changing should work on Android (finished #3148, https://github.com/Frenzie/koreader-base/commit/ad47ca64d4941a7a2600d41eb86a3fc9f9b99e23)

It's time to use it in "Fullscreen" (https://github.com/koreader/koreader/issues/3148) Android toggle.

Not tested. Testers welcome.