### PR TITLE
Wikipedia full & epub: swap symbols for H3 and H4

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -574,8 +574,8 @@ end
 -- have a quite consistent size/weight in all fonts.
 local th1_sym = "\xE2\x96\x88"         -- full block (big black rectangle) (never met, only for web page title?)
 local th2_sym = "\xE2\x96\x89"         -- big black square
-local th3_sym = "\xC2\xA0\xE2\x97\x86" -- black diamond (indented, nicer)
-local th4_sym = "\xE2\x97\xA4"         -- black upper left triangle
+local th3_sym = "\xC2\xA0\xE2\x97\xA4" -- black upper left triangle (indented, nicer)
+local th4_sym = "\xE2\x97\x86"         -- black diamond
 local th5_sym = "\xE2\x9C\xBF"         -- black florette
 local th6_sym = "\xE2\x9D\x96"         -- black diamond minus white x
 -- Others available in most fonts
@@ -615,8 +615,8 @@ end
 -- have a quite consistent size/weight in all fonts.
 local h1_sym = "\xE2\x96\x88"     -- full block (big black rectangle) (never met, only for web page title?)
 local h2_sym = "\xE2\x96\x89"     -- big black square
-local h3_sym = "\xE2\x97\x86"     -- black diamond
-local h4_sym = "\xE2\x97\xA4"     -- black upper left triangle
+local h3_sym = "\xE2\x97\xA4"     -- black upper left triangle
+local h4_sym = "\xE2\x97\x86"     -- black diamond
 local h5_sym = "\xE2\x9C\xBF"     -- black florette
 local h6_sym = "\xE2\x9D\x96"     -- black diamond minus white x
 -- Other available ones in most fonts


### PR DESCRIPTION
I added the wikipedia full page one year ago (and Save as epub a bit later), and I'm often a bit confused by the choice of symbols I made for prefixing H3 and H4 headings (there're not many usable symbols available in all fonts to choose from - and they should be the same in the epub that can be read with crengine with user fonts).
There's something in their density/alignment that, I think, is misleading in the feeling of hierarchy we get, and it feels better if we swap them:

before => after - What do you think ?
<kbd>![before](https://user-images.githubusercontent.com/24273478/35221591-fe9bd450-ff7a-11e7-939e-a3ebcf6e9779.png)</kbd> => <kbd>![after](https://user-images.githubusercontent.com/24273478/35221593-00ba702a-ff7b-11e7-8a59-a3de27bb9e9c.png)</kbd>

(headings start with h2 - many h3 and h4 in articles, but hard to find articles with h5, and nearly impossible that include h6)

I think this feels better. Dunno if there are many people that use these wikipedia features, and if they already got used to the existing symbols and if it's really not right to change them one year later :)
