### PR TITLE
cre: cache re-use fix, warnings and allow cache sizes increase

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -48,7 +48,8 @@ function CreDocument:cacheInit()
         os.execute("rm -r ./cr3cache")
     end
     cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache", 1024*1024*32,
-        G_reader_settings:nilOrTrue("cre_compress_cached_data"))
+        G_reader_settings:nilOrTrue("cre_compress_cached_data"),
+        G_reader_settings:readSetting("cre_storage_size_factor"))
 end
 
 function CreDocument:engineInit()


### PR DESCRIPTION
This should considerably speed up the re-opening of big epub books from their cache.

Full technical details in https://github.com/koreader/crengine/pull/100 (and https://github.com/koreader/koreader-base/pull/601):
Bump crengine for cache re-use fix and warnings when cache sizes reached.
Allow for increasing some crengine cache sizes with a new setting: `"cre_storage_size_factor" = 1.5` (or `2`, or `4`...)

I don't know it we should already increase theses size with a default like:
```lua
+ G_reader_settings:readSetting("cre_storage_size_factor") or 2.0)
```
or wait a few nightlys for that.

Just mentionning bellow the new warnings that could be seen in crash.log here (so users searching issues would find this post).

KOReader and its epub rendering engine (crengine) may work very well in spite of these warnings.
But they may also exhibit some bugs that could be related to these max sizes being reached.
**So, the first thing to do, when noticing a bug AND any of the below warnings, is to increase the cache sizes until no more warnings are logged, and see if the bug is still there.**

To increase the cache size, add to your `settings.reader.lua`: `"cre_storage_size_factor" = 4,` (or more, or less)

- If the bug is still there: ok, it is unrelated to this cache sizes limits: fill a new issue.
- If the bug disappear: it is related to cache sizes limits, and you have the solution to increase the sizes limit! But tell us here (in this issue) about it: bug description, warning logged, book size (and title if possible), and the value needed for `"cre_storage_size_factor" to be fine...
<br/><br/>
```
CRE WARNING: storage for ELEMENTS' STYLE DATA reached max allowed uncompressed size (1163264 > 1048576)
             consider setting or increasing 'cre_storage_size_factor'
```
This one about **ELEMENTS' STYLE DATA** would probably cause this other warning when re-opening a book from cache:
```
CRE WARNING: cached rendering is invalid (style hash mismatch): doing full rendering
```
and it means the cache can't be re-used, and re-opening an already opened book would take a long time.
If this warning about `cached rendering is invalid (style hash mismatch)` is logged without any of the others, we have some other kind of coding bug.
<br/><br/>

```
CRE WARNING: storage for TEXT NODES reached max allowed uncompressed size (2912144 > 2621440)
             consider setting or increasing 'cre_storage_size_factor'
```
This one about **TEXT NODES** may be the reason for rendering problems (we've seen table rendering problems in #3623).
<br/><br/>

```
CRE WARNING: storage for RENDERED RECTS reached max allowed uncompressed size (1736704 > 1572864)
             consider setting or increasing 'cre_storage_size_factor'
```
No bug yet seen when this one about **RENDERED RECTS**  is reached. May be a slight slow done in page turning speed, that gets better when we increase sizes till we make this warning disappear.
<br/><br/>

```
CRE WARNING: storage for ELEMENTS reached max allowed uncompressed size (5203232 > 4718592)
             consider setting or increasing 'cre_storage_size_factor'
```
No bug yet seen when this one about **ELEMENTS**  is reached
