### PR TITLE
[feat] DocumentRegistry: add getProviders() and preferred by weight

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -26,6 +26,7 @@ local CreDocument = Document:new{
     fallback_font = G_reader_settings:readSetting("fallback_font") or "Noto Sans CJK SC",
     default_css = "./data/cr3.css",
     options = CreOptions,
+    provider_name = "Cool Reader Engine",
 }
 
 -- NuPogodi, 20.05.12: inspect the zipfile content
@@ -524,27 +525,31 @@ function CreDocument:findText(pattern, origin, reverse, caseInsensitive)
 end
 
 function CreDocument:register(registry)
-    registry:addProvider("azw", "application/azw", self)
-    registry:addProvider("epub", "application/epub", self)
-    registry:addProvider("chm", "application/chm", self)
-    registry:addProvider("doc", "application/doc", self)
-    registry:addProvider("fb2", "application/fb2", self)
-    registry:addProvider("fb2.zip", "application/zip", self)
-    registry:addProvider("html", "application/html", self)
-    registry:addProvider("html.zip", "application/zip", self)
-    registry:addProvider("htm", "application/htm", self)
-    registry:addProvider("htm.zip", "application/zip", self)
+    registry:addProvider("azw", "application/vnd.amazon.mobi8-ebook", self, 90)
+    registry:addProvider("chm", "application/vnd.ms-htmlhelp", self, 90)
+    registry:addProvider("doc", "application/msword", self, 90)
+    registry:addProvider("epub", "application/epub+zip", self, 100)
+    registry:addProvider("fb2", "application/fb2", self, 90)
+    registry:addProvider("fb2.zip", "application/zip", self, 90)
+    registry:addProvider("htm", "text/html", self, 100)
+    registry:addProvider("html", "text/html", self, 100)
+    registry:addProvider("htm.zip", "application/zip", self, 100)
+    registry:addProvider("html.zip", "application/zip", self, 100)
     registry:addProvider("log", "text/plain", self)
     registry:addProvider("log.zip", "application/zip", self)
     registry:addProvider("md", "text/plain", self)
     registry:addProvider("md.zip", "application/zip", self)
-    registry:addProvider("mobi", "application/mobi", self)
-    registry:addProvider("pdb", "application/pdb", self)
-    registry:addProvider("prc", "application/prc", self)
+    registry:addProvider("mobi", "application/x-mobipocket-ebook", self, 90)
+    -- Palmpilot Document File
+    registry:addProvider("pdb", "application/vnd.palm", self, 90)
+    -- Palmpilot Resource File
+    registry:addProvider("prc", "application/vnd.palm", self)
     registry:addProvider("tcr", "application/tcr", self)
-    registry:addProvider("txt", "text/plain", self)
-    registry:addProvider("txt.zip", "application/zip", self)
-    registry:addProvider("rtf", "application/rtf", self)
+    registry:addProvider("txt", "text/plain", self, 90)
+    registry:addProvider("txt.zip", "application/zip", self, 90)
+    registry:addProvider("rtf", "application/rtf", self, 90)
+    registry:addProvider("xhtml", "application/xhtml+xml", self, 90)
+    registry:addProvider("zip", "application/zip", self, 10)
 end
 
 return CreDocument

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -12,6 +12,7 @@ local DjvuDocument = Document:new{
     options = KoptOptions,
     koptinterface = nil,
     color_bb_type = Blitbuffer.TYPE_BBRGB24,
+    provider_name = "DjVu Libre",
 }
 
 -- check DjVu magic string to validate
@@ -136,8 +137,8 @@ function DjvuDocument:drawPage(target, x, y, rect, pageno, zoom, rotation, gamma
 end
 
 function DjvuDocument:register(registry)
-    registry:addProvider("djvu", "application/djvu", self)
-    registry:addProvider("djv", "application/djvu", self)
+    registry:addProvider("djv", "image/vnd.djvu", self, 100)
+    registry:addProvider("djvu", "image/vnd.djvu", self, 100)
 end
 
 return DjvuDocument

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -13,6 +13,7 @@ local PdfDocument = Document:new{
     dc_null = DrawContext.new(),
     options = KoptOptions,
     koptinterface = nil,
+    provider_name = "MuPDF",
 }
 
 function PdfDocument:init()
@@ -237,11 +238,40 @@ function PdfDocument:drawPage(target, x, y, rect, pageno, zoom, rotation, gamma,
 end
 
 function PdfDocument:register(registry)
-    registry:addProvider("pdf", "application/pdf", self)
-    registry:addProvider("cbz", "application/cbz", self)
-    registry:addProvider("cbt", "application/cbt", self)
-    registry:addProvider("zip", "application/zip", self)
-    registry:addProvider("xps", "application/xps", self)
+    --- Document types ---
+    registry:addProvider("cbt", "application/vnd.comicbook+tar", self, 100)
+    registry:addProvider("cbz", "application/vnd.comicbook+zip", self, 100)
+    registry:addProvider("epub", "application/epub+zip", self, 50)
+    registry:addProvider("fb2", "application/fb2", self, 80)
+    registry:addProvider("htm", "text/html", self, 90)
+    registry:addProvider("html", "text/html", self, 90)
+    registry:addProvider("pdf", "application/pdf", self, 100)
+    registry:addProvider("tar", "application/x-tar", self, 10)
+    registry:addProvider("xhtml", "application/xhtml+xml", self, 100)
+    registry:addProvider("xml", "application/xml", self, 10)
+    registry:addProvider("xps", "application/oxps", self, 100)
+    registry:addProvider("zip", "application/zip", self, 100)
+
+    --- Picture types ---
+    registry:addProvider("gif", "image/gif", self, 90)
+    -- MS HD Photo == JPEG XR
+    registry:addProvider("hdp", "image/vnd.ms-photo", self, 90)
+    registry:addProvider("j2k", "image/jp2", self, 90)
+    registry:addProvider("jp2", "image/jp2", self, 90)
+    registry:addProvider("jpeg", "image/jpeg", self, 90)
+    registry:addProvider("jpg", "image/jpeg", self, 90)
+    -- JPEG XR
+    registry:addProvider("jxr", "image/jxr", self, 90)
+    registry:addProvider("pam", "image/x-portable-arbitrarymap", self, 90)
+    registry:addProvider("pbm", "image/x‑portable‑bitmap", self, 90)
+    registry:addProvider("pgm", "image/x‑portable‑bitmap", self, 90)
+    registry:addProvider("png", "image/png", self, 90)
+    registry:addProvider("pnm", "image/x‑portable‑bitmap", self, 90)
+    registry:addProvider("ppm", "image/gif", self, 90)
+    registry:addProvider("tif", "image/tiff", self, 90)
+    registry:addProvider("tiff", "image/tiff", self, 90)
+    -- Windows Media Photo == JPEG XR
+    registry:addProvider("wdp", "image/vnd.ms-photo", self, 90)
 end
 
 return PdfDocument

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -6,7 +6,8 @@ local pic = nil
 local PicDocument = Document:new{
     _document = false,
     is_pic = true,
-    dc_null = DrawContext.new()
+    dc_null = DrawContext.new(),
+    provider_name = "Picture Document",
 }
 
 function PicDocument:init()
@@ -53,10 +54,10 @@ function PicDocument:getCoverPageImage()
 end
 
 function PicDocument:register(registry)
-    registry:addProvider("jpeg", "image/jpeg", self)
-    registry:addProvider("jpg", "image/jpeg", self)
-    registry:addProvider("png", "image/png", self)
-    registry:addProvider("gif", "image/gif", self)
+    registry:addProvider("gif", "image/gif", self, 100)
+    registry:addProvider("jpg", "image/jpeg", self, 100)
+    registry:addProvider("jpeg", "image/jpeg", self, 100)
+    registry:addProvider("png", "image/png", self, 100)
 end
 
 return PicDocument

--- a/spec/unit/document_registry_spec.lua
+++ b/spec/unit/document_registry_spec.lua
@@ -1,0 +1,23 @@
+describe("document registry module", function()
+    local DocumentRegistry
+
+    setup(function()
+        require("commonrequire")
+        DocumentRegistry = require("document/documentregistry")
+    end)
+
+    it("should get preferred rendering engine", function()
+        assert.is_equal("Cool Reader Engine",
+                        DocumentRegistry:getProvider("bla.epub").provider_name)
+        assert.is_equal("MuPDF",
+                        DocumentRegistry:getProvider("bla.pdf").provider_name)
+    end)
+
+    it("should return all supported rendering engines", function()
+        local providers = DocumentRegistry:getProviders("bla.epub")
+        assert.is_equal("Cool Reader Engine",
+                        providers[1].provider.provider_name)
+        assert.is_equal("MuPDF",
+                        providers[2].provider.provider_name)
+    end)
+end)


### PR DESCRIPTION
This is step one toward "open with".

References https://github.com/koreader/koreader/issues/3345

* Fix up some mimetypes
* Add XHTML to supported filetypes
* Add a few image files to MuPDF
  * ".bmp",
  * ".gif",
  * ".hdp",
  * ".j2k",
  * ".jp2",
  * ".jpeg",
  * ".jpg",
  * ".jpx",
  * ".jxr",
  * ".pam",
  * ".pbm",
  * ".pgm",
  * ".png",
  * ".pnm",
  * ".ppm",
  * ".tif",
  * ".tiff",
  * ".wdp",

@poire-z Any thoughts on this before I start thinking about GUI and settings?

PS Regarding GUI, I was thinking maybe something like this:

![screenshot_2018-01-31_18-05-20](https://user-images.githubusercontent.com/202757/35636415-560d7f44-06b1-11e8-909a-e1bbb4967be8.png)
