### PR TITLE
Use our font when embedded font is off

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -409,7 +409,13 @@ function CreDocument:setFontFace(new_font_face)
         --  +25601: uses existing real font-family, but use our font even
         --          for font-family: monospace
         -- +256001: prefer our font to any existing font-family font
-        self._document:setAsPreferredFontWithBias(new_font_face, 1)
+        if self.configurable.embedded_fonts == 0 then
+            --use our font when embedded fonts is off
+            self._document:setAsPreferredFontWithBias(new_font_face, 256001)
+        else
+            -- use existing real font-family when embedded fonts is on (publisher font)
+            self._document:setAsPreferredFontWithBias(new_font_face, 1)
+        end
     end
 end
 


### PR DESCRIPTION
Ref: #3149 
The option `Embedded Fonts` does not always work as it should. Publisher fonts cannot always be turned off.
Change bias from
`setAsPreferredFontWithBias(new_font_face, 1)`
to 
`setAsPreferredFontWithBias(new_font_face, 25601)`
usually works but not always.
Using a value of `setAsPreferredFontWithBias(new_font_face, 256001)` disables the publisher's fonts forever, which is not good when you want to use them.

That's why I've made use of the `setAsPreferredFontWithBias()` function depending on whether the embendded fonts option is on or off.
embendded fonts **off** -> `setAsPreferredFontWithBias(new_font_face, 256001)`
embendded fonts **on** -> `setAsPreferredFontWithBias(new_font_face, 1)`