### PR TITLE
Try to inhibit USBMS on Kindles

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -83,10 +83,12 @@ function Kindle:setDateTime(year, month, day, hour, min, sec)
 end
 
 function Kindle:usbPlugIn()
-    -- NOTE: We do NOT support running in USBMS mode (we cannot, we live there).
-    --       And, AFAICT, we have no sane way of disabling USBMS mode without breaking either us or the framework,
-    --       c.f., https://github.com/koreader/koreader/issues/3220
-    --       That means shit will blow up in fun and interesting ways if someone actually tries that.
+    -- NOTE: We cannot support running in USBMS mode (we cannot, we live on the partition being exported!).
+    --       But since that's the default state of the Kindle system, we have to try to make nice...
+    --       To that end, we're currently SIGSTOPping volumd to inhibit the system's USBMS mode handling.
+    --       It's not perfect (f.g., if the system is setup for USBMS and not USBNet,
+    --       the frontlight will be turned off when plugged in), but it at least prevents users from completely
+    --       shooting themselves in the foot (c.f., https://github.com/koreader/koreader/issues/3220)!
     --       On the upside, we don't have to bother waking up the WM to show us the USBMS screen :D.
     -- NOTE: If the device is put in USBNet mode before we even start, everything's peachy, though :).
     self.charging_mode = true

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -42,6 +42,7 @@ fi
 
 # Keep track of what we do with pillow...
 export AWESOME_STOPPED="no"
+export VOLUMD_STOPPED="no"
 PILLOW_HARD_DISABLED="no"
 PILLOW_SOFT_DISABLED="no"
 PASSCODE_DISABLED="no"
@@ -243,6 +244,13 @@ if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "sysv" ]; then
     killall -stop cvm
 fi
 
+# SIGSTOP volumd, to inhibit USBMS (sysv & upstart)
+if [ -e "/etc/init.d/volumd" ] || [ -e "/etc/upstart/volumd.conf" ]; then
+    logmsg "Stopping volumd . . ."
+    killall -stop volumd
+    VOLUMD_STOPPED="yes"
+fi
+
 # finally call reader
 logmsg "Starting KOReader . . ."
 # That's not necessary when using KPVBooklet ;).
@@ -290,6 +298,12 @@ fi
 if grep ${KOREADER_DIR}/fonts/linkfonts /proc/mounts >/dev/null 2>&1; then
     logmsg "Unmounting linkfonts . . ."
     umount ${KOREADER_DIR}/fonts/linkfonts
+fi
+
+# Resume volumd, if need be
+if [ "${VOLUMD_STOPPED}" = "yes" ]; then
+    logmsg "Resuming volumd . . ."
+    killall -cont volumd
 fi
 
 # Resume cvm (only if we stopped it)


### PR DESCRIPTION
re: #3955 

Looks safe enough.
Queued events that accumulate during the STOP properly get processed as bogus on resume.
And if the device is still plugged in on resume, you're thrown into the framework's USBMS handling, and it works.

Quickly tested on a PW2 on FW 5.8.1. YMMV on other setups.