### PR TITLE
Set default 'cre_storage_size_factor' to 20

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -47,9 +47,17 @@ function CreDocument:cacheInit()
     if lfs.attributes("./cr3cache", "mode") == "directory" then
         os.execute("rm -r ./cr3cache")
     end
+    -- crengine various in-memory caches max-sizes are rather small
+    -- (2.5 / 4.5 / 1.5 / 1 MB), and we can avoid some bugs if we
+    -- increase them. Let's multiply them by 20 (each cache would
+    -- grow only when needed, depending on book characteristics).
+    -- People who would get out of memory crashes with big books on
+    -- older devices can decrease that with setting:
+    --   "cre_storage_size_factor"=1    (or 2, or 5)
+    local default_cre_storage_size_factor = 20
     cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache", 1024*1024*32,
         G_reader_settings:nilOrTrue("cre_compress_cached_data"),
-        G_reader_settings:readSetting("cre_storage_size_factor"))
+        G_reader_settings:readSetting("cre_storage_size_factor") or default_cre_storage_size_factor)
 end
 
 function CreDocument:engineInit()


### PR DESCRIPTION
Increase default crengine in-memory cache sizes to avoid pack/unpack of chunks that is known to be the cause of bugs (rendering, cache re-use...).
Details in https://github.com/koreader/koreader/pull/3700 and https://github.com/koreader/crengine/pull/100