### PR TITLE
Fix typo in wikipedia epub stylesheet

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -542,7 +542,7 @@ hr.koreaderwikifrontpage {
 a {
     display:inline;
     text-decoration: underline;
-    color: black,
+    color: black;
     font-weight: normal;
 }
 /* No underline for links without their href that we removed */


### PR DESCRIPTION
Tests with mupdf 1.12 as epub rendering engine had it report this warning on wikipedia saved as epub:
`error: css syntax error: expected value (OEBPS/stylesheet.css:36)`