### PR TITLE
Tapplus shortcut

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -251,6 +251,20 @@ function FileManagerMenu:setUpdateItemTable()
             self:exitOrRestart(function() UIManager:restartKOReader() end)
         end,
     }
+    if not Device:isTouchDevice() then
+        --add a shortcut on non touch-device
+        --because this menu is not accessible otherwise
+        self.menu_items.plus_menu = {
+            icon = "resources/icons/appbar.plus.png",
+            remember = false,
+            callback = function()
+                self:onCloseFileManagerMenu()
+                self.ui:tapPlus()
+            end,
+        }
+    else
+        self.menu_items.plus_menu = {}
+    end
 
     local order = require("ui/elements/filemanager_menu_order")
 

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -3,6 +3,7 @@ local order = {
         "setting",
         "tools",
         "search",
+        "plus_menu",
         "main",
     },
     setting = {
@@ -88,6 +89,7 @@ local order = {
         "----------------------------",
         "about",
     },
+    plus_menu = {},
     exit_menu = {
         "restart_koreader",
         "----------------------------",

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -115,7 +115,10 @@ function ButtonTable:addHorizontalSep(vspan_before, add_line, vspan_after, black
 end
 
 function ButtonTable:onSelectByKeyPress()
-    self:getFocusItem().callback()
+    local item = self:getFocusItem()
+    if item.enabled then
+        item.callback()
+    end
 end
 
 return ButtonTable

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -41,7 +41,7 @@ function ButtonTable:init()
     end
     local row_cnt = #self.buttons
     for i = 1, row_cnt do
-        self.buttons_layout[i] = {}
+        local buttons_layout_line = {}
         local horizontal_group = HorizontalGroup:new{}
         local row = self.buttons[i]
         local column_cnt = #row
@@ -69,7 +69,7 @@ function ButtonTable:init()
                     h = button_dim.h,
                 }
             }
-            self.buttons_layout[i][j] = button
+            buttons_layout_line[j] = button
             table.insert(horizontal_group, button)
             if j < column_cnt then
                 table.insert(horizontal_group, vertical_sep)
@@ -78,6 +78,10 @@ function ButtonTable:init()
         table.insert(self.container, horizontal_group)
         if i < row_cnt then
             self:addHorizontalSep(true, true, true)
+        end
+        if column_cnt > 0 then
+            --Only add line that are not separator to the focusmanager
+            table.insert(self.buttons_layout, buttons_layout_line)
         end
     end -- end for each button line
     self:addHorizontalSep(true, false, false)

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -1,7 +1,6 @@
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
-
 --[[
 Wrapper Widget that manages focus for a whole dialog
 
@@ -56,12 +55,12 @@ function FocusManager:onFocusMove(args)
     local current_item = self.layout[self.selected.y][self.selected.x]
     while true do
         if not self.layout[self.selected.y + dy] then
-            --vertical borders, try to wraparound
+            --horizontal border, try to wraparound
             if not self:wrapAround(dy) then
                 break
             end
         elseif not self.layout[self.selected.y + dy][self.selected.x + dx] then
-           --vertical border, no wraparound
+            --vertical border, no wraparound
             break
         else
             self.selected.y = self.selected.y + dy

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -1,5 +1,6 @@
-local InputContainer = require("ui/widget/container/inputcontainer")
 local Event = require("ui/event")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local logger = require("logger")
 local UIManager = require("ui/uimanager")
 --[[
 Wrapper Widget that manages focus for a whole dialog
@@ -65,6 +66,7 @@ function FocusManager:onFocusMove(args)
         else
             self.selected.y = self.selected.y + dy
             self.selected.x = self.selected.x + dx
+            logger.dbg("Cursor position : ".. self.selected.y .." : "..self.selected.x)
         end
 
         if self.layout[self.selected.y][self.selected.x] ~= current_item

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1092,7 +1092,7 @@ function Menu:onSelect()
 end
 
 function Menu:onRight()
-    local item = self.item_table[(self.page-1)*self.perpage+self.selected.y] 
+    local item = self.item_table[(self.page-1)*self.perpage+self.selected.y]
     if item then
         self:onMenuHold(item)
     end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -793,6 +793,9 @@ function Menu:init()
         self.key_events.Select = {
             {"Press"}, doc = "select current menu item"
         }
+        self.key_events.Right = {
+            {"Right"}, doc = "hold  menu item"
+        }
     end
 
 
@@ -1084,6 +1087,14 @@ function Menu:onSelect()
     local item = self.item_table[(self.page-1)*self.perpage+self.selected.y]
     if item then
         self:onMenuSelect(item)
+    end
+    return true
+end
+
+function Menu:onRight()
+    local item = self.item_table[(self.page-1)*self.perpage+self.selected.y] 
+    if item then
+        self:onMenuHold(item)
     end
     return true
 end

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -1,5 +1,6 @@
 local Device = require("device")
 local DocumentRegistry = require("document/documentregistry")
+local Event = require("ui/event")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local ImageViewer = require("ui/widget/imageviewer")
 local Menu = require("ui/widget/menu")
@@ -93,7 +94,7 @@ function CoverMenu:updateItems(select_number)
             -- reset focus manager accordingly
             self.selected = { x = 1, y = select_number }
             -- set focus to requested menu item
-            self.item_group[select_number]:onFocus()
+            self:getFocusItem():handleEvent(Event:new("Focus"))
             -- This will not work with our MosaicMenu, as a MosaicMenuItem is
             -- not a direct child of item_group (which contains VerticalSpans
             -- and HorizontalGroup...)


### PR DESCRIPTION
Add an element in the filemanager touchmenu to open the tapPlus menu on non touch device only.

On Sdl, you have to comment `isTouchDevice = yes` to see it.
![2018-03-18-105727_540x720_scrot](https://user-images.githubusercontent.com/3342132/37564686-3fedc27e-2a9b-11e8-851a-c843ae9fb4bc.png)
