### PR TITLE
bump crengine: LI and CITE fixes are now the defaults

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -380,6 +380,7 @@ You can enable individual tweaks on this book with a tap, or view more details a
                 end,
                 enabled_func = is_enabled,
                 sub_item_table = sub_item_table,
+                separator = item.separator,
             })
         elseif item.id then -- tweak menu item
             -- Set a default priority of 0 if item doesn't have one

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -20,7 +20,6 @@ local CreDocument = Document:new{
 
     _document = false,
     _loaded = false,
-    _cre_dom_version = nil,
 
     line_space_percent = 100,
     default_font = "Noto Serif",
@@ -121,9 +120,6 @@ function CreDocument:init()
         error(self._document)  -- will contain error message
     end
 
-    -- get DOM engine latest version
-    self._cre_dom_version = self._document:getIntProperty("crengine.dom.version")
-
     -- adjust font sizes according to screen dpi
     self._document:adjustFontSizes(Screen:getDPI())
 
@@ -143,7 +139,7 @@ function CreDocument:init()
 end
 
 function CreDocument:getLatestDomVersion()
-    return self._cre_dom_version
+    return cre.getLatestDomVersion()
 end
 
 function CreDocument:getOldestDomVersion()
@@ -151,7 +147,8 @@ function CreDocument:getOldestDomVersion()
 end
 
 function CreDocument:requestDomVersion(version)
-    self._document:setIntProperty("crengine.dom.version", version)
+    logger.dbg("CreDocument: requesting DOM version:", version)
+    cre.requestDomVersion(version)
 end
 
 function CreDocument:loadDocument(full_document)

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -129,32 +129,6 @@ img {
     {
         title = _("Workarounds"),
         {
-            id = "html_tags_fix";
-            title = _("Correct handling of some HTML elements"),
-            description = _("Make some HTML elements (eg: <cite>) behave as they should (inline/block).\nThis may break past bookmarks and highlights."),
-            css = [[
-cite { display: inline; font-style: italic; }
-            ]],
-        },
-        {
-            id = "list_item_block";
-            title = _("Better rendering of list items"),
-            description = _("Correctly render list items as block elements.\nThis may break past bookmarks and highlights."),
-            css = [[
-li {display: -cr-list-item-block; }
-            ]],
-        },
-        {
-            id = "list_items_fix";
-            title = _("Fix some list items issues"),
-            description = _("Work around some crengine list items rendering issues."),
-            css = [[
-li > p:first-child   { display: inline !important; }
-li > div:first-child { display: inline !important; }
-            ]],
-            separator = true,
-        },
-        {
             id = "border_all_none";
             title = _("Remove all borders"),
             description = _("Work around a crengine bug that makes a border drawn when {border: black solid 0px}."),

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -963,10 +963,6 @@ ul, ol {
 li.gallerybox {
     display: inline;
 }
-/* helps crengine to not display them as block elements */
-time, abbr, sup {
-    display: inline;
-}
 ]])
 
     -- ----------------------------------------------------------------


### PR DESCRIPTION
Books previously opened (that have a metadata.lua, whether with highlights or not, but because they all have a last_xpointer that points to the current page, that can be broken too by the changes)
will continue to have the old wrong behaviour, so they won't be impacted by the breaking changes.
Update cre_dom_version code to use the new functions from cre.cpp.
Remove these Workarounds from Style tweaks.

See https://github.com/koreader/koreader/issues/3940#issuecomment-391667791 and previous discussion for context.
Will need a base and crengine bump for:
- Adds cre.getLatestDomVersion() and cre.requestDomVersion() https://github.com/koreader/koreader-base/pull/679
- Use latest `<li>` and `<cite>` fixes as default https://github.com/koreader/crengine/pull/192

Users that would really want the old list item behaviour on new books (why would they?!) can add a User style tweak with `li {display: -cr-list-item-final; }`
