### PR TITLE
UIManager: avoid painting widgets covered by a full screen widget

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -775,6 +775,7 @@ function FileManager:showFiles(path, focused_file)
     restoreScreenMode()
     local file_manager = FileManager:new{
         dimen = Screen:getSize(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
         root_path = path,
         focused_file = focused_file,
         onExit = function()

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -128,6 +128,7 @@ function FileManagerHistory:onShowHist()
         ui = self.ui,
         width = Screen:getWidth(),
         height = Screen:getHeight(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
         is_borderless = true,
         is_popout = false,
         onMenuHold = self.onMenuHold,

--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -61,6 +61,7 @@ function OPDSCatalog:showCatalog()
     logger.dbg("show OPDS catalog")
     UIManager:show(OPDSCatalog:new{
         dimen = Screen:getSize(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
         onExit = function()
             --UIManager:quit()
         end

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -235,6 +235,7 @@ function ReaderBookmark:onShowBookmark()
 
     self.bookmark_menu = CenterContainer:new{
         dimen = Screen:getSize(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
         bm_menu,
     }
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -335,6 +335,7 @@ function ReaderToc:onShowToc()
 
     local menu_container = CenterContainer:new{
         dimen = Screen:getSize(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
         toc_menu,
     }
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -467,6 +467,7 @@ function ReaderUI:doShowReader(file, provider)
     G_reader_settings:saveSetting("lastfile", file)
     local reader = ReaderUI:new{
         dimen = Screen:getSize(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
         document = document,
     }
     UIManager:show(reader)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -141,7 +141,7 @@ function Screensaver:show(event, fallback_message)
         UIManager:close(self.left_msg)
         self.left_msg = nil
     end
-    local covers_fullscreen
+    local covers_fullscreen = true -- hint for UIManager:_repaint()
     local overlay_message
     local prefix = event and event.."_" or "" -- "", "poweroff_" or "reboot_"
     local screensaver_type = G_reader_settings:readSetting(prefix.."screensaver_type")
@@ -188,7 +188,6 @@ function Screensaver:show(event, fallback_message)
                     if not self:whiteBackground() then
                         background = Blitbuffer.COLOR_BLACK
                     end
-                    covers_fullscreen = true -- hint for UIManager:_repaint()
                 else
                     screensaver_type = "random_image"
                 end
@@ -214,7 +213,6 @@ function Screensaver:show(event, fallback_message)
                     view = instance.view,
                     readonly = true,
                 }
-                covers_fullscreen = true -- hint for UIManager:_repaint()
             else
                 screensaver_type = "message"
             end
@@ -245,13 +243,11 @@ function Screensaver:show(event, fallback_message)
             if not self:whiteBackground() then
                 background = Blitbuffer.COLOR_BLACK
             end
-            covers_fullscreen = true -- hint for UIManager:_repaint()
         end
     end
     if screensaver_type == "readingprogress" then
         if Screensaver.getReaderProgress ~= nil then
             widget = Screensaver.getReaderProgress()
-            covers_fullscreen = true -- hint for UIManager:_repaint()
         else
             screensaver_type = "message"
         end
@@ -260,8 +256,7 @@ function Screensaver:show(event, fallback_message)
         local screensaver_message = G_reader_settings:readSetting(prefix.."screensaver_message")
         if not self:whiteBackground() then
             background = nil -- no background filling, let book text visible
-        else
-            covers_fullscreen = true -- hint for UIManager:_repaint()
+            covers_fullscreen = false
         end
         if screensaver_message == nil then
             screensaver_message = fallback_message or default_screensaver_message

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -141,6 +141,7 @@ function Screensaver:show(event, fallback_message)
         UIManager:close(self.left_msg)
         self.left_msg = nil
     end
+    local covers_fullscreen
     local overlay_message
     local prefix = event and event.."_" or "" -- "", "poweroff_" or "reboot_"
     local screensaver_type = G_reader_settings:readSetting(prefix.."screensaver_type")
@@ -187,6 +188,7 @@ function Screensaver:show(event, fallback_message)
                     if not self:whiteBackground() then
                         background = Blitbuffer.COLOR_BLACK
                     end
+                    covers_fullscreen = true -- hint for UIManager:_repaint()
                 else
                     screensaver_type = "random_image"
                 end
@@ -212,6 +214,7 @@ function Screensaver:show(event, fallback_message)
                     view = instance.view,
                     readonly = true,
                 }
+                covers_fullscreen = true -- hint for UIManager:_repaint()
             else
                 screensaver_type = "message"
             end
@@ -242,11 +245,13 @@ function Screensaver:show(event, fallback_message)
             if not self:whiteBackground() then
                 background = Blitbuffer.COLOR_BLACK
             end
+            covers_fullscreen = true -- hint for UIManager:_repaint()
         end
     end
     if screensaver_type == "readingprogress" then
         if Screensaver.getReaderProgress ~= nil then
             widget = Screensaver.getReaderProgress()
+            covers_fullscreen = true -- hint for UIManager:_repaint()
         else
             screensaver_type = "message"
         end
@@ -255,6 +260,8 @@ function Screensaver:show(event, fallback_message)
         local screensaver_message = G_reader_settings:readSetting(prefix.."screensaver_message")
         if not self:whiteBackground() then
             background = nil -- no background filling, let book text visible
+        else
+            covers_fullscreen = true -- hint for UIManager:_repaint()
         end
         if screensaver_message == nil then
             screensaver_message = fallback_message or default_screensaver_message
@@ -275,6 +282,7 @@ function Screensaver:show(event, fallback_message)
         self.left_msg = ScreenSaverWidget:new{
             widget = widget,
             background = background,
+            covers_fullscreen = covers_fullscreen,
         }
         self.left_msg.modal = true
         -- refresh whole screen for other types

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -93,6 +93,7 @@ function BookStatusWidget:init()
     end
 
     local screen_size = Screen:getSize()
+    self.covers_fullscreen = true -- hint for UIManager:_repaint()
     self[1] = FrameContainer:new{
         width = screen_size.w,
         height = screen_size.h,

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -100,6 +100,9 @@ function ImageViewer:init()
             Swipe = { GestureRange:new{ ges = "swipe", range = range } },
         }
     end
+    if self.fullscreen then
+        self.covers_fullscreen = true -- hint for UIManager:_repaint()
+    end
     self:update()
 end
 

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -278,6 +278,9 @@ function KeyValuePage:init()
         w = self.width or Screen:getWidth(),
         h = self.height or Screen:getHeight(),
     }
+    if self.dimen.w == Screen:getWidth() and self.dimen.h == Screen:getHeight() then
+        self.covers_fullscreen = true -- hint for UIManager:_repaint()
+    end
 
     if Device:hasKeys() then
         self.key_events = {


### PR DESCRIPTION
Navigating the TOC, viewing a full screen image, browsing reading stats... would call paintTo() on ReaderUI (so, asking the engine to render the page) or FileManager (so, rendering cover images) even though their content is hidden.
Widgets registering to UIManager have to explicitely state they cover the full screen with `covers_fullscreen = true`  (UIManager can't know, parts of their dimen may be transparent, e.g. if it is a CenterContainer, like an InfoMessage has dimension of the full screen).

This makes these things snappier.
(We can't do that for the top menu, as the book text is displayed below, and when changing menu items, the next one may be smaller, so book text has to be displayed - so, this still lags a bit by the same time taken by page turn).

I've been testing this only for a few minutes, and haven't seen side effects.
There is still the business of calling the refreshes (refresh_func, refresh_stack) that I don't know if this may mess with them. I guess not as it's the late widgets (so, on top and displayed) that can only be registering some refreshes/setDirty , but...

I've set `covers_fullscreen = true` to ReaderUI and FileManager, because some time ago, i've seen a FileManager cover image being transiently redrawn when changing fonts on a Reader! I can't reproduce it now, and logs don't show this could happen.. So it may have been fixed.
I also set it to Screensaver hoping it could solve https://github.com/koreader/koreader/issues/3130#issuecomment-373312341 - but I doubt it: this issue is with refreshes - avoiding some painting in a single refresh would change nothing - so I may remove them as they make screensaver.lua a bit ugly.