### PR TITLE
bump crengine: alternative TOC, no page break on borders

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -488,7 +488,10 @@ function ReaderFooter:genAllFooterText()
 end
 
 -- this method should never get called when footer is disabled
-function ReaderFooter:setTocMarkers()
+function ReaderFooter:setTocMarkers(reset)
+    if reset then
+        self.progress_bar.ticks = nil
+    end
     if self.settings.toc_markers then
         if self.progress_bar.ticks ~= nil then return end
         local ticks_candidates = {}

--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -186,7 +186,7 @@ function ReaderHyphenation:onPreRenderDocument(config)
     if hyph_alg then
         self.ui.document:setHyphDictionary(hyph_alg)
     end
-    -- If we haven't set any, hardcoded English_US_hyphen_(Alan).pdb (in cre.cpp) will be used
+    -- If we haven't set any, hardcoded English_US.pattern (in cre.cpp) will be used
     self.hyph_alg = cre.getSelectedHyphDict()
     -- Apply hyphenation sides limits
     local hyph_settings = self.hyph_algs_settings[self.hyph_alg] or {}

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1,5 +1,6 @@
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
 local Font = require("ui/font")
@@ -19,6 +20,7 @@ local ReaderToc = InputContainer:new{
     collapse_depth = 2,
     expanded_nodes = {},
     toc_menu_title = _("Table of contents"),
+    alt_toc_menu_title = _("Table of contents *"),
 }
 
 function ReaderToc:init()
@@ -88,6 +90,16 @@ end
 
 function ReaderToc:fillToc()
     if self.toc and #self.toc > 0 then return end
+    if self.ui.document:canHaveAlternativeToc() then
+        if self.ui.doc_settings:readSetting("alternative_toc") then
+            -- (if the document has a cache, the previously built alternative
+            -- TOC was saved and has been reloaded, and this will be avoided)
+            if not self.ui.document:isTocAlternativeToc() then
+                self:resetToc()
+                self.ui.document:buildAlternativeToc()
+            end
+        end
+    end
     self.toc = self.ui.document:getToc()
 end
 
@@ -456,11 +468,43 @@ end
 function ReaderToc:addToMainMenu(menu_items)
     -- insert table to main reader menu
     menu_items.table_of_contents = {
-        text = self.toc_menu_title,
+        text_func = function()
+            return self.ui.document:isTocAlternativeToc() and self.alt_toc_menu_title or self.toc_menu_title
+        end,
         callback = function()
             self:onShowToc()
         end,
     }
+    if self.ui.document:canHaveAlternativeToc() then
+        menu_items.table_of_contents.hold_callback = function()
+            if self.ui.document:isTocAlternativeToc() then
+                UIManager:show(ConfirmBox:new{
+                    text = _("The table of content for this book is currently an alternative one built from the document headings.\nDo you want to get back the original table of content? (The book will be reloaded.)"),
+                    ok_callback = function()
+                        self.ui.doc_settings:delSetting("alternative_toc")
+                        self.ui.document:invalidateCacheFile()
+                        -- Allow for ConfirmBox to be closed before showing
+                        -- "Opening file" InfoMessage
+                        UIManager:scheduleIn(0.5, function ()
+                            self.ui:reloadDocument()
+                        end)
+                    end,
+                })
+            else
+                UIManager:show(ConfirmBox:new{
+                    text = _("Do you want to use an alternative table of content built from the document headings?"),
+                    ok_callback = function()
+                        self:resetToc()
+                        self.ui.document:buildAlternativeToc()
+                        self.ui.doc_settings:saveSetting("alternative_toc", true)
+                        self:onShowToc()
+                        self.view.footer:setTocMarkers(true)
+                        self.view.footer:updateFooter()
+                    end,
+                })
+            end
+        end
+    end
 end
 
 return ReaderToc

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -611,6 +611,18 @@ function CreDocument:getCacheFilePath()
     return self._document:getCacheFilePath()
 end
 
+function CreDocument:canHaveAlternativeToc()
+    return true
+end
+
+function CreDocument:isTocAlternativeToc()
+    return self._document:isTocAlternativeToc()
+end
+
+function CreDocument:buildAlternativeToc()
+    self._document:buildAlternativeToc()
+end
+
 function CreDocument:register(registry)
     registry:addProvider("azw", "application/vnd.amazon.mobi8-ebook", self, 90)
     registry:addProvider("chm", "application/vnd.ms-htmlhelp", self, 90)

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -254,6 +254,14 @@ function Document:getToc()
     return self._document:getToc()
 end
 
+function Document:canHaveAlternativeToc()
+    return false
+end
+
+function Document:isTocAlternativeToc()
+    return false
+end
+
 function Document:getPageLinks(pageno)
     return nil
 end

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -902,10 +902,12 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
     epub:add("OEBPS/stylesheet.css", [[
 /* make section headers looks left aligned and avoid some page breaks */
 h1, h2 {
+    page-break-before: always;
+    page-break-after: avoid;
     text-align: left;
 }
-h3, h4, h5, h6, h7 {
-    page-break-before: avoid;
+h3, h4, h5, h6 {
+    page-break-before: auto;
     page-break-after: avoid;
     text-align: left;
 }
@@ -950,6 +952,11 @@ div.thumb {
     padding-top: ]].. (include_images and "0.5em" or "0.15em") .. [[;
     text-align: center;
     font-size: 90%;
+    page-break-inside: avoid;
+}
+/* these are contained in div.thumb, avoid page break in between them */
+div.thumbcaption, div.magnify {
+    page-break-before: avoid;
 }
 /* show a box around image in gallery list (li.gallery
  * is set up a bit differently than div.thumb - we try
@@ -967,10 +974,16 @@ li.gallerybox div.thumb {
     border: solid 1px white;
     margin: 0;
     padding: 0;
+    page-break-after: avoid;
 }
 /* override this one often set in style="" with various values */
 li.gallerybox div.thumb div {
     margin: 0 !important;
+}
+/* avoid page break between gallery image and text */
+div.gallerytext {
+    page-break-before: avoid;
+    page-break-inside: avoid;
 }
 li.gallerybox div.gallerytext p {
     text-align: center;


### PR DESCRIPTION
Includes:
- Avoid page break between a node and its borders https://github.com/koreader/crengine/pull/207
- Allow building an alternative TOC from document headings https://github.com/koreader/crengine/pull/205

On CRE documents, allows toggling between original TOC and an alternative TOC with long-press on the "Table of content" menu item.
<kbd>![image](https://user-images.githubusercontent.com/24273478/41361664-e7728290-6f2f-11e8-9a2c-55cd757f3c04.png)</kbd>

It shows it's an alternative TOC in the menu with this small `*` (I tried to find other unicode symbols, but they were all too visible, and it felt strange with this simple menu often accessed - that small `*` feels discreet enough).
<kbd>![image](https://user-images.githubusercontent.com/24273478/41361691-f54900ce-6f2f-11e8-99cf-99eb6a5dd9a2.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/41361707-027b7998-6f30-11e8-8908-cea488136055.png)</kbd>



(For now, it's a bit undocumented, and needs people to know that long-press does something. I'm not yet sure how to make that obvious - popup when original TOC is empty, but that could be bothering if the alt toc is ugly or empty too - or if we should fill the TOC, when empty or not, with a few more items at the end with no callback but just as lines of a message saying one can request an other TOC by holding on the menu... anyway, that can be kept for another PR as I don't want this cre bump to be held too long, as I have one more rendering fix coming on).

Also update the Wikipedia stylesheet to further avoid page-breaks between images and their caption, so a full bordered wikipedia thumbnail is always full on a single page.