### PR TITLE
bump crengine: fix vertical-align and others

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -185,6 +185,11 @@ img {
 }
             ]],
         },
+        {
+            id = "image_valign_middle";
+            title = _("Middle align images with text"),
+            css = [[img { vertical-align: middle; }]],
+        },
     },
     -- No current need for workarounds
     -- {


### PR DESCRIPTION
bump crengine, which includes:
- Avoid uneeded re-rendering on load when with full status bar https://github.com/koreader/crengine/pull/238
- Update french hyphenation pattern https://github.com/koreader/crengine/pull/239
- https://github.com/koreader/crengine/pull/240 https://github.com/koreader/koreader-base/pull/751 :
  - Fix border-collapse on table cells in some cases
  - Fix line-height inheritance when no unit
  - Fix: don't ignore space following an image
  - Fix: ignore occasional space at start of line
  - Fix possible segfault when viewing HTML
  - Fix and extend support of vertical-align

Also includes:
- [build] Pull in thirdparty repos with --depth 50 https://github.com/koreader/koreader-base/pull/675.

Also add a style tweak to middle align images with text, which may make some text with inline icons and such nicer than with the default `vertical-align: baseline` (depending on images sizes and selected Zoom/DPI).
For example in Wikipedia EPUBs (not sure yet if we should explicitely add a `vertical-align: middle` to inline images when saving as EPUB)