### PR TITLE
TextBoxWidget: optimize memory usage

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -273,14 +273,14 @@ function MenuItem:init()
                 if item_name.vertical_string_list[lines + 1] then
                     offset = item_name.vertical_string_list[lines + 1].offset - 2
                 else -- shouldn't happen, but just in case
-                    offset = #item_name.char_width_list
+                    offset = #item_name.charlist
                 end
                 local ellipsis_size = RenderText:sizeUtf8Text(0, self.content_width,
                     Font:getFace(self.font, self.font_size), "…", true, self.bold).x
                 local removed_char_width= 0
                 while removed_char_width < ellipsis_size  do
                     -- the width of each char has already been calculated by TextBoxWidget
-                    removed_char_width = removed_char_width + item_name.char_width_list[offset].width
+                    removed_char_width = removed_char_width + item_name:geCharWidth(offset)
                     offset = offset - 1
                 end
                 self.text = table.concat(item_name.charlist, '', 1, offset) .. "…"

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -225,7 +225,7 @@ function TextBoxWidget:_splitCharWidthList()
                 prev_c = adjusted_idx-1 >= 1 and self.charlist[adjusted_idx-1] or false
             end
             if adjusted_idx == offset or adjusted_idx == idx then
-                -- either a very long english word occuppying more than one line,
+                -- either a very long english word occupying more than one line,
                 -- or the excessive char is itself splittable:
                 -- we let that excessive char for next line
                 if adjusted_idx == offset then -- let the fact a long word was splitted be known

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -192,8 +192,9 @@ function TextBoxWidget:_splitCharWidthList()
             end
         end
 
+        -- end_offset will be the idx of char at end of line
         offset = idx -- idx of char at start of line
-        end_offset = nil -- idx of char at end of line
+
         -- We append chars until the accumulated width exceeds `targeted_width`,
         -- or a newline occurs, or no more chars to consume.
         cur_line_width = 0
@@ -264,7 +265,7 @@ function TextBoxWidget:_splitCharWidthList()
                         -- nb of spaces to which we'll add 1 more pixel
                         local space_add1_nb = fill_width - space_add_w * nbspaces
                         for cidx = offset, end_offset do
-                            local pad = 0
+                            local pad
                             if self.charlist[cidx] == " " then
                                 pad = space_add_w
                                 if space_add1_nb > 0 then


### PR DESCRIPTION
By reducing the number of data structures, and avoiding nested tables, which seemed to impose a lot of work on the garbage collector.

When browsing full wikipedia page, we quickly end up with a few 100MB of memory used, that seem to never be released. I tried to track memory leaks, but found nothing obvious. There may be some thus.
But often, the same action of viewing the same page does not provoke the same increase of mem usage.
Also, it sometimes happens that koreader becomes very slow, even on simple actions, while still being in the 100-200 MB range, which may be the garbage collector at work.

This PR removes the huge (3 items for each letter in text) `self.char_width_list` table:
https://github.com/koreader/koreader/blob/3cc9313cc6acfbfe499c5f89597c8fc7449a5ede/frontend/ui/widget/textboxwidget.lua#L134-L142
and we instead keep the smaller (1 int for each charcode seen) `char_width_cache` table, and we get width from it when needed.

It also removes the `cur_line_text` string from:
https://github.com/koreader/koreader/blob/3cc9313cc6acfbfe499c5f89597c8fc7449a5ede/frontend/ui/widget/textboxwidget.lua#L295-L300
and store the `end_offset` instead, so we can get the text from `charlist` only when needed.
We also get rid of `char_pads`, and use `self.idx_pad` instead, and we build `char_pads` from it when needed.

There are other small things that could be updated after that (like the few uses of `vertical_string_list[ln+1].offset`, that we now have as `end_offset`), but I didn't to limit the risk of this PR.

With this, viewing full wikipedia pages are smoother (didn't feel any slow down like before over a few minutes of testing) and use less memory (it still feels like it leaks a bit, but some memory increase is quite often re-used, and I even witnessed some decrease).
