### PR TITLE
Screenshot as screensaver image

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -143,13 +143,6 @@ return {
                 callback = function()
                     G_reader_settings:saveSetting("screensaver_stretch_images", not stretchImages())
                 end,
-            },
-            {
-                text = _("Screenshot as screensaver"),
-                checked_func = screenshoterScreensaver,
-                callback = function()
-                    G_reader_settings:saveSetting("screenshooter_as_screensaver", not screenshoterScreensaver())
-                end,
                 separator = true,
             },
             {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -12,6 +12,7 @@ local function lastFile()
 end
 local function whiteBackground() return G_reader_settings:isTrue("screensaver_white_background") end
 local function stretchImages() return G_reader_settings:isTrue("screensaver_stretch_images") end
+local function screenshoterScreensaver() return G_reader_settings:isTrue("screenshooter_as_screensaver") end
 
 return {
     {
@@ -141,6 +142,13 @@ return {
                 checked_func = stretchImages,
                 callback = function()
                     G_reader_settings:saveSetting("screensaver_stretch_images", not stretchImages())
+                end,
+            },
+            {
+                text = _("Screenshot as screensaver"),
+                checked_func = screenshoterScreensaver,
+                callback = function()
+                    G_reader_settings:saveSetting("screenshooter_as_screensaver", not screenshoterScreensaver())
                 end,
                 separator = true,
             },

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -12,7 +12,6 @@ local function lastFile()
 end
 local function whiteBackground() return G_reader_settings:isTrue("screensaver_white_background") end
 local function stretchImages() return G_reader_settings:isTrue("screensaver_stretch_images") end
-local function screenshoterScreensaver() return G_reader_settings:isTrue("screenshooter_as_screensaver") end
 
 return {
     {

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -39,22 +39,15 @@ end
 
 function Screenshoter:onScreenshot(filename)
     local screenshot_name = filename or os.date(self.screenshot_fn_fmt)
-    local widget
-    if G_reader_settings:isTrue("screenshooter_as_screensaver") then
-        widget = ConfirmBox:new{
-            text = T( _("Saving screenshot to %1.\nWould you like to set it as screensaver?"), screenshot_name),
-            ok_text = _("Yes"),
-            ok_callback = function()
-                G_reader_settings:saveSetting("screensaver_type", "image_file")
-                G_reader_settings:saveSetting("screensaver_image", screenshot_name)
-            end,
-        }
-    else
-        widget = InfoMessage:new{
-            text = T( _("Saving screenshot to %1."), screenshot_name),
-            timeout = 3,
-        }
-    end
+    local widget = ConfirmBox:new{
+        text = T( _("Saving screenshot to %1.\nWould you like to set it as screensaver?"), screenshot_name),
+        ok_text = _("Yes"),
+        ok_callback = function()
+            G_reader_settings:saveSetting("screensaver_type", "image_file")
+            G_reader_settings:saveSetting("screensaver_image", screenshot_name)
+        end,
+        cancel_text = _("No"),
+    }
     UIManager:show(widget)
     Screen:shot(screenshot_name)
     -- trigger full refresh

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -1,7 +1,6 @@
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local GestureRange = require("ui/gesturerange")
-local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
 local Screen = require("device").screen


### PR DESCRIPTION
Close: #2115 
Option to save a screenshot as the current screensaver image. Defalut this option is disabled. You can activate it in `Screensaver -> Settings -> Screenshot as screensaver`
![test - koreader_137](https://user-images.githubusercontent.com/22982594/43275680-c462d8c8-9102-11e8-9d5c-5ce3da24ff64.png)

Than you can do it
![a - koreader_136](https://user-images.githubusercontent.com/22982594/43275600-86355a4e-9102-11e8-9534-abfbc703323d.png)
