### PR TITLE
Add HTML widget in GoodReads review

### DIFF
--- a/plugins/goodreads.koplugin/goodreadsapi.lua
+++ b/plugins/goodreads.koplugin/goodreadsapi.lua
@@ -88,28 +88,6 @@ function GoodreadsApi:getTotalResults()
     return self.total_result
 end
 
-local function cleanHTMLTags(str_html)
-    local cleaner = {
-        { "&amp;", "&" },
-        { "&#151;", "-" },
-        { "&#146;", "'" },
-        { "&#160;", " " },
-        { "<!%[CDATA%[(.*)%]%]>", "%1" },
-        { "<br%s/>", "\n" },
-        { "%-%-", "%-" },
-        { "</p>", "\n" },
-        { "(%b<>)", "" },
-        { "\n\n*", "\n" },
-        { "\n*$", "" },
-        { "^\n*", "" },
-    }
-    for i=1, #cleaner do
-        local cleans = cleaner[i]
-        str_html = string.gsub(str_html, cleans[1], cleans[2])
-    end
-    return str_html
-end
-
 local function showIdTable(data)
     if data == nil then
         UIManager:show(InfoMessage:new{text =_("Network problem.\nCheck connection.")})
@@ -132,7 +110,8 @@ local function showIdTable(data)
     local id = data1:match("<id>([^<]+)</id>"):gsub("<![[]CDATA[[]", ""):gsub("]]>$", "")
     local author = data1:match("<name>([^<]+)</name>")
     local description = data1:match("<description>(.*)</description>")
-    description = cleanHTMLTags(description)
+    description = string.gsub(description, "<!%[CDATA%[(.*)%]%]>", "%1")
+    description = string.gsub(description, "%-%-", "%—")
     --change format from medium to large
     local image = data1:match("<image_url>([^<]+)</image_url>"):gsub("([0-9]+)m/", "%1l/")
     local day = data1:match("<original_publication_day[^>]+>([^<]+)</original_publication_day>")

--- a/plugins/goodreads.koplugin/goodreadsbook.lua
+++ b/plugins/goodreads.koplugin/goodreadsbook.lua
@@ -17,7 +17,7 @@ local TextWidget = require("ui/widget/textwidget")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = require("device").screen
-local ScrollTextWidget = require("ui/widget/scrolltextwidget")
+local ScrollHtmlWidget = require("ui/widget/scrollhtmlwidget")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local https = require('ssl.https')
@@ -227,18 +227,29 @@ function GoodreadsBook:genBookInfoGroup()
 end
 
 function GoodreadsBook:bookReview()
+    local css = [[
+        @page {
+            margin: 0;
+            font-family: 'Noto Sans';
+        }
+
+        body {
+            margin: 0;
+            line-height: 1.3;
+            text-align: justify;
+        }
+        ]]
+
     local book_meta_info_group = VerticalGroup:new{
         align = "center",
         padding = 0,
         bordersize = 0,
-        ScrollTextWidget:new{
-            text = self.dates.description,
-            face = self.medium_font_face,
-            padding = 0,
+        ScrollHtmlWidget:new{
+            html_body = self.dates.description,
+            css = css,
             width = self.screen_width * 0.9,
             height = self.screen_height * 0.48,
             dialog = self,
-            justified = true,
         }
     }
     return CenterContainer:new{


### PR DESCRIPTION
After adding generic HTML widget in #3573 now we can show descriptions (review) in GoodReads as HTML.
Before:
![image](https://user-images.githubusercontent.com/22982594/39642661-b40e6e68-4fd2-11e8-854d-2a7c9c0312da.png)

After:
![image](https://user-images.githubusercontent.com/22982594/39642741-f3e1a492-4fd2-11e8-83e7-1664fe31c4d6.png)


