### PR TITLE
Wiki saved as EPUB: stylesheet fix

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -940,7 +940,6 @@ a.newwikinonexistent {
 }
 /* show a box around image thumbnails */
 div.thumb {
-    width: 80%;
     border: dotted 1px black;
     margin-top: 0.5em;
     margin-bottom: 0.5em;


### PR DESCRIPTION
Removes `width:80%` as it was never supported by crengine (the effect was achieved thanks to margins and paddings).
Wikipedia saved articles from now on won't be effected by a double effect if we later add full support for `width:` into crengine.