### PR TITLE
Ability to change file browser font size

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -146,6 +146,9 @@ DDICT_FONT_SIZE = 20
 -- e.g. 2 changes the sensitivity by 1/2, 3 by 1/3 etc.
 FRONTLIGHT_SENSITIVITY_DECREASE = 2
 
+-- File Manager a.k.a KOReader File Browser files and dirs font size
+FILE_BROWSER_ITEMS_FONT_SIZE = 22
+
 -- Normally, KOReader will present file lists sorted in case insensitive manner
 -- when presenting an alphatically sorted list. So the Order is "A, b, C, d".
 -- You can switch to a case sensitive sort ("A", "C", "b", "d") by disabling

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -25,7 +25,7 @@ local function kobostrcoll(str1, str2)
 end
 
 local FileChooser = Menu:extend{
-    cface = Font:getFace("smallinfofont"),
+    cface = Font:getFace("smallinfofont", FILE_BROWSER_ITEMS_FONT_SIZE),
     no_title = true,
     path = lfs.currentdir(),
     parent = nil,


### PR DESCRIPTION
Allows to change file browser directories and files font size (from variable in `defaults.lua`)

Default value (22) is equal to previous used value: https://github.com/koreader/koreader/blob/06dfe4fb78ed48f655c2beef902a77696e77205a/frontend/ui/font.lua#L70
