### PR TITLE
Add info when copy or cut file

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -566,8 +566,15 @@ function FileManager:pasteHere(file)
         local basename = util.basename(self.clipboard)
         local mode = lfs.attributes(dest .."/" .. basename, "mode")
         if mode == "file" or mode == "directory" then
+            local text
+            if mode == "file" then
+                text = T(_("The file %1 already exists. Do you want to overwrite it?"), basename)
+            else
+                text = T(_("The directory %1 already exists. Do you want to overwrite it?"), basename)
+            end
+
             UIManager:show(ConfirmBox:new {
-                text = T(_("The %1 %2 already exists. Do you want to overwrite it?"), mode, basename),
+                text = text,
                 ok_text = _("Overwrite"),
                 ok_callback = function()
                     info_file()


### PR DESCRIPTION
Adding missing information after copying or cutting in FileManager.
Adding confirm when file exist in destination location.

![koreader_045](https://user-images.githubusercontent.com/22982594/34470297-d5ed7416-ef2e-11e7-96d6-4f04bab69237.png)
![koreader_044](https://user-images.githubusercontent.com/22982594/34470299-d8fe1c96-ef2e-11e7-86c3-693be6fc425e.png)
