### PR TITLE
[fix, i18n] ui/widget/frontlightwidget: translators don't need to wor…

### DIFF
--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -401,7 +401,8 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         })
 
     local text_auto_nl = TextBoxWidget:new{
-        text = _("Maximum at:  "),
+        -- @TODO implement padding_right (etc.) on TextBoxWidget and remove the two-space hack
+        text = _("Maximum at:") .. "  ",
         face = self.larger_font_face,
         alignment = "right",
         fgcolor = self.powerd.auto_warmth and Blitbuffer.COLOR_BLACK or


### PR DESCRIPTION
…ry about number of spaces

Transifex warns about some issues but this is not one of them.

The proper solution would be `padding_right`. But although it's supported on FrameContainer it's not passed on through TextBoxWidget.