### PR TITLE
Gesture manager - fix refresh switch to night mode

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -180,7 +180,7 @@ function ReaderGesture:gestureAction(action)
     elseif action == "night_mode" then
         local night_mode = G_reader_settings:readSetting("night_mode") or false
         Screen:toggleNightMode()
-        UIManager:setDirty(nil, "full")
+        UIManager:setDirty("all", "full")
         G_reader_settings:saveSetting("night_mode", not night_mode)
     elseif action == "full_refresh" then
         if self.view then


### PR DESCRIPTION
See comment: https://github.com/koreader/koreader/pull/4240#issuecomment-425810456

> Also (not investigated, was just testing), when setting bottom left to toggle night mode, night mode is not immediately set: you need to change page or trigger full refresh to see it.