### PR TITLE
Two-column navigation

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -776,7 +776,7 @@ function ReaderPaging:onGotoPageRel(diff)
             -- or switch to another page (we are crossing the end of a column)
 
             x_pan_off = self.visible_area.w * diff
-            x_pan_off = Math.roundAwayFromZero(y_pan_off)
+            x_pan_off = Math.roundAwayFromZero(x_pan_off)
             new_va.x = Math.roundAwayFromZero(self.visible_area.x+x_pan_off)
             new_va.y = Math.roundAwayFromZero(self.visible_area.y)
             -- inter-column displacement (horizontal)

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -760,6 +760,63 @@ function ReaderPaging:onGotoPageRel(diff)
         -- negative x panning if writing direction is right to left
         local direction = self.ui.document.configurable.writing_direction
         x_pan_off = self.visible_area.w * diff * (direction == 1 and -1 or 1)
+
+    elseif self.zoom_mode:find("column") then
+        -- zoom mode for two-column navigation
+
+        y_pan_off = self.visible_area.h * diff
+        y_pan_off = Math.roundAwayFromZero(y_pan_off)
+        new_va.x = Math.roundAwayFromZero(self.visible_area.x)
+        new_va.y = Math.roundAwayFromZero(self.visible_area.y+y_pan_off)
+        -- intra-column navigation (vertical), this is the default behavior
+        -- if we do not reach the end of a column
+
+        if new_va:notIntersectWith(self.page_area) then
+            -- if we leave the page, we must either switch to the other column
+            -- or switch to another page (we are crossing the end of a column)
+
+            x_pan_off = self.visible_area.w * diff
+            x_pan_off = Math.roundAwayFromZero(y_pan_off)
+            new_va.x = Math.roundAwayFromZero(self.visible_area.x+x_pan_off)
+            new_va.y = Math.roundAwayFromZero(self.visible_area.y)
+            -- inter-column displacement (horizontal)
+
+            if new_va:notIntersectWith(self.page_area) then
+              -- if we leave the page with horizontal displacement, then we are
+              -- already in the border column, we must turn the page
+
+              local new_page = self.current_page + diff
+              if diff > 0 and new_page == self.number_of_pages + 1 then
+                  self.ui:handleEvent(Event:new("EndOfBook"))
+              else
+                  self:_gotoPage(new_page)
+              end
+
+              if  y_pan_off < 0 then
+                  -- if we are going back to previous page, reset view area
+                  -- to bottom right of previous page, end of second column
+                  self.view:PanningUpdate(self.page_area.w, self.page_area.h)
+              end
+
+            else
+              -- if we do not leave the page with horizontal displacement,
+              -- it means that we can stay on this page and switch column
+
+              if diff > 0 then
+                -- end of first column, set view area to the top right of
+                -- current page, beginning of second column
+                self.view:PanningUpdate(self.page_area.w, -self.page_area.h)
+              else
+                -- move backwards to the first column, set the view area to the
+                -- bottom left of the current page
+                self.view:PanningUpdate(-self.page_area.w, self.page_area.h)
+              end
+            end
+
+            -- if we are here, the panning has already been updated so return
+            return true
+        end
+
     elseif self.zoom_mode ~= "free" then  -- do nothing in "free" zoom mode
         -- must be fit content or page zoom mode
         if self.visible_area.w == self.page_area.w then

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -760,7 +760,6 @@ function ReaderPaging:onGotoPageRel(diff)
         -- negative x panning if writing direction is right to left
         local direction = self.ui.document.configurable.writing_direction
         x_pan_off = self.visible_area.w * diff * (direction == 1 and -1 or 1)
-
     elseif self.zoom_mode:find("column") then
         -- zoom mode for two-column navigation
 

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -63,6 +63,11 @@ function ReaderZooming:init()
                 doc = "zoom to fit content height",
                 event = "SetZoomMode", args = "contentheight"
             },
+            ZoomToFitColumn = {
+                { "Shift", "C" },
+                doc = "zoom to fit column",
+                event = "SetZoomMode", args = "colu"
+            },
         }
     end
     if Device:isTouchDevice() then
@@ -226,7 +231,8 @@ function ReaderZooming:getZoom(pageno)
     local page_size = self.ui.document:getNativePageDimensions(pageno)
     if self.zoom_mode == "content"
     or self.zoom_mode == "contentwidth"
-    or self.zoom_mode == "contentheight" then
+    or self.zoom_mode == "contentheight"
+    or self.zoom_mode == "column" then
         local ubbox_dimen = self.ui.document:getUsedBBoxDimensions(pageno, 1)
         -- if bbox is larger than the native page dimension render the full page
         -- See discussion in koreader/koreader#970.
@@ -263,6 +269,8 @@ function ReaderZooming:getZoom(pageno)
         end
     elseif self.zoom_mode == "contentwidth" or self.zoom_mode == "pagewidth" then
         zoom = zoom_w
+    elseif self.zoom_mode == "column" then
+        zoom = zoom_w * 2
     elseif self.zoom_mode == "contentheight" or self.zoom_mode == "pageheight" then
         zoom = zoom_h
     elseif self.zoom_mode == "free" then
@@ -351,6 +359,12 @@ function ReaderZooming:addToMainMenu(menu_items)
                     checked_func = function() return self.zoom_mode == "page" end,
                     callback = self:genSetZoomModeCallBack("page"),
                     hold_callback = function() self:makeDefault("page") end,
+                },
+                {
+                    text = _("Zoom to fit column"),
+                    checked_func = function() return self.zoom_mode == "column" end,
+                    callback = self:genSetZoomModeCallBack("column"),
+                    hold_callback = function() self:makeDefault("column") end,
                 },
             }
         }

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -335,6 +335,7 @@ function ReaderZooming:addToMainMenu(menu_items)
                     checked_func = function() return self.zoom_mode == "contentheight" end,
                     callback = self:genSetZoomModeCallBack("contentheight"),
                     hold_callback = function() self:makeDefault("contentheight") end,
+                    separator = true,
                 },
                 {
                     text = _("Zoom to fit page width"),
@@ -347,6 +348,13 @@ function ReaderZooming:addToMainMenu(menu_items)
                     checked_func = function() return self.zoom_mode == "pageheight" end,
                     callback = self:genSetZoomModeCallBack("pageheight"),
                     hold_callback = function() self:makeDefault("pageheight") end,
+                    separator = true,
+                },
+                {
+                    text = _("Zoom to fit column"),
+                    checked_func = function() return self.zoom_mode == "column" end,
+                    callback = self:genSetZoomModeCallBack("column"),
+                    hold_callback = function() self:makeDefault("column") end,
                 },
                 {
                     text = _("Zoom to fit content"),
@@ -359,12 +367,6 @@ function ReaderZooming:addToMainMenu(menu_items)
                     checked_func = function() return self.zoom_mode == "page" end,
                     callback = self:genSetZoomModeCallBack("page"),
                     hold_callback = function() self:makeDefault("page") end,
-                },
-                {
-                    text = _("Zoom to fit column"),
-                    checked_func = function() return self.zoom_mode == "column" end,
-                    callback = self:genSetZoomModeCallBack("column"),
-                    hold_callback = function() self:makeDefault("column") end,
                 },
             }
         }


### PR DESCRIPTION
New zoom configuration available among the others
Allows to easily navigate in two-column documents
In order to  work properly, **scroll mode must be deactivated**
The best zoom is obtained with proper cropping around the two columns (should be the default one for content-width)