### PR TITLE
screensaver: change default & show messages on reboot and poweroff

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -71,7 +71,7 @@ return {
     {
         text = _("Use message as screensaver"),
         checked_func = function()
-            if screensaverType() == "message" then
+            if screensaverType() == "message" or screensaverType() == nil then
                 return true
             else
                 return false
@@ -84,7 +84,7 @@ return {
     {
         text = _("Leave screen as it is"),
         checked_func = function()
-            if screensaverType() == nil or screensaverType() == "disable" then
+            if screensaverType() == "disable" then
                 return true
             else
                 return false


### PR DESCRIPTION
Use "message" as the default for screensaver (instead of "disable") (https://github.com/koreader/koreader/pull/3535#issuecomment-353337143)

On Kobo 
Fix: display message on poweroff or reboot (https://github.com/koreader/koreader/pull/3535#issuecomment-352355865)
Allows for overwritting these default messages with the classic screensaver settings, by just prepending "poweroff_" or "reboot_" to them. (https://github.com/koreader/koreader/pull/3535#issuecomment-352498497)

So one can manually add to its settings.reader.lua:
```
"poweroff_screensaver_type" = "random_image" or "message", "cover", "bookstatus", "readingprogress", "disable",
"poweroff_screensaver_dir" = "path to same as screensaver_dir or alternate dir for poweroff image(s)",
"poweroff_screensaver_message" = "message to use instead of Powered off",
```
```
"reboot_screensaver_type" = "random_image" or "message", "cover", "bookstatus", "readingprogress", "disable",
"reboot_screensaver_dir" = "path to same as screensaver_dir or alternate dir for reboot image(s)",
"reboot_screensaver_message" = "message to use instead of Rebooting...",
```

(A bit too much work to add these to menus...)

