### PR TITLE
[WIP] Pocketbook-suspend plugin

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -75,19 +75,18 @@ function ReaderConfig:onShowConfigMenu()
     self.config_dialog:onShowConfigPanel(self.last_panel_index)
     UIManager:show(self.config_dialog)
 
-    return true
 end
 
 function ReaderConfig:onTapShowConfigMenu()
     if self.activation_menu ~= "swipe" then
-        self:onShowConfigMenu()
+        self.ui:handleEvent(Event:new("ShowConfigMenu"))
         return true
     end
 end
 
 function ReaderConfig:onSwipeShowConfigMenu(ges)
     if self.activation_menu ~= "tap" and ges.direction == "north" then
-        self:onShowConfigMenu()
+        self.ui:handleEvent(Event:new("ShowConfigMenu"))
         return true
     end
 end
@@ -107,6 +106,7 @@ function ReaderConfig:onCloseCallback()
     self.last_panel_index = self.config_dialog.panel_index
     self.config_dialog = nil
     self.ui:handleEvent(Event:new("RestoreHinting"))
+    self.ui:handleEvent(Event:new("CloseConfigMenu"))
 end
 
 -- event handler for readercropping

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -294,15 +294,12 @@ function ReaderMenu:onShowReaderMenu()
     -- maintain a reference to menu_container
     self.menu_container = menu_container
     UIManager:show(menu_container)
-
-    return true
 end
 
 function ReaderMenu:onCloseReaderMenu()
     self.last_tab_index = self.menu_container[1].last_index
     self:onSaveSettings()
     UIManager:close(self.menu_container)
-    return true
 end
 
 function ReaderMenu:onSwipeShowMenu(ges)

--- a/plugins/pocketbook_suspend.koplugin/main.lua
+++ b/plugins/pocketbook_suspend.koplugin/main.lua
@@ -1,0 +1,76 @@
+local Device = require("device")
+local logger = require("logger")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+
+if Device:isSDL() then
+    Device.enableHwSuspend = function() 
+        logger.dbg("called enableHwSuspend()")
+    end
+    Device.disableHwSuspend = function() 
+        logger.dbg("called disableHwSuspend()")
+    end
+elseif not Device:isPocketBook() then
+    return { disabled = true, }
+end
+
+local PocketBookInsomnia = WidgetContainer:new{
+    name = 'PocketBookInsomnia',
+    enabled = true,
+}
+
+function PocketBookInsomnia:init()
+    self.reader_menu_active = false
+    self.config_menu_active = false
+end
+
+function PocketBookInsomnia:setSuspendState(on, postpone_ms)
+    if Device:isSDL() then
+        logger.dbg("called setSuspendState("
+            .. on  .. "," .. postpone_ms .. ")")
+    else
+        require("ffi/input").setSuspendState(on, postpone_ms)
+    end
+end
+
+-- wait 2000ms before enabeling suspend so the ReaderUI-Widget is
+-- drawn first
+function PocketBookInsomnia:onReaderReady()
+    logger.dbg("called onReaderReady()")
+    PocketBookInsomnia:setSuspendState(1,2000)
+end
+
+function PocketBookInsomnia:onShowReaderMenu()
+    logger.dbg("called onShowReaderMenu()")
+    if not self.config_menu_active then
+        PocketBookInsomnia:setSuspendState(0,0)
+    end
+    self.reader_menu_active = true
+end
+
+function PocketBookInsomnia:onCloseReaderMenu()
+    logger.dbg("called onCloseReaderMenu()")
+    self.reader_menu_active = false
+    if not self.config_menu_active then
+        PocketBookInsomnia:setSuspendState(1,2000)
+    end
+end
+
+function PocketBookInsomnia:onShowConfigMenu()
+    logger.dbg("called onShowConfigMenu()")
+    if not self.reader_menu_active then
+        PocketBookInsomnia:setSuspendState(0,0)
+    end
+    self.config_menu_active = true
+end
+
+function PocketBookInsomnia:onCloseConfigMenu()
+    logger.dbg("called onCloseConfigMenu()")
+    self.config_menu_active = false
+    if not self.reader_menu_active then
+        PocketBookInsomnia:setSuspendState(1,2000)
+    end
+end
+
+return PocketBookInsomnia

--- a/plugins/pocketbook_suspend.koplugin/main.lua
+++ b/plugins/pocketbook_suspend.koplugin/main.lua
@@ -4,27 +4,27 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 
 if Device:isSDL() then
-    Device.enableHwSuspend = function() 
+    Device.enableHwSuspend = function()
         logger.dbg("called enableHwSuspend()")
     end
-    Device.disableHwSuspend = function() 
+    Device.disableHwSuspend = function()
         logger.dbg("called disableHwSuspend()")
     end
 elseif not Device:isPocketBook() then
     return { disabled = true, }
 end
 
-local PocketBookInsomnia = WidgetContainer:new{
-    name = 'PocketBookInsomnia',
+local PocketBookSuspend = WidgetContainer:new{
+    name = 'PocketBookSuspend',
     enabled = true,
 }
 
-function PocketBookInsomnia:init()
+function PocketBookSuspend:init()
     self.reader_menu_active = false
     self.config_menu_active = false
 end
 
-function PocketBookInsomnia:setSuspendState(on, postpone_ms)
+function PocketBookSuspend:setSuspendState(on, postpone_ms)
     if Device:isSDL() then
         logger.dbg("called setSuspendState("
             .. on  .. "," .. postpone_ms .. ")")
@@ -35,41 +35,41 @@ end
 
 -- wait 2000ms before enabeling suspend so the ReaderUI-Widget is
 -- drawn first
-function PocketBookInsomnia:onReaderReady()
+function PocketBookSuspend:onReaderReady()
     logger.dbg("called onReaderReady()")
-    PocketBookInsomnia:setSuspendState(1,2000)
+    PocketBookSuspend:setSuspendState(1,2000)
 end
 
-function PocketBookInsomnia:onShowReaderMenu()
+function PocketBookSuspend:onShowReaderMenu()
     logger.dbg("called onShowReaderMenu()")
     if not self.config_menu_active then
-        PocketBookInsomnia:setSuspendState(0,0)
+        PocketBookSuspend:setSuspendState(0,0)
     end
     self.reader_menu_active = true
 end
 
-function PocketBookInsomnia:onCloseReaderMenu()
+function PocketBookSuspend:onCloseReaderMenu()
     logger.dbg("called onCloseReaderMenu()")
     self.reader_menu_active = false
     if not self.config_menu_active then
-        PocketBookInsomnia:setSuspendState(1,2000)
+        PocketBookSuspend:setSuspendState(1,2000)
     end
 end
 
-function PocketBookInsomnia:onShowConfigMenu()
+function PocketBookSuspend:onShowConfigMenu()
     logger.dbg("called onShowConfigMenu()")
     if not self.reader_menu_active then
-        PocketBookInsomnia:setSuspendState(0,0)
+        PocketBookSuspend:setSuspendState(0,0)
     end
     self.config_menu_active = true
 end
 
-function PocketBookInsomnia:onCloseConfigMenu()
+function PocketBookSuspend:onCloseConfigMenu()
     logger.dbg("called onCloseConfigMenu()")
     self.config_menu_active = false
     if not self.reader_menu_active then
-        PocketBookInsomnia:setSuspendState(1,2000)
+        PocketBookSuspend:setSuspendState(1,2000)
     end
 end
 
-return PocketBookInsomnia
+return PocketBookSuspend

--- a/plugins/pocketbook_suspend.koplugin/main.lua
+++ b/plugins/pocketbook_suspend.koplugin/main.lua
@@ -1,6 +1,5 @@
 local Device = require("device")
 local logger = require("logger")
-local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 


### PR DESCRIPTION
Plugin which controls auto-suspending on PB-devices. 

Depends on https://github.com/koreader/koreader-base/pull/576

- Re-enable suspension as soon as possible after initial loading of the application has finished
- Disable suspension while in menues to smoothen user-experience.

For this to work i had to modify event-handling in ``readerconfig.lua`` and ``readermenu.lua`` slightly - i am not quite sure if this is the way to go, suggestions welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/3540)
<!-- Reviewable:end -->
