### PR TITLE
turn missing translations into a warning

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -51,7 +51,7 @@ function GetText_mt.__index.changeLang(new_lang)
     local po = io.open(file, "r")
 
     if not po then
-        logger.err("cannot open translation file:", file)
+        logger.warn("cannot open translation file:", file)
         return false
     end
 


### PR DESCRIPTION
This is not fatal and can be mistaken by new users for the cause of all their problems, like I did in #2621.