### PR TITLE
coverbrowser: keep up to date with recent core changes

### DIFF
--- a/plugins/coverbrowser.koplugin/xutil.lua
+++ b/plugins/coverbrowser.koplugin/xutil.lua
@@ -1,5 +1,4 @@
 local ffi = require("ffi")
-local C = ffi.C
 
 -- Utilities functions needed by this plugin, but that may be added to
 -- existing base/ffi/ files

--- a/plugins/coverbrowser.koplugin/xutil.lua
+++ b/plugins/coverbrowser.koplugin/xutil.lua
@@ -5,52 +5,6 @@ local C = ffi.C
 -- existing base/ffi/ files
 local xutil = {}
 
-
--- Sub-process management (may be put into base/ffi/util.lua)
-function xutil.runInSubProcess(func)
-    local pid = C.fork()
-    if pid == 0 then -- child process
-        -- Just run the provided lua code object in this new process,
-        -- and exit immediatly (so we do not release drivers and
-        -- resources still used by parent process)
-        func()
-        os.exit(0)
-    end
-    -- parent/main process, return pid of child
-    if pid == -1 then -- On failure, -1 is returned in the parent
-        return false
-    end
-    return pid
-end
-
-function xutil.isSubProcessDone(pid)
-    local status = ffi.new('int[1]')
-    local ret = C.waitpid(pid, status, 1) -- 1 = WNOHANG : don't wait, just tell
-    -- status = tonumber(status[0])
-    -- local logger = require("logger")
-    -- logger.dbg("waitpid for", pid, ":", ret, "/", status)
-    -- still running: ret = 0 , status = 0
-    -- exited: ret = pid , status = 0 or 9 if killed
-    -- no more running: ret = -1 , status = 0
-    if ret == pid or ret == -1 then
-        return true
-    end
-end
-
-function xutil.terminateSubProcess(pid)
-    local done = xutil.isSubProcessDone(pid)
-    if not done then
-        -- local logger = require("logger")
-        -- logger.dbg("killing subprocess", pid)
-        -- we kill with signal 9/SIGKILL, which may be violent, but ensures
-        -- that it is terminated (a process may catch or ignore SIGTERM)
-        C.kill(pid, 9)
-        -- process will still have to be collected with calls to util.isSubProcessDone(),
-        -- which may still return false for some small amount of time after our kill()
-    end
-end
-
-
 -- Data compression/decompression of strings thru zlib (may be put in a new base/ffi/zlib.lua)
 -- from http://luajit.org/ext_ffi_tutorial.html
 ffi.cdef[[
@@ -78,7 +32,6 @@ function xutil.zlib_uncompress(zdata, datalen)
     assert(res == 0)
     return ffi.string(buf, buflen[0])
 end
-
 
 -- Not provided by base/thirdparty/lua-ljsqlite3/init.lua
 -- Add a timeout to a lua-ljsqlite3 connection


### PR DESCRIPTION
Just some internal updates to coverbrowser plugin code:
- Remove the subprocess management functions from xutil.lua, as they are now available in base/ffi/util.lua, and use them from there.
- Also use the cre_storage_size_factor setting when processing credocuments, to avoid CRE WARNINGs while indexing too (so, a user like me don't go thinking "_why this setting that I just increased that seemed to work does not work anymore now, as I see these warnings again!_")
- Fix dealing with MuPDF document opening failures (previously, these were not noticed and indexing was retried each time).