### PR TITLE
Style tweaks: add a few text alignement tweaks

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -59,6 +59,36 @@ local CssTweaks = {
             },
         },
         {
+            title = _("Text alignment"),
+            {
+                id = "text_align_most_left",
+                title = _("Left align most text"),
+                description = _("Enforce left alignment of text in common text elements."),
+                css = [[body, p, li { text-align: left !important; }]],
+                priority = 2, -- so it overrides the justify below
+            },
+            {
+                id = "text_align_all_left",
+                title = _("Left align all elements"),
+                description = _("Enforce left alignment of text in all elements."),
+                css = [[* { text-align: left !important; }]],
+                priority = 2, -- so it overrides the justify below
+                separator = true,
+            },
+            {
+                id = "text_align_most_justify",
+                title = _("Justify most text"),
+                description = _("Text justification is the default, but may be overriden by publisher styles. This will re-enable it for most common text elements."),
+                css = [[body, p, li { text-align: justify !important; }]],
+            },
+            {
+                id = "text_align_all_justify",
+                title = _("Justify all elements"),
+                description = _("Text justification is the default, but may be overriden by publisher styles. This will re-enable it for all elements, which may lose centering in some of them."),
+                css = [[* { text-align: justify !important; }]],
+            },
+        },
+        {
             id = "sub_sup_smaller";
             title = _("Smaller sub- and superscript"),
             description = _("Prevent sub- and superscript from affecting line-height."),

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -78,13 +78,13 @@ local CssTweaks = {
             {
                 id = "text_align_most_justify",
                 title = _("Justify most text"),
-                description = _("Text justification is the default, but may be overriden by publisher styles. This will re-enable it for most common text elements."),
+                description = _("Text justification is the default, but it may be overridden by publisher styles. This will re-enable it for most common text elements."),
                 css = [[body, p, li { text-align: justify !important; }]],
             },
             {
                 id = "text_align_all_justify",
                 title = _("Justify all elements"),
-                description = _("Text justification is the default, but may be overriden by publisher styles. This will re-enable it for all elements, which may lose centering in some of them."),
+                description = _("Text justification is the default, but it may be overridden by publisher styles. This will re-enable it for all elements, which may lose centering in some of them."),
                 css = [[* { text-align: justify !important; }]],
             },
         },


### PR DESCRIPTION
Adds a few Text alignment tweaks, as suggested by @didierm in https://github.com/koreader/koreader/pull/3944#issuecomment-390411361.

`Justify most text` might be enough to re-enable justification if a publisher has disabled it.
`Justify all text` is radical (will remove centering of images and text in Wikipedia EPUB), but is available in case the previous one is not enough.
Did the same to enforce left alignment, as @Frenzie seems to like it and @cramoisi think KOReader should have that option. See https://github.com/koreader/crengine/pull/150#issuecomment-386855291.

<kbd>![image](https://user-images.githubusercontent.com/24273478/40542335-1a147a06-6020-11e8-82b6-cf862087991a.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/40542320-088054f4-6020-11e8-8792-89e091fc521f.png)</kbd>

(I have no current need for these tweaks, so I just checked on a few books if they would work as someone might expect. Feel free to adapt them if I missed some elements).