### PR TITLE
One more øMQ FFI fix that slipped through the cracks

### DIFF
--- a/frontend/ui/message/streammessagequeue.lua
+++ b/frontend/ui/message/streammessagequeue.lua
@@ -22,7 +22,7 @@ function StreamMessageQueue:start()
     if rc ~= 0 then
         error("cannot connect to " .. endpoint)
     end
-    local id_size = ffi.new("size_t[1]", 256)
+    local id_size = ffi.new("unsigned int[1]", 256)
     local buffer = ffi.new("uint8_t[?]", id_size[0])
     -- @todo: check return of zmq_getsockopt
     zmq.zmq_getsockopt(self.socket, C.ZMQ_IDENTITY, buffer, id_size)


### PR DESCRIPTION
(Actually should be size_t, but gcc-lua downgraded that to the
pointed-to type, for... reasons?).

Fix #4187