### PR TITLE
Wallabag: fix for un-configured plugin error

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -689,6 +689,9 @@ end
 
 function Wallabag:readSettings()
     local wb_settings = LuaSettings:open(DataStorage:getSettingsDir().."/wallabag.lua")
+    if not wb_settings.data.wallabag then
+        wb_settings.data.wallabag = {}
+    end
     return wb_settings
 end
 


### PR DESCRIPTION
When the Wallabag plugin is not configured, there is an error loading the absent config file.
Setting a value of {} fixes it (thanks poire-z).