### PR TITLE
Support the virtualKeyboard on non touch-device

### DIFF
--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -111,8 +111,8 @@ function DropBox:config(item, callback)
         height = Screen:getHeight() * 0.2,
         input_type = "text",
     }
-    self.settings_dialog:onShowKeyboard()
     UIManager:show(self.settings_dialog)
+    self.settings_dialog:onShowKeyboard()
 end
 
 function DropBox:info(token)

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -140,8 +140,8 @@ function Ftp:config(item, callback)
         height = Screen:getHeight() * 0.2,
         input_type = "text",
     }
-    self.settings_dialog:onShowKeyboard()
     UIManager:show(self.settings_dialog)
+    self.settings_dialog:onShowKeyboard()
 end
 
 function Ftp:info(item)

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -264,8 +264,8 @@ function FileManager:init()
                                 },
                             }},
                         }
-                        fileManager.rename_dialog:onShowKeyboard()
                         UIManager:show(fileManager.rename_dialog)
+                        fileManager.rename_dialog:onShowKeyboard()
                     end,
                 }
             },
@@ -404,8 +404,8 @@ function FileManager:tapPlus()
                             }
                         },
                     }
-                    self.input_dialog:onShowKeyboard()
                     UIManager:show(self.input_dialog)
+                    self.input_dialog:onShowKeyboard()
                 end,
             },
         },

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -138,8 +138,8 @@ function FileSearcher:showSearch()
             },
         },
     }
-    self.search_dialog:onShowKeyboard()
     UIManager:show(self.search_dialog)
+    self.search_dialog:onShowKeyboard()
 end
 
 function FileSearcher:showSearchResults()

--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -205,8 +205,8 @@ function Search:ShowSearch()
             width = Screen:getWidth() * 0.8,
             height = Screen:getHeight() * 0.2,
         }
-        self.search_dialog:onShowKeyboard()
         UIManager:show(self.search_dialog)
+        self.search_dialog:onShowKeyboard()
     else
         if self.error then
             UIManager:show(InfoMessage:new{

--- a/frontend/apps/filemanager/filemanagersetdefaults.lua
+++ b/frontend/apps/filemanager/filemanagersetdefaults.lua
@@ -154,8 +154,8 @@ function SetDefaults:init()
                     input_type = setting_type,
                     width = Screen:getWidth() * 0.95,
                 }
-                self.set_dialog:onShowKeyboard()
                 UIManager:show(self.set_dialog)
+                self.set_dialog:onShowKeyboard()
             end
 
             table.insert(self.results, {
@@ -205,8 +205,8 @@ function SetDefaults:init()
                     width = Screen:getWidth() * 0.95,
                     height = Screen:getHeight() * 0.2,
                 }
-                self.set_dialog:onShowKeyboard()
                 UIManager:show(self.set_dialog)
+                self.set_dialog:onShowKeyboard()
             end
 
             table.insert(self.results, {
@@ -244,8 +244,8 @@ function SetDefaults:init()
                     input_type = setting_type,
                     width = Screen:getWidth() * 0.95,
                 }
-                self.set_dialog:onShowKeyboard()
                 UIManager:show(self.set_dialog)
+                self.set_dialog:onShowKeyboard()
             end
 
             table.insert(self.results, {

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -482,8 +482,8 @@ function ReaderBookmark:renameBookmark(item, from_highlight)
             }
         },
     }
-    self.input:onShowKeyboard()
     UIManager:show(self.input)
+    self.input:onShowKeyboard()
 end
 
 function ReaderBookmark:toggleBookmark(pn_or_xp)

--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -84,8 +84,8 @@ function ReaderGoto:onShowGotoDialog()
         },
         input_type = "number",
     }
-    self.goto_dialog:onShowKeyboard()
     UIManager:show(self.goto_dialog)
+    self.goto_dialog:onShowKeyboard()
 end
 
 function ReaderGoto:onShowSkimtoDialog()

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -58,8 +58,8 @@ function ReaderWikipedia:lookupInput()
             }
         },
     }
-    self.input_dialog:onShowKeyboard()
     UIManager:show(self.input_dialog)
+    self.input_dialog:onShowKeyboard()
 end
 
 function ReaderWikipedia:addToMainMenu(menu_items)
@@ -165,8 +165,8 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                             }
                         },
                     }
-                    wikilang_input:onShowKeyboard()
                     UIManager:show(wikilang_input)
+                    wikilang_input:onShowKeyboard()
                 end,
             },
             { -- setting used by dictquicklookup

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -521,8 +521,8 @@ function ReaderUI:unlockDocumentWithPassword(document, try_again)
         },
         text_type = "password",
     }
-    self.password_dialog:onShowKeyboard()
     UIManager:show(self.password_dialog)
+    self.password_dialog:onShowKeyboard()
 end
 
 function ReaderUI:onVerifyPassword(document)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -130,8 +130,8 @@ function Screensaver:setMessage()
             },
         },
     }
-    self.input_dialog:onShowKeyboard()
     UIManager:show(self.input_dialog)
+    self.input_dialog:onShowKeyboard()
 end
 
 function Screensaver:show(event, fallback_message)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -477,8 +477,8 @@ function UIManager:sendEvent(event)
             end
             if widget.widget.is_always_active then
                 -- active widgets will handle this event
-                -- Note: is_always_active widgets currently are vitualkeyboard and
-                -- readerconfig
+                -- Note: is_always_active widgets currently are widgets that want to show a keyboard
+                -- and readerconfig
                 checked_widgets[widget] = true
                 if widget.widget:handleEvent(event) then return end
             end

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -575,8 +575,8 @@ function BookStatusWidget:onSwitchFocus(inputbox)
             },
         },
     }
-    self.note_dialog:onShowKeyboard()
     UIManager:show(self.note_dialog)
+    self.note_dialog:onShowKeyboard()
 end
 
 function BookStatusWidget:closeInputDialog()

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -85,7 +85,7 @@ function ButtonTable:init()
         end
     end -- end for each button line
     self:addHorizontalSep(true, false, false)
-    if Device:hasDPad() or Device:hasKeyboard() then
+    if Device:hasKeys() then
         self.layout = self.buttons_layout
         self.layout[1][1]:onFocus()
         self.key_events.SelectByKeyPress = { {{"Press", "Enter"}} }

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -236,8 +236,8 @@ function InputContainer:onInput(input)
             },
         },
     }
-    self.input_dialog:onShowKeyboard()
     UIManager:show(self.input_dialog)
+    self.input_dialog:onShowKeyboard()
 end
 
 function InputContainer:closeInputDialog()

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -860,8 +860,8 @@ function DictQuickLookup:lookupInputWord(hint)
             }
         },
     }
-    self.input_dialog:onShowKeyboard()
     UIManager:show(self.input_dialog)
+    self.input_dialog:onShowKeyboard()
 end
 
 function DictQuickLookup:inputLookup()

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -1,3 +1,4 @@
+local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local logger = require("logger")
@@ -33,13 +34,15 @@ function FocusManager:init()
     if not self.selected then
         self.selected = { x = 1, y = 1 }
     end
-    self.key_events = {
-        -- these will all generate the same event, just with different arguments
-        FocusUp =    { {"Up"},    doc = "move focus up",    event = "FocusMove", args = {0, -1} },
-        FocusDown =  { {"Down"},  doc = "move focus down",  event = "FocusMove", args = {0,  1} },
-        FocusLeft =  { {"Left"},  doc = "move focus left",  event = "FocusMove", args = {-1, 0} },
-        FocusRight = { {"Right"}, doc = "move focus right", event = "FocusMove", args = {1,  0} },
-    }
+    if Device:hasKeys() then
+        self.key_events = {
+            -- these will all generate the same event, just with different arguments
+            FocusUp =    { {"Up"},    doc = "move focus up",    event = "FocusMove", args = {0, -1} },
+            FocusDown =  { {"Down"},  doc = "move focus down",  event = "FocusMove", args = {0,  1} },
+            FocusLeft =  { {"Left"},  doc = "move focus left",  event = "FocusMove", args = {-1, 0} },
+            FocusRight = { {"Right"}, doc = "move focus right", event = "FocusMove", args = {1,  0} },
+        }
+    end
 end
 
 function FocusManager:onFocusMove(args)

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -65,7 +65,9 @@ function FocusManager:onFocusMove(args)
             end
         elseif not self.layout[self.selected.y + dy][self.selected.x] then
             --inner horizontal border, trying to be clever and step down
-            self:_verticalStep(dy)
+            if not self:_verticalStep(dy) then
+                break
+            end
         elseif not self.layout[self.selected.y + dy][self.selected.x + dx] then
             --vertical border, no wraparound
             break
@@ -100,7 +102,7 @@ function FocusManager:_wrapAround(dy)
         self.selected.y = y
         if not self.layout[self.selected.y][self.selected.x] then
             --call verticalStep on the current line to perform the search
-            self:_verticalStep(0)
+            return self:_verticalStep(0)
         end
         return true
     else
@@ -110,6 +112,10 @@ end
 
 function FocusManager:_verticalStep(dy)
     local x = self.selected.x
+    if type(self.layout[self.selected.y + dy]) ~= "table" or self.layout[self.selected.y + dy] == {} then
+        logger.err("[FocusManager] : Malformed layout")
+        return false
+    end
     --looking for the item on the line below, the closest on the left side
     while not self.layout[self.selected.y + dy][x] do
         x = x - 1
@@ -118,15 +124,12 @@ function FocusManager:_verticalStep(dy)
             x = self.selected.x
             while not self.layout[self.selected.y + dy][x] do
                 x = x + 1
-                if x>100 then
-                    logger.dbg("[FocusManager] : Something went very wrong")
-                    break
-                end
             end
         end
     end
     self.selected.x = x
     self.selected.y = self.selected.y + dy
+    return true
 end
 
 function FocusManager:getFocusItem()

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -115,6 +115,10 @@ function FocusManager:_verticalStep(dy)
             x = self.selected.x
             while not self.layout[self.selected.y + dy][x] do
                 x = x + 1
+                if x>100 then
+                    logger.dbg("[FocusManager] : Something went very wrong")
+                    break
+                end
             end
         end
     end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -18,8 +18,8 @@ Example:
         show_icon = false,
         timeout = 5,  -- This widget will vanish in 5 seconds.
     }
-    sample_input:onShowKeyboard()
     UIManager:show(sample_input)
+    sample_input:onShowKeyboard()
 ]]
 
 local Blitbuffer = require("ffi/blitbuffer")

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -197,7 +197,7 @@ function InputDialog:init()
         }
     }
     --little hack to piggyback on the layout of the button_table to handle the new InputText
-    table.insert(self.button_table.layout, #self.button_table.layout, {self._input_widget})
+    table.insert(self.button_table.layout, 1, {self._input_widget})
 
     self[1] = CenterContainer:new{
         dimen = Geom:new{

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -67,6 +67,7 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = require("device").screen
 
 local InputDialog = InputContainer:new{
+    is_always_active = true,
     title = "",
     input = "",
     input_hint = "",

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -34,8 +34,8 @@ Example:
             }
         },
     }
-    sample_input:onShowKeyboard()
     UIManager:show(sample_input)
+    sample_input:onShowKeyboard()
 
 If it would take the user more than half a minute to recover from a mistake,
 a "Cancel" button <em>must</em> be added to the dialog. The cancellation button

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -50,6 +50,7 @@ longer than three words it should just read "OK".
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
+local Device = require("device")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
@@ -64,7 +65,7 @@ local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
-local Screen = require("device").screen
+local Screen = Device.screen
 
 local InputDialog = InputContainer:new{
     is_always_active = true,
@@ -196,8 +197,10 @@ function InputDialog:init()
             }
         }
     }
-    --little hack to piggyback on the layout of the button_table to handle the new InputText
-    table.insert(self.button_table.layout, 1, {self._input_widget})
+    if Device:hasKeys() then
+        --little hack to piggyback on the layout of the button_table to handle the new InputText
+        table.insert(self.button_table.layout, 1, {self._input_widget})
+    end
 
     self[1] = CenterContainer:new{
         dimen = Geom:new{

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -196,6 +196,8 @@ function InputDialog:init()
             }
         }
     }
+    --little hack to piggyback on the layout of the button_table to handle the new InputText
+    table.insert(self.button_table.layout, #self.button_table.layout, {self._input_widget})
 
     self[1] = CenterContainer:new{
         dimen = Geom:new{

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -91,6 +91,18 @@ if Device.isTouchDevice() then
 elseif Device.hasDPad() then
     Keyboard = require("ui/widget/virtualkeyboard")
     function InputText:initEventListener() end --do nothing but doesn't crash for now
+
+    function InputText:onFocus()
+        self.key_events.ShowKeyboard = { {"Press"}, doc = "show keyboard" }
+        self:focus()
+        return true
+    end
+
+    function InputText:onUnfocus()
+        self.key_events = {}
+        self:unfocus()
+        return true
+    end
 else
     Keyboard = require("ui/widget/physicalkeyboard")
     function InputText:initEventListener() end
@@ -241,6 +253,7 @@ end
 
 function InputText:onShowKeyboard()
     UIManager:show(self.keyboard)
+    return true
 end
 
 function InputText:onCloseKeyboard()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -88,7 +88,7 @@ if Device.isTouchDevice() then
             end)
         end
     end
-elseif not Device.hasKeyboard() then
+elseif Device.hasDPad() then
     Keyboard = require("ui/widget/virtualkeyboard")
     function InputText:initEventListener() end --do nothing but doesn't crash for now
 else

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -219,8 +219,9 @@ function InputText:initKeyboard()
     if self.input_type == "number" then
         keyboard_layout = 4
     end
+    self.key_events = nil
     self.keyboard = Keyboard:new{
-        layout = keyboard_layout,
+        keyboard_layout = keyboard_layout,
         inputbox = self,
         width = Screen:getWidth(),
     }

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -130,9 +130,9 @@ function MultiInputDialog:onSwitchFocus(inputbox)
     -- focus new inputbox
     self._input_widget = inputbox
     self._input_widget:focus()
-    self._input_widget:onShowKeyboard()
 
     UIManager:show(self)
+    self._input_widget:onShowKeyboard()
 end
 
 return MultiInputDialog

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -132,8 +132,6 @@ function MultiInputDialog:onSwitchFocus(inputbox)
     -- focus new inputbox
     self._input_widget = inputbox
     self._input_widget:focus()
-
-    UIManager:show(self)
     self._input_widget:onShowKeyboard()
 end
 

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -78,6 +78,8 @@ function MultiInputDialog:init()
         })
     end
 
+    --remove the not needed hack in inputdialog
+    table.remove(self.button_table.layout, 1)
     -- Add same vertical space after than before InputText
     table.insert(VerticalGroupData,CenterContainer:new{
         dimen = Geom:new{

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -48,6 +48,8 @@ function MultiInputDialog:init()
             scroll = false,
             parent = self,
         }
+        --little hack to piggyback on the layout of the button_table to handle the new InputText
+        table.insert(self.button_table.layout, #self.button_table.layout, {input_field[k]})
         if field.description then
             input_description[k] = FrameContainer:new{
                 padding = self.description_padding,

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -48,8 +48,10 @@ function MultiInputDialog:init()
             scroll = false,
             parent = self,
         }
-        --little hack to piggyback on the layout of the button_table to handle the new InputText
-        table.insert(self.button_table.layout, #self.button_table.layout, {input_field[k]})
+        if Device:hasKeys() then
+            --little hack to piggyback on the layout of the button_table to handle the new InputText
+            table.insert(self.button_table.layout, #self.button_table.layout, {input_field[k]})
+        end
         if field.description then
             input_description[k] = FrameContainer:new{
                 padding = self.description_padding,
@@ -78,8 +80,10 @@ function MultiInputDialog:init()
         })
     end
 
-    --remove the not needed hack in inputdialog
-    table.remove(self.button_table.layout, 1)
+    if Device:hasKeys() then
+        --remove the not needed hack in inputdialog
+        table.remove(self.button_table.layout, 1)
+    end
     -- Add same vertical space after than before InputText
     table.insert(VerticalGroupData,CenterContainer:new{
         dimen = Geom:new{

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -300,8 +300,8 @@ function NetworkItem:onEditNetwork()
             },
         },
     }
-    password_input:onShowKeyboard()
     UIManager:show(password_input)
+    password_input:onShowKeyboard()
     return true
 end
 
@@ -331,8 +331,8 @@ function NetworkItem:onAddNetwork()
             },
         },
     }
-    password_input:onShowKeyboard()
     UIManager:show(password_input)
+    password_input:onShowKeyboard()
     return true
 end
 

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -139,8 +139,8 @@ function NumberPickerWidget:paintWidget()
                     },
                 },
             }
-            input:onShowKeyboard()
             UIManager:show(input)
+            input:onShowKeyboard()
         end
     end
 

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -146,8 +146,8 @@ function OPDSBrowser:addNewCatalog()
         width = Screen:getWidth() * 0.95,
         height = Screen:getHeight() * 0.2,
     }
-    self.add_server_dialog:onShowKeyboard()
     UIManager:show(self.add_server_dialog)
+    self.add_server_dialog:onShowKeyboard()
 end
 
 function OPDSBrowser:editCalibreServer()
@@ -187,8 +187,8 @@ function OPDSBrowser:editCalibreServer()
         width = Screen:getWidth() * 0.95,
         height = Screen:getHeight() * 0.2,
     }
-    self.add_server_dialog:onShowKeyboard()
     UIManager:show(self.add_server_dialog)
+    self.add_server_dialog:onShowKeyboard()
 end
 
 function OPDSBrowser:genItemTableFromRoot()
@@ -322,8 +322,8 @@ function OPDSBrowser:fetchWithLogin(host, callback)
         height = Screen:getHeight() * 0.4,
     }
 
-    self.login_dialog:onShowKeyboard()
     UIManager:show(self.login_dialog)
+    self.login_dialog:onShowKeyboard()
 end
 
 function OPDSBrowser:closeDialog()
@@ -679,8 +679,8 @@ function OPDSBrowser:editOPDSServer(item)
         width = Screen:getWidth() * 0.95,
         height = Screen:getHeight() * 0.2,
     }
-    self.edit_server_dialog:onShowKeyboard()
     UIManager:show(self.edit_server_dialog)
+    self.edit_server_dialog:onShowKeyboard()
 end
 
 function OPDSBrowser:deleteOPDSServer(item)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -160,7 +160,7 @@ function VirtualKey:invert(invert)
 end
 
 local VirtualKeyboard = FocusManager:new{
-    is_always_active = false,
+    modal = true,
     disable_double_tap = true,
     inputbox = nil,
     KEYS = {}, -- table to store layouts

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -216,8 +216,8 @@ function EvernoteExporter:login()
         height = Screen:getHeight() * 0.4,
     }
 
-    self.login_dialog:onShowKeyboard()
     UIManager:show(self.login_dialog)
+    self.login_dialog:onShowKeyboard()
 end
 
 function EvernoteExporter:closeDialog()

--- a/plugins/goodreads.koplugin/main.lua
+++ b/plugins/goodreads.koplugin/main.lua
@@ -143,8 +143,8 @@ How to generate a key and a secret key:
         height = Screen:getHeight() * 0.2,
         input_type = "text",
     }
-    self.settings_dialog:onShowKeyboard()
     UIManager:show(self.settings_dialog)
+    self.settings_dialog:onShowKeyboard()
 end
 
 function Goodreads:saveSettings(fields)
@@ -227,8 +227,8 @@ function Goodreads:search(search_type)
             }
         },
     }
-    search_input:onShowKeyboard()
     UIManager:show(search_input)
+    search_input:onShowKeyboard()
 end
 
 return Goodreads

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -290,8 +290,8 @@ function KOSync:login()
         height = Screen:getHeight() * 0.4,
     }
 
-    self.login_dialog:onShowKeyboard()
     UIManager:show(self.login_dialog)
+    self.login_dialog:onShowKeyboard()
 end
 
 function KOSync:closeDialog()

--- a/plugins/perceptionexpander.koplugin/main.lua
+++ b/plugins/perceptionexpander.koplugin/main.lua
@@ -153,8 +153,8 @@ function PerceptionExpander:showSettingsDialog()
         width = Screen:getWidth() * 0.8,
         height = Screen:getHeight() * 0.3,
     }
-    self.settings_dialog:onShowKeyboard()
     UIManager:show(self.settings_dialog)
+    self.settings_dialog:onShowKeyboard()
 end
 
 function PerceptionExpander:addToMainMenu(menu_items)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -662,8 +662,8 @@ function ReaderStatistics:updateSettings()
         height = Screen:getHeight() * 0.2,
         input_type = "number",
     }
-    self.settings_dialog:onShowKeyboard()
     UIManager:show(self.settings_dialog)
+    self.settings_dialog:onShowKeyboard()
 end
 
 function ReaderStatistics:addToMainMenu(menu_items)

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -39,8 +39,8 @@ function Terminal:start()
             end,
         }}},
     }
-    self.input:onShowKeyboard()
     UIManager:show(self.input)
+    self.input:onShowKeyboard()
 end
 
 function Terminal:execute()


### PR DESCRIPTION
Now when opening a widget with the virtualkeyboard, the focus is first on the keyboard, then press `Back` to close the keyboard, then the focus is on the widget itself. `Press` to reopen the keyboard.

My solution is to change the order of the widget. The last one (on top) will be the virtualkeybard so it catch all the keybinding, and below it, make the dialog `is_always_active = true `so it can receive touch event.

There is still some visual weirdness with the focus on the keyboard but it's not a problem.
