### PR TITLE
Fix for FTP folder being saved to an unused setting.

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -311,9 +311,8 @@ function CloudStorage:configCloud(type)
                 address = fields[2],
                 username = fields[3],
                 password = fields[4],
-                folder = fields[5],
+                url = fields[5],
                 type = "ftp",
-                url = "/"
             })
         elseif type == "webdav" then
             table.insert(cs_servers,{
@@ -323,7 +322,6 @@ function CloudStorage:configCloud(type)
                 password = fields[4],
                 url = fields[5],
                 type = "webdav",
-                --url = "/"
             })
         end
         cs_settings:saveSetting("cs_servers", cs_servers)
@@ -361,7 +359,7 @@ function CloudStorage:editCloudServer(item)
                     server.address = fields[2]
                     server.username = fields[3]
                     server.password = fields[4]
-                    server.folder = fields[5]
+                    server.url = fields[5]
                     cs_servers[i] = server
                     break
                 end

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -65,7 +65,7 @@ function Ftp:config(item, callback)
         text_address = item.address
         text_username = item.username
         text_password = item.password
-        text_folder = item.folder
+        text_folder = item.url
     else
         title = _("Add FTP account")
     end


### PR DESCRIPTION
The settings screen for the FTP cloud storage has a setting for a folder but that is then never used. Going back to edit the settings after saving, the folder is back to its default value. 
The fix is simply to change the field it is saved to.
