### PR TITLE
ReaderRolling: update footer when TOC is updated

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -563,6 +563,7 @@ function ReaderRolling:updatePos()
         self.old_doc_height = new_height
         self.old_page = new_page
         self.ui:handleEvent(Event:new("UpdateToc"))
+        self.view.footer:updateFooter()
     end
     UIManager:setDirty(self.view.dialog, "partial")
 end


### PR DESCRIPTION
Footer item "pages left in chapter" (the `=> 3` in the screenshots below) was wrong just after changing font sizes or some other layout option (the footer was drown before this happen, and not after, until we later change page). So, just call it again (it's fast) when we have updated the TOC.

Seems to also fix possible wrong ticks position in that case (may be only when cache is used/re-used, for some not really obvious reason).

Before, when changing font sizes to really small or really huge, we could get:

![overflowed](https://user-images.githubusercontent.com/24273478/40019788-86ab8398-57c0-11e8-9313-e00a3b8fc377.png)

![underflowed](https://user-images.githubusercontent.com/24273478/40019790-87fa96da-57c0-11e8-8399-391b9e37cbbb.png)

After this, we get:

![good_smaller_font](https://user-images.githubusercontent.com/24273478/40019796-910048a6-57c0-11e8-8e73-aaeca8a0b824.png)

![good_greater_font](https://user-images.githubusercontent.com/24273478/40019798-9279bd8e-57c0-11e8-93b5-4c09d30722e3.png)

May be this fixes #3778 too?