### PR TITLE
Hide "no framework" buttons on FW 5.x

### DIFF
--- a/platform/kindle/extensions/koreader/menu.json
+++ b/platform/kindle/extensions/koreader/menu.json
@@ -22,6 +22,7 @@
 		},
 		{
 			"name": "Start the filemanager (no framework)",
+			"if": "\"Kindle2\" -m \"KindleDX\" -m \"KindleDXG\" -m \"Kindle3\" -m \"Kindle4\" -m || || || ||",
 			"priority": 3,
 			"action": "/mnt/us/koreader/koreader.sh",
 			"params": "--kual --framework_stop /mnt/us/documents",
@@ -30,6 +31,7 @@
 		},
 		{
 			"name": "Open the last document (no framework)",
+			"if": "\"Kindle2\" -m \"KindleDX\" -m \"KindleDXG\" -m \"Kindle3\" -m \"Kindle4\" -m || || || ||",
 			"priority": 4,
 			"action": "/mnt/us/koreader/koreader.sh",
 			"params": "--kual --framework_stop",


### PR DESCRIPTION
It's generally broken, and useless there.

The main intended use-case is the DX/DXg, because of its larger screen &
low RAM leading to more severe memory constraints.