### PR TITLE
Add menu item for toggling auto_book_status

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -23,12 +23,6 @@ function ReaderStatus:init()
     else
         self.total_pages = self.document:getPageCount()
         self.ui.menu:registerToMainMenu(self)
-        -- register event listener if enabled
-        if G_reader_settings:nilOrTrue("auto_book_status") then
-            self.onEndOfBook = function()
-                self:showStatus()
-            end
-        end
     end
 end
 
@@ -39,6 +33,12 @@ function ReaderStatus:addToMainMenu(menu_items)
             self:showStatus()
         end,
     }
+end
+
+function ReaderStatus:onEndOfBook()
+    if G_reader_settings:nilOrTrue("auto_book_status") then
+        self:showStatus()
+    end
 end
 
 function ReaderStatus:showStatus()

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -125,37 +125,51 @@ if Device:isAndroid() then
     table.insert(common_settings.screen.sub_item_table, require("ui/elements/screen_fullscreen_menu_table"))
 end
 
-common_settings.save_document = {
-    text = _("Save document"),
+common_settings.document = {
+    text = _("Document"),
     sub_item_table = {
         {
-            text = _("Prompt"),
-            checked_func = function()
-                local setting = G_reader_settings:readSetting("save_document")
-                return setting == "prompt" or setting == nil
-            end,
-            callback = function()
-                G_reader_settings:delSetting("save_document")
-            end,
+            text = _("Save document (write highlights into PDF)"),
+            sub_item_table = {
+                {
+                    text = _("Prompt"),
+                    checked_func = function()
+                        local setting = G_reader_settings:readSetting("save_document")
+                        return setting == "prompt" or setting == nil
+                    end,
+                    callback = function()
+                        G_reader_settings:delSetting("save_document")
+                    end,
+                },
+                {
+                    text = _("Always"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("save_document")
+                                   == "always"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("save_document", "always")
+                    end,
+                },
+                {
+                    text = _("Disable"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("save_document")
+                                   == "disable"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("save_document", "disable")
+                    end,
+                },
+            },
         },
         {
-            text = _("Always"),
+            text = _("Show book status at end of document "),
             checked_func = function()
-                return G_reader_settings:readSetting("save_document")
-                           == "always"
+                return G_reader_settings:nilOrTrue("auto_book_status")
             end,
             callback = function()
-                G_reader_settings:saveSetting("save_document", "always")
-            end,
-        },
-        {
-            text = _("Disable"),
-            checked_func = function()
-                return G_reader_settings:readSetting("save_document")
-                           == "disable"
-            end,
-            callback = function()
-                G_reader_settings:saveSetting("save_document", "disable")
+                G_reader_settings:flipNilOrTrue("auto_book_status")
             end,
         },
     },

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -23,7 +23,7 @@ local order = {
         "----------------------------",
         "network",
         "screen",
-        "save_document",
+        "document",
         "----------------------------",
         "language",
         "time",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -42,7 +42,7 @@ local order = {
         "network",
         "screen",
         "screensaver",
-        "save_document",
+        "document",
         "----------------------------",
         "language",
         "time",


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/3638#issuecomment-361369153 (and #2363, #2366).  Closes #3638.
Any suggestion for a better `"Save document (write highlights into PDF)"` ?
I understand the setting and menu title was made for a generic _save any stuff that make sense for this document format to the document itself_, but for now, it only works with PDF, and only for saving highlights into the PDF file. (The generic title `Save document` does not give any hint about what this could do, and got me perplexed since I first saw it :)