### PR TITLE
Adds "Better rendering of list items" to Style tweaks

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -274,9 +274,11 @@ function ReaderMenu:onShowReaderMenu(tab_index)
 end
 
 function ReaderMenu:onCloseReaderMenu()
-    self.last_tab_index = self.menu_container[1].last_index
-    self:onSaveSettings()
-    UIManager:close(self.menu_container)
+    if self.menu_container then
+        self.last_tab_index = self.menu_container[1].last_index
+        self:onSaveSettings()
+        UIManager:close(self.menu_container)
+    end
     return true
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -188,6 +188,7 @@ function ReaderRolling:onCloseDocument()
             self.ui.document:invalidateCacheFile()
         end
     end
+    logger.dbg("cre cache used:", self.ui.document:getCacheFilePath() or "none")
 end
 
 function ReaderRolling:onCheckDomStyleCoherence()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1,4 +1,5 @@
 local Blitbuffer = require("ffi/blitbuffer")
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Event = require("ui/event")
@@ -179,6 +180,29 @@ end
 -- we cannot do it in onSaveSettings() because getLastPercent() uses self.ui.document
 function ReaderRolling:onCloseDocument()
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
+    -- also checks if DOM is coherent with styles; if not, invalidate the
+    -- cache, so a new DOM is built on next opening
+    if self.ui.document:isBuiltDomStale() then
+        if self.ui.document:hasCacheFile() then
+            logger.dbg("cre DOM may not be in sync with styles, invalidating cache file for a full reload at next opening")
+            self.ui.document:invalidateCacheFile()
+        end
+    end
+end
+
+function ReaderRolling:onCheckDomStyleCoherence()
+    if self.ui.document:isBuiltDomStale() then
+        UIManager:show(ConfirmBox:new{
+            text = _("Styles have changed in such a way that fully reloading the document may be needed for a correct rendering.\nDo you want to reload the document?"),
+            ok_callback = function()
+                -- Allow for ConfirmBox to be closed before showing
+                -- "Opening file" InfoMessage
+                UIManager:scheduleIn(0.5, function ()
+                    self.ui:reloadDocument()
+                end)
+            end,
+        })
+    end
 end
 
 function ReaderRolling:onSaveSettings()
@@ -566,6 +590,12 @@ function ReaderRolling:updatePos()
         self.view.footer:updateFooter()
     end
     UIManager:setDirty(self.view.dialog, "partial")
+    -- Allow for the new rendering to be shown before possibly showing
+    -- the "Styles have changes..." ConfirmBox so the user can decide
+    -- if it is really needed
+    UIManager:scheduleIn(0.1, function ()
+        self:onCheckDomStyleCoherence()
+    end)
 end
 
 --[[

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -263,8 +263,10 @@ function ReaderStyleTweak:updateCssText(apply)
         local tweaks = {}
         for id, enabled in pairs(self.global_tweaks) do
             -- there are only enabled tweaks in global_tweaks, but we don't
-            -- use them if they are disabled in doc_tweaks
-            if self.doc_tweaks[id] ~= false then
+            -- add them here if they appear in doc_tweaks (if enabled in
+            -- doc_tweaks, they'll be added below; if disabled, they should
+            -- not be added)
+            if self.doc_tweaks[id] == nil then
                 table.insert(tweaks, self.tweaks_by_id[id])
             end
         end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -646,4 +646,17 @@ function ReaderUI:onHome()
     return true
 end
 
+function ReaderUI:reloadDocument(after_close_callback)
+    local file = self.document.file
+    local provider = getmetatable(self.document).__index
+    self:handleEvent(Event:new("CloseReaderMenu"))
+    self:handleEvent(Event:new("CloseConfigMenu"))
+    self:onClose()
+    if after_close_callback then
+        -- allow caller to do stuff between close an re-open
+        after_close_callback(file, provider)
+    end
+    self:showReader(file, provider)
+end
+
 return ReaderUI

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -601,6 +601,10 @@ function CreDocument:invalidateCacheFile()
     self._document:invalidateCacheFile()
 end
 
+function CreDocument:getCacheFilePath()
+    return self._document:getCacheFilePath()
+end
+
 function CreDocument:register(registry)
     registry:addProvider("azw", "application/vnd.amazon.mobi8-ebook", self, 90)
     registry:addProvider("chm", "application/vnd.ms-htmlhelp", self, 90)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -589,6 +589,18 @@ function CreDocument:enableInternalHistory(toggle)
     self._document:setIntProperty("crengine.highlight.bookmarks", toggle and 2 or 0)
 end
 
+function CreDocument:isBuiltDomStale()
+    return self._document:isBuiltDomStale()
+end
+
+function CreDocument:hasCacheFile()
+    return self._document:hasCacheFile()
+end
+
+function CreDocument:invalidateCacheFile()
+    self._document:invalidateCacheFile()
+end
+
 function CreDocument:register(registry)
     registry:addProvider("azw", "application/vnd.amazon.mobi8-ebook", self, 90)
     registry:addProvider("chm", "application/vnd.ms-htmlhelp", self, 90)

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -13,46 +13,6 @@ local _ = require("gettext")
 
 local CssTweaks = {
     {
-        title = _("Enhancements"),
-        {
-            id = "html_tags_fix";
-            title = _("Correct handling of some HTML elements"),
-            description = _("Make some HTML elements (eg: <cite>) behave as they should (inline/block).\nThis may break past bookmarks and highlights."),
-            css = [[
-cite { display: inline; font-style: italic; }
-            ]],
-        },
-        {
-            id = "list_item_block";
-            title = _("Better rendering of list items"),
-            description = _("Correctly render list items as block elements.\nThis may break past bookmarks and highlights."),
-            css = [[
-li {display: -cr-list-item-block; }
-            ]],
-            separator = true,
-        },
-        {
-            title = _("Workarounds"),
-            {
-                id = "list_items_fix";
-                title = _("Fix some list items issues"),
-                description = _("Work around some crengine list items rendering issues."),
-                css = [[
-li > p:first-child   { display: inline !important; }
-li > div:first-child { display: inline !important; }
-                ]],
-            },
-            {
-                id = "border_all_none";
-                title = _("Remove all borders"),
-                description = _("Work around a crengine bug that makes a border drawn when {border: black solid 0px}."),
-                -- css = [[* { border-style: none !important; }]],
-                -- Better to keep the layout implied by width, just draw them in white
-                css = [[* { border-color: white !important; }]],
-            },
-        },
-    },
-    {
         title = _("Page"),
         {
             id = "margin_body_0";
@@ -102,11 +62,12 @@ li > div:first-child { display: inline !important; }
             id = "sub_sup_smaller";
             title = _("Smaller sub- and superscript"),
             description = _("Prevent sub- and superscript from affecting line-height."),
+            priority = 5, -- so we can override "font_size_all_inherit"
             -- https://friendsofepub.github.io/eBookTricks/
             -- https://github.com/koreader/koreader/issues/3923#issuecomment-386510294
             css = [[
-sup { font-size: 50%; vertical-align: super; }
-sub { font-size: 50%; vertical-align: middle; }
+sup { font-size: 50% !important; vertical-align: super !important; }
+sub { font-size: 50% !important; vertical-align: middle !important; }
             ]],
             separator = true,
         },
@@ -163,6 +124,43 @@ img {
    width: 100% !important;
 }
             ]],
+        },
+    },
+    {
+        title = _("Workarounds"),
+        {
+            id = "html_tags_fix";
+            title = _("Correct handling of some HTML elements"),
+            description = _("Make some HTML elements (eg: <cite>) behave as they should (inline/block).\nThis may break past bookmarks and highlights."),
+            css = [[
+cite { display: inline; font-style: italic; }
+            ]],
+        },
+        {
+            id = "list_item_block";
+            title = _("Better rendering of list items"),
+            description = _("Correctly render list items as block elements.\nThis may break past bookmarks and highlights."),
+            css = [[
+li {display: -cr-list-item-block; }
+            ]],
+        },
+        {
+            id = "list_items_fix";
+            title = _("Fix some list items issues"),
+            description = _("Work around some crengine list items rendering issues."),
+            css = [[
+li > p:first-child   { display: inline !important; }
+li > div:first-child { display: inline !important; }
+            ]],
+            separator = true,
+        },
+        {
+            id = "border_all_none";
+            title = _("Remove all borders"),
+            description = _("Work around a crengine bug that makes a border drawn when {border: black solid 0px}."),
+            -- css = [[* { border-style: none !important; }]],
+            -- Better to keep the layout implied by width, just draw them in white
+            css = [[* { border-color: white !important; }]],
         },
     },
 }

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -13,6 +13,46 @@ local _ = require("gettext")
 
 local CssTweaks = {
     {
+        title = _("Enhancements"),
+        {
+            id = "html_tags_fix";
+            title = _("Correct handling of some HTML elements"),
+            description = _("Make some HTML elements (eg: <cite>) behave as they should (inline/block).\nThis may break past bookmarks and highlights."),
+            css = [[
+cite { display: inline; font-style: italic; }
+            ]],
+        },
+        {
+            id = "list_item_block";
+            title = _("Better rendering of list items"),
+            description = _("Correctly render list items as block elements.\nThis may break past bookmarks and highlights."),
+            css = [[
+li {display: -cr-list-item-block; }
+            ]],
+            separator = true,
+        },
+        {
+            title = _("Workarounds"),
+            {
+                id = "list_items_fix";
+                title = _("Fix some list items issues"),
+                description = _("Work around some crengine list items rendering issues."),
+                css = [[
+li > p:first-child   { display: inline !important; }
+li > div:first-child { display: inline !important; }
+                ]],
+            },
+            {
+                id = "border_all_none";
+                title = _("Remove all borders"),
+                description = _("Work around a crengine bug that makes a border drawn when {border: black solid 0px}."),
+                -- css = [[* { border-style: none !important; }]],
+                -- Better to keep the layout implied by width, just draw them in white
+                css = [[* { border-color: white !important; }]],
+            },
+        },
+    },
+    {
         title = _("Page"),
         {
             id = "margin_body_0";
@@ -34,6 +74,30 @@ local CssTweaks = {
     },
     {
         title = _("Text"),
+        {
+            title = _("Links color and weight"),
+            {
+                id = "a_black";
+                title = _("Links always black"),
+                css = [[a { color: black !important; }]],
+            },
+            {
+                id = "a_blue";
+                title = _("Links always blue"),
+                css = [[a { color: blue !important; }]],
+                separator = true,
+            },
+            {
+                id = "a_bold";
+                title = _("Links always bold"),
+                css = [[a { font-weight: bold !important; }]],
+            },
+            {
+                id = "a_not_bold";
+                title = _("Links never bold"),
+                css = [[a { font-weight: normal !important; }]],
+            },
+        },
         {
             id = "sub_sup_smaller";
             title = _("Smaller sub- and superscript"),
@@ -65,30 +129,6 @@ sub { font-size: 50%; vertical-align: middle; }
             description = _("Disable font-size specified in embedded styles."),
             css = [[* { font-size: inherit !important; }]],
             separator = true,
-        },
-        {
-            title = _("Links color and weight"),
-            {
-                id = "a_black";
-                title = _("Links always black"),
-                css = [[a { color: black !important; }]],
-            },
-            {
-                id = "a_blue";
-                title = _("Links always blue"),
-                css = [[a { color: blue !important; }]],
-                separator = true,
-            },
-            {
-                id = "a_bold";
-                title = _("Links always bold"),
-                css = [[a { font-weight: bold !important; }]],
-            },
-            {
-                id = "a_not_bold";
-                title = _("Links never bold"),
-                css = [[a { font-weight: normal !important; }]],
-            },
         },
     },
     {
@@ -123,34 +163,6 @@ img {
    width: 100% !important;
 }
             ]],
-        },
-    },
-    {
-        title = _("Workarounds"),
-        {
-            id = "html_tags_fix";
-            title = _("Fix some HTML elements"),
-            description = _("Make some HTML elements (eg: <cite>) behave as they should (inline/block).\nThis may break past bookmarks and highlights."),
-            css = [[
-cite { display: inline; font-style: italic; }
-            ]],
-        },
-        {
-            id = "list_items_fix";
-            title = _("Fix some list items issues"),
-            description = _("Work around some crengine list items rendering issues."),
-            css = [[
-li > p:first-child   { display: inline !important; }
-li > div:first-child { display: inline !important; }
-            ]],
-        },
-        {
-            id = "border_all_none";
-            title = _("Remove all borders"),
-            description = _("Work around a crengine bug that makes a border drawn when {border: black solid 0px}."),
-            -- css = [[* { border-style: none !important; }]],
-            -- Better to keep the layout implied by width, just draw them in white
-            css = [[* { border-color: white !important; }]],
         },
     },
 }


### PR DESCRIPTION
See https://github.com/koreader/crengine/pull/188 for details about this _alternative rendering method for list items_.
~~Also reorganize Style tweaks (demote Workarounds by moving it into a new Enhancements menu - might look strange,  would it be better in Misc?, - I don't want to add another top level item for it).~~
<kbd>![image](https://user-images.githubusercontent.com/24273478/40278119-78455292-5c2b-11e8-8d6d-dab5aff12a09.png)</kbd>

Check the build DOM is still coherent with styles on stylesheet change, and propose to reload the document if not. Also invalidate cache in that case so a new DOM is built at next opening.
<kbd>![image](https://user-images.githubusercontent.com/24273478/40278101-28db056c-5c2b-11e8-99da-680579e3c728.png)</kbd>

One may get this message when using a Style tweak (or toggling Embedded styles) that change some `display:`, when there are actually nodes in the document that are affected. When toggling back, the DOM is now again in sync with styles, and nothing is needed (cache won't be invalidated). This message allows a user to toggle back and avoid a possibly time consuming reload of the document.
One could also get this message when some book is opened that uses a cache file, some styles changes, the book closed, and `Purge .sdr` called for this book: on next opening, the cached DOM do not match the initial styles states, so this message would appear, just to reload with an invalidated cache.

About this new list items rendering as block, I wonder if we should do something about the first P or DIV in a LI. Our P have a default style with `text-indent: 1.2em`, which is nice and good for main text.

We currently show things as:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40278136-bdd44020-5c2b-11e8-97b8-c527254ef4cd.png)</kbd>
Firefox, who does not set any text-indent on P, shows:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40278147-e9ce7646-5c2b-11e8-816e-291a46d0158a.png)</kbd>

By adding `li > p:first-child {text-indent: 0;}` to the tweak , we'd get:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40278162-32e13184-5c2c-11e8-9ca1-2ee2383ba289.png)</kbd>
but I'm not really sure it's better :)


