### PR TITLE
Wrap names and configure number of items per page

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -148,6 +148,7 @@ function FileManager:init()
         is_popout = false,
         is_borderless = true,
         has_close_button = true,
+        perpage = G_reader_settings:readSetting("items_per_page"),
         file_filter = function(filename)
             if DocumentRegistry:getProvider(filename) then
                 return true
@@ -477,8 +478,8 @@ function FileManager:onClose()
     return true
 end
 
-function FileManager:onRefresh()
-    self.file_chooser:refreshPath()
+function FileManager:onRefresh(value)
+    self.file_chooser:refreshPath(value)
     return true
 end
 

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -478,8 +478,8 @@ function FileManager:onClose()
     return true
 end
 
-function FileManager:onRefresh(value)
-    self.file_chooser:refreshPath(value)
+function FileManager:onRefresh()
+    self.file_chooser:refreshPath()
     return true
 end
 

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -152,6 +152,7 @@ function FileSearcher:showSearchResults()
         show_parent = menu_container,
         onMenuHold = self.onMenuHold,
         cface = Font:getFace("smallinfofont"),
+        perpage = G_reader_settings:readSetting("items_per_page") or 14,
         _manager = self,
     }
     table.insert(menu_container, self.search_menu)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -91,6 +91,26 @@ function FileManagerMenu:setUpdateItemTable()
         checked_func = function() return self.ui.file_chooser.show_hidden end,
         callback = function() self.ui:toggleHiddenFiles() end
     }
+    self.menu_items.items_per_page = {
+        text = _("Items per page"),
+        callback = function()
+            local SpinWidget = require("ui/widget/spinwidget")
+            local curr_items = G_reader_settings:readSetting("items_per_page") or 14
+            local items = SpinWidget:new{
+                width = Screen:getWidth() * 0.6,
+                value = curr_items,
+                value_min = 6,
+                value_max = 24,
+                ok_text = _("Set items"),
+                title_text =  _("Items per page"),
+                callback = function(spin)
+                    G_reader_settings:saveSetting("items_per_page", spin.value)
+                    self.ui:onRefresh(true)
+                end
+            }
+            UIManager:show(items)
+        end
+    }
     self.menu_items.sort_by = self.ui:getSortingMenuTable()
     self.menu_items.reverse_sorting = {
         text = _("Reverse sorting"),

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -105,7 +105,7 @@ function FileManagerMenu:setUpdateItemTable()
                 title_text =  _("Items per page"),
                 callback = function(spin)
                     G_reader_settings:saveSetting("items_per_page", spin.value)
-                    self.ui:onRefresh(true)
+                    self.ui:onRefresh()
                 end
             }
             UIManager:show(items)

--- a/frontend/apps/filemanager/filemanagersetdefaults.lua
+++ b/frontend/apps/filemanager/filemanagersetdefaults.lua
@@ -91,6 +91,7 @@ function SetDefaults:init()
         width = Screen:getWidth()-15,
         height = Screen:getHeight()-15,
         cface = Font:getFace("smallinfofont"),
+        perpage = G_reader_settings:readSetting("items_per_page") or 14,
         show_parent = menu_container,
         _manager = self,
     }

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -218,6 +218,7 @@ function ReaderBookmark:onShowBookmark()
         width = Screen:getWidth(),
         height = Screen:getHeight(),
         cface = Font:getFace("x_smallinfofont"),
+        line_color = require("ffi/blitbuffer").COLOR_WHITE,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -218,6 +218,7 @@ function ReaderBookmark:onShowBookmark()
         width = Screen:getWidth(),
         height = Screen:getHeight(),
         cface = Font:getFace("x_smallinfofont"),
+        perpage = G_reader_settings:readSetting("items_per_page") or 14,
         line_color = require("ffi/blitbuffer").COLOR_WHITE,
         on_close_ges = {
             GestureRange:new{

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -317,6 +317,8 @@ function ReaderToc:onShowToc()
         width = Screen:getWidth(),
         height = Screen:getHeight(),
         cface = Font:getFace("x_smallinfofont"),
+        single_line = true,
+        perpage = G_reader_settings:readSetting("items_per_page") or 14,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -319,6 +319,7 @@ function ReaderToc:onShowToc()
         cface = Font:getFace("x_smallinfofont"),
         single_line = true,
         perpage = G_reader_settings:readSetting("items_per_page") or 14,
+        line_color = require("ffi/blitbuffer").COLOR_WHITE,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -8,6 +8,7 @@ local order = {
     setting = {
         "filemanager_display_mode",
         "show_hidden_files",
+        "items_per_page",
         "----------------------------",
         "sort_by",
         "reverse_sorting",

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -34,6 +34,7 @@ local FileChooser = Menu:extend{
     collate = "strcoll", -- or collate = "access",
     reverse_collate = false,
     path_items = {}, -- store last browsed location(item index) for each path
+    perpage = G_reader_settings:readSetting("items_per_page"),
 }
 
 function FileChooser:init()
@@ -221,7 +222,10 @@ function FileChooser:updateItems(select_number)
     self.path_items[self.path] = (self.page - 1) * self.perpage + (select_number or 1)
 end
 
-function FileChooser:refreshPath()
+function FileChooser:refreshPath(update_perpage)
+    if update_perpage then
+        self.perpage = G_reader_settings:readSetting("items_per_page")
+    end
     local itemmatch = nil
     if self.focused_path then
         itemmatch = {path = self.focused_path}

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -222,10 +222,8 @@ function FileChooser:updateItems(select_number)
     self.path_items[self.path] = (self.page - 1) * self.perpage + (select_number or 1)
 end
 
-function FileChooser:refreshPath(update_perpage)
-    if update_perpage then
-        self.perpage = G_reader_settings:readSetting("items_per_page")
-    end
+function FileChooser:refreshPath()
+    self.perpage = G_reader_settings:readSetting("items_per_page")
     local itemmatch = nil
     if self.focused_path then
         itemmatch = {path = self.focused_path}

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -223,7 +223,6 @@ function FileChooser:updateItems(select_number)
 end
 
 function FileChooser:refreshPath()
-    self.perpage = G_reader_settings:readSetting("items_per_page")
     local itemmatch = nil
     if self.focused_path then
         itemmatch = {path = self.focused_path}

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -476,6 +476,7 @@ local Menu = FocusManager:new{
 }
 
 function Menu:_recalculateDimen()
+    self.perpage = G_reader_settings:readSetting("items_per_page") or 14
     self.span_width = 0
     self.dimen.w = self.width
     self.dimen.h = self.height

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -311,7 +311,7 @@ function MenuItem:init()
     }
 
     self._underline_container = UnderlineContainer:new{
-        color = Blitbuffer.COLOR_GREY,
+        color = self.line_color,
         linesize = self.linesize,
         vertical_align = "center",
         padding = 0,
@@ -472,6 +472,7 @@ local Menu = FocusManager:new{
     close_callback = nil,
     linesize = Size.line.medium,
     perpage = G_reader_settings:readSetting("items_per_page") or 14,
+    line_color = Blitbuffer.COLOR_GREY,
 }
 
 function Menu:_recalculateDimen()
@@ -797,6 +798,7 @@ function Menu:updateItems(select_number)
                 menu = self,
                 linesize = self.linesize,
                 single_line = self.single_line,
+                line_color = self.line_color,
             }
             table.insert(self.item_group, item_tmp)
             -- this is for focus manager

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -357,7 +357,7 @@ function MenuItem:onFocus()
 end
 
 function MenuItem:onUnfocus()
-    self._underline_container.color = Blitbuffer.COLOR_WHITE
+    self._underline_container.color = self.line_color
     self.key_events = {}
     return true
 end

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -1,0 +1,201 @@
+local Blitbuffer = require("ffi/blitbuffer")
+local ButtonTable = require("ui/widget/buttontable")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local CloseButton = require("ui/widget/closebutton")
+local Device = require("device")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local Font = require("ui/font")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local LineWidget = require("ui/widget/linewidget")
+local OverlapGroup = require("ui/widget/overlapgroup")
+local NumberPickerWidget = require("ui/widget/numberpickerwidget")
+local Size = require("ui/size")
+local TextWidget = require("ui/widget/textwidget")
+local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+local Screen = Device.screen
+
+local SpinWidget = InputContainer:new{
+    title_face = Font:getFace("x_smalltfont"),
+    width = Screen:getWidth() * 0.95,
+    height = Screen:getHeight(),
+    value = 1,
+    value_max = 20,
+    value_min = 0,
+    ok_text = _("OK"),
+    cancel_text = _("Cancel"),
+}
+
+function SpinWidget:init()
+    self.medium_font_face = Font:getFace("ffont")
+    self.light_bar = {}
+    self.screen_width = Screen:getWidth()
+    self.screen_height = Screen:getHeight()
+    if Device:hasKeys() then
+        self.key_events = {
+            Close = { {"Back"}, doc = "close spin widget" }
+        }
+    end
+    if Device:isTouchDevice() then
+        self.ges_events = {
+            TapClose = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = Geom:new{
+                        w = self.screen_width,
+                        h = self.screen_height,
+                    }
+                },
+            },
+         }
+    end
+    self:update()
+end
+
+function SpinWidget:update()
+    local value_widget = NumberPickerWidget:new{
+        show_parent = self,
+        width = self.screen_width * 0.2,
+        value = self.value,
+        value_min = self.value_min,
+        value_max = self.value_max,
+        value_step = 1,
+        value_hold_step = 4,
+    }
+    local value_group = HorizontalGroup:new{
+        align = "center",
+        value_widget,
+    }
+
+    local value_title = FrameContainer:new{
+        padding = Size.padding.default,
+        margin = Size.margin.title,
+        bordersize = 0,
+        TextWidget:new{
+            text = self.title_text,
+            face = self.title_face,
+            bold = true,
+            width = self.width,
+        },
+    }
+    local value_line = LineWidget:new{
+        dimen = Geom:new{
+            w = self.width,
+            h = Size.line.thick,
+        }
+    }
+    local value_bar = OverlapGroup:new{
+        dimen = {
+            w = self.width,
+            h = value_title:getSize().h
+        },
+        value_title,
+        CloseButton:new{ window = self, padding_top = Size.margin.title, },
+    }
+    local buttons = {
+        {
+            {
+                text = self.cancel_text,
+                callback = function()
+                    self:onClose()
+                end,
+            },
+            {
+                text = self.ok_text,
+                callback = function()
+                    if self.callback then
+                        self.value = value_widget:getValue()
+                        self:callback(self)
+                    end
+                    self:onClose()
+                end,
+            },
+        }
+    }
+
+    local ok_cancel_buttons = ButtonTable:new{
+        width = self.width - 2*Size.padding.default,
+        buttons = buttons,
+        zero_sep = true,
+        show_parent = self,
+    }
+
+    self.spin_frame = FrameContainer:new{
+        radius = Size.radius.window,
+        padding = 0,
+        margin = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        VerticalGroup:new{
+            align = "left",
+            value_bar,
+            value_line,
+            CenterContainer:new{
+                dimen = Geom:new{
+                    w = self.width,
+                    h = self.screen_height * 0.25,
+                },
+                value_group
+            },
+            CenterContainer:new{
+                dimen = Geom:new{
+                    w = self.width,
+                    h = ok_cancel_buttons:getSize().h,
+                },
+                ok_cancel_buttons
+            }
+        }
+    }
+    self[1] = WidgetContainer:new{
+        align = "center",
+        dimen =Geom:new{
+            x = 0, y = 0,
+            w = self.screen_width,
+            h = self.screen_height,
+        },
+        FrameContainer:new{
+            bordersize = 0,
+            self.spin_frame,
+        }
+    }
+    UIManager:setDirty(self, function()
+        return "ui", self.spin_frame.dimen
+    end)
+end
+
+function SpinWidget:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "partial", self.spin_frame.dimen
+    end)
+    return true
+end
+
+function SpinWidget:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self.spin_frame.dimen
+    end)
+    return true
+end
+
+function SpinWidget:onAnyKeyPressed()
+    UIManager:close(self)
+    return true
+end
+
+function SpinWidget:onTapClose(arg, ges_ev)
+    if ges_ev.pos:notIntersectWith(self.spin_frame.dimen) then
+        self:onClose()
+    end
+    return true
+end
+
+function SpinWidget:onClose()
+    UIManager:close(self)
+    return true
+end
+
+return SpinWidget

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -137,7 +137,7 @@ function SpinWidget:update()
             CenterContainer:new{
                 dimen = Geom:new{
                     w = self.width,
-                    h = self.screen_height * 0.25,
+                    h = value_group:getSize().h + self.screen_height * 0.1,
                 },
                 value_group
             },


### PR DESCRIPTION
Close: #2013 and #3488

+ Allow filenames to wrap so that we can see the full name
+ Configure number of items per page (from 6 to 24) - default is 14
+ The font size is calculated depending on number of items
+ Used for File browser, History, Search Result, Table of contents (only single line), File chooser, OPDS catalog

![koreader_052](https://user-images.githubusercontent.com/22982594/34785279-ee54c7b2-f630-11e7-8fdb-e360a53362cb.png)
![koreader_053](https://user-images.githubusercontent.com/22982594/34785282-f36bd614-f630-11e7-8de7-113bdcabea3b.png)
![koreader_054](https://user-images.githubusercontent.com/22982594/34785285-f67bbc2a-f630-11e7-9762-86cc3a7c3a2e.png)
![koreader_055](https://user-images.githubusercontent.com/22982594/34785292-fbc9eefe-f630-11e7-9bfa-975759fdc6a0.png)
![koreader_056](https://user-images.githubusercontent.com/22982594/34785298-011338e8-f631-11e7-81a0-f1435b07c8c0.png)
![koreader_057](https://user-images.githubusercontent.com/22982594/34785300-049238a2-f631-11e7-9eb1-44c43cd55a4e.png)
![koreader_058](https://user-images.githubusercontent.com/22982594/34785305-07ed591e-f631-11e7-9d54-670124f757a0.png)
![koreader_059](https://user-images.githubusercontent.com/22982594/34785310-0ad5a8f2-f631-11e7-81f0-ac9855c27f58.png)

