### PR TITLE
Fixes ffi/blitbuffer.lua:173: attempt to index local 'color' (a number value)

### DIFF
--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -131,7 +131,7 @@ Background = InputContainer:new{
     },
     -- contains a gray rectangular desktop
     FrameContainer:new{
-        background = 3,
+        background = Blitbuffer.COLOR_GREY,
         bordersize = 0,
         dimen = Screen:getSize(),
         Widget:new{
@@ -252,7 +252,7 @@ M = Menu:new{
 readerwindow = CenterContainer:new{
     dimen = Screen:getSize(),
     FrameContainer:new{
-        background = 0
+        background = Blitbuffer.COLOR_BLACK,
     }
 }
 reader = ReaderUI:new{


### PR DESCRIPTION
Full stack trace:
```
./luajit: ./ffi/blitbuffer.lua:173: attempt to index local 'color' (a number value)
stack traceback:
        ./ffi/blitbuffer.lua:173: in function 'set'
        ./ffi/blitbuffer.lua:602: in function 'setter'
        ./ffi/blitbuffer.lua:944: in function 'paintRect'
        ./ffi/blitbuffer.lua:1135: in function 'paintRoundedRect'
        frontend/ui/widget/container/framecontainer.lua:66: in function 'paintTo'
        frontend/ui/widget/container/inputcontainer.lua:81: in function 'paintTo'
        frontend/ui/uimanager.lua:616: in function '_repaint'
        frontend/ui/uimanager.lua:683: in function 'handleInput'
        frontend/ui/uimanager.lua:765: in function 'run'
        ./tools/wbuilder.lua:462: in main chunk
```

To reproduce:
1. Uncomment UIManager:show(Background:new()) in wbuilder.lua
2. Start wbuilder

Note: the new grey background color (Blitbuffer.COLOR_GREY) might be different than it was previously (3).