### PR TITLE
Filemanager - sort by percent of book

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -689,6 +689,8 @@ function FileManager:getSortingMenuTable()
         modification = {_("date modified"), _("Sort by date modified")},
         size = {_("size"), _("Sort by size")},
         type = {_("type"), _("Sort by type")},
+        percent_unopened_first = {_("percent - unopened first"), _("Sort by percent - unopened first")},
+        percent_unopened_last = {_("percent - unopened last"), _("Sort by percent - unopened last")},
     }
     local set_collate_table = function(collate)
         return {
@@ -713,6 +715,8 @@ function FileManager:getSortingMenuTable()
             set_collate_table("modification"),
             set_collate_table("size"),
             set_collate_table("type"),
+            set_collate_table("percent_unopened_first"),
+            set_collate_table("percent_unopened_last"),
         }
     }
 end


### PR DESCRIPTION
I added the option to sort books by reading percent. Two options to choose from:
+ sort books when book not yet open are first listed
+ sort books when book not yet open are last listed

I'm not sure that this will not affect the performance of the file browser. I tested on my Kindle and I didn't notice any decrease in performance.

![koreader_062](https://user-images.githubusercontent.com/22982594/35054013-f2f325d6-fbab-11e7-9cba-0c1eed344aba.png)

![koreader_061](https://user-images.githubusercontent.com/22982594/35054020-f7b6b4a2-fbab-11e7-99bf-49ab3a83f654.png)
