### PR TITLE
[fix] Better fix for libSDL2-2.0.so.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,8 +304,7 @@ appimageupdate: all
 	ln -sf ../../$(APPIMAGE_DIR)/koreader.desktop $(INSTALL_DIR)/koreader
 	ln -sf ../../resources/koreader.png $(INSTALL_DIR)/koreader
 	# TODO at best this is DebUbuntu specific
-	ln -sf /usr/lib/x86_64-linux-gnu/libSDL2.so $(INSTALL_DIR)/koreader/libs || \
-		ln -sf /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 $(INSTALL_DIR)/koreader/libs/libSDL2.so
+	ln -sf /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 $(INSTALL_DIR)/koreader/libs/libSDL2.so
 ifeq ("$(wildcard $(APPIMAGETOOL))","")
 	# download appimagetool
 	wget "$(APPIMAGETOOL_URL)"


### PR DESCRIPTION
Systems with libSDL2.so seem to have libSDL2-2.0.so.0, but those without only have libSDL2-2.0.so.0