### PR TITLE
[Cervantes]: misc fixes & improvements

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -29,30 +29,30 @@ local Cervantes = Generic:new{
 }
 -- Cervantes Touch
 local CervantesTouch = Cervantes:new{
-    model = "Cervantes Touch",
+    model = "CervantesTouch",
     display_dpi = 167,
 }
 -- Cervantes TouchLight / Fnac Touch Plus
 local CervantesTouchLight = Cervantes:new{
-    model = "Cervantes TouchLight",
+    model = "CervantesTouchLight",
     display_dpi = 167,
     hasFrontlight = yes,
 }
 -- Cervantes 2013 / Fnac Touch Light
 local Cervantes2013 = Cervantes:new{
-    model = "Cervantes 2013",
+    model = "Cervantes2013",
     display_dpi = 212,
     hasFrontlight = yes,
 }
 -- Cervantes 3 / Fnac Touch Light 2
 local Cervantes3 = Cervantes:new{
-    model = "Cervantes 3",
+    model = "Cervantes3",
     display_dpi = 300,
     hasFrontlight = yes,
 }
 -- Cervantes 4
 local Cervantes4 = Cervantes:new{
-    model = "Cervantes 4",
+    model = "Cervantes4",
     display_dpi = 300,
     hasFrontlight = yes,
     hasNaturalLight = yes,

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -13,6 +13,14 @@ local function getProductId()
     return product_id
 end
 
+local function isConnected()
+    local file = io.open("/sys/class/net/eth0/carrier", "rb")
+    if not file then return 0 end
+    local carrier = tonumber(file:read("*all")) or 0
+    file:close()
+    return carrier
+end
+
 local Cervantes = Generic:new{
     model = "Cervantes",
     isCervantes = yes,
@@ -142,6 +150,7 @@ end
 function Cervantes:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOffWifi(complete_callback)
         logger.info("Cervantes: disabling WiFi")
+        self:releaseIP()
         os.execute("./disable-wifi.sh")
         if complete_callback then
             complete_callback()
@@ -163,7 +172,7 @@ function Cervantes:initNetworkManager(NetworkMgr)
         os.execute("./restore-wifi-async.sh")
     end
     function NetworkMgr:isWifiOn()
-        return 0 == os.execute("lsmod | grep -q 8189fs")
+        return 1 == isConnected()
     end
 end
 

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -90,7 +90,7 @@ function NetworkMgr:beforeWifiAction(callback)
  end
 
 function NetworkMgr:isConnected()
-    if Device:isAndroid() then
+    if Device:isAndroid() or Device:isCervantes() then
         return self:isWifiOn()
     else
         -- `-c1` try only once; `-w2` wait 2 seconds
@@ -187,7 +187,7 @@ function NetworkMgr:getRestoreMenuTable()
     return {
         text = _("Automatically restore Wi-Fi connection after resume"),
         checked_func = function() return G_reader_settings:nilOrTrue("auto_restore_wifi") end,
-        enabled_func = function() return Device:isCervantes() or Device:isKobo() end,
+        enabled_func = function() return Device:isKobo() end,
         callback = function() G_reader_settings:flipNilOrTrue("auto_restore_wifi") end,
     }
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -209,38 +209,31 @@ function UIManager:init()
             end
         end
         self.event_handlers["Charging"] = function()
-            logger.info("USB POWER IN")
-            --[[self:_beforeCharging()
+            self:_beforeCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            end
         end
         self.event_handlers["NotCharging"] = function()
-            logger.info("USB POWER OUT")
-            --[[self:_afterNotCharging()
+            self:_afterNotCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            end
         end
         self.event_handlers["UsbPlugIn"] = function()
-            logger.info("USB HOST IN")
-            --[[self:_beforeCharging()
+            self:_beforeCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            end
         end
         self.event_handlers["USbPlugOut"] = function()
-            logger.info("USB HOST OUT")
-            --[[self:_afterNotCharging()
+            self:_afterNotCharging()
             if Device.screen_saver_mode then
                 self:suspend()
-            end]]--
+            end
         end
         self.event_handlers["__default__"] = function(input_event)
-            -- Suspension in Cervantes can be interrupted by screen updates. We ignore user touch input
-            -- in screen_saver_mode so screen updates won't be triggered in suspend mode.
-            -- We should not call self:suspend() in screen_saver_mode lest we stay on forever
-            -- trying to reschedule suspend. Other systems take care of unintended wake-up.
+            -- Same as in Kobo: we want to ignore keys during suspension
             if not Device.screen_saver_mode then
                 self:sendEvent(input_event)
             end

--- a/platform/cervantes/enable-wifi.sh
+++ b/platform/cervantes/enable-wifi.sh
@@ -4,7 +4,7 @@ CTRL_INTERFACE="/var/run/wpa_supplicant"
 
 # create a new configuration if neccesary.
 if [ ! -f "$WPA_SUPPLICANT_CONF" ]; then
-    echo "ctrl_interface=DIR=${CTRL_INTERFACE}" >"$WPA_SUPPLICANT_CONF"
+    echo "ctrl_interface=${CTRL_INTERFACE}" >"$WPA_SUPPLICANT_CONF"
     echo "update_config=1" >>"$WPA_SUPPLICANT_CONF"
     sync
 fi
@@ -14,5 +14,8 @@ if ! lsmod | grep -q 8189fs; then
     sleep 1
 fi
 
-ifconfig eth0 up && sleep 1
-wpa_supplicant -B -D wext -i eth0 -s -O "$CTRL_INTERFACE" -c "$WPA_SUPPLICANT_CONF" 2>/dev/null
+ifconfig eth0 up
+sleep 1
+
+pidof wpa_supplicant >/dev/null \
+    || wpa_supplicant -i eth0 -s -O "$CTRL_INTERFACE" -c "$WPA_SUPPLICANT_CONF" -B -D wext 2>/dev/null

--- a/platform/cervantes/koreader-standalone.sh
+++ b/platform/cervantes/koreader-standalone.sh
@@ -33,8 +33,11 @@ if [ -b /dev/mmcblk1p1 ]; then
     mount /dev/mmcblk1p1 /mnt/sd
 fi
 
-# remove wireless module since it wastes battery.
-if lsmod | grep -q 8189fs; then
+# stop connman daemon, KOReader will use wpa_supplicant directly.
+[ -x /etc/init.d/connman ] && /etc/init.d/connman stop
+
+# for Cervantes 4 unload realtek module.
+if [ "$PCB_ID" -eq 68 ] && lsmod | grep -q 8189fs; then
     modprobe -r 8189fs
 fi
 

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -13,7 +13,7 @@ ko_update_check() {
     NEWUPDATE="${KOREADER_DIR}/ota/koreader.updated.tar"
     INSTALLED="${KOREADER_DIR}/ota/koreader.installed.tar"
     if [ -f "${NEWUPDATE}" ]; then
-        #./fbink -q -y -7 -pmh "Updating KOReader"
+        ./fbink -q -y -7 -pmh "Updating KOReader"
         # NOTE: See frontend/ui/otamanager.lua for a few more details on how we squeeze a percentage out of tar's checkpoint feature
         # NOTE: %B should always be 512 in our case, so let stat do part of the maths for us instead of using %s ;).
         FILESIZE="$(stat -c %b "${NEWUPDATE}")"
@@ -25,12 +25,12 @@ ko_update_check() {
         # Cleanup behind us...
         if [ "${fail}" -eq 0 ]; then
             mv "${NEWUPDATE}" "${INSTALLED}"
-            #    ./fbink -q -y -6 -pm "Update successful :)"
-            #    ./fbink -q -y -5 -pm "KOReader will start momentarily . . ."
-            #else
-            #    # Huh ho...
-            #    ./fbink -q -y -6 -pmh "Update failed :("
-            #    ./fbink -q -y -5 -pm "KOReader may fail to function properly!"
+            ./fbink -q -y -6 -pm "Update successful :)"
+            ./fbink -q -y -5 -pm "KOReader will start momentarily . . ."
+        else
+            # Huh ho...
+            ./fbink -q -y -6 -pmh "Update failed :("
+            ./fbink -q -y -5 -pm "KOReader may fail to function properly!"
         fi
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
         unset BLOCKS CPOINTS

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -76,6 +76,7 @@ fi
 
 if [ "${STANDALONE}" != "true" ]; then
     stopapp.sh >/dev/null 2>&1
+    [ -x /etc/init.d/connman ] && /etc/init.d/connman stop
 fi
 
 RETURN_VALUE=85
@@ -85,5 +86,6 @@ while [ "${RETURN_VALUE}" -eq 85 ]; do
 done
 
 if [ "${STANDALONE}" != "true" ]; then
+    [ -x /etc/init.d/connman ] && /etc/init.d/connman start
     restart.sh >/dev/null 2>&1
 fi


### PR DESCRIPTION
device: fix device names by removing spaces to match the base logic (https://github.com/koreader/koreader-base/pull/755)
wireless: read status from sysfs, disable auto_restore_wifi, improved compat w/ QBookApp.
power: suspend on power wake, like kobos
scripts: enable fbink visual feedback during OTA updates.
standalone: add support for https://github.com/pazos/cervantes-safemode, to start/stop usbnet & usb mass storage until #4306 is ready.