### PR TITLE
KeyValuePage: align value to the right when half-overflow

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -181,7 +181,7 @@ function BookInfo:show(file, book_props)
 
     local widget = KeyValuePage:new{
         title = _("Book information"),
-        half_overflow_right_align = true,
+        value_overflow_align = "right",
         kv_pairs = kv_pairs,
     }
     UIManager:show(widget)

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -181,6 +181,7 @@ function BookInfo:show(file, book_props)
 
     local widget = KeyValuePage:new{
         title = _("Book information"),
+        half_overflow_right_align = true,
         kv_pairs = kv_pairs,
     }
     UIManager:show(widget)

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -129,7 +129,7 @@ local KeyValueItem = InputContainer:new{
     height = nil,
     textviewer_width = nil,
     textviewer_height = nil,
-    half_overflow_right_align = false,
+    value_overflow_align = "left",
 }
 
 function KeyValueItem:init()
@@ -175,7 +175,7 @@ function KeyValueItem:init()
             end
         -- misalign to fit all info
         else
-            if self.half_overflow_right_align then
+            if self.value_overflow_align == "right" then
                 key_w = frame_internal_width - value_w_rendered
             else
                 key_w = key_w_rendered + space_w_rendered
@@ -257,7 +257,9 @@ local KeyValuePage = InputContainer:new{
     -- index for the first item to show
     show_page = 1,
     use_top_page_count = false,
-    half_overflow_right_align = false,
+    -- aligment of value when key or value overflows its reserved width (for
+    -- now: 50%): "left" (stick to key), "right" (stick to scren right border)
+    value_overflow_align = "left",
 }
 
 function KeyValuePage:init()
@@ -455,7 +457,7 @@ function KeyValuePage:_populateItems()
                     callback_back = entry.callback_back,
                     textviewer_width = self.textviewer_width,
                     textviewer_height = self.textviewer_height,
-                    half_overflow_right_align = self.half_overflow_right_align,
+                    value_overflow_align = self.value_overflow_align,
                     show_parent = self,
                 }
             )

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -129,6 +129,7 @@ local KeyValueItem = InputContainer:new{
     height = nil,
     textviewer_width = nil,
     textviewer_height = nil,
+    half_overflow_right_align = false,
 }
 
 function KeyValueItem:init()
@@ -174,7 +175,11 @@ function KeyValueItem:init()
             end
         -- misalign to fit all info
         else
-            key_w = frame_internal_width - value_w_rendered
+            if self.half_overflow_right_align then
+                key_w = frame_internal_width - value_w_rendered
+            else
+                key_w = key_w_rendered + space_w_rendered
+            end
             self.show_key = self.key
             self.show_value = self.value
         end
@@ -252,6 +257,7 @@ local KeyValuePage = InputContainer:new{
     -- index for the first item to show
     show_page = 1,
     use_top_page_count = false,
+    half_overflow_right_align = false,
 }
 
 function KeyValuePage:init()
@@ -449,6 +455,7 @@ function KeyValuePage:_populateItems()
                     callback_back = entry.callback_back,
                     textviewer_width = self.textviewer_width,
                     textviewer_height = self.textviewer_height,
+                    half_overflow_right_align = self.half_overflow_right_align,
                     show_parent = self,
                 }
             )

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -174,7 +174,7 @@ function KeyValueItem:init()
             end
         -- misalign to fit all info
         else
-            key_w = key_w_rendered + space_w_rendered
+            key_w = frame_internal_width - value_w_rendered
             self.show_key = self.key
             self.show_value = self.value
         end


### PR DESCRIPTION
Question of taste (so it's ok if Before is preferred).

Before:
![01before](https://user-images.githubusercontent.com/24273478/31886792-146840ba-b7f6-11e7-9c4c-1c72a1202b73.png)

After:
![02after](https://user-images.githubusercontent.com/24273478/31886794-1614b7a4-b7f6-11e7-9783-80442951962c.png)
