### PR TITLE
Improve ConfigDialog

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -151,6 +151,8 @@ function ConfigOption:init()
     local default_option_padding = Size.padding.large
     local max_option_name_width = 0
     local txt_width = 0
+    local padding_small = Size.padding.small
+    local padding_button = Size.padding.button
     for c = 1, #self.options do
         local name_font_face = self.options[c].name_font_face and self.options[c].name_font_face or "cfont"
         local name_font_size = self.options[c].name_font_size and self.options[c].name_font_size or default_name_font_size
@@ -200,8 +202,8 @@ function ConfigOption:init()
                 local text = self.options[c].name_text
                 local face = Font:getFace(name_font_face, name_font_size)
                 local width_name_text = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text).x
-                if math.floor(name_align * Screen:getWidth()) - 2*Size.padding.small < width_name_text then
-                    text = RenderText:truncateTextByWidth(text, face, name_align * Screen:getWidth() - 2*Size.padding.small)
+                if math.floor(name_align * Screen:getWidth()) - 2*padding_small < width_name_text then
+                    text = RenderText:truncateTextByWidth(text, face, name_align * Screen:getWidth() - 2*padding_small)
                 end
 
                 local option_name_container = RightContainer:new{
@@ -212,7 +214,7 @@ function ConfigOption:init()
                     bordersize = 0,
                     face = face,
                     enabled = enabled,
-                    padding = Size.padding.small,
+                    padding = padding_small,
                     text_font_face = name_font_face,
                     text_font_size = name_font_size,
                     text_font_bold = false,
@@ -317,7 +319,7 @@ function ConfigOption:init()
                                 face = Font:getFace(item_font_face, item_font_size[d]),
                                 fgcolor = Blitbuffer.gray(enabled and 1.0 or 0.5),
                             },
-                            padding = Size.padding.button,
+                            padding = padding_button,
                             color = d == current_item and Blitbuffer.gray(enabled and 1.0 or 0.5) or Blitbuffer.COLOR_WHITE,
                             enabled = enabled,
                         }
@@ -334,7 +336,7 @@ function ConfigOption:init()
                                 face = face,
                                 fgcolor = Blitbuffer.gray(enabled and 1.0 or 0.5),
                             },
-                            padding = -Size.padding.button,
+                            padding = -padding_button,
                             color = d == current_item and Blitbuffer.gray(enabled and 1.0 or 0.5) or Blitbuffer.COLOR_WHITE,
                             enabled = enabled,
                         }
@@ -374,7 +376,7 @@ function ConfigOption:init()
                             file = self.options[c].item_icons[d],
                             dim = not enabled,
                         },
-                        padding = -Size.padding.button,
+                        padding = -padding_button,
                         color = d == current_item and Blitbuffer.gray(enabled and 1.0 or 0.5) or Blitbuffer.COLOR_WHITE,
                         enabled = enabled,
                     }

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -66,11 +66,18 @@ function ToggleSwitch:init()
         w = self.width / self.n_pos,
         h = self.height / self.row_count,
     }
+    local button_width = math.floor(self.width / self.n_pos)
     for i = 1, #self.toggle do
+        local text = self.toggle[i]
+        local face = Font:getFace(self.font_face, self.font_size)
+        local txt_width = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text, nil, self.bold).x
+        if  button_width - Size.padding.default < txt_width then
+            text = RenderText:truncateTextByWidth(text, face, button_width - Size.padding.default, nil, self.bold)
+        end
         local label = ToggleLabel:new{
             align = "center",
-            text = self.toggle[i],
-            face = Font:getFace(self.font_face, self.font_size),
+            text = text,
+            face = face,
         }
         local content = CenterContainer:new{
             dimen = center_dimen,


### PR DESCRIPTION
Close: #2538 
It truncates strings (item texts and buttons) if they are too wide. It's also possible to add hold_callback function when we hold name_text (not used yet).

Before:
![zaznaczenie_010](https://user-images.githubusercontent.com/22982594/32136221-82a4cf4a-bc0a-11e7-9cf9-b9f9dec15f21.png)

After:
![zaznaczenie_015](https://user-images.githubusercontent.com/22982594/32136224-88b481c8-bc0a-11e7-950b-2f1447d9cda6.png)

Before:
![zaznaczenie_011](https://user-images.githubusercontent.com/22982594/32136225-90ebea98-bc0a-11e7-8388-eca90d128e2e.png)

After:
![zaznaczenie_014](https://user-images.githubusercontent.com/22982594/32136227-962fc2fe-bc0a-11e7-8b39-45a6a7c5d3dd.png)

Before:
![zaznaczenie_012](https://user-images.githubusercontent.com/22982594/32136228-9b745d6a-bc0a-11e7-9673-c82afa0fe2a4.png)

After:
![zaznaczenie_013](https://user-images.githubusercontent.com/22982594/32136229-9d94abcc-bc0a-11e7-8ec6-e67b720d2163.png)
