### PR TITLE
[Key navigation] The back key can be used to go to the parent folder.

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -373,18 +373,25 @@ end
 
 function FileChooser:onBack()
     local back_to_exit = G_reader_settings:readSetting("back_to_exit") or "prompt"
-    if back_to_exit == "always" then
-        return self:onClose()
-    elseif back_to_exit == "disable" then
-        return true
-    elseif back_to_exit == "prompt" then
-            UIManager:show(ConfirmBox:new{
-                text = _("Exit KOReader?"),
-                ok_text = _("Exit"),
-                ok_callback = function()
-                    self:onClose()
-                end
-            })
+    local back_in_filemanager = G_reader_settings:readSetting("back_in_filemanager") or "default"
+    if back_in_filemanager == "default" then
+        if back_to_exit == "always" then
+            return self:onClose()
+        elseif back_to_exit == "disable" then
+            return true
+        elseif back_to_exit == "prompt" then
+                UIManager:show(ConfirmBox:new{
+                    text = _("Exit KOReader?"),
+                    ok_text = _("Exit"),
+                    ok_callback = function()
+                        self:onClose()
+                    end
+                })
+
+            return true
+        end
+    elseif back_in_filemanager == "parent_folder" then
+        self:changeToPath(string.format("%s/..", self.path))
         return true
     end
 end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -167,6 +167,31 @@ if Device:hasKeys() then
                     },
                 },
             },
+            {
+                text = _("Back key in the filemanager"),
+                sub_item_table = {
+                    {
+                        text = _("Default"),
+                        checked_func = function()
+                            return G_reader_settings:readSetting("back_in_filemanager")
+                                       == "default"
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("back_in_filemanager", "default")
+                        end,
+                    },
+                    {
+                        text = _("Go to parent folder"),
+                        checked_func = function()
+                            return G_reader_settings:readSetting("back_in_filemanager")
+                                       == "parent_folder"
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("back_in_filemanager", "parent_folder")
+                        end,
+                    },
+                },
+            },
         }
     }
 end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -168,7 +168,7 @@ if Device:hasKeys() then
                 },
             },
             {
-                text = _("Back key in the filemanager"),
+                text = _("Back key in file browser"),
                 sub_item_table = {
                     {
                         text = _("Default"),


### PR DESCRIPTION
The menu to select this behavior is under "Gear" > "Navigation"
It default to the current behavior named "default"