### PR TITLE
reader.lua: add version to ascii art

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -8,7 +8,9 @@ io.stdout:write([[
  | . \ |_| |  _ <  __/ (_| | (_| |  __/ |
  |_|\_\___/|_| \_\___|\__,_|\__,_|\___|_|
 
- [*] Current time: ]], os.date("%x-%X"), "\n\n")
+ It's a scroll... It's a codex... It's KOReader!
+
+ [*] Current time: ]], os.date("%x-%X"), "\n")
 io.stdout:flush()
 
 -- load default settings
@@ -17,6 +19,9 @@ local DataStorage = require("datastorage")
 pcall(dofile, DataStorage:getDataDir() .. "/defaults.persistent.lua")
 
 require("setupkoenv")
+
+io.stdout:write(" [*] Version: ", require("version"):getCurrentRevision(), "\n\n")
+io.stdout:flush()
 
 -- read settings and check for language override
 -- has to be done before requiring other files because


### PR DESCRIPTION
As suggested by @poire-z in https://github.com/koreader/koreader/pull/3723#issuecomment-370557018

```
---------------------------------------------
                launching...
  _  _____  ____                _
 | |/ / _ \|  _ \ ___  __ _  __| | ___ _ __
 | ' / | | | |_) / _ \/ _` |/ _` |/ _ \ '__|
 | . \ |_| |  _ <  __/ (_| | (_| |  __/ |
 |_|\_\___/|_| \_\___|\__,_|\__,_|\___|_|

 It's a scroll... It's a codex... It's KOReader!

 [*] Current time: 03/05/18-23:08:05
 [*] Version: blablabla-21-g076bf406
```

![screenshot_2018-03-05_23-08-41](https://user-images.githubusercontent.com/202757/37002589-81e743f6-20ca-11e8-8b0b-bec3fa329333.png)
