### PR TITLE
Menu: don't underline items on touch devices

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -368,8 +368,20 @@ function MenuItem:init()
     }
 end
 
-function MenuItem:onFocus()
-    self._underline_container.color = Blitbuffer.COLOR_BLACK
+function MenuItem:onFocus(initial_focus)
+    if Device:isTouchDevice() then
+        -- Devices which are Keys capable will get this onFocus called by
+        -- updateItems(), which will toggle the underline color of first item.
+        -- If the device is also Touch capable, let's not show the initial
+        -- underline for a prettier display (it will be shown only when keys
+        -- are used).
+        if not initial_focus or self.menu.did_focus_with_keys then
+            self._underline_container.color = Blitbuffer.COLOR_BLACK
+            self.menu.did_focus_with_keys = true
+        end
+    else
+        self._underline_container.color = Blitbuffer.COLOR_BLACK
+    end
     self.key_events = self.active_key_events
     return true
 end
@@ -830,7 +842,7 @@ function Menu:updateItems(select_number)
             -- reset focus manager accordingly
             self.selected = { x = 1, y = select_number }
             -- set focus to requested menu item
-            self.item_group[select_number]:onFocus()
+            self.item_group[select_number]:onFocus(true)
         end
         -- update page information
         self.page_info_text:setText(util.template(_("page %1 of %2"), self.page, self.page_num))


### PR DESCRIPTION
First item would be underlined if the device is both Touch and Keys capable (emulator, android, pocketbook; kobo touch, some kindle...), which is not really pretty, and a bit confusing (is that line a header?) It happens since #3621. This PR delays that underlining on Touch devices until keys for focusing are really used.

<kbd>![toc_underlined](https://user-images.githubusercontent.com/24273478/35809203-4100856c-0a88-11e8-8195-6183f7988480.png)</kbd>