### PR TITLE
TOC, bookmarks: remember current page + Search: only remember initial page

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -241,6 +241,7 @@ function ReaderBookmark:onShowBookmark()
     -- buid up menu widget method as closure
     local bookmark = self
     function bm_menu:onMenuChoice(item)
+        bookmark.ui.link:addCurrentLocationToStack()
         bookmark:gotoBookmark(item.page)
     end
 

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -199,6 +199,15 @@ function ReaderLink:onTap(_, ges)
     end
 end
 
+--- Remember current location so we can go back to it
+function ReaderLink:addCurrentLocationToStack()
+    if self.ui.document.info.has_pages then
+        table.insert(self.location_stack, self.ui.paging:getBookLocation())
+    else
+        table.insert(self.location_stack, self.ui.rolling:getBookLocation())
+    end
+end
+
 --- Goes to link.
 function ReaderLink:onGotoLink(link)
     logger.dbg("onGotoLink:", link)
@@ -206,7 +215,7 @@ function ReaderLink:onGotoLink(link)
         -- internal pdf links have a "page" attribute, while external ones have an "uri" attribute
         if link.page then -- Internal link
             logger.dbg("Internal link:", link)
-            table.insert(self.location_stack, self.ui.paging:getBookLocation())
+            self:addCurrentLocationToStack()
             self.ui:handleEvent(Event:new("GotoPage", link.page + 1))
             return true
         end
@@ -220,7 +229,7 @@ function ReaderLink:onGotoLink(link)
         -- which accepts both of the above legitimate xpointer as input.
         if self.ui.document:isXPointerInDocument(link) then
             logger.dbg("Internal link:", link)
-            table.insert(self.location_stack, self.ui.rolling:getBookLocation())
+            self:addCurrentLocationToStack()
             self.ui:handleEvent(Event:new("GotoXPointer", link))
             return true
         end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -209,13 +209,15 @@ function ReaderLink:addCurrentLocationToStack()
 end
 
 --- Goes to link.
-function ReaderLink:onGotoLink(link)
+function ReaderLink:onGotoLink(link, neglect_current_location)
     logger.dbg("onGotoLink:", link)
     if self.ui.document.info.has_pages then
         -- internal pdf links have a "page" attribute, while external ones have an "uri" attribute
         if link.page then -- Internal link
             logger.dbg("Internal link:", link)
-            self:addCurrentLocationToStack()
+            if not neglect_current_location then
+                self:addCurrentLocationToStack()
+            end
             self.ui:handleEvent(Event:new("GotoPage", link.page + 1))
             return true
         end
@@ -229,7 +231,9 @@ function ReaderLink:onGotoLink(link)
         -- which accepts both of the above legitimate xpointer as input.
         if self.ui.document:isXPointerInDocument(link) then
             logger.dbg("Internal link:", link)
-            self:addCurrentLocationToStack()
+            if not neglect_current_location then
+                self:addCurrentLocationToStack()
+            end
             self.ui:handleEvent(Event:new("GotoXPointer", link))
             return true
         end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -28,16 +28,19 @@ function ReaderSearch:addToMainMenu(menu_items)
 end
 
 function ReaderSearch:onShowSearchDialog(text)
+    local neglect_current_location = false
     local do_search = function(search_func, _text, param)
         return function()
             local res = search_func(self, _text, param)
             if res then
                 if self.ui.document.info.has_pages then
-                    self.ui.link:onGotoLink({page = res.page - 1})
+                    self.ui.link:onGotoLink({page = res.page - 1}, neglect_current_location)
                     self.view.highlight.temp[res.page] = res
                 else
-                    self.ui.link:onGotoLink(res[1].start)
+                    self.ui.link:onGotoLink(res[1].start, neglect_current_location)
                 end
+                -- Don't add result pages to location ("Go back") stack
+                neglect_current_location = true
             end
         end
     end

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -345,6 +345,7 @@ function ReaderToc:onShowToc()
             item.state.callback()
         else
             toc_menu:close_callback()
+            self.ui.link:addCurrentLocationToStack()
             self.ui:handleEvent(Event:new("GotoPage", item.page))
         end
     end


### PR DESCRIPTION
When selecting an item in TOC and bookmarks list and going to its page, remember current page so we can go back to it. See #3645. Closes #3645.

When in Full text search: only add the initial page to the location stack - and not every search result's page - so we can easily go back to it. See #3616 Issue 1).