### PR TITLE
fix: rename "Calibre companion" to "Calibre wireless connection" in Plugin management menu

### DIFF
--- a/plugins/calibrecompanion.koplugin/_meta.lua
+++ b/plugins/calibrecompanion.koplugin/_meta.lua
@@ -1,6 +1,6 @@
 local _ = require("gettext")
 return {
     name = "calibrecompanion",
-    fullname = _("Calibre companion"),
+    fullname = _("Calibre wireless connection"),
     description = _([[Send documents from calibre library directly to device via Wi-Fi connection]]),
 }


### PR DESCRIPTION
"Calibre Companion" should named as "Calibre wireless connection" within Plugin management menu, and make it consistent with [Plugin menu](https://github.com/koreader/koreader/blob/3e363926c3444be118e99d6d2306a3c8c2968d4d/plugins/calibrecompanion.koplugin/main.lua#L99).

## Ref:

- PR #1370
- https://www.mobileread.com/forums/showthread.php?t=253228