### PR TITLE
Go back to the latest AppImageKit release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ SONY_PRSTUX_DIR=$(PLATFORM_DIR)/sony-prstux
 
 # appimage setup
 APPIMAGETOOL=appimagetool-x86_64.AppImage
-APPIMAGETOOL_URL=https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+APPIMAGETOOL_URL=https://github.com/AppImage/AppImageKit/releases/download/10/appimagetool-x86_64.AppImage
 
 # set to 1 if in Docker
 DOCKER:=$(shell grep -q docker /proc/1/cgroup && echo 1)


### PR DESCRIPTION
Instead of a live snapshot, because master now has a hard-dep on cairo.

Fix https://github.com/koreader/koreader-base/issues/730