### PR TITLE
bump crengine: HTML and rendering fixes

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -156,17 +156,10 @@ img {
             ]],
         },
     },
-    {
-        title = _("Workarounds"),
-        {
-            id = "border_all_none";
-            title = _("Remove all borders"),
-            description = _("Work around a crengine bug that makes a border drawn when {border: black solid 0px}."),
-            -- css = [[* { border-style: none !important; }]],
-            -- Better to keep the layout implied by width, just draw them in white
-            css = [[* { border-color: white !important; }]],
-        },
-    },
+    -- No current need for workarounds
+    -- {
+    --     title = _("Workarounds"),
+    -- },
 }
 
 return CssTweaks

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -920,10 +920,7 @@ h1.koreaderwikifrontpage, h5.koreaderwikifrontpage {
 p.koreaderwikifrontpage {
     font-style: italic;
     font-size: 90%;
-    margin-left: 2em;
-    margin-right: 2em;
-    margin-top: 1em;
-    margin-bottom: 1em;
+    margin: 1em 2em 1em 2em;
 }
 hr.koreaderwikifrontpage {
     margin-left: 20%;
@@ -941,28 +938,52 @@ a {
 a.newwikinonexistent {
     text-decoration: none;
 }
-/* show a box around image thumbnails */
-div.thumb {
-    border: dotted 1px black;
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-    margin-left: 2.5em;
-    margin-right: 2.5em;
-    padding-top: ]].. (include_images and "0.5em" or "0.15em") .. [[;
-    padding-bottom: 0.2em;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
-    text-align: center;
-    font-size: 90%;
-}
 /* don't waste left margin for notes and list of pages */
 ul, ol {
     margin-left: 0em;
 }
-/* avoid a line with a standalone bullet */
-li.gallerybox {
-    display: inline;
+/* show a box around image thumbnails */
+div.thumb {
+    border: dotted 1px black;
+    margin:  0.5em 2.5em 0.5em 2.5em;
+    padding: 0.5em 0.5em 0.2em 0.5em;
+    padding-top: ]].. (include_images and "0.5em" or "0.15em") .. [[;
+    text-align: center;
+    font-size: 90%;
 }
+/* show a box around image in gallery list (li.gallery
+ * is set up a bit differently than div.thumb - we try
+ * to make them look the same */
+li.gallerybox {
+    list-style-type: none;
+    border: dotted 1px black;
+    margin:  0.5em 2.5em 0.5em 2.5em;
+    padding: 0.5em 0.5em 0.2em 0.5em;
+    padding-top: ]].. (include_images and "0.5em" or "0.15em") .. [[;
+    text-align: center;
+    font-size: 90%;
+}
+li.gallerybox div.thumb {
+    border: solid 1px white;
+    margin: 0;
+    padding: 0;
+}
+/* override this one often set in style="" with various values */
+li.gallerybox div.thumb div {
+    margin: 0 !important;
+}
+li.gallerybox div.gallerytext p {
+    text-align: center;
+    font-size: 90%;
+}
+.citation {
+    font-style: italic;
+}
+/* hide some view/edit/discuss short links displayed as "v m d" */
+.nv-view, .nv-edit, .nv-talk {
+    display: none;
+}
+/* hiding .noprint may discard some interesting links */
 ]])
 
     -- ----------------------------------------------------------------


### PR DESCRIPTION
Includes:
- Fix getting xpointer to current page https://github.com/koreader/crengine/pull/195
- epub.css cleanup https://github.com/koreader/crengine/pull/194
- fb2def.h update https://github.com/koreader/crengine/pull/196
- Fix a few edge-case rendering issues https://github.com/koreader/crengine/pull/197
- Fix border being drawn in spite of 'border-width: 0' https://github.com/koreader/crengine/pull/198

Also update Wikipedia epub.css stylesheets regarding recent HTML fixes and enhancements.
Remove "Remove all borders" workaround tweak, as it's now fixed.

Some class name based styles have been removed from epub.css, mostly some stuff related to the FB2 format that was probably the first format supported by Cool Reader. For those nostalgic of these added styles, here's a file with them that can be put in `koreader/styletweaks `and applied via `User style tweaks`:
[CoolReader epub additions.css.txt](https://github.com/koreader/koreader/files/2064916/CoolReader.epub.additions.css.txt)
