### PR TITLE
Allow select single image as screensaver

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -152,7 +152,7 @@ function ReaderMenu:setUpdateItemTable()
             text = _("Screensaver"),
             sub_item_table = require("ui/elements/screensaver_menu"),
         }
-        table.remove(self.menu_items.screensaver.sub_item_table, 8)
+        table.remove(self.menu_items.screensaver.sub_item_table, 9)
         table.insert(self.menu_items.screensaver.sub_item_table, ss_book_settings)
     end
     -- main menu tab
@@ -320,10 +320,10 @@ end
 
 function ReaderMenu:onCloseDocument()
     if Device:supportsScreensaver() then
-        -- Remove the 8th item we added (which cleans up references to document
+        -- Remove the 9th item we added (which cleans up references to document
         -- and doc_settings embedded in functions)
         local screensaver_sub_item_table = require("ui/elements/screensaver_menu")
-        table.remove(screensaver_sub_item_table, 8)
+        table.remove(screensaver_sub_item_table, 9)
     end
 end
 

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -56,6 +56,19 @@ return {
         end
     },
     {
+        text = _("Use image as screensaver"),
+        checked_func = function()
+            if screensaverType() == "image_file" then
+                return true
+            else
+                return false
+            end
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "image_file")
+        end
+    },
+    {
         text = _("Use reading progress as screensaver"),
         enabled_func = function() return Screensaver.getReaderProgress ~= nil and lastFile() ~= nil end,
         checked_func = function()
@@ -102,6 +115,12 @@ return {
                 text = _("Screensaver folder"),
                 callback = function()
                     Screensaver:chooseFolder()
+                end,
+            },
+            {
+                text = _("Screensaver image"),
+                callback = function()
+                    Screensaver:chooseFile()
                 end,
             },
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -99,7 +99,6 @@ function Screensaver:chooseFile()
                     local image_chooser = FileChooser:new{
                     title = _("Choose screensaver image"),
                     no_title = false,
-                    is_popout = false,
                     path = self.root_path,
                     focused_path = self.focused_file,
                     collate = G_reader_settings:readSetting("collate") or "strcoll",

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -316,6 +316,9 @@ function Screensaver:show(event, fallback_message)
     end
     if screensaver_type == "image_file" then
         local screensaver_image = G_reader_settings:readSetting(prefix.."screensaver_image")
+        if screensaver_image == nil and prefix ~= "" then
+            screensaver_image = G_reader_settings:readSetting("screensaver_image")
+        end
         if screensaver_image == nil then
             screensaver_image = DataStorage:getDataDir() .. "/resources/koreader.png"
         end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -1,6 +1,7 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
+local DataStorage = require("datastorage")
 local Device = require("device")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
@@ -78,11 +79,76 @@ function Screensaver:chooseFolder()
     })
     local screensaver_dir = G_reader_settings:readSetting("screensaver_dir")
     if screensaver_dir == nil then
-        local DataStorage = require("datastorage")
         screensaver_dir = DataStorage:getDataDir() .. "/screenshots/"
     end
     self.choose_dialog = ButtonDialogTitle:new{
         title = T(_("Current screensaver image directory:\n %1"), screensaver_dir),
+        buttons = buttons
+    }
+    UIManager:show(self.choose_dialog)
+end
+
+function Screensaver:chooseFile()
+    local buttons = {}
+    table.insert(buttons, {
+        {
+            text = _("Choose screensaver image"),
+            callback = function()
+                UIManager:close(self.choose_dialog)
+                local FileChooser = require("ui/widget/filechooser")
+                    local image_chooser = FileChooser:new{
+                    title = _("Choose screensaver image"),
+                    no_title = false,
+                    is_popout = false,
+                    path = self.root_path,
+                    focused_path = self.focused_file,
+                    collate = G_reader_settings:readSetting("collate") or "strcoll",
+                    reverse_collate = G_reader_settings:isTrue("reverse_collate"),
+                    show_parent = self.show_parent,
+                    width = Screen:getWidth(),
+                    height = Screen:getHeight(),
+                    is_popout = false,
+                    is_borderless = true,
+                    has_close_button = true,
+                    perpage = G_reader_settings:readSetting("items_per_page"),
+                    file_filter = function(filename)
+                        local util = require("util")
+                        local suffix = util.getFileNameSuffix(filename)
+                        if suffix == "jpeg" or suffix == "jpg" or suffix == "png" then
+                            return true
+                        end
+                    end,
+                }
+                function image_chooser:onFileSelect(file)  -- luacheck: ignore
+                    local ConfirmBox = require("ui/widget/confirmbox")
+                    UIManager:show(ConfirmBox:new{
+                        text = T(_("Set screensaver image to:\n%1"), require("ffi/util").basename(file)),
+                        ok_callback = function()
+                            G_reader_settings:saveSetting("screensaver_image", file)
+                            UIManager:close(image_chooser)
+                        end
+                    })
+                    return true
+                end
+
+                UIManager:show(image_chooser)
+            end,
+        }
+    })
+    table.insert(buttons, {
+        {
+            text = _("Close"),
+            callback = function()
+                UIManager:close(self.choose_dialog)
+            end,
+        }
+    })
+    local screensaver_image = G_reader_settings:readSetting("screensaver_image")
+    if screensaver_image == nil then
+        screensaver_image = DataStorage:getDataDir() .. "/resources/koreader.png"
+    end
+    self.choose_dialog = ButtonDialogTitle:new{
+        title = T(_("Current screensaver image:\n %1"), screensaver_image),
         buttons = buttons
     }
     UIManager:show(self.choose_dialog)
@@ -230,7 +296,6 @@ function Screensaver:show(event, fallback_message)
     if screensaver_type == "random_image" then
         local screensaver_dir = G_reader_settings:readSetting(prefix.."screensaver_dir")
         if screensaver_dir == nil then
-            local DataStorage = require("datastorage")
             screensaver_dir = DataStorage:getDataDir() .. "/screenshots/"
         end
         local image_file = getRandomImage(screensaver_dir)
@@ -239,6 +304,27 @@ function Screensaver:show(event, fallback_message)
         else
             widget = ImageWidget:new{
                 file = image_file,
+                file_do_cache = false,
+                alpha = true,
+                height = Screen:getHeight(),
+                width = Screen:getWidth(),
+                scale_factor = not self:stretchImages() and 0 or nil,
+            }
+            if not self:whiteBackground() then
+                background = Blitbuffer.COLOR_BLACK
+            end
+        end
+    end
+    if screensaver_type == "image_file" then
+        local screensaver_image = G_reader_settings:readSetting(prefix.."screensaver_image")
+        if screensaver_image == nil then
+            screensaver_image = DataStorage:getDataDir() .. "/resources/koreader.png"
+        end
+        if  lfs.attributes(screensaver_image, "mode") ~= "file" then
+            screensaver_type = "message"
+        else
+            widget = ImageWidget:new{
+                file = screensaver_image,
                 file_do_cache = false,
                 alpha = true,
                 height = Screen:getHeight(),

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -294,6 +294,9 @@ function Screensaver:show(event, fallback_message)
     end
     if screensaver_type == "random_image" then
         local screensaver_dir = G_reader_settings:readSetting(prefix.."screensaver_dir")
+        if screensaver_dir == nil and prefix ~= "" then
+            screensaver_dir = G_reader_settings:readSetting("screensaver_dir")
+        end
         if screensaver_dir == nil then
             screensaver_dir = DataStorage:getDataDir() .. "/screenshots/"
         end
@@ -350,6 +353,9 @@ function Screensaver:show(event, fallback_message)
         if not self:whiteBackground() then
             background = nil -- no background filling, let book text visible
             covers_fullscreen = false
+        end
+        if screensaver_message == nil and prefix ~= "" then
+            screensaver_message = G_reader_settings:readSetting("screensaver_message")
         end
         if screensaver_message == nil then
             screensaver_message = fallback_message or default_screensaver_message


### PR DESCRIPTION
This PR adds support for setting single image as screensaver.
You can activate this function in `Screensaver -> Use image as screensaver`
![aaa - koreader_129](https://user-images.githubusercontent.com/22982594/43045014-dd7dff4a-8db0-11e8-81f9-7f5f1b8f7a11.png)

You can select image to dispaly in `Screensaver -> Settings -> Screensaver image` 
![aaa - koreader_130](https://user-images.githubusercontent.com/22982594/43045022-f6a2591c-8db0-11e8-9cfe-86d565a02f69.png)

default is /resources/koreader.png
![a - koreader_131](https://user-images.githubusercontent.com/22982594/43045032-205aec9c-8db1-11e8-994a-3f1bc1191c24.png)

You can choose a different file in `Choose screensaver image` 
![koreader - koreader_132](https://user-images.githubusercontent.com/22982594/43045042-5d29a370-8db1-11e8-8395-3a7c8638e4f1.png)



