### PR TITLE
Fix size of DCREREADER_CONFIG_FONT_SIZE and fix focus/unfocus in MultiInputDialog

### DIFF
--- a/frontend/apps/filemanager/filemanagersetdefaults.lua
+++ b/frontend/apps/filemanager/filemanagersetdefaults.lua
@@ -173,6 +173,8 @@ function SetDefaults:init()
                     table.insert(fields, {
                         text = tostring(k) .. " = " .. tostring(v),
                         hint = "",
+                        padding = Screen:scaleBySize(2),
+                        margin = Screen:scaleBySize(2),
                     })
                 end
                 self.set_dialog = MultiInputDialog:new{

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -47,6 +47,8 @@ function MultiInputDialog:init()
             focused = k == 1 and true or false,
             scroll = false,
             parent = self,
+            padding = field.padding or nil,
+            margin = field.margin or nil,
         }
         if Device:hasKeys() then
             --little hack to piggyback on the layout of the button_table to handle the new InputText
@@ -134,6 +136,9 @@ function MultiInputDialog:onSwitchFocus(inputbox)
     -- unfocus current inputbox
     self._input_widget:unfocus()
     self._input_widget:onCloseKeyboard()
+    UIManager:setDirty(nil, function()
+        return "ui", self.dialog_frame.dimen
+    end)
 
     -- focus new inputbox
     self._input_widget = inputbox


### PR DESCRIPTION
Close: #3680 
Fix: 
* size of window DCREREADER_CONFIG_FONT_SIZE in Advanced settings
* after leave inputtext (eg first on top to second one) we should set last one as unfocus - one inputtext should be focused in the same time.

Before:
![test - koreader_117](https://user-images.githubusercontent.com/22982594/42400379-97b5bf5c-8171-11e8-904d-f20b69542046.png)

After:
![test - koreader_118](https://user-images.githubusercontent.com/22982594/42400374-913acdfc-8171-11e8-99b3-da2a61f7b901.png)
