### PR TITLE
ReaderBack: allow for disabling back history

### DIFF
--- a/frontend/apps/reader/modules/readerback.lua
+++ b/frontend/apps/reader/modules/readerback.lua
@@ -9,6 +9,9 @@ local ReaderBack = EventListener:new{
     location_stack = {},
     -- a limit not intended to be a practical limit but just a failsafe
     max_stack = 5000,
+    -- allow for disabling back history, and having Back key
+    -- quit immediately (useful for some developers)
+    disabled = G_reader_settings:isFalse("enable_back_history"),
 }
 
 function ReaderBack:init()
@@ -48,11 +51,13 @@ end
 
 -- Scroll mode crengine
 function ReaderBack:onPosUpdate()
+    if self.disabled then return end
     self:addCurrentLocationToStack()
 end
 
 -- Paged media
 function ReaderBack:onPageUpdate()
+    if self.disabled then return end
     self:addCurrentLocationToStack()
 end
 
@@ -64,7 +69,9 @@ end
 function ReaderBack:onBack()
     local location_stack = self.location_stack
 
-    if #location_stack > 1 then
+    if self.disabled then
+        self.ui:handleEvent(Event:new("Close"))
+    elseif #location_stack > 1 then
         local saved_location = table.remove(location_stack)
 
         if saved_location then


### PR DESCRIPTION
Mostly useful for developers for quick launch & quit of the emulator. See why _I_ want that in https://github.com/koreader/koreader/pull/3821#issuecomment-379239310 

This allows getting the old behaviour by adding to `settings.reader.lua`:
`["enable_back_history"] = false,`

ReaderBack has also moved the back action from the <kbd>Backspace</kbd> to the <kbd>Esc</kbd>. To replace <kbd>Esc</kbd> with the old <kbd>Backspace</kbd>, create `koreader-emulator-x86_64-linux-gnu-debug/koreader/settings/event_map.lua` with:
```
return {
   [42] = "Back"
}
```
