### PR TITLE
[wip]: add usb gadget management to KOReader

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -22,6 +22,7 @@ local Cervantes = Generic:new{
     touch_mirrored_x = true,
     touch_probe_ev_epoch_time = true,
     hasOTAUpdates = yes,
+    hasUsbGadget = yes,
     hasKeys = yes,
     internal_storage_mount_point = "/mnt/public/",
 }
@@ -200,6 +201,20 @@ function Cervantes:reboot()
 end
 function Cervantes:powerOff()
     os.execute("halt")
+end
+
+-- usb
+function Cervantes:usbStorageIn()
+    os.execute("./enable-usbms.sh")
+end
+function Cervantes:usbStorageOut()
+    os.execute("./disable-usbms.sh")
+end
+function Cervantes:usbNetworkIn()
+    os.execute("./enable-usbnet.sh")
+end
+function Cervantes:usbNetworkOut()
+    os.execute("./disable-usbnet.sh")
 end
 
 -------------- device probe ------------

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -21,6 +21,7 @@ local Device = {
     hasKeyboard = no,
     hasKeys = no,
     hasDPad = no,
+    hasUsbGadget = no,
     isTouchDevice = no,
     hasFrontlight = no,
     needsTouchScreenProbe = no,
@@ -205,6 +206,18 @@ function Device:setDateTime(year, month, day, hour, min, sec) end
 
 -- Device specific method if any setting needs being saved
 function Device:saveSettings() end
+
+-- Device specific method to start usb mass storage
+function Device:usbStorageIn() end
+
+-- Device specific method to stop usb mass storage
+function Device:usbStorageOut() end
+
+-- Device specific method to start usb network
+function Device:usbNetworkIn() end
+
+-- Device specific method to stop usb network
+function Device:usbNetworkOut() end
 
 --[[
 prepare for application shutdown

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -10,6 +10,7 @@ local Device = Generic:new{
     model = "SDL",
     isSDL = yes,
     hasKeyboard = yes,
+    hasUsbGadget = yes,
     hasKeys = yes,
     hasDPad = yes,
     hasFrontlight = yes,
@@ -194,6 +195,22 @@ function Device:simulateResume()
     UIManager:show(InfoMessage:new{
         text = _("Resume")
     })
+end
+
+function Device:usbStorageIn()
+    logger.info("Fake Usb Storage In")
+end
+
+function Device:usbStorageOut()
+    logger.info("Fake Usb Storage Out")
+end
+
+function Device:usbNetworkIn()
+    logger.info("Fake Usb Network In")
+end
+
+function Device:usbNetworkOut()
+    logger.info("Fake Usb Network Out")
 end
 
 return Device

--- a/frontend/device/usbgadget.lua
+++ b/frontend/device/usbgadget.lua
@@ -1,0 +1,135 @@
+local Device = require("device")
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+
+local UsbGadget = {}
+
+-- get, set and check current mode.
+local function getMode()
+    local mode = G_reader_settings:readSetting("usb_mode")
+    return mode or "charge"
+end
+
+local function setMode(mode)
+    G_reader_settings:saveSetting("usb_mode", mode)
+    G_reader_settings:flush()
+end
+
+local function isEqual(mode)
+    if getMode() == mode then
+        return true
+    else
+        return false
+    end
+end
+
+-- get, set and check current lock state
+local function getLockState()
+    local state = G_reader_settings:readSetting("usb_mode_locked")
+    if not state then return 0 end
+    return state
+end
+
+local function setLockState(lock)
+    if not lock == 0 and not lock == 1 then return end
+    G_reader_settings:saveSetting("usb_mode_locked", lock)
+    G_reader_settings:flush()
+end
+
+local function isLocked()
+    if getLockState() == 1 then
+        return true
+    else
+        return false
+    end
+end
+
+-- from https://stackoverflow.com/questions/1410862/concatenation-of-tables-in-lua
+local function tableConcat(t1,t2)
+    for i=1,#t2 do
+        t1[#t1+1] = t2[i]
+    end
+    return t1
+end
+
+--[[ Plug In ]]--
+function UsbGadget:plugIn()
+    local mode = getMode()
+    local lock = getLockState()
+    if mode == "network" and lock == 0 then
+        setLockState(1)
+        Device:usbNetworkIn()
+    elseif mode == "storage" and lock == 0 then
+        local ConfirmBox = require("ui/widget/confirmbox")
+        UIManager:show(ConfirmBox:new{
+            text = _("Share storage via USB?\n"),
+            ok_text = _("Share"),
+            ok_callback = function()
+                setLockState(1)
+                Device:usbStorageIn()
+            end,
+        })
+    end
+end
+
+--[[ Plug Out ]]--
+function UsbGadget:plugOut()
+    local mode = getMode()
+    local lock = getLockState()
+    if mode == "network" and lock == 1 then
+        setLockState(0)
+        Device:usbNetworkOut()
+    elseif mode == "storage" and lock == 1 then
+        setLockState(0)
+        Device:usbStorageOut()
+    end
+end
+
+--[[ Menu ]]--
+function UsbGadget:getMenuTable()
+    local menu = {
+        {
+            text = _("Disabled"),
+            enabled_func = function() return not isLocked() end,
+            checked_func = function() return isEqual("charge") end,
+            callback = function() setMode("charge") end,
+        },
+        {
+            text = _("Storage"),
+            enabled_func = function() return not isLocked() end,
+            checked_func = function() return isEqual("storage") end,
+            callback = function() setMode("storage") end,
+        },
+        {
+            text = _("Network"),
+            enabled_func = function() return not isLocked() end,
+            checked_func = function() return isEqual("network") end,
+            callback = function() setMode("network") end,
+            separator = true,
+        },
+    }
+
+    local test = nil
+    if Device:isSDL() then
+        -- add a submenu to test plug/unplug events on SDL devices.
+        test = {
+            {
+                text = _("test USB events"),
+                sub_item_table = {
+                    {
+                        text = _("UsbHostPlugIn"),
+                        callback = function() UsbGadget:plugIn() end,
+                    },
+                    {
+                        text = _("UsbHostPlugOut"),
+                        callback = function() UsbGadget:plugOut() end,
+                    },
+                },
+            },
+        }
+    end
+    if not test then return menu end
+    return tableConcat(menu, test)
+end
+
+return UsbGadget

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -21,6 +21,14 @@ if Device:hasFrontlight() then
     }
 end
 
+if Device:hasUsbGadget() then
+    local UsbGadget = require("device/usbgadget")
+    common_settings.usb_gadget = {
+        text = _("USB Mode"),
+        sub_item_table = UsbGadget:getMenuTable()
+    }
+end
+
 if Device:setDateTime() then
     common_settings.time = {
         text = _("Time and date"),

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -37,6 +37,7 @@ local order = {
         "time",
         "battery",
         "gesture",
+        "usb_gadget",
     },
     network = {
         "network_wifi",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -59,6 +59,7 @@ local order = {
         "time",
         "battery",
         "gesture",
+        "usb_gadget",
     },
     network = {
         "network_wifi",

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -209,32 +209,32 @@ function UIManager:init()
             end
         end
         self.event_handlers["Charging"] = function()
-            logger.info("USB POWER IN")
-            --[[self:_beforeCharging()
+            self:_beforeCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            end
         end
         self.event_handlers["NotCharging"] = function()
-            logger.info("USB POWER OUT")
-            --[[self:_afterNotCharging()
+            self:_afterNotCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            end
         end
         self.event_handlers["UsbPlugIn"] = function()
-            logger.info("USB HOST IN")
-            --[[self:_beforeCharging()
+            self:_beforeCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            else
+                require("device/usbgadget"):plugIn()
+            end
         end
-        self.event_handlers["USbPlugOut"] = function()
-            logger.info("USB HOST OUT")
-            --[[self:_afterNotCharging()
+        self.event_handlers["UsbPlugOut"] = function()
+            self:_afterNotCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            else
+                require("device/usbgadget"):plugOut()
+            end
         end
         self.event_handlers["__default__"] = function(input_event)
             -- Suspension in Cervantes can be interrupted by screen updates. We ignore user touch input

--- a/platform/cervantes/disable-usbms.sh
+++ b/platform/cervantes/disable-usbms.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# exit w/ error if usbms kernel module is not loaded
 lsmod | grep -q g_file_storage || exit 1
 
 modprobe -r g_file_storage
@@ -14,13 +15,12 @@ else
     PARTITION="${DISK}0p4"
 fi
 
-MOUNT_ARGS="noatime,nodiratime,shortname=mixed,utf8"
-
+# fsck internal partition
 dosfsck -a -w "$PARTITION" >dosfsck.log 2>&1
 
-mount -o "$MOUNT_ARGS" -t vfat "$PARTITION" /mnt/onboard
+MOUNT_ARGS="noatime,nodiratime,shortname=mixed,utf8"
+mount -o "$MOUNT_ARGS" -t vfat "$PARTITION" /mnt/public
 
 PARTITION=${DISK}1p1
 
 [ -e "$PARTITION" ] && mount -o "$MOUNT_ARGS" -t vfat "$PARTITION" /mnt/sd
-

--- a/platform/cervantes/disable-usbnet.sh
+++ b/platform/cervantes/disable-usbnet.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# turn down network interface
+ifconfig usb0 down
+
+# disable telnet if running
+pkill -0 inetd && kill -9 "$(pidof inetd)"
+
+# unload usbnet modules
+modprobe -r g_ether
+sleep 1

--- a/platform/cervantes/enable-usbms.sh
+++ b/platform/cervantes/enable-usbms.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-# based on https://github.com/baskerville/plato/blob/master/scripts/usb-enable.sh
+# adapted to BQ Cervantes from Baskerville's Plato
+# https://github.com/baskerville/plato/blob/master/scripts/usb-enable.sh
 
+# exit w/ error if usbms kernel module is loaded
 lsmod | grep -q g_file_storage && exit 1
 
+# internal storage partition scheme differs between models.
 PCB_ID=$(/usr/bin/ntxinfo /dev/mmcblk0 | grep pcb | cut -d ":" -f2)
 DISK=/dev/mmcblk
 
@@ -15,6 +18,10 @@ else
     PARTITIONS="${DISK}0p4"
 fi
 
+# for BQ Cervantes
+MODULE_PARAMETERS="vendor=0x2A47 product=${PRODUCT_ID} vendor_id=BQ product_id=Cervantes"
+
+# share sdcard if present
 [ -e "${DISK}1p1" ] && PARTITIONS="${PARTITIONS},${DISK}1p1"
 
 sync
@@ -24,10 +31,14 @@ for name in public sd; do
     DIR=/mnt/"$name"
     if grep -q "$DIR" /proc/mounts; then
         umount "$DIR" || umount -l "$DIR"
+        # exit w/ error if partition is still mounted
+        mountpoint -q "$DIR" && exit 2
     fi
 done
 
-MODULE_PARAMETERS="vendor=0x2A47 product=${PRODUCT_ID} vendor_id=BQ product_id=Cervantes"
-modprobe g_file_storage file="$PARTITIONS" stall=1 removable=1 "$MODULE_PARAMETERS"
-
+# shellcheck disable=SC2086
+modprobe g_file_storage file="$PARTITIONS" stall=1 removable=1 $MODULE_PARAMETERS
 sleep 1
+
+# normal exit
+exit 0

--- a/platform/cervantes/enable-usbnet.sh
+++ b/platform/cervantes/enable-usbnet.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# start usbnet using BQ scripts (192.168.4.1/24 w/ hardcoded MAC addr)
+/usr/bin/usbup.sh
+
+# start telnet if isn't running
+if ! pkill -0 inetd; then
+    /usr/sbin/inetd
+fi
+


### PR DESCRIPTION
Related to #2597, but with the idea to support more devices (Kobos/Bq) and other usb gadget modules (like usbnet).

The idea is that every supported device implement its own methods to start/stop mass storage & usbnet. Those methods are called from UsbGadgetPlugIn/UsbGadgetPlugOut, which should be hooked to the appropiate "fake" usb events sent from base.

I wrote all this on the emulator, which AFAIK doesn't generate these events. So I added a couple of entries to simulate usb plug in / usb plug out and see the effects depending on current selected mode.

TODO:
If usbGadgetPlugIn and mode == mass storage we need to disable wireless, buttons, plugins, etc. Almost like before suspending but without actually suspending the device. The device needs to stay waiting for a wake event, which should be triggered when the usb connection with a computer is removed.

I need a bit of help with this.