### PR TITLE
Add support for PocketBook 630

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -210,6 +210,15 @@ local PocketBook740 = PocketBook:new{
     emu_events_dev = "/var/dev/shm/emu_events",
 }
 
+-- PocketBook HD Touch
+local PocketBook630 = PocketBook:new{
+    isTouchDevice = yes,
+    hasKeys = yes,
+    hasFrontlight = yes,
+    display_dpi = 212,
+    emu_events_dev = "/dev/shm/emu_events",
+}
+
 -- PocketBook Color Lux
 local PocketBookColorLux = PocketBook:new{
     isTouchDevice = yes,
@@ -235,6 +244,8 @@ elseif codename == "PocketBook 624" then
     return PocketBook624
 elseif codename == "PocketBook 623" then
     return PocketBook623
+elseif codename == "PocketBook 630" then
+    return PocketBook630
 elseif codename == "PB740" then
     return PocketBook740
 elseif codename == "PocketBook Color Lux" then


### PR DESCRIPTION
Fix: unrecognized PocketBook model PocketBook 630