### PR TITLE
Better display OpenWithDialog widget

### DIFF
--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -55,6 +55,7 @@ function CheckButton:initCheckButton(checked)
     self._textwidget = TextWidget:new{
         text = self.text,
         face = self.face,
+        max_width = self.max_width,
     }
     self._horizontalgroup = HorizontalGroup:new{
         self._checkmark,

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -34,6 +34,7 @@ local CheckButton = InputContainer:new{
     overlap_align = "right",
     text = nil,
     toggle_text = nil,
+    max_width = nil,
     window = nil,
 
     padding = Screen:scaleBySize(5),

--- a/frontend/ui/widget/openwithdialog.lua
+++ b/frontend/ui/widget/openwithdialog.lua
@@ -5,6 +5,7 @@ This widget displays an open with dialog.
 local Blitbuffer = require("ffi/blitbuffer")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local CheckButton = require("ui/widget/checkbutton")
+local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local InputDialog = require("ui/widget/inputdialog")
@@ -12,6 +13,7 @@ local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local RadioButtonTable = require("ui/widget/radiobuttontable")
 local Size = require("ui/size")
+local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local _ = require("gettext")
@@ -22,6 +24,7 @@ local OpenWithDialog = InputDialog:extend{}
 function OpenWithDialog:init()
     -- init title and buttons in base class
     InputDialog.init(self)
+    self.face = Font:getFace("cfont", 22)
 
     self.radio_button_table = RadioButtonTable:new{
         radio_buttons = self.radio_buttons,
@@ -29,6 +32,7 @@ function OpenWithDialog:init()
         focused = true,
         scroll = false,
         parent = self,
+        face = self.face,
     }
 
     self._check_file_button = self._check_file_button or CheckButton:new{
@@ -42,7 +46,9 @@ function OpenWithDialog:init()
         end,
 
         width = self.width * 0.9,
+        max_width = self.width * 0.9 - 2*Size.border.window,
         height = self.height,
+        face = self.face,
 
         parent = self,
     }
@@ -66,7 +72,9 @@ function OpenWithDialog:init()
         end,
 
         width = self.width * 0.9,
+        max_width = self.width * 0.9 - 2*Size.border.window,
         height = self.height,
+        face = self.face,
 
         parent = self,
     }
@@ -81,6 +89,7 @@ function OpenWithDialog:init()
 
     self.dialog_frame = FrameContainer:new{
         radius = Size.radius.window,
+        bordersize = Size.border.window,
         padding = 0,
         margin = 0,
         background = Blitbuffer.COLOR_WHITE,
@@ -151,6 +160,9 @@ function OpenWithDialog:init()
 end
 
 function OpenWithDialog:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "partial", self[1][1].dimen
+    end)
     return true
 end
 

--- a/frontend/ui/widget/radiobutton.lua
+++ b/frontend/ui/widget/radiobutton.lua
@@ -39,14 +39,17 @@ function RadioButton:init()
     self._checked_widget = TextWidget:new{
         text = "◉ " .. self.text,
         face = self.face,
+        max_width = self.max_width,
     }
     self._unchecked_widget = TextWidget:new{
         text = "◯ " .. self.text,
         face = self.face,
+        max_width = self.max_width,
     }
     self._empty_widget = TextWidget:new{
         text = "" .. self.text,
         face = self.face,
+        max_width = self.max_width,
     }
     self._widget_size = self._unchecked_widget:getSize()
     if self.width == nil then

--- a/frontend/ui/widget/radiobuttontable.lua
+++ b/frontend/ui/widget/radiobuttontable.lua
@@ -1,6 +1,7 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local Device = require("device")
 local FocusManager = require("ui/widget/focusmanager")
+local Font = require("ui/font")
 local Geom = require("ui/geometry")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local LineWidget = require("ui/widget/linewidget")
@@ -23,9 +24,7 @@ local RadioButtonTable = FocusManager:new{
     padding = Size.padding.button,
 
     zero_sep = false,
-    button_font_face = "cfont",
-    button_font_size = 20,
-
+    face = Font:getFace("cfont", 22),
     _first_button = nil,
     checked_button = nil,
 }
@@ -66,8 +65,7 @@ function RadioButtonTable:init()
                 bordersize = 0,
                 margin = 0,
                 padding = 0,
-                text_font_face = self.button_font_face,
-                text_font_size = self.button_font_size,
+                face = self.face,
 
                 show_parent = self.show_parent or self,
                 parent = self.parent or self,


### PR DESCRIPTION
* add refresh after tap Cancel button,
* radiobutton and checkbutton with the same font size,
* truncates text outside window,
* better control font face and size in OpenWithDialog and RadioButtonTable widgets,

Before:
![a - koreader_122](https://user-images.githubusercontent.com/22982594/42733904-afa936fa-883a-11e8-9e3a-4d14b950936d.png)

After:
![a - koreader_123](https://user-images.githubusercontent.com/22982594/42733905-b454c73c-883a-11e8-834a-00f551774b1f.png)
![a - koreader_124](https://user-images.githubusercontent.com/22982594/42733906-b816e80a-883a-11e8-9284-08fb5a7e6b2e.png)

