### PR TITLE
Tweak/unbreak my CPUFreq experiment

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -497,7 +497,7 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
                     -- documents): we drew our black marker in the margin, we
                     -- can just draw a white one to make it disappear
                     Screen.bb:paintRect(0, screen_y, marker_w, marker_h, Blitbuffer.COLOR_WHITE)
-                    Screen["refreshFast"](Screen, 0, screen_y, marker_w, marker_h)
+                    Screen["refreshUI"](Screen, 0, screen_y, marker_w, marker_h)
                 end
                 UIManager:scheduleIn(marker_setting, self.unmark_func)
             end

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -9,7 +9,8 @@ cd "${KOREADER_DIR}" || exit
 
 # Switch to a sensible CPUFreq governor, even if the HW appears not to give an actual fuck about this...
 ORIG_CPUFREQ_GOV="$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)"
-echo "ondemand" >"/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
+# NOTE: Ideally, we'd want ondemand, but it's not supported on every kernel (if any?)...
+echo "performance" >"/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
 
 # update to new version from OTA directory
 ko_update_check() {

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -138,6 +138,8 @@ end
 
 function BookInfoManager:createDB()
     local db_conn = SQ3.open(self.db_location)
+    -- Make it WAL
+    db_conn:exec("PRAGMA journal_mode=WAL;")
     -- Less error cases to check if we do it that way
     -- Create it (noop if already there)
     db_conn:exec(BOOKINFO_DB_SCHEMA)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -266,6 +266,8 @@ function ReaderStatistics:partialMd5(file)
 end
 
 function ReaderStatistics:createDB(conn)
+    -- Make it WAL
+    conn:exec("PRAGMA journal_mode=WAL;")
     local sql_stmt = [[
         CREATE TABLE IF NOT EXISTS book
             (


### PR DESCRIPTION
After a round of testing (and facepalming, and headdesking...).

Anyway, make it more conservative in general, which, hopefully, means it's now basically a giant NOP, and leaves us poor Mark5 fuckers in the mud, because there's no real solution.

At least I have something new to blame for the terrible battery life or performance on Mk5 now ;).

Re #4114 for the gory details in the middle of my ramblings ;).

----

Also, a couple unrelated fix:

* Minor ghosting tweak for the location swap markers.
* Switch SQLite DBs to WAL, it appears to mesh well with our workflow.