### PR TITLE
[fix] setupkoenv: change "ERROR" to "(warning)"

### DIFF
--- a/setupkoenv.lua
+++ b/setupkoenv.lua
@@ -26,7 +26,7 @@ ffi.load = function(lib)
     local lib_path = package.searchpath(lib, "./lib?.so;./libs/lib?.so;./libs/lib?.so.1")
 
     if not lib_path then
-        io.write("ffi.load ERROR: ", re, "\n")
+        io.write("ffi.load (warning): ", re, "\n")
         error('Not able to load dynamic library: ' .. lib)
     else
         io.write("ffi.load (assisted searchpath): ", lib_path, "\n")


### PR DESCRIPTION
Not all failures to load are fatal. I still worry that this might be too noisy but it'd be useful to always have available.