### PR TITLE
Proper page changes using the up and down keys

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -807,7 +807,7 @@ function Menu:updateItems(select_number)
         end -- if i <= self.items
     end -- for c=1, self.perpage
     if self.item_group[1] then
-        if not Device:isTouchDevice() then
+        if not Device:isTouchDevice() or Device:hasKeys() then
             -- only draw underline for nontouch device
             -- reset focus manager accordingly
             self.selected = { x = 1, y = select_number }


### PR DESCRIPTION
On devices with keyboard (also on emulator).
Last item on page + key down = next page and select first item 
First item on page + key up = prev page and select last item