### PR TITLE
NewsDownloader: Compatibility for uses with previous configuration files

### DIFF
--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -1,12 +1,12 @@
 return {
 	-- list your feeds here:
 
-    { "http://feeds.reuters.com/Reuters/worldNews?format=xml", limit = 2, download_full_article=false},
+    { "http://feeds.reuters.com/Reuters/worldNews?format=xml", limit = 2, download_full_article=true},
 
-    { "https://www.pcworld.com/index.rss", limit = 7 , download_full_article=true},
+    { "https://www.pcworld.com/index.rss", limit = 7 , download_full_article=false},
 
 		-- comment out line ("--" at line start) to stop downloading source
-    --{ "http://www.football.co.uk/international/rss.xml", limit = 0 , download_full_article=true},
+    --{ "http://www.football.co.uk/international/rss.xml", limit = 0 , download_full_article=false},
 
 
 

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -161,7 +161,7 @@ function NewsDownloader:loadConfigAndProcessFeeds()
     for idx, feed in ipairs(feed_config) do
         local url = feed[1]
         local limit = feed.limit
-        local download_full_article = feed.download_full_article == nil or feed.download_full_article == "" or feed.download_full_article
+        local download_full_article = feed.download_full_article == nil or or feed.download_full_article
         if url and limit then
             info = InfoMessage:new{ text = T(_("Processing: %1"), url) }
             UIManager:show(info)

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -161,7 +161,7 @@ function NewsDownloader:loadConfigAndProcessFeeds()
     for idx, feed in ipairs(feed_config) do
         local url = feed[1]
         local limit = feed.limit
-        local download_full_article = feed.download_full_article == nil or or feed.download_full_article
+        local download_full_article = feed.download_full_article == nil or feed.download_full_article
         if url and limit then
             info = InfoMessage:new{ text = T(_("Processing: %1"), url) }
             UIManager:show(info)

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -161,7 +161,7 @@ function NewsDownloader:loadConfigAndProcessFeeds()
     for idx, feed in ipairs(feed_config) do
         local url = feed[1]
         local limit = feed.limit
-        local download_full_article = feed.download_full_article
+        local download_full_article = feed.download_full_article == nil or feed.download_full_article == "" or feed.download_full_article
         if url and limit then
             info = InfoMessage:new{ text = T(_("Processing: %1"), url) }
             UIManager:show(info)


### PR DESCRIPTION
Compatibilty for existing NewsDownloader users. There would be no need to adapt their configuration files to changes in N.D.

+ fix sample feed configuration (pc world was not working for download_full_article)

As my `./kod run` doesn't work (after pull?) [neither clean nor build works] I wasn't able to test it:(