### PR TITLE
Fix crash and History with books in read-only directories

### DIFF
--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -16,7 +16,7 @@ local HISTORY_DIR = DataStorage:getHistoryDir()
 
 local function buildCandidate(file_path)
     -- Ignore empty files.
-    if lfs.attributes(file_path, "mode") == "file" then
+    if file_path and lfs.attributes(file_path, "mode") == "file" then
         return { file_path, lfs.attributes(file_path, "modification") }
     else
         return nil
@@ -64,6 +64,7 @@ end
 
 function DocSettings:getPathFromHistory(hist_name)
     if hist_name == nil or hist_name == '' then return '' end
+    if hist_name:sub(-4) ~= ".lua" then return '' end -- ignore .lua.old backups
     -- 1. select everything included in brackets
     local s = string.match(hist_name,"%b[]")
     if s == nil or s == '' then return '' end
@@ -74,6 +75,7 @@ end
 
 function DocSettings:getNameFromHistory(hist_name)
     if hist_name == nil or hist_name == '' then return '' end
+    if hist_name:sub(-4) ~= ".lua" then return '' end -- ignore .lua.old backups
     local s = string.match(hist_name, "%b[]")
     if s == nil or s == '' then return '' end
     -- at first, search for path length
@@ -112,7 +114,7 @@ function DocSettings:open(docfile)
     -- New sidecar file
     table.insert(candidates, buildCandidate(new.sidecar_file))
     -- Backup file of new sidecar file
-    table.insert(candidates, buildCandidate(new.sidecar_file .. ".old"))
+    table.insert(candidates, buildCandidate(new.sidecar_file and (new.sidecar_file .. ".old")))
     -- Legacy sidecar file
     table.insert(candidates, buildCandidate(new.legacy_sidecar_file))
     -- Legacy history folder


### PR DESCRIPTION
docsettings can be stored either as a sidecar file (prefered, when possible), or as a .lua file in the koreader/history/ folder (good, when book is in a read-only directory where we can't create the
.sdr/ directory).
They are managed correctly if for some reason, the book directory becomes writable: the docsettings in history/ is read, used, and removed when a docsetting in a .sdr/ can be saved.
These docsettings in koreader/history/ contribute to the History list build: they are put it in history.lua, and the duplicates on next history.lua builds are removed.

This fix a crash when a book is in a read-only directory. Closes #3869.
I verified that I can now open on Android books stored on the external SDCard, and the docsetting is saved in koreader/history/ . Closes #3365. Closes #3483.
Also fix History containing strange entries like "Book.epub.lua", that came from the koreader/history/book.epub.lua.old backup, that weren't removed as they are not a duplicate. Closes #4118.
