### PR TITLE
Fix some issues with movable dict window

### DIFF
--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -40,7 +40,7 @@ local MovableContainer = InputContainer:new{
     _moved_offset_y = 0,
     -- Internal state between events
     _touch_pre_pan_was_inside = false,
-    _moving = true,
+    _moving = false,
     _move_relative_x = nil,
     _move_relative_y = nil,
     -- Original painting position from outer widget

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -148,10 +148,21 @@ function HtmlBoxWidget:getPosFromAbsPos(abs_pos)
     return pos
 end
 
-function HtmlBoxWidget:onHoldStartText(_, ges)
+function HtmlBoxWidget:onHoldStartText(callback, ges)
     self.hold_start_pos = self:getPosFromAbsPos(ges.pos)
+
+    if not self.hold_start_pos then
+        if callback then
+            callback(false) -- let know we are not selecting
+        end
+        return false -- let event be processed by other widgets
+    end
+
     self.hold_start_tv = TimeVal.now()
 
+    if callback then
+        callback(true) -- let know we are selecting
+    end
     return true
 end
 

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -762,11 +762,25 @@ end
 local FIND_START = 1
 local FIND_END = 2
 
-function TextBoxWidget:onHoldStartText(_, ges)
-    -- just store hold start position and timestamp, will be used on release
+function TextBoxWidget:onHoldStartText(callback, ges)
+    -- store hold start position and timestamp, will be used on release
     self.hold_start_x = ges.pos.x - self.dimen.x
     self.hold_start_y = ges.pos.y - self.dimen.y
+
+    -- check coordinates are actually inside our area
+    if self.hold_start_x < 0 or self.hold_start_x > self.dimen.w or
+        self.hold_start_y < 0 or self.hold_start_y > self.dimen.h then
+        self.hold_start_tv = nil -- don't process coming HoldRelease event
+        if callback then
+            callback(false) -- let know we are not selecting
+        end
+        return false -- let event be processed by other widgets
+    end
+
     self.hold_start_tv = TimeVal.now()
+    if callback then
+        callback(true) -- let know we are selecting
+    end
     return true
 end
 


### PR DESCRIPTION
Some Hold and move (hold on title and move away from dict window) would not work (we need the HoldStart and HoldRelease gesture to have a range on the whole screen, so they can be ignored by TextBoxWidget and pop up to DictQuickLookup, which will forward the event to MovableContainer).

Pan (=swipe with hold at end) on the definition text would move the window (it now does nothing: proper text selection still needs Hold on word at start).
Also increase hold duration from 2s to 3s (for switching lookup between dict/wikipedia) to be consistent with the 3s duration in readerhighlight.
(See #3717 about these)

(It wasn't easy to get right, I hope I have not introduced other strange behaviour...)