### PR TITLE
[Feature] Support DjVu metadata

### DIFF
--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -54,11 +54,20 @@ function DjvuDocument:updateColorRendering()
 end
 
 function DjvuDocument:getProps()
+    local props = self._document:getMetadata()
     local _, _, docname = self.file:find(".*/(.*)")
     docname = docname or self.file
-    return {
-        title = docname:match("(.*)%.")
-    }
+
+    -- According to djvused(1), the convention is that
+    -- BibTex keys are always lowercase and DocInfo capitalized
+    props.title = props.title or props.Title or docname:match("(.*)%.")
+    props.authors = props.author or props.Author
+    props.series = props.series or props.Series
+    props.language = props.language or props.Language
+    props.keywords = props.keywords or props.Keywords
+    props.description = props.description or props.Description
+
+    return props
 end
 
 function DjvuDocument:getPageTextBoxes(pageno)


### PR DESCRIPTION
## Overview

As of f71627cf, DjVu support for metadata is faked by setting the document tite to the file's basename. This is fixes that. It is the frontend companion to koreader/koreader-base#753, as such the continuous integration will inevitably fail until base integrates those changes.

If there's a better protocol for this kind of split pull request, please let me know.

## Notes

This is my first foray into koreader's codebase as well as lua programming, so please forgive any boneheadeness. I tried to model the `DjvuDocument:getProps()` method after its namesake in `frontend/document/pdfdocument.lua`.

The silliness with capitalized keys versus lowercase, as mentioned in the code comment, comes from the covention mentioned in djvused(1). I considered `lower()`ing all `props` keys into a new table, but I figured that, with just six keys, it's best to be explicit about the identifications.

Anyway, if I've made obvious mistakes or there is a better way to do things, please let me know. I hope this turns out to be useful.