### PR TITLE
Tapplus shortcut

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -251,6 +251,20 @@ function FileManagerMenu:setUpdateItemTable()
             self:exitOrRestart(function() UIManager:restartKOReader() end)
         end,
     }
+    if not Device:isTouchDevice() then
+        --add a shortcut on non touch-device
+        --because this menu is not accessible otherwise
+        self.menu_items.plus_menu = {
+            icon = "resources/icons/appbar.plus.png",
+            remember = false,
+            callback = function()
+                self:onCloseFileManagerMenu()
+                self.ui:tapPlus()
+            end,
+        }
+    else
+        self.menu_items.plus_menu = {}
+    end
 
     local order = require("ui/elements/filemanager_menu_order")
 

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -262,8 +262,6 @@ function FileManagerMenu:setUpdateItemTable()
                 self.ui:tapPlus()
             end,
         }
-    else
-        self.menu_items.plus_menu = {}
     end
 
     local order = require("ui/elements/filemanager_menu_order")

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -3,6 +3,7 @@ local order = {
         "setting",
         "tools",
         "search",
+        "plus_menu",
         "main",
     },
     setting = {
@@ -88,6 +89,7 @@ local order = {
         "----------------------------",
         "about",
     },
+    plus_menu = {},
     exit_menu = {
         "restart_koreader",
         "----------------------------",

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -129,23 +129,17 @@ function MenuSorter:sort(item_table, order)
             end
         end
     end
-    -- @TODO avoid this extra mini-loop
     -- cleanup, top-level items shouldn't have sub_item_table
+    -- they should, however have one going in
+    local menu_buttons_offset = 0
     for i,top_menu in ipairs(menu_table["KOMenu:menu_buttons"]) do
-        menu_table["KOMenu:menu_buttons"][i] = menu_table["KOMenu:menu_buttons"][i].sub_item_table
-    end
-
-    --Compress the table in case we don't want to show some top-level items
-    local tmp = {}
-    for i,top_menu in pairs(menu_table["KOMenu:menu_buttons"]) do
-        if type(i) == "number"  then
-            table.insert(tmp,top_menu)
+        if menu_table["KOMenu:menu_buttons"][i].sub_item_table then
+            menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = menu_table["KOMenu:menu_buttons"][i].sub_item_table
         else
-            tmp[i] = top_menu
+            menu_table["KOMenu:menu_buttons"][i] = nil
+            menu_buttons_offset = menu_buttons_offset + 1
         end
     end
-    menu_table["KOMenu:menu_buttons"] = tmp
-
     -- handle disabled
     if order["KOMenu:disabled"] then
         for _,item in ipairs(order["KOMenu:disabled"]) do

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -135,6 +135,17 @@ function MenuSorter:sort(item_table, order)
         menu_table["KOMenu:menu_buttons"][i] = menu_table["KOMenu:menu_buttons"][i].sub_item_table
     end
 
+    --Compress the table in case we don't want to show some top-level items
+    local tmp = {}
+    for i,top_menu in pairs(menu_table["KOMenu:menu_buttons"]) do
+        if type(i) == "number"  then
+            table.insert(tmp,top_menu)
+        else
+            tmp[i] = top_menu
+        end
+    end
+    menu_table["KOMenu:menu_buttons"] = tmp
+
     -- handle disabled
     if order["KOMenu:disabled"] then
         for _,item in ipairs(order["KOMenu:disabled"]) do

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -1,5 +1,6 @@
 local Device = require("device")
 local DocumentRegistry = require("document/documentregistry")
+local Event = require("ui/event")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local ImageViewer = require("ui/widget/imageviewer")
 local Menu = require("ui/widget/menu")
@@ -93,7 +94,7 @@ function CoverMenu:updateItems(select_number)
             -- reset focus manager accordingly
             self.selected = { x = 1, y = select_number }
             -- set focus to requested menu item
-            self.item_group[select_number]:onFocus()
+            self:getFocusItem():handleEvent(Event:new("Focus"))
             -- This will not work with our MosaicMenu, as a MosaicMenuItem is
             -- not a direct child of item_group (which contains VerticalSpans
             -- and HorizontalGroup...)


### PR DESCRIPTION
Add an element in the filemanager touchmenu to open the tapPlus menu on non touch device only.

![2018-03-18-105727_540x720_scrot](https://user-images.githubusercontent.com/3342132/37564686-3fedc27e-2a9b-11e8-851a-c843ae9fb4bc.png)
