### PR TITLE
Fix a few edge cases crashes and issues

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -93,9 +93,6 @@ function ReaderConfig:onSwipeShowConfigMenu(ges)
 end
 
 function ReaderConfig:onSetDimensions(dimen)
-    if Device:isTouchDevice() then
-        self:initGesListener()
-    end
     -- since we cannot redraw config_dialog with new size, we close
     -- the old one on screen size change
     if self.config_dialog then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -579,7 +579,9 @@ function ReaderFooter:_updateFooterText()
     end
     self.text_container.dimen.w = self.text_width
     self.horizontal_group:resetLayout()
-    UIManager:setDirty(self.view.dialog, "ui", self.footer_content.dimen)
+    UIManager:setDirty(self.view.dialog, function()
+        return "ui", self.footer_content.dimen
+    end)
 end
 
 function ReaderFooter:onPageUpdate(pageno)

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -85,7 +85,9 @@ function ReaderToc:onPageUpdate(pageno)
 end
 
 function ReaderToc:onPosUpdate(pos, pageno)
-    self.pageno = pageno
+    if pageno then
+        self.pageno = pageno
+    end
 end
 
 function ReaderToc:fillToc()

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -695,7 +695,9 @@ function Menu:init()
     -- return button
     self.page_return_arrow = Button:new{
         icon = "resources/icons/appbar.arrow.left.up.png",
-        callback = function() self:onReturn() end,
+        callback = function()
+            if self.onReturn then self:onReturn() end
+        end,
         bordersize = 0,
         show_parent = self,
         readonly = self.return_arrow_propagation,


### PR DESCRIPTION
- ReaderConfig does not need to call again self:initGesListener() on screen rotation/resize, as it uses the TouchZone infrastructure that deals itself with rotation. So, it was adding new same gestures that were overriding tap on footer and preventing it from working. See https://github.com/koreader/koreader/issues/4332#issuecomment-437768464. Closes #4332.
- ReaderFooter: fix refresh area (which was too small when toggling from hidden to visible)
- ReaderToc: fix crash when showing TOC in scroll mode after rotation. See https://github.com/koreader/koreader/issues/4328#issuecomment-437700619
- Menu: fix crash when no onReturn defined (could happen when tap on bottom left corner when showing an empty TOC). Closes #4330.