### PR TITLE
coverbrowser: fix some vertical alignments

### DIFF
--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -160,13 +160,13 @@ function ListMenuItem:init()
     -- even with classic menu)
     self.underline_h = 1 -- smaller than default (3) to not shift our vertical aligment
     self._underline_container = UnderlineContainer:new{
-        vertical_align = "center",
+        vertical_align = "top",
+        padding = 0,
         dimen = Geom:new{
             w = self.width,
             h = self.height
         },
         linesize = self.underline_h,
-        padding = 0,
         -- widget : will be filled in self:update()
     }
     self[1] = self._underline_container

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -348,7 +348,8 @@ function MosaicMenuItem:init()
     -- even with classic menu)
     self.underline_h = 1 -- smaller than default (3), don't waste space
     self._underline_container = UnderlineContainer:new{
-        vertical_align = "center",
+        vertical_align = "top",
+        padding = 0,
         dimen = Geom:new{
             w = self.width,
             h = self.height


### PR DESCRIPTION
Fix vertical wrong alignment of the _book opened_ hint, introduced by the recent correction to UnderlineContainer (https://github.com/koreader/koreader/pull/3745#issuecomment-373119098).
This was probably the right thing (top, no padding) I should have done at the time, and may be it worked fine enough just because of the bug in UnderLineContainer :)

<kbd>![uglyhint](https://user-images.githubusercontent.com/24273478/37668879-c5c5e0fe-2c65-11e8-9739-3debf9837774.png)</kbd>

I noticed this while testing file browser in full screen ~~desktop~~ emulator mode, so I guess it was good to have it:)
Don't merge yet, I'll verify tonight it displays as fine on my Kobo (where i didn't notice any problem recently).