### PR TITLE
[fix] add OSX build prerequisites cmake and makedepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ KOReader
 
 KOReader is a document viewer application, originally created for Kindle
 e-ink readers. It currently runs on Kindle, Kobo, PocketBook, Ubuntu Touch
-and Android (2.3+) devices. Developers can also run a KOReader emulator
+and Android devices. Developers can also run a KOReader emulator
 for development purposes on desktop PCs with Linux, Windows and 
-Mac OSX (experimental for now).
+Mac OSX.
 
 Main features for users
 -----------------------
@@ -101,7 +101,7 @@ ld: cannot find -lglib-2.0`
 
 Mac OSX users may need to install these tools:
 ```
-brew install nasm binutils libtool autoconf automake sdl2 lua51
+brew install nasm binutils libtool autoconf automake cmake makedepend sdl2 lua51
 ```
 
 The KOReader Android build requires `ant`, `openjdk-8-jdk` and `p7zip-full`. A compatible version of the Android NDK and SDK will be downloaded automatically by `./kodev build android` if no NDK or SDK is provided in environment variables. For that purpose you can use `NDK=/ndk/location SDK=/sdk/location ./kodev build android`.


### PR DESCRIPTION
Tested on darwin-15.6, darwin-16.7 and darwin-17.2. This should fix #2651 and fix #3464.