### PR TITLE
kodev: two small fixes

### DIFF
--- a/kodev
+++ b/kodev
@@ -125,6 +125,8 @@ usage: build <OPTIONS> <TARGET>
 OPTIONS:
 
     -v, --verbose   Build in verbose mode.
+    --debug         include debugging symbols (default for emulator)
+    --no-debug      no debugging symbols (default for target devices)
 
 TARGET:
 ${SUPPORTED_TARGETS}"
@@ -139,6 +141,14 @@ ${SUPPORTED_TARGETS}"
             -h | --help)
                 echo "${BUILD_HELP_MSG}"
                 exit 0
+                ;;
+            --no-debug)
+                export KODEBUG=
+                KODEBUG_NO_DEFAULT=1
+                ;;
+            --debug)
+                export KODEBUG=1
+                KODEBUG_NO_DEFAULT=1
                 ;;
             *)
                 echo "ERROR: unknown option \"$PARAM\""
@@ -207,9 +217,10 @@ ${SUPPORTED_TARGETS}"
             assert_ret_zero $?
             ;;
         *)
-            # As kodev-run (to run the emulator) builds by default a debug build,
-            # let's do that here too.
-            export KODEBUG=1
+            if [ -z "${KODEBUG_NO_DEFAULT+x}" ]; then # no explicite --debug / --no-debug
+                # Builds by default a debug build, as kodev-run does
+                export KODEBUG=1
+            fi
             make
             assert_ret_zero $? "Failed to build emulator! Try run with -v for more information."
             setup_env

--- a/kodev
+++ b/kodev
@@ -207,6 +207,9 @@ ${SUPPORTED_TARGETS}"
             assert_ret_zero $?
             ;;
         *)
+            # As kodev-run (to run the emulator) builds by default a debug build,
+            # let's do that here too.
+            export KODEBUG=1
             make
             assert_ret_zero $? "Failed to build emulator! Try run with -v for more information."
             setup_env
@@ -546,14 +549,14 @@ TARGET:
                 CATCHSEGV=$(which catchsegv)
             fi
 
-            KOREADER_COMMAND="${CATCHSEGV} ./reader.lua -d ${args}"
+            KOREADER_COMMAND="${CATCHSEGV} ./reader.lua -d"
 
             if [ ! -z "${gdb}" ]; then
-                KOREADER_COMMAND="${gdb} ./luajit reader.lua -d ${args}"
+                KOREADER_COMMAND="${gdb} ./luajit reader.lua -d"
             fi
 
             if [ ! -z "${valgrind}" ]; then
-                KOREADER_COMMAND="${valgrind} ./luajit reader.lua -d ${args}"
+                KOREADER_COMMAND="${valgrind} ./luajit reader.lua -d"
             fi
 
             echo "[*] Running KOReader with arguments: $*..."
@@ -564,6 +567,7 @@ TARGET:
                     args="$*"
                     [[ $args != /* ]] && args="${CURDIR}/${args}"
                 fi
+                KOREADER_COMMAND="$KOREADER_COMMAND ${args}"
 
                 RETURN_VALUE=85
                 while [ $RETURN_VALUE -eq 85 ]; do

--- a/kodev
+++ b/kodev
@@ -217,8 +217,8 @@ ${SUPPORTED_TARGETS}"
             assert_ret_zero $?
             ;;
         *)
-            if [ -z "${KODEBUG_NO_DEFAULT+x}" ]; then # no explicite --debug / --no-debug
-                # Builds by default a debug build, as kodev-run does
+            if [ -z "${KODEBUG_NO_DEFAULT+x}" ]; then # no explicit --debug / --no-debug
+                # builds a debug build by default, like kodev-run
                 export KODEBUG=1
             fi
             make


### PR DESCRIPTION
- kodev-run: fix use of $args (see https://github.com/koreader/koreader/pull/3379#issuecomment-346462122)
- kodev-build: build the emulator in debug mode, for consistency with kodev-run (see https://github.com/koreader/koreader/pull/3439#issuecomment-354370470)