### PR TITLE
PocketBook: Use libinkview for battery-percentage/charging status

### DIFF
--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -6,14 +6,14 @@ ffi.cdef[[
 void OpenScreen();
 int GetFrontlightState(void);
 void SetFrontlightState(int flstate);
+int GetBatteryPower();
+int IsCharging();
 ]]
 
 local PocketBookPowerD = BasePowerD:new{
     is_charging = nil,
     fl_min = 0,
     fl_max = 100,
-    batt_capacity_file = "/sys/devices/platform/sun5i-i2c.0/i2c-0/0-0034/axp20-supplyer.28/power_supply/battery/capacity",
-    is_charging_file = "/sys/devices/platform/sun5i-i2c.0/i2c-0/0-0034/axp20-supplyer.28/power_supply/battery/status",
 }
 
 function PocketBookPowerD:init()
@@ -35,14 +35,15 @@ function PocketBookPowerD:setIntensityHW(intensity)
 end
 
 function PocketBookPowerD:getCapacityHW()
-    return self:read_int_file(self.batt_capacity_file)
+    return inkview.GetBatteryPower()
 end
 
 function PocketBookPowerD:isChargingHW()
-    self.is_charging = self:read_str_file(self.is_charging_file)
-    return self.is_charging == "Charging"
-    -- or we can query using SDK method `IsCharging`
-    --return inkview.IsCharging() == 1
+    if inkview.IsCharging() > 0 then
+        return true
+    else
+        return false
+    end
 end
 
 return PocketBookPowerD


### PR DESCRIPTION
This PR removes the need for hard-coded ``/sys/device/*``-paths in ``pocketbook/powerd.lua`` to get charging/battery-status information and uses libinkview instead.