### PR TITLE
CreDocument: fix document loading interferences

### DIFF
--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -504,6 +504,9 @@ function Search:onMenuHold(item)
     local thumbnail
     local doc = DocumentRegistry:openDocument(item.path)
     if doc then
+        if doc.loadDocument then -- CreDocument
+            doc:loadDocument(false) -- load only metadata
+        end
         thumbnail = doc:getCoverPageImage()
         doc:close()
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -263,6 +263,11 @@ function ReaderUI:init()
             document = self.document,
         })
     else
+        -- load crengine default settings (from cr3.ini, some of these
+        -- will be overriden by our settings by some reader modules below)
+        if self.document.setupDefaultView then
+            self.document:setupDefaultView()
+        end
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
             if not self.document:loadDocument() then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -249,6 +249,9 @@ function Screensaver:show(event, fallback_message)
         if exclude ~= true then
             if lfs.attributes(lastfile, "mode") == "file" then
                 local doc = DocumentRegistry:openDocument(lastfile)
+                if doc.loadDocument then -- CreDocument
+                    doc:loadDocument(false) -- load only metadata
+                end
                 local image = doc:getCoverPageImage()
                 doc:close()
                 if image ~= nil then


### PR DESCRIPTION
When a main document is opened for displaying, some other document openings (for getting metadata or cover image) could affect the main document.
Split some code from CreDocument:init() into another new method CreDocument:setupDefaultView(), that will only be called by ReaderUI when opening the main document (and not by these other openings like Book inforation, View cover...)
Details in https://github.com/koreader/koreader/issues/4346#issuecomment-440036496. Closes #4346.
Will need a base bump for https://github.com/koreader/koreader-base/pull/766.

Also speed up some of these other openings (Search, Screensaver) by using doc:loadDocument(false) to load only metadata and avoid parsing the HTML.