### PR TITLE
[fix] calibrecompanion.plugin

### DIFF
--- a/plugins/calibrecompanion.koplugin/main.lua
+++ b/plugins/calibrecompanion.koplugin/main.lua
@@ -61,7 +61,7 @@ end
 
 function CalibreCompanion:find_calibre_server()
     local socket = require("socket")
-    local udp = socket.udp()
+    local udp = socket.udp4()
     udp:setoption("broadcast", true)
     udp:setsockname("*", 8134)
     udp:settimeout(3)


### PR DESCRIPTION
Fixes #3794. 

Upstream luasocket https://github.com/diegonehab/luasocket/commit/96965b179c7311f850f72a8629b9ba6d3a31d117 switched from just `socket.udp()` to `socket.udp4()` and `socket.udp6()`.