### PR TITLE
Re-exec startup script on Kindle/Kobo when an OTA update is processed on startup

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -487,7 +487,7 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
         self.mark_func = function()
             self.mark_func = nil
             Screen.bb:paintRect(0, screen_y, marker_w, marker_h, Blitbuffer.COLOR_BLACK)
-            Screen["refreshUI"](Screen, 0, screen_y, marker_w, marker_h)
+            Screen["refreshFast"](Screen, 0, screen_y, marker_w, marker_h)
             if type(marker_setting) == "number" then -- hide it
                 self.unmark_func = function()
                     self.unmark_func = nil
@@ -497,7 +497,7 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
                     -- documents): we drew our black marker in the margin, we
                     -- can just draw a white one to make it disappear
                     Screen.bb:paintRect(0, screen_y, marker_w, marker_h, Blitbuffer.COLOR_WHITE)
-                    Screen["refreshUI"](Screen, 0, screen_y, marker_w, marker_h)
+                    Screen["refreshFast"](Screen, 0, screen_y, marker_w, marker_h)
                 end
                 UIManager:scheduleIn(marker_setting, self.unmark_func)
             end

--- a/platform/kindle/extensions/koreader/README.txt
+++ b/platform/kindle/extensions/koreader/README.txt
@@ -12,7 +12,13 @@ K3 Yes
 K4 Yes
 Touch Yes
 PW Yes
+PW2 Yes
+KT Yes
 Voyage Yes
+PW3 Yes
+KOA Yes
+KT2 Yes
+KOA2 Yes
 
 REQUIRES: koreader
 

--- a/platform/kindle/extensions/koreader/config.xml
+++ b/platform/kindle/extensions/koreader/config.xml
@@ -2,7 +2,7 @@
 <extension>
 	<information>
 		<name>KOReader</name>
-		<version>0.2</version>
+		<version>1.0</version>
 		<author>KOReader Dev Team</author>
 		<id>KOReader</id>
 	</information>

--- a/platform/kindle/extensions/koreader/menu.json
+++ b/platform/kindle/extensions/koreader/menu.json
@@ -8,7 +8,7 @@
 			"name": "Start the filemanager",
 			"priority": 1,
 			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "/mnt/us/documents",
+			"params": "--kual /mnt/us/documents",
 			"status": false,
 			"internal": "status Start KOReader on the File Manager"
 		},
@@ -16,6 +16,7 @@
 			"name": "Open the last document",
 			"priority": 2,
 			"action": "/mnt/us/koreader/koreader.sh",
+			"params": "--kual",
 			"status": false,
 			"internal": "status Start KOReader on the last document"
 		},
@@ -23,7 +24,7 @@
 			"name": "Start the filemanager (no framework)",
 			"priority": 3,
 			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--framework_stop /mnt/us/documents",
+			"params": "--kual --framework_stop /mnt/us/documents",
 			"status": false,
 			"internal": "status Kill the framework and start KOReader's FM"
 		},
@@ -31,7 +32,7 @@
 			"name": "Open the last document (no framework)",
 			"priority": 4,
 			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--framework_stop",
+			"params": "--kual --framework_stop",
 			"status": false,
 			"internal": "status Kill the framework and start KOReader"
 		},
@@ -39,7 +40,7 @@
 			"name": "Start the filemanager (ASAP)",
 			"priority": 5,
 			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--asap /mnt/us/documents",
+			"params": "--kual --asap /mnt/us/documents",
 			"status": false,
 			"internal": "status Start KOreader on the File Manager ASAP"
 		},
@@ -47,7 +48,7 @@
 			"name": "Open the last document (ASAP)",
 			"priority": 6,
 			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--asap",
+			"params": "--kual --asap",
 			"status": false,
 			"internal": "status Start KOreader on the last document ASAP"
 		},

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -47,19 +47,28 @@ PILLOW_HARD_DISABLED="no"
 PILLOW_SOFT_DISABLED="no"
 PASSCODE_DISABLED="no"
 
+REEXEC_FLAGS=""
 # Keep track of if we were started through KUAL
-FROM_KUAL="no"
+if [ "${1}" = "--kual" ]; then
+    shift 1
+    FROM_KUAL="yes"
+    REEXEC_FLAGS="${REEXEC_FLAGS} --kual"
+else
+    FROM_KUAL="no"
+fi
 
 # By default, don't stop the framework.
-if [ "$1" = "--framework_stop" ]; then
+if [ "${1}" = "--framework_stop" ]; then
     shift 1
     STOP_FRAMEWORK="yes"
     NO_SLEEP="no"
-elif [ "$1" = "--asap" ]; then
+    REEXEC_FLAGS="${REEXEC_FLAGS} --framework_stop"
+elif [ "${1}" = "--asap" ]; then
     # Start as soon as possible, without sleeping to workaround UI quirks
     shift 1
     NO_SLEEP="yes"
     STOP_FRAMEWORK="no"
+    REEXEC_FLAGS="${REEXEC_FLAGS} --asap"
     # Don't sleep during eips calls either...
     export EIPS_NO_SLEEP="true"
 else
@@ -67,19 +76,19 @@ else
     NO_SLEEP="no"
 fi
 
-# Detect if we were started by KUAL by checking our nice value...
-if [ "$(nice)" = "5" ]; then
-    FROM_KUAL="yes"
-    if [ "${NO_SLEEP}" = "no" ]; then
-        # Yield a bit to let stuff stop properly...
-        logmsg "Hush now . . ."
-        # NOTE: This may or may not be terribly useful...
-        usleep 250000
-    fi
+# If we were started by KUAL (either Kindlet or Booklet), we have a few more things to do...
+if [ "${FROM_KUAL}" = "yes" ]; then
+    # Yield a bit to let stuff stop properly...
+    logmsg "Hush now . . ."
+    # NOTE: This may or may not be terribly useful...
+    usleep 250000
 
-    # Kindlet threads spawn with a nice value of 5, go back to a neutral value
-    logmsg "Be nice!"
-    renice -n -5 $$
+    # If we were started by the KUAL Kindlet, and not the Booklet, we have a nice value to correct...
+    if [ "$(nice)" = "5" ]; then
+        # Kindlet threads spawn with a nice value of 5, go back to a neutral value
+        logmsg "Be nice!"
+        renice -n -5 $$
+    fi
 fi
 
 # we're always starting from our working directory
@@ -120,8 +129,14 @@ ko_update_check() {
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
     fi
 }
-# NOTE: Keep doing an initial update check, in addition to one during the restart loop...
+# NOTE: Keep doing an initial update check, in addition to one during the restart loop, so we can pickup potential updates of this very script...
 ko_update_check
+# If an update happened, and was successful, reexec
+if [ -n "${fail}" ] && [ "${fail}" -eq 0 ]; then
+    # By now, we know we're in the right directory, and our script name is pretty much set in stone, so we can forgo using $0
+    # NOTE: REEXEC_FLAGS *needs* to be unquoted: we *want* word splitting here ;).
+    exec ./koreader.sh ${REEXEC_FLAGS} "${@}"
+fi
 
 # load our own shared libraries if possible
 export LD_LIBRARY_PATH="${KOREADER_DIR}/libs:${LD_LIBRARY_PATH}"

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -28,8 +28,13 @@ ko_update_check() {
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
     fi
 }
-# NOTE: Keep doing an initial update check, in addition to one during the restart loop...
+# NOTE: Keep doing an initial update check, in addition to one during the restart loop, so we can pickup potential updates of this very script...
 ko_update_check
+# If an update happened, and was successful, reexec
+if [ -n "${fail}" ] && [ "${fail}" -eq 0 ]; then
+    # By now, we know we're in the right directory, and our script name is pretty much set in stone, so we can forgo using $0
+    exec ./koreader.sh "${@}"
+fi
 
 # load our own shared libraries if possible
 export LD_LIBRARY_PATH="${KOREADER_DIR}/libs:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
So we can pickup potential updates to the startup script itself.

* Also, fix KUAL detection on Kindle when using the Booklet version of KUAL. (This requires an update of the KUAL extension!).