### PR TITLE
Keep some menus open when Tap or Hold

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -637,7 +637,6 @@ function FileManager:pasteHere(file)
                     timeout = 2,
                 })
             end
-            util.execute(self.cp_bin, "-r", orig, dest)
         end
 
         local info_file

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -115,6 +115,12 @@ function FileManagerMenu:setUpdateItemTable()
     }
     self.menu_items.items_per_page = {
         text = _("Items per page"),
+        help_text = _([[This sets the number of items per page in:
+- File browser and history in 'classic' display mode
+- File and directory choosers
+- Table of content
+- Bookmarks list]]),
+        keep_menu_open = true,
         callback = function()
             local SpinWidget = require("ui/widget/spinwidget")
             local curr_items = G_reader_settings:readSetting("items_per_page") or 14

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -117,7 +117,7 @@ function FileManagerMenu:setUpdateItemTable()
         text = _("Items per page"),
         help_text = _([[This sets the number of items per page in:
 - File browser and history in 'classic' display mode
-- File and directory choosers
+- File and directory selection
 - Table of content
 - Bookmarks list]]),
         keep_menu_open = true,

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -228,6 +228,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
             },
             {
                 text = _("Info on dictionary order"),
+                keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{
                         text = T(_(
@@ -262,6 +263,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
             },
             {
                 text = _("Clean dictionary lookup history"),
+                keep_menu_open = true,
                 callback = function()
                     UIManager:show(ConfirmBox:new{
                         text = _("Clean dictionary lookup history?"),

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -68,9 +68,8 @@ function ReaderFont:init()
             callback = function()
                 self:setFont(v)
             end,
-            hold_may_update_menu = true,
-            hold_callback = function(refresh_menu_func)
-                self:makeDefault(v, refresh_menu_func)
+            hold_callback = function(touchmenu_instance)
+                self:makeDefault(v, touchmenu_instance)
             end,
             checked_func = function()
                 return v == self.font_face
@@ -310,14 +309,14 @@ function ReaderFont:setFont(face)
     end
 end
 
-function ReaderFont:makeDefault(face, refresh_menu_func)
+function ReaderFont:makeDefault(face, touchmenu_instance)
     if face then
         UIManager:show(MultiConfirmBox:new{
             text = T( _("Would you like %1 to be used as the default font (★), or the fallback font (�)?\n\nCharacters not found in the active font are shown in the fallback font instead."), face),
             choice1_text = _("Default"),
             choice1_callback = function()
                 G_reader_settings:saveSetting("cre_font", face)
-                if refresh_menu_func then refresh_menu_func() end
+                if touchmenu_instance then touchmenu_instance:updateItems() end
             end,
             choice2_text = _("Fallback"),
             choice2_callback = function()
@@ -325,7 +324,7 @@ function ReaderFont:makeDefault(face, refresh_menu_func)
                     G_reader_settings:saveSetting("fallback_font", face)
                     self.ui:handleEvent(Event:new("UpdatePos"))
                 end
-                if refresh_menu_func then refresh_menu_func() end
+                if touchmenu_instance then touchmenu_instance:updateItems() end
             end,
         })
     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -103,7 +103,9 @@ function ReaderHighlight:genHighlightDrawerMenu()
             callback = function()
                 self.view.highlight.disabled = not self.view.highlight.disabled
             end,
-            hold_callback = function() self:makeDefault(not self.view.highlight.disabled) end,
+            hold_callback = function(touchmenu_instance)
+                self:makeDefault(not self.view.highlight.disabled)
+            end,
         },
         get_highlight_style("lighten"),
         get_highlight_style("underscore"),
@@ -736,7 +738,6 @@ function ReaderHighlight:makeDefault(highlight_disabled)
             G_reader_settings:saveSetting("highlight_disabled", highlight_disabled)
         end,
     })
-    self.view.highlight.disabled = highlight_disabled
 end
 
 return ReaderHighlight

--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -112,8 +112,7 @@ function ReaderHyphenation:init()
                     -- signal readerrolling to update pos in new height, and redraw page
                     self.ui:handleEvent(Event:new("UpdatePos"))
                 end,
-                hold_may_update_menu = true,
-                hold_callback = function(refresh_menu_func)
+                hold_callback = function(touchmenu_instance)
                     UIManager:show(MultiConfirmBox:new{
                         -- No real need for a way to remove default one, we can just
                         -- toggle between setting a default OR a fallback (if a default
@@ -125,13 +124,13 @@ function ReaderHyphenation:init()
                         choice1_callback = function()
                             G_reader_settings:saveSetting("hyph_alg_default", v.filename)
                             G_reader_settings:delSetting("hyph_alg_fallback")
-                            if refresh_menu_func then refresh_menu_func() end
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
                         end,
                         choice2_text = _("Fallback"),
                         choice2_callback = function()
                             G_reader_settings:saveSetting("hyph_alg_fallback", v.filename)
                             G_reader_settings:delSetting("hyph_alg_default")
-                            if refresh_menu_func then refresh_menu_func() end
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
                         end,
                     })
                 end,

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -154,13 +154,15 @@ If any of the other Swipe to follow link options is enabled, this will work only
         text = _("Go back to previous location"),
         enabled_func = function() return #self.location_stack > 0 end,
         callback = function() self:onGoBackLink() end,
-        hold_callback = function() UIManager:show(ConfirmBox:new{
-            text = _("Clear location history?"),
-            ok_text = _("Clear"),
-            ok_callback = function()
-                self.location_stack = {}
-            end,
-        })
+        hold_callback = function(touchmenu_instance)
+            UIManager:show(ConfirmBox:new{
+                text = _("Clear location history?"),
+                ok_text = _("Clear"),
+                ok_callback = function()
+                    self.location_stack = {}
+                    touchmenu_instance:closeMenu()
+                end,
+            })
         end,
     }
 end

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -338,7 +338,6 @@ function ReaderStyleTweak:init()
             self.enabled = not self.enabled
             self:updateCssText(true) -- apply it immediately
         end,
-        hold_may_update_menu = true, -- just to keep menu opened
         hold_callback = function()
             UIManager:show(InfoMessage:new{
                 text = _(
@@ -398,8 +397,7 @@ You can enable individual tweaks on this book with a tap, or view more details a
                     end
                     return title
                 end,
-                hold_may_update_menu = true,
-                hold_callback = function(refresh_menu_func)
+                hold_callback = function(touchmenu_instance)
                     UIManager:show(TweakInfoWidget:new{
                         tweak = item,
                         is_global_default = self.global_tweaks[item.id],
@@ -409,7 +407,7 @@ You can enable individual tweaks on this book with a tap, or view more details a
                             else
                                 self.global_tweaks[item.id] = true
                             end
-                            refresh_menu_func()
+                            touchmenu_instance:updateItems()
                             self:updateCssText(true) -- apply it immediately
                         end
                     })

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -476,11 +476,12 @@ function ReaderToc:addToMainMenu(menu_items)
         end,
     }
     if self.ui.document:canHaveAlternativeToc() then
-        menu_items.table_of_contents.hold_callback = function()
+        menu_items.table_of_contents.hold_callback = function(touchmenu_instance)
             if self.ui.document:isTocAlternativeToc() then
                 UIManager:show(ConfirmBox:new{
                     text = _("The table of content for this book is currently an alternative one built from the document headings.\nDo you want to get back the original table of content? (The book will be reloaded.)"),
                     ok_callback = function()
+                        touchmenu_instance:closeMenu()
                         self.ui.doc_settings:delSetting("alternative_toc")
                         self.ui.document:invalidateCacheFile()
                         -- Allow for ConfirmBox to be closed before showing
@@ -494,6 +495,7 @@ function ReaderToc:addToMainMenu(menu_items)
                 UIManager:show(ConfirmBox:new{
                     text = _("Do you want to use an alternative table of content built from the document headings?"),
                     ok_callback = function()
+                        touchmenu_instance:closeMenu()
                         self:resetToc()
                         self.ui.document:buildAlternativeToc()
                         self.ui.doc_settings:saveSetting("alternative_toc", true)

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -125,8 +125,8 @@ function ReaderTypeset:genStyleSheetMenu()
             callback = function()
                 self:setStyleSheet(css_file or self.ui.document.default_css)
             end,
-            hold_callback = function()
-                self:makeDefaultStyleSheet(css_file, text)
+            hold_callback = function(touchmenu_instance)
+                self:makeDefaultStyleSheet(css_file, text, touchmenu_instance)
             end,
             checked_func = function()
                 if not css_file then -- "Auto"
@@ -301,11 +301,12 @@ function ReaderTypeset:makeDefaultFloatingPunctuation()
     })
 end
 
-function ReaderTypeset:makeDefaultStyleSheet(css, text)
+function ReaderTypeset:makeDefaultStyleSheet(css, text, touchmenu_instance)
     UIManager:show(ConfirmBox:new{
         text = T( _("Set default style to %1?"), text),
         ok_callback = function()
             G_reader_settings:saveSetting("copt_css", css)
+            if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })
 end

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -118,6 +118,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Set Wikipedia languages"),
+                keep_menu_open = true,
                 callback = function()
                     local wikilang_input
                     local function save_wikilang()
@@ -171,6 +172,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
             },
             { -- setting used by dictquicklookup
                 text = _("Set Wikipedia 'Save as EPUB' directory"),
+                keep_menu_open = true,
                 callback = function()
                     local choose_directory = function()
                         -- Default directory as chosen by DictQuickLookup
@@ -298,6 +300,7 @@ Where do you want them saved?]])
             },
             {
                 text = _("Clean Wikipedia history"),
+                keep_menu_open = true,
                 callback = function()
                     UIManager:show(ConfirmBox:new{
                         text = _("Clean Wikipedia history?"),

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -318,62 +318,41 @@ end
 
 function ReaderZooming:addToMainMenu(menu_items)
     if self.ui.document.info.has_pages then
+        local function getZoomModeMenuItem(text, mode, separator)
+            return {
+                text_func = function()
+                    local default_zoom_mode = G_reader_settings:readSetting("zoom_mode") or self.DEFAULT_ZOOM_MODE
+                    return text .. (mode == default_zoom_mode and "   ★" or "")
+                end,
+                checked_func = function()
+                    return self.zoom_mode == mode
+                end,
+                callback = self:genSetZoomModeCallBack(mode),
+                hold_callback = function(touchmenu_instance)
+                    self:makeDefault(mode, touchmenu_instance)
+                end,
+                separator = separator,
+            }
+        end
         menu_items.switch_zoom_mode = {
             text = _("Switch zoom mode"),
             enabled_func = function()
                 return self.ui.document.configurable.text_wrap ~= 1
             end,
             sub_item_table = {
-                {
-                    text = _("Zoom to fit content width"),
-                    checked_func = function() return self.zoom_mode == "contentwidth" end,
-                    callback = self:genSetZoomModeCallBack("contentwidth"),
-                    hold_callback = function() self:makeDefault("contentwidth") end,
-                },
-                {
-                    text = _("Zoom to fit content height"),
-                    checked_func = function() return self.zoom_mode == "contentheight" end,
-                    callback = self:genSetZoomModeCallBack("contentheight"),
-                    hold_callback = function() self:makeDefault("contentheight") end,
-                    separator = true,
-                },
-                {
-                    text = _("Zoom to fit page width"),
-                    checked_func = function() return self.zoom_mode == "pagewidth" end,
-                    callback = self:genSetZoomModeCallBack("pagewidth"),
-                    hold_callback = function() self:makeDefault("pagewidth") end,
-                },
-                {
-                    text = _("Zoom to fit page height"),
-                    checked_func = function() return self.zoom_mode == "pageheight" end,
-                    callback = self:genSetZoomModeCallBack("pageheight"),
-                    hold_callback = function() self:makeDefault("pageheight") end,
-                    separator = true,
-                },
-                {
-                    text = _("Zoom to fit column"),
-                    checked_func = function() return self.zoom_mode == "column" end,
-                    callback = self:genSetZoomModeCallBack("column"),
-                    hold_callback = function() self:makeDefault("column") end,
-                },
-                {
-                    text = _("Zoom to fit content"),
-                    checked_func = function() return self.zoom_mode == "content" end,
-                    callback = self:genSetZoomModeCallBack("content"),
-                    hold_callback = function() self:makeDefault("content") end,
-                },
-                {
-                    text = _("Zoom to fit page"),
-                    checked_func = function() return self.zoom_mode == "page" end,
-                    callback = self:genSetZoomModeCallBack("page"),
-                    hold_callback = function() self:makeDefault("page") end,
-                },
+                getZoomModeMenuItem(_("Zoom to fit content width"), "contentwidth"),
+                getZoomModeMenuItem(_("Zoom to fit content height"), "contentheight", true),
+                getZoomModeMenuItem(_("Zoom to fit page width"), "pagewidth"),
+                getZoomModeMenuItem(_("Zoom to fit page height"), "pageheight", true),
+                getZoomModeMenuItem(_("Zoom to fit column"), "column"),
+                getZoomModeMenuItem(_("Zoom to fit content"), "content"),
+                getZoomModeMenuItem(_("Zoom to fit page"), "page"),
             }
         }
     end
 end
 
-function ReaderZooming:makeDefault(zoom_mode)
+function ReaderZooming:makeDefault(zoom_mode, touchmenu_instance)
     UIManager:show(ConfirmBox:new{
         text = T(
             _("Set default zoom mode to %1?"),
@@ -381,6 +360,7 @@ function ReaderZooming:makeDefault(zoom_mode)
         ),
         ok_callback = function()
             G_reader_settings:saveSetting("zoom_mode", zoom_mode)
+            if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })
 end

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -15,6 +15,7 @@ end
 local version = require("version"):getCurrentRevision()
 common_info.version = {
     text = _("Version"),
+    keep_menu_open = true,
     callback = function()
         UIManager:show(InfoMessage:new{
             text = version,
@@ -41,6 +42,7 @@ common_info.quickstart_guide = {
 }
 common_info.about = {
     text = _("About"),
+    keep_menu_open = true,
     callback = function()
         UIManager:show(InfoMessage:new{
             text = T(_("KOReader %1\n\nA document viewer for E Ink devices.\n\nLicensed under Affero GPL v3. All dependencies are free software.\n\nhttp://koreader.rocks/"), version),
@@ -49,6 +51,7 @@ common_info.about = {
 }
 common_info.report_bug = {
     text = _("Report a bug"),
+    keep_menu_open = true,
     callback = function()
         local model = Device.model
         UIManager:show(InfoMessage:new{
@@ -69,6 +72,7 @@ end
 if Device:isKobo() then
     common_info.reboot = {
         text = _("Reboot the device"),
+        keep_menu_open = true,
         callback = function()
             UIManager:show(ConfirmBox:new{
                 text = _("Are you sure you want to reboot the device?"),
@@ -81,6 +85,7 @@ if Device:isKobo() then
     }
     common_info.poweroff = {
         text = _("Power off"),
+        keep_menu_open = true,
         callback = function()
             UIManager:show(ConfirmBox:new{
                 text = _("Are you sure you want to power off the device?"),

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -27,6 +27,7 @@ if Device:setDateTime() then
         sub_item_table = {
             {
                 text = _("Set time"),
+                keep_menu_open = true,
                 callback = function()
                     local now_t = os.date("*t")
                     local curr_hour = now_t.hour
@@ -55,6 +56,7 @@ if Device:setDateTime() then
             },
             {
                 text = _("Set date"),
+                keep_menu_open = true,
                 callback = function()
                     local now_t = os.date("*t")
                     local curr_year = now_t.year

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -113,18 +113,21 @@ return {
         sub_item_table = {
             {
                 text = _("Screensaver folder"),
+                keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFolder()
                 end,
             },
             {
                 text = _("Screensaver image"),
+                keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFile()
                 end,
             },
             {
                 text = _("Screensaver message"),
+                keep_menu_open = true,
                 callback = function()
                     Screensaver:setMessage()
                 end,

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -123,11 +123,11 @@ function NetworkMgr:getWifiMenuTable()
         text = _("Wi-Fi connection"),
         enabled_func = function() return Device:isAndroid() or Device:isKindle() or Device:isKobo() end,
         checked_func = function() return NetworkMgr:isOnline() end,
-        callback = function(menu)
+        callback = function(touchmenu_instance)
             local wifi_status = NetworkMgr:isOnline()
             local complete_callback = function()
                 -- notify touch menu to update item check state
-                menu:updateItems()
+                touchmenu_instance:updateItems()
                 local Event = require("ui/event")
                 -- if wifi was on, this callback will only be executed when the network has been
                 -- disconnected.
@@ -188,16 +188,17 @@ function NetworkMgr:getRestoreMenuTable()
         text = _("Automatically restore Wi-Fi connection after resume"),
         checked_func = function() return G_reader_settings:nilOrTrue("auto_restore_wifi") end,
         enabled_func = function() return Device:isKobo() end,
-        callback = function(menu) G_reader_settings:flipNilOrTrue("auto_restore_wifi") end,
+        callback = function() G_reader_settings:flipNilOrTrue("auto_restore_wifi") end,
     }
 end
 
 function NetworkMgr:getInfoMenuTable()
     return {
         text = _("Network info"),
+        keep_menu_open = true,
         -- TODO: also show network info when device is authenticated to router but offline
         enabled_func = function() return self:isOnline() end,
-        callback = function(menu)
+        callback = function()
             if Device.retrieveNetworkInfo then
                 UIManager:show(InfoMessage:new{
                     text = Device:retrieveNetworkInfo(),
@@ -249,7 +250,7 @@ function NetworkMgr:getDismissScanMenuTable()
         text = _("Dismiss Wi-Fi scan popup after connection"),
         checked_func = function() return G_reader_settings:nilOrTrue("auto_dismiss_wifi_scan") end,
         --enabled_func = function() return Device:isKobo() end,
-        callback = function(menu) G_reader_settings:flipNilOrTrue("auto_dismiss_wifi_scan") end,
+        callback = function() G_reader_settings:flipNilOrTrue("auto_dismiss_wifi_scan") end,
     }
 end
 

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -143,6 +143,7 @@ local InputDialog = InputContainer:new{
                       -- This string is then shown:
                       -- - on success: as the notification text instead of the default one
                       -- - on failure: in an InfoMessage
+    close_callback = nil, -- Called when closing (if discarded or saved, after save_callback if saved)
 
     -- For use by TextEditor plugin:
     view_pos_callback = nil, -- Called with no arg to get initial top_line_num/charpos,
@@ -607,6 +608,7 @@ function InputDialog:_addSaveCloseButtons()
                     cancel_text = self.close_cancel_button_text or _("Cancel"),
                     choice1_text = self.close_discard_button_text or _("Discard"),
                     choice1_callback = function()
+                        if self.close_callback then self.close_callback() end
                         UIManager:close(self)
                         UIManager:show(Notification:new{
                             text = self.close_discarded_notif_text or _("Changes discarded"),
@@ -626,6 +628,7 @@ function InputDialog:_addSaveCloseButtons()
                                     })
                                 end
                             else -- nil or true
+                                if self.close_callback then self.close_callback() end
                                 UIManager:close(self)
                                 UIManager:show(Notification:new{
                                     text = msg or _("Saved"),
@@ -637,6 +640,7 @@ function InputDialog:_addSaveCloseButtons()
                 })
             else
                 -- Not modified, exit without any message
+                if self.close_callback then self.close_callback() end
                 UIManager:close(self)
             end
         end,

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -693,7 +693,9 @@ function TouchMenu:onMenuSelect(item)
         self.touch_menu_callback()
     end
     if item.tap_input or type(item.tap_input_func) == "function" then
-        self:closeMenu()
+        if not item.keep_menu_open then
+            self:closeMenu()
+        end
         if item.tap_input then
             self:onInput(item.tap_input)
         else
@@ -714,10 +716,14 @@ function TouchMenu:onMenuSelect(item)
                 -- put stuff in scheduler so we can see
                 -- the effect of inverted menu item
                 UIManager:tickAfterNext(function()
+                    -- Provide callback with us, so it can call our
+                    -- closemenu() or updateItems() when it sees fit
+                    -- (if not providing checked or checked_fund, caller
+                    -- must set keep_menu_open=true if that is wished)
                     callback(self)
                     if refresh then
                         self:updateItems()
-                    else
+                    elseif not item.keep_menu_open then
                         self:closeMenu()
                     end
                 end)
@@ -737,7 +743,9 @@ function TouchMenu:onMenuHold(item)
         self.touch_menu_callback()
     end
     if item.hold_input or type(item.hold_input_func) == "function" then
-        self:closeMenu()
+        if item.hold_keep_menu_open == false then
+            self:closeMenu()
+        end
         if item.hold_input then
             self:onInput(item.hold_input)
         else
@@ -750,12 +758,15 @@ function TouchMenu:onMenuHold(item)
         end
         if callback then
             UIManager:tickAfterNext(function()
-                if item.hold_may_update_menu then
-                    callback(function() self:updateItems() end)
-                else
+                -- With hold, the default is to keep menu open, as we're
+                -- most often showing a ConfirmBox that can be cancelled
+                -- (provide hold_keep_menu_open=false to override)
+                if item.hold_keep_menu_open == false then
                     self:closeMenu()
-                    callback()
                 end
+                -- Provide callback with us, so it can call our
+                -- closemenu() or updateItems() when it sees fit
+                callback(self)
             end)
         end
     elseif item.help_text or type(item.help_text_func) == "function" then

--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -4,10 +4,11 @@ local InfoMessage = require("ui/widget/infomessage")  -- luacheck:ignore
 local InputDialog = require("ui/widget/inputdialog")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local ffiutil = require("ffi/util")
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
-local T = require("ffi/util").template
+local T = ffiutil.template
 
 -- This plugin uses a patched dropbear that adds two things:
 -- the -n option to bypass password checks
@@ -136,16 +137,31 @@ function SSH:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Start SSH server"),
-                callback = function() return self:start() end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    self:start()
+                    -- sleeping might not be needed, but it gives the feeling
+                    -- something has been done and feedback is accurate
+                    ffiutil.sleep(1)
+                    touchmenu_instance:updateItems()
+                end,
                 enabled_func = function() return not self:isRunning() end,
             },
             {
                 text = _("Stop SSH server"),
-                callback = function() return self:stop() end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    self:stop()
+                    -- sleeping might not be needed, but it gives the feeling
+                    -- something has been done and feedback is accurate
+                    ffiutil.sleep(1)
+                    touchmenu_instance:updateItems()
+                end,
                 enabled_func = function() return self:isRunning() end,
             },
             {
                 text = _("Change SSH port"),
+                keep_menu_open = true,
                 enabled_func = function() return not self:isRunning() end,
                 callback = function() return self:show_port_dialog() end,
             },
@@ -157,6 +173,7 @@ function SSH:addToMainMenu(menu_items)
             },
             {
                 text = _("SSH public key"),
+                keep_menu_open = true,
                 callback = function()
                     local info = InfoMessage:new{
                         timeout = 60,

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -293,6 +293,7 @@ end
 function BatteryStatWidget:addToMainMenu(menu_items)
     menu_items.battery_statistics = {
         text = _("Battery statistics"),
+        keep_menu_open = true,
         callback = function()
             BatteryStat:showStatistics()
         end,

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -334,6 +334,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     },
                     {
                         text = _("Prune cache of removed books"),
+                        keep_menu_open = true,
                         callback = function()
                             local ConfirmBox = require("ui/widget/confirmbox")
                             UIManager:close(self.file_dialog)
@@ -356,6 +357,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     },
                     {
                         text = _("Compact cache database"),
+                        keep_menu_open = true,
                         callback = function()
                             local ConfirmBox = require("ui/widget/confirmbox")
                             UIManager:close(self.file_dialog)
@@ -377,6 +379,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     },
                     {
                         text = _("Delete cache database"),
+                        keep_menu_open = true,
                         callback = function()
                             local ConfirmBox = require("ui/widget/confirmbox")
                             UIManager:close(self.file_dialog)

--- a/plugins/goodreads.koplugin/main.lua
+++ b/plugins/goodreads.koplugin/main.lua
@@ -29,12 +29,15 @@ function Goodreads:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Settings"),
+                keep_menu_open = true,
                 callback = function() self:updateSettings() end,
             },
             {
                 text = _("Search all books"),
-                callback = function()
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
                     if self.goodreads_key ~= ""  then
+                        touchmenu_instance:closeMenu()
                         self:search("all")
                     else
                         UIManager:show(InfoMessage:new{
@@ -45,8 +48,10 @@ function Goodreads:addToMainMenu(menu_items)
             },
             {
                 text = _("Search for book by title"),
-                callback = function()
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
                     if self.goodreads_key ~= ""  then
+                        touchmenu_instance:closeMenu()
                         self:search("title")
                     else
                         UIManager:show(InfoMessage:new{
@@ -57,10 +62,11 @@ function Goodreads:addToMainMenu(menu_items)
             },
             {
                 text = _("Search for book by author"),
-                callback = function()
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
                     if self.goodreads_key ~= ""  then
+                        touchmenu_instance:closeMenu()
                         self:search("author")
-
                     else
                         UIManager:show(InfoMessage:new{
                             text = _("Please set up your Goodreads key in the settings dialog"),

--- a/plugins/kobolight.koplugin/main.lua
+++ b/plugins/kobolight.koplugin/main.lua
@@ -230,6 +230,7 @@ end
 function KoboLight:addToMainMenu(menu_items)
     menu_items.frontlight_gesture_controller = {
         text = _("Frontlight gesture controller"),
+        keep_menu_open = true,
         callback = function()
             local image_name
             local nl_text = ""

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -94,6 +94,7 @@ function KOSync:addToMainMenu(menu_items)
                     return self.kosync_userkey and (_("Logout"))
                         or _("Register") .. " / " .. _("Login")
                 end,
+                keep_menu_open = true,
                 callback_func = function()
                     return self.kosync_userkey and
                         function() self:logout() end or
@@ -205,6 +206,7 @@ function KOSync:addToMainMenu(menu_items)
             },
             {
                 text = _("Custom sync server"),
+                keep_menu_open = true,
                 tap_input_func = function()
                     return {
                         title = _("Custom progress sync server address"),

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -74,6 +74,7 @@ function NewsDownloader:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Download news"),
+                keep_menu_open = true,
                 callback = function()
                     if not NetworkMgr:isOnline() then
                         wifi_enabled_before_action = false
@@ -96,6 +97,7 @@ function NewsDownloader:addToMainMenu(menu_items)
             },
             {
                 text = _("Remove news"),
+                keep_menu_open = true,
                 callback = function() self:removeNewsButKeepFeedConfig() end,
             },
             {
@@ -103,16 +105,19 @@ function NewsDownloader:addToMainMenu(menu_items)
                 sub_item_table = {
                     {
                         text = _("Change feeds configuration"),
+                        keep_menu_open = true,
                         callback = function() self:changeFeedConfig() end,
                     },
                     {
                         text = _("Set custom download directory"),
+                        keep_menu_open = true,
                         callback = function() self:setCustomDownloadDirectory() end,
                     },
                 },
             },
             {
                 text = _("Help"),
+                keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{
                         text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),

--- a/plugins/perceptionexpander.koplugin/main.lua
+++ b/plugins/perceptionexpander.koplugin/main.lua
@@ -173,12 +173,14 @@ function PerceptionExpander:addToMainMenu(menu_items)
             },
             {
                 text = _("Settings"),
+                keep_menu_open = true,
                 callback = function()
                     self:showSettingsDialog()
                 end,
             },
             {
                 text = _("About"),
+                keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{
                         text = _("For more information see wiki page Perception Expander Plugin"),

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -69,7 +69,8 @@ function ReadTimer:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Time"),
-                callback = function()
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
                     local now_t = os.date("*t")
                     local curr_hour = now_t.hour
                     local curr_min = now_t.min
@@ -80,6 +81,7 @@ function ReadTimer:addToMainMenu(menu_items)
                         ok_text = _("Set timer"),
                         title_text =  _("Set reader timer"),
                         callback = function(time)
+                            touchmenu_instance:closeMenu()
                             self:unschedule()
                             local timer_sec_from_mignight = time.hour*3600 + time.min*60
                             local seconds
@@ -125,7 +127,8 @@ function ReadTimer:addToMainMenu(menu_items)
             },
             {
                 text = _("Minutes from now"),
-                callback = function()
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
                     local remain_time = {}
                     local remain_hours, remain_minutes = self:remainingTime()
                     if not remain_hours and not remain_minutes then
@@ -142,6 +145,7 @@ function ReadTimer:addToMainMenu(menu_items)
                         ok_text = _("Set timer"),
                         title_text =  _("Set reader timer from now (hours:minutes)"),
                         callback = function(time)
+                            touchmenu_instance:closeMenu()
                             self:unschedule()
                             local seconds = time.hour * 3600 + time.min * 60
                             if seconds > 0 then
@@ -175,11 +179,13 @@ function ReadTimer:addToMainMenu(menu_items)
             },
             {
                 text = _("Stop timer"),
+                keep_menu_open = true,
                 enabled_func = function()
                     return self:scheduled()
                 end,
-                callback = function()
+                callback = function(touchmenu_instance)
                     self:unschedule()
+                    touchmenu_instance:updateItems()
                 end,
             },
         },

--- a/plugins/send2ebook.koplugin/main.lua
+++ b/plugins/send2ebook.koplugin/main.lua
@@ -62,6 +62,7 @@ function Send2Ebook:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Download and remove from server"),
+                keep_menu_open = true,
                 callback = function()
                   if not NetworkMgr:isOnline() then
                       wifi_enabled_before_action = false
@@ -84,18 +85,22 @@ function Send2Ebook:addToMainMenu(menu_items)
             },
             {
                 text = _("Remove read (opened) articles"),
+                keep_menu_open = true,
                 callback = self.removeReadActicles,
             },
             {
                 text = _("Set custom download directory"),
+                keep_menu_open = true,
                 callback =  self.setCustomDownloadDirectory,
             },
             {
                 text = _("Settings"),
+                keep_menu_open = true,
                 callback = self.editFtpConnection,
             },
             {
                 text = _("Help"),
+                keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{
                         text = T(_('Send2Ebook lets you send articles found on PC/Android phone to your Ebook reader (using ftp server).\n\nMore details: https://github.com/mwoz123/send2ebook\n\nDownloads to local folder: %1'), download_dir_path)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -676,16 +676,19 @@ function ReaderStatistics:addToMainMenu(menu_items)
             self:getStatisticEnabledMenuItem(),
             {
                 text = _("Settings"),
+                keep_menu_open = true,
                 callback = function() self:updateSettings() end,
             },
             {
                 text = _("Reset book statistics"),
+                keep_menu_open = true,
                 callback = function()
                     self:resetBook()
                 end
             },
             {
                 text = _("Current book"),
+                keep_menu_open = true,
                 callback = function()
                     UIManager:show(KeyValuePage:new{
                         title = _("Statistics"),
@@ -696,6 +699,7 @@ function ReaderStatistics:addToMainMenu(menu_items)
             },
             {
                 text = _("Reading progress"),
+                keep_menu_open = true,
                 callback = function()
                     self:insertDB(self.id_curr_book)
                     local current_period, current_pages = self:getCurrentBookStats()
@@ -717,6 +721,7 @@ function ReaderStatistics:addToMainMenu(menu_items)
             },
             {
                 text = _("Time range"),
+                keep_menu_open = true,
                 callback = function()
                     self:statMenu()
                 end

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -249,6 +249,7 @@ end
 function SystemStatWidget:addToMainMenu(menu_items)
     menu_items.system_statistics = {
         text = _("System statistics"),
+        keep_menu_open = true,
         callback = function()
             SystemStat:showStatistics()
         end,

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -88,6 +88,7 @@ end
 function Terminal:addToMainMenu(menu_items)
     menu_items.terminal = {
         text = _("Terminal emulator"),
+        keep_menu_open = true,
         callback = function()
             self:start()
         end,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -78,12 +78,14 @@ end
 
 function TextEditor:getSubMenuItems()
     self:loadSettings()
+    self.whenDoneFunc = nil -- discard reference to previous TouchMenu instance
     local sub_item_table = {
         {
             text = _("Text editor settings"),
             sub_item_table = {
                 {
                     text = _("Set text font size"),
+                    keep_menu_open = true,
                     callback = function()
                         local SpinWidget = require("ui/widget/spinwidget")
                         local font_size = self.font_size
@@ -118,13 +120,17 @@ function TextEditor:getSubMenuItems()
         },
         {
             text = _("Select a file to open"),
-            callback = function()
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                self:setupWhenDoneFunc(touchmenu_instance)
                 self:chooseFile()
             end,
         },
         {
             text = _("Edit a new empty file"),
-            callback = function()
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                self:setupWhenDoneFunc(touchmenu_instance)
                 self:newFile()
             end,
             separator = true,
@@ -135,10 +141,13 @@ function TextEditor:getSubMenuItems()
         local directory, filename = util.splitFilePathName(file_path) -- luacheck: no unused
         table.insert(sub_item_table, {
             text = T("%1. %2", i, filename),
-            callback = function()
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                self:setupWhenDoneFunc(touchmenu_instance)
                 self:checkEditFile(file_path, true)
             end,
-            hold_callback = function()
+            _texteditor_id = file_path, -- for removal from menu itself
+            hold_callback = function(touchmenu_instance)
                 -- Show full path and some info, and propose to remove from history
                 local text
                 local attr = lfs.attributes(file_path)
@@ -157,12 +166,40 @@ function TextEditor:getSubMenuItems()
                     cancel_text = _("No"),
                     ok_callback = function()
                         self:removeFromHistory(file_path)
+                        -- Also remove from menu itself
+                        for i=1, #sub_item_table do
+                            if sub_item_table[i]._texteditor_id == file_path then
+                                table.remove(sub_item_table, i)
+                                break
+                            end
+                        end
+                        touchmenu_instance:updateItems()
                     end,
                 })
             end,
         })
     end
     return sub_item_table
+end
+
+function TextEditor:setupWhenDoneFunc(touchmenu_instance)
+    -- This will keep a reference to the TouchMenu instance, that may not
+    -- get released if file opening is aborted while in the file selection
+    -- widgets and dialogs (quite complicated to call a resetWhenDoneFunc()
+    -- in every abort case). But :getSubMenuItems() will release it when
+    -- the TextEditor menu is opened again.
+    self.whenDoneFunc = function()
+        touchmenu_instance.item_table = self:getSubMenuItems()
+        touchmenu_instance.page = 1
+        touchmenu_instance:updateItems()
+    end
+end
+
+function TextEditor:execWhenDoneFunc()
+    if self.whenDoneFunc then
+        self.whenDoneFunc()
+        self.whenDoneFunc = nil
+    end
 end
 
 function TextEditor:removeFromHistory(file_path)
@@ -415,6 +452,10 @@ function TextEditor:editFile(file_path, readonly)
         -- File restoring callback
         reset_callback = function(content) -- Will add a Reset button
             return self:readFileContent(file_path), _("Text reset to last saved content")
+        end,
+        -- Close callback
+        close_callback = function()
+            self:execWhenDoneFunc()
         end,
         -- File saving callback
         save_callback = function(content, closing) -- Will add Save/Close buttons

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -167,9 +167,9 @@ function TextEditor:getSubMenuItems()
                     ok_callback = function()
                         self:removeFromHistory(file_path)
                         -- Also remove from menu itself
-                        for i=1, #sub_item_table do
-                            if sub_item_table[i]._texteditor_id == file_path then
-                                table.remove(sub_item_table, i)
+                        for j=1, #sub_item_table do
+                            if sub_item_table[j]._texteditor_id == file_path then
+                                table.remove(sub_item_table, j)
                                 break
                             end
                         end

--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -56,6 +56,7 @@ end
 
 local menuItem = {
     text = _("Synchronize time"),
+    keep_menu_open = true,
     callback = function()
         if NetworkMgr:isOnline() then
             execute()


### PR DESCRIPTION
TouchMenu: added options to menu items with the following defaults:
```
    keep_menu_open = false
    hold_keep_menu_open = true
```
So, default for Tap callback is to close menu, and for Hold callback to keep menu open.
(There is already a classic case where the menu is kept open when Tap: when the menu item has a checkbox - so the checkboxes can be updated - this PR allows doing more things like that in non checkbox cases.)

In both cases, provide the TouchMenu instance as the 1st argument to the callback functions (instead of a `refresh_menu_func` I added in #3941) so the callback can do more things, like closing, refreshing, changing menu items text and re-ordering...
(So, reworked #3941 as TouchMenu was alreadying providing the TouchMenu instance to the Tap callback, and it was used in ReaderBookmark and NetworkMgr - didn't see that at the time)

I set these options to the non-default value for some of the menu items where _I felt_ it was right. And also when there's a ConfirmBox after the Tap, where the user could select Cancel (only when selecting OK would the menu be closed).
May be I missed some, may be people won't like it for others, so feel free to correct me and add the ones I missed (or did not do).
(Should menu be kept open for Book status and Book information ?)

In some cases, if you want to keep the menu open, you need to add some code to update the menu items depending on what the callback did, so the kept open menu shows the real state of things and provides feedback of what the callback has done.

So, a bit more code added for:
- ReaderZooming: show symbol for default (like it was done for ReaderFont, ReaderHyphenation...)
- TextEditor plugin: update the previously opened files list in real time, so the menu can be kept open and used as the TextEditor main interface.
- SSH plugin: keep menu open and update the Start/Stop state in real time.
- ReadTimer plugin: tried to do what feels right (but I don't use it).


I haven't really checked the Network menu, as I don't use it. May be it needs a few more `keep_menu_open=true`, and some menu update code.


As I don't use the following plugins, and have no real way to test most of them, I haven't touched much of them, but I feel like they would need some menu to be kept open :)
```
plugins/calibrecompanion.koplugin/main.lua
plugins/evernote.koplugin/main.lua
plugins/goodreads.koplugin/main.lua (keep open if search() ?)
plugins/keepalive.koplugin/main.lua (could be made to keep open with real feedback but no real feedback)
plugins/kosync.koplugin/main.lua (checked_func needed?)
plugins/zsync.koplugin/main.lua (checked_func needed?)
```

There are also a few cases (ReaderHighlight enable/disable, Overlap enable/disable...) where hold sets a boolean default, and we have currently no visual symbol for that. But it feels that would make the menu too crowded, so it may not be needed for these rarely used/defaulted settings.

Closes #4170.
