### PR TITLE
OPDS fixes: support for www.ebooksgratuits.com catalog, fix for archive.org

### DIFF
--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -80,7 +80,9 @@ function OPDSParser:parse(text)
     text = text:gsub("<br>", "<br />")
     text = text:gsub("<br/>", "<br />")
     -- some OPDS catalogs wrap text in a CDATA section, remove it as it causes parsing problems
-    text = text:gsub("<!%[CDATA%[(.-)%]%]>","%1")
+    text = text:gsub("<!%[CDATA%[(.-)%]%]>", function (s)
+        return s:gsub( "%p", {["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;" } )
+    end )
     local xlex = luxl.new(text, #text)
     return self:createFlatXTable(xlex)
 end

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -40,6 +40,7 @@ function OPDSParser:createFlatXTable(xlex, curr_element)
     local txt
     for event, offset, size in xlex:Lexemes() do
         txt = ffi.string(xlex.buf + offset, size)
+
         if event == luxl.EVENT_START then
             if txt ~= "xml" then
                 -- does current element already have something
@@ -79,6 +80,8 @@ function OPDSParser:parse(text)
     -- but will kick the ass of luxl
     text = text:gsub("<br>", "<br />")
     text = text:gsub("<br/>", "<br />")
+    -- some OPDS catalogs wrap text in a CDATA marker, remove it as it causes parsing problems
+    text = text:gsub("<!%[CDATA%[(.-)%]%]>","%1")
     local xlex = luxl.new(text, #text)
     return self:createFlatXTable(xlex)
 end

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -40,7 +40,6 @@ function OPDSParser:createFlatXTable(xlex, curr_element)
     local txt
     for event, offset, size in xlex:Lexemes() do
         txt = ffi.string(xlex.buf + offset, size)
-
         if event == luxl.EVENT_START then
             if txt ~= "xml" then
                 -- does current element already have something
@@ -80,7 +79,7 @@ function OPDSParser:parse(text)
     -- but will kick the ass of luxl
     text = text:gsub("<br>", "<br />")
     text = text:gsub("<br/>", "<br />")
-    -- some OPDS catalogs wrap text in a CDATA marker, remove it as it causes parsing problems
+    -- some OPDS catalogs wrap text in a CDATA section, remove it as it causes parsing problems
     text = text:gsub("<!%[CDATA%[(.-)%]%]>","%1")
     local xlex = luxl.new(text, #text)
     return self:createFlatXTable(xlex)

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -264,11 +264,12 @@ end
 function OPDSBrowser:fetchFeed(item_url, username, password)
     local request, sink = {}, {}
     local parsed = url.parse(item_url)
+    local hostname = parsed.host
     local auth = string.format("%s:%s", username, password)
     request['url'] = item_url
     request['method'] = 'GET'
     request['sink'] = ltn12.sink.table(sink)
-    request['headers'] = { Authorization = "Basic " .. mime.b64(auth), }
+    request['headers'] = { Authorization = "Basic " .. mime.b64(auth), ["Host"] = hostname, },
     logger.info("request", request)
     http.TIMEOUT, https.TIMEOUT = 10, 10
     local httpRequest = parsed.scheme == 'http' and http.request or https.request
@@ -472,12 +473,13 @@ function OPDSBrowser:downloadFile(item, format, remote_url)
         UIManager:scheduleIn(1, function()
             logger.dbg("downloading file", local_path, "from", remote_url)
             local parsed = url.parse(remote_url)
+            local hostname = parsed.host
             http.TIMEOUT, https.TIMEOUT = 20, 20
             local httpRequest = parsed.scheme == 'http' and http.request or https.request
             local auth = string.format("%s:%s", item.username, item.password)
             local __, c = httpRequest {
                 url = remote_url,
-                headers = { Authorization = "Basic " .. mime.b64(auth), },
+                headers = { Authorization = "Basic " .. mime.b64(auth), ["Host"] = hostname, },
                 sink = ltn12.sink.file(io.open(local_path, "w")),
             }
             if c == 200 then

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -77,7 +77,7 @@ function OPDSBrowser:init()
           },
           {
              title = "Internet Archive",
-             url = "https://bookserver.archive.org",
+             url = "https://bookserver.archive.org/",
           },
         }
         G_reader_settings:saveSetting("opds_servers", servers)

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -269,7 +269,7 @@ function OPDSBrowser:fetchFeed(item_url, username, password)
     request['url'] = item_url
     request['method'] = 'GET'
     request['sink'] = ltn12.sink.table(sink)
-    request['headers'] = { Authorization = "Basic " .. mime.b64(auth), ["Host"] = hostname, },
+    request['headers'] = { Authorization = "Basic " .. mime.b64(auth), ["Host"] = hostname, }
     logger.info("request", request)
     http.TIMEOUT, https.TIMEOUT = 10, 10
     local httpRequest = parsed.scheme == 'http' and http.request or https.request


### PR DESCRIPTION
Added supports the French catalog _Ebooks Libre et Gratuits_ at https://www.ebooksgratuits.com/opds/index.php
(Catalog not added to the default list; it needs to be entered manually by users)
- added Host header
- filtered CDATA section out

Fix for Internet Archive URL in the default servers
- trailing slash required for the links to work

Fixes #4279