### PR TITLE
Font menu: add symbols for default and fallback fonts

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -61,7 +61,7 @@ function ReaderFont:init()
                     text = text .. "   ★"
                 end
                 if v == fallback_font then
-                    text = text .. "   ♻"
+                    text = text .. "   �"
                 end
                 return text
             end,

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -61,7 +61,7 @@ function ReaderFont:init()
                     text = text .. "   ★"
                 end
                 if v == fallback_font then
-                    text = text.."   ♻"
+                    text = text .. "   ♻"
                 end
                 return text
             end,

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -289,7 +289,7 @@ end
 function ReaderFont:makeDefault(face, refresh_menu_func)
     if face then
         UIManager:show(MultiConfirmBox:new{
-            text = T( _("Set %1 as fallback font? Characters not found in the active font are shown in the fallback font instead."), face),
+            text = T( _("Would you like %1 to be used as the default font (★), or the fallback font (�)?\n\nCharacters not found in the active font are shown in the fallback font instead."), face),
             choice1_text = _("Default"),
             choice1_callback = function()
                 G_reader_settings:saveSetting("cre_font", face)

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -353,7 +353,7 @@ function ReaderFont:buildFontsTestDocument()
     if not dir then dir = require("apps/filemanager/filemanagerutil").getDefaultDir() end
     if not dir then dir = "." end
     local fonts_test_path = dir .. "/fonts-test-all.html"
-    local f = io.open(fonts_test_path, "w")
+    f = io.open(fonts_test_path, "w")
     -- Using <section><title>...</title></section> allows for a TOC to be built
     f:write(string.format([[
 <?xml version="1.0" encoding="UTF-8"?>

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -1,4 +1,5 @@
 local CenterContainer = require("ui/widget/container/centercontainer")
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
 local Input = Device.input
@@ -51,18 +52,45 @@ function ReaderFont:init()
     local face_list = cre.getFontFaces()
     for k,v in ipairs(face_list) do
         table.insert(self.face_table, {
-            text = v,
+            text_func = function()
+                -- defaults are hardcoded in credocument.lua
+                local default_font = G_reader_settings:readSetting("cre_font") or self.ui.document.default_font
+                local fallback_font = G_reader_settings:readSetting("fallback_font") or self.ui.document.fallback_font
+                local text = v
+                if v == default_font then
+                    text = text .. "   ★"
+                end
+                if v == fallback_font then
+                    text = text.."   ♻"
+                end
+                return text
+            end,
             callback = function()
                 self:setFont(v)
             end,
-            hold_callback = function()
-                self:makeDefault(v)
+            hold_may_update_menu = true,
+            hold_callback = function(refresh_menu_func)
+                self:makeDefault(v, refresh_menu_func)
             end,
             checked_func = function()
                 return v == self.font_face
             end
         })
         face_list[k] = {text = v}
+    end
+    if self:hasFontsTestSample() then
+        self.face_table[#self.face_table].separator = true
+        table.insert(self.face_table, {
+            text = _("Generate fonts test html document"),
+            callback = function()
+                UIManager:show(ConfirmBox:new{
+                    text = _("Would you like to generate a html document showing some sample text rendered with each available font?");
+                    ok_callback = function()
+                        self:buildFontsTestDocument()
+                    end
+                })
+            end
+        })
     end
     self.ui.menu:registerToMainMenu(self)
 end
@@ -100,10 +128,12 @@ end
 
 function ReaderFont:onReadSettings(config)
     self.font_face = config:readSetting("font_face")
+            or G_reader_settings:readSetting("cre_font")
             or self.ui.document.default_font
     self.ui.document:setFontFace(self.font_face)
 
     self.header_font_face = config:readSetting("header_font_face")
+            or G_reader_settings:readSetting("header_font")
             or self.ui.document.header_font
     self.ui.document:setHeaderFont(self.header_font_face)
 
@@ -256,17 +286,22 @@ function ReaderFont:setFont(face)
     end
 end
 
-function ReaderFont:makeDefault(face)
+function ReaderFont:makeDefault(face, refresh_menu_func)
     if face then
         UIManager:show(MultiConfirmBox:new{
             text = T( _("Set %1 as fallback font? Characters not found in the active font are shown in the fallback font instead."), face),
             choice1_text = _("Default"),
             choice1_callback = function()
                 G_reader_settings:saveSetting("cre_font", face)
+                if refresh_menu_func then refresh_menu_func() end
             end,
             choice2_text = _("Fallback"),
             choice2_callback = function()
-                G_reader_settings:saveSetting("fallback_font", face)
+                if self.ui.document:setFallbackFontFace(face) then
+                    G_reader_settings:saveSetting("fallback_font", face)
+                    self.ui:handleEvent(Event:new("UpdatePos"))
+                end
+                if refresh_menu_func then refresh_menu_func() end
             end,
         })
     end
@@ -300,6 +335,65 @@ function ReaderFont:onAdjustPinch(ges)
     self:onChangeSize("decrease", delta_int)
     UIManager:close(info)
     return true
+end
+
+function ReaderFont:hasFontsTestSample()
+    local font_test_sample = require("datastorage"):getSettingsDir() .. "/fonts-test-sample.html"
+    local lfs = require("libs/libkoreader-lfs")
+    return lfs.attributes(font_test_sample, "mode") == "file"
+end
+
+function ReaderFont:buildFontsTestDocument()
+    local font_test_sample = require("datastorage"):getSettingsDir() .. "/fonts-test-sample.html"
+    local f = io.open(font_test_sample, "r")
+    if not f then return nil end
+    local html_sample = f:read("*all")
+    f:close()
+    local dir = G_reader_settings:readSetting("home_dir")
+    if not dir then dir = require("apps/filemanager/filemanagerutil").getDefaultDir() end
+    if not dir then dir = "." end
+    local fonts_test_path = dir .. "/fonts-test-all.html"
+    local f = io.open(fonts_test_path, "w")
+    -- Using <section><title>...</title></section> allows for a TOC to be built
+    f:write(string.format([[
+<?xml version="1.0" encoding="UTF-8"?>
+<html>
+<head>
+<title>%s</title>
+</head>
+<body>
+<section id="list"><title>%s</title></section>
+]], _("Available fonts test document"), _("AVAILABLE FONTS")))
+    local face_list = cre.getFontFaces()
+    f:write("<div style='margin: 2em'>\n")
+    for _, font_name in ipairs(face_list) do
+        local font_id = font_name:gsub(" ", "_"):gsub("'", "_")
+        f:write(string.format("  <div><a href='#%s'>%s</a></div>\n", font_id, font_name))
+    end
+    f:write("</div>\n\n")
+    for _, font_name in ipairs(face_list) do
+        local font_id = font_name:gsub(" ", "_"):gsub("'", "_")
+        f:write(string.format("<section id='%s'><title>%s</title></section>\n", font_id, font_name))
+        f:write(string.format("<div style='font-family: %s'>\n", font_name))
+        f:write(html_sample)
+        f:write("\n</div>\n\n")
+    end
+    f:write("</body></html>\n")
+    f:close()
+    UIManager:show(ConfirmBox:new{
+        text = T(_("Document created as:\n%1\n\nWould you like to read it now?"), fonts_test_path),
+        ok_callback = function()
+            -- close current ReaderUI in 1 sec, and create a new one
+            UIManager:scheduleIn(1.0, function()
+                local ReaderUI = require("apps/reader/readerui")
+                local reader = ReaderUI:_getRunningInstance()
+                if reader then
+                    reader:onClose()
+                end
+                ReaderUI:showReader(fonts_test_path)
+            end)
+        end,
+    })
 end
 
 return ReaderFont

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -81,10 +81,10 @@ function ReaderFont:init()
     if self:hasFontsTestSample() then
         self.face_table[#self.face_table].separator = true
         table.insert(self.face_table, {
-            text = _("Generate fonts test html document"),
+            text = _("Generate fonts test HTML document"),
             callback = function()
                 UIManager:show(ConfirmBox:new{
-                    text = _("Would you like to generate a html document showing some sample text rendered with each available font?");
+                    text = _("Would you like to generate an HTML document showing some sample text rendered with each available font?");
                     ok_callback = function()
                         self:buildFontsTestDocument()
                     end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -23,9 +23,9 @@ local CreDocument = Document:new{
     _cre_dom_version = nil,
 
     line_space_percent = 100,
-    default_font = G_reader_settings:readSetting("cre_font") or "Noto Serif",
-    header_font = G_reader_settings:readSetting("header_font") or "Noto Sans",
-    fallback_font = G_reader_settings:readSetting("fallback_font") or "Noto Sans CJK SC",
+    default_font = "Noto Serif",
+    header_font = "Noto Sans",
+    fallback_font = "Noto Sans CJK SC",
     default_css = "./data/cr3.css",
     options = CreOptions,
     provider = "crengine",
@@ -128,7 +128,8 @@ function CreDocument:init()
     self._document:adjustFontSizes(Screen:getDPI())
 
     -- set fallback font face
-    self._document:setStringProperty("crengine.font.fallback.face", self.fallback_font)
+    self._document:setStringProperty("crengine.font.fallback.face",
+        G_reader_settings:readSetting("fallback_font") or self.fallback_font)
 
     -- We would have liked to call self._document:loadDocument(self.file)
     -- here, to detect early if file is a supported document, but we
@@ -403,6 +404,22 @@ function CreDocument:setFontFace(new_font_face)
         --          for font-family: monospace
         -- +256001: prefer our font to any existing font-family font
         self._document:setAsPreferredFontWithBias(new_font_face, 1)
+    end
+end
+
+function CreDocument:setFallbackFontFace(new_fallback_font_face)
+    if new_fallback_font_face then
+        logger.dbg("CreDocument: set fallback font face", new_fallback_font_face)
+        self._document:setStringProperty("crengine.font.fallback.face", new_fallback_font_face)
+        -- crengine may not accept our fallback font, we need to check
+        local set_fallback_font_face = self._document:getStringProperty("crengine.font.fallback.face")
+        logger.dbg("CreDocument: crengine fallback font face", set_fallback_font_face)
+        if set_fallback_font_face ~= new_fallback_font_face then
+            logger.info("CreDocument:", new_fallback_font_face, "is not usable as a fallback font")
+            return false
+        end
+        self.fallback_font = new_fallback_font_face
+        return true
     end
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -726,8 +726,12 @@ function TouchMenu:onMenuHold(item)
         end
         if callback then
             UIManager:scheduleIn(0.1, function()
-                self:closeMenu()
-                callback()
+                if item.hold_may_update_menu then
+                    callback(function() self:updateItems() end)
+                else
+                    self:closeMenu()
+                    callback()
+                end
             end)
         end
     end


### PR DESCRIPTION
Adds symbols for default and fallback fonts.
Also allows for updating the fallback font and see results in real-time on the underlying document.
Also adds a menu item to generate a html document showing some sample text rendered with each available font.

<kbd>![image](https://user-images.githubusercontent.com/24273478/39866447-13600106-5451-11e8-9e7a-d2ed77e00133.png)</kbd>
(our default fallback font Noto Sans CJK has wrong glyphs for greek, so it's nice being able to see how others do - will need a base bump for https://github.com/koreader/crengine/pull/186 for real-time update).

I recently came across https://poliseuse.wordpress.com/ (in french) which has reviews for many fonts and their use on ereaders - and I like testing fonts :)
I used to manually make some html document with the same text displayed with each font, so I can more easily (than with changing fonts with the menu) compare fonts.
With this new set of fonts to test, I thought that koreader could as well build that html document instead of me manually :)

So, this new menu item will display only if the user has a file `koreader/settings/fonts-test-sample.html` with some HTML snippet of his choice (*), and will generate a file in the home directory named `fonts-test-all.html`, that will allow comparing all fonts with the help of koreader features (Skim to widget, swipe to go to latest bookmarks...):
<kbd>![image](https://user-images.githubusercontent.com/24273478/39866782-5954ebee-5452-11e8-932b-0f3c989d355c.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/39866968-0e932386-5453-11e8-82ab-8494a95905bc.png)</kbd>

(*) dunno if this is a sufficiently interesting feature to have us add a default `fonts-test-sample.html` with some koreader blablah (sufficiently long so one can see paragraphs, wraps, line-height...), and some words/texts of various alphabets, CJK, links, superscripts, subscripts, numbers, italic... but if yes, feel free to write it :)