### PR TITLE
Make findcalibre actually useful

### DIFF
--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -83,7 +83,7 @@ function Search:getCalibre()
         end
     else
         if string.sub(SEARCH_LIBRARY_PATH, string.len(SEARCH_LIBRARY_PATH)) ~= "/" then
-            SEARCH_LIBRARY_PATH = SEARCH_LIBRARY_PATH .. "/"  -- luacheck: ignore
+            _G['SEARCH_LIBRARY_PATH'] = SEARCH_LIBRARY_PATH .. "/"
         end
         if io.open(SEARCH_LIBRARY_PATH .. calibre, "r") == nil then
             if io.open(SEARCH_LIBRARY_PATH .. "." .. calibre, "r") == nil then
@@ -107,7 +107,7 @@ function Search:getCalibre()
     local dummy
 
     if string.sub(SEARCH_LIBRARY_PATH2, string.len(SEARCH_LIBRARY_PATH2)) ~= "/" then
-        SEARCH_LIBRARY_PATH2 = SEARCH_LIBRARY_PATH2 .. "/"  -- luacheck: ignore
+        _G['SEARCH_LIBRARY_PATH2'] = SEARCH_LIBRARY_PATH2 .. "/"
     end
     if io.open(SEARCH_LIBRARY_PATH2 .. calibre, "r") == nil then
         if io.open(SEARCH_LIBRARY_PATH2 .. "." .. calibre, "r") ~= nil then

--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -60,7 +60,7 @@ local function findcalibre(root)
                             -- NOTE: No-one should actually rely on that, as the value is *NEVER* saved to the defaults.
                             --       (SetDefaults can only do that with values modified from within its own advanced menu).
                             _G['SEARCH_LIBRARY_PATH'] = root .. "/"
-                            logger.info("Found a SEARCH_LIBRARY_PATH @", SEARCH_LIBRARY_PATH)
+                            logger.info("FMSearch: Found a SEARCH_LIBRARY_PATH @", SEARCH_LIBRARY_PATH)
                         end
                     elseif mode == "directory" then
                         t = findcalibre(fullPath)
@@ -131,11 +131,11 @@ function Search:getCalibre()
                 if self.metafile_2 then
                     if lfs.attributes(koreaderfile, "modification") > lfs.attributes(self.metafile_2, "modification") then
                         self.use_own_metadata_file = true
-                        logger.info("Using our own simplified metadata file as it's newer (", lfs.attributes(koreaderfile, "modification"), ") than", self.metafile_2, "(", lfs.attributes(self.metafile_2, "modification"), ")")
+                        logger.info("FMSearch: Using our own simplified metadata file as it's newer than", self.metafile_2)
                     end
                 else
                     self.use_own_metadata_file = true
-                    logger.info("Using our own simplified metadata file as it's newer (", lfs.attributes(koreaderfile, "modification"), ") than", self.metafile_1, "(", lfs.attributes(self.metafile_1, "modification"), ")")
+                    logger.info("FMSearch: Using our own simplified metadata file as it's newer than", self.metafile_1)
                 end
             end
         end
@@ -379,7 +379,7 @@ function Search:find(option)
             end
         end
         if not self.use_own_metadata_file then
-            logger.info("Writing our own simplified metadata file . . .")
+            logger.info("FMSearch: Writing our own simplified metadata file . . .")
             local g = io.open(koreaderfile, "w")
             g:write("#metadata.koreader Version 1.1\n")
 

--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -51,7 +51,7 @@ local function findcalibre(root)
             else
                 if entity ~= "." and entity ~= ".." then
                     local fullPath=root .. "/" .. entity
-                    local mode = lfs.attributes(fullPath,"mode")
+                    local mode = lfs.attributes(fullPath, "mode")
                     if mode == "file" then
                         if entity == calibre or entity == "." .. calibre then
                             t = root .. "/" .. entity
@@ -127,13 +127,15 @@ function Search:getCalibre()
     if self.metafile_1 then
         pcall(lfs.mkdir("temp"))
         if io.open(koreaderfile, "r") then
-            if lfs.attributes(koreaderfile).modification > lfs.attributes(self.metafile_1).modification then
+            if lfs.attributes(koreaderfile, "modification") > lfs.attributes(self.metafile_1, "modification") then
                 if self.metafile_2 then
-                    if lfs.attributes(koreaderfile).modification > lfs.attributes(self.metafile_2).modification then
+                    if lfs.attributes(koreaderfile, "modification") > lfs.attributes(self.metafile_2, "modification") then
                         self.use_own_metadata_file = true
+                        logger.info("Using our own simplified metadata file as it's newer (", lfs.attributes(koreaderfile, "modification"), ") than", self.metafile_2, "(", lfs.attributes(self.metafile_2, "modification"), ")")
                     end
                 else
                     self.use_own_metadata_file = true
+                    logger.info("Using our own simplified metadata file as it's newer (", lfs.attributes(koreaderfile, "modification"), ") than", self.metafile_1, "(", lfs.attributes(self.metafile_1, "modification"), ")")
                 end
             end
         end
@@ -375,6 +377,7 @@ function Search:find(option)
             end
         end
         if not self.use_own_metadata_file then
+            logger.info("Writing our own simplified metadata file . . .")
             local g = io.open(koreaderfile, "w")
             g:write("#metadata.koreader Version 1.1\n")
 
@@ -454,14 +457,14 @@ function Search:find(option)
                 end
             end
             g.close()
-            if lfs.attributes(koreaderfile).modification < lfs.attributes(self.metafile_1).modification then
+            if lfs.attributes(koreaderfile, "modification") < lfs.attributes(self.metafile_1, "modification") then
                 lfs.touch(koreaderfile,
-                          lfs.attributes(self.metafile_1).modification + 1,
-                          lfs.attributes(self.metafile_1).modification + 1)
+                          lfs.attributes(self.metafile_1, "modification") + 1,
+                          lfs.attributes(self.metafile_1, "modification") + 1)
             end
             if self.metafile_2 then
-                if lfs.attributes(koreaderfile).modification < lfs.attributes(self.metafile_2).modification then
-                    lfs.touch(koreaderfile, lfs.attributes(self.metafile_2).modification + 1, lfs.attributes(self.metafile_2).modification + 1)
+                if lfs.attributes(koreaderfile, "modification") < lfs.attributes(self.metafile_2, "modification") then
+                    lfs.touch(koreaderfile, lfs.attributes(self.metafile_2, "modification") + 1, lfs.attributes(self.metafile_2, "modification") + 1)
                 end
             end
         end

--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -59,8 +59,8 @@ local function findcalibre(root)
                             -- so that we actually can convert a book's relative path to its absolute path.
                             -- NOTE: No-one should actually rely on that, as the value is *NEVER* saved to the defaults.
                             --       (SetDefaults can only do that with values modified from within its own advanced menu).
-                            logger.info("Found a SEARCH_LIBRARY_PATH @", root .. "/")
-                            SEARCH_LIBRARY_PATH = root .. "/"
+                            _G['SEARCH_LIBRARY_PATH'] = root .. "/"
+                            logger.info("Found a SEARCH_LIBRARY_PATH @", SEARCH_LIBRARY_PATH)
                         end
                     elseif mode == "directory" then
                         t = findcalibre(fullPath)

--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -243,7 +243,7 @@ function Search:find(option)
     local firstrun
 
     -- removes leading and closing characters and converts hex-unicodes
-    local ReplaceHexChars = function(s,n,j)
+    local ReplaceHexChars = function(s, n, j)
         local l=string.len(s)
 
         if string.sub(s, l, l) == "\"" then
@@ -252,7 +252,7 @@ function Search:find(option)
             s=string.sub(s, n, string.len(s)-j)
         end
 
-        s=string.gsub(s,"\\u([a-f0-9][a-f0-9][a-f0-9][a-f0-9])",function(w) return util.unichar(tonumber(w, 16)) end)
+        s=string.gsub(s, "\\u([a-f0-9][a-f0-9][a-f0-9][a-f0-9])", function(w) return util.unichar(tonumber(w, 16)) end)
 
         return s
     end
@@ -269,11 +269,11 @@ function Search:find(option)
         while line ~= "    ], " and line ~= "    ]" do
             line = f:read()
             if line ~= "    ], " and line ~= "    ]" then
-                self.data[i][s] = self.data[i][s] .. "," .. ReplaceHexChars(line,8,3)
+                self.data[i][s] = self.data[i][s] .. "," .. ReplaceHexChars(line, 8, 3)
                 if s == self.authors then
-                    self.data[i][self.authors2] = self.data[i][self.authors2] .. " & " .. ReplaceHexChars(line,8,3)
+                    self.data[i][self.authors2] = self.data[i][self.authors2] .. " & " .. ReplaceHexChars(line, 8, 3)
                 elseif s == self.tags then
-                    local tags_line = ReplaceHexChars(line,8,3)
+                    local tags_line = ReplaceHexChars(line, 8, 3)
                     self.data[i][self.tags2] = self.data[i][self.tags2] .. " & " .. tags_line
                     self.data[i][self.tags3] = self.data[i][self.tags3] .. "\t" .. tags_line
                     self.browse_tags[tags_line] = (self.browse_tags[tags_line] or 0) + 1
@@ -348,7 +348,7 @@ function Search:find(option)
                     end
                     if DocumentRegistry:hasProvider(self.data[i][self.path]) then
                         if upsearch ~= "" then
-                            if string.find(search_content,upsearch,nil,true) then
+                            if string.find(search_content, upsearch, nil, true) then
                                 i = i + 1
                             end
                         else
@@ -400,7 +400,7 @@ function Search:find(option)
                     end
 
                     if upsearch ~= "" then
-                        if string.find(search_content,upsearch,nil,true) then
+                        if string.find(search_content, upsearch, nil, true) then
                             i = i + 1
                         end
                     else
@@ -410,7 +410,7 @@ function Search:find(option)
                             end
                         elseif option == "tags" then
                             local found = false
-                            for j in string.gmatch(self.data[i][self.tags3],"\t[^\t]+") do
+                            for j in string.gmatch(self.data[i][self.tags3], "\t[^\t]+") do
                                 if j~="\t" and self.browse_tags[string.sub(j, 2)] then
                                     found = true
                                 end
@@ -428,18 +428,18 @@ function Search:find(option)
                 elseif line == "    \"tags\": [" then -- TAGS
                     ReadMultipleLines(self.tags)
                 elseif string.sub(line, 1, 11) == "    \"title\"" then -- TITLE
-                    self.data[i][self.title] = ReplaceHexChars(line,15,3)
+                    self.data[i][self.title] = ReplaceHexChars(line, 15, 3)
                 elseif string.sub(line, 1, 11) == "    \"lpath\"" then -- LPATH
-                    self.data[i][self.path] = ReplaceHexChars(line,15,3)
+                    self.data[i][self.path] = ReplaceHexChars(line, 15, 3)
                     if firstrun then
                         self.data[i][self.path] = SEARCH_LIBRARY_PATH .. self.data[i][self.path]
                     else
                         self.data[i][self.path] = SEARCH_LIBRARY_PATH2 .. self.data[i][self.path]
                     end
                 elseif string.sub(line, 1, 12) == "    \"series\"" and line ~= "    \"series\": null, " then -- SERIES
-                    self.data[i][self.series] = ReplaceHexChars(line,16,3)
+                    self.data[i][self.series] = ReplaceHexChars(line, 16, 3)
                 elseif string.sub(line, 1, 18) == "    \"series_index\"" and line ~= "    \"series_index\": null, " then -- SERIES_INDEX
-                    self.data[i][self.series_index] = ReplaceHexChars(line,21,2)
+                    self.data[i][self.series_index] = ReplaceHexChars(line, 21, 2)
                 end
                 line = f:read()
 
@@ -491,7 +491,7 @@ function Search:onMenuHold(item)
         if f == nil then
             item.info = item.info .. "\n" .. _("File not found!")
         else
-            item.info = item.info .. "\n" .. _("Size:") .. " " .. string.format("%4.1fM",lfs.attributes(item.path, "size")/1024/1024)
+            item.info = item.info .. "\n" .. _("Size:") .. " " .. string.format("%4.1fM", lfs.attributes(item.path, "size")/1024/1024)
             f:close()
         end
         item.notchecked = false
@@ -599,7 +599,7 @@ function Search:browse(option, run, chosen)
             for v,n in util.orderedPairs(self.browse_series) do
                 dummy = v
                 if not SEARCH_CASESENSITIVE then dummy = string.upper(dummy) end
-                if string.find(dummy,upsearch,nil,true) then
+                if string.find(dummy, upsearch, nil, true) then
                     table.insert(self.results, {
                         text = v .. " (" .. tostring(self.browse_series[v]) .. ")",
                         callback = function()
@@ -612,7 +612,7 @@ function Search:browse(option, run, chosen)
             for v,n in util.orderedPairs(self.browse_tags) do
                 dummy = v
                 if not SEARCH_CASESENSITIVE then dummy = string.upper(dummy) end
-                if string.find(dummy,upsearch,nil,true) then
+                if string.find(dummy, upsearch, nil, true) then
                     table.insert(self.results, {
                         text = v .. " (" .. tostring(self.browse_tags[v]) .. ")",
                         callback = function()
@@ -642,7 +642,7 @@ function Search:browse(option, run, chosen)
                     if self.data[i][self.series_index] == "0.0" then
                         text = self.data[i][self.title] .. " (" .. self.data[i][self.authors] .. ")"
                     else
-                        text = string.format("%6.1f",self.data[i][self.series_index]:gsub(".0$","")) .. ": " .. self.data[i][self.title] .. " (" .. self.data[i][self.authors] .. ")"
+                        text = string.format("%6.1f", self.data[i][self.series_index]:gsub(".0$","")) .. ": " .. self.data[i][self.title] .. " (" .. self.data[i][self.authors] .. ")"
                     end
                 else
                     text = self.data[i][self.authors] .. ": " .. self.data[i][self.title]

--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -311,7 +311,7 @@ function Search:find(option)
             local g = io.open(koreaderfile, "r")
             line = g:read()
             if line ~= "#metadata.Koreader Version 1.1" and line ~= "#metadata.koreader Version 1.1" then
-                self.use_own_metadata_file =  false
+                self.use_own_metadata_file = false
                 g:close()
             else
                 line = g:read()
@@ -348,6 +348,8 @@ function Search:find(option)
                             self.browse_tags[string.sub(j, 2)] = (self.browse_tags[string.sub(j, 2)] or 0) + 1
                         end
                     end
+                    -- NOTE: This skips kePubs downloaded by nickel, because they don't have a file extension,
+                    --       they're stored as .kobo/kepub/<UUID>
                     if DocumentRegistry:hasProvider(self.data[i][self.path]) then
                         if upsearch ~= "" then
                             if string.find(search_content, upsearch, nil, true) then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -123,7 +123,7 @@ local KoboSnow = Kobo:new{
 }
 
 -- Kobo Aura H2O2, Rev2:
--- FIXME: Shares FL/NaturalLight issues with the Clara (#4015)
+-- FIXME: Check if the Clara fix actually helps here... (#4015)
 local KoboSnowRev2 = Kobo:new{
     model = "Kobo_snow",
     hasFrontlight = yes,
@@ -134,8 +134,8 @@ local KoboSnowRev2 = Kobo:new{
     hasNaturalLight = yes,
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/lm3630a_ledb",
-        frontlight_red = "/sys/class/backlight/lm3630a_led",
-        frontlight_green = "/sys/class/backlight/lm3630a_leda",
+        frontlight_red = "/sys/class/backlight/lm3630a_leda",
+        frontlight_green = "/dev/null",
     },
 }
 
@@ -179,7 +179,6 @@ local KoboPika = Kobo:new{
 }
 
 -- Kobo Clara HD:
--- FIXME: Check that NaturalLight behaves properly (c.f., #4015)
 local KoboNova = Kobo:new{
     model = "Kobo_nova",
     hasFrontlight = yes,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -189,7 +189,11 @@ local KoboNova = Kobo:new{
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/lm3630a_ledb",
         frontlight_red = "/sys/class/backlight/lm3630a_leda",
-        frontlight_green = "/sys/class/backlight/lm3630a_led1b",
+        -- NOTE: There doesn't appear to be a dedicated "green" LED, instead,
+        --       there's a knob that mixes the white & red ones together (/sys/class/backlight/lm3630a_led).
+        --       c.f., https://www.mobileread.com/forums/showpost.php?p=3728236&postcount=2947
+        --       Because I'm not familiar with sysfs_light.lua, just throw green into the void, and hope for the best...
+        frontlight_green = "/dev/null",
     },
 }
 

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -108,14 +108,18 @@ function ScrollTextWidget:getCharPos()
     return self.text_widget:getCharPos()
 end
 
-function ScrollTextWidget:updateScrollBar()
+function ScrollTextWidget:updateScrollBar(is_partial)
     local low, high = self.text_widget:getVisibleHeightRatios()
     if low ~= self.prev_low or high ~= self.prev_high then
         self.prev_low = low
         self.prev_high = high
         self.v_scroll_bar:set(low, high)
+        local refreshfunc = "ui"
+        if is_partial then
+            refreshfunc = "partial"
+        end
         UIManager:setDirty(self.dialog, function()
-            return "partial", self.dimen
+            return refreshfunc, self.dimen
         end)
     end
 end
@@ -152,22 +156,22 @@ end
 
 function ScrollTextWidget:scrollDown()
     self.text_widget:scrollDown();
-    self:updateScrollBar()
+    self:updateScrollBar(true)
 end
 
 function ScrollTextWidget:scrollUp()
     self.text_widget:scrollUp();
-    self:updateScrollBar()
+    self:updateScrollBar(true)
 end
 
 function ScrollTextWidget:scrollToTop()
     self.text_widget:scrollToTop();
-    self:updateScrollBar()
+    self:updateScrollBar(true)
 end
 
 function ScrollTextWidget:scrollToBottom()
     self.text_widget:scrollToBottom();
-    self:updateScrollBar()
+    self:updateScrollBar(true)
 end
 
 function ScrollTextWidget:scrollText(direction)
@@ -177,12 +181,12 @@ function ScrollTextWidget:scrollText(direction)
     else
         self.text_widget:scrollUp()
     end
-    self:updateScrollBar()
+    self:updateScrollBar(true)
 end
 
 function ScrollTextWidget:scrollToRatio(ratio)
     self.text_widget:scrollToRatio(ratio)
-    self:updateScrollBar()
+    self:updateScrollBar(true)
 end
 
 function ScrollTextWidget:onScrollText(arg, ges)


### PR DESCRIPTION
By setting SEARCH_LIBRARY_PATH when a Calibre tree is found, so that
book paths can properly be constructed.

Users should still very much set it themselves, but at least everything
works as intended when not, instead of mysteriously half-breaking later.

Drop the SetDefaults bits, it appeared to have been added to fix no-ops
detected by Luacheck, and it's actually non-functional, because
SetDefaults doesn't handle saving variables it did not itself assign.
So this was just causing the "Do you want to save new defaults" popup to
show up on exit, but it couldn't actually do anything useful (like, say,
save the new SEARCH_LIBRARY_PATH value).

fix #4082