### PR TITLE
Fix Menusorter

### DIFF
--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -136,7 +136,7 @@ function MenuSorter:sort(item_table, order)
         if menu_table["KOMenu:menu_buttons"][i].sub_item_table then
             local tmp  = menu_table["KOMenu:menu_buttons"][i].sub_item_table
             menu_table["KOMenu:menu_buttons"][i] = nil
-            menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = tmp 
+            menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = tmp
         else
             menu_table["KOMenu:menu_buttons"][i] = nil
             menu_buttons_offset = menu_buttons_offset + 1

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -134,7 +134,9 @@ function MenuSorter:sort(item_table, order)
     local menu_buttons_offset = 0
     for i,top_menu in ipairs(menu_table["KOMenu:menu_buttons"]) do
         if menu_table["KOMenu:menu_buttons"][i].sub_item_table then
-            menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = menu_table["KOMenu:menu_buttons"][i].sub_item_table
+            local tmp  = menu_table["KOMenu:menu_buttons"][i].sub_item_table
+            menu_table["KOMenu:menu_buttons"][i] = nil
+            menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = tmp 
         else
             menu_table["KOMenu:menu_buttons"][i] = nil
             menu_buttons_offset = menu_buttons_offset + 1

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -141,8 +141,6 @@ function MenuSorter:sort(item_table, order)
         else
             menu_buttons_offset = menu_buttons_offset + 1
         end
-
-        menu_button = nil
     end
     -- handle disabled
     if order["KOMenu:disabled"] then

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -131,11 +131,11 @@ function MenuSorter:sort(item_table, order)
     end
     -- cleanup, top-level items shouldn't have sub_item_table
     -- they should, however have one going in
+    -- Also, compress the menu table.
     local menu_buttons_offset = 0
     for i,top_menu in ipairs(menu_table["KOMenu:menu_buttons"]) do
-        local menu_button  = menu_table["KOMenu:menu_buttons"][i].sub_item_table
+        local menu_button = menu_table["KOMenu:menu_buttons"][i].sub_item_table
         menu_table["KOMenu:menu_buttons"][i] = nil
-
         if menu_button then
             menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = menu_button
         else

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -133,14 +133,16 @@ function MenuSorter:sort(item_table, order)
     -- they should, however have one going in
     local menu_buttons_offset = 0
     for i,top_menu in ipairs(menu_table["KOMenu:menu_buttons"]) do
-        if menu_table["KOMenu:menu_buttons"][i].sub_item_table then
-            local tmp  = menu_table["KOMenu:menu_buttons"][i].sub_item_table
-            menu_table["KOMenu:menu_buttons"][i] = nil
-            menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = tmp
+        local menu_button  = menu_table["KOMenu:menu_buttons"][i].sub_item_table
+        menu_table["KOMenu:menu_buttons"][i] = nil
+
+        if menu_button then
+            menu_table["KOMenu:menu_buttons"][i-menu_buttons_offset] = menu_button
         else
-            menu_table["KOMenu:menu_buttons"][i] = nil
             menu_buttons_offset = menu_buttons_offset + 1
         end
+
+        menu_button = nil
     end
     -- handle disabled
     if order["KOMenu:disabled"] then


### PR DESCRIPTION
See : https://github.com/koreader/koreader/pull/3773#issuecomment-379181517

@Frenzie How do you feel about this ?

Now the layout look like this : 
```

{ { {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.cabinet.files.png",
    id = "filemanager_settings"
  }, { {...}, {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.settings.png",
    id = "setting"
  }, { {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.tools.png",
    id = "tools"
  }, { {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.magnify.browse.png",
    id = "search"
  }, { {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/menu-icon.png",
    id = "main"
  },
  id = "KOMenu:menu_buttons"
}

```
Instead of this : 

```
{ { {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.cabinet.files.png",
    id = "filemanager_settings"
  }, { {...}, {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.settings.png",
    id = "setting"
  }, { {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.tools.png",
    id = "tools"
  }, { {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/appbar.magnify.browse.png",
    id = "search"
  }, <1>{ {...}, {...}, {...}, {...}, {...}, {...},
    icon = "resources/icons/menu-icon.png",
    id = "main"
  }, {
    id = "main",
    sub_item_table = <table 1>
  },
  id = "KOMenu:menu_buttons"
}

```

