### PR TITLE
show OTA updates on supported devices

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -17,6 +17,7 @@ local Device = Generic:new{
     display_dpi = android.lib.AConfiguration_getDensity(android.app.config),
     hasClipboard = yes,
     hasColorScreen = yes,
+    hasOTAUpdates = yes,
 }
 
 function Device:init()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -51,6 +51,9 @@ local Device = {
     -- but is actually a color eInk screen with 24bit per pixel.
     -- The refresh is still based on bytes. (This solves issue #4193.)
     has3BytesWideFrameBuffer = no,
+
+    -- set to yes on devices that support over-the-air incremental updates.
+    hasOTAUpdates = no,
 }
 
 function Device:new(o)

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -51,6 +51,7 @@ local Kindle = Generic:new{
     isKindle = yes,
     -- NOTE: We can cheat by adding a platform-specific entry here, because the only code that will check for this is here.
     isSpecialOffers = isSpecialOffers(),
+    hasOTAUpdates = yes,
 }
 
 function Kindle:initNetworkManager(NetworkMgr)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -24,6 +24,7 @@ local Kobo = Generic:new{
     isKobo = yes,
     isTouchDevice = yes, -- all of them are
     hasBGRFrameBuffer = yes, -- True when >16bpp
+    hasOTAUpdates = yes,
 
     -- most Kobos have X/Y switched for the touch screen
     touch_switch_xy = true,

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -54,6 +54,7 @@ local PocketBook = Generic:new{
     model = "PocketBook",
     isPocketBook = yes,
     isInBackGround = false,
+    hasOTAUpdates = yes,
 }
 
 function PocketBook:init()

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -10,6 +10,7 @@ local SonyPRSTUX = Generic:new{
     model = "Sony PRSTUX",
     isSonyPRSTUX = yes,
     hasKeys = yes,
+    hasOTAUpdates = yes,
 }
 
 

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -7,8 +7,7 @@ local T = require("ffi/util").template
 
 local common_info = {}
 
-if Device:isKindle() or Device:isKobo() or Device:isPocketBook()
-    or Device:isAndroid() then
+if Device:hasOTAUpdates() then
     local OTAManager = require("ui/otamanager")
     common_info.ota_update = OTAManager:getOTAMenuTable()
 end

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -93,8 +93,7 @@ local order = {
         "----------------------------",
         "system_statistics",
         "----------------------------",
-        "ota_update", --[[ if Device:isKindle() or Device:isKobo() or
-                           Device:isPocketBook() or Device:isAndroid() ]]--
+        "ota_update", -- if Device:hasOTAUpdates()
         "version",
         "help",
         "----------------------------",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -114,8 +114,7 @@ local order = {
         "----------------------------",
         "system_statistics",
         "----------------------------",
-        "ota_update", --[[ if Device:isKindle() or Device:isKobo() or
-                           Device:isPocketBook() or Device:isAndroid() ]]--
+        "ota_update", -- if Device:hasOTAUpdates()
         "version",
         "help",
         "----------------------------",

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -57,6 +57,8 @@ function OTAManager:getOTAModel()
         return "pocketbook"
     elseif Device:isAndroid() then
         return "android"
+    elseif Device:isSonyPRSTUX() then
+        return "sony-prstux"
     else
         return ""
     end


### PR DESCRIPTION
Remove Android since we cannot provide OTA updates other than upgrading the APK, which is done outside KOReader

Pinging @v01d about PRSTUX devices. Would they support over-the-air updates?