### PR TITLE
Remove cre cache file when deleting a book

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -659,7 +659,13 @@ function FileManager:deleteFile(file)
     end
     if ok and not err then
         if is_doc then
-            DocSettings:open(file):purge()
+            local doc_settings = DocSettings:open(file)
+            -- remove cache if any
+            local cache_file_path = doc_settings:readSetting("cache_file_path")
+            if cache_file_path then
+                os.remove(cache_file_path)
+            end
+            doc_settings:purge()
         end
         UIManager:show(InfoMessage:new{
             text = util.template(_("Deleted %1"), file),

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -180,15 +180,17 @@ end
 -- we cannot do it in onSaveSettings() because getLastPercent() uses self.ui.document
 function ReaderRolling:onCloseDocument()
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
-    -- also checks if DOM is coherent with styles; if not, invalidate the
-    -- cache, so a new DOM is built on next opening
-    if self.ui.document:isBuiltDomStale() then
-        if self.ui.document:hasCacheFile() then
+    local cache_file_path = self.ui.document:getCacheFilePath() -- nil if no cache file
+    self.ui.doc_settings:saveSetting("cache_file_path", cache_file_path)
+    if self.ui.document:hasCacheFile() then
+        -- also checks if DOM is coherent with styles; if not, invalidate the
+        -- cache, so a new DOM is built on next opening
+        if self.ui.document:isBuiltDomStale() then
             logger.dbg("cre DOM may not be in sync with styles, invalidating cache file for a full reload at next opening")
             self.ui.document:invalidateCacheFile()
         end
     end
-    logger.dbg("cre cache used:", self.ui.document:getCacheFilePath() or "none")
+    logger.dbg("cre cache used:", cache_file_path or "none")
 end
 
 function ReaderRolling:onCheckDomStyleCoherence()


### PR DESCRIPTION
Store the cache file path in book settings, so we can delete it too when deleting the book.