### PR TITLE
[UX] DPI: show concrete numbers and add more custom DPI presets

### DIFF
--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -11,53 +11,88 @@ local function setDPI(_dpi)
     local InfoMessage = require("ui/widget/infomessage")
     local UIManager = require("ui/uimanager")
     UIManager:show(InfoMessage:new{
-        text = _("This will take effect after restarting."),
+        text = T(_("DPI set to %1. This will take effect after restarting."), _dpi),
     })
+    G_reader_settings:saveSetting("screen_dpi", _dpi)
     Screen:setDPI(_dpi)
 end
 
+local dpi_auto = Screen:getDPI()
+local dpi_small = 120
+local dpi_medium = 160
+local dpi_large = 240
+local dpi_xlarge = 320
+local dpi_xxlarge = 480
+local dpi_xxxlarge = 640
 
 return {
     text = _("Screen DPI"),
     sub_item_table = {
         {
-            text = _("Auto"),
+            text = T(_("Auto DPI (%1)"), dpi_auto),
+            help_text = _("The DPI of your screen is automatically detected so items can be drawn with the right amount of pixels. This will usually display at (roughly) the same size on different devices, while remaining sharp. Increasing the DPI setting will result in larger text and icons, while a lower DPI setting will look smaller on the screen."),
             checked_func = function()
                 return dpi() == nil
             end,
             callback = function() setDPI() end
         },
         {
-            text = _("Small"),
+            text = T(_("Small (%1)"), dpi_small),
             checked_func = function()
                 local _dpi, _custom = dpi(), custom()
                 return _dpi and _dpi <= 140 and _dpi ~= _custom
             end,
-            callback = function() setDPI(120) end
+            callback = function() setDPI(dpi_small) end
         },
         {
-            text = _("Medium"),
+            text = T(_("Medium (%1)"), dpi_medium),
             checked_func = function()
                 local _dpi, _custom = dpi(), custom()
                 return _dpi and _dpi > 140 and _dpi <= 200 and _dpi ~= _custom
             end,
-            callback = function() setDPI(160) end
+            callback = function() setDPI(dpi_medium) end
         },
         {
-            text = _("Large"),
+            text = T(_("Large (%1)"), dpi_large),
             checked_func = function()
                 local _dpi, _custom = dpi(), custom()
-                return _dpi and _dpi > 200 and _dpi ~= _custom
+                return _dpi and _dpi > 200 and _dpi <= 280 and _dpi ~= _custom
             end,
-            callback = function() setDPI(240) end
+            callback = function() setDPI(dpi_large) end
         },
         {
-            text = T(_("Custom DPI: %1 (hold to set)"), custom() or 160),
+            text = T(_("Extra large (%1)"), dpi_xlarge),
+            checked_func = function()
+                local _dpi, _custom = dpi(), custom()
+                return _dpi and _dpi > 280 and _dpi <= 400 and _dpi ~= _custom
+            end,
+            callback = function() setDPI(dpi_xlarge) end
+        },
+        {
+            text = T(_("Extra-Extra Large (%1)"), dpi_xxlarge),
+            checked_func = function()
+                local _dpi, _custom = dpi(), custom()
+                return _dpi and _dpi > 400 and _dpi <= 560 and _dpi ~= _custom
+            end,
+            callback = function() setDPI(dpi_xxlarge) end
+        },
+        {
+            text = T(_("Extra-Extra-Extra Large (%1)"), dpi_xxxlarge),
+            checked_func = function()
+                local _dpi, _custom = dpi(), custom()
+                return _dpi and _dpi > 560 and _dpi ~= _custom
+            end,
+            callback = function() setDPI(dpi_xxxlarge) end
+        },
+        {
+            text_func = function()
+                return T(_("Custom DPI: %1 (hold to set)"), custom() or dpi_auto)
+            end,
             checked_func = function()
                 local _dpi, _custom = dpi(), custom()
                 return _custom and _dpi == _custom
             end,
-            callback = function() setDPI(custom() or 160) end,
+            callback = function() setDPI(custom() or dpi_auto) end,
             hold_input = {
                 title = _("Enter custom screen DPI"),
                 type = "number",


### PR DESCRIPTION
Follow-up of #4388.

Implements the suggestion by @turkeyphant from <https://github.com/koreader/koreader/issues/2589#issuecomment-445474155>.

Also adds a little explanatory message when holding on the Auto DPI option.

## Before
![screenshot_2018-12-08_21-17-31](https://user-images.githubusercontent.com/202757/49690294-b34c7580-fb2e-11e8-9afc-e59480cc380f.png)

## After
![screenshot_2018-12-08_21-15-42](https://user-images.githubusercontent.com/202757/49690289-9fa10f00-fb2e-11e8-95b2-64be613be59d.png)
![screenshot_2018-12-08_21-15-49](https://user-images.githubusercontent.com/202757/49690290-9fa10f00-fb2e-11e8-8d8d-df8035e71b1b.png)
