### PR TITLE
TextEditor: allow scrolling by lines with Pan

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -128,6 +128,8 @@ local InputDialog = InputContainer:new{
         -- note that the text widget can be scrolled with Swipe North/South even when no button
     keyboard_hidden = false, -- start with keyboard hidden in full fullscreen mode
                              -- needs add_nav_bar to have a Show keyboard button to get it back
+    scroll_by_pan = false, -- allow scrolling by lines with Pan (= Swipe, but wait a bit at end
+                           -- of gesture before releasing) (may conflict with movable)
 
     -- If save_callback provided, a Save and a Close buttons will be added to the first row
     -- if reset_callback provided, a Reset button will be added (before Save) to the first row
@@ -359,6 +361,7 @@ function InputDialog:init()
         edit_callback = self._buttons_edit_callback, -- nil if no Save/Close buttons
         scroll_callback = self._buttons_scroll_callback, -- nil if no Nav or Scroll buttons
         scroll = true,
+        scroll_by_pan = self.scroll_by_pan,
         cursor_at_end = self.cursor_at_end,
         readonly = self.readonly,
         parent = self,

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -30,6 +30,7 @@ local InputText = InputContainer:new{
     parent = nil, -- parent dialog that will be set dirty
     edit_callback = nil, -- called with true when text modified, false on init or text re-set
     scroll_callback = nil, -- called with (low, high) when view is scrolled (cf ScrollTextWidget)
+    scroll_by_pan = false, -- allow scrolling by lines with Pan (needs scroll=true)
 
     width = nil,
     height = nil, -- when nil, will be set to original text height (possibly
@@ -322,6 +323,7 @@ function InputText:initTextBox(text, char_added)
             height = self.height,
             dialog = self.parent,
             scroll_callback = self.scroll_callback,
+            scroll_by_pan = self.scroll_by_pan,
         }
     else
         self.text_widget = TextBoxWidget:new{

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -684,6 +684,32 @@ function TextBoxWidget:scrollUp()
     end
 end
 
+function TextBoxWidget:scrollLines(nb_lines)
+    -- nb_lines can be negative
+    if nb_lines == 0 then
+        return
+    end
+    self.image_show_alt_text = nil
+    local new_line_num = self.virtual_line_num + nb_lines
+    if new_line_num < 1 then
+        new_line_num = 1
+    end
+    if new_line_num > #self.vertical_string_list - self.lines_per_page + 1 then
+        new_line_num = #self.vertical_string_list - self.lines_per_page + 1
+    end
+    self.virtual_line_num = new_line_num
+    self:free()
+    self:_renderText(self.virtual_line_num, self.virtual_line_num + self.lines_per_page - 1)
+    if self.editable then
+        local x, y = self:_getXYForCharPos()
+        if y < 0 or y >= self.text_height then
+            -- move cursor to first line of visible area
+            local ln = self.height == nil and 1 or self.virtual_line_num
+            self:moveCursorToCharPos(self.vertical_string_list[ln] and self.vertical_string_list[ln].offset or 1)
+        end
+    end
+end
+
 function TextBoxWidget:scrollToTop()
     self.image_show_alt_text = nil
     if self.virtual_line_num > 1 then

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -701,7 +701,7 @@ function TextBoxWidget:scrollLines(nb_lines)
     self:free()
     self:_renderText(self.virtual_line_num, self.virtual_line_num + self.lines_per_page - 1)
     if self.editable then
-        local x, y = self:_getXYForCharPos()
+        local x, y = self:_getXYForCharPos() -- luacheck: no unused
         if y < 0 or y >= self.text_height then
             -- move cursor to first line of visible area
             local ln = self.height == nil and 1 or self.virtual_line_num

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -378,6 +378,7 @@ function TextEditor:editFile(file_path, readonly)
         cursor_at_end = false,
         readonly = readonly,
         add_nav_bar = true,
+        scroll_by_pan = true,
         buttons = is_lua and {{
             -- First button on first row, that will be filled with Reset|Save|Close
             {


### PR DESCRIPTION
Feature of ScrollTextWidget, only used for now by TextEditor.
Pan is like Swipe, but wait a bit at end of gesture to release: the line on which Pan was started will be moved to where Pan is released.

May conflict with MovableContainer (so not enabled for DictQuickLookup, where it could have been nice - but it would work only with text dictionaries, not with HTML ones, as ScrollHtmlWidget can't really do that).

Useful to make a whole block of text contained into view, and not be limited by rigid page by page scrolling (eg: to move the `function Widget:name()` at top of screen and have a wider view  of it while you wonder wtf that function does :)