### PR TITLE
[fix, build] kodev: test for PB TC in $PATH

### DIFF
--- a/kodev
+++ b/kodev
@@ -213,7 +213,7 @@ ${SUPPORTED_TARGETS}"
             assert_ret_zero $?
             ;;
         pocketbook)
-            if [ ! -d "${CURDIR}/base/toolchain/pocketbook-toolchain" ]; then
+            if ! command -v arm-obreey-linux-gnueabi-gcc>/dev/null && [ ! -d "${CURDIR}/base/toolchain/pocketbook-toolchain" ]; then
                 make pocketbook-toolchain
                 assert_ret_zero $?
             fi


### PR DESCRIPTION
Includes and depends on base bump with:

* [build, fix] Support PocketBook TC in path https://github.com/koreader/koreader-base/pull/765