### PR TITLE
PathChooser: clearer usage and behaviour

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -191,7 +191,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                                 },
                                 {
                                     {
-                                    text = _("Change (select directory by long-pressing)"),
+                                    text = _("Select another directory"),
                                     callback = function()
                                         UIManager:close(dialog)
                                         -- Use currently read book's directory as starting point,
@@ -218,7 +218,6 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                                         end
                                         local PathChooser = require("ui/widget/pathchooser")
                                         local path_chooser = PathChooser:new{
-                                            -- title = _("Wikipedia 'Save as EPUB' directory"),
                                             select_directory = true,
                                             select_file = false,
                                             path = dir,

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -218,15 +218,11 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                                         end
                                         local PathChooser = require("ui/widget/pathchooser")
                                         local path_chooser = PathChooser:new{
-                                            title = _("Wikipedia 'Save as EPUB' directory"),
+                                            -- title = _("Wikipedia 'Save as EPUB' directory"),
+                                            select_directory = true,
+                                            select_file = false,
                                             path = dir,
-                                            show_hidden = G_reader_settings:readSetting("show_hidden"),
                                             onConfirm = function(path)
-                                                -- hack to remove additional parent
-                                                if path:sub(-3, -1) == "/.." then
-                                                    path = path:sub(1, -4)
-                                                end
-                                                path = require("ffi/util").realpath(path)
                                                 G_reader_settings:saveSetting("wikipedia_save_dir", path)
                                                 UIManager:show(InfoMessage:new{
                                                     text = T(_("Wikipedia 'Save as EPUB' directory set to:\n%1"), path),

--- a/frontend/ui/downloadmgr.lua
+++ b/frontend/ui/downloadmgr.lua
@@ -24,7 +24,7 @@ local util = require("ffi/util")
 local _ = require("gettext")
 
 local DownloadMgr = {
-    title = _("Long press to choose download directory"),
+    -- title = _("Long press to choose download directory"),
     onConfirm = function() end,
 }
 
@@ -42,7 +42,7 @@ function DownloadMgr:chooseDir()
     local download_dir = G_reader_settings:readSetting("download_dir")
     local path = download_dir and util.realpath(download_dir .. "/..") or lastdir
     local path_chooser = PathChooser:new{
-        title = self.title,
+        title = self.title or true, -- use default title if none provided
         select_directory = true,
         select_file = false,
         show_files = false,

--- a/frontend/ui/downloadmgr.lua
+++ b/frontend/ui/downloadmgr.lua
@@ -40,17 +40,16 @@ end
 function DownloadMgr:chooseDir()
     local lastdir = G_reader_settings:readSetting("lastdir")
     local download_dir = G_reader_settings:readSetting("download_dir")
+    local path = download_dir and util.realpath(download_dir .. "/..") or lastdir
     local path_chooser = PathChooser:new{
         title = self.title,
+        select_directory = true,
+        select_file = false,
+        show_files = false,
         height = Screen:getHeight(),
-        path = download_dir and (download_dir .. "/..") or lastdir,
-        show_hidden = G_reader_settings:readSetting("show_hidden"),
+        path = path,
         onConfirm = function(path)
-            -- hack to remove additional parent
-            if path:sub(-3, -1) == "/.." then
-                path = path:sub(1, -4)
-            end
-            self.onConfirm(util.realpath(path))
+            self.onConfirm(path)
         end
     }
     UIManager:show(path_chooser)

--- a/frontend/ui/downloadmgr.lua
+++ b/frontend/ui/downloadmgr.lua
@@ -48,8 +48,8 @@ function DownloadMgr:chooseDir()
         show_files = false,
         height = Screen:getHeight(),
         path = path,
-        onConfirm = function(path)
-            self.onConfirm(path)
+        onConfirm = function(dir_path)
+            self.onConfirm(dir_path)
         end
     }
     UIManager:show(path_chooser)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -198,6 +198,7 @@ function FileChooser:genItemTableFromPath(path)
 
     table.sort(dirs, sorting)
     if path ~= "/" then table.insert(dirs, 1, {name = ".."}) end
+    if self.show_current_dir_for_hold then table.insert(dirs, 1, {name = "."}) end
     table.sort(files, sorting)
 
     local item_table = {}
@@ -214,8 +215,16 @@ function FileChooser:genItemTableFromPath(path)
         else
             istr = util.template(_("%1 items"), num_items)
         end
+        local text
+        if dir.name == ".." then
+            text = "⬆ ../"
+        elseif dir.name == "." then -- possible with show_current_dir_for_hold
+            text = _("Long press to select current directory")
+        else
+            text = dir.name.."/"
+        end
         table.insert(item_table, {
-            text = dir.name == ".." and  "⬆ ../" or dir.name.."/",
+            text = text,
             mandatory = istr,
             path = subdir_path,
             is_go_up = dir.name == ".."

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -219,7 +219,7 @@ function FileChooser:genItemTableFromPath(path)
         if dir.name == ".." then
             text = "⬆ ../"
         elseif dir.name == "." then -- possible with show_current_dir_for_hold
-            text = _("Long press to select current directory")
+            text = _("Long-press to select current directory")
         else
             text = dir.name.."/"
         end

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -54,7 +54,19 @@ function PathChooser:onMenuSelect(item)
         return true
     end
     path = ffiutil.realpath(path)
-    if lfs.attributes(path, "mode") ~= "directory" then
+    if not path then
+        -- If starting in a no-more existing directory, allow
+        -- not getting stuck in it
+        self:changeToPath("/")
+        return true
+    end
+    local attr = lfs.attributes(path)
+    if not attr then
+        -- Same as above
+        self:changeToPath("/")
+        return true
+    end
+    if attr.mode ~= "directory" then
         -- Do nothing if Tap on other than directories
         return true
     end
@@ -73,7 +85,13 @@ function PathChooser:onMenuHold(item)
         path = path:sub(1, -3)
     end
     path = ffiutil.realpath(path)
+    if not path then
+        return true
+    end
     local attr = lfs.attributes(path)
+    if not attr then
+        return true
+    end
     if attr.mode == "file" and not self.select_file then
         return true
     end

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -83,17 +83,17 @@ function PathChooser:onMenuHold(item)
     local title
     if attr.mode == "file" then
         if self.detailed_file_info then
-            local filesize = util.getFriendlySize(attr.size)
+            local filesize = util.getFormattedSize(attr.size)
             local lastmod = os.date("%Y-%m-%d %H:%M", attr.modification)
-            title = T(_("Select this file?\n%1\n(size: %2 - last modified: %3)"),
+            title = T(_("Select this file?\n\n%1\n\nFile size: %2 bytes\nLast modified: %3"),
                         path, filesize, lastmod)
         else
-            title = T(_("Select this file?\n%1"), path)
+            title = T(_("Select this file?\n\n%1"), path)
         end
     elseif attr.mode == "directory" then
-        title = T(_("Select this directory?\n%1"), path)
+        title = T(_("Select this directory?\n\n%1"), path)
     else -- just in case we get something else
-        title = T(_("Select this path?\n%1"), path)
+        title = T(_("Select this path?\n\n%1"), path)
     end
     local onConfirm = self.onConfirm
     self.button_dialog = ButtonDialogTitle:new{

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -85,7 +85,7 @@ function PathChooser:onMenuHold(item)
         if self.detailed_file_info then
             local filesize = util.getFriendlySize(attr.size)
             local lastmod = os.date("%Y-%m-%d %H:%M", attr.modification)
-            title = T(_("Select this file?\n%1\n\n(size: %2 - last modified: %3)"),
+            title = T(_("Select this file?\n%1\n(size: %2 - last modified: %3)"),
                         path, filesize, lastmod)
         else
             title = T(_("Select this file?\n%1"), path)

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -25,7 +25,7 @@ local PathChooser = FileChooser:extend{
 }
 
 function PathChooser:init()
-    if not title then -- default titles depending on options
+    if not self.title then -- default titles depending on options
         if self.select_directory and not self.select_file then
             self.title = _("Select directory (long press to confirm)")
         elseif not self.select_directory and self.select_file then
@@ -50,7 +50,7 @@ function PathChooser:onMenuSelect(item)
         -- Don't navigate to same directory
         return true
     end
-    local path = util.realpath(path)
+    path = util.realpath(path)
     if lfs.attributes(path, "mode") ~= "directory" then
         -- Do nothing if Tap on other than directories
         return true
@@ -69,7 +69,7 @@ function PathChooser:onMenuHold(item)
     if path:sub(-2, -1) == "/." then -- with show_current_dir_for_hold
         path = path:sub(1, -3)
     end
-    local path = util.realpath(path)
+    path = util.realpath(path)
     local path_type = lfs.attributes(path, "mode")
     if path_type == "file" and not self.select_file then
         return true

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -1,46 +1,107 @@
-local ButtonDialog = require("ui/widget/buttondialog")
+local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local FileChooser = require("ui/widget/filechooser")
+local Font = require("ui/font")
 local UIManager = require("ui/uimanager")
+local lfs = require("libs/libkoreader-lfs")
 local util = require("ffi/util")
 local _ = require("gettext")
+local T = util.template
 
 local PathChooser = FileChooser:extend{
-    title = _("Choose Path"),
+    title = nil, -- a generic title will be set in init() if none given
     no_title = false,
     show_path = true,
     is_popout = false,
     covers_fullscreen = true, -- set it to false if you set is_popout = true
     is_borderless = true,
-    show_filesize = false,
-    file_filter = function() return false end, -- filter out regular files
+    -- smaller font to allow displaying our long titles
+    tface = Font:getFace("smalltfont"),
+
+    select_directory = true, -- allow selecting directories
+    select_file = true,      -- allow selecting files
+    show_files = true, -- show files, even if select_files=false
+    -- (directories are always shown, to allow navigation)
+    show_hidden = G_reader_settings:readSetting("show_hidden"),
 }
 
+function PathChooser:init()
+    if not title then -- default titles depending on options
+        if self.select_directory and not self.select_file then
+            self.title = _("Select directory (long press to confirm)")
+        elseif not self.select_directory and self.select_file then
+            self.title = _("Select file (long press to confirm)")
+        else
+            self.title = _("Select path (long press to confirm)")
+        end
+    end
+    if not self.show_files then
+        self.file_filter = function() return false end -- filter out regular files
+    end
+    if self.select_directory then
+        -- Let FileChooser display "Long press to select current directory"
+        self.show_current_dir_for_hold = true
+    end
+    FileChooser.init(self)
+end
+
 function PathChooser:onMenuSelect(item)
-    self.path = util.realpath(item.path)
-    local sub_table = self:genItemTableFromPath(self.path)
-    -- if sub table only have one entry(itself) we do nothing
-    if #sub_table > 1 then
-        self:changeToPath(item.path)
+    local path = item.path
+    if path:sub(-2, -1) == "/." then -- with show_current_dir_for_hold
+        -- Don't navigate to same directory
+        return true
+    end
+    local path = util.realpath(path)
+    if lfs.attributes(path, "mode") ~= "directory" then
+        -- Do nothing if Tap on other than directories
+        return true
+    end
+    -- Let this method check permissions and if we can list
+    -- this directory: we should get at least one item: ".."
+    local sub_table = self:genItemTableFromPath(path)
+    if #sub_table > 0 then
+        self:changeToPath(path)
     end
     return true
 end
 
 function PathChooser:onMenuHold(item)
+    local path = item.path
+    if path:sub(-2, -1) == "/." then -- with show_current_dir_for_hold
+        path = path:sub(1, -3)
+    end
+    local path = util.realpath(path)
+    local path_type = lfs.attributes(path, "mode")
+    if path_type == "file" and not self.select_file then
+        return true
+    end
+    if path_type == "directory" and not self.select_directory then
+        return true
+    end
+    local title
+    if path_type == "file" then
+        title = T(_("Select this file?\n%1"), path)
+    elseif path_type == "directory" then
+        title = T(_("Select this directory?\n%1"), path)
+    else -- just in case we get something else
+        title = T(_("Select this path?\n%1"), path)
+    end
     local onConfirm = self.onConfirm
-    self.button_dialog = ButtonDialog:new{
+    self.button_dialog = ButtonDialogTitle:new{
+        title = title,
         buttons = {
             {
                 {
-                    text = _("Confirm"),
+                    text = _("Cancel"),
                     callback = function()
-                        if onConfirm then onConfirm(item.path) end
                         UIManager:close(self.button_dialog)
-                        UIManager:close(self)
                     end,
                 },
                 {
-                    text = _("Cancel"),
+                    text = _("Select"),
                     callback = function()
+                        if onConfirm then
+                            onConfirm(path)
+                        end
                         UIManager:close(self.button_dialog)
                         UIManager:close(self)
                     end,


### PR DESCRIPTION
Explicit new options: `select_directory`, `select_file`, `show_files`.
With `select_directory=true`, show an entry to select current directory (so, removed undocumented hack "hold on .. to select current directory"). This goes well with the newly displayed current path under the title.

With `select_directory=true` and `show_files=true` in the various display modes:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43627309-12cac32e-96f6-11e8-9783-57c143fbd1b0.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/43627326-288f67e6-96f6-11e8-9351-d14e8741a307.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/43627413-9b18800e-96f6-11e8-8a54-d0bb3d43cd7b.png)</kbd>

With `select_directory=false` and `select_files=true` 
<kbd>![image](https://user-images.githubusercontent.com/24273478/43627424-a9dca7c8-96f6-11e8-8044-a31ff84296eb.png)</kbd>

With `select_directory=true` , `select_files=false` and `show_files=false` (default behaviour for stuff that use DownloadMgr):
<kbd>![image](https://user-images.githubusercontent.com/24273478/43627446-c34d6fee-96f6-11e8-8db3-34b1d7577b17.png)</kbd>
