### PR TITLE
coverbrowser: close sqlite db after init

### DIFF
--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -73,6 +73,7 @@ function CoverBrowser:init()
     self:setupFileManagerDisplayMode(BookInfoManager:getSetting("filemanager_display_mode"))
     self:setupHistoryDisplayMode(BookInfoManager:getSetting("history_display_mode"))
     init_done = true
+    BookInfoManager:closeDbConnection() -- will be re-opened if needed
 end
 
 function CoverBrowser:addToMainMenu(menu_items)


### PR DESCRIPTION
Don't keep a handle on bookinfo_cache.sqlite3 when "Start with: last book".
It was and is closed/released when leaving filemanager and opening a book. It wasn't just when starting with opening a book (where we still go into plugins init()).
That didn't hurt, but it makes things cleaner when looking at luajit opened files.