### PR TITLE
Notification are displayed too short

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -219,7 +219,7 @@ function ReaderFont:onSetFontSize(new_size)
     self.ui:handleEvent(Event:new("UpdatePos"))
     UIManager:show(Notification:new{
         text = T( _("Font size set to %1."), self.font_size),
-        timeout = 1,
+        timeout = 2,
     })
 
     return true
@@ -229,7 +229,7 @@ function ReaderFont:onSetLineSpace(space)
     self.line_space_percent = math.min(200, math.max(80, space))
     UIManager:show(Notification:new{
         text = T( _("Line spacing set to %1%."), self.line_space_percent),
-        timeout = 1,
+        timeout = 2,
     })
     self.ui.document:setInterlineSpacePercent(self.line_space_percent)
     self.ui:handleEvent(Event:new("UpdatePos"))
@@ -256,7 +256,7 @@ function ReaderFont:onSetFontGamma(gamma)
     local gamma_level = self.ui.document:getGammaLevel()
     UIManager:show(Notification:new{
         text = T( _("Font gamma set to %1."), gamma_level),
-        timeout = 1
+        timeout = 2,
     })
     self.ui:handleEvent(Event:new("RedrawCurrentView"))
     return true
@@ -277,7 +277,7 @@ function ReaderFont:setFont(face)
         self.font_face = face
         UIManager:show(Notification:new{
             text = T( _("Redrawing with font %1."), face),
-            timeout = 1,
+            timeout = 2,
         })
 
         self.ui.document:setFontFace(face)

--- a/frontend/apps/reader/modules/readerfrontlight.lua
+++ b/frontend/apps/reader/modules/readerfrontlight.lua
@@ -75,7 +75,7 @@ function ReaderFrontLight:onShowIntensity()
     end
     UIManager:show(Notification:new{
         text = new_text,
-        timeout = 1.0,
+        timeout = 2,
     })
     return true
 end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -418,7 +418,7 @@ function ReaderLink:onSwipe(arg, ges)
                 -- so the user knows why
                 UIManager:show(Notification:new{
                     text = _("Location history is empty"),
-                    timeout = 1.0,
+                    timeout = 2,
                 })
                 return true
             end

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -8,6 +8,7 @@ local Device = require("device")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
@@ -26,13 +27,27 @@ local Notification = InputContainer:new{
 function Notification:init()
     if Device:hasKeys() then
         self.key_events = {
-            AnyKeyPressed = { { Input.group.Any }, seqtext = "any key", doc = "close dialog" }
+            AnyKeyPressed = { { Input.group.Any },
+                seqtext = "any key", doc = "close dialog" }
         }
     end
+    if Device:isTouchDevice() then
+        self.ges_events.TapClose = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    x = 0, y = 0,
+                    w = Screen:getWidth(),
+                    h = Screen:getHeight(),
+                }
+            }
+        }
+    end
+
     -- we construct the actual content here because self.text is only available now
     local text_widget = TextWidget:new{
         text = self.text,
-        face = self.face
+        face = self.face,
     }
     local widget_size = text_widget:getSize()
     self[1] = CenterContainer:new{
@@ -77,7 +92,16 @@ end
 function Notification:onAnyKeyPressed()
     -- triggered by our defined key events
     UIManager:close(self)
-    return true
+    if self.readonly ~= true then
+        return true
+    end
+end
+
+function Notification:onTapClose()
+    UIManager:close(self)
+    if self.readonly ~= true then
+        return true
+    end
 end
 
 return Notification


### PR DESCRIPTION
I think the notification messages are displayed too short (eg. `Line spacing set to...`, `Font size set to...`). I changed from 1 second to 2.
I also fixed the problem with blocking the UI when displaying the message. Now notification box is closed after taping anywhere (like InfoMessage).