### PR TITLE
Fix overlap in scroll mode for cre documents

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -289,7 +289,7 @@ function ReaderFooter:resetLayout()
 end
 
 function ReaderFooter:getHeight()
-    return self.footer_text:getSize().h
+    return self.footer_content:getSize().h
 end
 
 function ReaderFooter:disableFooter()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -473,7 +473,7 @@ function ReaderRolling:onGotoViewRel(diff)
         local page_visible_height = self.ui.dimen.h - footer_height
         local pan_diff = diff * page_visible_height
         if self.show_overlap_enable then
-            overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0) * self.overlap_lines
+            local overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0) * self.overlap_lines
             if pan_diff > overlap_h then
                 pan_diff = pan_diff - overlap_h
             elseif pan_diff < -overlap_h then

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -41,7 +41,8 @@ local ReaderRolling = InputContainer:new{
     xpointer = nil,
     panning_steps = ReaderPanning.panning_steps,
     show_overlap_enable = nil,
-    overlap = 20,
+    -- nb of lines from previous page to show on next page (scroll mode only)
+    overlap_lines = G_reader_settings:readSetting("copt_overlap_lines") or 1,
     cre_top_bar_enabled = false,
 }
 
@@ -468,16 +469,21 @@ end
 function ReaderRolling:onGotoViewRel(diff)
     logger.dbg("goto relative screen:", diff, ", in mode: ", self.view.view_mode)
     if self.view.view_mode == "scroll" then
-        local pan_diff = diff * self.ui.dimen.h
+        local footer_height = (self.view.footer_visible and 1 or 0) * self.view.footer:getHeight()
+        local page_visible_height = self.ui.dimen.h - footer_height
+        local pan_diff = diff * page_visible_height
         if self.show_overlap_enable then
-            if pan_diff > self.overlap then
-                pan_diff = pan_diff - self.overlap
-            elseif pan_diff < -self.overlap then
-                pan_diff = pan_diff + self.overlap
+            overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0) * self.overlap_lines
+            if pan_diff > overlap_h then
+                pan_diff = pan_diff - overlap_h
+            elseif pan_diff < -overlap_h then
+                pan_diff = pan_diff + overlap_h
             end
         end
         local old_pos = self.current_pos
-        self:_gotoPos(self.current_pos + pan_diff)
+        -- Only draw dim area when we moved a whole page (not when smaller scroll with Pan)
+        local do_dim_area = math.abs(diff) == 1
+        self:_gotoPos(self.current_pos + pan_diff, do_dim_area)
         if diff > 0 and old_pos == self.current_pos then
             self.ui:handleEvent(Event:new("EndOfBook"))
         end
@@ -588,21 +594,25 @@ end
 --[[
     PosUpdate event is used to signal other widgets that pos has been changed.
 --]]
-function ReaderRolling:_gotoPos(new_pos)
+function ReaderRolling:_gotoPos(new_pos, do_dim_area)
     if new_pos == self.current_pos then return end
     if new_pos < 0 then new_pos = 0 end
     if new_pos > self.doc_height then new_pos = self.doc_height end
     -- adjust dim_area according to new_pos
-    if self.view.view_mode ~= "page" and self.show_overlap_enable then
+    if self.view.view_mode ~= "page" and self.show_overlap_enable and do_dim_area then
+        local footer_height = (self.view.footer_visible and 1 or 0) * self.view.footer:getHeight()
+        local page_visible_height = self.ui.dimen.h - footer_height
         local panned_step = new_pos - self.current_pos
         self.view.dim_area.x = 0
-        self.view.dim_area.h = self.ui.dimen.h - math.abs(panned_step)
+        self.view.dim_area.h = page_visible_height - math.abs(panned_step)
         self.view.dim_area.w = self.ui.dimen.w
         if panned_step < 0 then
-            self.view.dim_area.y = self.ui.dimen.h - self.view.dim_area.h
+            self.view.dim_area.y = page_visible_height - self.view.dim_area.h
         elseif panned_step > 0 then
             self.view.dim_area.y = 0
         end
+    else
+        self.view:resetDimArea()
     end
     self.ui.document:gotoPos(new_pos)
     -- The current page we get in scroll mode may be a bit innacurate,

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -577,7 +577,7 @@ describe("Readerfooter module", function()
 
         assert.falsy(footer.has_no_mode)
         assert.truthy(readerui.view.footer_visible)
-        assert.is.same(24, footer:getHeight())
+        assert.is.same(15, footer:getHeight())
     end)
 
     it("should return correct footer height when all modes are disabled", function()
@@ -595,7 +595,7 @@ describe("Readerfooter module", function()
 
         assert.truthy(footer.has_no_mode)
         assert.falsy(readerui.view.footer_visible)
-        assert.is.same(24, footer:getHeight())
+        assert.is.same(15, footer:getHeight())
     end)
 
     it("should disable footer if settings.disabled is true", function()


### PR DESCRIPTION
Uses a setting `["copt_overlap_lines"] = N,` (default to `1`) for the number of text lines from previous page to show on next page (instead of a hardcoded and unscaled 20).
Takes footer height into account for overlap calculation and dim area.
Shows overlap only when changing pages (not when panning: it was changing at each pan step and it was real ugly).

It may help a bit with #3813 by just being more accurate, but there's still the misconfort of text lines being cut or dim'ed in the middle. But we can't do much more in scroll mode, when we have no knowledge of text rendering: we just cut slices of the whole document height.
(Doing overlap and dim in page mode would be a far more complex work!)

Also fix `ReaderFooter:getHeight()` which was returning a higher height than the real one since footer refactoring over the years.
**This may have some effect on PDF documents too.** (logically, it's better, but as I don't read much of them, I'm not sure if it has ever been noticed): when going to next page, a bit more of the previous page content was shown on the next page.
Taking footer size into account for PDF has been added by https://github.com/koreader/koreader/pull/2079. It may have been or not accurate at the time, I don't know. Since then, there's been many works on ReaderFooter, including a massive rework by @houqp. And it seems that now, the returned value is no more accurate.
With:
https://github.com/koreader/koreader/blob/c16cfa0e59c4207f50e9a62991edbc4d6274a9aa/defaults.lua#L133-L137
on my emulator (with a `scaleBySize()` factor of 1), we got `22` from `ReaderFooter:getHeight()`.
With this change, we get the expected (and accurate for overlap and dim area display for credocument) `14`.
The 22 comes from the DMINIBAR_FONT_SIZE = 14 , which probably makes the TextWidget have a real height of 22. This text is then put into a RightContainer of height 14, which must center it in the final container of height 14, so there was no visible problem.
But using this 22 for footer height is just wrong.

(Still to be tested by me on my device this evening.)