### PR TITLE
credocument: deal with loadDocument() failures

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -98,23 +98,23 @@ function BookInfo:show(file, book_props)
     -- If still no book_props (book never opened or empty 'stats'), open the
     -- document to get them
     if not book_props then
-        local pages
         local document = DocumentRegistry:openDocument(file)
-        if document.loadDocument then -- needed for crengine
-            document:loadDocument()
+        if document then
+            book_props = document:getProps()
+            -- For CreDocuments, we would need:
             -- document:render()
-            -- It would be needed to get nb of pages, but the nb obtained
-            -- by simply calling here document:getPageCount() is wrong,
-            -- often 2 to 3 times the nb of pages we see when opening
-            -- the document (may be some other cre settings should be applied
-            -- before calling render() ?)
+            -- to get nb of pages, but the nb obtained by simply calling
+            -- here document:getPageCount() is wrong, often 2 to 3 times
+            -- the nb of pages we see when opening the document (may be some
+            -- other cre settings should be applied before calling render() ?)
+            if not document.render then -- it's not a CreDocument
+                -- for all others than crengine, we seem to get an accurate nb of pages
+                book_props.pages = document:getPageCount()
+            end
+            DocumentRegistry:closeDocument(file)
         else
-            -- for all others than crengine, we seem to get an accurate nb of pages
-            pages = document:getPageCount()
+            book_props = {}
         end
-        book_props = document:getProps()
-        book_props.pages = pages
-        DocumentRegistry:closeDocument(file)
     end
 
     local title = book_props.title

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -320,9 +320,6 @@ function ReaderUI:init()
         document = self.document,
         ui = self,
     })
-if not self.document.info.has_pages then
-self.document:loadDocument()
-end
     -- koreader plugins
     for _, plugin_module in ipairs(PluginLoader:loadPlugins()) do
         local ok, plugin_or_err = PluginLoader:createPluginInstance(
@@ -343,6 +340,9 @@ end
     -- we only read settings after all the widgets are initialized
     self:handleEvent(Event:new("ReadSettings", self.doc_settings))
 
+if not self.document.info.has_pages then
+self.document:loadDocument()
+end
     for _,v in ipairs(self.postInitCallback) do
         v()
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -263,7 +263,6 @@ function ReaderUI:init()
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
-
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)
             self:handleEvent(Event:new("PreRenderDocument", self.doc_settings))
@@ -340,9 +339,6 @@ function ReaderUI:init()
     -- we only read settings after all the widgets are initialized
     self:handleEvent(Event:new("ReadSettings", self.doc_settings))
 
-if not self.document.info.has_pages then
-self.document:loadDocument()
-end
     for _,v in ipairs(self.postInitCallback) do
         v()
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -263,6 +263,8 @@ function ReaderUI:init()
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
+            self.document:loadDocument()
+
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)
             self:handleEvent(Event:new("PreRenderDocument", self.doc_settings))

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -89,6 +89,7 @@ end
 function ReaderUI:init()
     -- cap screen refresh on pan to 2 refreshes per second
     local pan_rate = Screen.eink and 2.0 or 30.0
+self.document:loadDocument()
 
     self.postInitCallback = {}
     self.postReaderCallback = {}
@@ -263,7 +264,6 @@ function ReaderUI:init()
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
-            self.document:loadDocument()
 
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -337,12 +337,12 @@ function ReaderUI:init()
         end
     end
 
-if not self.document.info.has_pages then
-self.document:loadDocument()
-end
     -- we only read settings after all the widgets are initialized
     self:handleEvent(Event:new("ReadSettings", self.doc_settings))
 
+if not self.document.info.has_pages then
+self.document:loadDocument()
+end
     for _,v in ipairs(self.postInitCallback) do
         v()
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -263,6 +263,36 @@ function ReaderUI:init()
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
+            if not self.document:loadDocument() then
+                -- Sadly, we had to delay loadDocument() till here, so we only
+                -- know now if this document is valid and recognized or not.
+                -- We can't do much more than crash properly here (still better than
+                -- going on and segfaulting when calling other methods on unitiliazed
+                -- _document)
+                -- We must still remove it from lastfile and history (as it has
+                -- already been added there) so that koreader don't crash again
+                -- at next launch...
+                local readhistory = require("readhistory")
+                readhistory:removeItemByPath(self.document.file)
+                if G_reader_settings:readSetting("lastfile") == self.document.file then
+                    G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
+                end
+                -- As we are in a coroutine, we can pause and show an InfoMessage before exiting
+                local _coroutine = coroutine.running()
+                if coroutine then
+                    logger.warn("crengine failed recognizing or parsing this file: unsupported or invalid document")
+                    UIManager:show(InfoMessage:new{
+                        text = _("Failed recognizing or parsing this file: unsupported or invalid document.\nKOReader will exit now."),
+                        dismiss_callback = function()
+                            coroutine.resume(_coroutine, false)
+                        end,
+                    })
+                    coroutine.yield() -- pause till InfoMessage is dismissed
+                end
+                -- We have to error and exit the coroutine anyway to avoid any segfault
+                error("crengine failed recognizing or parsing this file: unsupported or invalid document")
+            end
+
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)
             self:handleEvent(Event:new("PreRenderDocument", self.doc_settings))

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -89,7 +89,7 @@ end
 function ReaderUI:init()
     -- cap screen refresh on pan to 2 refreshes per second
     local pan_rate = Screen.eink and 2.0 or 30.0
-if self.document.info.has_pages then
+if not self.document.info.has_pages then
 self.document:loadDocument()
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -337,12 +337,12 @@ function ReaderUI:init()
         end
     end
 
-    -- we only read settings after all the widgets are initialized
-    self:handleEvent(Event:new("ReadSettings", self.doc_settings))
-
 if not self.document.info.has_pages then
 self.document:loadDocument()
 end
+    -- we only read settings after all the widgets are initialized
+    self:handleEvent(Event:new("ReadSettings", self.doc_settings))
+
     for _,v in ipairs(self.postInitCallback) do
         v()
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -89,7 +89,9 @@ end
 function ReaderUI:init()
     -- cap screen refresh on pan to 2 refreshes per second
     local pan_rate = Screen.eink and 2.0 or 30.0
+if self.document.info.has_pages then
 self.document:loadDocument()
+end
 
     self.postInitCallback = {}
     self.postReaderCallback = {}

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -264,33 +264,7 @@ function ReaderUI:init()
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
             if not self.document:loadDocument() then
-                -- Sadly, we had to delay loadDocument() till here, so we only
-                -- know now if this document is valid and recognized or not.
-                -- We can't do much more than crash properly here (still better than
-                -- going on and segfaulting when calling other methods on unitiliazed
-                -- _document)
-                -- We must still remove it from lastfile and history (as it has
-                -- already been added there) so that koreader don't crash again
-                -- at next launch...
-                local readhistory = require("readhistory")
-                readhistory:removeItemByPath(self.document.file)
-                if G_reader_settings:readSetting("lastfile") == self.document.file then
-                    G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
-                end
-                -- As we are in a coroutine, we can pause and show an InfoMessage before exiting
-                local _coroutine = coroutine.running()
-                if coroutine then
-                    logger.warn("crengine failed recognizing or parsing this file: unsupported or invalid document")
-                    UIManager:show(InfoMessage:new{
-                        text = _("Failed recognizing or parsing this file: unsupported or invalid document.\nKOReader will exit now."),
-                        dismiss_callback = function()
-                            coroutine.resume(_coroutine, false)
-                        end,
-                    })
-                    coroutine.yield() -- pause till InfoMessage is dismissed
-                end
-                -- We have to error and exit the coroutine anyway to avoid any segfault
-                error("crengine failed recognizing or parsing this file: unsupported or invalid document")
+                self:dealWithLoadDocumentFailure()
             end
 
             -- used to read additional settings after the document has been
@@ -587,6 +561,36 @@ function ReaderUI:onClose()
     if _running_instance == self then
         _running_instance = nil
     end
+end
+
+function ReaderUI:dealWithLoadDocumentFailure()
+    -- Sadly, we had to delay loadDocument() to about now, so we only
+    -- know now this document is not valid or recognized.
+    -- We can't do much more than crash properly here (still better than
+    -- going on and segfaulting when calling other methods on unitiliazed
+    -- _document)
+    -- We must still remove it from lastfile and history (as it has
+    -- already been added there) so that koreader don't crash again
+    -- at next launch...
+    local readhistory = require("readhistory")
+    readhistory:removeItemByPath(self.document.file)
+    if G_reader_settings:readSetting("lastfile") == self.document.file then
+        G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
+    end
+    -- As we are in a coroutine, we can pause and show an InfoMessage before exiting
+    local _coroutine = coroutine.running()
+    if coroutine then
+        logger.warn("crengine failed recognizing or parsing this file: unsupported or invalid document")
+        UIManager:show(InfoMessage:new{
+            text = _("Failed recognizing or parsing this file: unsupported or invalid document.\nKOReader will exit now."),
+            dismiss_callback = function()
+                coroutine.resume(_coroutine, false)
+            end,
+        })
+        coroutine.yield() -- pause till InfoMessage is dismissed
+    end
+    -- We have to error and exit the coroutine anyway to avoid any segfault
+    error("crengine failed recognizing or parsing this file: unsupported or invalid document")
 end
 
 return ReaderUI

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -263,8 +263,6 @@ function ReaderUI:init()
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
-            self.document:loadDocument()
-
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)
             self:handleEvent(Event:new("PreRenderDocument", self.doc_settings))

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -89,9 +89,6 @@ end
 function ReaderUI:init()
     -- cap screen refresh on pan to 2 refreshes per second
     local pan_rate = Screen.eink and 2.0 or 30.0
---if not self.document.info.has_pages then
---self.document:loadDocument()
---end
 
     self.postInitCallback = {}
     self.postReaderCallback = {}
@@ -266,7 +263,6 @@ function ReaderUI:init()
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
-self.document:loadDocument()
 
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)
@@ -324,6 +320,9 @@ self.document:loadDocument()
         document = self.document,
         ui = self,
     })
+if not self.document.info.has_pages then
+self.document:loadDocument()
+end
     -- koreader plugins
     for _, plugin_module in ipairs(PluginLoader:loadPlugins()) do
         local ok, plugin_or_err = PluginLoader:createPluginInstance(

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -89,9 +89,9 @@ end
 function ReaderUI:init()
     -- cap screen refresh on pan to 2 refreshes per second
     local pan_rate = Screen.eink and 2.0 or 30.0
-if not self.document.info.has_pages then
-self.document:loadDocument()
-end
+--if not self.document.info.has_pages then
+--self.document:loadDocument()
+--end
 
     self.postInitCallback = {}
     self.postReaderCallback = {}
@@ -266,6 +266,7 @@ end
     else
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
+self.document:loadDocument()
 
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -108,6 +108,7 @@ function CreDocument:init()
 
     -- set fallback font face
     self._document:setStringProperty("crengine.font.fallback.face", self.fallback_font)
+self._document:setStringProperty("font.face.default", self.default_font)
 
     self.is_open = true
     self.info.has_pages = false

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -110,7 +110,7 @@ function CreDocument:init()
 
     -- setting a default font before loading document actually do prevent
     -- some crashes
-    self._document:setStringProperty("font.face.default", self.default_font)
+    -- self._document:setStringProperty("font.face.default", self.default_font)
 
     -- Make crengine actually parse the document now, so we can
     -- return an error if it is not recognized (instead of segfaulting

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -18,7 +18,6 @@ local CreDocument = Document:new{
     PAGE_VIEW_MODE = 1,
 
     _document = false,
-    _loaded = false,
 
     line_space_percent = 100,
     default_font = G_reader_settings:readSetting("cre_font") or "Noto Serif",
@@ -109,22 +108,25 @@ function CreDocument:init()
     -- set fallback font face
     self._document:setStringProperty("crengine.font.fallback.face", self.fallback_font)
 
+    -- setting a default font before loading document actually do prevent
+    -- some crashes
+    self._document:setStringProperty("font.face.default", self.default_font)
+
+    -- Make crengine actually parse the document now, so we can
+    -- return an error if it is not recognized (instead of segfaulting
+    -- when calling other methods on self._document)
+    if not self._document:loadDocument(self.file) then
+        self._document:close()
+        error("cre:loadDocument() failed")
+    end
+
     self.is_open = true
     self.info.has_pages = false
     self:_readMetadata()
     self.info.configurable = true
 end
 
-function CreDocument:loadDocument()
-    if not self._loaded then
-        self._document:loadDocument(self.file)
-        self._loaded = true
-    end
-end
-
 function CreDocument:render()
-    -- load document before rendering
-    self:loadDocument()
     -- set visible page count in landscape
     if math.max(Screen:getWidth(), Screen:getHeight()) / Screen:getDPI()
         < DCREREADER_TWO_PAGE_THRESHOLD then
@@ -160,7 +162,6 @@ end
 
 function CreDocument:getCoverPageImage()
     -- don't need to render document in order to get cover image
-    self:loadDocument()
     local data, size = self._document:getCoverPageImageData()
     if data and size then
         local Mupdf = require("ffi/mupdf")

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -18,7 +18,6 @@ local CreDocument = Document:new{
     PAGE_VIEW_MODE = 1,
 
     _document = false,
-    _loaded = false,
 
     line_space_percent = 100,
     default_font = G_reader_settings:readSetting("cre_font") or "Noto Serif",
@@ -108,8 +107,18 @@ function CreDocument:init()
 
     -- set fallback font face
     self._document:setStringProperty("crengine.font.fallback.face", self.fallback_font)
-self._document:setStringProperty("font.face.default", self.default_font)
-self._document:loadDocument(self.file)
+
+    -- setting a default font before loading document actually do prevent
+    -- some crashes
+    self._document:setStringProperty("font.face.default", self.default_font)
+
+    -- Make crengine actually parse the document now, so we can
+    -- return an error if it is not recognized (instead of segfaulting
+    -- when calling other methods on self._document)
+    if not self._document:loadDocument(self.file) then
+        self._document:close()
+        error("cre:loadDocument() failed")
+    end
 
     self.is_open = true
     self.info.has_pages = false
@@ -117,16 +126,7 @@ self._document:loadDocument(self.file)
     self.info.configurable = true
 end
 
-function CreDocument:loadDocument()
-    if not self._loaded then
-        self._document:loadDocument(self.file)
-        self._loaded = true
-    end
-end
-
 function CreDocument:render()
-    -- load document before rendering
-    self:loadDocument()
     -- set visible page count in landscape
     if math.max(Screen:getWidth(), Screen:getHeight()) / Screen:getDPI()
         < DCREREADER_TWO_PAGE_THRESHOLD then
@@ -162,7 +162,6 @@ end
 
 function CreDocument:getCoverPageImage()
     -- don't need to render document in order to get cover image
-    self:loadDocument()
     local data, size = self._document:getCoverPageImageData()
     if data and size then
         local Mupdf = require("ffi/mupdf")

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -109,6 +109,7 @@ function CreDocument:init()
     -- set fallback font face
     self._document:setStringProperty("crengine.font.fallback.face", self.fallback_font)
 self._document:setStringProperty("font.face.default", self.default_font)
+self._document:loadDocument(self.file)
 
     self.is_open = true
     self.info.has_pages = false

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -168,7 +168,7 @@ end
 function CreDocument:getCoverPageImage()
     -- don't need to render document in order to get cover image
     if not self:loadDocument() then
-        return nil -- no recognized by crengine
+        return nil -- not recognized by crengine
     end
     local data, size = self._document:getCoverPageImageData()
     if data and size then

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -112,6 +112,9 @@ function CreDocument:init()
     -- some crashes
     self._document:setStringProperty("font.face.default", self.default_font)
 
+    -- avoid initial blank page (and make unit tests not fail ?)
+    self._document:setIntProperty("crengine.file.txt.preformatted", 1)
+
     -- Make crengine actually parse the document now, so we can
     -- return an error if it is not recognized (instead of segfaulting
     -- when calling other methods on self._document)

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -363,72 +363,85 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
 
     -- Proceed with extracting info
     local document = DocumentRegistry:openDocument(filepath)
+    local loaded = true
     if document then
-        -- For CreDocuments, we would need:
-        -- document:render()
-        -- to get nb of pages, but the nb obtained by simply calling
-        -- here document:getPageCount() is wrong, often 2 to 3 times
-        -- the nb of pages we see when opening the document (may be some
-        -- other cre settings should be applied before calling render() ?)
-        if not document.render then -- it's not a CreDocument
+        local pages
+        if document.loadDocument then -- needed for crengine
+            -- Setting a default font before loading document
+            -- actually do prevent some crashes
+            document:setFontFace(document.default_font)
+            if not document:loadDocument() then
+                -- failed loading, calling other methods would segfault
+                loaded = false
+            end
+            -- For CreDocument, we would need to call document:render()
+            -- to get nb of pages, but the nb obtained by simply calling
+            -- here document:getPageCount() is wrong, often 2 to 3 times
+            -- the nb of pages we see when opening the document (may be
+            -- some other cre settings should be applied before calling
+            -- render() ?)
+        else
             -- for all others than crengine, we seem to get an accurate nb of pages
-            local pages = document:getPageCount()
+            pages = document:getPageCount()
+        end
+        if loaded then
             dbrow.pages = pages
-        end
-        local props = document:getProps()
-        if next(props) then -- there's at least one item
-            dbrow.has_meta = 'Y'
-        end
-        if props.title and props.title ~= "" then dbrow.title = props.title end
-        if props.authors and props.authors ~= "" then dbrow.authors = props.authors end
-        if props.series and props.series ~= "" then dbrow.series = props.series end
-        if props.language and props.language ~= "" then dbrow.language = props.language end
-        if props.keywords and props.keywords ~= "" then dbrow.keywords = props.keywords end
-        if props.description and props.description ~= "" then dbrow.description = props.description end
-        if cover_specs then
-            local spec_sizetag = cover_specs.sizetag
-            local spec_max_cover_w = cover_specs.max_cover_w
-            local spec_max_cover_h = cover_specs.max_cover_h
+            local props = document:getProps()
+            if next(props) then -- there's at least one item
+                dbrow.has_meta = 'Y'
+            end
+            if props.title and props.title ~= "" then dbrow.title = props.title end
+            if props.authors and props.authors ~= "" then dbrow.authors = props.authors end
+            if props.series and props.series ~= "" then dbrow.series = props.series end
+            if props.language and props.language ~= "" then dbrow.language = props.language end
+            if props.keywords and props.keywords ~= "" then dbrow.keywords = props.keywords end
+            if props.description and props.description ~= "" then dbrow.description = props.description end
+            if cover_specs then
+                local spec_sizetag = cover_specs.sizetag
+                local spec_max_cover_w = cover_specs.max_cover_w
+                local spec_max_cover_h = cover_specs.max_cover_h
 
-            dbrow.cover_fetched = 'Y' -- we had a try at getting a cover
-            -- XXX make picdocument return a blitbuffer of the image
-            local cover_bb = document:getCoverPageImage()
-            if cover_bb then
-                dbrow.has_cover = 'Y'
-                dbrow.cover_sizetag = spec_sizetag
-                -- we should scale down the cover to our max size
-                local cbb_w, cbb_h = cover_bb:getWidth(), cover_bb:getHeight()
-                local scale_factor = 1
-                if cbb_w > spec_max_cover_w or cbb_h > spec_max_cover_h then
-                    -- scale down if bigger than what we will display
-                    scale_factor = math.min(spec_max_cover_w / cbb_w, spec_max_cover_h / cbb_h)
-                    cbb_w = math.min(math.floor(cbb_w * scale_factor)+1, spec_max_cover_w)
-                    cbb_h = math.min(math.floor(cbb_h * scale_factor)+1, spec_max_cover_h)
-                    local new_bb
-                    if self.use_legacy_image_scaling then
-                        new_bb = cover_bb:scale(cbb_w, cbb_h)
-                    else
-                        new_bb = Mupdf.scaleBlitBuffer(cover_bb, cbb_w, cbb_h)
+                dbrow.cover_fetched = 'Y' -- we had a try at getting a cover
+                -- XXX make picdocument return a blitbuffer of the image
+                local cover_bb = document:getCoverPageImage()
+                if cover_bb then
+                    dbrow.has_cover = 'Y'
+                    dbrow.cover_sizetag = spec_sizetag
+                    -- we should scale down the cover to our max size
+                    local cbb_w, cbb_h = cover_bb:getWidth(), cover_bb:getHeight()
+                    local scale_factor = 1
+                    if cbb_w > spec_max_cover_w or cbb_h > spec_max_cover_h then
+                        -- scale down if bigger than what we will display
+                        scale_factor = math.min(spec_max_cover_w / cbb_w, spec_max_cover_h / cbb_h)
+                        cbb_w = math.min(math.floor(cbb_w * scale_factor)+1, spec_max_cover_w)
+                        cbb_h = math.min(math.floor(cbb_h * scale_factor)+1, spec_max_cover_h)
+                        local new_bb
+                        if self.use_legacy_image_scaling then
+                            new_bb = cover_bb:scale(cbb_w, cbb_h)
+                        else
+                            new_bb = Mupdf.scaleBlitBuffer(cover_bb, cbb_w, cbb_h)
+                        end
+                        cover_bb:free()
+                        cover_bb = new_bb
                     end
-                    cover_bb:free()
-                    cover_bb = new_bb
+                    dbrow.cover_w = cbb_w
+                    dbrow.cover_h = cbb_h
+                    dbrow.cover_btype = cover_bb:getType()
+                    dbrow.cover_bpitch = cover_bb.pitch
+                    local cover_data = Blitbuffer.tostring(cover_bb)
+                    cover_bb:free() -- free bb before compressing to save memory
+                    dbrow.cover_datalen = cover_data:len()
+                    local cover_dataz = xutil.zlib_compress(cover_data)
+                    -- release memory used by uncompressed data:
+                    cover_data = nil -- luacheck: no unused
+                    dbrow.cover_dataz = SQ3.blob(cover_dataz) -- cast to blob for sqlite
+                    logger.dbg("cover for", filename, "scaled by", scale_factor, "=>", cbb_w, "x", cbb_h, "(compressed from ", dbrow.cover_datalen, " to ", cover_dataz:len())
                 end
-                dbrow.cover_w = cbb_w
-                dbrow.cover_h = cbb_h
-                dbrow.cover_btype = cover_bb:getType()
-                dbrow.cover_bpitch = cover_bb.pitch
-                local cover_data = Blitbuffer.tostring(cover_bb)
-                cover_bb:free() -- free bb before compressing to save memory
-                dbrow.cover_datalen = cover_data:len()
-                local cover_dataz = xutil.zlib_compress(cover_data)
-                -- release memory used by uncompressed data:
-                cover_data = nil -- luacheck: no unused
-                dbrow.cover_dataz = SQ3.blob(cover_dataz) -- cast to blob for sqlite
-                logger.dbg("cover for", filename, "scaled by", scale_factor, "=>", cbb_w, "x", cbb_h, "(compressed from ", dbrow.cover_datalen, " to ", cover_dataz:len())
             end
         end
         DocumentRegistry:closeDocument(filepath)
-    else
+    end
+    if not loaded then
         dbrow.unsupported = _("not readable by engine")
         dbrow.cover_fetched = 'Y' -- so we don't try again if we're called later if cover_specs
     end

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -364,19 +364,13 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
     -- Proceed with extracting info
     local document = DocumentRegistry:openDocument(filepath)
     if document then
-        if document.loadDocument then -- needed for crengine
-            -- Setting a default font before loading document
-            -- actually do prevent some crashes
-            document:setFontFace(document.default_font)
-            document:loadDocument()
-            -- Not needed for getting props:
-            -- document:render()
-            -- It would be needed to get nb of pages, but the nb obtained
-            -- by simply calling here document:getPageCount() is wrong,
-            -- often 2 to 3 times the nb of pages we see when opening
-            -- the document (may be some other cre settings should be applied
-            -- before calling render() ?)
-        else
+        -- For CreDocuments, we would need:
+        -- document:render()
+        -- to get nb of pages, but the nb obtained by simply calling
+        -- here document:getPageCount() is wrong, often 2 to 3 times
+        -- the nb of pages we see when opening the document (may be some
+        -- other cre settings should be applied before calling render() ?)
+        if not document.render then -- it's not a CreDocument
             -- for all others than crengine, we seem to get an accurate nb of pages
             local pages = document:getPageCount()
             dbrow.pages = pages


### PR DESCRIPTION
If cre:loadDocument() failed recognizing the document format (for example: a .epub in which /mimetype file is absent - crengine looks for this file in a zip to consider it a valid epub), koreader would still keep calling other methods on it, which would make crengine segfaults. With this, we can properly return an error
if document opening failed, so we never call other methods.
Will need a base bump for https://github.com/koreader/koreader-base/pull/582