### PR TITLE
Add 'cre_min_space_condensing_percent' setting

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -132,6 +132,13 @@ function CreDocument:init()
             G_reader_settings:readSetting("cre_header_status_font_size"))
     end
 
+    -- min space condensing percent (how much we can decrease a space width to
+    -- make text fit on a line) default is 50%
+    if G_reader_settings:readSetting("cre_min_space_condensing_percent") then
+        self._document:setIntProperty("crengine.style.space.condensing.percent",
+            G_reader_settings:readSetting("cre_min_space_condensing_percent"))
+    end
+
     -- set fallback font face
     self._document:setStringProperty("crengine.font.fallback.face",
         G_reader_settings:readSetting("fallback_font") or self.fallback_font)


### PR DESCRIPTION
Default in crengine is 50%, and this may be too much for some users (words can look too much stuck to each other on some lines).
This manual setting may help testing if 70% or 80% is better, by adding to `settings.reader.lua`:
`"cre_min_space_condensing_percent" = 80`

(No real idea where to put that in menu or bottom config panel, and if that's really needed - should help testing if some other value is better then 50%.)