### PR TITLE
Show current and default values in config dialog (epub)

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -26,7 +26,7 @@ local function showValues(configurable, option)
     local default = G_reader_settings:readSetting("copt_"..option.name)
     local current = configurable[option.name]
     local value_default, value_current
-    if not option.suffix then option.suffix = "" end
+    local suffix = option.name_text_suffix or ""
     if option.name == "screen_mode" then
         current = Screen:getScreenMode()
     end
@@ -48,20 +48,20 @@ local function showValues(configurable, option)
         default = arg_table[default]
         current = arg_table[current]
     end
-    if option.true_values and option.toggle and option.values and value_default then
+    if option.name_text_true_values and option.toggle and option.values and value_default then
         UIManager:show(InfoMessage:new{
             text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3 (%6%4)"), option.name_text,
-                current, default, option.suffix, value_current, value_default)
+                current, default, suffix, value_current, value_default)
         })
-    elseif option.true_values and option.toggle and option.values and not value_default then
+    elseif option.name_text_true_values and option.toggle and option.values and not value_default then
         UIManager:show(InfoMessage:new{
             text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3"), option.name_text,
-                current, default, option.suffix, value_current)
+                current, default, suffix, value_current)
         })
     else
         UIManager:show(InfoMessage:new{
             text = T(_("%1:\nCurrent value: %2%4\nDefault value: %3%4"), option.name_text, current,
-                default, option.suffix)
+                default, suffix)
         })
     end
 end
@@ -171,9 +171,10 @@ local CreOptions = {
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM,
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_LARGE,
                 },
-                suffix = "%",
-                true_values = true,
                 name_text_hold_callback = showValues,
+                -- used by showValues
+                name_text_suffix = "%",
+                name_text_true_values = true,
             },
             {
                 name = "page_margins",

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -60,7 +60,7 @@ end
 local function showValues(configurable, title ,setting_default, setting_curr, suffix, arg_string, true_values)
     local default = G_reader_settings:readSetting(setting_default)
     local current = configurable[setting_curr]
-    local value_defalut, value_current
+    local value_default, value_current
     if setting_curr == "screen_mode" then
         current = Screen:getScreenMode()
     end
@@ -73,14 +73,14 @@ local function showValues(configurable, title ,setting_default, setting_curr, su
         end
     elseif arg_string then
         value_current = current
-        value_defalut = default
+        value_default = default
         default = arg_string[default]
         current = arg_string[current]
     end
     if true_values and arg_string then
         UIManager:show(InfoMessage:new{
             text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3 (%6%4)"), title, current, default, suffix,
-            value_current, value_defalut)
+            value_current, value_default)
         })
     else
         UIManager:show(InfoMessage:new{
@@ -112,8 +112,15 @@ local function showValuesMargins(configurable, title ,setting_default, setting_c
 
     if not default then
         UIManager:show(InfoMessage:new{
-            text = T(_("%1:\nCurrent value: %2\n  left: %3\n  top: %4\n  right: %5\n  bottom: %6\nDefault value:\n  not set"),
-                title, current_string, current[1], current[2], current[3], current[4])
+            text = T(_([[
+%1:
+Current value: %2
+  left: %3
+  top: %4
+  right: %5
+  bottom: %6
+Default value:  not set
+]]),        title, current_string, current[1], current[2], current[3], current[4])
         })
     else
         local default_string
@@ -125,9 +132,19 @@ local function showValuesMargins(configurable, title ,setting_default, setting_c
             default_string = S.LARGE
         end
         UIManager:show(InfoMessage:new{
-            text = T(_("%1:\nCurrent value: %2\n  left: %3\n  top: %4\n  right: %5\n  bottom: %6\n" ..
-                "Defalut value: %7\n  left: %8\n  top: %9\n  right: %10\n  bottom: %11"),
-                title, current_string, current[1], current[2], current[3], current[4], default_string, default[1],
+            text = T(_([[
+%1:
+Current value: %2
+  left: %3
+  top: %4
+  right: %5
+  bottom: %6
+Default value: %7
+  left: %8
+  top: %9
+  right: %10
+  bottom: %11
+]]),            title, current_string, current[1], current[2], current[3], current[4], default_string, default[1],
                 default[2], default[3], default[4])
         })
     end

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -22,42 +22,47 @@ local function enable_if_equals(configurable, option, value)
     return configurable[option] == value
 end
 
-local function showValues(configurable, title ,setting_default, setting_curr, suffix, arg_string, arg_values, true_values)
-    local default = G_reader_settings:readSetting(setting_default)
-    local current = configurable[setting_curr]
+local function showValues(configurable, option)
+    local default = G_reader_settings:readSetting("copt_"..option.name)
+    local current = configurable[option.name]
     local value_default, value_current
-    if setting_curr == "screen_mode" then
+    if not option.suffix then option.suffix = "" end
+    if option.name == "screen_mode" then
         current = Screen:getScreenMode()
     end
     local arg_table = {}
-    if arg_string then
-        for i=1,#arg_string do
-            arg_table[arg_values[i]] = arg_string[i]
+    if option.toggle and option.values then
+        for i=1,#option.toggle do
+            arg_table[option.values[i]] = option.toggle[i]
         end
     end
     if not default then
         default = "not set"
-        suffix = ""
-        if arg_string then
+        if option.toggle then
             value_current = current
             current = arg_table[current]
         end
-    elseif arg_string then
+    elseif option.toggle and option.values then
         value_current = current
         value_default = default
         default = arg_table[default]
         current = arg_table[current]
     end
-    if true_values and arg_string then
+    if option.true_values and option.toggle and option.values and value_default then
         UIManager:show(InfoMessage:new{
-            text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3 (%6%4)"), title, current, default, suffix,
-            value_current, value_default)
+            text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3 (%6%4)"), option.name_text,
+                current, default, option.suffix, value_current, value_default)
+        })
+    elseif option.true_values and option.toggle and option.values and not value_default then
+        UIManager:show(InfoMessage:new{
+            text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3"), option.name_text,
+                current, default, option.suffix, value_current)
         })
     else
         UIManager:show(InfoMessage:new{
-            text = T(_("%1:\nCurrent value: %2%4\nDefault value: %3%4"), title, current, default, suffix)
+            text = T(_("%1:\nCurrent value: %2%4\nDefault value: %3%4"), option.name_text, current,
+                default, option.suffix)
         })
-
     end
 end
 
@@ -69,18 +74,16 @@ local function tableComp(a,b)
     return true
 end
 
-local function showValuesMargins(configurable, title ,setting_default, setting_curr)
-    local default = G_reader_settings:readSetting(setting_default)
-    local current = configurable[setting_curr]
+local function showValuesMargins(configurable, option)
+    local default = G_reader_settings:readSetting("copt_"..option.name)
+    local current = configurable[option.name]
     local current_string
-    if tableComp(current, DCREREADER_CONFIG_MARGIN_SIZES_SMALL) then
-        current_string = S.SMALL
-    elseif tableComp(current, DCREREADER_CONFIG_MARGIN_SIZES_MEDIUM) then
-        current_string = S.MEDIUM
-    elseif tableComp(current, DCREREADER_CONFIG_MARGIN_SIZES_LARGE) then
-        current_string = S.LARGE
+    for i=1,#option.toggle do
+        if tableComp(current, option.values[i]) then
+            current_string = option.toggle[i]
+            break
+        end
     end
-
     if not default then
         UIManager:show(InfoMessage:new{
             text = T(_([[
@@ -90,17 +93,16 @@ Current value: %2
   top: %4
   right: %5
   bottom: %6
-Default value:  not set
-]]),        title, current_string, current[1], current[2], current[3], current[4])
+Default value: not set]]),
+                option.name_text, current_string, current[1], current[2], current[3], current[4])
         })
     else
         local default_string
-        if tableComp(default, DCREREADER_CONFIG_MARGIN_SIZES_SMALL) then
-            default_string = S.SMALL
-        elseif tableComp(default, DCREREADER_CONFIG_MARGIN_SIZES_MEDIUM) then
-            default_string = S.MEDIUM
-        elseif tableComp(default, DCREREADER_CONFIG_MARGIN_SIZES_LARGE) then
-            default_string = S.LARGE
+        for i=1,#option.toggle do
+            if tableComp(default, option.values[i]) then
+                default_string = option.toggle[i]
+                break
+            end
         end
         UIManager:show(InfoMessage:new{
             text = T(_([[
@@ -114,9 +116,9 @@ Default value: %7
   left: %8
   top: %9
   right: %10
-  bottom: %11
-]]),            title, current_string, current[1], current[2], current[3], current[4], default_string, default[1],
-                default[2], default[3], default[4])
+  bottom: %11]]),
+                option.name_text, current_string, current[1], current[2], current[3], current[4],
+                default_string, default[1], default[2], default[3], default[4])
         })
     end
 end
@@ -135,9 +137,7 @@ local CreOptions = {
                 default_arg = "portrait",
                 current_func = function() return Screen:getScreenMode() end,
                 event = "ChangeScreenMode",
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_screen_mode", opt.name, "")
-                end,
+                name_text_hold_callback = showValues,
             }
         }
     },
@@ -153,9 +153,7 @@ local CreOptions = {
                 args = {"scroll", "page"},
                 default_arg = "page",
                 event = "SetViewMode",
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_view_mode", opt.name, "", opt.toggle, opt.values)
-                end,
+                name_text_hold_callback = showValues,
             },
             {
                 name = "line_spacing",
@@ -173,9 +171,9 @@ local CreOptions = {
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM,
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_LARGE,
                 },
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_line_spacing", opt.name, "%", opt.toggle, opt.values, true)
-                end,
+                suffix = "%",
+                true_values = true,
+                name_text_hold_callback = showValues,
             },
             {
                 name = "page_margins",
@@ -193,9 +191,7 @@ local CreOptions = {
                     DCREREADER_CONFIG_MARGIN_SIZES_MEDIUM,
                     DCREREADER_CONFIG_MARGIN_SIZES_LARGE,
                 },
-                name_text_hold_callback = function(configurable, opt)
-                    showValuesMargins(configurable, opt.name_text, "copt_page_margins", opt.name, "")
-                end,
+                name_text_hold_callback = showValuesMargins,
             },
         }
     },
@@ -222,8 +218,12 @@ local CreOptions = {
                 args = {"decrease", "increase"},
                 alternate = false,
                 name_text_hold_callback = function(configurable)
-                    showValues(configurable, _("Font size"), "copt_font_size", "font_size", "")
-                end,
+                    local opt = {
+                        name = "font_size",
+                        name_text = _("Font Size"),
+                    }
+                    showValues(configurable, opt)
+                end
             }
         }
     },
@@ -238,9 +238,7 @@ local CreOptions = {
                 default_value = 0,
                 args = {0, 1},
                 event = "ToggleFontBolder",
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_font_weight", opt.name, "", opt.toggle, opt.values)
-                end,
+                name_text_hold_callback = showValues,
             },
             {
                 name = "font_gamma",
@@ -253,9 +251,7 @@ local CreOptions = {
                 args = {10, 15, 25, 30, 36, 43, 49, 56},
                 -- gamma values for these indexes are:
                 labels = {0.8, 1.0, 1.45, 1.90, 2.50, 4.0, 8.0, 15.0},
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_font_gamma", opt.name, "")
-                end,
+                name_text_hold_callback = showValues,
             },
             {
                 name = "font_hinting",
@@ -265,9 +261,7 @@ local CreOptions = {
                 default_value = 2,
                 args = {0, 1, 2},
                 event = "SetFontHinting",
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_font_hinting", opt.name, "", opt.toggle, opt.values)
-                end,
+                name_text_hold_callback = showValues,
             }
         }
     },
@@ -283,9 +277,7 @@ local CreOptions = {
                 args = {0, 1},
                 default_arg = DCREREADER_PROGRESS_BAR,
                 event = "SetStatusLine",
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_status_line", opt.name, "", opt.toggle, opt.values)
-                end,
+                name_text_hold_callback = showValues,
             },
             {
                 name = "embedded_css",
@@ -296,9 +288,7 @@ local CreOptions = {
                 args = {true, false},
                 default_arg = nil,
                 event = "ToggleEmbeddedStyleSheet",
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_embedded_css", opt.name, "", opt.toggle, opt.values)
-                end,
+                name_text_hold_callback = showValues,
             },
             {
                 name = "embedded_fonts",
@@ -312,9 +302,7 @@ local CreOptions = {
                 enabled_func = function(configurable)
                     return enable_if_equals(configurable, "embedded_css", 1)
                 end,
-                name_text_hold_callback = function(configurable, opt)
-                    showValues(configurable, opt.name_text, "copt_embedded_fonts", opt.name, "", opt.toggle, opt.values)
-                end,
+                name_text_hold_callback = showValues,
             },
         },
     },

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -18,64 +18,35 @@ local Aa = setmetatable({"Aa"}, {
     end
 })
 
-local arg_view_mode = {
-    [0] = S.VIEW_PAGE,
-    [1] = S.VIEW_SCROLL,
-}
-local arg_line_spacing = {
-    [DCREREADER_CONFIG_LINE_SPACE_PERCENT_SMALL] = S.SMALL,
-    [DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM] = S.MEDIUM,
-    [DCREREADER_CONFIG_LINE_SPACE_PERCENT_LARGE] = S.LARGE,
-}
-
-local arg_font_weight = {
-    [0] = S.REGULAR,
-    [1] = S.BOLD,
-}
-
-local arg_font_hinting = {
-    [0] = S.OFF,
-    [1] = S.NATIVE,
-    [2] = S.AUTO,
-}
-local arg_status_line = {
-    [0] = S.FULL,
-    [1] = S.MINI,
-}
-
-local arg_embedded_css = {
-    [0] = S.OFF,
-    [1] = S.ON,
-}
-
-local arg_embedded_fonts = {
-    [0] = S.OFF,
-    [1] = S.ON,
-}
-
 local function enable_if_equals(configurable, option, value)
     return configurable[option] == value
 end
 
-local function showValues(configurable, title ,setting_default, setting_curr, suffix, arg_string, true_values)
+local function showValues(configurable, title ,setting_default, setting_curr, suffix, arg_string, arg_values, true_values)
     local default = G_reader_settings:readSetting(setting_default)
     local current = configurable[setting_curr]
     local value_default, value_current
     if setting_curr == "screen_mode" then
         current = Screen:getScreenMode()
     end
+    local arg_table = {}
+    if arg_string then
+        for i=1,#arg_string do
+            arg_table[arg_values[i]] = arg_string[i]
+        end
+    end
     if not default then
         default = "not set"
         suffix = ""
         if arg_string then
             value_current = current
-            current = arg_string[current]
+            current = arg_table[current]
         end
     elseif arg_string then
         value_current = current
         value_default = default
-        default = arg_string[default]
-        current = arg_string[current]
+        default = arg_table[default]
+        current = arg_table[current]
     end
     if true_values and arg_string then
         UIManager:show(InfoMessage:new{
@@ -164,8 +135,8 @@ local CreOptions = {
                 default_arg = "portrait",
                 current_func = function() return Screen:getScreenMode() end,
                 event = "ChangeScreenMode",
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.SCREEN_MODE, "copt_screen_mode", "screen_mode", "")
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_screen_mode", opt.name, "")
                 end,
             }
         }
@@ -182,8 +153,8 @@ local CreOptions = {
                 args = {"scroll", "page"},
                 default_arg = "page",
                 event = "SetViewMode",
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.VIEW_MODE, "copt_view_mode", "view_mode", "", arg_view_mode)
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_view_mode", opt.name, "", opt.toggle, opt.values)
                 end,
             },
             {
@@ -202,8 +173,8 @@ local CreOptions = {
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM,
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_LARGE,
                 },
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.LINE_SPACING, "copt_line_spacing", "line_spacing", "%", arg_line_spacing, true)
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_line_spacing", opt.name, "%", opt.toggle, opt.values, true)
                 end,
             },
             {
@@ -222,8 +193,8 @@ local CreOptions = {
                     DCREREADER_CONFIG_MARGIN_SIZES_MEDIUM,
                     DCREREADER_CONFIG_MARGIN_SIZES_LARGE,
                 },
-                name_text_hold_callback = function(configurable)
-                    showValuesMargins(configurable, S.PAGE_MARGIN, "copt_page_margins", "page_margins", "")
+                name_text_hold_callback = function(configurable, opt)
+                    showValuesMargins(configurable, opt.name_text, "copt_page_margins", opt.name, "")
                 end,
             },
         }
@@ -267,8 +238,8 @@ local CreOptions = {
                 default_value = 0,
                 args = {0, 1},
                 event = "ToggleFontBolder",
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.FONT_WEIGHT, "copt_font_weight", "font_weight", "", arg_font_weight)
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_font_weight", opt.name, "", opt.toggle, opt.values)
                 end,
             },
             {
@@ -282,8 +253,8 @@ local CreOptions = {
                 args = {10, 15, 25, 30, 36, 43, 49, 56},
                 -- gamma values for these indexes are:
                 labels = {0.8, 1.0, 1.45, 1.90, 2.50, 4.0, 8.0, 15.0},
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.CONTRAST, "copt_font_gamma", "font_gamma", "")
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_font_gamma", opt.name, "")
                 end,
             },
             {
@@ -294,8 +265,8 @@ local CreOptions = {
                 default_value = 2,
                 args = {0, 1, 2},
                 event = "SetFontHinting",
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.FONT_HINT, "copt_font_hinting", "font_hinting", "", arg_font_hinting)
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_font_hinting", opt.name, "", opt.toggle, opt.values)
                 end,
             }
         }
@@ -312,8 +283,8 @@ local CreOptions = {
                 args = {0, 1},
                 default_arg = DCREREADER_PROGRESS_BAR,
                 event = "SetStatusLine",
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.PROGRESS_BAR, "copt_status_line", "status_line", "", arg_status_line)
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_status_line", opt.name, "", opt.toggle, opt.values)
                 end,
             },
             {
@@ -325,8 +296,8 @@ local CreOptions = {
                 args = {true, false},
                 default_arg = nil,
                 event = "ToggleEmbeddedStyleSheet",
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.EMBEDDED_STYLE, "copt_embedded_css", "embedded_css", "", arg_embedded_css)
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_embedded_css", opt.name, "", opt.toggle, opt.values)
                 end,
             },
             {
@@ -341,8 +312,8 @@ local CreOptions = {
                 enabled_func = function(configurable)
                     return enable_if_equals(configurable, "embedded_css", 1)
                 end,
-                name_text_hold_callback = function(configurable)
-                    showValues(configurable, S.EMBEDDED_FONTS, "copt_embedded_fonts", "embedded_fonts", "", arg_embedded_fonts)
+                name_text_hold_callback = function(configurable, opt)
+                    showValues(configurable, opt.name_text, "copt_embedded_fonts", opt.name, "", opt.toggle, opt.values)
                 end,
             },
         },

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -233,7 +233,11 @@ function ConfigOption:init()
                     text_font_face = name_font_face,
                     text_font_size = name_font_size,
                     text_font_bold = false,
-                    hold_callback = self.options[c].name_text_hold_callback,
+                    hold_callback = function()
+                        if self.options[c].name_text_hold_callback then
+                            self.options[c].name_text_hold_callback(self.config.configurable)
+                        end
+                    end,
                 }
                 table.insert(option_name_container, option_name)
                 table.insert(horizontal_group, option_name_container)

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -235,7 +235,7 @@ function ConfigOption:init()
                     text_font_bold = false,
                     hold_callback = function()
                         if self.options[c].name_text_hold_callback then
-                            self.options[c].name_text_hold_callback(self.config.configurable)
+                            self.options[c].name_text_hold_callback(self.config.configurable, self.options[c])
                         end
                     end,
                 }


### PR DESCRIPTION
After long press on name of options in config dialog we can see now current and default value. For now only for epub (cre) documents.
Long press on "View Mode"
![romeo and juliet - koreader_092](https://user-images.githubusercontent.com/22982594/40076420-215199fa-587f-11e8-85c6-b21b3ed9d2db.png)

Long press on "Line Spacing"
![romeo and juliet - koreader_093](https://user-images.githubusercontent.com/22982594/40076424-235358a6-587f-11e8-8107-b68c8a4673b2.png)

Long press on "Margin"
![romeo and juliet - koreader_094](https://user-images.githubusercontent.com/22982594/40076431-25832b1a-587f-11e8-9751-875fc7af70a2.png)
