### PR TITLE
Style tweaks: re-order Allow hyphenation on all text

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -89,15 +89,6 @@ local CssTweaks = {
             },
         },
         {
-            id = "hyphenate_all_auto";
-            title = _("Allow hyphenation on all text"),
-            description = _("Allow hyphenation to happen on all text (except headings), in case the publisher has disabled it."),
-            css = [[
-* { hyphenate: auto !important; }
-h1, h2, h3, h4, h5, h6 { hyphenate: none !important; }
-            ]],
-        },
-        {
             id = "sub_sup_smaller";
             title = _("Smaller sub- and superscript"),
             description = _("Prevent sub- and superscript from affecting line-height."),
@@ -109,6 +100,15 @@ sup { font-size: 50% !important; vertical-align: super !important; }
 sub { font-size: 50% !important; vertical-align: sub !important; }
             ]],
             separator = true,
+        },
+        {
+            id = "hyphenate_all_auto";
+            title = _("Allow hyphenation on all text"),
+            description = _("Allow hyphenation to happen on all text (except headings), in case the publisher has disabled it."),
+            css = [[
+* { hyphenate: auto !important; }
+h1, h2, h3, h4, h5, h6 { hyphenate: none !important; }
+            ]],
         },
         {
             id = "lineheight_all_inherit";


### PR DESCRIPTION
#4047 should be just below with the other Ignore publisher stuff (as we allow hyphenation by default, it's really a kind of Ignore publisher something).
<kbd>![image](https://user-images.githubusercontent.com/24273478/42271801-7fbafb40-7f84-11e8-8962-988f56b5e62e.png)</kbd>
