### PR TITLE
Change default widget from GoTo to SkimTo after long press on footer

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -688,7 +688,7 @@ end
 
 function ReaderFooter:onHoldFooter()
     if self.mode == MODE.off then return end
-    self.ui:handleEvent(Event:new("ShowGotoDialog"))
+    self.ui:handleEvent(Event:new("ShowSkimtoDialog"))
     return true
 end
 


### PR DESCRIPTION
See comment: https://github.com/koreader/koreader/issues/4094#issuecomment-406858743

> And launch the SkimTo widget instead of the Goto widget. The SkimTo widget is more pratical, and it looks more logical: you tap on the footer which usually displays the progress bar: launch a widget that display the same kind of progress bar that you can additionally tap on to go to that position.