### PR TITLE
Hyphenation: speed up book loading by setting hyph algo earlier

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -163,8 +163,12 @@ end
 function CreDocument:loadDocument(full_document)
     if not self._loaded then
         local only_metadata = full_document == false
+        logger.dbg("CreDocument: loading document...")
         if self._document:loadDocument(self.file, only_metadata) then
             self._loaded = true
+            logger.dbg("CreDocument: loading done.")
+        else
+            logger.dbg("CreDocument: loading failed.")
         end
     end
     return self._loaded
@@ -178,10 +182,12 @@ function CreDocument:render()
         < DCREREADER_TWO_PAGE_THRESHOLD then
         self:setVisiblePageCount(1)
     end
+    logger.dbg("CreDocument: rendering document...")
     self._document:renderDocument()
     if not self.info.has_pages then
         self.info.doc_height = self._document:getFullHeight()
     end
+    logger.dbg("CreDocument: rendering done.")
 end
 
 function CreDocument:close()


### PR DESCRIPTION
The hyphenation algo setup was the only one using onPreRenderDocument, because it needed access to the document language to set accordingly the hyphenation algorithm.

Setting the hyph algo before loading the document may save crengine from re-doing some expensive work at render time (the hyph algo is accounted in the nodeStyleHash, and would cause a mismatch if it is different at render time from how it was at load time - "English US" by default - causing a full re-init of the nodes styles.)
We will only re-set it on pre-render (only then, after loading, we know the document language) if it's really needed: when no algo saved in book settings, no default algo, and book has some language defined.

Before, the hyphenation settings were only and always applied after loading. It was working similar to this (with the logs this PR adds):
```
08/07/18-18:10:10 DEBUG CreDocument: set gamma index 15
08/07/18-18:10:10 DEBUG Hyphenation: no algo set
08/07/18-18:10:10 DEBUG CreDocument: set hyphenation left hyphen min 2
08/07/18-18:10:10 DEBUG CreDocument: set hyphenation right hyphen min 2
08/07/18-18:10:10 DEBUG CreDocument: set hyphenation trust soft hyphens 0
08/07/18-18:10:10 DEBUG Hyphenation: keeping current crengine algo: English_US.pattern
08/07/18-18:10:10 DEBUG CreDocument: requesting DOM version: 20180528
08/07/18-18:10:10 DEBUG CreDocument: loading document...
08/07/18-18:10:11 DEBUG CreDocument: loading done.
08/07/18-18:10:11 DEBUG Hyphenation: updating for doc language fr : English_US.pattern => French.pattern
08/07/18-18:10:11 DEBUG CreDocument: set hyphenation dictionary French.pattern
08/07/18-18:10:11 DEBUG CreDocument: set hyphenation left hyphen min 2
08/07/18-18:10:11 DEBUG CreDocument: set hyphenation right hyphen min 1
08/07/18-18:10:11 DEBUG CreDocument: set hyphenation trust soft hyphens 0
08/07/18-18:10:11 DEBUG CreDocument: set visible page count 1
08/07/18-18:10:11 DEBUG CreDocument: rendering document...
checkRenderContext: Style hash doesn't match b3a9c9c6!=65a8043a
  /\ this makes crengine actually reset all the node styles it has built when loading
DOCUMENT 1 rendering context is changed - full render required...
08/07/18-18:10:12 DEBUG CreDocument: rendering done.
```

Now, we can get this:
```
08/07/18-18:13:43 DEBUG CreDocument: set gamma index 15
08/07/18-18:13:43 DEBUG Hyphenation: using fallback  French.pattern , might be overriden by doc language
08/07/18-18:13:43 DEBUG CreDocument: set hyphenation dictionary French.pattern
08/07/18-18:13:43 DEBUG CreDocument: set hyphenation left hyphen min 2
08/07/18-18:13:43 DEBUG CreDocument: set hyphenation right hyphen min 1
08/07/18-18:13:43 DEBUG CreDocument: set hyphenation trust soft hyphens 0
08/07/18-18:13:43 DEBUG CreDocument: requesting DOM version: 20180528
08/07/18-18:13:43 DEBUG CreDocument: loading document...
08/07/18-18:13:44 DEBUG CreDocument: loading done.
08/07/18-18:13:44 DEBUG Hyphenation: current French.pattern is right for doc language: fr
08/07/18-18:13:44 DEBUG CreDocument: set visible page count 1
08/07/18-18:13:44 DEBUG CreDocument: rendering document...
08/07/18-18:13:44 DEBUG CreDocument: rendering done.
```
or this:
```
08/07/18-18:14:40 DEBUG CreDocument: set gamma index 15
08/07/18-18:14:40 DEBUG Hyphenation: using default  French.pattern
08/07/18-18:14:40 DEBUG CreDocument: set hyphenation dictionary French.pattern
08/07/18-18:14:40 DEBUG CreDocument: set hyphenation left hyphen min 2
08/07/18-18:14:40 DEBUG CreDocument: set hyphenation right hyphen min 1
08/07/18-18:14:40 DEBUG CreDocument: set hyphenation trust soft hyphens 0
08/07/18-18:14:40 DEBUG CreDocument: requesting DOM version: 20180528
08/07/18-18:14:40 DEBUG CreDocument: loading document...
08/07/18-18:14:40 DEBUG CreDocument: loading done.
08/07/18-18:14:40 DEBUG Hyphenation: not overriding French.pattern with doc language: fr
08/07/18-18:14:40 DEBUG CreDocument: set visible page count 1
08/07/18-18:14:40 DEBUG CreDocument: rendering document...
08/07/18-18:14:40 DEBUG CreDocument: rendering done.
```
or this
```
08/07/18-18:15:10 DEBUG CreDocument: set gamma index 15
08/07/18-18:15:10 DEBUG Hyphenation: using default  French.pattern
08/07/18-18:15:10 DEBUG CreDocument: set hyphenation dictionary French.pattern
08/07/18-18:15:10 DEBUG CreDocument: set hyphenation left hyphen min 2
08/07/18-18:15:10 DEBUG CreDocument: set hyphenation right hyphen min 1
08/07/18-18:15:10 DEBUG CreDocument: set hyphenation trust soft hyphens 0
08/07/18-18:15:10 DEBUG CreDocument: requesting DOM version: 20180528
08/07/18-18:15:10 DEBUG CreDocument: loading document...
08/07/18-18:15:10 DEBUG CreDocument: loading done.
08/07/18-18:15:10 DEBUG Hyphenation: not overriding French.pattern with doc language: en
08/07/18-18:15:10 DEBUG CreDocument: set visible page count 1
08/07/18-18:15:10 DEBUG CreDocument: rendering document...
08/07/18-18:15:10 DEBUG CreDocument: rendering done.
```
and only when necessary this full re-rendering:
```
08/07/18-18:16:32 DEBUG CreDocument: set gamma index 15
08/07/18-18:16:32 DEBUG Hyphenation: using fallback  French.pattern , might be overriden by doc language
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation dictionary French.pattern
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation left hyphen min 2
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation right hyphen min 1
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation trust soft hyphens 0
08/07/18-18:16:32 DEBUG CreDocument: requesting DOM version: 20180528
08/07/18-18:16:32 DEBUG CreDocument: loading document...
08/07/18-18:16:32 DEBUG CreDocument: loading done.
08/07/18-18:16:32 DEBUG Hyphenation: updating for doc language en : French.pattern => English_US.pattern
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation dictionary English_US.pattern
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation left hyphen min 2
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation right hyphen min 2
08/07/18-18:16:32 DEBUG CreDocument: set hyphenation trust soft hyphens 0
08/07/18-18:16:32 DEBUG CreDocument: set visible page count 1
08/07/18-18:16:32 DEBUG CreDocument: rendering document...
checkRenderContext: Style hash doesn't match 5bc7055d!=a9c8cae9
DOCUMENT 1 rendering context is changed - full render required...
08/07/18-18:16:32 DEBUG CreDocument: rendering done.
```

On my big sample book (which gets another `Stylesheet has doesn't match`, which I have yet to fix, so I can't use it to show), which takes 13s for loading and 11s for rendering on the emulator, this recusrive node style init accounts for 4-5 seconds in the 13s, and also for 4-5 seconds in the 11s. So, that's potentially a 25% speed up in loading time in some conditions for us non English_US readers :)