### PR TITLE
Truncate path in filemanager

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -21,6 +21,7 @@ local PluginLoader = require("pluginloader")
 local ReaderDictionary = require("apps/reader/modules/readerdictionary")
 local ReaderUI = require("apps/reader/readerui")
 local ReaderWikipedia = require("apps/reader/modules/readerwikipedia")
+local RenderText = require("ui/rendertext")
 local Screenshoter = require("ui/widget/screenshoter")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
@@ -39,6 +40,20 @@ local function restoreScreenMode()
     if Screen:getScreenMode() ~= screen_mode then
         Screen:setScreenMode(screen_mode or "portrait")
     end
+end
+
+local function truncatePath(text)
+    local screen_width = Screen:getWidth()
+    local face = Font:getFace("xx_smallinfofont")
+    local reserve_text = string.reverse(text)
+    local txt_width = RenderText:sizeUtf8Text(0, screen_width, face, reserve_text, nil, false).x
+    if  screen_width - 2 * Size.padding.small < txt_width then
+        reserve_text = RenderText:truncateTextByWidth(reserve_text, face, screen_width - 2 * Size.padding.small, nil, false)
+        -- string.reverse() breaks "…" so we delete it
+        reserve_text = reserve_text:sub(1, -5)
+        text = "…" .. string.reverse(reserve_text)
+    end
+    return text
 end
 
 local FileManager = InputContainer:extend{
@@ -67,7 +82,7 @@ function FileManager:init()
 
     self.path_text = TextWidget:new{
         face = Font:getFace("xx_smallinfofont"),
-        text = filemanagerutil.abbreviate(self.root_path),
+        text = truncatePath(filemanagerutil.abbreviate(self.root_path)),
     }
 
     self.banner = FrameContainer:new{
@@ -117,7 +132,7 @@ function FileManager:init()
     self.focused_file = nil -- use it only once
 
     function file_chooser:onPathChanged(path)  -- luacheck: ignore
-        FileManager.instance.path_text:setText(filemanagerutil.abbreviate(path))
+        FileManager.instance.path_text:setText(truncatePath(filemanagerutil.abbreviate(path)))
         UIManager:setDirty(FileManager.instance, function()
             return "ui", FileManager.instance.path_text.dimen
         end)

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -45,13 +45,13 @@ end
 local function truncatePath(text)
     local screen_width = Screen:getWidth()
     local face = Font:getFace("xx_smallinfofont")
-    local reserve_text = string.reverse(text)
-    local txt_width = RenderText:sizeUtf8Text(0, screen_width, face, reserve_text, nil, false).x
+    local reversed_text = string.reverse(text)
+    local txt_width = RenderText:sizeUtf8Text(0, screen_width, face, reversed_text, nil, false).x
     if  screen_width - 2 * Size.padding.small < txt_width then
-        reserve_text = RenderText:truncateTextByWidth(reserve_text, face, screen_width - 2 * Size.padding.small, nil, false)
+        reversed_text = RenderText:truncateTextByWidth(reversed_text, face, screen_width - 2 * Size.padding.small, nil, false)
         -- string.reverse() breaks "…" so we delete it
-        reserve_text = reserve_text:sub(1, -5)
-        text = "…" .. string.reverse(reserve_text)
+        reversed_text = reversed_text:sub(1, -5)
+        text = "…" .. string.reverse(reversed_text)
     end
     return text
 end


### PR DESCRIPTION
When the path in file manager is too wide we truncate it at the beginning like that:
before
![zaznaczenie_040](https://user-images.githubusercontent.com/22982594/34389927-cf2c1524-eb3c-11e7-9c60-b20eb22e05e3.png)
after
![zaznaczenie_041](https://user-images.githubusercontent.com/22982594/34389934-d6db182e-eb3c-11e7-9d42-5bdb3d5bccbb.png)


