### PR TITLE
[fix] kodev update $VERSION for `run android`

### DIFF
--- a/kodev
+++ b/kodev
@@ -2,6 +2,7 @@
 
 CURDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSION=$(git describe HEAD)
+VERSION=${VERSION}_$(git describe HEAD | xargs git show -s --format=format:"%cd" --date=short)
 
 # Default Android build to arm.
 ANDROID_ARCH=${ANDROID_ARCH:-arm}
@@ -323,7 +324,7 @@ ${SUPPORTED_RELEASE_TARGETS}"
     done
 
     if [ "${ignore_translation}" -eq 0 ]; then
-        if which tx>/dev/null; then
+        if command -v tx>/dev/null; then
             make po || {
                 echo "ERROR: failed to fetch translation."
                 echo "Tip: Use --ignore-translation OPTION if you want to build a release without translation."
@@ -358,10 +359,10 @@ ${SUPPORTED_RELEASE_TARGETS}"
         android)
             kodev-build android
             export PATH=$PATH:${CURDIR}/base/toolchain/android-sdk-linux/tools
-            which android &>/dev/null || {
+            command -v android &>/dev/null || {
                 make -C "${CURDIR}/base/toolchain" android-sdk
             }
-            ANDROID_HOME=$(dirname "$(dirname "$(which android)")")
+            ANDROID_HOME=$(dirname "$(dirname "$(command -v android)")")
             export ANDROID_HOME
             export PATH=$PATH:${NDK}
             make TARGET=android update
@@ -559,7 +560,7 @@ TARGET:
             # run with catchsegv by default when it is available
             # see https://github.com/koreader/koreader/issues/2878#issuecomment-326796777
             if command -v catchsegv >/dev/null; then
-                CATCHSEGV=$(which catchsegv)
+                CATCHSEGV=$(command -v catchsegv)
             fi
 
             KOREADER_COMMAND="${CATCHSEGV} ./reader.lua -d"


### PR DESCRIPTION
As in 16061370f48026eb18bdfa30e9ed2faf94e59387, leftover from #3723.

Also replaced a few non-standard `which` by `command -v` as per new shellcheck rule.
See https://github.com/koalaman/shellcheck/wiki/SC2230