### PR TITLE
metadata: support multiple authors

### DIFF
--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -266,10 +266,11 @@ function BookStatusWidget:genBookInfoGroup()
 
     }
     -- author
-    local text_author = TextWidget:new{
+    local text_author = TextBoxWidget:new{
         text = self.props.authors,
         face = self.small_font_face,
-        padding = Size.padding.default
+        width = width,
+        alignment = "center",
     }
     table.insert(book_meta_info_group,
         CenterContainer:new{

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -145,12 +145,19 @@ function KeyValueItem:init()
         }
     end
 
+    -- self.value may contain some control characters (\n \t...) that would
+    -- be rendered as a square. Replace them with a shorter and nicer '|'.
+    -- (Let self.value untouched, as with Hold, the original value can be
+    -- displayed correctly in TextViewer.)
+    local tvalue = tostring(self.value)
+    tvalue = tvalue:gsub("[\n\t]", "|")
+
     local frame_padding = Size.padding.default
     local frame_internal_width = self.width - frame_padding * 2
     local key_w = frame_internal_width / 2
     local value_w = frame_internal_width / 2
     local key_w_rendered = RenderText:sizeUtf8Text(0, frame_internal_width, self.tface, self.key).x
-    local value_w_rendered = RenderText:sizeUtf8Text(0, frame_internal_width, self.cface, self.value).x
+    local value_w_rendered = RenderText:sizeUtf8Text(0, frame_internal_width, self.cface, tvalue).x
     local space_w_rendered = RenderText:sizeUtf8Text(0, frame_internal_width, self.cface, " ").x
     if key_w_rendered > key_w or value_w_rendered > value_w then
         -- truncate key or value so they fit in one row
@@ -158,10 +165,10 @@ function KeyValueItem:init()
             if key_w_rendered >= value_w_rendered then
                 key_w = frame_internal_width - value_w_rendered
                 self.show_key = RenderText:truncateTextByWidth(self.key, self.tface, frame_internal_width - value_w_rendered)
-                self.show_value = self.value
+                self.show_value = tvalue
             else
                 key_w = key_w_rendered + space_w_rendered
-                self.show_value = RenderText:truncateTextByWidth(self.value, self.cface, frame_internal_width - key_w_rendered,
+                self.show_value = RenderText:truncateTextByWidth(tvalue, self.cface, frame_internal_width - key_w_rendered,
                     false, false, true)
                 self.show_key = self.key
             end
@@ -182,14 +189,14 @@ function KeyValueItem:init()
                 key_w = key_w_rendered + space_w_rendered
             end
             self.show_key = self.key
-            self.show_value = self.value
+            self.show_value = tvalue
         end
     else
         if self.value_align == "right" then
             key_w = frame_internal_width - value_w_rendered
         end
         self.show_key = self.key
-        self.show_value = self.value
+        self.show_value = tvalue
     end
 
     self[1] = FrameContainer:new{

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -405,7 +405,7 @@ function ListMenuItem:update()
                 if authors and authors:find("\n") then
                     authors = util.splitToArray(authors, "\n")
                     if #authors > 2 then
-                        authors = { authors[1], authors[2].."  et al." }
+                        authors = { authors[1], T(_("%1 et al."), authors[2]) }
                     end
                     authors = table.concat(authors, "\n")
                 end

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -399,6 +399,16 @@ function ListMenuItem:update()
             else
                 title = bookinfo.title and bookinfo.title or filename_without_suffix
                 authors = bookinfo.authors
+                -- If multiple authors (crengine separates them with \n), we
+                -- can display them on multiple lines, but limit to 2, and
+                -- append "et al." to the 2nd if there are more
+                if authors and authors:find("\n") then
+                    authors = util.splitToArray(authors, "\n")
+                    if #authors > 2 then
+                        authors = { authors[1], authors[2].."  et al." }
+                    end
+                    authors = table.concat(authors, "\n")
+                end
             end
             -- add Series metadata if requested
             if bookinfo.series then

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -26,6 +26,7 @@ local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
+local T = require("ffi/util").template
 local getMenuText = require("util").getMenuText
 
 local BookInfoManager = require("bookinfomanager")
@@ -143,7 +144,7 @@ function FakeCover:init()
     if authors and authors:find("\n") then
         authors = util.splitToArray(authors, "\n")
         if #authors > 3 then
-            authors = { authors[1], authors[2], authors[3], _("et al.") }
+            authors = { authors[1], authors[2], T(_("%1 et al."), authors[3]) }
         end
         authors = table.concat(authors, "\n")
     end

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -143,7 +143,7 @@ function FakeCover:init()
     if authors and authors:find("\n") then
         authors = util.splitToArray(authors, "\n")
         if #authors > 3 then
-            authors = { authors[1], authors[2], authors[3], "et al." }
+            authors = { authors[1], authors[2], authors[3], _("et al.") }
         end
         authors = table.concat(authors, "\n")
     end

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -23,6 +23,7 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
+local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
 local getMenuText = require("util").getMenuText
@@ -135,6 +136,16 @@ function FakeCover:init()
         title = title:gsub("|", "\n")
         -- Also replace underscores with spaces
         title = title:gsub("_", " ")
+    end
+    -- If multiple authors (crengine separates them with \n), we
+    -- can display them on multiple lines, but limit to 3, and
+    -- append "et al." on a 4th line if there are more
+    if authors and authors:find("\n") then
+        authors = util.splitToArray(authors, "\n")
+        if #authors > 3 then
+            authors = { authors[1], authors[2], authors[3], "et al." }
+        end
+        authors = table.concat(authors, "\n")
     end
 
     -- We build the VerticalGroup widget with decreasing font sizes till


### PR DESCRIPTION
crengine may now give us multiple authors (if multiple `<dc:creator>` in epub metadata) separated by `\n`.
Deal with that where needed. Limit the number of authors displayed in coverbrowser views.
See discussion in #3583. Closes #3583.
Will need a crengine bump for https://github.com/koreader/crengine/pull/93 to get these `\n`.

Should give us:

<kbd>![list_et_al](https://user-images.githubusercontent.com/24273478/35186018-b3da5ee6-fe0d-11e7-895a-5ba3a6cc269e.png)</kbd>

<kbd>![mosaic_et_al](https://user-images.githubusercontent.com/24273478/35186019-b6b6486e-fe0d-11e7-9cae-36baf7b4cd97.png)</kbd>

When Hold on book and using _Book information_:
<kbd>![bookinfo_kvpage](https://user-images.githubusercontent.com/24273478/35186021-b9b6d772-fe0d-11e7-95d3-e549e5ae972a.png)</kbd>

<kbd>![bookinfo_kvpage2](https://user-images.githubusercontent.com/24273478/35186023-bb57af34-fe0d-11e7-8b8d-53e750ec9040.png)</kbd>
(I had to choose a generic separator, as `\n` were displayed as an ugly white square by KeyValuePage - so we lose the `; ` hardcoded for Keywords).

When Hold on truncated metadata to view it with text viewer (we let the original `\n` be)

<kbd>![textviewer](https://user-images.githubusercontent.com/24273478/35186024-be412a0e-fe0d-11e7-912f-68abee2a7241.png)</kbd>

