### PR TITLE
Wikipedia Save as EPUB: fix some wiki links and speedup download

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -759,7 +759,7 @@ time, abbr, sup {
 ]], page_cleaned, page_htmltitle, lang:upper(), saved_on, see_online_version, html))
 
     -- Force a GC to free the memory we used till now (the second call may
-    -- help reclaming more memory).
+    -- help reclaim more memory).
     collectgarbage()
     collectgarbage()
 
@@ -829,7 +829,7 @@ time, abbr, sup {
     logger.info("successfully created:", epub_path)
 
     -- Force a GC to free the memory we used (the second call may help
-    -- reclaming more memory).
+    -- reclaim more memory).
     collectgarbage()
     collectgarbage()
     return true


### PR DESCRIPTION
- Fix links to wikipedia pages containing '?oldid=123', that wouldn't work when used back thru the API.
- Make external links to other wikipedias with a different langage work (it didnt work for non-ascii page titles)
- Speedup download of images by using a newly added 'fast_refresh' option to Trapper:info() to bypass UIManager.

Timing the images download part (which often takes 30s to a few minutes) shows that for smal images:
- http request would take 300ms
- updating the InfoMessage "Fetching image 3/47..." would take 700ms.

With this Trapper option,  the display of the InfoMessage is really faster (although a bit hacky, but I didn't find another way of getting speed than blitting to Screen and bypassing UIManager).
It's still slow, mainly because our http.lua/socket.lua code is doing, for each request, the full dns lookup/tcp connection/download/close tcp connection. It could be a lot faster if it had support for http keep-alive, but it doesn't.