### PR TITLE
[fix] Stop the kobo_touch_probe test from causing problems for other tests.

### DIFF
--- a/tools/kobo_touch_probe.lua
+++ b/tools/kobo_touch_probe.lua
@@ -9,10 +9,13 @@ local DataStorage = require("datastorage")
 local _ = require("gettext")
 
 -- read settings and check for language override
+-- but don't re-read if already done, to avoid causing problems for unit tests
 -- has to be done before requiring other files because
 -- they might call gettext on load
-G_reader_settings = require("luasettings"):open(
-    DataStorage:getDataDir().."/settings.reader.lua")
+if G_reader_settings == nil then
+    G_reader_settings = require("luasettings"):open(
+        DataStorage:getDataDir().."/settings.reader.lua")
+end
 local lang_locale = G_reader_settings:readSetting("language")
 if lang_locale then
     _.changeLang(lang_locale)


### PR DESCRIPTION
Previously, it caused problems because it was overriding `G_reader_settings`,
which caused the `translator` test to fail on the second (but not first) run.

---

tl;dr: this is an example of one test affecting another negatively, and I tried other ways to fix it too, but at least this way seems to work. I tried to explain the underlying problem and my reasoning below.

This one took me a little while, not just to isolate where and figure out what was going on, but also to fix, as there's apparently some magic in there that was working against me. (It doesn't really help that I'm pretty much learning Lua as I go along here, as well as the Koreader codebase...)

The whole thing started with me being annoyed by and wanting to fix a failure I was seeing in the translator test, figuring that the test probably wasn't cleaning up after itself or something like that (since it didn't fail on the first run, only from the second). That wasn't actually the case though - or rather, only sort of, and not that test's fault. It is actually removing again the setting it adds. However, the touch-probe test caused it to use the wrong settings file, as the test harness uses a different file than the tool does, and although the harness removes that settings file, it doesn't remove the `.old` file, so on the second run the probe test ended up loading back in the _previous_ settings, from before the translator's setting was removed, while the test assumes default values are in use.

I first tried fixing this in the probe test itself, by saving `G_reader_settings` before `require`ing the file, and restoring it after - but I couldn't get it to work that way. I tried both with a `teardown` function and in the test function itself, and stdout debugging in those showed that it was getting set back to the original value - but by the time the next test file got loaded/run, it was set to the overridden value again. My best guess is that `require` allows the newly loaded file to change some things (namely globals) that its caller (the test) for some reason can't.