### PR TITLE
Screensaver: for poweroff, use menu settings with added overlay message

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -281,6 +281,15 @@ function ReaderMenu:onCloseReaderMenu()
     return true
 end
 
+function ReaderMenu:onCloseDocument()
+    if Device:supportsScreensaver() then
+        -- Remove the 8th item we added (which cleans up references to document
+        -- and doc_settings embedded in functions)
+        local screensaver_sub_item_table = require("ui/elements/screensaver_menu")
+        table.remove(screensaver_sub_item_table, 8)
+    end
+end
+
 function ReaderMenu:_getTabIndexFromLocation(ges)
     if self.tab_item_table == nil then
         self:setUpdateItemTable()

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -128,58 +128,22 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:supportsScreensaver() then
         local ss_book_settings = {
-            text = _("Current book cover settings"),
+            text = _("Exclude this book's cover from screensaver"),
             enabled_func = function()
                 return not (self.ui == nil or self.ui.document == nil)
                     and G_reader_settings:readSetting('screensaver_type') == "cover"
             end,
-            sub_item_table = {
-                {
-                    text = _("Exclude this book's cover from screensaver"),
-                    checked_func = function()
-                        return self.ui.doc_settings:readSetting("exclude_screensaver") == true
-                    end,
-                    callback = function()
-                        if Screensaver:excluded() then
-                            self.ui.doc_settings:saveSetting("exclude_screensaver", false)
-                        else
-                            self.ui.doc_settings:saveSetting("exclude_screensaver", true)
-                        end
-                        self.ui:saveSettings()
-                    end
-                },
-                {
-                    text = _("Stretch book cover to fit screen"),
-                    checked_func = function()
-                        local settings_stretch_cover = self.ui.doc_settings:readSetting("stretch_cover")
-                        if  settings_stretch_cover == nil and G_reader_settings:readSetting("stretch_cover_default") then
-                            return true
-                        else
-                            return self.ui.doc_settings:readSetting("stretch_cover") == true
-                        end
-                    end,
-                    callback = function()
-                        self.ui.doc_settings:saveSetting("stretch_cover", not Screensaver:stretchCover())
-                        self.ui:saveSettings()
-                    end,
-                    hold_callback = function()
-                        local ConfirmBox = require("ui/widget/confirmbox")
-                        UIManager:show(ConfirmBox:new {
-                            text = _("Stretch all book covers to fit screen?"),
-                            cancel_text = _("Don't stretch"),
-                            cancel_callback = function()
-                                G_reader_settings:delSetting("stretch_cover_default")
-                                return
-                            end,
-                            ok_text = _("Stretch"),
-                            ok_callback = function()
-                                G_reader_settings:saveSetting("stretch_cover_default", true)
-                                return
-                            end,
-                        })
-                    end,
-                },
-            }
+            checked_func = function()
+                return self.ui and self.ui.doc_settings and self.ui.doc_settings:readSetting("exclude_screensaver") == true
+            end,
+            callback = function()
+                if Screensaver:excluded() then
+                    self.ui.doc_settings:saveSetting("exclude_screensaver", false)
+                else
+                    self.ui.doc_settings:saveSetting("exclude_screensaver", true)
+                end
+                self.ui:saveSettings()
+            end
         }
 
         self.menu_items.screensaver = {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -10,7 +10,8 @@ local function lastFile()
         return last_file
     end
 end
-local function messageBackground() return G_reader_settings:isTrue("message_background") end
+local function whiteBackground() return G_reader_settings:isTrue("screensaver_white_background") end
+local function stretchImages() return G_reader_settings:isTrue("screensaver_stretch_images") end
 
 return {
     {
@@ -110,12 +111,17 @@ return {
                 end,
             },
             {
-                text = _("White background in message"),
-                checked_func = function()
-                    return messageBackground()
-                end,
+                text = _("White background behind message and images"),
+                checked_func = whiteBackground,
                 callback = function()
-                    G_reader_settings:saveSetting("message_background", not messageBackground())
+                    G_reader_settings:saveSetting("screensaver_white_background", not whiteBackground())
+                end,
+            },
+            {
+                text = _("Stretch covers and images to fit screen"),
+                checked_func = stretchImages,
+                callback = function()
+                    G_reader_settings:saveSetting("screensaver_stretch_images", not stretchImages())
                 end,
                 separator = true,
             },


### PR DESCRIPTION
Followup to #3572 to have a better default for poweroff/reboot instead of `message`: use the same settings as chosen in menu for Sleep/Suspend, and add to it a small overlay message, so the user can distinguish between suspend (no message) and poweroff (overlay message). (does not work when "Leave screen as is", as we took the shortcut of returning early and not displaying any widget at all).
See https://github.com/koreader/koreader/issues/3610#issuecomment-358059678 (and https://github.com/koreader/koreader/pull/3535#issuecomment-353461264 for the overlay idea,)
Closes #3591. Closes #3610.

Since I made these screenshots, I moved the message to the top right, so it does not hide the bottom widget parts:
<kbd>![screensaver1](https://user-images.githubusercontent.com/24273478/35147551-4cfefcbc-fd0f-11e7-8b2b-a166605ec881.png)</kbd> <kbd>![screensaver2](https://user-images.githubusercontent.com/24273478/35147555-4fa9eb98-fd0f-11e7-91d2-26166baa2b86.png)</kbd> <kbd>![screensaver3](https://user-images.githubusercontent.com/24273478/35147558-5190f82a-fd0f-11e7-8bb4-78ab49f9ebdc.png)</kbd>
