### PR TITLE
coverbrowser list view: show book status

### DIFF
--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -477,7 +477,7 @@ function BookStatusWidget:generateSwitchGroup(width)
         default_value = 2,
         args = args,
         default_arg = "reading",
-        toggle = { _("Finished"), _("Reading"), _("Abandoned") },
+        toggle = { _("Finished"), _("Reading"), _("On hold") },
         values = { 1, 2, 3 },
         name = "book_status",
         alternate = false,

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -477,7 +477,7 @@ function BookStatusWidget:generateSwitchGroup(width)
         default_value = 2,
         args = args,
         default_arg = "reading",
-        toggle = { _("Complete"), _("Reading"), _("Abandoned") },
+        toggle = { _("Finished"), _("Reading"), _("Abandoned") },
         values = { 1, 2, 3 },
         name = "book_status",
         alternate = false,

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -340,10 +340,10 @@ function ListMenuItem:update()
                     if status == "complete" then
                         pages_str = T(_("Finished - %1 pages"), pages)
                     else
-                        pages_str = T(_("Abandoned - %1 pages"), pages)
+                        pages_str = T(_("On hold - %1 pages"), pages)
                     end
                 else
-                    pages_str = status == "complete" and _("Finished") or _("Abandoned")
+                    pages_str = status == "complete" and _("Finished") or _("On hold")
                 end
             elseif percent_finished then
                 if pages then

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -305,18 +305,18 @@ function ListMenuItem:update()
             end
             -- Current page / pages are available or more accurate in .sdr/metadata.lua
             -- We use a cache (cleaned at end of this browsing session) to store
-            -- page and percent read from sidecar files, to avoid re-parsing them
-            -- when re-rendering a visited page
+            -- page, percent read and book status from sidecar files, to avoid
+            -- re-parsing them when re-rendering a visited page
             if not self.menu.cover_info_cache then
                 self.menu.cover_info_cache = {}
             end
             local pages_str = ""
-            local percent_finished
+            local percent_finished, status
             local pages = bookinfo.pages -- default to those in bookinfo db
             if DocSettings:hasSidecarFile(self.filepath) then
                 self.been_opened = true
                 if self.menu.cover_info_cache[self.filepath] then
-                    pages, percent_finished = unpack(self.menu.cover_info_cache[self.filepath])
+                    pages, percent_finished, status = unpack(self.menu.cover_info_cache[self.filepath])
                 else
                     local docinfo = DocSettings:open(self.filepath)
                     -- We can get nb of page in the new 'doc_pages' setting, or from the old 'stats.page'
@@ -327,11 +327,25 @@ function ListMenuItem:update()
                             pages = docinfo.data.stats.pages
                         end
                     end
+                    if docinfo.data.summary and docinfo.data.summary.status then
+                        status = docinfo.data.summary.status
+                    end
                     percent_finished = docinfo.data.percent_finished
-                    self.menu.cover_info_cache[self.filepath] = {pages, percent_finished}
+                    self.menu.cover_info_cache[self.filepath] = {pages, percent_finished, status}
                 end
             end
-            if percent_finished then
+            if status == "complete" or status == "abandoned" then
+                -- Display these instead of the read %
+                if pages then
+                    if status == "complete" then
+                        pages_str = T(_("Finished - %1 pages"), pages)
+                    else
+                        pages_str = T(_("Abandoned - %1 pages"), pages)
+                    end
+                else
+                    pages_str = status == "complete" and _("Finished") or _("Abandoned")
+                end
+            elseif percent_finished then
                 if pages then
                     pages_str = T(_("%1 % of %2 pages"), math.floor(100*percent_finished), pages)
                 else


### PR DESCRIPTION
Replace reading percentage with 'Finished' or 'Abandoned' when book status is no more 'Reading' (can be changed back via Book Status widget). See https://github.com/koreader/koreader/pull/2940#issuecomment-369911064.

<kbd>![status2](https://user-images.githubusercontent.com/24273478/36904544-2f5e7a46-1e31-11e8-9c30-4c17771e8e8a.png)</kbd>
