### PR TITLE
[wip]: move old kobos to singletouch and new cervantes to multitouch.

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -26,7 +26,6 @@ local Cervantes = Generic:new{
     isCervantes = yes,
     isAlwaysPortrait = yes,
     isTouchDevice = yes,
-    touch_legacy = true, -- SingleTouch input events
     touch_switch_xy = true,
     touch_mirrored_x = true,
     touch_probe_ev_epoch_time = true,
@@ -44,16 +43,19 @@ local CervantesTouch = Cervantes:new{
     model = "CervantesTouch",
     display_dpi = 167,
     hasFrontlight = no,
+    touch_legacy = true,
 }
 -- Cervantes TouchLight / Fnac Touch Plus
 local CervantesTouchLight = Cervantes:new{
     model = "CervantesTouchLight",
     display_dpi = 167,
+    touch_legacy = true,
 }
 -- Cervantes 2013 / Fnac Touch Light
 local Cervantes2013 = Cervantes:new{
     model = "Cervantes2013",
     display_dpi = 212,
+    touch_legacy = true,
 }
 -- Cervantes 3 / Fnac Touch Light 2
 local Cervantes3 = Cervantes:new{

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -26,6 +26,7 @@ local Cervantes = Generic:new{
     isCervantes = yes,
     isAlwaysPortrait = yes,
     isTouchDevice = yes,
+    touch_legacy = true,
     touch_switch_xy = true,
     touch_mirrored_x = true,
     touch_probe_ev_epoch_time = true,
@@ -43,19 +44,16 @@ local CervantesTouch = Cervantes:new{
     model = "CervantesTouch",
     display_dpi = 167,
     hasFrontlight = no,
-    touch_legacy = true,
 }
 -- Cervantes TouchLight / Fnac Touch Plus
 local CervantesTouchLight = Cervantes:new{
     model = "CervantesTouchLight",
     display_dpi = 167,
-    touch_legacy = true,
 }
 -- Cervantes 2013 / Fnac Touch Light
 local Cervantes2013 = Cervantes:new{
     model = "Cervantes2013",
     display_dpi = 212,
-    touch_legacy = true,
 }
 -- Cervantes 3 / Fnac Touch Light 2
 local Cervantes3 = Cervantes:new{
@@ -66,6 +64,9 @@ local Cervantes3 = Cervantes:new{
 local Cervantes4 = Cervantes:new{
     model = "Cervantes4",
     display_dpi = 300,
+    touch_legacy = false,
+    touch_switch_xy = false,
+    touch_mirrored_x = false,
     hasNaturalLight = yes,
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/lm3630a_ledb",

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -570,8 +570,21 @@ function Input:handleTouchEvPhoenix(ev)
     end
 end
 function Input:handleTouchEvLegacy(ev)
-    -- Single Touch Protocol. Some devices emit both singletouch and multitouch events.
-    -- In those devices the 'handleTouchEv' function doesn't work as expected. Use this function instead.
+    --[[ Single Touch Protocol
+
+        ABS_X
+        ABS_Y
+        ABS_PRESSURE
+        SYN_REPORT
+
+        ABS_PRESSURE is used to detect touch (ev.value = 1) and release (ev.value = 0) events.
+
+        If you are porting KOReader to a new device (2013+) you probably won't need this function,
+        since even lazy companies are implementing MT-B on top of ST
+        see: https://github.com/koreader/koreader/issues/4275#issuecomment-430827648
+
+        This is used on legacy Kobos(Touch,Mini,AuraHD,Glo) and Cervantes(Touch,TouchLight,2013)
+    ]]--
     if ev.type == EV_ABS then
         if #self.MTSlots == 0 then
             table.insert(self.MTSlots, self:getMtSlot(self.cur_slot))

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -467,21 +467,6 @@ function Input:handleTouchEv(ev)
             self:setCurrentMtSlot("x", ev.value)
         elseif ev.code == ABS_MT_POSITION_Y then
             self:setCurrentMtSlot("y", ev.value)
-
-        -- code to emulate mt protocol on kobos
-        -- we "confirm" abs_x, abs_y only when pressure ~= 0
-        elseif ev.code == ABS_X then
-            self:setCurrentMtSlot("abs_x", ev.value)
-        elseif ev.code == ABS_Y then
-            self:setCurrentMtSlot("abs_y", ev.value)
-        elseif ev.code == ABS_PRESSURE then
-            if ev.value ~= 0 then
-                self:setCurrentMtSlot("id", 1)
-                self:confirmAbsxy()
-            else
-                self:cleanAbsxy()
-                self:setCurrentMtSlot("id", -1)
-            end
         end
     elseif ev.type == EV_SYN then
         if ev.code == SYN_REPORT then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -47,6 +47,7 @@ local KoboTrilogy = Kobo:new{
     model = "Kobo_trilogy",
     needsTouchScreenProbe = yes,
     touch_switch_xy = false,
+    touch_legacy = true,
     -- Some Kobo Touch models' kernel does not generate touch event with epoch
     -- timestamp. This flag will probe for those models and setup event adjust
     -- hook accordingly
@@ -58,6 +59,7 @@ local KoboTrilogy = Kobo:new{
 local KoboPixie = Kobo:new{
     model = "Kobo_pixie",
     display_dpi = 200,
+    touch_legacy = true,
     -- bezel:
     viewport = Geom:new{x=0, y=2, w=596, h=794},
 }
@@ -92,6 +94,7 @@ local KoboDragon = Kobo:new{
     model = "Kobo_dragon",
     hasFrontlight = yes,
     display_dpi = 265,
+    touch_legacy = true,
 }
 
 -- Kobo Glo:
@@ -99,6 +102,7 @@ local KoboKraken = Kobo:new{
     model = "Kobo_kraken",
     hasFrontlight = yes,
     display_dpi = 212,
+    touch_legacy = true,
 }
 
 -- Kobo Aura:
@@ -433,6 +437,10 @@ function Kobo:initEventAdjustHooks()
 
     if self.touch_phoenix_protocol then
         self.input.handleTouchEv = self.input.handleTouchEvPhoenix
+    end
+
+    if self.touch_legacy then
+        self.input.handleTouchEv = self.input.handleTouchEvLegacy
     end
 
     -- Accelerometer on the Forma


### PR DESCRIPTION
**It needs testing in a Kobo Touch/Mini/AuraHD/Glo**
If you have one of those devices and want to test you'll need at least KOReader 2018.11.

1. add the line `self.input.handleTouchEv = self.input.handleTouchEvLegacy` in [frontend/device/kobo/device.lua#L417](https://github.com/koreader/koreader/blob/master/frontend/device/kobo/device.lua#L417) just before the 'end'
2. see if the touchscreen works as normal and provide feedback here :+1: 
