### PR TITLE
dict: convert htmlentities in non-html text results

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -439,6 +439,8 @@ local function tidyMarkup(results)
                     def = def:gsub(format_escape, "%1")
                 end
             end
+            -- convert any htmlentities (&gt;, &quot;...)
+            def = util.htmlEntitiesToUtf8(def)
             -- ignore all markup tags
             def = def:gsub("%b<>", "")
             -- strip all leading empty lines/spaces


### PR DESCRIPTION
Seen that kind of results:
<kbd>![image](https://user-images.githubusercontent.com/24273478/39470881-72c73c3a-4d40-11e8-874a-e783c1c3c65f.png)</kbd>

We already remove html tags (after what this PR does, so this PR will convert twircely encoded html to tags, that will then be removed), so I hope it's fine and there's no non-html dictionary in the wild that uses litteral stuff that looks like these html entities or tags that have meaning in their definitions...
