### PR TITLE
Style menu cleanup

### DIFF
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -146,7 +146,7 @@ function ReaderTypeset:genStyleSheetMenu()
         css_files["fb2.css"] = nil
     end
     -- Add the obsoleted ones to the Obsolete sub menu
-    local obsoleted_css = {} -- for check_func of the Obsoleted sub menu itself
+    local obsoleted_css = {} -- for check_func of the Obsolete sub menu itself
     for __, css in ipairs(OBSOLETED_CSS) do
         obsoleted_css[css_files[css]] = css
         if css_files[css] then
@@ -167,9 +167,9 @@ function ReaderTypeset:genStyleSheetMenu()
     style_table[#style_table].separator = true
     table.insert(style_table, {
         text_func = function()
-            local text = _("Obsoleted")
+            local text = _("Obsolete")
             if obsoleted_css[self.css] then
-                text = T(_("Obsoleted (%1)"), obsoleted_css[self.css])
+                text = T(_("Obsolete (%1)"), obsoleted_css[self.css])
             end
             if obsoleted_css[G_reader_settings:readSetting("copt_css")] then
                 text = text .. "   ★"

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -19,13 +19,9 @@ end
 
 function ReaderTypeset:onReadSettings(config)
     self.css = config:readSetting("css") or G_reader_settings:readSetting("copt_css")
+                or self.ui.document.default_css
     local tweaks_css = self.ui.styletweak:getCssText()
-    if self.css then
-        self.ui.document:setStyleSheet(self.css, tweaks_css)
-    else
-        self.ui.document:setStyleSheet(self.ui.document.default_css, tweaks_css)
-        self.css = self.ui.document.default_css
-    end
+    self.ui.document:setStyleSheet(self.css, tweaks_css)
 
     self.embedded_fonts = config:readSetting("embedded_fonts")
     if self.embedded_fonts == nil then
@@ -90,41 +86,101 @@ function ReaderTypeset:onToggleEmbeddedFonts(toggle)
     return true
 end
 
+-- June 2018: epub.css has been cleaned to be more conforming to HTML specs
+-- and to not include class name based styles (with conditional compatiblity
+-- styles for previously opened documents). It should be usable on all
+-- HTML based documents, except FB2 which has some incompatible specs.
+-- These other css files have not been updated in the same way, and are
+-- kept as-is for when a previously opened document requests one of them.
+local OBSOLETED_CSS = {
+    "chm.css",
+    "cr3.css",
+    "doc.css",
+    "dict.css",
+    "htm.css",
+    "rtf.css",
+    "txt.css",
+}
+
 function ReaderTypeset:genStyleSheetMenu()
-    local style_table = {}
-    local file_list = {
-        {
-            text = _("Clear all external styles"),
-            css = ""
-        },
-        {
-            text = _("Auto"),
-            css = self.ui.document.default_css
-        },
-    }
-    for f in lfs.dir("./data") do
-        if lfs.attributes("./data/"..f, "mode") == "file" and string.match(f, "%.css$") then
-            table.insert(file_list, {
-                text = f,
-                css = "./data/"..f
-            })
-        end
-    end
-    table.sort(file_list, function(v1,v2) return v1.text < v2.text end) -- sort by name
-    for i,file in ipairs(file_list) do
-        table.insert(style_table, {
-            text = file["text"],
+    local getStyleMenuItem = function(text, css_file, separator)
+        return {
+            text_func = function()
+                return text .. (css_file == G_reader_settings:readSetting("copt_css") and "   ★" or "")
+            end,
             callback = function()
-                self:setStyleSheet(file["css"])
+                self:setStyleSheet(css_file or self.ui.document.default_css)
             end,
             hold_callback = function()
-                self:makeDefaultStyleSheet(file["css"], file["text"])
+                self:makeDefaultStyleSheet(css_file, text)
             end,
             checked_func = function()
-                return file.css == self.css
-            end
-        })
+                if not css_file then -- "Auto"
+                    return self.css == self.ui.document.default_css
+                end
+                return css_file == self.css
+            end,
+            separator = separator,
+        }
     end
+
+    local style_table = {}
+    local obsoleted_table = {}
+
+    table.insert(style_table, getStyleMenuItem(_("Clear all external styles"), ""))
+    table.insert(style_table, getStyleMenuItem(_("Auto"), nil, true))
+
+    local css_files = {}
+    for f in lfs.dir("./data") do
+        if lfs.attributes("./data/"..f, "mode") == "file" and string.match(f, "%.css$") then
+            css_files[f] = "./data/"..f
+        end
+    end
+    -- Add the 2 main styles
+    if css_files["epub.css"] then
+        table.insert(style_table, getStyleMenuItem(_("HTML / EPUB (epub.css)"), css_files["epub.css"]))
+        css_files["epub.css"] = nil
+    end
+    if css_files["fb2.css"] then
+        table.insert(style_table, getStyleMenuItem(_("FictionBook (fb2.css)"), css_files["fb2.css"], true))
+        css_files["fb2.css"] = nil
+    end
+    -- Add the obsoleted ones to the Obsolete sub menu
+    local obsoleted_css = {} -- for check_func of the Obsoleted sub menu itself
+    for __, css in ipairs(OBSOLETED_CSS) do
+        obsoleted_css[css_files[css]] = css
+        if css_files[css] then
+            table.insert(obsoleted_table, getStyleMenuItem(css, css_files[css]))
+            css_files[css] = nil
+        end
+    end
+    -- Sort and add the remaining (user added) files if any
+    local user_files = {}
+    for css, css_file in pairs(css_files) do
+        table.insert(user_files, css)
+    end
+    table.sort(user_files)
+    for __, css in ipairs(user_files) do
+        table.insert(style_table, getStyleMenuItem(css, css_files[css]))
+    end
+
+    style_table[#style_table].separator = true
+    table.insert(style_table, {
+        text_func = function()
+            local text = _("Obsoleted")
+            if obsoleted_css[self.css] then
+                text = T(_("Obsoleted (%1)"), obsoleted_css[self.css])
+            end
+            if obsoleted_css[G_reader_settings:readSetting("copt_css")] then
+                text = text .. "   ★"
+            end
+            return text
+        end,
+        sub_item_table = obsoleted_table,
+        checked_func = function()
+            return obsoleted_css[self.css] ~= nil
+        end
+    })
     return style_table
 end
 
@@ -226,15 +282,12 @@ function ReaderTypeset:makeDefaultFloatingPunctuation()
 end
 
 function ReaderTypeset:makeDefaultStyleSheet(css, text)
-    text = text or css
-    if css then
-        UIManager:show(ConfirmBox:new{
-            text = T( _("Set default style to %1?"), text),
-            ok_callback = function()
-                G_reader_settings:saveSetting("copt_css", css)
-            end,
-        })
-    end
+    UIManager:show(ConfirmBox:new{
+        text = T( _("Set default style to %1?"), text),
+        ok_callback = function()
+            G_reader_settings:saveSetting("copt_css", css)
+        end,
+    })
 end
 
 function ReaderTypeset:onSetPageMargins(margins)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -127,9 +127,9 @@ function CreDocument:init()
     -- adjust font sizes according to screen dpi
     self._document:adjustFontSizes(Screen:getDPI())
 
-    if G_reader_settings:readSetting("full_status_bar_font_size") then
+    if G_reader_settings:readSetting("cre_header_status_font_size") then
         self._document:setIntProperty("crengine.page.header.font.size",
-            G_reader_settings:readSetting("full_status_bar_font_size"))
+            G_reader_settings:readSetting("cre_header_status_font_size"))
     end
 
     -- set fallback font face

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -101,15 +101,18 @@ function CreDocument:init()
         -- and return extention of the 1st file
         file_type = self:zipContentExt(self.file) or "unknown"
     end
-    -- these two format use the same css file
-    if file_type == "html" then
-        file_type = "htm"
+
+    -- June 2018: epub.css has been cleaned to be more conforming to HTML specs
+    -- and to not include class name based styles (with conditional compatiblity
+    -- styles for previously opened documents). It should be usable on all
+    -- HTML based documents, except FB2 which has some incompatible specs.
+    -- The other css files (htm.css, rtf.css...) have not been updated in the
+    -- same way, and are kept as-is for when a previously opened document
+    -- requests one of them.
+    self.default_css = "./data/epub.css"
+    if file_type == "fb2" then
+        self.default_css = "./data/fb2.css"
     end
-    -- if native css-file doesn't exist, one needs to use default cr3.css
-    if not io.open("./data/"..file_type..".css") then
-        file_type = "cr3"
-    end
-    self.default_css = "./data/"..file_type..".css"
 
     -- @TODO check the default view_mode to a global user configurable
     -- variable  22.12 2012 (houqp)
@@ -123,6 +126,11 @@ function CreDocument:init()
 
     -- adjust font sizes according to screen dpi
     self._document:adjustFontSizes(Screen:getDPI())
+
+    if G_reader_settings:readSetting("full_status_bar_font_size") then
+        self._document:setIntProperty("crengine.page.header.font.size",
+            G_reader_settings:readSetting("full_status_bar_font_size"))
+    end
 
     -- set fallback font face
     self._document:setStringProperty("crengine.font.fallback.face",

--- a/spec/unit/readerrolling_spec.lua
+++ b/spec/unit/readerrolling_spec.lua
@@ -187,7 +187,7 @@ describe("Readerrolling module", function()
             local ReaderView = require("apps/reader/modules/readerview")
             local saved_handler = ReaderView.onPageUpdate
             ReaderView.onPageUpdate = function(_self)
-                assert.are.same(7, _self.ui.document:getPageCount())
+                assert.are.same(6, _self.ui.document:getPageCount())
             end
             local test_book = "spec/front/unit/data/sample.txt"
             require("docsettings"):open(test_book):purge()


### PR DESCRIPTION
See https://github.com/koreader/crengine/pull/194#issuecomment-392834289 and https://github.com/koreader/crengine/pull/194#issuecomment-393293287 for the reasoning.
(TLDR: those other css are mostly duplicates, and epub.css should be better than any of them.)

Use epub.css as the main default style, with all file formats except FB2 (which needs fb2.css).
([epub.css has been cleaned recently](https://github.com/koreader/crengine/pull/194) to be more conforming to HTML specs and to not include class name based styles - with conditional compatiblity styles for previously opened documents. It should be usable on all HTML based documents, except FB2 which has some incompatible specs.)

Consider all shipped css files other than "epub.css" and "fb2.css" obsolete, and put them in a sub-menu (these other css files have not been updated in the same way, and are kept as-is for when a previously opened document requests one of them).

Add an icon indicating which style is set as default (like it's been done for the Font and Style tweaks menus).

Also set the font size of the full status bar (available with cre documents) when the setting `cre_header_status_font_size` is present in `settings.reader.lua` (to add manually). See #3994. Closes #3995.

Default menu:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40976852-9c32db7e-68cf-11e8-9035-78d97e64b3aa.png)</kbd>

When previously opened HTML file re-opened:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40976882-ae38462e-68cf-11e8-98ed-f1ccf6397ca7.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/40976901-ba426c10-68cf-11e8-9c5a-b1a5e2cc9485.png)</kbd>

With external styles clears and with user added .css in koreader/data/:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40976929-d6d62c4a-68cf-11e8-92a8-ee3af110c84c.png)</kbd>


