### PR TITLE
[UX] Inform about hold to set custom DPI, up DPI limit to 900

### DIFF
--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -1,5 +1,6 @@
 local _ = require("gettext")
 local Screen = require("device").screen
+local T = require("ffi/util").template
 
 
 local function dpi() return G_reader_settings:readSetting("screen_dpi") end
@@ -10,7 +11,7 @@ local function setDPI(_dpi)
     local InfoMessage = require("ui/widget/infomessage")
     local UIManager = require("ui/uimanager")
     UIManager:show(InfoMessage:new{
-        text = _("This will take effect on next restart."),
+        text = _("This will take effect after restarting."),
     })
     Screen:setDPI(_dpi)
 end
@@ -51,23 +52,24 @@ return {
             callback = function() setDPI(240) end
         },
         {
-            text = _("Custom DPI") .. ": " .. (custom() or 160),
+            text = T(_("Custom DPI: %1 (hold to set)"), custom() or 160),
             checked_func = function()
                 local _dpi, _custom = dpi(), custom()
                 return _custom and _dpi == _custom
             end,
             callback = function() setDPI(custom() or 160) end,
             hold_input = {
-                title = _("Input screen DPI"),
+                title = _("Enter custom screen DPI"),
                 type = "number",
-                hint = "(90 - 600)",
+                hint = "(90 - 900)",
                 callback = function(input)
                     local _dpi = tonumber(input)
                     _dpi = _dpi < 90 and 90 or _dpi
-                    _dpi = _dpi > 600 and 600 or _dpi
+                    _dpi = _dpi > 900 and 900 or _dpi
                     G_reader_settings:saveSetting("custom_screen_dpi", _dpi)
                     setDPI(_dpi)
                 end,
+                ok_text = _("Set custom DPI"),
             },
         },
     }


### PR DESCRIPTION
* It was unclear that you needed to hold to set DPI, see https://github.com/koreader/koreader/issues/2589#issuecomment-445471384

* Up the DPI limit to 900 as several Android devices have already breached 800. This will increase the possibility of crashes due to a higher setting even on relatively high-DPI devices, but that was always already an issue.

* Also brings the custom DPI dialog box in line with the UX guidelines as per <http://koreader.rocks/doc/modules/ui.widget.confirmbox.html>.

## Before
![screenshot_2018-12-08_17-40-53](https://user-images.githubusercontent.com/202757/49688392-8f2e6b80-fb11-11e8-821f-a0d26793728a.png)
![screenshot_2018-12-08_17-41-05](https://user-images.githubusercontent.com/202757/49688393-8f2e6b80-fb11-11e8-9fce-fca5d1066af6.png)

## After
![screenshot_2018-12-08_17-40-37](https://user-images.githubusercontent.com/202757/49688391-8f2e6b80-fb11-11e8-80b2-056dc7dc2387.png)
![screenshot_2018-12-08_17-44-11](https://user-images.githubusercontent.com/202757/49688394-8f2e6b80-fb11-11e8-9c37-2f726daedc1e.png)
