### PR TITLE
Prevent open Readeing Progress in Reading statistics in landscape

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -693,6 +693,7 @@ function ReaderStatistics:addToMainMenu(menu_items)
             },
             {
                 text = _("Reading progress"),
+                enabled_func = function() return Screen:getWidth() < Screen:getHeight() end,
                 callback = function()
                     self:insertDB(self.id_curr_book)
                     local current_period, current_pages = self:getCurrentBookStats()


### PR DESCRIPTION
In landscape mode reading progress looks terrible so I disable it.

![marsjanin - koreader_115](https://user-images.githubusercontent.com/22982594/42339149-6f181e22-808c-11e8-9866-c94f07daa29f.png)
