### PR TITLE
Selection menu: allow viewing HTML

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -118,7 +118,7 @@ function FileManagerMenu:setUpdateItemTable()
         help_text = _([[This sets the number of items per page in:
 - File browser and history in 'classic' display mode
 - File and directory selection
-- Table of content
+- Table of contents
 - Bookmarks list]]),
         keep_menu_open = true,
         callback = function()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -192,6 +192,10 @@ function ReaderHighlight:onTapPageSavedHighlight(ges)
 end
 
 function ReaderHighlight:onTapXPointerSavedHighlight(ges)
+    -- Getting screen boxes is done for each tap on screen (changing pages,
+    -- showing menu...). We might want to cache these boxes per page (and
+    -- clear that cache when page layout change or highlights are added
+    -- or removed).
     local cur_page
     -- In scroll mode, we'll need to check for highlights in previous or next
     -- page too as some parts of them may be displayed

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -473,6 +473,10 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
 end
 
 function ReaderView:drawXPointerSavedHighlight(bb, x, y)
+    -- Getting screen boxes is done for each tap on screen (changing pages,
+    -- showing menu...). We might want to cache these boxes per page (and
+    -- clear that cache when page layout change or highlights are added
+    -- or removed).
     local cur_page
     -- In scroll mode, we'll need to check for highlights in previous or next
     -- page too as some parts of them may be displayed
@@ -499,7 +503,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
             -- (A highlight starting on cur_page-17 and ending on cur_page+13 is
             -- a highlight to consider)
             if start_page <= cur_page + neighbour_pages and end_page >= cur_page - neighbour_pages then
-                local boxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1)
+                local boxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1, true) -- get_segments=true
                 if boxes then
                     for _, box in pairs(boxes) do
                         local rect = self:pageToScreenTransform(page, box)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -367,6 +367,30 @@ function CreDocument:getLinkFromPosition(pos)
     return self._document:getLinkFromPosition(pos.x, pos.y)
 end
 
+function CreDocument:getDocumentFileContent(filepath)
+    if filepath then
+        return self._document:getDocumentFileContent(filepath)
+    end
+end
+
+function CreDocument:getTextFromXPointer(xp)
+    if xp then
+        return self._document:getTextFromXPointer(xp)
+    end
+end
+
+function CreDocument:getHTMLFromXPointer(xp, flags, from_final_parent)
+    if xp then
+        return self._document:getHTMLFromXPointer(xp, flags, from_final_parent)
+    end
+end
+
+function CreDocument:getHTMLFromXPointers(xp0, xp1, flags, from_root_node)
+    if xp0 and xp1 then
+        return self._document:getHTMLFromXPointers(xp0, xp1, flags, from_root_node)
+    end
+end
+
 function CreDocument:gotoPos(pos)
     logger.dbg("CreDocument: goto position", pos)
     self._document:gotoPos(pos)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -274,10 +274,10 @@ function CreDocument:getTextFromPositions(pos0, pos1)
     end
 end
 
-function CreDocument:getScreenBoxesFromPositions(pos0, pos1)
+function CreDocument:getScreenBoxesFromPositions(pos0, pos1, get_segments)
     local line_boxes = {}
     if pos0 and pos1 then
-        local word_boxes = self._document:getWordBoxesFromPositions(pos0, pos1)
+        local word_boxes = self._document:getWordBoxesFromPositions(pos0, pos1, get_segments)
         for i = 1, #word_boxes do
             local line_box = word_boxes[i]
             table.insert(line_boxes, Geom:new{
@@ -303,6 +303,10 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
         -- But it is all fine if we use TYPE_BBRGB16.
         self.buffer = Blitbuffer.new(rect.w, rect.h, self.render_color and Blitbuffer.TYPE_BBRGB16 or nil)
     end
+    -- TODO: self.buffer could be re-used when no page/layout/highlights
+    -- change has been made, to avoid having crengine redraw the exact
+    -- same buffer.
+    -- And it could only change when some other methods from here are called
     self._document:drawCurrentPage(self.buffer, self.render_color)
     target:blitFrom(self.buffer, x, y, 0, 0, rect.w, rect.h)
 end

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -25,11 +25,32 @@ local CssTweaks = {
             title = _("Ignore all publisher margins"),
             priority = 2,
             css = [[* { margin: 0 !important; }]],
+            separator = true,
         },
         {
             id = "titles_page-break-before_avoid ";
             title = _("Avoid blank page on chapter start"),
-            css = [[h1, h2, h3, .title, .title1, .title2, .title3 { page-break-before: avoid !important; }]],
+            priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
+            css = [[h1, h2, h3 { page-break-before: auto !important; }]],
+
+        },
+        {
+            id = "docfragment_page-break-before_avoid ";
+            title = _("Avoid blank page on chapter end"),
+            priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
+            css = [[DocFragment { page-break-before: auto !important; }]],
+        },
+        {
+            id = "publisher_page-breaks_avoid ";
+            title = _("Avoid publisher page breaks"),
+            description = _("Disable all publisher page breaks, keeping only KOReader's epub.css ones.\nWhen combined with the two previous tweaks, all page-breaks are disabled."),
+            css = [[
+* { page-break-before: auto !important; page-break-after: auto !important; }
+/* put back epub.css page-breaks */
+DocFragment { page-break-before: always !important; }
+h1, h2, h3 { page-break-before: always !important; page-break-after: avoid !important; }
+h4, h5, h6 { page-break-after: avoid !important; }
+            ]],
         },
     },
     {

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -39,6 +39,8 @@ local Font = {
         -- font for displaying input content
         -- we have to use mono here for better distance controlling
         infont = "droid/DroidSansMono.ttf",
+        -- small mono font for displaying code
+        smallinfont = "droid/DroidSansMono.ttf",
 
         -- font for info messages
         infofont = "noto/NotoSans-Regular.ttf",
@@ -66,6 +68,7 @@ local Font = {
         hpkfont = 20,
         hfont = 24,
         infont = 22,
+        smallinfont = 16,
         infofont = 24,
         smallinfofont = 22,
         smallinfofontbold = 22,

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -37,6 +37,7 @@ local TextViewer = InputContainer:new{
     width = nil,
     height = nil,
     buttons_table = nil,
+    justified = true,
 
     title_face = Font:getFace("x_smalltfont"),
     text_face = Font:getFace("x_smallinfofont"),
@@ -156,7 +157,7 @@ function TextViewer:init()
         width = self.width - 2*self.text_padding - 2*self.text_margin,
         height = textw_height - 2*self.text_padding -2*self.text_margin,
         dialog = self,
-        justified = true,
+        justified = self.justified,
     }
     self.textw = FrameContainer:new{
         padding = self.text_padding,


### PR DESCRIPTION
Allow viewing selection HTML, for easier debugging of rendering issues.
We should now be able to see the HTML and CSS used by a book, and why it renders in such a way - and, thanks to the text editor, to create and test a Style tweak, all that directly on the device (before, you needed a computer to look at the EPUB and see what kind of tweak was needed). Requested in https://github.com/koreader/koreader/pull/3944#issuecomment-421562673.

Also fix highlighting of some multi-lines texts.

Details and screenshots in https://github.com/koreader/crengine/pull/236 and https://github.com/koreader/koreader-base/pull/740. Will need bumps for these.

Also adds 2 page-break related Style tweaks, and fix a typo in some help text.
