### PR TITLE
[fix] Version pattern: add two extra numbers for point release

### DIFF
--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -27,15 +27,16 @@ end
 -- @treturn string short git commit version hash such as `704d4238`
 function Version:getNormalizedVersion(rev)
     if not rev then return end
-    local year, month, revision = rev:match("v(%d%d%d%d)%.(%d%d)-?(%d*)")
+    local year, month, point, revision = rev:match("v(%d%d%d%d)%.(%d%d)%.?(%d?%d?)-?(%d*)")
 
     year = tonumber(year)
     month = tonumber(month)
+    point = tonumber(point)
     revision = tonumber(revision)
 
     local commit = rev:match("-%d*-g(%x*)[%d_%-]*")
     -- NOTE: * 10000 to handle at most 9999 commits since last tag ;).
-    return ((year or 0) * 100 + (month or 0)) * 10000 + (revision or 0), commit
+    return ((year or 0) * 100 + (month or 0)) * 1000000 + (point or 0) * 10000 + (revision or 0), commit
 end
 
 --- Returns current version of KOReader.

--- a/spec/unit/version_spec.lua
+++ b/spec/unit/version_spec.lua
@@ -13,48 +13,50 @@ describe("Version module", function()
         assert.is_true(4 == year:len())
         assert.is_true(2 == month:len())
     end)
-    it("should get normalized current version", function()
-        assert.is_true(12 == tostring(Version:getNormalizedCurrentVersion()):len())
-    end)
-    it("should get normalized version", function()
-        local rev = "v2015.11-982-g704d4238"
-        local version, commit = Version:getNormalizedVersion(rev)
-        local expected_version = 201511000982
-        local expected_commit = "704d4238"
-        assert.are.same(expected_version, version)
-        assert.are.same(expected_commit, commit)
-    end)
-    it("should get normalized version with four number revision", function()
-        local rev = "v2015.11-1755-gecd7b5b_2018-07-02"
-        local version, commit = Version:getNormalizedVersion(rev)
-        local expected_version = 201511001755
-        local expected_commit = "ecd7b5b"
-        assert.are.same(expected_version, version)
-        assert.are.same(expected_commit, commit)
-    end)
-    it("should get normalized stable version", function()
-        local rev = "v2018.11"
-        local version, commit = Version:getNormalizedVersion(rev)
-        local expected_version = 201811000000
-        local expected_commit = nil
-        assert.are.same(expected_version, version)
-        assert.are.same(expected_commit, commit)
-    end)
-    it("should get normalized stable point release version", function()
-        local rev = "v2018.11.1"
-        local version, commit = Version:getNormalizedVersion(rev)
-        local expected_version = 201811010000
-        local expected_commit = nil
-        assert.are.same(expected_version, version)
-        assert.are.same(expected_commit, commit)
-    end)
-    it("should get normalized point release nightly version", function()
-        local rev = "v2018.11.1-1755-gecd7b5b_2018-07-02"
-        local version, commit = Version:getNormalizedVersion(rev)
-        local expected_version = 201811011755
-        local expected_commit = "ecd7b5b"
-        assert.are.same(expected_version, version)
-        assert.are.same(expected_commit, commit)
+    describe("normalized", function()
+        it("should get current version", function()
+            assert.is_true(12 == tostring(Version:getNormalizedCurrentVersion()):len())
+        end)
+        it("should get version", function()
+            local rev = "v2015.11-982-g704d4238"
+            local version, commit = Version:getNormalizedVersion(rev)
+            local expected_version = 201511000982
+            local expected_commit = "704d4238"
+            assert.are.same(expected_version, version)
+            assert.are.same(expected_commit, commit)
+        end)
+        it("should get version with four number revision", function()
+            local rev = "v2015.11-1755-gecd7b5b_2018-07-02"
+            local version, commit = Version:getNormalizedVersion(rev)
+            local expected_version = 201511001755
+            local expected_commit = "ecd7b5b"
+            assert.are.same(expected_version, version)
+            assert.are.same(expected_commit, commit)
+        end)
+        it("should get stable version", function()
+            local rev = "v2018.11"
+            local version, commit = Version:getNormalizedVersion(rev)
+            local expected_version = 201811000000
+            local expected_commit = nil
+            assert.are.same(expected_version, version)
+            assert.are.same(expected_commit, commit)
+        end)
+        it("should get stable point release version", function()
+            local rev = "v2018.11.1"
+            local version, commit = Version:getNormalizedVersion(rev)
+            local expected_version = 201811010000
+            local expected_commit = nil
+            assert.are.same(expected_version, version)
+            assert.are.same(expected_commit, commit)
+        end)
+        it("should get point release nightly version", function()
+            local rev = "v2018.11.1-1755-gecd7b5b_2018-07-02"
+            local version, commit = Version:getNormalizedVersion(rev)
+            local expected_version = 201811011755
+            local expected_commit = "ecd7b5b"
+            assert.are.same(expected_version, version)
+            assert.are.same(expected_commit, commit)
+        end)
     end)
     it("should fail gracefully", function()
         local version, commit = Version:getNormalizedVersion()

--- a/spec/unit/version_spec.lua
+++ b/spec/unit/version_spec.lua
@@ -6,7 +6,7 @@ describe("Version module", function()
     end)
     it("should get current revision", function()
         local rev = Version:getCurrentRevision()
-        local year, month, point, revision = rev:match("v(%d%d%d%d)%.(%d%d).?(%d?)-?(%d*)") -- luacheck: ignore 211
+        local year, month, point, revision = rev:match("v(%d%d%d%d)%.(%d%d)%.?(%d?)-?(%d*)") -- luacheck: ignore 211
         local commit = rev:match("-%d*-g(%x*)[%d_%-]*") -- luacheck: ignore 211
         assert.is_truthy(year)
         assert.is_truthy(month)
@@ -14,20 +14,44 @@ describe("Version module", function()
         assert.is_true(2 == month:len())
     end)
     it("should get normalized current version", function()
-        assert.is_true(10 == tostring(Version:getNormalizedCurrentVersion()):len())
+        assert.is_true(12 == tostring(Version:getNormalizedCurrentVersion()):len())
     end)
     it("should get normalized version", function()
         local rev = "v2015.11-982-g704d4238"
         local version, commit = Version:getNormalizedVersion(rev)
-        local expected_version = 2015110982
+        local expected_version = 201511000982
         local expected_commit = "704d4238"
         assert.are.same(expected_version, version)
         assert.are.same(expected_commit, commit)
     end)
-    it("should also get normalized version", function()
+    it("should get normalized version with four number revision", function()
         local rev = "v2015.11-1755-gecd7b5b_2018-07-02"
         local version, commit = Version:getNormalizedVersion(rev)
-        local expected_version = 2015111755
+        local expected_version = 201511001755
+        local expected_commit = "ecd7b5b"
+        assert.are.same(expected_version, version)
+        assert.are.same(expected_commit, commit)
+    end)
+    it("should get normalized stable version", function()
+        local rev = "v2018.11"
+        local version, commit = Version:getNormalizedVersion(rev)
+        local expected_version = 201811000000
+        local expected_commit = nil
+        assert.are.same(expected_version, version)
+        assert.are.same(expected_commit, commit)
+    end)
+    it("should get normalized stable point release version", function()
+        local rev = "v2018.11.1"
+        local version, commit = Version:getNormalizedVersion(rev)
+        local expected_version = 201811010000
+        local expected_commit = nil
+        assert.are.same(expected_version, version)
+        assert.are.same(expected_commit, commit)
+    end)
+    it("should get normalized point release nightly version", function()
+        local rev = "v2018.11.1-1755-gecd7b5b_2018-07-02"
+        local version, commit = Version:getNormalizedVersion(rev)
+        local expected_version = 201811011755
         local expected_commit = "ecd7b5b"
         assert.are.same(expected_version, version)
         assert.are.same(expected_commit, commit)


### PR DESCRIPTION
Also see #4303.

#4299 was an emergency patch. This should fix it up properly.