### PR TITLE
BookInformation: speedup getting EPUB metadata/cover

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -103,7 +103,7 @@ function BookInfo:show(file, book_props)
             local loaded = true
             local pages
             if document.loadDocument then -- CreDocument
-                if not document:loadDocument() then
+                if not document:loadDocument(false) then -- load only metadata
                     -- failed loading, calling other methods would segfault
                     loaded = false
                 end
@@ -173,6 +173,9 @@ function BookInfo:show(file, book_props)
         local widget
         local document = DocumentRegistry:openDocument(file)
         if document then
+            if document.loadDocument then -- CreDocument
+                document:loadDocument(false) -- load only metadata
+            end
             local cover_bb = document:getCoverPageImage()
             if cover_bb then
                 widget = ImageViewer:new{

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -234,7 +234,7 @@ function CoverMenu:updateItems(select_number)
                 UIManager:close(self.file_dialog)
 
                 -- Replace Book information callback to use directly our bookinfo
-                orig_buttons[4][2].callback = function()
+                orig_buttons[4][3].callback = function()
                     FileManagerBookInfo:show(file, bookinfo)
                     UIManager:close(self.file_dialog)
                 end


### PR DESCRIPTION
Use the recently added option to loadDocument() to load only metadata.
coverbrowser: also plug optimised callback to the right button ("Book information" was shifted when "Open with..." was added). It was for some weeks plugged to "Convert".