### PR TITLE
Dict: scroll back with tap: go to bottom of prev definition

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -697,7 +697,13 @@ function DictQuickLookup:onTapCloseDict(arg, ges_ev)
     -- will pop it up for us here when it can't scroll anymore).
     -- This allow for continuous reading of results' definitions with tap.
     if ges_ev.pos.x < Screen:getWidth()/2 then
+        local prev_index = self.dict_index
         self:changeToPrevDict()
+        if self.dict_index ~= prev_index then
+            -- Jump directly to bottom of previous dict definition
+            -- to keep "continuous reading with tap" consistent
+            self.definition_widget[1]:scrollToRatio(1) -- 1 = 100% = bottom
+        end
     else
         self:changeToNextDict()
     end

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -11,7 +11,7 @@ local HorizontalSpan = require("ui/widget/horizontalspan")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
 local VerticalScrollBar = require("ui/widget/verticalscrollbar")
-
+local Math = require("optmath")
 local Input = Device.input
 local Screen = Device.screen
 
@@ -80,6 +80,21 @@ function ScrollHtmlWidget:init()
             ScrollUp = {{Input.group.PgBack}, doc = "scroll up"},
         }
     end
+end
+
+function ScrollHtmlWidget:scrollToRatio(ratio)
+    ratio = math.max(0, math.min(1, ratio)) -- ensure ratio is between 0 and 1 (100%)
+    local page_num = 1 + Math.round((self.htmlbox_widget.page_count - 1) * ratio)
+    if page_num == self.htmlbox_widget.page_number then
+        return
+    end
+    self.htmlbox_widget.page_number = page_num
+    self.v_scroll_bar:set((page_num-1) / self.htmlbox_widget.page_count, page_num / self.htmlbox_widget.page_count)
+    self.htmlbox_widget:freeBb()
+    self.htmlbox_widget:_render()
+    UIManager:setDirty(self.dialog, function()
+        return "partial", self.dimen
+    end)
 end
 
 function ScrollHtmlWidget:scrollText(direction)

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -110,6 +110,14 @@ function ScrollTextWidget:scrollText(direction)
     end)
 end
 
+function ScrollTextWidget:scrollToRatio(ratio)
+    local low, high = self.text_widget:scrollToRatio(ratio)
+    self.v_scroll_bar:set(low, high)
+    UIManager:setDirty(self.dialog, function()
+        return "partial", self.dimen
+    end)
+end
+
 function ScrollTextWidget:onScrollText(arg, ges)
     if ges.direction == "north" then
         self:scrollText(1)

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -26,6 +26,7 @@ local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
+local Math = require("optmath")
 local logger = require("logger")
 local util = require("util")
 local Screen = require("device").screen
@@ -638,6 +639,21 @@ function TextBoxWidget:scrollUp()
         else
             self.virtual_line_num = self.virtual_line_num - visible_line_count
         end
+        self:_renderText(self.virtual_line_num, self.virtual_line_num + visible_line_count - 1)
+    end
+    return (self.virtual_line_num - 1) / #self.vertical_string_list, (self.virtual_line_num - 1 + visible_line_count) / #self.vertical_string_list
+end
+
+function TextBoxWidget:scrollToRatio(ratio)
+    self.image_show_alt_text = nil
+    ratio = math.max(0, math.min(1, ratio)) -- ensure ratio is between 0 and 1 (100%)
+    local visible_line_count = self:getVisLineCount()
+    local page_count = 1 + math.floor((#self.vertical_string_list - 1) / visible_line_count)
+    local page_num = 1 + Math.round((page_count - 1) * ratio)
+    local line_num = 1 + (page_num - 1) * visible_line_count
+    if line_num ~= self.virtual_line_num then
+        self:free()
+        self.virtual_line_num = line_num
         self:_renderText(self.virtual_line_num, self.virtual_line_num + visible_line_count - 1)
     end
     return (self.virtual_line_num - 1) / #self.vertical_string_list, (self.virtual_line_num - 1 + visible_line_count) / #self.vertical_string_list


### PR DESCRIPTION
When using Tap to scroll dict definitions for continuous reading, if one misses the bottom by taping too much and happen on the next definition, _Tap on left part of definition_ to go one page up would bring you to top of previous definition, and you would have to tap tap tap to reach again bottom.
This PR makes it jump to bottom of it, which feels more natural and expected.
One can still use swipe left to go to top of prev definition.
