### PR TITLE
Style tweaks: move some sub-menus to first-level menu

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -189,76 +189,76 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
         },
     },
     {
-        title = _("Miscellaneous"),
+        title = _("Tables"),
         {
-            title = _("Tables"),
-            {
-                id = "table_full_width";
-                title = _("Full-width tables"),
-                description = _("Make table expand to the full width of the page. (Tables with small content now use only the width needed to display that content. This restores the previous behavior.)"),
-                css = [[table { width: 100% !important; }]],
-            },
-            {
-                id = "table_td_width_auto";
-                title = _("Ignore publisher table and cell widths"),
-                description = _("Ignore table and cells widths specified by the publisher, and let the engine decide the most appropriate widths."),
-                css = [[table, td, th { width: auto !important; }]],
-            },
-            {
-                id = "table_margin_left_right_auto";
-                title = _("Center small tables"),
-                description = _("Horizontally center tables that do not use the full page width."),
-                css = [[table { margin-left: auto !important; margin-right: auto !important; }]],
-                separator = true,
-            },
-            {
-                id = "td_vertical_align_none";
-                title = _("Ignore publisher vertical alignment in tables"),
-                -- Using "vertical-align: top" would vertical-align children text nodes to top.
-                -- "vertical-align: baseline" has no meaning in table rendering, and is as fine
-                css = [[td { vertical-align: baseline !important; }]],
-            },
-            {
-                id = "table_row_odd_even";
-                title = _("Alternate background color of table rows"),
-                css = [[
+            id = "table_full_width";
+            title = _("Full-width tables"),
+            description = _("Make table expand to the full width of the page. (Tables with small content now use only the width needed to display that content. This restores the previous behavior.)"),
+            css = [[table { width: 100% !important; }]],
+        },
+        {
+            id = "table_td_width_auto";
+            title = _("Ignore publisher table and cell widths"),
+            description = _("Ignore table and cells widths specified by the publisher, and let the engine decide the most appropriate widths."),
+            css = [[table, td, th { width: auto !important; }]],
+        },
+        {
+            id = "table_margin_left_right_auto";
+            title = _("Center small tables"),
+            description = _("Horizontally center tables that do not use the full page width."),
+            css = [[table { margin-left: auto !important; margin-right: auto !important; }]],
+            separator = true,
+        },
+        {
+            id = "td_vertical_align_none";
+            title = _("Ignore publisher vertical alignment in tables"),
+            -- Using "vertical-align: top" would vertical-align children text nodes to top.
+            -- "vertical-align: baseline" has no meaning in table rendering, and is as fine
+            css = [[td { vertical-align: baseline !important; }]],
+        },
+        {
+            id = "table_row_odd_even";
+            title = _("Alternate background color of table rows"),
+            css = [[
 tr:nth-child(odd)  { background-color: #EEE !important; }
 tr:nth-child(even) { background-color: #CCC !important; }
-                ]],
-            },
-            {
-                id = "table_force_border";
-                title = _("Show borders on all tables"),
-                css = [[
-table, tcaption, tr, th, td { border: black solid 1px; border-collapse: collapse; }
-                ]],
-                separator = true,
-            },
+            ]],
         },
         {
-            title = _("Images"),
-            {
-                id = "image_full_width";
-                title = _("Full-width images"),
-                description = _("Useful for books containing only images, when they are smaller than your screen. May stretch images in some cases."),
-                -- This helped me once with a book. Will mess with aspect ratio
-                -- when images have a style="width: NNpx; heigh: NNpx"
-                css = [[
-img {
-   text-align: center !important;
-   text-indent: 0px !important;
-   display: block !important;
-   width: 100% !important;
-}
-                ]],
-            },
-            {
-                id = "image_valign_middle";
-                title = _("Vertically center-align images relative to text"),
-                css = [[img { vertical-align: middle; }]],
-            },
+            id = "table_force_border";
+            title = _("Show borders on all tables"),
+            css = [[
+table, tcaption, tr, th, td { border: black solid 1px; border-collapse: collapse; }
+            ]],
+            separator = true,
         },
     },
+    {
+        title = _("Images"),
+        {
+            id = "image_full_width";
+            title = _("Full-width images"),
+            description = _("Useful for books containing only images, when they are smaller than your screen. May stretch images in some cases."),
+            -- This helped me once with a book. Will mess with aspect ratio
+            -- when images have a style="width: NNpx; heigh: NNpx"
+            css = [[
+img {
+text-align: center !important;
+text-indent: 0px !important;
+display: block !important;
+width: 100% !important;
+}
+            ]],
+        },
+        {
+            id = "image_valign_middle";
+            title = _("Vertically center-align images relative to text"),
+            css = [[img { vertical-align: middle; }]],
+        },
+    },
+    -- {
+    --     title = _("Miscellaneous"),
+    -- },
     -- No current need for workarounds
     -- {
     --     title = _("Workarounds"),

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -13,7 +13,7 @@ local _ = require("gettext")
 
 local CssTweaks = {
     {
-        title = _("Page"),
+        title = _("Pages"),
         {
             id = "margin_body_0";
             title = _("Ignore publisher page margins"),
@@ -54,31 +54,43 @@ h4, h5, h6 { page-break-after: avoid !important; }
         },
     },
     {
-        title = _("Text"),
+        title = _("Paragraphs"),
         {
-            title = _("Links color and weight"),
-            {
-                id = "a_black";
-                title = _("Links always black"),
-                css = [[a { color: black !important; }]],
-            },
-            {
-                id = "a_blue";
-                title = _("Links always blue"),
-                css = [[a { color: blue !important; }]],
-                separator = true,
-            },
-            {
-                id = "a_bold";
-                title = _("Links always bold"),
-                css = [[a { font-weight: bold !important; }]],
-            },
-            {
-                id = "a_not_bold";
-                title = _("Links never bold"),
-                css = [[a { font-weight: normal !important; }]],
-            },
+            id = "paragraph_no_indent";
+            title = _("No indentation on first paragraph line"),
+            description = _("Do not indent the first line of paragraphs."),
+            css = [[p + p { text-indent: 0 !important; }]],
         },
+        {
+            id = "paragraph_indent";
+            title = _("Indentation on first paragraph line"),
+            description = _("Indentation on the first line of a paragraph is the default, but it may be overridden by publisher styles. This will force KOReader's defaults on common elements."),
+            css = [[
+p { text-indent: 1.2em !important; }
+body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
+            ]],
+        },
+        {
+            id = "paragraph_whitespace";
+            title = _("Spacing between paragraphs"),
+            description = _("Add a line of whitespace between paragraphs."),
+            css = [[p + p { margin-top: 1em !important; }]],
+        },
+        {
+            id = "paragraph_whitespace_half";
+            title = _("Spacing between paragraphs (half)"),
+            description = _("Add half a line of whitespace between paragraphs."),
+            css = [[p + p { margin-top: .5em !important; }]],
+        },
+        {
+            id = "paragraph_no_whitespace";
+            title = _("No spacing between paragraphs"),
+            description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
+            css = [[p, li { margin: 0 !important; }]],
+        },
+    },
+    {
+        title = _("Text"),
         {
             title = _("Text alignment"),
             {
@@ -107,42 +119,6 @@ h4, h5, h6 { page-break-after: avoid !important; }
                 title = _("Justify all elements"),
                 description = _("Text justification is the default, but it may be overridden by publisher styles. This will re-enable it for all elements, which may lose centering in some of them."),
                 css = [[* { text-align: justify !important; }]],
-            },
-        },
-        {
-            title = _("Paragraph display"),
-            {
-                id = "paragraph_no_indent";
-                title = _("No indentation on first paragraph line"),
-                description = _("Do not indent the first line of paragraphs."),
-                css = [[p + p { text-indent: 0 !important; }]],
-            },
-            {
-                id = "paragraph_indent";
-                title = _("Indentation on first paragraph line"),
-                description = _("Indentation on the first line of a paragraph is the default, but it may be overridden by publisher styles. This will force KOReader's defaults on common elements."),
-                css = [[
-p { text-indent: 1.2em !important; }
-body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
-                ]],
-            },
-            {
-                id = "paragraph_whitespace";
-                title = _("Spacing between paragraphs"),
-                description = _("Add a line of whitespace between paragraphs."),
-                css = [[p + p { margin-top: 1em !important; }]],
-            },
-            {
-                id = "paragraph_whitespace_half";
-                title = _("Spacing between paragraphs (half)"),
-                description = _("Add half a line of whitespace between paragraphs."),
-                css = [[p + p { margin-top: .5em !important; }]],
-            },
-            {
-                id = "paragraph_no_whitespace";
-                title = _("No spacing between paragraphs"),
-                description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
-                css = [[p, li { margin: 0 !important; }]],
             },
         },
         {
@@ -186,6 +162,30 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
             description = _("Disable font-size specified in embedded styles."),
             css = [[* { font-size: inherit !important; }]],
             separator = true,
+        },
+    },
+    {
+        title = _("Links"),
+        {
+            id = "a_black";
+            title = _("Links always black"),
+            css = [[a { color: black !important; }]],
+        },
+        {
+            id = "a_blue";
+            title = _("Links always blue"),
+            css = [[a { color: blue !important; }]],
+            separator = true,
+        },
+        {
+            id = "a_bold";
+            title = _("Links always bold"),
+            css = [[a { font-weight: bold !important; }]],
+        },
+        {
+            id = "a_not_bold";
+            title = _("Links never bold"),
+            css = [[a { font-weight: normal !important; }]],
         },
     },
     {
@@ -256,6 +256,7 @@ width: 100% !important;
             css = [[img { vertical-align: middle; }]],
         },
     },
+    -- No current need for Miscellaneous
     -- {
     --     title = _("Miscellaneous"),
     -- },

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -54,42 +54,6 @@ h4, h5, h6 { page-break-after: avoid !important; }
         },
     },
     {
-        title = _("Paragraphs"),
-        {
-            id = "paragraph_no_indent";
-            title = _("No indentation on first paragraph line"),
-            description = _("Do not indent the first line of paragraphs."),
-            css = [[p + p { text-indent: 0 !important; }]],
-        },
-        {
-            id = "paragraph_indent";
-            title = _("Indentation on first paragraph line"),
-            description = _("Indentation on the first line of a paragraph is the default, but it may be overridden by publisher styles. This will force KOReader's defaults on common elements."),
-            css = [[
-p { text-indent: 1.2em !important; }
-body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
-            ]],
-        },
-        {
-            id = "paragraph_whitespace";
-            title = _("Spacing between paragraphs"),
-            description = _("Add a line of whitespace between paragraphs."),
-            css = [[p + p { margin-top: 1em !important; }]],
-        },
-        {
-            id = "paragraph_whitespace_half";
-            title = _("Spacing between paragraphs (half)"),
-            description = _("Add half a line of whitespace between paragraphs."),
-            css = [[p + p { margin-top: .5em !important; }]],
-        },
-        {
-            id = "paragraph_no_whitespace";
-            title = _("No spacing between paragraphs"),
-            description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
-            css = [[p, li { margin: 0 !important; }]],
-        },
-    },
-    {
         title = _("Text"),
         {
             title = _("Text alignment"),
@@ -165,27 +129,39 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
         },
     },
     {
-        title = _("Links"),
+        title = _("Paragraphs"),
         {
-            id = "a_black";
-            title = _("Links always black"),
-            css = [[a { color: black !important; }]],
+            id = "paragraph_no_indent";
+            title = _("No indentation on first paragraph line"),
+            description = _("Do not indent the first line of paragraphs."),
+            css = [[p + p { text-indent: 0 !important; }]],
         },
         {
-            id = "a_blue";
-            title = _("Links always blue"),
-            css = [[a { color: blue !important; }]],
-            separator = true,
+            id = "paragraph_indent";
+            title = _("Indentation on first paragraph line"),
+            description = _("Indentation on the first line of a paragraph is the default, but it may be overridden by publisher styles. This will force KOReader's defaults on common elements."),
+            css = [[
+p { text-indent: 1.2em !important; }
+body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
+            ]],
         },
         {
-            id = "a_bold";
-            title = _("Links always bold"),
-            css = [[a { font-weight: bold !important; }]],
+            id = "paragraph_whitespace";
+            title = _("Spacing between paragraphs"),
+            description = _("Add a line of whitespace between paragraphs."),
+            css = [[p + p { margin-top: 1em !important; }]],
         },
         {
-            id = "a_not_bold";
-            title = _("Links never bold"),
-            css = [[a { font-weight: normal !important; }]],
+            id = "paragraph_whitespace_half";
+            title = _("Spacing between paragraphs (half)"),
+            description = _("Add half a line of whitespace between paragraphs."),
+            css = [[p + p { margin-top: .5em !important; }]],
+        },
+        {
+            id = "paragraph_no_whitespace";
+            title = _("No spacing between paragraphs"),
+            description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
+            css = [[p, li { margin: 0 !important; }]],
         },
     },
     {
@@ -231,6 +207,30 @@ tr:nth-child(even) { background-color: #CCC !important; }
 table, tcaption, tr, th, td { border: black solid 1px; border-collapse: collapse; }
             ]],
             separator = true,
+        },
+    },
+    {
+        title = _("Links"),
+        {
+            id = "a_black";
+            title = _("Links always black"),
+            css = [[a { color: black !important; }]],
+        },
+        {
+            id = "a_blue";
+            title = _("Links always blue"),
+            css = [[a { color: blue !important; }]],
+            separator = true,
+        },
+        {
+            id = "a_bold";
+            title = _("Links always bold"),
+            css = [[a { font-weight: bold !important; }]],
+        },
+        {
+            id = "a_not_bold";
+            title = _("Links never bold"),
+            css = [[a { font-weight: normal !important; }]],
         },
     },
     {

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -144,6 +144,7 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
 p { text-indent: 1.2em !important; }
 body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
             ]],
+            separator = true,
         },
         {
             id = "paragraph_whitespace";


### PR DESCRIPTION
It just occured to me that we don't need yhe first-level menu to be short if it contains no tweak itself (only the submenus with toggable tweaks need to be kept shorter to let room below to see the tweak effects).

For now with this PR (just moved Tables and Images out from `Miscellaneous>`)
<kbd>![image](https://user-images.githubusercontent.com/24273478/49668017-2eddf200-fa5d-11e8-9f2c-39d76ab85730.png)</kbd>
We have room for 8 submenus containers of tweaks (10 minus the top info item minus the bottom user style tweaks) if we want them all on a single page.

The only submenu that contains itself submenus is `Text>`:
<kbd>![image](https://user-images.githubusercontent.com/24273478/49668124-7cf2f580-fa5d-11e8-87ae-6a23ecf2a315.png)</kbd>

So, we have room for the 3 submenus from `Text>` (but `Text>` followed by `Text alignment>` would look a bit strange - we could keep it inside `Text>`, no real need to move them all to top.)
I'd like to keep a slot for a (for now removed) `Miscellaneous>`.

We could then have:
```
Enable style tweaks (hold for info)
--------
Page>
Paragraphs>
Text>
Text alignment>
Links>
Tables>
Images>
Miscellaneous>
--------
User style tweaks
```
Any idea/comment about order and titles ?