### PR TITLE
TouchMenu: added hook to show help text on long-press

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -105,7 +105,7 @@ function ReaderLink:addToMainMenu(menu_items)
                     G_reader_settings:saveSetting("swipe_to_go_back",
                         not isSwipeToGoBackEnabled())
                 end,
-                help_text = _([[Swipe to the right to go back to the previous location after you have followed a link. When the location stack is empty, swiping to the right takes you normally to previous page.]]),
+                help_text = _([[Swipe to the right to go back to the previous location after you have followed a link. When the location stack is empty, swiping to the right takes you to the previous page.]]),
             },
             {
                 text = _("Swipe to follow first link on page"),
@@ -117,7 +117,7 @@ function ReaderLink:addToMainMenu(menu_items)
                         G_reader_settings:delSetting("swipe_to_follow_nearest_link") -- can't have both
                     end
                 end,
-                help_text = _([[Swipe to the left to go the first link in the current page.]]),
+                help_text = _([[Swipe to the left to follow the first link in the current page.]]),
             },
             {
                 text = _("Swipe to follow nearest link"),
@@ -129,7 +129,7 @@ function ReaderLink:addToMainMenu(menu_items)
                         G_reader_settings:delSetting("swipe_to_follow_first_link") -- can't have both
                     end
                 end,
-                help_text = _([[Swipe to the left to go the link nearest to where you started the swipe. This is useful when a small font is used and taping on small links is tedious.]]),
+                help_text = _([[Swipe to the left to follow the link nearest to where you started the swipe. This is useful when a small font is used and tapping on small links is tedious.]]),
                 separator = true,
             },
             {
@@ -140,8 +140,8 @@ function ReaderLink:addToMainMenu(menu_items)
                         not isSwipeToJumpToLatestBookmarkEnabled())
                 end,
                 help_text = _([[Swipe to the left to go the most recently bookmarked page.
-This can be useful to quickly swipe back and forth between your reading and some reference page (for example a map, a characters list...)
-If any of the other Swipe to follow link option is enabled, this will work only when the current page contains no link.]]),
+This can be useful to quickly swipe back and forth between what you are reading and some reference page (for example notes, a map or a characters list).
+If any of the other Swipe to follow link options is enabled, this will work only when the current page contains no link.]]),
             },
         }
     }

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -95,6 +95,7 @@ function ReaderLink:addToMainMenu(menu_items)
                         not isTapToFollowLinksOn())
                 end,
                 separator = true,
+                help_text = _([[Tap on links to follow them.]]),
             },
 
             {
@@ -104,6 +105,7 @@ function ReaderLink:addToMainMenu(menu_items)
                     G_reader_settings:saveSetting("swipe_to_go_back",
                         not isSwipeToGoBackEnabled())
                 end,
+                help_text = _([[Swipe to the right to go back to the previous location after you have followed a link. When the location stack is empty, swiping to the right takes you normally to previous page.]]),
             },
             {
                 text = _("Swipe to follow first link on page"),
@@ -115,6 +117,7 @@ function ReaderLink:addToMainMenu(menu_items)
                         G_reader_settings:delSetting("swipe_to_follow_nearest_link") -- can't have both
                     end
                 end,
+                help_text = _([[Swipe to the left to go the first link in the current page.]]),
             },
             {
                 text = _("Swipe to follow nearest link"),
@@ -126,6 +129,7 @@ function ReaderLink:addToMainMenu(menu_items)
                         G_reader_settings:delSetting("swipe_to_follow_first_link") -- can't have both
                     end
                 end,
+                help_text = _([[Swipe to the left to go the link nearest to where you started the swipe. This is useful when a small font is used and taping on small links is tedious.]]),
                 separator = true,
             },
             {
@@ -135,6 +139,9 @@ function ReaderLink:addToMainMenu(menu_items)
                     G_reader_settings:saveSetting("swipe_to_jump_to_latest_bookmark",
                         not isSwipeToJumpToLatestBookmarkEnabled())
                 end,
+                help_text = _([[Swipe to the left to go the most recently bookmarked page.
+This can be useful to quickly swipe back and forth between your reading and some reference page (for example a map, a characters list...)
+If any of the other Swipe to follow link option is enabled, this will work only when the current page contains no link.]]),
             },
         }
     }

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -15,6 +15,7 @@ local GestureRange = require("ui/gesturerange")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
 local IconButton = require("ui/widget/iconbutton")
+local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
@@ -719,7 +720,7 @@ function TouchMenu:onMenuHold(item)
         else
             self:onInput(item.hold_input_func())
         end
-    else
+    elseif item.hold_callback or type(item.hold_callback_func) == "function" then
         local callback = item.hold_callback
         if item.hold_callback_func then
             callback = item.hold_callback_func()
@@ -733,6 +734,14 @@ function TouchMenu:onMenuHold(item)
                     callback()
                 end
             end)
+        end
+    elseif item.help_text or type(item.help_text_func) == "function" then
+        local help_text = item.help_text
+        if item.help_text_func then
+            help_text = item.help_text_func()
+        end
+        if help_text then
+            UIManager:show(InfoMessage:new{ text = help_text, })
         end
     end
     return true


### PR DESCRIPTION
When there is no hold callback attached to a menu item, a help_text attribute, when present, is shown in an InfoMessage.
This is one more step towards an _inline user manual_ as envisionned by @KenMaltby in https://github.com/koreader/koreader/pull/3952#issuecomment-390365232, after @robert00s recent works in #3952 and #3967.

I added just a few to the items in the `Links>` submenu (as I added some of these).
Dunno to which level of information we should go (facts, suggestions for different use cases...).
<kbd>![image](https://user-images.githubusercontent.com/24273478/40545037-a0e22254-602a-11e8-8296-f9b62c9563c0.png)</kbd>

Just curious how it works for translation, when we just correct a typo in some english message: do they see their previous entered translation, or it's lost as it's no more associated to the now modified message?