### PR TITLE
bump base: crengine, freetype, libjpeg-turbo

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -20,6 +20,7 @@ local CreDocument = Document:new{
 
     _document = false,
     _loaded = false,
+    _cre_dom_version = nil,
 
     line_space_percent = 100,
     default_font = G_reader_settings:readSetting("cre_font") or "Noto Serif",
@@ -120,6 +121,9 @@ function CreDocument:init()
         error(self._document)  -- will contain error message
     end
 
+    -- get DOM engine latest version
+    self._cre_dom_version = self._document:getIntProperty("crengine.dom.version")
+
     -- adjust font sizes according to screen dpi
     self._document:adjustFontSizes(Screen:getDPI())
 
@@ -135,6 +139,18 @@ function CreDocument:init()
     self.info.has_pages = false
     self:_readMetadata()
     self.info.configurable = true
+end
+
+function CreDocument:getLatestDomVersion()
+    return self._cre_dom_version
+end
+
+function CreDocument:getOldestDomVersion()
+    return 20171225 -- arbitrary day in the past
+end
+
+function CreDocument:requestDomVersion(version)
+    self._document:setIntProperty("crengine.dom.version", version)
 end
 
 function CreDocument:loadDocument(full_document)

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -17,14 +17,9 @@ describe("ReaderLink module", function()
             document = DocumentRegistry:openDocument(sample_epub),
         }
         local logger = require("logger")
-        readerui.rolling:onGotoPage(4)
-        logger.warn(readerui.document:getPageLinks())
-        readerui.rolling:onGotoPage(5)
-        logger.warn(readerui.document:getPageLinks())
         readerui.rolling:onGotoPage(6)
-        logger.warn(readerui.document:getPageLinks())
         readerui.link:onTap(nil, {pos = {x = 336, y = 166}})
-        assert.is.same(36, readerui.rolling.current_page)
+        assert.is.same(40, readerui.rolling.current_page)
     end)
 
     it("should jump to links in pdf page mode", function()
@@ -59,9 +54,9 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
-        readerui.rolling:onGotoPage(5)
-        readerui.link:onTap(nil, {pos = {x = 336, y = 156}})
-        assert.is.same(36, readerui.rolling.current_page)
+        readerui.rolling:onGotoPage(6)
+        readerui.link:onTap(nil, {pos = {x = 336, y = 166}})
+        assert.is.same(40, readerui.rolling.current_page)
         readerui.link:onGoBackLink()
         assert.is.same(4, readerui.rolling.current_page)
     end)

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -16,8 +16,8 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
-        readerui.rolling:onGotoPage(4)
-        readerui.link:onTap(nil, {pos = {x = 336, y = 688}})
+        readerui.rolling:onGotoPage(6)
+        readerui.link:onTap(nil, {pos = {x = 336, y = 156}})
         assert.is.same(36, readerui.rolling.current_page)
     end)
 
@@ -53,8 +53,8 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
-        readerui.rolling:onGotoPage(4)
-        readerui.link:onTap(nil, {pos = {x = 336, y = 698}})
+        readerui.rolling:onGotoPage(5)
+        readerui.link:onTap(nil, {pos = {x = 336, y = 156}})
         assert.is.same(36, readerui.rolling.current_page)
         readerui.link:onGoBackLink()
         assert.is.same(4, readerui.rolling.current_page)

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -17,7 +17,7 @@ describe("ReaderLink module", function()
             document = DocumentRegistry:openDocument(sample_epub),
         }
         readerui.rolling:onGotoPage(4)
-        readerui.link:onTap(nil, {pos = {x = 336, y = 668}})
+        readerui.link:onTap(nil, {pos = {x = 336, y = 688}})
         assert.is.same(36, readerui.rolling.current_page)
     end)
 
@@ -54,7 +54,7 @@ describe("ReaderLink module", function()
             document = DocumentRegistry:openDocument(sample_epub),
         }
         readerui.rolling:onGotoPage(4)
-        readerui.link:onTap(nil, {pos = {x = 336, y = 668}})
+        readerui.link:onTap(nil, {pos = {x = 336, y = 698}})
         assert.is.same(36, readerui.rolling.current_page)
         readerui.link:onGoBackLink()
         assert.is.same(4, readerui.rolling.current_page)

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -16,7 +16,6 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
-        local logger = require("logger")
         readerui.rolling:onGotoPage(6)
         readerui.link:onTap(nil, {pos = {x = 336, y = 166}})
         assert.is.same(40, readerui.rolling.current_page)
@@ -58,7 +57,7 @@ describe("ReaderLink module", function()
         readerui.link:onTap(nil, {pos = {x = 336, y = 166}})
         assert.is.same(40, readerui.rolling.current_page)
         readerui.link:onGoBackLink()
-        assert.is.same(4, readerui.rolling.current_page)
+        assert.is.same(6, readerui.rolling.current_page)
     end)
 
     it("should be able to go back after link jump in pdf page mode", function()

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -16,8 +16,14 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
+        local logger = require("logger")
+        readerui.rolling:onGotoPage(4)
+        logger.warn(readerui.document:getPageLinks())
+        readerui.rolling:onGotoPage(5)
+        logger.warn(readerui.document:getPageLinks())
         readerui.rolling:onGotoPage(6)
-        readerui.link:onTap(nil, {pos = {x = 336, y = 156}})
+        logger.warn(readerui.document:getPageLinks())
+        readerui.link:onTap(nil, {pos = {x = 336, y = 166}})
         assert.is.same(36, readerui.rolling.current_page)
     end)
 


### PR DESCRIPTION
Includes:
- [build] FreeType: bump to 2.9.1 https://github.com/koreader/koreader-base/pull/663
- [build] bump libjpeg-turbo to 1.5.3 https://github.com/koreader/koreader-base/pull/664
- bump crengine:
  - Fix CSS selector specificity computation https://github.com/koreader/crengine/pull/171
  - [fix] crengine/src/lvfntman.cpp: improve letter_spacing limit https://github.com/koreader/crengine/pull/173
  - [fix] crengine/src/lvxml.cpp: add all empty HTML elements https://github.com/koreader/crengine/pull/175
  - html head styles: fix styles not being applied https://github.com/koreader/crengine/pull/174
  - Hyphenation: increase MAX_PATTERN_SIZE from 16 to 35
  - html documents: proper handling of `<BR>` tags https://github.com/koreader/crengine/pull/172
  - Allows requesting old (broken) XML/DOM building code https://github.com/koreader/crengine/pull/172#issuecomment-386384050

cre.cpp: setStyleSheet(): accept filepath and/or css text, and added getIntProperty() and getStringProperty()

credocument/readerrolling: request older XML/DOM building code for books previously opened, to not lose bookmarks and highlights.
I put in 2 `logger.info()` to let people know. Not sure if we need to tell them :) or if we can find a better single line info message.

