### PR TITLE
UI Behavior tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 KOReader is a document viewer application, originally created for Kindle
 e-ink readers. It currently runs on Kindle, Kobo, PocketBook, Ubuntu Touch
 and Android devices. Developers can also run a KOReader emulator
-for development purposes on desktop PCs with Linux, Windows and 
+for development purposes on desktop PCs with Linux, Windows and
 Mac OSX.
 
 Main features for users
@@ -103,6 +103,12 @@ The packages `pkg-config-arm-linux-gnueabihf` and `pkg-config-arm-linux-gnueabi`
 block you from building for Kobo or Kindle. Remove them if you get an ld error,
 `/usr/lib/gcc-cross/arm-linux-gnueabihf/4.8/../../../../arm-linux-gnueabihf/bin/
 ld: cannot find -lglib-2.0`
+
+**NOTE:** In the specific case of Kindle & Kobo targets, while we make some effort to support these Linaro/Ubuntu TCs,
+they do *not* exactly target the proper devices. While your build will go fine, this may lead to runtime failure.
+As time goes by, and/or the more bleeding-edge your distro is, the greater the risk for mismatch gets.
+Thankfully, we have a distribution-agnostic solution for you: [koxtoolchain](https://github.com/koreader/koxtoolchain)!
+This will allow you to build the *exact* same TCs used to build the nightlies, thanks to the magic of [crosstool-ng](https://github.com/crosstool-ng/crosstool-ng).
 
 On Mac OS X you may need to install the following tools using [Homebrew](https://brew.sh/):
 ```

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -161,7 +161,7 @@ function FileManager:init()
     function file_chooser:onPathChanged(path)  -- luacheck: ignore
         FileManager.instance.path_text:setText(truncatePath(filemanagerutil.abbreviate(path)))
         UIManager:setDirty(FileManager.instance, function()
-            return "ui", FileManager.instance.path_text.dimen
+            return "partial", FileManager.instance.path_text.dimen
         end)
         return true
     end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -1,6 +1,7 @@
 local Generic = require("device/generic/device")
 local _, android = pcall(require, "android")
 local ffi = require("ffi")
+local C = ffi.C
 local logger = require("logger")
 
 local function yes() return true end
@@ -26,11 +27,11 @@ function Device:init()
         event_map = require("device/android/event_map"),
         handleMiscEv = function(this, ev)
             logger.dbg("Android application event", ev.code)
-            if ev.code == ffi.C.APP_CMD_SAVE_STATE then
+            if ev.code == C.APP_CMD_SAVE_STATE then
                 return "SaveState"
-            elseif ev.code == ffi.C.APP_CMD_GAINED_FOCUS then
+            elseif ev.code == C.APP_CMD_GAINED_FOCUS then
                 this.device.screen:refreshFull()
-            elseif ev.code == ffi.C.APP_CMD_WINDOW_REDRAW_NEEDED then
+            elseif ev.code == C.APP_CMD_WINDOW_REDRAW_NEEDED then
                 this.device.screen:refreshFull()
             end
         end,
@@ -47,13 +48,13 @@ function Device:init()
 
     -- check if we have a keyboard
     if android.lib.AConfiguration_getKeyboard(android.app.config)
-       == ffi.C.ACONFIGURATION_KEYBOARD_QWERTY
+       == C.ACONFIGURATION_KEYBOARD_QWERTY
     then
         self.hasKeyboard = yes
     end
     -- check if we have a touchscreen
     if android.lib.AConfiguration_getTouchscreen(android.app.config)
-       ~= ffi.C.ACONFIGURATION_TOUCHSCREEN_NOTOUCH
+       ~= C.ACONFIGURATION_TOUCHSCREEN_NOTOUCH
     then
         self.isTouchDevice = yes
     end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -26,6 +26,7 @@ local Device = {
     needsTouchScreenProbe = no,
     hasClipboard = no,
     hasColorScreen = no,
+    hasBGRFrameBuffer = no,
 
     -- use these only as a last resort. We should abstract the functionality
     -- and have device dependent implementations in the corresponting
@@ -64,6 +65,8 @@ function Device:init()
         if G_reader_settings:has("color_rendering") then return G_reader_settings:isTrue("color_rendering") end
         return self.screen.isColorScreen()
     end
+
+    self.screen.isBGRFrameBuffer = self.hasBGRFrameBuffer
 
     local is_eink = G_reader_settings:readSetting("eink")
     self.screen.eink = (is_eink == nil) or is_eink

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -248,6 +248,10 @@ local KindleOasis2 = Kindle:new{
     hasFrontlight = yes,
     display_dpi = 300,
     touch_dev = "/dev/input/by-path/platform-30a30000.i2c-event",
+
+    -- NOTE: Incomplete, but at least they're confirmed.
+    --batt_capacity_file = "/sys/class/power_supply/max77796-battery/capacity",
+    --is_charging_file = "/sys/class/power_supply/max77796-charger/charging",
 }
 
 local KindleBasic2 = Kindle:new{

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -23,6 +23,7 @@ local Kobo = Generic:new{
     model = "Kobo",
     isKobo = yes,
     isTouchDevice = yes, -- all of them are
+    hasBGRFrameBuffer = yes, -- has always been the case, even on 16bpp FWs
 
     -- most Kobos have X/Y switched for the touch screen
     touch_switch_xy = true,

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -7,6 +7,7 @@ local Geom = require("ui/geometry")
 local RenderImage = require("ui/renderimage")
 local Screen = require("device").screen
 local ffi = require("ffi")
+local C = ffi.C
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
@@ -205,7 +206,7 @@ function CreDocument:getCoverPageImage()
     local data, size = self._document:getCoverPageImageData()
     if data and size then
         local image = RenderImage:renderImageData(data, size)
-        ffi.C.free(data) -- free the userdata we got from crengine
+        C.free(data) -- free the userdata we got from crengine
         return image
     end
 end
@@ -215,7 +216,7 @@ function CreDocument:getImageFromPosition(pos, want_frames)
     if data and size then
         logger.dbg("CreDocument: got image data from position", data, size)
         local image = RenderImage:renderImageData(data, size, want_frames)
-        ffi.C.free(data) -- free the userdata we got from crengine
+        C.free(data) -- free the userdata we got from crengine
         return image
     end
 end

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -31,7 +31,7 @@ function PdfDocument:init()
     self:updateColorRendering()
     if pdf.bgr == nil then
         pdf.bgr = false
-        if Device:isKobo() then
+        if Device:hasBGRFrameBuffer() then
             pdf.bgr = true
         end
     end

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -6,6 +6,7 @@ local KoptOptions = require("ui/data/koptoptions")
 local logger = require("logger")
 local util = require("util")
 local pdf = nil
+local C = ffi.C
 
 local PdfDocument = Document:new{
     _document = false,
@@ -152,13 +153,13 @@ function PdfDocument:saveHighlight(pageno, item)
         quadpoints[8*i-1] = item.pboxes[i].y
     end
     local page = self._document:openPage(pageno)
-    local annot_type = ffi.C.PDF_ANNOT_HIGHLIGHT
+    local annot_type = C.PDF_ANNOT_HIGHLIGHT
     if item.drawer == "lighten" then
-        annot_type = ffi.C.PDF_ANNOT_HIGHLIGHT
+        annot_type = C.PDF_ANNOT_HIGHLIGHT
     elseif item.drawer == "underscore" then
-        annot_type = ffi.C.PDF_ANNOT_UNDERLINE
+        annot_type = C.PDF_ANNOT_UNDERLINE
     elseif item.drawer == "strikeout" then
-        annot_type = ffi.C.PDF_ANNOT_STRIKEOUT
+        annot_type = C.PDF_ANNOT_STRIKEOUT
     end
     page:addMarkupAnnotation(quadpoints, n, annot_type)
     page:close()

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -5,8 +5,10 @@ local DrawContext = require("ffi/drawcontext")
 local KoptOptions = require("ui/data/koptoptions")
 local logger = require("logger")
 local util = require("util")
-local pdf = nil
+local ffi = require("ffi")
 local C = ffi.C
+local pdf = nil
+
 
 local PdfDocument = Document:new{
     _document = false,

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -137,7 +137,6 @@ end
 
 function PdfDocument:saveHighlight(pageno, item)
     self.is_edited = true
-    local ffi = require("ffi")
     -- will also need mupdf_h.lua to be evaluated once
     -- but this is guaranteed at this point
     local n = #item.pboxes

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -1,5 +1,6 @@
 local Cache = require("cache")
 local CacheItem = require("cacheitem")
+local Device = require("device")
 local Document = require("document/document")
 local DrawContext = require("ffi/drawcontext")
 local KoptOptions = require("ui/data/koptoptions")
@@ -28,6 +29,12 @@ function PdfDocument:init()
     -- and :postRenderPage() when mupdf is called without kopt involved.
     pdf.color = false
     self:updateColorRendering()
+    if pdf.bgr == nil then
+        pdf.bgr = false
+        if Device:isKobo() then
+            pdf.bgr = true
+        end
+    end
     self.koptinterface = require("document/koptinterface")
     self.configurable:loadDefaults(self.options)
     local ok

--- a/frontend/ui/elements/avoid_flashing_ui.lua
+++ b/frontend/ui/elements/avoid_flashing_ui.lua
@@ -1,0 +1,12 @@
+local _ = require("gettext")
+
+return {
+    text = _("Avoid mandatory black flashes in UI"),
+    checked_func = function()
+        return G_reader_settings:isTrue("avoid_flashing_ui")
+    end,
+    callback = function()
+        G_reader_settings:flipNilOrFalse("avoid_flashing_ui")
+    end,
+}
+

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -113,6 +113,7 @@ common_settings.screen = {
         require("ui/elements/screen_disable_double_tap_table"),
         require("ui/elements/flash_ui"),
         require("ui/elements/flash_keyboard"),
+        require("ui/elements/avoid_flashing_ui"),
     },
 }
 if Screen.isColorScreen() then

--- a/frontend/ui/message/streammessagequeue.lua
+++ b/frontend/ui/message/streammessagequeue.lua
@@ -5,6 +5,7 @@ local MessageQueue = require("ui/message/messagequeue")
 local _ = require("ffi/zeromq_h")
 local zmq = ffi.load("libs/libzmq.so.4")
 local czmq = ffi.load("libs/libczmq.so.1")
+local C = ffi.C
 
 local StreamMessageQueue = MessageQueue:new{
     host = nil,
@@ -13,7 +14,7 @@ local StreamMessageQueue = MessageQueue:new{
 
 function StreamMessageQueue:start()
     self.context = czmq.zctx_new();
-    self.socket = czmq.zsocket_new(self.context, ffi.C.ZMQ_STREAM)
+    self.socket = czmq.zsocket_new(self.context, C.ZMQ_STREAM)
     self.poller = czmq.zpoller_new(self.socket, nil)
     local endpoint = string.format("tcp://%s:%d", self.host, self.port)
     logger.warn("connect to endpoint", endpoint)
@@ -24,7 +25,7 @@ function StreamMessageQueue:start()
     local id_size = ffi.new("size_t[1]", 256)
     local buffer = ffi.new("uint8_t[?]", id_size[0])
     -- @todo: check return of zmq_getsockopt
-    zmq.zmq_getsockopt(self.socket, ffi.C.ZMQ_IDENTITY, buffer, id_size)
+    zmq.zmq_getsockopt(self.socket, C.ZMQ_IDENTITY, buffer, id_size)
     self.id = ffi.string(buffer, id_size[0])
     logger.dbg("id", #self.id, self.id)
 end

--- a/frontend/ui/renderimage.lua
+++ b/frontend/ui/renderimage.lua
@@ -3,6 +3,7 @@ Image rendering module.
 ]]
 
 local ffi = require("ffi")
+local Device = require("device")
 local logger = require("logger")
 
 -- Will be loaded when needed
@@ -66,7 +67,12 @@ end
 -- @treturn BlitBuffer
 function RenderImage:renderImageDataWithMupdf(data, size, width, height)
     if not Mupdf then Mupdf = require("ffi/mupdf") end
-    local ok, image = pcall(Mupdf.renderImage, data, size, width, height)
+    -- NOTE: Kobo's fb is BGR, not RGB. Handle the conversion in MuPDF if needed.
+    local bgr = false
+    if Device:isKobo() then
+        bgr = true
+    end
+    local ok, image = pcall(Mupdf.renderImage, data, size, width, height, bgr)
     logger.dbg("Mupdf.renderImage", ok, image)
     if not ok then
         logger.info("failed rendering image (mupdf):", image)

--- a/frontend/ui/renderimage.lua
+++ b/frontend/ui/renderimage.lua
@@ -68,11 +68,13 @@ end
 function RenderImage:renderImageDataWithMupdf(data, size, width, height)
     if not Mupdf then Mupdf = require("ffi/mupdf") end
     -- NOTE: Kobo's fb is BGR, not RGB. Handle the conversion in MuPDF if needed.
-    local bgr = false
-    if Device:isKobo() then
-        bgr = true
+    if Mupdf.bgr == nil then
+        Mupdf.bgr = false
+        if Device:isKobo() then
+            Mupdf.bgr = true
+        end
     end
-    local ok, image = pcall(Mupdf.renderImage, data, size, width, height, bgr)
+    local ok, image = pcall(Mupdf.renderImage, data, size, width, height)
     logger.dbg("Mupdf.renderImage", ok, image)
     if not ok then
         logger.info("failed rendering image (mupdf):", image)

--- a/frontend/ui/renderimage.lua
+++ b/frontend/ui/renderimage.lua
@@ -70,7 +70,7 @@ function RenderImage:renderImageDataWithMupdf(data, size, width, height)
     -- NOTE: Kobo's fb is BGR, not RGB. Handle the conversion in MuPDF if needed.
     if Mupdf.bgr == nil then
         Mupdf.bgr = false
-        if Device:isKobo() then
+        if Device:hasBGRFrameBuffer() then
             Mupdf.bgr = true
         end
     end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -379,6 +379,8 @@ flashui: like ui, but flashing.
 flashpartial: like partial, but flashing (and not counting towards flashing promotions).
               Can be used when closing an UI element, to avoid ghosting.
               You can even drop the region in these cases, to ensure a fullscreen flash.
+              NOTE: On REAGL devices, "flashpartial" will NOT actually flash (by design).
+                    As such, even onClose, you might prefer "flashui" in some instances...
 
 NOTE: You'll notice a trend on UI elements that are usually shown *over* some kind of text
       of using "ui" onShow & onUpdate, but "partial" onClose.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -371,9 +371,9 @@ ui: medium fidelity refresh (f.g., mixed content).
     Should apply to most UI elements.
 fast: low fidelity refresh (f.g., monochrome content).
       Should apply to most highlighting effects achieved through inversion.
-      Note that if your highlighted element contaisn text,
-      you might want to keep the unhighlight refresh as ui for crisper text.
-      (Or optimize that refresh away entirely if you can get away with it).
+      Note that if your highlighted element contains text,
+      you might want to keep the unhighlight refresh as "ui" instead, for crisper text.
+      (Or optimize that refresh away entirely, if you can get away with it).
 flashui: like ui, but flashing.
          Can be used when showing a UI element for the first time, to avoid ghosting.
 flashpartial: like partial, but flashing (and not counting towards flashing promotions).

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -712,7 +712,6 @@ function UIManager:_repaint()
     -- execute refreshes:
     for _, refresh in ipairs(self._refresh_stack) do
         dbg:v("triggering refresh", refresh)
-        -- FIXME: bound to screen size?
         Screen[refresh_methods[refresh.mode]](Screen,
             refresh.region.x - 1, refresh.region.y - 1,
             refresh.region.w + 2, refresh.region.h + 2)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -371,6 +371,9 @@ ui: medium fidelity refresh (f.g., mixed content).
     Should apply to most UI elements.
 fast: low fidelity refresh (f.g., monochrome content).
       Should apply to most highlighting effects achieved through inversion.
+      Note that if your highlighted element contaisn text,
+      you might want to keep the unhighlight refresh as ui for crisper text.
+      (Or optimize that refresh away entirely if you can get away with it).
 flashui: like ui, but flashing.
          Can be used when showing a UI element for the first time, to avoid ghosting.
 flashpartial: like partial, but flashing (and not counting towards flashing promotions).

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -349,6 +349,21 @@ the second parameter (refreshtype) can either specify a refreshtype
 (optionally in combination with a refreshregion - which is suggested)
 or a function that returns refreshtype AND refreshregion and is called
 after painting the widget.
+Here's a quick rundown of what each refreshtype should be used for:
+full: high-fidelity flashing update (f.g., large images).
+      Highest quality, but highest latency.
+      Don't abuse if you only want a flash (in this case, prefer flashpartial or flashui).
+partial: medium fidelity update (f.g., text on a white background).
+         Can be promoted to flashing after FULL_REFRESH_COUNT updates.
+         Don't abuse to avoid spurious flashes.
+ui: medium fidelity update (f.g., mixed content).
+    Should apply to most UI elements.
+fast: low fidelity update (f.g., monochrome content).
+      Should apply to most highlighting effects achieved through inversion.
+flashui: like ui, but flashing.
+         Can be used when showing a UI element for the first time, to avoid ghosting.
+flashpartial: like partial, but flashing.
+              Can be used when closing an UI element, to avoid ghosting.
 
 @usage
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -450,6 +450,18 @@ dbg:guard(UIManager, 'setDirty',
         end
     end)
 
+-- Clear the full repaint & refreshes queues.
+-- NOTE: Beware! This doesn't take any prisonners!
+--       You shouldn't have to resort to this unless in very specific circumstances!
+--       plugins/coverbrowser.koplugin/covermenu.lua building a franken-menu out of buttondialogtitle & buttondialog
+--       and wanting to avoid inheriting their original paint/refresh cycle being a prime example.
+function UIManager:clearRenderStack()
+    logger.dbg("clearRenderStack: Clearing the full render stack!")
+    self._dirty = {}
+    self._refresh_func_stack = {}
+    self._refresh_stack = {}
+end
+
 function UIManager:insertZMQ(zeromq)
     table.insert(self._zeromqs, zeromq)
     return zeromq

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -601,8 +601,6 @@ function UIManager:_refresh(mode, region)
     -- NOTE: Ideally, we'd only check partial w/ no region set (that neatly narrows it down to just the reader).
     --       In practice, we also want to promote refreshes in the FileManager,
     --       part of which is implemented as UI w/ a region...
-    --       If we wanted to go the extra mile and avoid full updates in menus,
-    --       we'd add a check for to confirm that region covers over ~80% of the screen area.
     if mode ~= "full" and mode ~= "flashpartial" and mode ~= "flashui" and mode ~= "fast" and not self.refresh_counted then
         self.refresh_count = (self.refresh_count + 1) % self.FULL_REFRESH_COUNT
         if self.refresh_count == self.FULL_REFRESH_COUNT - 1 then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -650,6 +650,20 @@ function UIManager:_refresh(mode, region)
     if not region and mode == "full" then
         self.refresh_count = 0 -- reset counter on explicit full refresh
     end
+    -- Handle downgrading flashing modes to non-flashing modes, according to user settings.
+    -- NOTE: Do it before "full" promotion and collision checks/update_mode.
+    if G_reader_settings:isTrue("avoid_flashing_ui") then
+        if mode == "flashui" then
+            mode = "ui"
+            logger.dbg("_refresh: downgraded flashui refresh to", mode)
+        elseif mode == "flashpartial" then
+            mode = "partial"
+            logger.dbg("_refresh: downgraded flashpartial refresh to", mode)
+        elseif mode == "partial" and region then
+            mode = "ui"
+            logger.dbg("_refresh: downgraded regional partial refresh to", mode)
+        end
+    end
     -- special case: "partial" refreshes
     -- will get promoted every self.FULL_REFRESH_COUNT refreshes
     -- since _refresh can be called mutiple times via setDirty called in
@@ -669,7 +683,7 @@ function UIManager:_refresh(mode, region)
             else
                 mode = "full"
             end
-            logger.dbg("promote refresh to", mode)
+            logger.dbg("_refresh: promote refresh to", mode)
         end
         self.refresh_counted = true
     end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -364,6 +364,7 @@ flashui: like ui, but flashing.
          Can be used when showing a UI element for the first time, to avoid ghosting.
 flashpartial: like partial, but flashing.
               Can be used when closing an UI element, to avoid ghosting.
+              You can even drop the region in these cases, to ensure a fullscreen flash.
 
 @usage
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -613,11 +613,11 @@ function UIManager:_refresh(mode, region)
     -- if no region is specified, define default region
     region = region or Geom:new{w=Screen:getWidth(), h=Screen:getHeight()}
 
-    --[[
-    -- FIXME: Disabled to try to identify everything that passes a stupid and/or broken region to setDirty...
-    --        While, ideally, we shouldn't merge updates w/ different waveform modes, this allows us to merge
-    --        the end of a selection HL (i.e., the un-inverse) with the following repaint, potentially avoiding
-    --        heavy ghosting or scrambling on the localized region of the HL because of the 2bit update mode...
+    -- NOTE:  While, ideally, we shouldn't merge updates w/ different waveform modes,
+    --        this allows us to optimize away a number of quirks of our rendering stack
+    --        (f.g., multiple setDirty calls queued when showing/closing a widget because of update mechanisms),
+    --        as well as a few actually effective merges
+    --        (f.g., the disappearance of a selection HL with the following menu update).
     for i = 1, #self._refresh_stack do
         -- check for collision with updates that are already enqueued
         if region:intersectWith(self._refresh_stack[i].region) then
@@ -631,7 +631,6 @@ function UIManager:_refresh(mode, region)
             return self:_refresh(mode, combined)
         end
     end
-    --]]
 
     -- if we hit no (more) collides, enqueue the update
     table.insert(self._refresh_stack, {mode = mode, region = region})

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -254,7 +254,7 @@ function UIManager:close(widget, refreshtype, refreshregion)
     if dirty and not widget.invisible then
         -- schedule remaining widgets to be painted
         for i = 1, #self._window_stack do
-            self:setDirty(self._window_stack[i].widget)
+            self:setDirty(self._window_stack[i].widget, "ui")
         end
         self:_refresh(refreshtype, refreshregion)
     end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -620,8 +620,13 @@ function UIManager:_refresh(mode, region)
     if mode == "partial" and not self.refresh_counted then
         self.refresh_count = (self.refresh_count + 1) % self.FULL_REFRESH_COUNT
         if self.refresh_count == self.FULL_REFRESH_COUNT - 1 then
-            logger.dbg("promote refresh to full refresh")
-            mode = "full"
+            -- NOTE: Promote to full if no region (reader), to flashpartial otherwise (UI)
+            if region then
+                mode = "flashpartial"
+            else
+                mode = "full"
+            end
+            logger.dbg("promote refresh to", mode)
         end
         self.refresh_counted = true
     end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -391,12 +391,8 @@ function UIManager:setDirty(widget, refreshtype, refreshregion)
         -- callback, will be issued after painting
         table.insert(self._refresh_func_stack, refreshtype)
         if dbg.is_on then
-            local rtype, region = refreshtype()
-            if region then
-                logger.dbg("setDirty", rtype and rtype or "nil", "from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "via func w/ region", region.x, region.y, region.w, region.h)
-            else
-                logger.dbg("setDirty", rtype and rtype or "nil", "from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "via func w/ NO region")
-            end
+            -- FIXME: We can't consume the return values of refreshtype by running it, because for a reason that is beyond me, that renders it useless later, meaning we then enqueue updates with bogus arguments...
+            logger.dbg("setDirty via a func")
         end
     else
         -- otherwise, enqueue refresh
@@ -588,6 +584,7 @@ Will return the mode that takes precedence.
 --]]
 local function update_mode(mode1, mode2)
     if refresh_modes[mode1] > refresh_modes[mode2] then
+        logger.dbg("update_mode: Update", mode2, "to", mode1)
         return mode1
     else
         return mode2
@@ -658,6 +655,7 @@ function UIManager:_refresh(mode, region)
     end
 
     -- if we hit no (more) collides, enqueue the update
+    dbg:v("_refresh: Enqueued", mode, "update on region", region)
     table.insert(self._refresh_stack, {mode = mode, region = region})
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -651,9 +651,9 @@ function UIManager:_refresh(mode, region)
     if mode == "partial" and not self.refresh_counted then
         self.refresh_count = (self.refresh_count + 1) % self.FULL_REFRESH_COUNT
         if self.refresh_count == self.FULL_REFRESH_COUNT - 1 then
-            -- NOTE: Promote to "full" if no region (reader), to "flashpartial" otherwise (UI)
+            -- NOTE: Promote to "full" if no region (reader), to "flashui" otherwise (UI)
             if region then
-                mode = "flashpartial"
+                mode = "flashui"
             else
                 mode = "full"
             end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -322,6 +322,17 @@ function UIManager:nextTick(action)
     return self:scheduleIn(0, action)
 end
 
+-- Run UI callbacks ASAP without skipping repaints?
+function UIManager:tickAfterNext(action)
+    return self:nextTick(function() self:nextTick(action) end)
+end
+--[[
+-- NOTE: This appears to work *nearly* just as well, but does sometimes go too fast (might depend on kernel HZ & NO_HZ settings?)
+function UIManager:tickAfterNext(action)
+    return self:scheduleIn(0.001, action)
+end
+--]]
+
 --[[-- Unschedules an execution task.
 
 In order to unschedule anonymous functions, store a reference.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -390,19 +390,23 @@ function UIManager:setDirty(widget, refreshtype, refreshregion)
     if type(refreshtype) == "function" then
         -- callback, will be issued after painting
         table.insert(self._refresh_func_stack, refreshtype)
-        local _, region = refreshtype()
-        if region then
-            logger.dbg("setDirty from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "via func w/ region x", region.x, "y", region.y, "w", region.w, "h", region.h)
-        else
-            logger.dbg("setDirty from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "via func w/ NO region")
+        if dbg.is_on then
+            local rtype, region = refreshtype()
+            if region then
+                logger.dbg("setDirty", rtype and rtype or "nil", "from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "via func w/ region", region.x, region.y, region.w, region.h)
+            else
+                logger.dbg("setDirty", rtype and rtype or "nil", "from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "via func w/ NO region")
+            end
         end
     else
         -- otherwise, enqueue refresh
         self:_refresh(refreshtype, refreshregion)
-        if refreshregion then
-            logger.dbg("setDirty from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "w/ region x", refreshregion.x, "y", refreshregion.y, "w", refreshregion.w, "h", refreshregion.h)
-        else
-            logger.dbg("setDirty from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "w/ NO region")
+        if dbg.is_on then
+            if refreshregion then
+                logger.dbg("setDirty", refreshtype and refreshtype or "nil", "from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "w/ region", refreshregion.x, refreshregion.y, refreshregion.w, refreshregion.h)
+            else
+                logger.dbg("setDirty", refreshtype and refreshtype or "nil", "from widget", widget and (widget.name or widget.id or tostring(widget)) or "nil", "w/ NO region")
+            end
         end
     end
 end
@@ -909,3 +913,5 @@ end
 
 UIManager:init()
 return UIManager
+
+// kate: indent-mode cstyle; indent-width 4; replace-tabs on;

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -925,5 +925,3 @@ end
 
 UIManager:init()
 return UIManager
-
--- kate: indent-mode cstyle; indent-width 4; replace-tabs on;

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -254,7 +254,7 @@ function UIManager:close(widget, refreshtype, refreshregion)
     if dirty and not widget.invisible then
         -- schedule remaining widgets to be painted
         for i = 1, #self._window_stack do
-            self:setDirty(self._window_stack[i].widget, "ui")
+            self:setDirty(self._window_stack[i].widget)
         end
         self:_refresh(refreshtype, refreshregion)
     end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -655,7 +655,7 @@ function UIManager:_refresh(mode, region)
     end
 
     -- if we hit no (more) collides, enqueue the update
-    dbg:v("_refresh: Enqueued", mode, "update on region", region)
+    logger.dbg("_refresh: Enqueued", mode, "update for region", region.x, region.y, region.w, region.h)
     table.insert(self._refresh_stack, {mode = mode, region = region})
 end
 
@@ -712,6 +712,7 @@ function UIManager:_repaint()
     -- execute refreshes:
     for _, refresh in ipairs(self._refresh_stack) do
         dbg:v("triggering refresh", refresh)
+        -- FIXME: bound to screen size?
         Screen[refresh_methods[refresh.mode]](Screen,
             refresh.region.x - 1, refresh.region.y - 1,
             refresh.region.w + 2, refresh.region.h + 2)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -914,4 +914,4 @@ end
 UIManager:init()
 return UIManager
 
-// kate: indent-mode cstyle; indent-width 4; replace-tabs on;
+-- kate: indent-mode cstyle; indent-width 4; replace-tabs on;

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -393,7 +393,8 @@ function UIManager:setDirty(widget, refreshtype, refreshregion)
         table.insert(self._refresh_func_stack, refreshtype)
         if dbg.is_on then
             -- FIXME: We can't consume the return values of refreshtype by running it, because for a reason that is beyond me, that renders it useless later, meaning we then enqueue updates with bogus arguments...
-            logger.dbg("setDirty via a func")
+            --        Track them in the _refresh() log...
+            logger.dbg("setDirty via a func from widget", widget and (widget.name or widget.id or tostring(widget)))
         end
     else
         -- otherwise, enqueue refresh

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -322,7 +322,7 @@ function UIManager:nextTick(action)
     return self:scheduleIn(0, action)
 end
 
--- Run UI callbacks ASAP without skipping repaints?
+-- Useful to run UI callbacks ASAP without skipping repaints
 function UIManager:tickAfterNext(action)
     return self:nextTick(function() self:nextTick(action) end)
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -380,7 +380,7 @@ flashpartial: like partial, but flashing (and not counting towards flashing prom
               Can be used when closing an UI element, to avoid ghosting.
               You can even drop the region in these cases, to ensure a fullscreen flash.
               NOTE: On REAGL devices, "flashpartial" will NOT actually flash (by design).
-                    As such, even onClose, you might prefer "flashui" in some instances...
+                    As such, even onClose, you might prefer "flashui" in some rare instances.
 
 NOTE: You'll notice a trend on UI elements that are usually shown *over* some kind of text
       of using "ui" onShow & onUpdate, but "partial" onClose.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -599,9 +599,10 @@ function UIManager:_refresh(mode, region)
     -- different widget before a real screen repaint, we should make sure
     -- refresh_count is incremented by only once at most for each repaint
     -- NOTE: Ideally, we'd only check partial w/ no region set (that neatly narrows it down to just the reader).
-    --       In practice, we also want to promote refreshes in the FileManager,
-    --       part of which is implemented as UI w/ a region...
-    if mode ~= "full" and mode ~= "flashpartial" and mode ~= "flashui" and mode ~= "fast" and not self.refresh_counted then
+    --       In practice, we also want to promote refreshes in a few other places, except purely text-poor UI elements.
+    --       (Putting "ui" in that list is problematic with a number of UI elements, most notably, ReaderHighlight,
+    --       because it is implemented as "ui" over the full viewport, since we can't devise a proper bounding box).
+    if mode == "partial" and not self.refresh_counted then
         self.refresh_count = (self.refresh_count + 1) % self.FULL_REFRESH_COUNT
         if self.refresh_count == self.FULL_REFRESH_COUNT - 1 then
             logger.dbg("promote refresh to full refresh")

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -527,7 +527,7 @@ function BookStatusWidget:generateSwitchGroup(width)
 end
 
 function BookStatusWidget:onConfigChoose(values, name, event, args, events, position)
-    UIManager:scheduleIn(0.05, function()
+    UIManager:tickAfterNext(function()
         if values then
             self:onChangeBookStatus(args, position)
         end

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -245,7 +245,7 @@ function BookStatusWidget:setStar(num)
 
     table.insert(self.stars_container, stars_group)
 
-    UIManager:setDirty(nil, "partial")
+    UIManager:setDirty(nil, "ui")
     return true
 end
 
@@ -531,7 +531,7 @@ function BookStatusWidget:onConfigChoose(values, name, event, args, events, posi
         if values then
             self:onChangeBookStatus(args, position)
         end
-        UIManager:setDirty("all")
+        UIManager:setDirty("all", "ui")
     end)
 end
 
@@ -542,7 +542,7 @@ end
 
 function BookStatusWidget:onClose()
     self:saveSummary()
-    UIManager:setDirty("all")
+    UIManager:setDirty("all", "partial")
     UIManager:close(self)
     return true
 end

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -542,7 +542,8 @@ end
 
 function BookStatusWidget:onClose()
     self:saveSummary()
-    UIManager:setDirty("all", "partial")
+    -- NOTE: Flash on close to avoid ghosting, since we show an image.
+    UIManager:setDirty("all", "flashpartial")
     UIManager:close(self)
     return true
 end

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -191,7 +191,8 @@ function Button:onTapSelectButton()
         if G_reader_settings:isFalse("flash_ui") then
             self.callback()
         else
-            UIManager:scheduleIn(0.0, function()
+            -- FIXME: For some mysterious reasons, we never see the effect of this highlight on the FM chevrons...
+            UIManager:nextTick(function()
                 self[1].invert = true
                 UIManager:setDirty(self.show_parent, function()
                     return "fast", self[1].dimen

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -191,17 +191,18 @@ function Button:onTapSelectButton()
         if G_reader_settings:isFalse("flash_ui") then
             self.callback()
         else
-            -- FIXME: For some mysterious reasons, we never see the effect of this highlight on the FM chevrons...
+            -- NOTE: Flag all widgets as dirty to force a repaint, so we actually get to see the highlight.
+            --       (For some reason (wrong widget passed to setDirty?), we never saw the effects on the FM chevrons without this hack).
             UIManager:nextTick(function()
                 self[1].invert = true
-                UIManager:setDirty(self.show_parent, function()
+                UIManager:setDirty("all", function()
                     return "fast", self[1].dimen
                 end)
             end)
             UIManager:scheduleIn(0.1, function()
                 self.callback()
                 self[1].invert = false
-                UIManager:setDirty(self.show_parent, function()
+                UIManager:setDirty("all", function()
                     return "fast", self[1].dimen
                 end)
             end)

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -193,13 +193,11 @@ function Button:onTapSelectButton()
         else
             -- NOTE: Flag all widgets as dirty to force a repaint, so we actually get to see the highlight.
             --       (For some reason (wrong widget passed to setDirty?), we never saw the effects on the FM chevrons without this hack).
-            UIManager:nextTick(function()
-                self[1].invert = true
-                UIManager:setDirty("all", function()
-                    return "fast", self[1].dimen
-                end)
+            self[1].invert = true
+            UIManager:setDirty("all", function()
+                return "fast", self[1].dimen
             end)
-            UIManager:scheduleIn(0.1, function()
+            UIManager:tickAfterNext(function()
                 self.callback()
                 self[1].invert = false
                 UIManager:setDirty("all", function()

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -66,9 +66,6 @@ function ButtonDialog:onShow()
 end
 
 function ButtonDialog:onCloseWidget()
-    -- NOTE: plugins/coverbrowser.koplugin/covermenu.lua builds a menu out of us, and as such inherits a full open/close cycle.
-    --       Which means this "partial" wins the upgrade game during UIManager's update coalescence...
-    --       Switching to "ui" works, but generally looks worse, so, don't.
     UIManager:setDirty(nil, function()
         return "partial", self[1][1].dimen
     end)

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -66,6 +66,9 @@ function ButtonDialog:onShow()
 end
 
 function ButtonDialog:onCloseWidget()
+    -- NOTE: plugins/coverbrowser.koplugin/covermenu.lua builds a menu out of us, and as such inherits a full open/close cycle.
+    --       Which means this "partial" wins the upgrade game during UIManager's update coalescence...
+    --       Switching to "ui" works, but generally looks worse, so, don't. 
     UIManager:setDirty(nil, function()
         return "partial", self[1][1].dimen
     end)

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -68,7 +68,7 @@ end
 function ButtonDialog:onCloseWidget()
     -- NOTE: plugins/coverbrowser.koplugin/covermenu.lua builds a menu out of us, and as such inherits a full open/close cycle.
     --       Which means this "partial" wins the upgrade game during UIManager's update coalescence...
-    --       Switching to "ui" works, but generally looks worse, so, don't. 
+    --       Switching to "ui" works, but generally looks worse, so, don't.
     UIManager:setDirty(nil, function()
         return "partial", self[1][1].dimen
     end)

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -86,6 +86,9 @@ function ButtonDialogTitle:onShow()
 end
 
 function ButtonDialogTitle:onCloseWidget()
+    -- NOTE: plugins/coverbrowser.koplugin/covermenu.lua builds a menu out of us, and as such inherits a full open/close cycle.
+    --       Which means this "partial" wins the upgrade game during UIManager's update coalescence...
+    --       Switching to "ui" works, but generally looks worse, so, don't.
     UIManager:setDirty(nil, function()
         return "partial", self[1][1].dimen
     end)

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -86,9 +86,6 @@ function ButtonDialogTitle:onShow()
 end
 
 function ButtonDialogTitle:onCloseWidget()
-    -- NOTE: plugins/coverbrowser.koplugin/covermenu.lua builds a menu out of us, and as such inherits a full open/close cycle.
-    --       Which means this "partial" wins the upgrade game during UIManager's update coalescence...
-    --       Switching to "ui" works, but generally looks worse, so, don't.
     UIManager:setDirty(nil, function()
         return "partial", self[1][1].dimen
     end)

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -78,7 +78,6 @@ function ButtonProgressWidget:update()
     UIManager:setDirty(self.show_parrent, function()
         return "ui", self.dimen
     end)
-UIManager:setDirty("all")
 end
 
 function ButtonProgressWidget:setPosition(position)

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -94,13 +94,11 @@ function CheckButton:onTapCheckButton()
         if G_reader_settings:isFalse("flash_ui") then
             self.callback()
         else
-            UIManager:nextTick(function()
-                self.invert = true
-                UIManager:setDirty(self.show_parent, function()
-                    return "fast", self.dimen
-                end)
+            self.invert = true
+            UIManager:setDirty(self.show_parent, function()
+                return "fast", self.dimen
             end)
-            UIManager:scheduleIn(0.1, function()
+            UIManager:tickAfterNext(function()
                 self.callback()
                 self.invert = false
                 UIManager:setDirty(self.show_parent, function()

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -94,7 +94,7 @@ function CheckButton:onTapCheckButton()
         if G_reader_settings:isFalse("flash_ui") then
             self.callback()
         else
-            UIManager:scheduleIn(0.0, function()
+            UIManager:nextTick(function()
                 self.invert = true
                 UIManager:setDirty(self.show_parent, function()
                     return "fast", self.dimen

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -724,7 +724,7 @@ end
 
 function ConfigDialog:onCloseWidget()
     UIManager:setDirty("all", function()
-        return "partial", self.dialog_frame.dimen
+        return "flashpartial", self.dialog_frame.dimen
     end)
 end
 
@@ -732,6 +732,8 @@ function ConfigDialog:onShowConfigPanel(index)
     self.panel_index = index
     local old_dimen = self.dialog_frame.dimen and self.dialog_frame.dimen:copy()
     self:update()
+    -- NOTE: Keep that one as UI to avoid delay when both this and the topmenu are shown.
+    --       Plus, this is also called for each tab anyway, so that wouldn't have been great.
     UIManager:setDirty("all", function()
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dialog_frame.dimen)

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -723,6 +723,7 @@ function ConfigDialog:update()
 end
 
 function ConfigDialog:onCloseWidget()
+    -- NOTE: As much as we would like to flash here, don't, because of adverse interactions with touchmenu that might lead to a double flash...
     UIManager:setDirty("all", function()
         return "partial", self.dialog_frame.dimen
     end)

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -455,7 +455,7 @@ function ConfigOption:init()
                     num_buttons = #self.options[c].values,
                     position = self.options[c].default_pos,
                     callback = function(arg)
-                        UIManager:scheduleIn(0.05, function()
+                        UIManager:tickAfterNext(function()
                             self.config:onConfigChoice(self.options[c].name, self.options[c].values[arg])
                             self.config:onConfigEvent(self.options[c].event, self.options[c].args[arg])
                             UIManager:setDirty("all")
@@ -764,7 +764,7 @@ function ConfigDialog:onConfigEvents(option_events, arg_index)
 end
 
 function ConfigDialog:onConfigChoose(values, name, event, args, events, position)
-    UIManager:scheduleIn(0.05, function()
+    UIManager:tickAfterNext(function()
         if values then
             self:onConfigChoice(name, values[position])
         end

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -723,9 +723,8 @@ function ConfigDialog:update()
 end
 
 function ConfigDialog:onCloseWidget()
-    -- NOTE: We pass a nil region to ensure a full-screen flash to avoid ghosting
     UIManager:setDirty("all", function()
-        return "flashpartial", nil
+        return "partial", self.dialog_frame.dimen
     end)
 end
 

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -723,8 +723,9 @@ function ConfigDialog:update()
 end
 
 function ConfigDialog:onCloseWidget()
+    -- NOTE: We pass a nil region to ensure a full-screen flash to avoid ghosting
     UIManager:setDirty("all", function()
-        return "flashpartial", self.dialog_frame.dimen
+        return "flashpartial", nil
     end)
 end
 

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -576,8 +576,9 @@ function DictQuickLookup:onCloseWidget()
             end
         end
     end
+    -- NOTE: Drop region to make it a full-screen flash
     UIManager:setDirty(nil, function()
-        return "flashpartial", self.dict_frame.dimen
+        return "flashpartial", nil
     end)
     return true
 end
@@ -775,7 +776,7 @@ function DictQuickLookup:onSwipe(arg, ges)
         else
             if self.refresh_callback then self.refresh_callback() end
             -- trigger a flashing text refresh
-            UIManager:setDirty(nil, "flashpartial")
+            UIManager:setDirty(nil, "flashpartial", self.dict_frame.dimen)
             -- a long diagonal swipe may also be used for taking a screenshot,
             -- so let it propagate
             return false

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -577,14 +577,14 @@ function DictQuickLookup:onCloseWidget()
         end
     end
     UIManager:setDirty(nil, function()
-        return "partial", self.dict_frame.dimen
+        return "flashpartial", self.dict_frame.dimen
     end)
     return true
 end
 
 function DictQuickLookup:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self.dict_frame.dimen
+        return "flashpartial", self.dict_frame.dimen
     end)
     return true
 end
@@ -774,8 +774,8 @@ function DictQuickLookup:onSwipe(arg, ges)
             self:changeToPrevDict()
         else
             if self.refresh_callback then self.refresh_callback() end
-            -- trigger full refresh
-            UIManager:setDirty(nil, "full")
+            -- trigger a flashing text refresh
+            UIManager:setDirty(nil, "flashpartial")
             -- a long diagonal swipe may also be used for taking a screenshot,
             -- so let it propagate
             return false

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -775,8 +775,8 @@ function DictQuickLookup:onSwipe(arg, ges)
             self:changeToPrevDict()
         else
             if self.refresh_callback then self.refresh_callback() end
-            -- trigger a flashing text refresh
-            UIManager:setDirty(nil, "flashui", self.dict_frame.dimen)
+            -- trigger a full-screen HQ flashing refresh
+            UIManager:setDirty(nil, "full")
             -- a long diagonal swipe may also be used for taking a screenshot,
             -- so let it propagate
             return false

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -554,7 +554,7 @@ function DictQuickLookup:update()
     UIManager:setDirty("all", function()
         local update_region = self.dict_frame and self.dict_frame.dimen and self.dict_frame.dimen:combine(orig_dimen) or orig_dimen
         logger.dbg("update dict region", update_region)
-        return "ui", update_region
+        return "partial", update_region
     end)
 end
 

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -578,14 +578,14 @@ function DictQuickLookup:onCloseWidget()
     end
     -- NOTE: Drop region to make it a full-screen flash
     UIManager:setDirty(nil, function()
-        return "flashpartial", nil
+        return "flashui", nil
     end)
     return true
 end
 
 function DictQuickLookup:onShow()
     UIManager:setDirty(self, function()
-        return "flashpartial", self.dict_frame.dimen
+        return "flashui", self.dict_frame.dimen
     end)
     return true
 end
@@ -776,7 +776,7 @@ function DictQuickLookup:onSwipe(arg, ges)
         else
             if self.refresh_callback then self.refresh_callback() end
             -- trigger a flashing text refresh
-            UIManager:setDirty(nil, "flashpartial", self.dict_frame.dimen)
+            UIManager:setDirty(nil, "flashui", self.dict_frame.dimen)
             -- a long diagonal swipe may also be used for taking a screenshot,
             -- so let it propagate
             return false

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -7,6 +7,7 @@ local UIManager = require("ui/uimanager")
 local ffi = require("ffi")
 local lfs = require("libs/libkoreader-lfs")
 local util = require("ffi/util")
+local C = ffi.C
 local _ = require("gettext")
 local Screen = Device.screen
 local getFileNameSuffix = require("util").getFileNameSuffix
@@ -18,7 +19,7 @@ int strcoll (const char *str1, const char *str2);
 
 -- string sort function respecting LC_COLLATE
 local function strcoll(str1, str2)
-    return ffi.C.strcoll(str1, str2) < 0
+    return C.strcoll(str1, str2) < 0
 end
 
 local function kobostrcoll(str1, str2)

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -82,7 +82,7 @@ function FocusManager:onFocusMove(args)
             -- we found a different object to focus
             current_item:handleEvent(Event:new("Unfocus"))
             self.layout[self.selected.y][self.selected.x]:handleEvent(Event:new("Focus"))
-            -- trigger a fast repaint, this seem to not count toward a fullscreen eink resfresh
+            -- trigger a fast repaint, this does not count toward a flashing eink resfresh
             -- TODO: is this really needed?
             UIManager:setDirty(self.show_parent or self, "fast")
             break

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -547,12 +547,13 @@ end
 
 function FrontLightWidget:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "partial", self.light_frame.dimen
+        return "flashpartial", self.light_frame.dimen
     end)
     return true
 end
 
 function FrontLightWidget:onShow()
+    -- NOTE: Keep this one as UI, it'll get coalesced...
     UIManager:setDirty(self, function()
         return "ui", self.light_frame.dimen
     end)

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -35,6 +35,12 @@ function HtmlBoxWidget:init()
             },
         }
     end
+    if Mupdf.bgr == nil then
+        Mupdf.bgr = false
+        if Device:isKobo() then
+            Mupdf.bgr = true
+        end
+    end
 end
 
 function HtmlBoxWidget:setContent(body, css, default_font_size)

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -37,7 +37,7 @@ function HtmlBoxWidget:init()
     end
     if Mupdf.bgr == nil then
         Mupdf.bgr = false
-        if Device:isKobo() then
+        if Device:hasBGRFrameBuffer() then
             Mupdf.bgr = true
         end
     end

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -95,14 +95,12 @@ function IconButton:onTapIconButton()
     if G_reader_settings:isFalse("flash_ui") then
         self.callback()
     else
-        UIManager:nextTick(function()
-            self.image.invert = true
-            UIManager:setDirty(self.show_parent, function()
-                return "fast", self.dimen
-            end)
+        self.image.invert = true
+        UIManager:setDirty(self.show_parent, function()
+            return "fast", self.dimen
         end)
         -- Make sure button reacts before doing callback
-        UIManager:scheduleIn(0.1, function()
+        UIManager:tickAfterNext(function()
             self.callback()
             self.image.invert = false
             UIManager:setDirty(self.show_parent, function()

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -95,13 +95,13 @@ function IconButton:onTapIconButton()
     if G_reader_settings:isFalse("flash_ui") then
         self.callback()
     else
-        UIManager:scheduleIn(0.0, function()
+        UIManager:nextTick(function()
             self.image.invert = true
             UIManager:setDirty(self.show_parent, function()
                 return "fast", self.dimen
             end)
         end)
-        -- make sure button reacts before doing callback
+        -- Make sure button reacts before doing callback
         UIManager:scheduleIn(0.1, function()
             self.callback()
             self.image.invert = false
@@ -126,12 +126,12 @@ end
 
 function IconButton:onFocus()
     --quick and dirty, need better way to show focus
-    self.image.invert=true
+    self.image.invert = true
     return true
 end
 
 function IconButton:onUnfocus()
-    self.image.invert=false
+    self.image.invert = false
     return true
 end
 

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -602,7 +602,7 @@ function ImageViewer:onCloseWidget()
         self._images_list.free()
     end
     UIManager:setDirty(nil, function()
-        return "partial", self.main_frame.dimen
+        return "flashpartial", self.main_frame.dimen
     end)
     return true
 end

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -602,7 +602,7 @@ function ImageViewer:onCloseWidget()
         self._images_list.free()
     end
     UIManager:setDirty(nil, function()
-        return "flashpartial", self.main_frame.dimen
+        return "flashui", self.main_frame.dimen
     end)
     return true
 end

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -237,11 +237,11 @@ function KeyValueItem:onTap()
             UIManager:setDirty(self.show_parent, function()
                 return "fast", self[1].dimen
             end)
-            UIManager:scheduleIn(0.1, function()
+            UIManager:tickAfterNext(function()
                 self.callback()
                 self[1].invert = false
                 UIManager:setDirty(self.show_parent, function()
-                    return "fast", self[1].dimen
+                    return "ui", self[1].dimen
                 end)
             end)
         end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -807,7 +807,9 @@ function Menu:onCloseWidget()
     -- For example, it's a dirty hack to use two menus(one this menu and one
     -- touch menu) in the filemanager in order to capture tap gesture to popup
     -- the filemanager menu.
-    UIManager:setDirty(nil, "flashpartial")
+    -- NOTE: For the same reason, don't make it flash,
+    --       because that'll trigger when we close the FM and open a book...
+    UIManager:setDirty(nil, "partial")
 end
 
 function Menu:updatePageInfo(select_number)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -807,7 +807,7 @@ function Menu:onCloseWidget()
     -- For example, it's a dirty hack to use two menus(one this menu and one
     -- touch menu) in the filemanager in order to capture tap gesture to popup
     -- the filemanager menu.
-    UIManager:setDirty(nil, "partial")
+    UIManager:setDirty(nil, "flashpartial")
 end
 
 function Menu:updatePageInfo(select_number)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -403,13 +403,14 @@ function MenuItem:onTapSelect(arg, ges)
         coroutine.resume(co)
     else
         self[1].invert = true
-        local refreshfunc = function()
+        UIManager:setDirty(self.show_parent, function()
             return "fast", self[1].dimen
-        end
-        UIManager:setDirty(self.show_parent, refreshfunc)
-        UIManager:scheduleIn(0.1, function()
+        end)
+        UIManager:tickAfterNext(function()
             self[1].invert = false
-            UIManager:setDirty(self.show_parent, refreshfunc)
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self[1].dimen
+            end)
             logger.dbg("creating coroutine for menu select")
             local co = coroutine.create(function()
                 self.menu:onMenuSelect(self.table, pos)
@@ -426,13 +427,14 @@ function MenuItem:onHoldSelect(arg, ges)
         self.menu:onMenuHold(self.table, pos)
     else
         self[1].invert = true
-        local refreshfunc = function()
+        UIManager:setDirty(self.show_parent, function()
             return "fast", self[1].dimen
-        end
-        UIManager:setDirty(self.show_parent, refreshfunc)
-        UIManager:scheduleIn(0.1, function()
+        end)
+        UIManager:tickAfterNext(function()
             self[1].invert = false
-            UIManager:setDirty(self.show_parent, refreshfunc)
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self[1].dimen
+            end)
             self.menu:onMenuHold(self.table, pos)
         end)
     end

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -73,7 +73,7 @@ end
 
 function Notification:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "partial", self[1][1].dimen
+        return "ui", self[1][1].dimen
     end)
     return true
 end

--- a/frontend/ui/widget/radiobutton.lua
+++ b/frontend/ui/widget/radiobutton.lua
@@ -113,13 +113,11 @@ function RadioButton:onTapCheckButton()
         if G_reader_settings:isFalse("flash_ui") then
             self.callback()
         else
-            UIManager:nextTick(function()
-                self.invert = true
-                UIManager:setDirty(self.show_parent, function()
-                    return "fast", self.dimen
-                end)
+            self.invert = true
+            UIManager:setDirty(self.show_parent, function()
+                return "fast", self.dimen
             end)
-            UIManager:scheduleIn(0.1, function()
+            UIManager:tickAfterNext(function()
                 self.callback()
                 self.invert = false
                 UIManager:setDirty(self.show_parent, function()

--- a/frontend/ui/widget/radiobutton.lua
+++ b/frontend/ui/widget/radiobutton.lua
@@ -113,7 +113,7 @@ function RadioButton:onTapCheckButton()
         if G_reader_settings:isFalse("flash_ui") then
             self.callback()
         else
-            UIManager:scheduleIn(0.0, function()
+            UIManager:nextTick(function()
                 self.invert = true
                 UIManager:setDirty(self.show_parent, function()
                     return "fast", self.dimen

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -247,7 +247,7 @@ function TextViewer:onSwipe(arg, ges)
             return true
         else
             -- trigger a flashing text refresh
-            UIManager:setDirty(nil, "flashpartial", self.frame.dimen)
+            UIManager:setDirty(nil, "flashui", self.frame.dimen)
             -- a long diagonal swipe may also be used for taking a screenshot,
             -- so let it propagate
             return false

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -246,8 +246,8 @@ function TextViewer:onSwipe(arg, ges)
             self.scroll_text_w:scrollText(-1)
             return true
         else
-            -- trigger full refresh
-            UIManager:setDirty(nil, "full")
+            -- trigger a flashing text refresh
+            UIManager:setDirty(nil, "flashpartial", self.frame.dimen)
             -- a long diagonal swipe may also be used for taking a screenshot,
             -- so let it propagate
             return false

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -140,7 +140,7 @@ function TouchMenuItem:onTapSelect(arg, ges)
             return "fast", self.dimen
         end)
         -- yield to main UI loop to invert item
-        UIManager:scheduleIn(0.1, function()
+        UIManager:tickAfterNext(function()
             self.menu:onMenuSelect(self.item)
             self.item_frame.invert = false
             UIManager:setDirty(self.show_parent, function()
@@ -161,16 +161,14 @@ function TouchMenuItem:onHoldSelect(arg, ges)
     if G_reader_settings:isFalse("flash_ui") then
         self.menu:onMenuHold(self.item)
     else
-        UIManager:nextTick(function()
-            self.item_frame.invert = true
-            UIManager:setDirty(self.show_parent, function()
-                return "fast", self.dimen
-            end)
+        self.item_frame.invert = true
+        UIManager:setDirty(self.show_parent, function()
+            return "fast", self.dimen
         end)
-        UIManager:scheduleIn(0.1, function()
+        UIManager:nextTick(function()
             self.menu:onMenuHold(self.item)
         end)
-        UIManager:scheduleIn(0.5, function()
+        UIManager:tickAfterNext(function()
             self.item_frame.invert = false
             UIManager:setDirty(self.show_parent, function()
                 return "fast", self.dimen
@@ -699,7 +697,7 @@ function TouchMenu:onMenuSelect(item)
             if callback then
                 -- put stuff in scheduler so we can see
                 -- the effect of inverted menu item
-                UIManager:scheduleIn(0.1, function()
+                UIManager:tickAfterNext(function()
                     callback(self)
                     if refresh then
                         self:updateItems()
@@ -735,7 +733,7 @@ function TouchMenu:onMenuHold(item)
             callback = item.hold_callback_func()
         end
         if callback then
-            UIManager:scheduleIn(0.1, function()
+            UIManager:tickAfterNext(function()
                 if item.hold_may_update_menu then
                     callback(function() self:updateItems() end)
                 else

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -161,7 +161,7 @@ function TouchMenuItem:onHoldSelect(arg, ges)
     if G_reader_settings:isFalse("flash_ui") then
         self.menu:onMenuHold(self.item)
     else
-        UIManager:scheduleIn(0.0, function()
+        UIManager:nextTick(function()
             self.item_frame.invert = true
             UIManager:setDirty(self.show_parent, function()
                 return "fast", self.dimen

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -593,12 +593,12 @@ function TouchMenu:updateItems()
     self.selected = { x = self.cur_tab, y = 1 } --reset the position of the focusmanager
 
     -- NOTE: We can't distinguish between a menu first popping up and just being updated,
-    --       so keep doing an "ui" refresh here, it'll count towards a flash promotion anyway.
+    --       so do a "partial" refresh here, it'll count towards a flash promotion that way.
     UIManager:setDirty("all", function()
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
-        return "ui", refresh_dimen
+        return "partial", refresh_dimen
     end)
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -598,16 +598,16 @@ function TouchMenu:updateItems()
     self.selected = { x = self.cur_tab, y = 1 } -- reset the position of the focusmanager
 
     -- NOTE: We use a slightly ugly hack to detect a brand new menu vs. a tab switch,
-    --       in order to flash on initial menu popup...
+    --       in order to optionally flash on initial menu popup...
     UIManager:setDirty("all", function()
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
         local refresh_type = "ui"
-        if self.is_fresh then
+        if self.is_fresh and not G_reader_settings:isFalse("flash_ui") then
             refresh_type = "flashui"
-            -- Drop the region, too, to make it full-screen. May help when starting from a "small" menu.
-            refresh_dimen = nil
+            -- Drop the region, too, to make it full-screen? May help when starting from a "small" menu.
+            --refresh_dimen = nil
             self.is_fresh = false
         end
         return refresh_type, refresh_dimen

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -606,6 +606,8 @@ function TouchMenu:updateItems()
         local refresh_type = "ui"
         if self.is_fresh then
             refresh_type = "flashui"
+            -- Drop the region, too, to make it full-screen. May help when starting from a "small" menu.
+            refresh_dimen = nil
             self.is_fresh = false
         end
         return refresh_type, refresh_dimen

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -604,7 +604,7 @@ function TouchMenu:updateItems()
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
         local refresh_type = "ui"
-        if self.is_fresh and not G_reader_settings:isFalse("flash_ui") then
+        if self.is_fresh then
             refresh_type = "flashui"
             -- Drop the region, too, to make it full-screen? May help when starting from a "small" menu.
             --refresh_dimen = nil

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -513,7 +513,7 @@ end
 
 function TouchMenu:onCloseWidget()
     -- NOTE: We pass a nil region to ensure a full-screen flash to avoid ghosting
-    UIManager:setDirty(nil, "flashpartial", nil)
+    UIManager:setDirty(nil, "flashui", nil)
 end
 
 function TouchMenu:_recalculatePageLayout()

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -105,7 +105,7 @@ function TouchMenuItem:init()
 
     self._underline_container = UnderlineContainer:new{
         vertical_align = "center",
-        dimen =self.dimen,
+        dimen = self.dimen,
         self.item_frame
     }
 
@@ -508,7 +508,7 @@ function TouchMenu:init()
 end
 
 function TouchMenu:onCloseWidget()
-    UIManager:setDirty(nil, "partial", self.dimen)
+    UIManager:setDirty(nil, "flashpartial", self.dimen)
 end
 
 function TouchMenu:_recalculatePageLayout()
@@ -592,6 +592,8 @@ function TouchMenu:updateItems()
     self.dimen.h = self.item_group:getSize().h + self.bordersize*2 + self.padding*2
     self.selected = { x = self.cur_tab, y = 1 } --reset the position of the focusmanager
 
+    -- NOTE: We can't distinguish between a menu first popping up and just being updated,
+    --       so keep doing an "ui" refresh here, it'll count towards a flash promotion anyway.
     UIManager:setDirty("all", function()
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -509,7 +509,8 @@ function TouchMenu:init()
 end
 
 function TouchMenu:onCloseWidget()
-    UIManager:setDirty(nil, "flashpartial", self.dimen)
+    -- NOTE: We pass a nil region to ensure a full-screen flash to avoid ghosting
+    UIManager:setDirty(nil, "flashpartial", nil)
 end
 
 function TouchMenu:_recalculatePageLayout()

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -143,9 +143,14 @@ function TouchMenuItem:onTapSelect(arg, ges)
         UIManager:tickAfterNext(function()
             self.menu:onMenuSelect(self.item)
             self.item_frame.invert = false
+            --[[
+            -- NOTE: We can optimize that repaint away, every entry in our menu will make at least the menu repaint just after anyways ;).
+            --       Plus, leaving that unhighlight as "fast" can lead to weird side-effects, depending on devices.
+            --       If it turns out this need to go back in, consider switching it to "ui".
             UIManager:setDirty(self.show_parent, function()
                 return "fast", self.dimen
             end)
+            --]]
         end)
     end
     return true
@@ -165,13 +170,13 @@ function TouchMenuItem:onHoldSelect(arg, ges)
         UIManager:setDirty(self.show_parent, function()
             return "fast", self.dimen
         end)
-        UIManager:nextTick(function()
+        UIManager:tickAfterNext(function()
             self.menu:onMenuHold(self.item)
         end)
-        UIManager:tickAfterNext(function()
+        UIManager:scheduleIn(0.5, function()
             self.item_frame.invert = false
             UIManager:setDirty(self.show_parent, function()
-                return "fast", self.dimen
+                return "ui", self.dimen
             end)
         end)
     end

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -219,20 +219,23 @@ function VirtualKeyboard:onPressKey()
     return true
 end
 
-function VirtualKeyboard:_refresh()
-    -- TODO: Ideally, ui onShow & partial onClose
+function VirtualKeyboard:_refresh(want_flash)
+    local refresh_type = "partial"
+    if want_flash then
+        refresh_type = "flashui"
+    end
     UIManager:setDirty(self, function()
-        return "ui", self[1][1].dimen
+        return refresh_type, self[1][1].dimen
     end)
 end
 
 function VirtualKeyboard:onShow()
-    self:_refresh()
+    self:_refresh(true)
     return true
 end
 
 function VirtualKeyboard:onCloseWidget()
-    self:_refresh()
+    self:_refresh(false)
     return true
 end
 
@@ -331,7 +334,7 @@ function VirtualKeyboard:setLayout(key)
         if self.utf8mode then self.umlautmode = false end
     end
     self:initLayout()
-    self:_refresh()
+    self:_refresh(true)
 end
 
 function VirtualKeyboard:addChar(key)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -108,6 +108,8 @@ function VirtualKey:init()
 end
 
 function VirtualKey:update_keyboard()
+    -- NOTE: We could arguably use "fast" when inverted & "ui" when not, but it doesn't change much,
+    --       and doesn't help with the graphics quirks of repeated "fast" updates on some devices.
     UIManager:setDirty(self.keyboard, function()
         logger.dbg("update key region", self[1].dimen)
         return "fast", self[1].dimen
@@ -129,7 +131,7 @@ function VirtualKey:onTapSelect()
         if self.callback then
             self.callback()
         end
-        UIManager:scheduleIn(0.1, function() self:invert(false) end)
+        UIManager:tickAfterNext(function() self:invert(false) end)
     else
         if self.callback then
             self.callback()
@@ -145,7 +147,7 @@ function VirtualKey:onHoldSelect()
         if self.hold_callback then
             self.hold_callback()
         end
-        UIManager:scheduleIn(0.1, function() self:invert(false) end)
+        UIManager:tickAfterNext(function() self:invert(false) end)
     else
         if self.hold_callback then
             self.hold_callback()

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -3,6 +3,7 @@ A.dl.library_path = A.dl.library_path .. ":" .. A.dir .. "/libs"
 A.log_name = 'KOReader'
 
 local ffi = require("ffi")
+local C = ffi.C
 ffi.cdef[[
     char *getenv(const char *name);
     int putenv(const char *envvar);
@@ -56,7 +57,7 @@ A.execute("chmod", "755", "./tar")
 A.execute("chmod", "755", "./zsync")
 
 -- set TESSDATA_PREFIX env var
-ffi.C.putenv("TESSDATA_PREFIX=/sdcard/koreader/data")
+C.putenv("TESSDATA_PREFIX=/sdcard/koreader/data")
 
 -- create fake command-line arguments
 arg = {"-d", file or "/sdcard"}

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -126,8 +126,8 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# export external font directory
-export EXT_FONT_DIR="/mnt/us/fonts"
+# export external font directories (In order: stock, legacy custom, stock extra, font hack)
+export EXT_FONT_DIR="/usr/java/lib/fonts;/mnt/us/fonts;/var/local/font/mnt;/mnt/us/linkfonts/fonts"
 
 # Only setup IPTables on evices where it makes sense to (FW 5.x & K4)
 if [ "${INIT_TYPE}" = "upstart" ] || [ "$(uname -r)" = "2.6.31-rt11-lab126" ]; then
@@ -137,39 +137,6 @@ if [ "${INIT_TYPE}" = "upstart" ] || [ "$(uname -r)" = "2.6.31-rt11-lab126" ]; t
     iptables -A INPUT -i wlan0 -p tcp --dport 49152:49162 -j ACCEPT
     # accept input ports for calibre companion
     iptables -A INPUT -i wlan0 -p udp --dport 8134 -j ACCEPT
-fi
-
-# bind-mount system fonts
-if ! grep ${KOREADER_DIR}/fonts/host /proc/mounts >/dev/null 2>&1; then
-    logmsg "Mounting system fonts . . ."
-    mount -o bind /usr/java/lib/fonts ${KOREADER_DIR}/fonts/host
-fi
-
-# bind-mount altfonts
-if [ -d /mnt/us/fonts ]; then
-    mkdir -p ${KOREADER_DIR}/fonts/altfonts
-    if ! grep ${KOREADER_DIR}/fonts/altfonts /proc/mounts >/dev/null 2>&1; then
-        logmsg "Mounting altfonts . . ."
-        mount -o bind /mnt/us/fonts ${KOREADER_DIR}/fonts/altfonts
-    fi
-fi
-
-# bind-mount csp fonts
-if [ -d /var/local/font/mnt ]; then
-    mkdir -p ${KOREADER_DIR}/fonts/cspfonts
-    if ! grep ${KOREADER_DIR}/fonts/cspfonts /proc/mounts >/dev/null 2>&1; then
-        logmsg "Mounting cspfonts . . ."
-        mount -o bind /var/local/font/mnt ${KOREADER_DIR}/fonts/cspfonts
-    fi
-fi
-
-# bind-mount linkfonts
-if [ -d /mnt/us/linkfonts/fonts ]; then
-    mkdir -p ${KOREADER_DIR}/fonts/linkfonts
-    if ! grep ${KOREADER_DIR}/fonts/linkfonts /proc/mounts >/dev/null 2>&1; then
-        logmsg "Mounting linkfonts . . ."
-        mount -o bind /mnt/us/linkfonts/fonts ${KOREADER_DIR}/fonts/linkfonts
-    fi
 fi
 
 # check if we need to disable the system passcode, because it messes with us in fun and interesting (and, more to the point, intractable) ways...
@@ -274,30 +241,6 @@ done
 if pidof reader.lua >/dev/null 2>&1; then
     logmsg "Sending a SIGTERM to stray KOreader processes . . ."
     killall -TERM reader.lua
-fi
-
-# unmount system fonts
-if grep ${KOREADER_DIR}/fonts/host /proc/mounts >/dev/null 2>&1; then
-    logmsg "Unmounting system fonts . . ."
-    umount ${KOREADER_DIR}/fonts/host
-fi
-
-# unmount altfonts
-if grep ${KOREADER_DIR}/fonts/altfonts /proc/mounts >/dev/null 2>&1; then
-    logmsg "Unmounting altfonts . . ."
-    umount ${KOREADER_DIR}/fonts/altfonts
-fi
-
-# unmount cspfonts
-if grep ${KOREADER_DIR}/fonts/cspfonts /proc/mounts >/dev/null 2>&1; then
-    logmsg "Unmounting cspfonts . . ."
-    umount ${KOREADER_DIR}/fonts/cspfonts
-fi
-
-# unmount linkfonts
-if grep ${KOREADER_DIR}/fonts/linkfonts /proc/mounts >/dev/null 2>&1; then
-    logmsg "Unmounting linkfonts . . ."
-    umount ${KOREADER_DIR}/fonts/linkfonts
 fi
 
 # Resume volumd, if need be

--- a/plugins/backgroundrunner.koplugin/main.lua
+++ b/plugins/backgroundrunner.koplugin/main.lua
@@ -221,7 +221,7 @@ function BackgroundRunner:_schedule()
     if self.running == false then
         logger.dbg("BackgroundRunnerWidget: start running @ ", os.time())
         self.running = true
-        UIManager:scheduleIn(2, function() self:_execute() end)
+        UIManager:scheduleIn(10, function() self:_execute() end)
     else
         logger.dbg("BackgroundRunnerWidget: a schedule is pending @ ",
                    os.time())

--- a/plugins/backgroundrunner.koplugin/main.lua
+++ b/plugins/backgroundrunner.koplugin/main.lua
@@ -221,7 +221,7 @@ function BackgroundRunner:_schedule()
     if self.running == false then
         logger.dbg("BackgroundRunnerWidget: start running @ ", os.time())
         self.running = true
-        UIManager:scheduleIn(10, function() self:_execute() end)
+        UIManager:scheduleIn(2, function() self:_execute() end)
     else
         logger.dbg("BackgroundRunnerWidget: a schedule is pending @ ",
                    os.time())

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -91,7 +91,7 @@ function CoverMenu:updateItems(select_number)
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
-        return "partial", refresh_dimen
+        return "ui", refresh_dimen
     end)
 
     -- As additionally done in FileChooser:updateItems()
@@ -139,9 +139,9 @@ function CoverMenu:updateItems(select_number)
                         if item.refresh_dimen then
                             -- MosaicMenuItem may exceed its own dimen in its paintTo
                             -- with its "description" hint
-                            return "partial", item.refresh_dimen
+                            return "ui", item.refresh_dimen
                         else
-                            return "partial", item[1].dimen
+                            return "ui", item[1].dimen
                         end
                     end
                     UIManager:setDirty(self.show_parent, refreshfunc)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -91,7 +91,7 @@ function CoverMenu:updateItems(select_number)
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
-        return "ui", refresh_dimen
+        return "partial", refresh_dimen
     end)
 
     -- As additionally done in FileChooser:updateItems()
@@ -139,9 +139,9 @@ function CoverMenu:updateItems(select_number)
                         if item.refresh_dimen then
                             -- MosaicMenuItem may exceed its own dimen in its paintTo
                             -- with its "description" hint
-                            return "ui", item.refresh_dimen
+                            return "partial", item.refresh_dimen
                         else
-                            return "ui", item[1].dimen
+                            return "partial", item[1].dimen
                         end
                     end
                     UIManager:setDirty(self.show_parent, refreshfunc)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -205,6 +205,8 @@ function CoverMenu:updateItems(select_number)
                 -- Close original ButtonDialogTitle (it has not yet been painted
                 -- on screen, so we won't see it)
                 UIManager:close(self.file_dialog)
+                -- And clear the rendering stack to avoid inheriting its dirty/refresh queue
+                UIManager:clearRenderStack()
 
                 -- Replace Book information callback to use directly our bookinfo
                 orig_buttons[4][3].callback = function()
@@ -320,6 +322,7 @@ function CoverMenu:onHistoryMenuHold(item)
     -- Close original ButtonDialog (it has not yet been painted
     -- on screen, so we won't see it)
     UIManager:close(self.histfile_dialog)
+    UIManager:clearRenderStack()
 
     -- Replace Book information callback to use directly our bookinfo
     orig_buttons[2][2].callback = function()
@@ -471,6 +474,7 @@ function CoverMenu:tapPlus()
     -- Close original ButtonDialogTitle (it has not yet been painted
     -- on screen, so we won't see it)
     UIManager:close(self.file_dialog)
+    UIManager:clearRenderStack()
 
     -- Add a new button to original buttons set
     table.insert(orig_buttons, {}) -- separator

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -139,9 +139,9 @@ function CoverMenu:updateItems(select_number)
                         if item.refresh_dimen then
                             -- MosaicMenuItem may exceed its own dimen in its paintTo
                             -- with its "description" hint
-                            return "partial", item.refresh_dimen
+                            return "ui", item.refresh_dimen
                         else
-                            return "partial", item[1].dimen
+                            return "ui", item[1].dimen
                         end
                     end
                     UIManager:setDirty(self.show_parent, refreshfunc)

--- a/plugins/goodreads.koplugin/doublekeyvaluepage.lua
+++ b/plugins/goodreads.koplugin/doublekeyvaluepage.lua
@@ -176,12 +176,12 @@ function DoubleKeyValueItem:onTap()
             UIManager:setDirty(self.show_parent, function()
                 return "fast", self[1].dimen
             end)
-            UIManager:scheduleIn(0.1, function()
+            UIManager:tickAfterNext(function()
                 self.callback()
                 UIManager:close(info)
                 self[1].invert = false
                 UIManager:setDirty(self.show_parent, function()
-                    return "fast", self[1].dimen
+                    return "ui", self[1].dimen
                 end)
             end)
         end

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -10,6 +10,7 @@ local NetworkMgr = require("ui/network/manager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local dateparser = require("lib.dateparser")
 local ffi = require("ffi")
+local C = ffi.C
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
@@ -355,7 +356,7 @@ function NewsDownloader:removeNewsButKeepFeedConfig()
             local entry_path = news_download_dir_path .. "/" .. entry
             local entry_mode = lfs.attributes(entry_path, "mode")
             if entry_mode == "file" then
-                ffi.C.remove(entry_path)
+                C.remove(entry_path)
             elseif entry_mode == "directory" then
                 FFIUtil.purgeDir(entry_path)
             end

--- a/plugins/zsync.koplugin/main.lua
+++ b/plugins/zsync.koplugin/main.lua
@@ -6,6 +6,7 @@ local DEBUG = require("dbg")
 local _ = require("gettext")
 
 local ffi = require("ffi")
+local C = ffi.C
 ffi.cdef[[
 int remove(const char *);
 int rmdir(const char *);
@@ -131,13 +132,13 @@ local function clearDirectory(dir, rmdir)
         local path = dir.."/"..f
         local mode = lfs.attributes(path, "mode")
         if mode == "file" then
-            ffi.C.remove(path)
+            C.remove(path)
         elseif mode == "directory" and f ~= "." and f ~= ".." then
             clearDirectory(path, true)
         end
     end
     if rmdir then
-        ffi.C.rmdir(dir)
+        C.rmdir(dir)
     end
 end
 


### PR DESCRIPTION
Okay, so, here goes!

This works in tandem (and, in fact, requires) [BASE#676](https://github.com/koreader/koreader-base/pull/676).

There's a lot of tiny moving parts, touching a lot of stuff.

The basic idea is twofold:

* Make the UI behave as closely as possible like the stock reader (be it the Kindle's framework or Nickel) in terms of waveform handling.
* Make the UI as reactive as possible, by tightening scheduling latency.

You'll see a few more black flashes, in a few new places, as well as *localized* black flashes. The goal being to avoid ghosting when applicable (mainly TouchMenu & DictQuickLookup).

Tested on a H2O for the non-REAGL path, and on a PW2 for the REAGL path ;).

I'm probably forgetting stuff, so, test away!