### PR TITLE
Set timeout for wifi result info message

### DIFF
--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -225,7 +225,7 @@ function NetworkItem:connect()
     end
 
     self:refresh()
-    UIManager:show(InfoMessage:new{text = text})
+    UIManager:show(InfoMessage:new{text = text, timeout = 3})
 end
 
 function NetworkItem:disconnect()


### PR DESCRIPTION
When Wifi is connected, the message "Connected." stays on the screen
waiting for the user feedback. The change sets reasonable timeout
for info message to disappear