### PR TITLE
[UX] SSH: double info dialog timeout

### DIFF
--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -65,7 +65,7 @@ function SSH:start()
     logger.dbg("[Network] Launching SSH server : ", cmd)
     if os.execute(cmd) == 0 then
         local info = InfoMessage:new{
-                timeout = 5,
+                timeout = 10,
                 text = string.format("%s %s \n %s",
                     _("SSH port: "), self.SSH_port,
                     Device.retrieveNetworkInfo and Device:retrieveNetworkInfo() or _("Could not retrieve network info.")),


### PR DESCRIPTION
I tried to actually use this feature and five seconds isn't enough time to register the relevant IP:port to connect.

I'd add a menu item to call up the info (without a timeout) but this is just a web interface quickie.