### PR TITLE
Wikipedia link: check if previously saved as EPUB

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -329,7 +329,7 @@ function DictQuickLookup:update()
                         local lang = self.lang or self.wiki_languages_copy[1]
                         -- Just to be safe (none of the invalid chars, except ':' for uninteresting
                         -- Portal: or File: wikipedia pages, should be in lookup_word)
-                        local cleaned_lookupword = util.replaceInvalidChars(self.lookupword)
+                        local cleaned_lookupword = util.replaceInvalidChars(self.lookupword:gsub("_", " "))
                         local filename = cleaned_lookupword .. "."..string.upper(lang)..".epub"
                         -- Find a directory to save file into
                         local dir

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -28,6 +28,7 @@ local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
 local ImageWidget = require("ui/widget/imagewidget")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local MovableContainer = require("ui/widget/container/movablecontainer")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
@@ -121,17 +122,19 @@ function MultiConfirmBox:init()
 
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),
-        FrameContainer:new{
-            background = Blitbuffer.COLOR_WHITE,
-            margin = self.margin,
-            padding = self.padding,
-            padding_bottom = 0, -- no padding below buttontable
-            VerticalGroup:new{
-                align = "left",
-                content,
-                -- Add same vertical space after than before content
-                VerticalSpan:new{ width = self.margin + self.padding },
-                button_table,
+        MovableContainer:new{
+            FrameContainer:new{
+                background = Blitbuffer.COLOR_WHITE,
+                margin = self.margin,
+                padding = self.padding,
+                padding_bottom = 0, -- no padding below buttontable
+                VerticalGroup:new{
+                    align = "left",
+                    content,
+                    -- Add same vertical space after than before content
+                    VerticalSpan:new{ width = self.margin + self.padding },
+                    button_table,
+                }
             }
         }
     }


### PR DESCRIPTION
As suggested in https://github.com/koreader/koreader/issues/3757#issuecomment-374201294 :


>> when I click on the same link (whose article is already downloaded) again then open the downloaded EPUB locally (instead of going online);

> This is a good idea: we could check at least, before going online do a lookup, if there is an EPUB of that link's article in the currently-being-read article EPUB directory (assuming you filled articles about the same topic in the same directory). 

Probably little chances I encounter this feature in my daily usage, but well...

<kbd>![image](https://user-images.githubusercontent.com/24273478/38429702-71ad1a3e-39bf-11e8-8903-c8c61354bd1a.png)</kbd>

Suggestion for alternate desription and (small) button texts ?

Also makes MultiConfirmBox movable, like ConfirmBox is.
The dictquicklookup `:gsub("_", " ")` was not really needed as it's done previously, except when one cancels the wikipedia lookup, but still choose to Save as EPUB from there (which I often do).