### PR TITLE
Do not execute background runner if device is suspended

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -597,7 +597,9 @@ function util.shell_escape(args)
     return table.concat(escaped_args, " ")
 end
 
-table.clear = function(t)  -- luacheck: ignore 122
+--- Clear all the elements from a table without reassignment.
+--- @table t the table to be cleared
+function util.clearTable(t)
     local c = #t
     for i = 0, c do t[i] = nil end
 end

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -597,4 +597,9 @@ function util.shell_escape(args)
     return table.concat(escaped_args, " ")
 end
 
+table.clear = function(t)
+    local c = #t
+    for i = 0, c do t[i] = nil end
+end
+
 return util

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -597,7 +597,7 @@ function util.shell_escape(args)
     return table.concat(escaped_args, " ")
 end
 
-table.clear = function(t)
+table.clear = function(t)  -- luacheck: ignore 122
     local c = #t
     for i = 0, c do t[i] = nil end
 end

--- a/spec/unit/background_runner_spec.lua
+++ b/spec/unit/background_runner_spec.lua
@@ -21,6 +21,11 @@ describe("BackgroundRunner widget tests", function()
         stopBackgroundRunner()
     end)
 
+    before_each(function()
+        require("util")
+        table.clear(PluginShare.backgroundJobs)
+    end)
+
     it("should start job", function()
         local executed = false
         table.insert(PluginShare.backgroundJobs, {
@@ -287,5 +292,66 @@ describe("BackgroundRunner widget tests", function()
         MockTime:increase(2)
         UIManager:handleInput()
         assert.are.equal(2, executed)
+    end)
+
+    it("should stop executing when suspending", function()
+        local executed = 0
+        local job = {
+            when = 1,
+            repeated = true,
+            executable = function()
+                executed = executed + 1
+            end,
+        }
+        table.insert(PluginShare.backgroundJobs, job)
+
+        MockTime:increase(2)
+        UIManager:handleInput()
+        MockTime:increase(2)
+        UIManager:handleInput()
+        assert.are.equal(1, executed)
+        -- Simulate a suspend event.
+        requireBackgroundRunner():onSuspend()
+        for i = 1, 10 do
+            MockTime:increase(2)
+            UIManager:handleInput()
+            assert.are.equal(2, executed)
+        end
+        -- Simulate a resume event.
+        requireBackgroundRunner():onResume()
+        MockTime:increase(2)
+        UIManager:handleInput()
+        assert.are.equal(3, executed)
+        MockTime:increase(2)
+        UIManager:handleInput()
+        assert.are.equal(4, executed)
+    end)
+
+    it("should not start multiple times after multiple onResume", function()
+        local executed = 0
+        local job = {
+            when = 1,
+            repeated = true,
+            executable = function()
+                executed = executed + 1
+            end,
+        }
+        table.insert(PluginShare.backgroundJobs, job)
+
+        for i = 1, 10 do
+            requireBackgroundRunner():onResume()
+        end
+
+        MockTime:increase(2)
+        UIManager:handleInput()
+        MockTime:increase(2)
+        UIManager:handleInput()
+        assert.are.equal(1, executed)
+        MockTime:increase(2)
+        UIManager:handleInput()
+        assert.are.equal(2, executed)
+        MockTime:increase(2)
+        UIManager:handleInput()
+        assert.are.equal(3, executed)
     end)
 end)

--- a/spec/unit/background_runner_spec.lua
+++ b/spec/unit/background_runner_spec.lua
@@ -22,8 +22,7 @@ describe("BackgroundRunner widget tests", function()
     end)
 
     before_each(function()
-        require("util")
-        table.clear(PluginShare.backgroundJobs)
+        require("util").clearTable(PluginShare.backgroundJobs)
     end)
 
     it("should start job", function()


### PR DESCRIPTION
On kindle voyage, the background runner may still execute a while even device has been suspended. Because kindle stock software may wake up the device to update itself. The behavior of the stock software impacts KOReader. For example, the AutoFrontlight plugin may turn on the frontlight unexpectedly.