### PR TITLE
[Menusorter] Ignore warning for the plus_menu.

### DIFF
--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -98,7 +98,9 @@ function MenuSorter:sort(item_table, order)
                 i = i + 1
             end
         else
-            if order_id ~= "KOMenu:disabled" then
+            if order_id ~= "KOMenu:disabled" and order_id ~="plus_menu" then
+                --"plus_menu" break an assumption of the menu_sorter, but it's ok, so ignore it.
+                --See : https://github.com/koreader/koreader/pull/3844#issuecomment-383092219
                 logger.warn("menu id not found:", order_id)
             end
         end


### PR DESCRIPTION
The plus_menu break the assumption of the menusorter about a tab beeing
always present.
See : https://github.com/koreader/koreader/pull/3844#issuecomment-383092219