### PR TITLE
[fix] Kobo suspend when touching screen

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -143,9 +143,10 @@ function UIManager:init()
         self.event_handlers["__default__"] = function(input_event)
             if Device.screen_saver_mode then
                 -- Suspension in Kobo can be interrupted by screen updates. We
-                -- ignore user touch input here so screen udpate won't be
+                -- ignore user touch input here so screen updates won't be
                 -- triggered in suspend mode
-                self:suspend()
+                -- We should not call self:suspend() here lest we stay on forever
+                -- trying to suspend. Other systems take care of unintended wake-up.
             else
                 self:sendEvent(input_event)
             end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -141,13 +141,11 @@ function UIManager:init()
             end
         end
         self.event_handlers["__default__"] = function(input_event)
-            if Device.screen_saver_mode then
-                -- Suspension in Kobo can be interrupted by screen updates. We
-                -- ignore user touch input here so screen updates won't be
-                -- triggered in suspend mode
-                -- We should not call self:suspend() here lest we stay on forever
-                -- trying to suspend. Other systems take care of unintended wake-up.
-            else
+            -- Suspension in Kobo can be interrupted by screen updates. We ignore user touch input
+            -- in screen_saver_mode so screen updates won't be triggered in suspend mode.
+            -- We should not call self:suspend() in screen_saver_mode lest we stay on forever
+            -- trying to reschedule suspend. Other systems take care of unintended wake-up.
+            if not Device.screen_saver_mode then
                 self:sendEvent(input_event)
             end
         end


### PR DESCRIPTION
As in https://github.com/koreader/koreader/issues/3706#issuecomment-370336452 Suspend kept being rescheduled on every touch while we should just ignore it.

Fixes #3706.