### PR TITLE
Fix possible crash with config panel when engine switched

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -118,7 +118,11 @@ end
 
 function ReaderConfig:onReadSettings(config)
     self.configurable:loadSettings(config, self.options.prefix.."_")
-    self.last_panel_index = config:readSetting("config_panel_index") or 1
+    local config_panel_index = config:readSetting("config_panel_index")
+    if config_panel_index then
+        config_panel_index = math.min(config_panel_index, #self.options)
+    end
+    self.last_panel_index = config_panel_index or 1
 end
 
 function ReaderConfig:onSaveSettings()


### PR DESCRIPTION
Reading an epub file with Mupdf would show 6 items in bottom config panel. Reading it with crengine would show only 5.
A crash would happen if we were on the 6th when leaving MuPDF, and later opening config panel with crengine.
```
./luajit: frontend/ui/widget/configdialog.lua:473: attempt to index a nil value
stack traceback:
        frontend/ui/widget/configdialog.lua:473: in function 'init'
        frontend/ui/widget/widget.lua:48: in function 'new'
        frontend/ui/widget/configdialog.lua:668: in function 'update'
        frontend/ui/widget/configdialog.lua:695: in function 'onShowConfigPanel'
        frontend/apps/reader/modules/readerconfig.lua:75: in function 'handleEvent'
        frontend/ui/widget/container/widgetcontainer.lua:87: in function 'propagateEvent'
        frontend/ui/widget/container/widgetcontainer.lua:105: in function 'handleEvent'
        frontend/apps/reader/modules/readermenu.lua:323: in function 'handler'
        frontend/ui/widget/container/inputcontainer.lua:197: in function 'handleEvent'
        frontend/ui/uimanager.lua:455: in function 'sendEvent'

```