### PR TITLE
VirtualKeyboard: scale icons to fit font height

### DIFF
--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -60,8 +60,14 @@ function VirtualKey:init()
 
     local label_widget
     if self.icon then
+        -- Scale icon to fit other characters height
+        -- (use *1.5 as our icons have a bit of white padding)
+        local icon_height = math.ceil(self.face.size * 1.5)
         label_widget = ImageWidget:new{
             file = self.icon,
+            scale_factor = 0, -- keep icon aspect ratio
+            height = icon_height,
+            width = icon_height * 100, -- to fit height when ensuring a/r
         }
     else
         label_widget = TextWidget:new{


### PR DESCRIPTION
As noticed in https://github.com/koreader/koreader/issues/3265#issuecomment-334292034, the 4 keys that use images could be too big or too small depending on screen size and DPI. They are now scaled in all cases to fit font height.

On my small emulator, before:
<kbd>![keyboard_before](https://user-images.githubusercontent.com/24273478/42509647-e6777062-844c-11e8-9100-7c8f959f339a.png)</kbd>

after:
<kbd>![keyboard_after](https://user-images.githubusercontent.com/24273478/42509649-e846a64c-844c-11e8-8485-3701171295e3.png)</kbd>

edit: I had a look and try at using various unicode symbols for these keys instead of our icons, but didn't find many unicode chars that looked as nice and fitting (size, weight, vertical alignment/centering) as our current icons - so best to stay with them.