### PR TITLE
Option to show dictionary in full screen

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -252,6 +252,15 @@ If you'd like to change the order in which dictionaries are queried (and their r
                 end,
             },
             { -- setting used by dictquicklookup
+                text = _("Full screen"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("dict_fullscreen")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrFalse("dict_fullscreen")
+                end,
+            },
+            { -- setting used by dictquicklookup
                 text = _("Justify text"),
                 checked_func = function()
                     return G_reader_settings:nilOrTrue("dict_justify")

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -252,12 +252,12 @@ If you'd like to change the order in which dictionaries are queried (and their r
                 end,
             },
             { -- setting used by dictquicklookup
-                text = _("Full screen"),
+                text = _("Large window"),
                 checked_func = function()
-                    return G_reader_settings:isTrue("dict_fullscreen")
+                    return G_reader_settings:isTrue("dict_largewindow")
                 end,
                 callback = function()
-                    G_reader_settings:flipNilOrFalse("dict_fullscreen")
+                    G_reader_settings:flipNilOrFalse("dict_largewindow")
                 end,
             },
             { -- setting used by dictquicklookup

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -165,7 +165,7 @@ function DictQuickLookup:update()
         w = Screen:getWidth(),
         h = Screen:getHeight(),
     }
-    if self.is_fullpage then
+    if self.is_fullpage or G_reader_settings:isTrue("dict_fullscreen") then
         -- bigger window if fullpage being shown - this will let
         -- some room anyway for footer display (time, battery...)
         self.height = Screen:getHeight()

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -165,7 +165,7 @@ function DictQuickLookup:update()
         w = Screen:getWidth(),
         h = Screen:getHeight(),
     }
-    if self.is_fullpage or G_reader_settings:isTrue("dict_fullscreen") then
+    if self.is_fullpage or G_reader_settings:isTrue("dict_largewindow") then
         -- bigger window if fullpage being shown - this will let
         -- some room anyway for footer display (time, battery...)
         self.height = Screen:getHeight()


### PR DESCRIPTION
I prefer to see as much definitions as possible on the dictionary screen, it makes it easier to find what you are looking for without turning pages, so I would like to add this option.

I wasn't sure about the terminology to use in the options so currently it is simply "Full screen".  I think "Full screen pop-up" or "Full screen dialog" could work too.

I left the default behavior as it was, so it's turned off by default.