### PR TITLE
Partial fix for 3477

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -57,7 +57,6 @@ local PocketBook = Generic:new{
 }
 
 function PocketBook:init()
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/pocketbook/powerd"):new{device = self}
     self.input = require("device/input"):new{
@@ -86,7 +85,6 @@ function PocketBook:init()
     -- here.
     -- Unhandled events will leave Input:waitEvent() as "GenericInput"
     self.input:registerEventAdjustHook(function(_input, ev)
-        -- han
         if ev.type == EVT_KEYDOWN or ev.type == EVT_KEYUP then
             ev.value = ev.type == EVT_KEYDOWN and 1 or 0
             ev.type = 1 -- linux/input.h Key-Event

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -71,6 +71,16 @@ function UIManager:init()
             Device:reboot()
         end)
     end
+    if Device:isPocketBook() then
+        self.event_handlers["Suspend"] = function()
+            self:_beforeSuspend()
+            Device:onPowerEvent("Power")
+        end
+        self.event_handlers["Resume"] = function()
+            Device:onPowerEvent("Power")
+            self:_afterResume()
+        end
+    end
     if Device:isKobo() then
         -- We do not want auto suspend procedure to waste battery during
         -- suspend. So let's unschedule it when suspending, and restart it after


### PR DESCRIPTION
Partial fix for https://github.com/koreader/koreader/issues/3477

Partial, as it will safe the state when suspending the reader by pressing the power-button.

However, it will still **not** safe the state when Pocketbooks autoPowerOff-Feature kicks in, as this does not create an event (e.g. no EVT_BACKGROUND) of any kind. 

As it is possible to disable and re-enable the autoPowerOff-Feature altogether i'll somehow work around this second issue, but this will involve ``input-pocketbook.h`` in ``koreader-base`` again, so i'll prepare another PR for that. 