### PR TITLE
Reader menu: adds "Open previous document"

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -238,7 +238,7 @@ function FileManagerMenu:setUpdateItemTable()
             end
             local last_file = G_reader_settings:readSetting("lastfile")
             local path, file_name = util.splitFilePathName(last_file); -- luacheck: no unused
-            return T(_("Open: %1"), file_name)
+            return T(_("Last: %1"), file_name)
         end,
         enabled_func = function()
             return G_reader_settings:readSetting("lastfile") ~= nil

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -238,7 +238,7 @@ function FileManagerMenu:setUpdateItemTable()
             end
             local last_file = G_reader_settings:readSetting("lastfile")
             local path, file_name = util.splitFilePathName(last_file); -- luacheck: no unused
-            return T(_("Open last document: %1"), file_name)
+            return T(_("Open: %1"), file_name)
         end,
         enabled_func = function()
             return G_reader_settings:readSetting("lastfile") ~= nil

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -194,7 +194,7 @@ function ReaderMenu:setUpdateItemTable()
                 return _("Open previous document")
             end
             local path, file_name = util.splitFilePathName(previous_file); -- luacheck: no unused
-            return T(_("Open: %1"), file_name)
+            return T(_("Previous: %1"), file_name)
         end,
         enabled_func = function()
             return previous_file ~= nil

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -663,4 +663,11 @@ function ReaderUI:reloadDocument(after_close_callback)
     self:showReader(file, provider)
 end
 
+function ReaderUI:switchDocument(new_file)
+    self:handleEvent(Event:new("CloseReaderMenu"))
+    self:handleEvent(Event:new("CloseConfigMenu"))
+    self:onClose()
+    self:showReader(new_file)
+end
+
 return ReaderUI

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -99,6 +99,8 @@ local order = {
     filemanager = {},
     main = {
         "history",
+        "open_previous_document",
+        "----------------------------",
         "book_status",
         "book_info",
         "----------------------------",

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -149,7 +149,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             callback = function() G_reader_settings:flipNilOrFalse("autoremove_deleted_items_from_history") end,
         },
         {
-            text = _("Show filename in Open last menu item"),
+            text = _("Show filename in Open last/previous menu items"),
             checked_func = function() return G_reader_settings:readSetting("open_last_menu_show_filename") end,
             callback = function() G_reader_settings:flipNilOrFalse("open_last_menu_show_filename") end,
         },


### PR DESCRIPTION
Allows for quick switching between 2 documents (and keep symmetry with FileManager menu "Open last document", the last document being the one currently opened by reader, so... previous :).
Proposed at https://github.com/koreader/koreader/pull/4042#issuecomment-402389052

<kbd>![image](https://user-images.githubusercontent.com/24273478/42319824-70402ecc-8053-11e8-8cbe-6be4a1888412.png)</kbd>

With `Display mode > Other settings > Show filename in Open last/previous menu items` enabled:

<kbd>![image](https://user-images.githubusercontent.com/24273478/42319906-bc409d66-8053-11e8-80e6-3b8b72ae7854.png)</kbd>
