### PR TITLE
Adds Wikipedia history

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -214,12 +214,12 @@ If you'd like to change the order in which dictionaries are queried (and their r
 - move all dictionary directories out of %1.
 - move them back there, one by one, in the order you want them to be used.]]), self.data_dir)
                     })
-                end
+                end,
             },
             {
-                text = _("Disable dictionary fuzzy search"),
+                text = _("Enable fuzzy search"),
                 checked_func = function()
-                    return self.disable_fuzzy_search == true
+                    return not self.disable_fuzzy_search == true
                 end,
                 callback = function()
                     self.disable_fuzzy_search = not self.disable_fuzzy_search
@@ -227,11 +227,12 @@ If you'd like to change the order in which dictionaries are queried (and their r
                 hold_callback = function()
                     self:makeDisableFuzzyDefault(self.disable_fuzzy_search)
                 end,
+                separator = true,
             },
             {
-                text = _("Disable dictionary lookup history"),
+                text = _("Enable dictionary lookup history"),
                 checked_func = function()
-                    return self.disable_lookup_history
+                    return not self.disable_lookup_history
                 end,
                 callback = function()
                     self.disable_lookup_history = not self.disable_lookup_history
@@ -250,6 +251,7 @@ If you'd like to change the order in which dictionaries are queried (and their r
                         end,
                     })
                 end,
+                separator = true,
             },
             { -- setting used by dictquicklookup
                 text = _("Large window"),

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -57,6 +57,7 @@ local order = {
         "dictionary_settings",
         "----------------------------",
         "wikipedia_lookup",
+        "wikipedia_history",
         "wikipedia_settings",
         "----------------------------",
         "find_book_in_calibre_catalog",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -75,6 +75,7 @@ local order = {
         "dictionary_settings",
         "----------------------------",
         "wikipedia_lookup",
+        "wikipedia_history",
         "wikipedia_settings",
         "----------------------------",
         "goodreads",


### PR DESCRIPTION
Just like Dictionary lookup history, with symbols to distinguish lookup queries from full page viewing, and language in brackets if different from current language (so users with one single language are not bothered by it). Taping on an item just relaunch the right query with appropriate language/full page or not.

<kbd>![wikipediahistory](https://user-images.githubusercontent.com/24273478/34078985-5fad9af8-e324-11e7-8d09-96ecd1d3985a.png)</kbd>

Also changed Disable to Enable in some menu items to be more positive.