### PR TITLE
Dismiss Wi-Fi scan popup after connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifneq ($(or $(EMULATE_READER),$(WIN32)),)
 	cd $(INSTALL_DIR)/koreader/spec/front/unit && test -e data || \
 		ln -sf ../../test ./data
 else
-	$(RCP) -fL $(KOR_BASE)/$(OUTPUT_DIR)/* $(INSTALL_DIR)/koreader/
+	$(RCP) -fL $(KOR_BASE)/$(OUTPUT_DIR)/. $(INSTALL_DIR)/koreader/.
 endif
 	for f in $(INSTALL_FILES); do \
 		ln -sf ../../$$f $(INSTALL_DIR)/koreader/; \
@@ -82,12 +82,12 @@ ifdef WIN32
 endif
 	@echo "[*] Install plugins"
 	@# TODO: link istead of cp?
-	$(RCP) plugins/* $(INSTALL_DIR)/koreader/plugins/
+	$(RCP) plugins/. $(INSTALL_DIR)/koreader/plugins/.
 	@# purge deleted plugins
 	for d in $$(ls $(INSTALL_DIR)/koreader/plugins); do \
 		test -d plugins/$$d || rm -rf $(INSTALL_DIR)/koreader/plugins/$$d ; done
 	@echo "[*] Installresources"
-	$(RCP) -pL resources/fonts/* $(INSTALL_DIR)/koreader/fonts/
+	$(RCP) -pL resources/fonts/. $(INSTALL_DIR)/koreader/fonts/.
 	install -d $(INSTALL_DIR)/koreader/{screenshots,data/{dict,tessdata},fonts/host,ota}
 ifeq ($(or $(EMULATE_READER),$(WIN32)),)
 	@echo "[*] Clean up, remove unused files for releases"

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -39,6 +39,7 @@ local order = {
         "network_restore",
         "network_info",
         "network_before_wifi_action",
+        "network_dismiss_scan",
         "----------------------------",
         "ssh",
     },

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -59,6 +59,7 @@ local order = {
         "network_restore",
         "network_info",
         "network_before_wifi_action",
+        "network_dismiss_scan",
         "----------------------------",
         "ssh",
     },

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -246,7 +246,7 @@ end
 
 function NetworkMgr:getDismissScanMenuTable()
     return {
-        text = _("Dismiss SSID scan popup on successfull autoconnect"),
+        text = _("Dismiss Wi-Fi scan popup after connection"),
         checked_func = function() return G_reader_settings:nilOrTrue("auto_dismiss_wifi_scan") end,
         --enabled_func = function() return Device:isKobo() end,
         callback = function(menu) G_reader_settings:flipNilOrTrue("auto_dismiss_wifi_scan") end,

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -244,12 +244,22 @@ function NetworkMgr:getBeforeWifiActionMenuTable()
    }
 end
 
+function NetworkMgr:getDismissScanMenuTable()
+    return {
+        text = _("Dismiss SSID scan popup on successfull autoconnect"),
+        checked_func = function() return G_reader_settings:nilOrTrue("auto_dismiss_wifi_scan") end,
+        --enabled_func = function() return Device:isKobo() end,
+        callback = function(menu) G_reader_settings:flipNilOrTrue("auto_dismiss_wifi_scan") end,
+    }
+end
+
 function NetworkMgr:getMenuTable(common_settings)
     common_settings.network_wifi = self:getWifiMenuTable()
     common_settings.network_proxy = self:getProxyMenuTable()
     common_settings.network_restore = self:getRestoreMenuTable()
     common_settings.network_info = self:getInfoMenuTable()
     common_settings.network_before_wifi_action = self:getBeforeWifiActionMenuTable()
+    common_settings.network_dismiss_scan = self:getDismissScanMenuTable()
 end
 
 function NetworkMgr:showNetworkMenu(complete_callback)

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -462,7 +462,9 @@ function NetworkSetting:init()
         local connected_item = self:getConnectedItem()
         if connected_item ~= nil then
             obtainIP()
-            UIManager:close(self, 'ui', self.dimen)
+            if G_reader_settings:nilOrTrue("auto_dismiss_wifi_scan") then
+                UIManager:close(self, 'ui', self.dimen)
+            end
             UIManager:show(InfoMessage:new{
                 text = T(_("Connected to network %1"), connected_item.info.ssid)
             })

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -384,7 +384,7 @@ function NetworkSetting:init()
     local items = {}
     table.sort(self.network_list,
                function(l, r) return l.signal_quality > r.signal_quality end)
-    for idx,network in ipairs(self.network_list) do
+    for idx, network in ipairs(self.network_list) do
         local bg
         if idx % 2 == 0 then
             bg = gray_bg
@@ -462,6 +462,7 @@ function NetworkSetting:init()
         local connected_item = self:getConnectedItem()
         if connected_item ~= nil then
             obtainIP()
+            UIManager:close(self, 'ui', self.dimen)
             UIManager:show(InfoMessage:new{
                 text = T(_("Connected to network %1"), connected_item.info.ssid)
             })


### PR DESCRIPTION
Addressing part of [my own comment](https://github.com/koreader/koreader/issues/4034#issuecomment-402540116) in #4034 ;). (Also, re #3757).

Made it a toggle (enabled by default), because I'm not quite sure if that's always a helpful behavior (i.e., on my Kobo, it autoconnects to my usual network, so, yeah, I want it. But I only have *one* saved network. What happens when I have multiples, and it chooses the wrong one? Can this actually happen?).

Is the autoconnect behavior actually device-specific, too?

I can only test this on a Kobo, because Kindle shmingle, so, yeah, RFC ;).