### PR TITLE
Add date to git-rev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ KOR_BASE?=base
 -include $(KOR_BASE)/Makefile.defs
 
 # we want VERSION to carry the version of koreader, not koreader-base
-VERSION=$(shell git describe HEAD)
+VERSION:=$(shell git describe HEAD)
+VERSION:=$(VERSION)_$(shell git describe HEAD | xargs git show -s --format=format:"%cd" --date=short)
 REVISION=$(shell git rev-parse --short HEAD)
 
 # set PATH to find CC in managed toolchains
@@ -49,7 +50,7 @@ INSTALL_FILES=reader.lua setupkoenv.lua frontend resources defaults.lua datastor
 all: $(if $(ANDROID),,$(KOR_BASE)/$(OUTPUT_DIR)/luajit)
 	$(MAKE) -C $(KOR_BASE)
 	install -d $(INSTALL_DIR)/koreader
-	rm -f $(INSTALL_DIR)/koreader/git-rev; echo $(VERSION) > $(INSTALL_DIR)/koreader/git-rev
+	rm -f $(INSTALL_DIR)/koreader/git-rev; echo "$(VERSION)" > $(INSTALL_DIR)/koreader/git-rev
 ifneq ($(or $(EMULATE_READER),$(WIN32)),)
 	cp -f $(KOR_BASE)/ev_replay.py $(INSTALL_DIR)/koreader/
 	@echo "[*] create symlink instead of copying files in development mode"


### PR DESCRIPTION
Adds an extra part at the end of the git-rev.

Before: `blablabla-21-g076bf406`
After: `blablabla-21-g076bf406_2018-03-05`

Fixes #2896

![screenshot_2018-03-05_21-24-12](https://user-images.githubusercontent.com/202757/36997943-9c098f78-20bb-11e8-8598-e55db329df5c.png)
