### PR TITLE
Fix some footnotes and full status bar issues

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -1,9 +1,11 @@
+local Event = require("ui/event")
 local EventListener = require("ui/widget/eventlistener")
 
 local ReaderCoptListener = EventListener:new{}
 
 function ReaderCoptListener:onReadSettings(config)
-    local view_mode = config:readSetting("copt_view_mode")
+    local view_mode = config:readSetting("copt_view_mode") or
+           G_reader_settings:readSetting("copt_view_mode")
     if view_mode == 0 then
         self.ui:registerPostReadyCallback(function()
             self.view:onSetViewMode("page")
@@ -14,8 +16,10 @@ function ReaderCoptListener:onReadSettings(config)
         end)
     end
 
-    local status_line = config:readSetting("copt_status_line") or DCREREADER_PROGRESS_BAR
-    self.document:setStatusLineProp(status_line)
+    local status_line = config:readSetting("copt_status_line") or
+             G_reader_settings:readSetting("copt_status_line") or
+             DCREREADER_PROGRESS_BAR
+    self.ui:handleEvent(Event:new("SetStatusLine", status_line, true))
 end
 
 function ReaderCoptListener:onSetFontSize(font_size)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -692,14 +692,25 @@ function ReaderFooter:onHoldFooter()
     return true
 end
 
-function ReaderFooter:onSetStatusLine(status_line)
+function ReaderFooter:onSetStatusLine(status_line, on_read_settings)
+    -- Ignore this event when it is first sent by ReaderCoptListener
+    -- on book loading, so we stay with the saved footer settings
+    if on_read_settings then
+        return
+    end
     -- 1 is min progress bar while 0 is full cre header progress bar
     if status_line == 1 then
+        -- If footer was off (if previously with full status bar), make the
+        -- footer visible, as if we taped on it (and so we don't duplicate
+        -- this code - not if flipping_visible as in this case, a ges.pos
+        -- argument to onTapFooter(ges) is required)
+        if self.mode == MODE.off and not self.view.flipping_visible then
+            self:onTapFooter()
+        end
         self.view.footer_visible = (self.mode ~= MODE.off)
     else
         self:applyFooterMode(MODE.off)
     end
-    self.ui.document:setStatusLineProp(status_line)
     self.ui:handleEvent(Event:new("UpdatePos"))
 end
 

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1016,6 +1016,7 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
     -- (which might not be seen when covered by FootnoteWidget)
     local close_callback = nil
     if link.from_xpointer then -- coherent xpointer
+        self.ui.document:highlightXPointer() -- clear any previous one
         self.ui.document:highlightXPointer(link.from_xpointer)
         UIManager:setDirty(self.dialog, "ui")
         close_callback = function(footnote_height)
@@ -1055,10 +1056,14 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
             UIManager:close(popup)
             self:onGotoLink(link, neglect_current_location)
         end,
-        on_tap_close_callback = function(arg, ges)
-            -- on tap outside, see if we are tapping on another footnote,
+        on_tap_close_callback = function(arg, ges, footnote_height)
+            -- On tap outside, see if we are tapping on another footnote,
             -- and display it if we do (avoid the need for 2 taps)
-            self:onTap(arg, ges)
+            if not self:onTap(arg, ges) then
+                -- If we did tap on another link, onTap has already cleared our
+                -- highlight. If not, call close_callback to unhighlight it.
+                close_callback(footnote_height)
+            end
         end,
         dialog = self.dialog,
     }

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -257,11 +257,15 @@ end
 --- Check if a xpointer to <a> node really points to itself
 function ReaderLink:isXpointerCoherent(a_xpointer)
     -- Get screen coordinates of xpointer
-    local doc_margins = self.ui.document._document:getPageMargins()
+    local doc_margins = self.ui.document:getPageMargins()
+    local header_height = self.ui.document:getHeaderHeight() -- top full status bar (0 when bottom mini bar used)
     local doc_y, doc_x = self.ui.document:getPosFromXPointer(a_xpointer)
     local top_y = self.ui.document:getCurrentPos()
     -- (strange, but using doc_margins.top is accurate even in scroll mode)
-    local screen_y = doc_y - top_y + doc_margins["top"]
+    local screen_y = doc_y - top_y
+    if self.view.view_mode == "page" then
+        screen_y = screen_y + doc_margins["top"] + header_height
+    end
     local screen_x = doc_x + doc_margins["left"]
     -- Get again link and a_xpointer from this position
     local re_link_xpointer, re_a_xpointer = self.ui.document:getLinkFromPosition({x = screen_x, y = screen_y}) -- luacheck: no unused
@@ -1045,7 +1049,7 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
     popup = FootnoteWidget:new{
         html = html,
         doc_font_size = Screen:scaleBySize(self.ui.font.font_size),
-        doc_margins = self.ui.document._document:getPageMargins(),
+        doc_margins = self.ui.document:getPageMargins(),
         close_callback = close_callback,
         follow_callback = function() -- follow the link on swipe west
             UIManager:close(popup)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -476,9 +476,10 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
         local doc_y = self.ui.document:getPosFromXPointer(marker_xp)
         local top_y = self.ui.document:getCurrentPos()
         local screen_y = doc_y - top_y
-        local doc_margins = self.ui.document._document:getPageMargins()
+        local doc_margins = self.ui.document:getPageMargins()
+        local header_height = self.ui.document:getHeaderHeight() -- top full status bar (0 when bottom mini bar used)
         if self.view.view_mode == "page" then
-            screen_y = screen_y + doc_margins["top"]
+            screen_y = screen_y + doc_margins["top"] + header_height
         end
         local marker_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0)
         -- Make it 4/5 of left margin wide (and bigger when huge margin)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -172,8 +172,6 @@ function ReaderRolling:onReadSettings(config)
         self.show_overlap_enable = DSHOWOVERLAP
     end
     self.inverse_reading_order = config:readSetting("inverse_reading_order") or false
-
-    self:onSetStatusLine(config:readSetting("copt_status_line") or DCREREADER_PROGRESS_BAR)
 end
 
 -- in scroll mode percent_finished must be save before close document
@@ -712,6 +710,9 @@ end
 --]]
 
 function ReaderRolling:onSetStatusLine(status_line)
+    -- in crengine: 0=header enabled, 1=disabled
+    -- in koreader: 0=top status bar, 1=bottom mini bar
+    self.ui.document:setStatusLineProp(status_line)
     self.cre_top_bar_enabled = status_line == 0
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -330,6 +330,14 @@ end
 function CreDocument:renderPage(pageno, rect, zoom, rotation)
 end
 
+function CreDocument:getPageMargins()
+    return self._document:getPageMargins()
+end
+
+function CreDocument:getHeaderHeight()
+    return self._document:getHeaderHeight()
+end
+
 function CreDocument:gotoXPointer(xpointer)
     logger.dbg("CreDocument: goto xpointer", xpointer)
     self._document:gotoXPointer(xpointer)

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -289,9 +289,6 @@ function FootnoteWidget:onShow()
 end
 
 function FootnoteWidget:onCloseWidget()
-    if self.close_callback then
-        self.close_callback(self.height)
-    end
     UIManager:setDirty(self.dialog, function()
         return "partial", self.container.dimen
     end)
@@ -310,7 +307,9 @@ function FootnoteWidget:onTapClose(arg, ges)
         -- it. This avoids having to tap 2 times to
         -- see another footnote.
         if self.on_tap_close_callback then
-            self.on_tap_close_callback(arg, ges)
+            self.on_tap_close_callback(arg, ges, self.height)
+        elseif self.close_callback then
+            self.close_callback(self.height)
         end
         return true
     end
@@ -320,6 +319,9 @@ end
 function FootnoteWidget:onSwipeFollow(arg, ges)
     if ges.direction == "west" then
         if self.follow_callback then
+            if self.close_callback then
+                self.close_callback(self.height)
+            end
             return self.follow_callback()
         end
     elseif ges.direction == "south" or ges.direction == "east" then
@@ -328,6 +330,9 @@ function FootnoteWidget:onSwipeFollow(arg, ges)
         -- work only when started outside the footnote.
         -- Also allow closing with swipe east (like we do to go back
         -- from link)
+        if self.close_callback then
+            self.close_callback(self.height)
+        end
         self:onClose()
         return true
     elseif ges.direction == "north" then

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -626,8 +626,8 @@ describe("Readerfooter module", function()
         assert.is.same(0, footer.mode)
         assert.falsy(readerui.view.footer_visible)
         readerui.view.footer:onSetStatusLine(1)
-        assert.is.same(0, footer.mode)
-        assert.falsy(readerui.view.footer_visible)
+        assert.is.same(1, footer.mode)
+        assert.truthy(readerui.view.footer_visible)
 
         footer.mode = 1
         readerui.view.footer:onSetStatusLine(1)


### PR DESCRIPTION
See individual commits messages.
Fix some issues reported at https://github.com/koreader/koreader/pull/4261#issuecomment-429265831

A few notes:

I moved the `self.ui.document:setStatusLineProp(status_line)` which is the call that enables the status bar in crengine from ReaderFooter to ReaderRolling, because it's more logical, and the `ReaderFooter:onSetStatusLine` is set to a no-op when footer is totally disabled.

I just discovered that Scroll mode and Full status bar don't work well together (no full status bar displayed when scroll mode is enabled). This looks like it's not supported by crengine itself (I have no intent to fix this combination of 2 rarely used options :)

I fixed: when switching Progress bar from 'full' to 'mini', show the mini bar again, with the side effect that the mini bar is now hidden when the full status bar is shown - including when loading a document when one have full status bar set. Previously, the mini bar was still shown with the full status bar !
So, people who liked to have both will have to tap on the footer to make the mini bar appear.
This behaviour looks more correct with the fact that full|mini is a toggle, so it's one or the other.
But I guess some people enjoyed having them both (because the top bar doesn't give much info).
We'll see if something needs to be done to have both...

