### PR TITLE
Bookmarks, CoverBrowser: scale dogear icon

### DIFF
--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -54,6 +54,11 @@ function ReaderDogear:onReadSettings(config)
 end
 
 function ReaderDogear:onSetPageMargins(margins)
+    if self.ui.document.info.has_pages then
+        -- we may get called by readerfooter (when hiding the footer)
+        -- on pdf documents and get margins=nil
+        return
+    end
     local margin_top, margin_right = margins[2], margins[3]
     -- As the icon is squared, we can take the max() instead of the min() of
     -- top & right margins and be sure no text is hidden by the icon

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -142,9 +142,9 @@ function ImageWidget:_loadfile()
         end
         local hash = "image|"..self.file.."|"..(width or "").."|"..(height or "")
         -- Do the scaling for DPI here, so it can be cached and not re-done
-        -- each time in _render()
+        -- each time in _render() (but not if scale_factor, to avoid double scaling)
         local scale_for_dpi_here = false
-        if self.scale_for_dpi and DPI_SCALE ~= 1 then
+        if self.scale_for_dpi and DPI_SCALE ~= 1 and not self.scale_factor then
             scale_for_dpi_here = true -- we'll do it before caching
             hash = hash .. "|d"
             self.already_scaled_for_dpi = true -- so we don't do it again in _render()

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -255,6 +255,26 @@ end
 -- Bookinfo management
 function BookInfoManager:getBookInfo(filepath, get_cover)
     local directory, filename = splitFilePathName(filepath)
+
+    -- CoverBrowser may be used by PathChooser, which will not filter out
+    -- files with unknown book extension. If not a supported extension,
+    -- returns a bookinfo like-object enough for a correct display and
+    -- to not trigger extraction, so we don't clutter DB with such files.
+    if not DocumentRegistry:hasProvider(filepath) then
+        return {
+            directory = directory,
+            filename = filename,
+            in_progress = 0,
+            cover_fetched = "Y",
+            has_meta = nil,
+            has_cover = nil,
+            ignore_meta = "Y",
+            ignore_cover = "Y",
+            -- for ListMenu to show the filename *with* suffix:
+            _no_provider = true
+        }
+    end
+
     self:openDbConnection()
     local row = self.get_stmt:bind(directory, filename):step()
     self.get_stmt:clearbind():reset() -- get ready for next query

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -36,10 +36,10 @@ local BookInfoManager = require("bookinfomanager")
 
 -- We will show a rotated dogear at bottom right corner of cover widget for
 -- opened files (the dogear will make it look like a "used book")
-local corner_mark = ImageWidget:new{
-    file = "resources/icons/dogear.png",
-    rotation_angle = 270
-}
+-- The ImageWidget Will be created when we know the available height (and
+-- recreated if height changes)
+local corner_mark_size = -1
+local corner_mark
 
 -- ItemShortCutIcon (for keyboard navigation) is private to menu.lua and can't be accessed,
 -- so we need to redefine it
@@ -605,7 +605,7 @@ function MosaicMenuItem:paintTo(bb, x, y)
     end
 
     -- to which we paint over a dogear if needed
-    if self.do_hint_opened and self.been_opened then
+    if corner_mark and self.do_hint_opened and self.been_opened then
         -- align it on bottom right corner of sub-widget
         local target =  self[1][1][1]
         local ix = self.width - math.ceil((self.width - target.dimen.w)/2) - corner_mark:getSize().w
@@ -713,6 +713,22 @@ function MosaicMenu:_recalculateDimen()
         w = self.item_width,
         h = self.item_height
     }
+
+    -- Create or replace corner_mark if needed
+    -- 1/12 (larger) or 1/16 (smaller) of cover looks allright
+    local mark_size = math.floor(math.min(self.item_width, self.item_height) / 16)
+    if mark_size ~= corner_mark_size then
+        corner_mark_size = mark_size
+        if corner_mark then
+            corner_mark:free()
+        end
+        corner_mark = ImageWidget:new{
+            file = "resources/icons/dogear.png",
+            rotation_angle = 270,
+            width = corner_mark_size,
+            height = corner_mark_size,
+        }
+    end
 end
 
 function MosaicMenu:_updateItemsBuildUI()


### PR DESCRIPTION
The Dogear icon is 20x20 pixels and was never scaled where used. Now:

The bookmark icon (top right of screen) is scaled to 1/32th of the screen width (previously, it was 1/30th on a 600px wide emulator, 1/53th on a GloHD).
So, it should stay the same size on a small emulator, and become 2 times bigger on a 1000px device.
1/32 looks like this:
<kbd>![after_pdf_bookmark](https://user-images.githubusercontent.com/24273478/42754452-cc3d15ec-88f4-11e8-8fb3-257c0e404ae0.png)</kbd>

On CreDocument, furthermore decrease its size if needed depending on the selected margins so it never overwrite the text (as margins are scaled for DPI, this somehow scale the icon for dpi too).
Before => after
<kbd>![before_bookmark](https://user-images.githubusercontent.com/24273478/42754439-c765f64c-88f4-11e8-81c1-7b0a5e853fd6.png)</kbd> => <kbd>![after_crebookmark](https://user-images.githubusercontent.com/24273478/42754445-c9b34c74-88f4-11e8-8a01-22d2531a9f52.png)</kbd>

CoverBrowser list view: scale it to the available room under the "N % of P page" text, so it does not cover "page".
<kbd>![before_listmenu](https://user-images.githubusercontent.com/24273478/42754575-47f4bf0a-88f5-11e8-9841-8af725ac5593.png)</kbd> => <kbd>![after_listmenu](https://user-images.githubusercontent.com/24273478/42754579-4b1b3ec0-88f5-11e8-9f96-c8ed601f7507.png)</kbd>

CoverBrowser mosaic view: scale it to 1/16th of the cover rectangle, which should prevent if from overwritting the text thanks to a max text width of 7/8 of the cover rectangle.

<kbd>![before_mosaicmenu](https://user-images.githubusercontent.com/24273478/42754594-58f581c2-88f5-11e8-9218-dbc70738971f.png)</kbd>
=>
<kbd>![after_mosaicmenu](https://user-images.githubusercontent.com/24273478/42754601-5c09eca4-88f5-11e8-893f-89a872d7a1bf.png)</kbd>

The above CoverBrowser screenshots were made on the emulator, and the icon size looks divided by 2. But the after size is actually how it looked before and still looks after on a GloHD.

Also for CoverBrowser: don't index metadata for unsupported document (which could happen when browsing files with PathChooser) and show full filename for such documents.

Also: ImageWidget: small fix in case we use both scale_factor and scale_for_dpi.

The 1/32 (for bookmark icons) and 1/16 (for coverbrowser mosaic view) can be changed if people find it too big or too small (they fit my liking, I like things small, but strangely, I don't bother the bigger bookmark icon).

Close #3265. Close #4046.