### PR TITLE
[CI] apply patch for busted junit testcase time

### DIFF
--- a/.ci/helper_luarocks.sh
+++ b/.ci/helper_luarocks.sh
@@ -13,6 +13,10 @@ travis_retry luarocks --local install luafilesystem
 travis_retry luarocks --local install ansicolors
 travis_retry luarocks --local install busted 2.0.rc12-1
 #- mv -f $HOME/.luarocks/bin/busted_bootstrap $HOME/.luarocks/bin/busted
+# Apply junit testcase time fix. This can be removed once there is a busted 2.0.rc13 or final
+# See https://github.com/Olivine-Labs/busted/commit/830f175c57ca3f9e79f95b8c4eaacf58252453d7
+sed -i 's|testcase_node.time = |testcase_node:set_attrib("time", |' "${HOME}/.luarocks/share/lua/5.1/busted/outputHandlers/junit.lua"
+
 travis_retry luarocks --local install luacheck
 travis_retry luarocks --local install lanes # for parallel luacheck
 


### PR DESCRIPTION
Apply junit testcase time fix so CircleCI can actually do something useful
with the results. This can be removed once there is a busted 2.0.rc13 or final

See https://github.com/Olivine-Labs/busted/commit/830f175c57ca3f9e79f95b8c4eaacf58252453d7