### PR TITLE
CoverBrowser: set default display modes on first launch

### DIFF
--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -58,6 +58,18 @@ function CoverBrowser:init()
         return
     end
 
+    -- Set up default display modes on first launch
+    if not G_reader_settings:isTrue("coverbrowser_initial_default_setup_done") then
+        -- Only if no display mode has been set yet
+        if not BookInfoManager:getSetting("filemanager_display_mode")
+            and not BookInfoManager:getSetting("history_display_mode") then
+            logger.info("CoverBrowser: setting default display modes")
+            BookInfoManager:saveSetting("filemanager_display_mode", "list_image_meta")
+            BookInfoManager:saveSetting("history_display_mode", "mosaic_image")
+        end
+        G_reader_settings:saveSetting("coverbrowser_initial_default_setup_done", true)
+    end
+
     self:setupFileManagerDisplayMode(BookInfoManager:getSetting("filemanager_display_mode"))
     self:setupHistoryDisplayMode(BookInfoManager:getSetting("history_display_mode"))
     init_done = true


### PR DESCRIPTION
As requested in https://github.com/koreader/koreader/pull/3817#issuecomment-377668725 :

> I'd definitely prefer defaulting to one of the detailed list views these days. Probably either detailed list with cover images and metadata or detailed list with cover images and filenames.

I tried _cover images and filenames_, which would be the less intrusive for people used to classic mode, but the bigger filename in bold was a bit strong for me (when compared to Classic mode with small font size). Metadata with title and authors on 2 lines looked nicer.

@KenMaltby : I believe you use classic mode: with this, on your next update, you'll be switched to some other modes, and you'll have to manually reset them to classic mode (and delete Cache DB if you want to keep things tidy). Is that ok ?
