### PR TITLE
Fix untranslatable strings

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -230,8 +230,8 @@ function ReaderDictionary:addToMainMenu(menu_items)
                 text = _("Info on dictionary order"),
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_([[
-If you'd like to change the order in which dictionaries are queried (and their results displayed), you can:
+                        text = T(_(
+[[If you'd like to change the order in which dictionaries are queried (and their results displayed), you can:
 - move all dictionary directories out of %1.
 - move them back there, one by one, in the order you want them to be used.]]), self.data_dir)
                     })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -345,8 +345,8 @@ function ReaderHighlight:onHoldPan(_, ges)
     UIManager:setDirty(self.dialog, "ui")
 end
 
-local info_message_ocr_text = _([[
-No OCR results or no language data.
+local info_message_ocr_text = _(
+[[No OCR results or no language data.
 
 KOReader has a build-in OCR engine for recognizing words in scanned PDF and DjVu documents. In order to use OCR in scanned pages, you need to install tesseract trained data for your document language.
 

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -341,8 +341,8 @@ function ReaderStyleTweak:init()
         hold_may_update_menu = true, -- just to keep menu opened
         hold_callback = function()
             UIManager:show(InfoMessage:new{
-                text = _([[
-Style tweaks allow changing small parts of book styles (including the publisher/embedded styles) to make visual adjustments or disable unwanted publisher layout choices.
+                text = _(
+[[Style tweaks allow changing small parts of book styles (including the publisher/embedded styles) to make visual adjustments or disable unwanted publisher layout choices.
 
 Some tweaks may be useful with some books, while resulting in undesirable effects with others.
 

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -251,8 +251,8 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                         home_dir = home_dir:gsub("^(.-)/*$", "%1") -- remove trailing slash
                         if home_dir and lfs.attributes(home_dir, "mode") == "directory" then
                             local wikipedia_dir = home_dir.."/Wikipedia"
-                            local text = _([[
-Wikipedia articles can be saved as an EPUB for more comfortable reading.
+                            local text = _(
+[[Wikipedia articles can be saved as an EPUB for more comfortable reading.
 
 You can select an existing directory, or use a default directory named "Wikipedia" in your reader's home directory.
 

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -93,8 +93,8 @@ function optionsutil.showValuesMargins(configurable, option)
     end
     if not default then
         UIManager:show(InfoMessage:new{
-            text = T(_([[
-%1:
+            text = T(_(
+[[%1:
 Current value: %2
   left: %3
   top: %4
@@ -112,8 +112,8 @@ Default value: not set]]),
             end
         end
         UIManager:show(InfoMessage:new{
-            text = T(_([[
-%1:
+            text = T(_(
+[[%1:
 Current value: %2
   left: %3
   top: %4

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -17,8 +17,8 @@ local language = G_reader_settings:readSetting("language") or "en"
 local version = Version:getNormalizedCurrentVersion()
 local rev = Version:getCurrentRevision()
 
-local quickstart_guide = T(_([[
-# KOReader Quickstart Guide
+local quickstart_guide = T(_(
+[[# KOReader Quickstart Guide
 
 Welcome to KOReader.
 

--- a/frontend/ui/widget/hyphenationlimits.lua
+++ b/frontend/ui/widget/hyphenationlimits.lua
@@ -144,8 +144,8 @@ function HyphenationLimitsWidget:update()
         CloseButton:new{ window = self, padding_top = Size.margin.title, },
     }
 
-    local hyph_into_text = _([[
-Set minimum length before hyphenation occurs.
+    local hyph_into_text = _(
+[[Set minimum length before hyphenation occurs.
 These settings will apply to all books with any hyphenation dictionary.
 'Use language defaults' resets them.]])
     local hyph_info = FrameContainer:new{

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -675,8 +675,8 @@ function BookInfoManager:extractBooksInDirectory(path, cover_specs)
     local Trapper = require("ui/trapper")
     local Screen = require("device").screen
 
-    local go_on = Trapper:confirm(_([[
-This will extract metadata and cover images for books in current directory.
+    local go_on = Trapper:confirm(_(
+[[This will extract metadata and cover images for books in current directory.
 Once extraction has started, you can abort at any moment by tapping on the screen.
 
 Cover images will be saved with the adequate size for the current display mode.
@@ -688,16 +688,16 @@ This extraction may take time and use some battery power: you may wish to keep y
         return
     end
 
-    local recursive = Trapper:confirm(_([[
-Do you want to extract book information for books in sub-directories too?]]
+    local recursive = Trapper:confirm(_(
+[[Do you want to extract book information for books in sub-directories too?]]
     ), _("Here only"), _("Here and under"))
 
-    local refresh_existing = Trapper:confirm(_([[
-Do you want to refresh metadata and covers that have already been extracted?]]
+    local refresh_existing = Trapper:confirm(_(
+[[Do you want to refresh metadata and covers that have already been extracted?]]
     ), _("Don't refresh"), _("Refresh"))
 
-    local prune = Trapper:confirm(_([[
-If you have removed many books, or have renamed some directories, it is good to remove them from the cache database.
+    local prune = Trapper:confirm(_(
+[[If you have removed many books, or have renamed some directories, it is good to remove them from the cache database.
 
 Do you want to prune cache of removed books?]]
     ), _("Don't prune"), _("Prune"))

--- a/plugins/goodreads.koplugin/main.lua
+++ b/plugins/goodreads.koplugin/main.lua
@@ -76,8 +76,8 @@ function Goodreads:updateSettings()
     local text_top
     local hint_bottom
     local text_bottom
-    local text_info = _([[
-How to generate a key and a secret key:
+    local text_info = _(
+[[How to generate a key and a secret key:
 
 1. Go to https://www.goodreads.com/user/sign_up and create an account
 2. Register for a development key on the following page: https://www.goodreads.com/user/sign_in?rd=true

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -197,8 +197,8 @@ function ReaderStatistics:checkInitDatabase()
     if self.convert_to_db then      -- if conversion to sqlite was doing earlier
         if not conn:exec("pragma table_info('book');") then
             UIManager:show(ConfirmBox:new{
-                text = T(_([[
-Cannot open database in %1.
+                text = T(_(
+[[Cannot open database in %1.
 The database may have been moved or deleted.
 Do you want to create an empty database?
 ]]),
@@ -222,8 +222,8 @@ Do you want to create an empty database?
         if not conn:exec("pragma table_info('book');") then
             if #ReadHistory.hist > 0 then
                 local info = InfoMessage:new{
-                    text =_([[
-New version of statistics plugin detected.
+                    text =_(
+[[New version of statistics plugin detected.
 Statistics data needs to be converted into the new database format.
 This may take a few minutes.
 Please wait…


### PR DESCRIPTION
Some problem somewhere with `[[...]]` strings starting with a leading newline. Should probably be allowed, but for now fix the few such cases to allow them being translated.
See #4085, and https://github.com/koreader/koreader/issues/4085#issuecomment-406059074 for proper and definitive solutions.