### PR TITLE
Fix the bug where "Press" key does not open config menu on Kindle 4 NT

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -12,7 +12,7 @@ local ReaderConfig = InputContainer:new{
 
 function ReaderConfig:init()
     if not self.dimen then self.dimen = Geom:new{} end
-    if Device:hasKeyboard() then
+    if Device:hasKeys() then
         self.key_events = {
             ShowConfigMenu = { {{"Press","AA"}}, doc = "show config dialog" },
         }


### PR DESCRIPTION
For Kindle 4NT `hasKeyboard = no`, therefore cannot open config menu. I change the if condition to check `hasKeys`.

I've tested on my Kindle 4NT and it works.