### PR TITLE
Wallabag fixes and improvements

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -388,7 +388,6 @@ function Wallabag:callAPI( method, apiurl, headers, body, filepath )
             end
         end
     else
-        local msg
         if filepath ~= "" then
             local entry_mode = lfs.attributes(filepath, "mode")
             if entry_mode == "file" then

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -204,7 +204,7 @@ function Wallabag:addToMainMenu(menu_items)
 
 Articles marked as finished or 100% read can be deleted from the server. Those articles can also be deleted automatically when downloading new articles if the 'Process deletions during download' option is enabled.
 
-The 'Synchronise remotely deleted files' option will remove local files that do not exist anymore on the server.]])
+The 'Synchronise remotely deleted files' option will remove local files that no longer exist on the server.]])
                             })
                         end,
                     }


### PR DESCRIPTION
- Tag not included in request if not set. Fixes #4337
- Skip failed download rather than stop everything. Fixes #4340
- Delete leftover file after failed download (ie HTML file with error description in it).
- Display number of failed files.
- Check number of articles before proceeding.
- Skip remote deletion process if disabled.