### PR TITLE
Smaller default touch zone for footer (minibar)

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -70,7 +70,7 @@ FOLLOW_LINK_TIMEOUT = 0.5
 -- h: height of tap zone in proportion of screen height
 DTAP_ZONE_MENU = {x = 1/8, y = 0, w = 3/4, h = 1/8}
 DTAP_ZONE_CONFIG = {x = 1/8, y = 7/8, w = 3/4, h = 1/8}
-DTAP_ZONE_MINIBAR = {x = 0, y = 15/16, w = 1, h = 1/16}
+DTAP_ZONE_MINIBAR = {x = 0, y = 31/32, w = 1, h = 1/32}
 DTAP_ZONE_FORWARD = {x = 1/4, y = 0, w = 3/4, h = 1}
 DTAP_ZONE_BACKWARD = {x = 0, y = 0, w = 1/4, h = 1}
 DTAP_ZONE_BOOKMARK = {x = 7/8, y = 0, w = 1/8, h = 1/8}


### PR DESCRIPTION
Close: #4094 
Preventing overlap long tap for footer and last line of text.