### PR TITLE
Close filemanger after open last document

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -230,6 +230,8 @@ function FileManagerMenu:setUpdateItemTable()
             local ReaderUI = require("apps/reader/readerui")
             ReaderUI:showReader(last_file)
             self:onCloseFileManagerMenu()
+            local FileManager = require("apps/filemanager/filemanager")
+            FileManager.instance:onClose()
         end
     }
     -- insert common info


### PR DESCRIPTION
Close: #3310 
Similar to that: https://github.com/koreader/koreader/blob/e83a0c107843e6577fd308cdab5a7ee3ecaba5dc/frontend/apps/filemanager/filemanager.lua#L170-L171 after open last document (from menu) we should also close filemanager instance.

This change fix problem: #3310 (Menu with plugin isn't synchronized)