### PR TITLE
Add new options to screensaver

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -4,8 +4,6 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local FileSearcher = require("apps/filemanager/filemanagerfilesearcher")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local InputDialog = require("ui/widget/inputdialog")
-local Screensaver = require("ui/screensaver")
 local Search = require("apps/filemanager/filemanagersearch")
 local SetDefaults = require("apps/filemanager/filemanagersetdefaults")
 local UIManager = require("ui/uimanager")
@@ -103,58 +101,7 @@ function FileManagerMenu:setUpdateItemTable()
     if Device:supportsScreensaver() then
         self.menu_items.screensaver = {
             text = _("Screensaver"),
-            sub_item_table = {
-                {
-                    text = _("Use last book's cover as screensaver"),
-                    checked_func = Screensaver.isUsingBookCover,
-                    callback = function()
-                        if Screensaver:isUsingBookCover() then
-                            G_reader_settings:saveSetting(
-                                "use_lastfile_as_screensaver", false)
-                        else
-                            G_reader_settings:delSetting(
-                                "use_lastfile_as_screensaver")
-                        end
-                        G_reader_settings:flush()
-                    end
-                },
-                {
-                    text = _("Screensaver folder"),
-                    callback = function()
-                        local ss_folder_path_input
-                        local function save_folder_path()
-                            G_reader_settings:saveSetting(
-                                "screensaver_folder", ss_folder_path_input:getInputText())
-                            G_reader_settings:flush()
-                            UIManager:close(ss_folder_path_input)
-                        end
-                        local curr_path = G_reader_settings:readSetting("screensaver_folder")
-                        ss_folder_path_input = InputDialog:new{
-                            title = _("Screensaver folder"),
-                            input = curr_path,
-                            input_hint = "/mnt/onboard/screensaver",
-                            input_type = "text",
-                            buttons = {
-                                {
-                                    {
-                                        text = _("Cancel"),
-                                        callback = function()
-                                            UIManager:close(ss_folder_path_input)
-                                        end,
-                                    },
-                                    {
-                                        text = _("Save"),
-                                        is_enter_default = true,
-                                        callback = save_folder_path,
-                                    },
-                                }
-                            },
-                        }
-                        ss_folder_path_input:onShowKeyboard()
-                        UIManager:show(ss_folder_path_input)
-                    end,
-                },
-            }
+            sub_item_table = require("ui/elements/screensaver_menu"),
         }
     end
     -- insert common settings

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -165,7 +165,7 @@ function ReaderMenu:setUpdateItemTable()
                     hold_callback = function()
                         local ConfirmBox = require("ui/widget/confirmbox")
                         UIManager:show(ConfirmBox:new {
-                            text = _("Stretch all book's cover image in screensaver?"),
+                            text = _("Stretch all book covers to fit screen"),
                             cancel_text = _("Disable by default"),
                             cancel_callback = function()
                                 G_reader_settings:delSetting("stretch_cover_default")

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -165,13 +165,13 @@ function ReaderMenu:setUpdateItemTable()
                     hold_callback = function()
                         local ConfirmBox = require("ui/widget/confirmbox")
                         UIManager:show(ConfirmBox:new {
-                            text = _("Stretch all book covers to fit screen"),
-                            cancel_text = _("Disable by default"),
+                            text = _("Stretch all book covers to fit screen?"),
+                            cancel_text = _("Don't stretch"),
                             cancel_callback = function()
                                 G_reader_settings:delSetting("stretch_cover_default")
                                 return
                             end,
-                            ok_text = _("Enable by default"),
+                            ok_text = _("Stretch"),
                             ok_callback = function()
                                 G_reader_settings:saveSetting("stretch_cover_default", true)
                                 return

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -155,7 +155,7 @@ function ReaderMenu:setUpdateItemTable()
                         if  settings_proportional == nil and G_reader_settings:readSetting("stretch_cover_default") then
                             return true
                         else
-                            return self.ui.doc_settings:readSetting("proportional_screensaver") == true
+                            return self.ui.doc_settings:readSetting("proportional_screensaver") == false
                         end
                     end,
                     callback = function()

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -149,23 +149,23 @@ function ReaderMenu:setUpdateItemTable()
                     end
                 },
                 {
-                    text = _("Auto stretch this book's cover image in screensaver"),
+                    text = _("Stretch book cover to fit screen"),
                     checked_func = function()
-                        local settings_proportional = self.ui.doc_settings:readSetting("proportional_screensaver")
-                        if  settings_proportional == nil and G_reader_settings:readSetting("stretch_cover_default") then
+                        local settings_stretch_cover = self.ui.doc_settings:readSetting("stretch_cover")
+                        if  settings_stretch_cover == nil and G_reader_settings:readSetting("stretch_cover_default") then
                             return true
                         else
-                            return self.ui.doc_settings:readSetting("proportional_screensaver") == false
+                            return self.ui.doc_settings:readSetting("stretch_cover") == true
                         end
                     end,
                     callback = function()
-                        self.ui.doc_settings:saveSetting("proportional_screensaver", not Screensaver:proportional())
+                        self.ui.doc_settings:saveSetting("stretch_cover", not Screensaver:stretchCover())
                         self.ui:saveSettings()
                     end,
                     hold_callback = function()
                         local ConfirmBox = require("ui/widget/confirmbox")
                         UIManager:show(ConfirmBox:new {
-                            text = _("Set auto stretch all book's cover image in screensaver"),
+                            text = _("Stretch all book's cover image in screensaver?"),
                             cancel_text = _("Disable by default"),
                             cancel_callback = function()
                                 G_reader_settings:delSetting("stretch_cover_default")

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -152,7 +152,7 @@ function ReaderMenu:setUpdateItemTable()
                     text = _("Auto stretch this book's cover image in screensaver"),
                     checked_func = function()
                         local settings_proportional = self.ui.doc_settings:readSetting("proportional_screensaver")
-                        if  settings_proportional == nil and G_reader_settings:readSetting("stretch_cover_defalut") then
+                        if  settings_proportional == nil and G_reader_settings:readSetting("stretch_cover_default") then
                             return true
                         else
                             return self.ui.doc_settings:readSetting("proportional_screensaver") == true
@@ -166,14 +166,14 @@ function ReaderMenu:setUpdateItemTable()
                         local ConfirmBox = require("ui/widget/confirmbox")
                         UIManager:show(ConfirmBox:new {
                             text = _("Set auto stretch all book's cover image in screensaver"),
-                            cancel_text = _("Disable by defalut"),
+                            cancel_text = _("Disable by default"),
                             cancel_callback = function()
-                                G_reader_settings:delSetting("stretch_cover_defalut")
+                                G_reader_settings:delSetting("stretch_cover_default")
                                 return
                             end,
                             ok_text = _("Enable by default"),
                             ok_callback = function()
-                                G_reader_settings:saveSetting("stretch_cover_defalut", true)
+                                G_reader_settings:saveSetting("stretch_cover_default", true)
                                 return
                             end,
                         })

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -137,7 +137,7 @@ function Device:onPowerEvent(ev)
         -- always suspend in portrait mode
         self.orig_rotation_mode = self.screen:getRotationMode()
         self.screen:setRotationMode(0)
-        require("ui/screensaver"):show("suspend", _("Sleeping"))
+        require("ui/screensaver"):show()
         self.screen:refreshFull()
         self.screen_saver_mode = true
         UIManager:scheduleIn(0.1, function()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -94,8 +94,8 @@ end
 
 function Kindle:intoScreenSaver()
     local Screensaver = require("ui/screensaver")
-    if self:supportsScreensaver() and Screensaver:isUsingBookCover() then
-        Screensaver:show("suspend")
+    if self:supportsScreensaver() then
+        Screensaver:show()
     end
     self.powerd:beforeSuspend()
     if self.charging_mode == false and self.screen_saver_mode == false then
@@ -114,7 +114,7 @@ function Kindle:outofScreenSaver()
             os.execute("killall -stop awesome")
         end
         local Screensaver = require("ui/screensaver")
-        if self:supportsScreensaver() and Screensaver.isUsingBookCover() then
+        if self:supportsScreensaver() then
             Screensaver:close()
         end
         local UIManager = require("ui/uimanager")

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -75,7 +75,7 @@ return {
         end
     },
     {
-        text = _("Disable screensaver"),
+        text = _("Disabled (let screen/page as it is)"),
         checked_func = function()
             if screensaverType() == nil or screensaverType() == "disable" then
                 return true
@@ -182,9 +182,3 @@ return {
         }
     }
 }
-
-
-
-
-
-

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -76,7 +76,7 @@ return {
         end
     },
     {
-        text = _("Disabled (leave screen/page as it is)"),
+        text = _("Leave screen as it is"),
         checked_func = function()
             if screensaverType() == nil or screensaverType() == "disable" then
                 return true

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -76,7 +76,7 @@ return {
         end
     },
     {
-        text = _("Disabled (let screen/page as it is)"),
+        text = _("Disabled (leave screen/page as it is)"),
         checked_func = function()
             if screensaverType() == nil or screensaverType() == "disable" then
                 return true

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -3,7 +3,13 @@ local _ = require("gettext")
 
 local function screensaverType() return G_reader_settings:readSetting("screensaver_type") end
 local function screensaverDelay() return G_reader_settings:readSetting("screensaver_delay") end
-local function lastFile() return G_reader_settings:readSetting("lastfile") end
+local function lastFile()
+    local lfs = require("libs/libkoreader-lfs")
+    local last_file = G_reader_settings:readSetting("lastfile")
+    if last_file and lfs.attributes(last_file, "mode") == "file" then
+        return last_file
+    end
+end
 local function messageBackground() return G_reader_settings:isTrue("message_background") end
 
 return {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -1,0 +1,190 @@
+local Screensaver = require("ui/screensaver")
+local _ = require("gettext")
+
+local function screensaverType() return G_reader_settings:readSetting("screensaver_type") end
+local function screensaverDelay() return G_reader_settings:readSetting("screensaver_delay") end
+local function lastFile() return G_reader_settings:readSetting("lastfile") end
+
+return {
+    {
+        text = _("Use last book's cover as screensaver"),
+        enabled_func = function() return lastFile() ~= nil end,
+        checked_func = function()
+            if screensaverType() == "cover" then
+                return true
+            else
+                return false
+            end
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "cover")
+        end
+    },
+    {
+        text = _("Use book status as screensaver"),
+        enabled_func = function() return lastFile() ~= nil end,
+        checked_func = function()
+            if screensaverType() == "bookstatus" then
+                return true
+            else
+                return false
+            end
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "bookstatus")
+        end
+    },
+    {
+        text = _("Use random image from folder as screensaver"),
+        checked_func = function()
+            if screensaverType() == "random_image" then
+                return true
+            else
+                return false
+            end
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "random_image")
+        end
+    },
+    {
+        text = _("Use reading progress as screensaver"),
+        enabled_func = function() return Screensaver.getReaderProgress ~= nil and lastFile() ~= nil end,
+        checked_func = function()
+            if screensaverType() == "readingprogress" then
+                return true
+            else
+                return false
+            end
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "readingprogress")
+        end
+    },
+    {
+        text = _("Use message as screensaver"),
+        checked_func = function()
+            if screensaverType() == "message" then
+                return true
+            else
+                return false
+            end
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "message")
+        end
+    },
+    {
+        text = _("Disable screensaver"),
+        checked_func = function()
+            if screensaverType() == nil or screensaverType() == "disable" then
+                return true
+            else
+                return false
+            end
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "disable")
+        end
+    },
+    {
+        text = _("Settings"),
+        sub_item_table = {
+            {
+                text = _("Screensaver folder"),
+                enabled_func = function()
+                    return screensaverType() == "random_image"
+                end,
+                callback = function()
+                    Screensaver:chooseFolder()
+                end,
+            },
+            {
+                text = _("Screensaver message"),
+                enabled_func = function()
+                    return screensaverType() == "message"
+                end,
+                callback = function()
+                    Screensaver:setMessage()
+                end,
+                separator = true,
+            },
+            {
+                text = _("Delay when exit from screensaver"),
+                sub_item_table = {
+                    {
+                        text = _("Disable"),
+                        checked_func = function()
+                            if screensaverDelay() == nil or screensaverDelay() == "disable" then
+                                return true
+                            else
+                                return false
+                            end
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_delay", "disable")
+                        end
+                    },
+                    {
+                        text = _("1 second"),
+                        checked_func = function()
+                            if screensaverDelay() == "1" then
+                                return true
+                            else
+                                return false
+                            end
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_delay", "1")
+                        end
+                    },
+                    {
+                        text = _("3 seconds"),
+                        checked_func = function()
+                            if screensaverDelay() == "3" then
+                                return true
+                            else
+                                return false
+                            end
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_delay", "3")
+                        end
+                    },
+                    {
+                        text = _("5 seconds"),
+                        checked_func = function()
+                            if screensaverDelay() == "5" then
+                                return true
+                            else
+                                return false
+                            end
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_delay", "5")
+                        end
+                    },
+                    {
+                        text = _("Tap to exit screensaver"),
+                        checked_func = function()
+                            if screensaverDelay() == "tap" then
+                                return true
+                            else
+                                return false
+                            end
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_delay", "tap")
+                        end
+                    },
+                }
+            }
+        }
+    }
+}
+
+
+
+
+
+

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -4,6 +4,7 @@ local _ = require("gettext")
 local function screensaverType() return G_reader_settings:readSetting("screensaver_type") end
 local function screensaverDelay() return G_reader_settings:readSetting("screensaver_delay") end
 local function lastFile() return G_reader_settings:readSetting("lastfile") end
+local function messageBackground() return G_reader_settings:isTrue("message_background") end
 
 return {
     {
@@ -92,20 +93,23 @@ return {
         sub_item_table = {
             {
                 text = _("Screensaver folder"),
-                enabled_func = function()
-                    return screensaverType() == "random_image"
-                end,
                 callback = function()
                     Screensaver:chooseFolder()
                 end,
             },
             {
                 text = _("Screensaver message"),
-                enabled_func = function()
-                    return screensaverType() == "message"
-                end,
                 callback = function()
                     Screensaver:setMessage()
+                end,
+            },
+            {
+                text = _("White background in message"),
+                checked_func = function()
+                    return messageBackground()
+                end,
+                callback = function()
+                    G_reader_settings:saveSetting("message_background", not messageBackground())
                 end,
                 separator = true,
             },

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -85,11 +85,13 @@ end
 
 function Screensaver:stretchCover()
     local lastfile = G_reader_settings:readSetting("lastfile")
-    local doc_settings = DocSettings:open(lastfile)
-    local stretch_cover_ss = doc_settings:readSetting("stretch_cover")
-    doc_settings:close()
-    if  stretch_cover_ss ~= nil then
-        return stretch_cover_ss
+    if DocSettings:hasSidecarFile(lastfile) then
+        local doc_settings = DocSettings:open(lastfile)
+        local stretch_cover_ss = doc_settings:readSetting("stretch_cover")
+        doc_settings:close()
+        if  stretch_cover_ss ~= nil then
+            return stretch_cover_ss
+        end
     end
     return G_reader_settings:readSetting("stretch_cover_default") or false
 end
@@ -151,13 +153,10 @@ function Screensaver:show()
     if screensaver_type == "cover" then
         local lastfile = G_reader_settings:readSetting("lastfile")
         local exclude = false -- consider it not excluded if there's no docsetting
-        local remove_sidecarfile = false
         if DocSettings:hasSidecarFile(lastfile) then
             local doc_settings = DocSettings:open(lastfile)
             exclude = doc_settings:readSetting("exclude_screensaver")
             doc_settings:close()
-        else
-            remove_sidecarfile = true
         end
         if exclude ~= true then
             background = Blitbuffer.COLOR_BLACK
@@ -182,11 +181,6 @@ function Screensaver:show()
             end
         else  --fallback to random images if this book cover is excluded
             screensaver_type = "random_image"
-        end
-        if remove_sidecarfile then
-            local filemanagerutil = require("apps/filemanager/filemanagerutil")
-            filemanagerutil.purgeSettings(lastfile)
-            filemanagerutil.removeFileFromHistoryIfWanted(lastfile)
         end
     end
     if screensaver_type == "bookstatus" then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -1,3 +1,4 @@
+local Blitbuffer = require("ffi/blitbuffer")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
 local Device = require("device")
@@ -139,6 +140,7 @@ function Screensaver:show()
     end
     local screensaver_type = G_reader_settings:readSetting("screensaver_type")
     local widget = nil
+    local background = Blitbuffer.COLOR_WHITE
     if screensaver_type == "cover" then
         local lastfile = G_reader_settings:readSetting("lastfile")
         local doc_settings = DocSettings:open(lastfile)
@@ -198,6 +200,9 @@ function Screensaver:show()
         end
     elseif screensaver_type == "message" then
         local screensaver_message = G_reader_settings:readSetting("screensaver_message")
+        if G_reader_settings:nilOrFalse("message_background") then
+            background = nil
+        end
         if screensaver_message == nil then
             screensaver_message = default_screensaver_message
         end
@@ -210,6 +215,7 @@ function Screensaver:show()
     if widget then
         self.left_msg = ScreenSaverWidget:new{
             widget = widget,
+            background = background,
         }
         self.left_msg.modal = true
         -- refresh whole screen for other types

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -133,9 +133,12 @@ function Screensaver:setMessage()
 end
 
 function Screensaver:show()
+    if self.left_msg then
+        UIManager:close(self.left_msg)
+        self.left_msg = nil
+    end
     local screensaver_type = G_reader_settings:readSetting("screensaver_type")
     local widget = nil
-    self.left_msg = nil
     if screensaver_type == "cover" then
         local lastfile = G_reader_settings:readSetting("lastfile")
         local doc_settings = DocSettings:open(lastfile)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -157,6 +157,25 @@ function Screensaver:show()
                 width = Screen:getWidth(),
                 scale_factor = self:proportional() and 0 or nil,
             }
+        --fallback to random images if this book cover is excluded
+        else
+            local screensaver_dir = G_reader_settings:readSetting("screensaver_dir")
+            if screensaver_dir == nil then
+                local DataStorage = require("datastorage")
+                screensaver_dir = DataStorage:getDataDir() .. "/screenshots/"
+            end
+            local image_file = getRandomImage(screensaver_dir)
+            if image_file == nil then
+                widget = nil
+            else
+                widget = ImageWidget:new{
+                    file = image_file,
+                    alpha = true,
+                    height = Screen:getHeight(),
+                    width = Screen:getWidth(),
+                    scale_factor = 0,
+                }
+            end
         end
         doc_settings:close()
     elseif screensaver_type == "bookstatus" then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -12,7 +12,7 @@ local _ = require("gettext")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
-local defalut_screensaver_message = _("Sleeping")
+local default_screensaver_message = _("Sleeping")
 local Screensaver = {}
 
 local function getRandomImage(dir)
@@ -89,7 +89,7 @@ function Screensaver:proportional()
     if  proprtional_ss ~= nil then
         return proprtional_ss
     end
-    return G_reader_settings:readSetting("stretch_cover_defalut") or false
+    return G_reader_settings:readSetting("stretch_cover_default") or false
 end
 
 function Screensaver:excluded()
@@ -104,7 +104,7 @@ function Screensaver:setMessage()
     local InputDialog = require("ui/widget/inputdialog")
     local screensaver_message = G_reader_settings:readSetting("screensaver_message")
     if screensaver_message == nil then
-        screensaver_message = defalut_screensaver_message
+        screensaver_message = default_screensaver_message
     end
     self.input_dialog = InputDialog:new{
         title = "Screensaver message",
@@ -146,7 +146,7 @@ function Screensaver:show()
             doc:close()
             widget = ImageWidget:new{
                 image = image,
-                image_disposable = false,
+                image_disposable = true,
                 alpha = true,
                 height = Screen:getHeight(),
                 width = Screen:getWidth(),
@@ -159,15 +159,16 @@ function Screensaver:show()
         local doc = DocumentRegistry:openDocument(lastfile)
         local doc_settings = DocSettings:open(lastfile)
         local instance = require("apps/reader/readerui"):_getRunningInstance()
-
-        widget = BookStatusWidget:new {
-            thumbnail = doc:getCoverPageImage(),
-            props = doc:getProps(),
-            document = doc,
-            settings = doc_settings,
-            view = instance.view,
-            readonly = true,
-        }
+        if instance ~= nil then
+            widget = BookStatusWidget:new {
+                thumbnail = doc:getCoverPageImage(),
+                props = doc:getProps(),
+                document = doc,
+                settings = doc_settings,
+                view = instance.view,
+                readonly = true,
+            }
+        end
         doc:close()
         doc_settings:close()
     elseif screensaver_type == "random_image" then
@@ -182,7 +183,6 @@ function Screensaver:show()
         else
             widget = ImageWidget:new{
                 file = image_file,
-                image_disposable = false,
                 alpha = true,
                 height = Screen:getHeight(),
                 width = Screen:getWidth(),
@@ -196,7 +196,7 @@ function Screensaver:show()
     elseif screensaver_type == "message" then
         local screensaver_message = G_reader_settings:readSetting("screensaver_message")
         if screensaver_message == nil then
-            screensaver_message = defalut_screensaver_message
+            screensaver_message = default_screensaver_message
         end
         widget = InfoMessage:new{
             text = screensaver_message,

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -68,13 +68,19 @@ function BookStatusWidget:init()
     self.medium_font_face = Font:getFace("ffont")
     self.large_font_face = Font:getFace("largeffont")
 
+    local button_enabled = true
+    if self.readonly then
+        button_enabled = false
+    end
+
     self.star = Button:new{
         icon = "resources/icons/stats.star.empty.png",
         bordersize = 0,
         radius = 0,
         margin = 0,
-        enabled = true,
+        enabled = button_enabled,
         show_parent = self,
+        readonly = self.readonly,
     }
     local screen_size = Screen:getSize()
     self[1] = FrameContainer:new{
@@ -116,20 +122,28 @@ function BookStatusWidget:getStatReadPages()
 end
 
 function BookStatusWidget:getStatusContent(width)
-    return VerticalGroup:new{
+    local close_button = nil
+    local status_header = self:genHeader(_("Book Status"))
+
+    if self.readonly ~= true then
+        close_button = CloseButton:new{ window = self }
+        status_header = self:genHeader(_("Update Status"))
+    end
+    local content = VerticalGroup:new{
         align = "left",
         OverlapGroup:new{
             dimen = Geom:new{ w = width, h = Size.item.height_default },
-            CloseButton:new{ window = self },
+            close_button,
         },
         self:genBookInfoGroup(),
         self:genHeader(_("Statistics")),
         self:genStatisticsGroup(width),
         self:genHeader(_("Review")),
         self:genSummaryGroup(width),
-        self:genHeader(_("Update Status")),
+        status_header,
         self:generateSwitchGroup(width),
     }
+    return content
 end
 
 function BookStatusWidget:genHeader(title)
@@ -411,6 +425,7 @@ function BookStatusWidget:genSummaryGroup(width)
         focused = false,
         padding = text_padding,
         parent = self,
+        readonly = self.readonly,
         hint = _("A few words about the book"),
     }
 
@@ -468,6 +483,10 @@ function BookStatusWidget:generateSwitchGroup(width)
         enabled = true,
     }
 
+    if self.readonly then
+        config.enable = false
+    end
+
     local switch = ToggleSwitch:new{
         width = width * 0.6,
         default_value = config.default_value,
@@ -481,6 +500,7 @@ function BookStatusWidget:generateSwitchGroup(width)
         values = config.values,
         enabled = config.enable,
         config = self,
+        readonly = self.readonly,
     }
     switch:setPosition(position)
 

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -210,7 +210,9 @@ function Button:onTapSelectButton()
     elseif type(self.tap_input_func) == "function" then
         self:onInput(self.tap_input_func())
     end
-    return true
+    if self.readonly ~= true then
+        return true
+    end
 end
 
 function Button:onHoldSelectButton()

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -163,13 +163,17 @@ function InfoMessage:onAnyKeyPressed()
     -- triggered by our defined key events
     self.dismiss_callback()
     UIManager:close(self)
-    return true
+    if self.readonly ~= true then
+        return true
+    end
 end
 
 function InfoMessage:onTapClose()
     self.dismiss_callback()
     UIManager:close(self)
-    return true
+    if self.readonly ~= true then
+        return true
+    end
 end
 
 return InfoMessage

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -72,8 +72,10 @@ end
 
 function InputText:init()
     self:initTextBox(self.text)
-    self:initKeyboard()
-    self:initEventListener()
+    if self.readonly ~= true then
+        self:initKeyboard()
+        self:initEventListener()
+    end
 end
 
 function InputText:initTextBox(text, char_added, is_password_type)

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -1,4 +1,3 @@
-local Blitbuffer = require("ffi/blitbuffer")
 local Device = require("device")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
@@ -9,6 +8,7 @@ local Screen = Device.screen
 
 local ScreenSaverWidget = InputContainer:new{
     widget = nil,
+    background = nil,
 }
 
 function ScreenSaverWidget:init()
@@ -44,7 +44,7 @@ function ScreenSaverWidget:update()
         bordersize = 0,
         padding = 0,
         margin = 0,
-        background = Blitbuffer.COLOR_WHITE,
+        background = self.background,
         width = self.width,
         height = self.height,
         self.widget,

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -1,0 +1,92 @@
+local Blitbuffer = require("ffi/blitbuffer")
+local Device = require("device")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local UIManager = require("ui/uimanager")
+local Screen = Device.screen
+
+local ScreenSaverWidget = InputContainer:new{
+    widget = nil,
+}
+
+function ScreenSaverWidget:init()
+    if Device:hasKeys() then
+        self.key_events = {
+            Close = { {"Back"}, doc = "close widget" },
+        }
+    end
+    if Device:isTouchDevice() then
+        local range = Geom:new{
+            x = 0, y = 0,
+            w = Screen:getWidth(),
+            h = Screen:getHeight(),
+        }
+        self.ges_events = {
+            Tap = { GestureRange:new{ ges = "tap", range = range } },
+        }
+    end
+    self:update()
+end
+
+function ScreenSaverWidget:update()
+    self.height = Screen:getHeight()
+    self.width = Screen:getWidth()
+
+    self.region = Geom:new{
+        x = 0, y = 0,
+        w = self.width,
+        h = self.height,
+    }
+    self.main_frame = FrameContainer:new{
+        radius = 0,
+        bordersize = 0,
+        padding = 0,
+        margin = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        width = self.width,
+        height = self.height,
+        self.widget,
+    }
+    self[1] = self.main_frame
+    UIManager:setDirty("all", function()
+        local update_region = self.main_frame.dimen
+        return "partial", update_region
+    end)
+end
+
+function ScreenSaverWidget:onShow()
+    UIManager:setDirty(self, function()
+        return "full", self.main_frame.dimen
+    end)
+    return true
+end
+
+function ScreenSaverWidget:onTap(_, ges)
+    if ges.pos:intersectWith(self.main_frame.dimen) then
+        self:onClose()
+        UIManager:setDirty("all", "full")
+    end
+    return true
+end
+
+function ScreenSaverWidget:onClose()
+    UIManager:close(self)
+    UIManager:setDirty("all", "full")
+    return true
+end
+
+function ScreenSaverWidget:onAnyKeyPressed()
+    self:onClose()
+    return true
+end
+
+function ScreenSaverWidget:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "partial", self.main_frame.dimen
+    end)
+    return true
+end
+
+return ScreenSaverWidget

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -161,7 +161,13 @@ function ToggleSwitch:calculatePosition(gev)
 end
 
 function ToggleSwitch:onTapSelect(arg, gev)
-    if not self.enabled then return true end
+    if not self.enabled then
+        if self.readonly ~= true then
+            return true
+        else
+            return
+        end
+    end
     local position = self:calculatePosition(gev)
     self:togglePosition(position)
     --[[

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -8,6 +8,7 @@ local MultiInputDialog = require("ui/widget/multiinputdialog")
 local ReaderFooter = require("apps/reader/modules/readerfooter")
 local ReaderProgress = require("readerprogress")
 local ReadHistory = require("readhistory")
+local Screensaver = require("ui/screensaver")
 local SQ3 = require("lua-ljsqlite3/init")
 local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
@@ -103,6 +104,24 @@ function ReaderStatistics:init()
         if self.is_enabled then
             return self.avg_time
         end
+    end
+    Screensaver.getReaderProgress = function()
+        local readingprogress
+        self:insertDB(self.id_curr_book)
+        local current_period, current_pages = self:getCurrentBookStats()
+        local today_period, today_pages = self:getTodayBookStats()
+        local dates_stats = self:getReadingProgressStats(7)
+        if dates_stats then
+            readingprogress = ReaderProgress:new{
+                dates = dates_stats,
+                current_period = current_period,
+                current_pages = current_pages,
+                today_period = today_period,
+                today_pages = today_pages,
+                readonly = true,
+            }
+        end
+        return readingprogress
     end
 end
 

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -67,11 +67,15 @@ function ReaderProgress:getTotalStats(stats_day)
 end
 
 function ReaderProgress:getStatusContent(width)
+    local close_button = nil
+    if self.readonly ~= true then
+        close_button = CloseButton:new{ window = self }
+    end
     return VerticalGroup:new{
         align = "left",
         OverlapGroup:new{
             dimen = Geom:new{ w = width, h = Size.item.height_default },
-            CloseButton:new{ window = self },
+            close_button,
         },
         self:genSingleHeader(_("Last week")),
         self:genSummaryWeek(width),


### PR DESCRIPTION
I prepared screensaver with new options. Tested on Kindle. Please check how it works on Kobo.
Closes: #1809 and #2904
Now we have that options:
+ cover image
+ book status 
+ random image (now we can choose folder with foldermanager)
+ reading progress
+ message (we can enter showing text) 
+ disable

I also added an option to define when the screensaver should be turned off. The default is after waking up the device, but also can be turned off after a few seconds or after tap screen. These options can be useful with sleeping covers.
Some screenshots:

![koreader_020](https://user-images.githubusercontent.com/22982594/33622523-638a621c-d9ee-11e7-8955-79e35002e727.png)
![koreader_021](https://user-images.githubusercontent.com/22982594/33622526-63be0d74-d9ee-11e7-8580-4208b931b7d9.png)
![koreader_022](https://user-images.githubusercontent.com/22982594/33622529-63f095dc-d9ee-11e7-85c1-afa0f8f6c3a3.png)
![koreader_023](https://user-images.githubusercontent.com/22982594/33622530-6418794e-d9ee-11e7-9e46-267c182b8e56.png)
![koreader_024](https://user-images.githubusercontent.com/22982594/33622531-644964fa-d9ee-11e7-9d0a-007b28ec4777.png)
![koreader_025](https://user-images.githubusercontent.com/22982594/33622532-647ae700-d9ee-11e7-80f3-e53f70f9cb96.png)
![koreader_026](https://user-images.githubusercontent.com/22982594/33622533-64a53e74-d9ee-11e7-93a5-9ee0309da0af.png)
![koreader_027](https://user-images.githubusercontent.com/22982594/33622534-64d261ce-d9ee-11e7-9193-3dbde2251d44.png)
![koreader_028](https://user-images.githubusercontent.com/22982594/33622535-65012ab8-d9ee-11e7-9348-520f5af2b739.png)


