### PR TITLE
Speedup dictionaries init

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -27,22 +27,32 @@ local function getIfosInDir(path)
     -- - No sorting, entries are processed in the order the dir_read_name() call
     --   returns them (inodes linked list)
     -- - If entry is a directory, Walk in it first and recurse
+    -- With a small optimisation to avoid walking dict subdirectories that
+    -- may contain many images: if .ifo found, don't recurse subdirectories.
     local ifos = {}
     local ok, iter, dir_obj = pcall(lfs.dir, path)
     if ok then
+        local ifo_found = false
+        local subdirs = {}
         for name in iter, dir_obj do
             if name ~= "." and name ~= ".." then
                 local fullpath = path.."/"..name
-                local attributes = lfs.attributes(fullpath)
-                if attributes ~= nil then
-                    if attributes.mode == "directory" then
-                        local dirifos = getIfosInDir(fullpath) -- recurse
-                        for _, ifo in pairs(dirifos) do
-                            table.insert(ifos, ifo)
-                        end
-                    elseif fullpath:match("%.ifo$") then
-                        table.insert(ifos, fullpath)
+                if fullpath:match("%.ifo$") then
+                    table.insert(ifos, fullpath)
+                    ifo_found = true
+                elseif not ifo_found then -- don't check for dirs anymore if we found one .ifo
+                    local attributes = lfs.attributes(fullpath)
+                    if attributes ~= nil and attributes.mode == "directory" then
+                        table.insert(subdirs, fullpath)
                     end
+                end
+            end
+        end
+        if not ifo_found and #subdirs > 0 then
+            for _, subdir in pairs(subdirs) do
+                local dirifos = getIfosInDir(subdir)
+                for _, ifo in pairs(dirifos) do
+                    table.insert(ifos, ifo)
                 end
             end
         end


### PR DESCRIPTION
When looking for .ifo to populate Dictionary settings menu, avoid walking sub-directories once we found a .ifo, as these sub-directories may contain a lot of images and other subdirs.
See https://github.com/koreader/koreader/pull/3144#issuecomment-344722499