### PR TITLE
[fix, UX] frontlightwidget: More space for text and centering

### DIFF
--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -413,9 +413,10 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         text = " " .. math.floor(self.powerd.max_warmth_hour) .. ":" ..
             self.powerd.max_warmth_hour % 1 * 6 .. "0",
         face = self.larger_font_face,
+        alignment = "center",
         fgcolor =self.powerd.auto_warmth and Blitbuffer.COLOR_BLACK or
             Blitbuffer.COLOR_GREY,
-        width = self.screen_width * 0.1
+        width = self.screen_width * 0.15
     }
     local button_minus_one_hour = Button:new{
         text = "−",


### PR DESCRIPTION
Otherwise clock display will have a line break for low DPI (see issue