### PR TITLE
Fix some minor plugin errors on exit

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -367,7 +367,7 @@ end
 
 function NewsDownloader:onCloseDocument()
     local document_full_path = self.ui.document.file
-    if  document_full_path and news_download_dir_path == string.sub(document_full_path, 1, string.len(news_download_dir_path)) then
+    if  document_full_path and news_download_dir_path and news_download_dir_path == string.sub(document_full_path, 1, string.len(news_download_dir_path)) then
         logger.dbg("NewsDownloader: document_full_path:", document_full_path)
         logger.dbg("NewsDownloader: news_download_dir_path:", news_download_dir_path)
         logger.dbg("NewsDownloader: removing NewsDownloader file from history.")

--- a/plugins/send2ebook.koplugin/main.lua
+++ b/plugins/send2ebook.koplugin/main.lua
@@ -213,7 +213,7 @@ end
 
 function Send2Ebook:onCloseDocument()
     local document_full_path = self.ui.document.file
-    if  document_full_path and download_dir_path == string.sub(document_full_path, 1, string.len(download_dir_path)) then
+    if  document_full_path and download_dir_path and download_dir_path == string.sub(document_full_path, 1, string.len(download_dir_path)) then
         logger.dbg("Send2Ebook: document_full_path:", document_full_path)
         logger.dbg("Send2Ebook: download_dir_path:", download_dir_path)
         logger.dbg("Send2Ebook: removing Send2Ebook file from history.")


### PR DESCRIPTION
Fix these errors seen in unit tests output (and when leaving emulator):

```
03/11/18-12:06:25 ERROR failed to call event handler onCloseDocument plugins/newsdownloader.koplugin/main.lua:370: bad argument #1 to 'len' (string expected, got nil)
03/11/18-12:06:25 ERROR failed to call event handler onCloseDocument plugins/send2ebook.koplugin/main.lua:216: bad argument #1 to 'len' (string expected, got nil)
```
