### PR TITLE
cre cache: allow for disabling compression

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -47,7 +47,8 @@ function CreDocument:cacheInit()
     if lfs.attributes("./cr3cache", "mode") == "directory" then
         os.execute("rm -r ./cr3cache")
     end
-    cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache", 1024*1024*32)
+    cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache", 1024*1024*32,
+        G_reader_settings:nilOrTrue("cre_compress_cached_data"))
 end
 
 function CreDocument:engineInit()


### PR DESCRIPTION
With `["cre_compress_cached_data"] = false,` in `settings.reader.lua`.
Not using compression for cache files does indeed take more space, but it does speed up opening, rendering, page turns, and closing, with big documents.
Details in https://github.com/koreader/crengine/pull/97 and originally in https://github.com/koreader/koreader/issues/3261#issuecomment-348710821.
