### PR TITLE
[Statistics] Add estimate end of read

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -964,7 +964,7 @@ function ReaderStatistics:getCurrentStat(id_book)
     total_read_pages = tonumber(total_read_pages)
     local avg_time_per_page = total_time_book / total_read_pages
     local time_to_read = (self.data.pages - self.view.state.page) * avg_time_per_page
-    local estimate_days_to_read = math.floor(time_to_read/(total_time_book/tonumber(total_days)))
+    local estimate_days_to_read = math.ceil(time_to_read/(total_time_book/tonumber(total_days)))
     local estimate_end_of_read_date = os.date("%Y-%m-%d", tonumber(os.time() + estimate_days_to_read * 86400))
     return {
         { _("Current period"), util.secondsToClock(current_period, false) },

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -981,7 +981,7 @@ function ReaderStatistics:getCurrentStat(id_book)
         -- adding 0.5 rounds to nearest integer with math.floor
         { _("Percentage completed"), math.floor(total_read_pages / self.data.pages * 100 + 0.5) .. "%" },
         { _("Average time per day"), util.secondsToClock(total_time_book/tonumber(total_days)), false },
-        { _("Estimate end of read"), string.format("%s (%d day(s))", estimate_end_of_read_date, estimate_days_to_read) },
+        { _("Estimated reading finished"), string.format("%s (%d day(s))", estimate_end_of_read_date, estimate_days_to_read) },
     }
 end
 

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -963,12 +963,15 @@ function ReaderStatistics:getCurrentStat(id_book)
     total_time_book = tonumber(total_time_book)
     total_read_pages = tonumber(total_read_pages)
     local avg_time_per_page = total_time_book / total_read_pages
+    local time_to_read = (self.data.pages - self.view.state.page) * avg_time_per_page
+    local estimate_days_to_read = math.floor(time_to_read/(total_time_book/tonumber(total_days)))
+    local estimate_end_of_read_date = os.date("%Y-%m-%d", tonumber(os.time() + estimate_days_to_read * 86400))
     return {
         { _("Current period"), util.secondsToClock(current_period, false) },
         { _("Current pages"), tonumber(current_pages) },
         { _("Today period"), util.secondsToClock(today_period, false) },
         { _("Today pages"), tonumber(today_pages) },
-        { _("Time to read"), util.secondsToClock((self.data.pages - self.view.state.page) * avg_time_per_page, false) },
+        { _("Time to read"), util.secondsToClock(time_to_read), false},
         { _("Total time"), util.secondsToClock(total_time_book, false) },
         { _("Total highlights"), tonumber(highlights) },
         { _("Total notes"), tonumber(notes) },
@@ -977,6 +980,8 @@ function ReaderStatistics:getCurrentStat(id_book)
         { _("Read pages/Total pages"), total_read_pages .. "/" .. self.data.pages },
         -- adding 0.5 rounds to nearest integer with math.floor
         { _("Percentage completed"), math.floor(total_read_pages / self.data.pages * 100 + 0.5) .. "%" },
+        { _("Average time per day"), util.secondsToClock(total_time_book/tonumber(total_days)), false },
+        { _("Estimate end of read"), string.format("%s (%d day(s))", estimate_end_of_read_date, estimate_days_to_read) },
     }
 end
 


### PR DESCRIPTION
Two new statistics in `Current book`:

* Estimate end of read
* Average time per day

![marsjanin - koreader_178](https://user-images.githubusercontent.com/22982594/45931166-23a11d00-bf6a-11e8-8a7d-d7a785aaa90d.png)
