### PR TITLE
Remove search highlights when closing search bar

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -136,6 +136,7 @@ function ReaderSearch:onShowSearchDialog(text)
         tap_close_callback = function()
             logger.dbg("highlight clear")
             self.ui.highlight:clear()
+            UIManager:setDirty(self.dialog, "ui")
         end,
     }
     do_search(self.searchFromCurrent, text, 0)()


### PR DESCRIPTION
They were indeed removed, but no full screen refresh was requested, so the highlights stayed visible.
Only happen when search term was typed (via `Full text search` menu), does not happen when search started from a word selected with Hold (the refresh was done in that case).
Not noticable on the emulator, as on the emulator, all refreshes are full screen, so closing the search bar sets its small area as dirty, which is enough to refresh the full screen.