### PR TITLE
ProgressWidget: add some bound checks

### DIFF
--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -68,10 +68,12 @@ function ProgressWidget:paintTo(bb, x, y)
                    my_size.w, my_size.h,
                    self.bordersize, self.bordercolor, self.radius)
     -- paint percentage infill
-    bb:paintRect(x+self.margin_h, math.ceil(y+self.margin_v+self.bordersize),
+    if self.percentage >= 0 and self.percentage <= 1 then
+        bb:paintRect(x+self.margin_h, math.ceil(y+self.margin_v+self.bordersize),
                  math.ceil((my_size.w-2*self.margin_h)*self.percentage),
                  my_size.h-2*(self.margin_v+self.bordersize), self.rectcolor)
-    if self.ticks and self.last then
+    end
+    if self.ticks and self.last and self.last > 0 then
         local bar_width = (my_size.w-2*self.margin_h)
         local y_pos = y + self.margin_v + self.bordersize
         local bar_height = my_size.h-2*(self.margin_v+self.bordersize)


### PR DESCRIPTION
Avoid drawing the fill bar our of the progress bar.
Avoid zero divided by zero that return '`nan`' (Not a Number), that does not bother lua code, but will crash libblitbuffer.so when it gets nan as a coordinate.

Fix crash on epub with an empty <body></body> (not on a standalone .html with that :|) reported at https://github.com/koreader/koreader/issues/3912#issuecomment-384642115.

This is a quick fix of the source of that specific crash, but getting `nan` may happen some places else.
A `nan` would go through [BB.checkBounds()](https://github.com/koreader/koreader-base/blob/2faf0891403033390b2b652a9a5d24ba489f2298/ffi/blitbuffer.lua#L684-L725) unchanged, and may crash when going into C land.
Dunno how checkBounds should do with `nan`, or if we should use everywhere `if x ~= x then return end` (looks like that's the way to check for nan :) https://stackoverflow.com/questions/37753694/lua-check-if-a-number-value-is-nan _according to IEEE 754, a nan value is considered not equal to any value, including itself_).