### PR TITLE
coverbrowser: quicker extraction of EPUB metadata

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -132,9 +132,9 @@ function CreDocument:init()
     self.info.configurable = true
 end
 
-function CreDocument:loadDocument()
+function CreDocument:loadDocument(only_metadata)
     if not self._loaded then
-        if self._document:loadDocument(self.file) then
+        if self._document:loadDocument(self.file, only_metadata) then
             self._loaded = true
         end
     end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -132,8 +132,9 @@ function CreDocument:init()
     self.info.configurable = true
 end
 
-function CreDocument:loadDocument(only_metadata)
+function CreDocument:loadDocument(full_document)
     if not self._loaded then
+        local only_metadata = full_document == false
         if self._document:loadDocument(self.file, only_metadata) then
             self._loaded = true
         end

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -372,7 +372,7 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
             -- Setting a default font before loading document
             -- actually do prevent some crashes
             document:setFontFace(document.default_font)
-            if not document:loadDocument() then
+            if not document:loadDocument(true) then -- only_metadata=true
                 -- failed loading, calling other methods would segfault
                 loaded = false
             end

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -372,7 +372,7 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
             -- Setting a default font before loading document
             -- actually do prevent some crashes
             document:setFontFace(document.default_font)
-            if not document:loadDocument(true) then -- only_metadata=true
+            if not document:loadDocument(false) then -- load only metadata
                 -- failed loading, calling other methods would segfault
                 loaded = false
             end


### PR DESCRIPTION
bump crengine:
Allow for quicker loading when interested in metadata only https://github.com/koreader/crengine/pull/123
Allow for more than 65535 different attribute values https://github.com/koreader/crengine/pull/124
Increase gamma values range https://github.com/koreader/crengine/pull/122