### PR TITLE
Fix sort-by-last-read when partition is mounted noatime

### DIFF
--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -181,9 +181,15 @@ end
 function ReadHistory:addItem(file)
     assert(self ~= nil)
     if file ~= nil and lfs.attributes(file, "mode") == "file" then
-        table.insert(self.hist, 1, buildEntry(os.time(), file))
+        local now = os.time()
+        table.insert(self.hist, 1, buildEntry(now, file))
         -- TODO(zijiehe): We do not need to sort if we can use binary insert and
         -- binary search.
+        -- util.execute("/bin/touch", "-a", file)
+        -- this emulates "touch -a" in LuaFileSystem's limited API, since the
+        -- device /bin/touch is a busybox that doesn't provide -a option
+        local mtime = lfs.attributes(file, "modification")
+        lfs.touch(file, now, mtime)
         self:_sort()
         self:_reduce()
         self:_flush()

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -186,8 +186,8 @@ function ReadHistory:addItem(file)
         -- TODO(zijiehe): We do not need to sort if we can use binary insert and
         -- binary search.
         -- util.execute("/bin/touch", "-a", file)
-        -- this emulates "touch -a" in LuaFileSystem's limited API, since the
-        -- device /bin/touch is a busybox that doesn't provide -a option
+        -- This emulates `touch -a` in LuaFileSystem's API, since it may be absent (Android)
+        -- or provided by busybox, which doesn't support the `-a` flag.
         local mtime = lfs.attributes(file, "modification")
         lfs.touch(file, now, mtime)
         self:_sort()


### PR DESCRIPTION
Fixes koreader/koreader#3988. This just manually updates the atime when an ebook is read (in the history logging code) rather than relying on the kernel. I think this is better than reworking the last-read comparison code to reference the history data automatically; that would be a much larger change, and the history list is trimmed anyway.

This uses the existing luafilesystem touch() call, which calls utime(). Thus, it explicitly reads and preserves the file mtime so that the "by modification" sort view won't be messed up. Philosophically, it would be preferable to call something in the utimensat() family and pass UTIME_OMIT, but the busybox `/bin/touch` available on the Kobo doesn't expose the `-a` option that would make that easy, and in practice one-second granularity is sufficient for this case.