### PR TITLE
HTML dict: fix continuous scroll with tap

### DIFF
--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -128,7 +128,7 @@ function ScrollHtmlWidget:onTapScrollText(arg, ges)
             return true
         end
     else
-        if self.htmlbox_widget.page_number <= self.htmlbox_widget.page_count then
+        if self.htmlbox_widget.page_number < self.htmlbox_widget.page_count then
             self:scrollText(1)
             return true
         end


### PR DESCRIPTION
Continuous scroll with tap (when you reach bottom of definition, tap leads you to the next definition) was working on text definitions, but not on html definitions