### PR TITLE
propose installing SDL on Linux

### DIFF
--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -32,7 +32,7 @@ local function probeDevice()
     --     return require("device/newport/device")
     -- end
 
-    error("did not find a hardware abstraction for this platform")
+    error("did not find a hardware abstraction for this platform, maybe you need to install SDL if you're on Linux?")
 end
 
 local dev = probeDevice()

--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -32,7 +32,7 @@ local function probeDevice()
     --     return require("device/newport/device")
     -- end
 
-    error("did not find a hardware abstraction for this platform, maybe you need to install SDL if you're on Linux?")
+    error("Could not find hardware abstraction for this platform. If you are trying to run the emulator, please ensure SDL is installed.")
 end
 
 local dev = probeDevice()


### PR DESCRIPTION
"hardware abstraction" didn't mean anything for me when I tried the emulator at first on Debian. In #2621, it was proposed to suggest installing SDL: do so here, although we do it for all platforms...