### PR TITLE
bump crengine: fix handling of soft-hyphens

### DIFF
--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -54,6 +54,29 @@ function ReaderHyphenation:init()
         enabled_func = function()
             return self.hyph_alg ~= "@none"
         end,
+    })
+    table.insert(self.hyph_table, {
+        text = _("Trust soft hyphens"),
+        callback = function()
+            G_reader_settings:flipNilOrFalse("hyph_trust_soft_hyphens")
+            self.ui.document:setTrustSoftHyphens(G_reader_settings:isTrue("hyph_trust_soft_hyphens"))
+            self.ui.toc:onUpdateToc()
+            self.ui:handleEvent(Event:new("UpdatePos"))
+        end,
+        checked_func = function()
+            -- for @none and @softhyphens, set the checkbox to reflect how
+            -- these trust soft hyphens, no matter what our setting is
+            if self.hyph_alg == "@none" then
+                return false
+            elseif self.hyph_alg == "@softhyphens" then
+                return true
+            else
+                return G_reader_settings:isTrue("hyph_trust_soft_hyphens")
+            end
+        end,
+        enabled_func = function()
+            return self.hyph_alg ~= "@none" and self.hyph_alg ~= "@softhyphens"
+        end,
         separator = true,
     })
 
@@ -113,7 +136,8 @@ function ReaderHyphenation:init()
                 end,
                 checked_func = function()
                     return v.filename == self.hyph_alg
-                end
+                end,
+                separator = v.separator,
             })
 
             self.lang_table[v.language] = v.filename
@@ -192,6 +216,7 @@ function ReaderHyphenation:onPreRenderDocument(config)
     local hyph_settings = self.hyph_algs_settings[self.hyph_alg] or {}
     self.ui.document:setHyphLeftHyphenMin(G_reader_settings:readSetting("hyph_left_hyphen_min") or hyph_settings.left_hyphen_min)
     self.ui.document:setHyphRightHyphenMin(G_reader_settings:readSetting("hyph_right_hyphen_min") or hyph_settings.right_hyphen_min)
+    self.ui.document:setTrustSoftHyphens(G_reader_settings:isTrue("hyph_trust_soft_hyphens"))
 end
 
 function ReaderHyphenation:addToMainMenu(menu_items)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -454,6 +454,11 @@ function CreDocument:setHyphRightHyphenMin(value)
     self._document:setIntProperty("crengine.hyphenation.right.hyphen.min", value or 2)
 end
 
+function CreDocument:setTrustSoftHyphens(toggle)
+    logger.dbg("CreDocument: set hyphenation trust soft hyphens", toggle and 1 or 0)
+    self._document:setIntProperty("crengine.hyphenation.trust.soft.hyphens", toggle and 1 or 0)
+end
+
 function CreDocument:clearSelection()
     logger.dbg("clear selection")
     self._document:clearSelection()


### PR DESCRIPTION
Adds a new Hyphenation method: `Soft-hyphens only`.
Adds a new toggable option, usable with Algorithm and language based methods: `Trust soft hyphens` (if enabled, if soft hyphens found in word: use them and skip regular method).
Details in https://github.com/koreader/crengine/pull/212. Closes #3431 .

<kbd>![image](https://user-images.githubusercontent.com/24273478/41846415-e1783b14-7876-11e8-8168-aab453ae45f7.png)</kbd>
