### PR TITLE
N.D. plugin : Display progress

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -157,7 +157,7 @@ function NewsDownloader:loadConfigAndProcessFeeds()
         local url = feed[1]
         local limit = feed.limit
         if url and limit then
-            info = InfoMessage:new{ text = T(_("Processing %1/%2: %3"), idx, total_feed_entries, url) }
+            info = InfoMessage:new{ text = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, url) }
             UIManager:show(info)
             -- processFeedSource is a blocking call, so manually force a UI refresh beforehand
             UIManager:forceRePaint()

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -152,11 +152,12 @@ function NewsDownloader:loadConfigAndProcessFeeds()
 
     local unsupported_feeds_urls = {}
 
+    local total_feed_entries = table.getn(feed_config)
     for idx, feed in ipairs(feed_config) do
         local url = feed[1]
         local limit = feed.limit
         if url and limit then
-            info = InfoMessage:new{ text = T(_("Processing: %1"), url) }
+            info = InfoMessage:new{ text = T(_("Processing %1/%2: %3"), idx, total_feed_entries, url) }
             UIManager:show(info)
             -- processFeedSource is a blocking call, so manually force a UI refresh beforehand
             UIManager:forceRePaint()


### PR DESCRIPTION
I thought it was already merged but it seems it's not.

Displays news downloader processing progress e.g:
"Processing 1/9", "Processing 4/9" etc.
