### PR TITLE
Wiki save as epub: close highlight menu when switching document

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -298,6 +298,10 @@ function DictQuickLookup:update()
                                                         local ReaderUI = require("apps/reader/readerui")
                                                         local reader = ReaderUI:_getRunningInstance()
                                                         if reader then
+                                                            -- close Highlight menu if any still shown
+                                                            if reader.highlight then
+                                                                reader.highlight:onClose()
+                                                            end
                                                             reader:onClose()
                                                         end
                                                         ReaderUI:showReader(epub_path)


### PR DESCRIPTION
Probably since https://github.com/koreader/koreader/issues/3305#issuecomment-334732632, when saving some wikipedia page as Epub, and deciding to switch to this epub when done, the highlight menu (no more closed since above fix) would remain, even after switching to filemanager and other documents.
Later, when exiting koreader, this forgotten highlight menu would be shown (as the last widget managed by UIManager), yet easy to dismiss by taping anywhere, but well, let's fix this.