### PR TITLE
[Fix] Make ScrollTextWidget:moveCursor return the new charpos.

### DIFF
--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -93,7 +93,7 @@ function ScrollTextWidget:focus()
 end
 
 function ScrollTextWidget:moveCursor(x, y)
-    self.text_widget:moveCursor(x, y)
+    return self.text_widget:moveCursor(x, y)
 end
 
 function ScrollTextWidget:scrollText(direction)


### PR DESCRIPTION
Found by using the InputText widget with scroll=true, and trying to enter text after tapping to move the cursor - wbuilder crashed with the error "./luajit: frontend/ui/widget/inputtext.lua:258: bad argument #2 to 'insert' (number expected, got nil)".