### PR TITLE
[fix] Dictionary no fuzzy search flag

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -427,7 +427,7 @@ function ReaderDictionary:stardictLookup(word, box, link)
         return
     end
     local lookup_cancelled = false
-    local common_options = self.disable_fuzzy_search and "-njf" or "-nj"
+    local common_options = self.disable_fuzzy_search and "-nje" or "-nj"
     for _, dict_dir in ipairs(dict_dirs) do
         if lookup_cancelled then
             break -- don't do any more lookup on additional dict_dirs


### PR DESCRIPTION
Upstream uses `-e` rather than the `-f` that was first introduced in our fork.

References https://github.com/koreader/koreader/issues/3429#issuecomment-339749396