### PR TITLE
Ensure "Open last/previous" point to existing files

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -228,6 +228,7 @@ function FileManager:init()
                             ok_callback = function()
                                 deleteFile(file)
                                 filemanagerutil.removeFileFromHistoryIfWanted(file)
+                                filemanagerutil.ensureLastFileExists()
                                 self:refreshPath()
                                 UIManager:close(self.file_dialog)
                             end,

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -87,6 +87,7 @@ function FileManagerHistory:onMenuHold(item)
                             FileManager:deleteFile(item.file)
                             filemanagerutil.removeFileFromHistoryIfWanted(item.file)
                             require("readhistory"):setDeleted(item)
+                            filemanagerutil.ensureLastFileExists()
                             self._manager:updateItemTable()
                             UIManager:close(self.histfile_dialog)
                         end,

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -50,16 +50,28 @@ function filemanagerutil.purgeSettings(file)
     end
 end
 
--- Remove from history and update lastfile to top item in history
+-- Remove from history (and update lastfile to an existing file)
 -- if autoremove_deleted_items_from_history is enabled
 function filemanagerutil.removeFileFromHistoryIfWanted(file)
     if G_reader_settings:readSetting("autoremove_deleted_items_from_history") then
         local readhistory = require("readhistory")
         readhistory:removeItemByPath(file)
-        if G_reader_settings:readSetting("lastfile") == file then
-            G_reader_settings:saveSetting("lastfile", #readhistory.hist > 0 and readhistory.hist[1].file or nil)
+        filemanagerutil.ensureLastFileExists()
+    end
+end
+
+-- Update lastfile setting to the most recent one in history
+-- that still exists
+function filemanagerutil.ensureLastFileExists()
+    local last_existing_file = nil
+    local readhistory = require("readhistory")
+    for i=1, #readhistory.hist do
+        if lfs.attributes(readhistory.hist[i].file, "mode") == "file" then
+            last_existing_file = readhistory.hist[i].file
+            break
         end
     end
+    G_reader_settings:saveSetting("lastfile", last_existing_file)
 end
 
 return filemanagerutil


### PR DESCRIPTION
In reader, after having opened doc1.html and doc2.html, being in doc2.html, going to History (where Delete on current book doc2.html is forbidden) and deleting doc1.html, we would still see in the top right menu: `Previous: doc1.html`, and taping on it would show the Opening dialog, an error, and KOReader would exit (UIManager: no widget left to show).
This fixes this by ensuring we alway refresh the previous document in that menu item to the previous still existing document.

I also ensured it globally for any Delete from FileManager or History invoked from FileManager, to fix: Reading doc1.html > File browser > delete doc1.html > Exiting Koreader > Opening Koreader > `Cannot open last file. This could be because it was deleted or because external storage is still being mounted. Do you want to retry?`

Deleted files still stay in History (for those that don't have the option to not do that enabled), they are just not candidates for the Open last/Open previous menu items.