### PR TITLE
Add some help texts to long press popup on bottom config titles

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -46,6 +46,8 @@ local CreOptions = {
                 default_arg = "page",
                 event = "SetViewMode",
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[- 'scroll' mode allows you to scroll the text like you would in a web browser (the 'Page Overlap' setting is only available in this mode).
+- 'page' mode splits the text into pages, at the most acceptable places (page numbers and the number of page may change when you change fonts, margins, styles...).]]),
             },
             {
                 name = "render_dpi",
@@ -56,6 +58,11 @@ local CreOptions = {
                 args = {0, 48, 96, 167, 212, 300},
                 event = "SetRenderDPI",
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[Sets the DPI used to scale CSS absolute units and images:
+- off: ignore absolute units (old engine behaviour).
+- 96¹’¹: at 96 dpi, 1 css pixel = 1 screen pixel; images are rendered as their original dimensions.
+- other values scale css absolute units and images by a factor (300 dpi = x3, 48 dpi = x0.5)
+Using your device's screen real DPI will make a css size of 1cm measures as 1cm.]]),
             },
             {
                 name = "line_spacing",
@@ -165,6 +172,11 @@ local CreOptions = {
                 args = {0, 1, 2},
                 event = "SetFontHinting",
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[Font hinting is the process by which fonts are adjusted for maximum readability on pixel based screens.
+
+- off: no hinting.
+- native: use the font internal hinting instructions.
+- auto: use FreeType hinting algorithm, ignoring font instructions.]]),
             },
             {
                 name = "space_condensing",
@@ -186,6 +198,7 @@ local CreOptions = {
                 -- used by showValues
                 name_text_suffix = "%",
                 name_text_true_values = true,
+                help_text = _([[Tells the rendering engine how much each 'space' character in the text can be reduced from its regular width to make words fit on a line (100% means no reduction).]]),
             }
         }
     },
@@ -202,6 +215,8 @@ local CreOptions = {
                 default_arg = DCREREADER_PROGRESS_BAR,
                 event = "SetStatusLine",
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[- 'full' displays a status bar at the top of the screen (this status bar can't be customized).
+- 'mini' displays a status bar at the bottom of the screen, which can be toggled by tapping. The items displayed can be customized via the main menu.]]),
             },
             {
                 name = "embedded_css",
@@ -213,6 +228,8 @@ local CreOptions = {
                 default_arg = nil,
                 event = "ToggleEmbeddedStyleSheet",
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[Enable or disable the publisher stylesheets embedded in the book.
+(Note that less radical changes can be achieved via Style Tweaks in the main menu.)]]),
             },
             {
                 name = "embedded_fonts",
@@ -227,6 +244,8 @@ local CreOptions = {
                     return optionsutil.enableIfEquals(configurable, "embedded_css", 1)
                 end,
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[Enable or disable the use of the fonts embedded in the book.
+(Disabling the fonts specified in the publisher stylesheets can also be achieved via Style Tweaks in the main menu.)]]),
             },
         },
     },

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -47,7 +47,7 @@ local CreOptions = {
                 event = "SetViewMode",
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[- 'scroll' mode allows you to scroll the text like you would in a web browser (the 'Page Overlap' setting is only available in this mode).
-- 'page' mode splits the text into pages, at the most acceptable places (page numbers and the number of pages may change when you change fonts, margins, styles...).]]),
+- 'page' mode splits the text into pages, at the most acceptable places (page numbers and the number of pages may change when you change fonts, margins, styles, etc.).]]),
             },
             {
                 name = "render_dpi",
@@ -58,12 +58,12 @@ local CreOptions = {
                 args = {0, 48, 96, 167, 212, 300},
                 event = "SetRenderDPI",
                 name_text_hold_callback = optionsutil.showValues,
-                help_text = _([[Sets the DPI used to scale CSS absolute units and images:
-- off: ignore absolute units (old engine behaviour).
-- 96¹’¹: at 96 dpi, 1 css pixel = 1 screen pixel and images are rendered at their original dimensions.
-- other values scale css absolute units and images by a factor (300 dpi = x3, 48 dpi = x0.5)
-Using your device's actual DPI will ensure 1cm in CSS actually translates to 1cm on screen.
-Note that your selected font size is not affected by changes of this setting.]]),
+                help_text = _([[Sets the DPI used to scale absolute CSS units and images:
+- off: ignore absolute units (old engine behavior).
+- 96¹’¹: at 96 DPI, 1 CSS pixel = 1 screen pixel and images are rendered at their original dimensions.
+- other values scale CSS absolute units and images by a factor (300 DPI = x3, 48 DPI = x0.5)
+Using your device's actual DPI will ensure 1 cm in CSS actually translates to 1 cm on screen.
+Note that your selected font size is not affected by this setting.]]),
             },
             {
                 name = "line_spacing",
@@ -229,7 +229,7 @@ Note that your selected font size is not affected by changes of this setting.]])
                 default_arg = nil,
                 event = "ToggleEmbeddedStyleSheet",
                 name_text_hold_callback = optionsutil.showValues,
-                help_text = _([[Enable or disable the publisher stylesheets embedded in the book.
+                help_text = _([[Enable or disable publisher stylesheets embedded in the book.
 (Note that less radical changes can be achieved via Style Tweaks in the main menu.)]]),
             },
             {

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -62,7 +62,8 @@ local CreOptions = {
 - off: ignore absolute units (old engine behaviour).
 - 96¹’¹: at 96 dpi, 1 css pixel = 1 screen pixel and images are rendered at their original dimensions.
 - other values scale css absolute units and images by a factor (300 dpi = x3, 48 dpi = x0.5)
-Using your device's actual DPI will ensure 1cm in CSS actually translates to 1cm on screen..]]),
+Using your device's actual DPI will ensure 1cm in CSS actually translates to 1cm on screen.
+Note that your selected font size is not affected by changes of this setting.]]),
             },
             {
                 name = "line_spacing",

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -47,7 +47,7 @@ local CreOptions = {
                 event = "SetViewMode",
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[- 'scroll' mode allows you to scroll the text like you would in a web browser (the 'Page Overlap' setting is only available in this mode).
-- 'page' mode splits the text into pages, at the most acceptable places (page numbers and the number of page may change when you change fonts, margins, styles...).]]),
+- 'page' mode splits the text into pages, at the most acceptable places (page numbers and the number of pages may change when you change fonts, margins, styles...).]]),
             },
             {
                 name = "render_dpi",
@@ -60,9 +60,9 @@ local CreOptions = {
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Sets the DPI used to scale CSS absolute units and images:
 - off: ignore absolute units (old engine behaviour).
-- 96¹’¹: at 96 dpi, 1 css pixel = 1 screen pixel; images are rendered as their original dimensions.
+- 96¹’¹: at 96 dpi, 1 css pixel = 1 screen pixel and images are rendered at their original dimensions.
 - other values scale css absolute units and images by a factor (300 dpi = x3, 48 dpi = x0.5)
-Using your device's screen real DPI will make a css size of 1cm measures as 1cm.]]),
+Using your device's actual DPI will ensure 1cm in CSS actually translates to 1cm on screen..]]),
             },
             {
                 name = "line_spacing",
@@ -172,11 +172,11 @@ Using your device's screen real DPI will make a css size of 1cm measures as 1cm.
                 args = {0, 1, 2},
                 event = "SetFontHinting",
                 name_text_hold_callback = optionsutil.showValues,
-                help_text = _([[Font hinting is the process by which fonts are adjusted for maximum readability on pixel based screens.
+                help_text = _([[Font hinting is the process by which fonts are adjusted for maximum readability on the screen's pixel grid.
 
 - off: no hinting.
 - native: use the font internal hinting instructions.
-- auto: use FreeType hinting algorithm, ignoring font instructions.]]),
+- auto: use FreeType's hinting algorithm, ignoring font instructions.]]),
             },
             {
                 name = "space_condensing",

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -203,6 +203,8 @@ local KoptOptions = {
                 values = {1, 0},
                 default_value = 0,
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[Remove watermarks from the rendered document.
+This can also be used to remove some gray background or convert a grayscale or color document to black & white and get more contrast for easier reading.]]),
             },
             {
                 name="doc_language",
@@ -213,6 +215,7 @@ local KoptOptions = {
                 event = "DocLangUpdate",
                 args = DKOPTREADER_CONFIG_DOC_LANGS_CODE,
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[(Used by the OCR engine.)]]),
             },
             {
                 name = "word_spacing",

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -204,7 +204,7 @@ local KoptOptions = {
                 default_value = 0,
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Remove watermarks from the rendered document.
-This can also be used to remove some gray background or convert a grayscale or color document to black & white and get more contrast for easier reading.]]),
+This can also be used to remove some gray background or to convert a grayscale or color document to black & white and get more contrast for easier reading.]]),
             },
             {
                 name="doc_language",

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -55,22 +55,22 @@ function optionsutil.showValues(configurable, option, prefix)
             end
         end
     end
-    if option.name_text_true_values and option.toggle and option.values and value_default then
-        UIManager:show(InfoMessage:new{
-            text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3 (%6%4)"), option.name_text,
-                current, default, suffix, value_current, value_default)
-        })
-    elseif option.name_text_true_values and option.toggle and option.values and not value_default then
-        UIManager:show(InfoMessage:new{
-            text = T(_("%1:\nCurrent value: %2 (%5%4)\nDefault value: %3"), option.name_text,
-                current, default, suffix, value_current)
-        })
-    else
-        UIManager:show(InfoMessage:new{
-            text = T(_("%1:\nCurrent value: %2%4\nDefault value: %3%4"), option.name_text, current,
-                default, suffix)
-        })
+    local help_text = ""
+    if option.help_text then
+        help_text = T("\n%1\n", option.help_text)
     end
+    local text
+    if option.name_text_true_values and option.toggle and option.values and value_default then
+        text = T(_("%1:\n%2\nCurrent value: %3 (%6%5)\nDefault value: %4 (%7%5)"), option.name_text, help_text,
+            current, default, suffix, value_current, value_default)
+    elseif option.name_text_true_values and option.toggle and option.values and not value_default then
+        text = T(_("%1\n%2\nCurrent value: %3 (%6%5)\nDefault value: %4"), option.name_text, help_text,
+            current, default, suffix, value_current)
+    else
+        text = T(_("%1\n%2\nCurrent value: %3%5\nDefault value: %4%5"), option.name_text, help_text,
+            current, default, suffix)
+    end
+    UIManager:show(InfoMessage:new{ text=text })
 end
 
 local function tableComp(a,b)


### PR DESCRIPTION
So we can explain a bit what these do (and go a bit into technical detail, as these do not jump to the user face but he asked for it :)


<kbd>![image](https://user-images.githubusercontent.com/24273478/42229119-fd9d8cfc-7ee5-11e8-80dd-a206f10c179b.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/42229573-11170758-7ee7-11e8-8c38-8bffa5fecafb.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/42229188-2d8888b8-7ee6-11e8-838b-4acd9a2da008.png)</kbd>

When no help text:

<kbd>![image](https://user-images.githubusercontent.com/24273478/42229098-f17a1350-7ee5-11e8-9fef-8d97e4f44bb7.png)</kbd>

Hope someone can add some to the PDF/KOPT side of the bottom config :)