### PR TITLE
Better display of text on buttons

### DIFF
--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -19,7 +19,7 @@ local ButtonTable = FocusManager:new{
         },
     },
     sep_width = Size.line.medium,
-    padding = Size.padding.button,
+    padding = Size.padding.default,
 
     zero_sep = false,
     button_font_face = "cfont",

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -86,6 +86,9 @@ function TextWidget:paintTo(bb, x, y)
     --end
     --bb:blitFrom(self._bb, x, y, 0, 0, self._length, self._bb:getHeight())
     --@TODO Don't use kerning for monospaced fonts.    (houqp)
+    if self.max_width and RenderText:sizeUtf8Text(0, Screen:getWidth(), self.face, self.text, true, self.bold).x > self.max_width then
+        self.text = RenderText:truncateTextByWidth(self.text, self.face, self.max_width, true)
+    end
     RenderText:renderUtf8Text(bb, x, y+self._baseline_h, self.face, self.text, true, self.bold,
                 self.fgcolor, self.max_width and self.max_width or self.width)
 end


### PR DESCRIPTION
Before:
![2a](https://user-images.githubusercontent.com/22982594/42323697-4ea8d724-8061-11e8-9924-d0cc942cbdb4.png)
After:
![4a](https://user-images.githubusercontent.com/22982594/42323707-53fe6d2e-8061-11e8-847b-0cfc53538507.png)
Before:
![1a](https://user-images.githubusercontent.com/22982594/42323719-5cc5fbca-8061-11e8-88d1-79afb187a884.png)

After:
![3a](https://user-images.githubusercontent.com/22982594/42323722-61d66f50-8061-11e8-9a88-8a96d66b7fb4.png)
