### PR TITLE
ReaderLink: allow following links to local files

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -395,14 +395,8 @@ function ReaderFont:buildFontsTestDocument()
     UIManager:show(ConfirmBox:new{
         text = T(_("Document created as:\n%1\n\nWould you like to read it now?"), fonts_test_path),
         ok_callback = function()
-            -- close current ReaderUI in 1 sec, and create a new one
             UIManager:scheduleIn(1.0, function()
-                local ReaderUI = require("apps/reader/readerui")
-                local reader = ReaderUI:_getRunningInstance()
-                if reader then
-                    reader:onClose()
-                end
-                ReaderUI:showReader(fonts_test_path)
+                self.ui:switchDocument(fonts_test_path)
             end)
         end,
     })

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -132,9 +132,8 @@ function ReaderStatus:openNextFile(next_file)
     end
     next_file = FileManager.instance.file_chooser:getNextFile(next_file)
     FileManager.instance:onClose()
-    local ReaderUI = require("apps/reader/readerui")
     if next_file then
-        ReaderUI:showReader(next_file)
+        self.ui:switchDocument(next_file)
     else
         UIManager:show(InfoMessage:new{
             text = _("This is the last file in the current folder. No next file to open."),

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -655,6 +655,7 @@ function ReaderUI:reloadDocument(after_close_callback)
     local provider = getmetatable(self.document).__index
     self:handleEvent(Event:new("CloseReaderMenu"))
     self:handleEvent(Event:new("CloseConfigMenu"))
+    self.highlight:onClose() -- close highlight dialog if any
     self:onClose()
     if after_close_callback then
         -- allow caller to do stuff between close an re-open
@@ -666,6 +667,7 @@ end
 function ReaderUI:switchDocument(new_file)
     self:handleEvent(Event:new("CloseReaderMenu"))
     self:handleEvent(Event:new("CloseConfigMenu"))
+    self.highlight:onClose() -- close highlight dialog if any
     self:onClose()
     self:showReader(new_file)
 end


### PR DESCRIPTION
Closes #3461.
Given that crengine is already reading buddy local files like linked images when rendering an HTML file, we can know navigate crawled/dumped web sites.

Also use the new ReaderUI:switchDocument(new_file) when already in ReaderUI in the other cases we switch document (so we have only one place to fix if need be).

I was a bit concerned while doing that about classic security issues when doing that, and wondered if we should add a checkbox to the `Links>` submenu: `Allow links to local files`.
But given we check it's a supported file (/etc/passwd is not), that our engine are quite dumb (no javascript engine to do malicious things), and that there is a ConfirmBox before following the link, we should be safe I think.
What do you think?

