### PR TITLE
Use toggle for CRE Contrast in bottom menu

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -123,7 +123,7 @@ local CreOptions = {
             {
                 name = "font_gamma",
                 name_text = S.CONTRAST,
-                item_text = {S.LIGHTER, S.DEFAULT, S.DARKER},
+                toggle = {S.LIGHTER, S.DEFAULT, S.DARKER},
                 default_value = DCREREADER_CONFIG_DEFAULT_FONT_GAMMA,
                 values = {
                     DCREREADER_CONFIG_LIGHTER_FONT_GAMMA,


### PR DESCRIPTION
Before: see https://github.com/koreader/koreader/pull/3194 https://github.com/koreader/koreader/pull/3356

After:
<kbd>![after](https://user-images.githubusercontent.com/24273478/32904741-633ce780-caf8-11e7-8469-8fb37722522b.png)</kbd>

I once tried that before @robert00s ' recent works on configdialog, and the texts were overflowing the toggles, so I guess that's the reason why it was not a toggle and stayed text. But now, as it fit, I see no reason not to upgrade it to ToggleSwitch and have them all look alike.