### PR TITLE
[Android]: use proper log levels

### DIFF
--- a/frontend/dbg.lua
+++ b/frontend/dbg.lua
@@ -21,7 +21,7 @@ local function LvDEBUG(lv, ...)
         end
     end
     if isAndroid then
-        android.LOGI("#"..line)
+        android.LOGV(line)
     else
         io.stdout:write(string.format("# %s %s\n", os.date("%x-%X"), line))
         io.stdout:flush()

--- a/frontend/logger.lua
+++ b/frontend/logger.lua
@@ -50,7 +50,15 @@ local function log(log_lvl, dump_lvl, ...)
         end
     end
     if isAndroid then
-        android.LOGI(LOG_PREFIX[log_lvl]..line)
+        if log_lvl == "dbg" then
+            android.LOGV(line)
+        elseif log_lvl == "info" then
+            android.LOGI(line)
+        elseif log_lvl == "warn" then
+            android.LOGW(line)
+        elseif log_lvl == "err" then
+            android.LOGE(line)
+        end
     else
         io.stdout:write(os.date("%x-%X"), " ", LOG_PREFIX[log_lvl], line, "\n")
         io.stdout:flush()

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -29,7 +29,10 @@ local file = A.jni:context(A.app.activity.vm, function(JNI)
         return JNI:to_string(path)
     end
 end)
-A.LOGI("intent file path " .. (file or ""))
+
+if file ~= nil then
+    A.LOGI("intent file path " .. file)
+end
 
 -- update koreader from ota
 local function update()


### PR DESCRIPTION
So we can filter messages in logcat.

For example: 

`adb logcat KOReader:V luajit-launcher:I *:S` will print verbose messages for KOReader and info or higher for luajit-launcher.

`adb logcat KOReader:V *:S` will print verbose messages for KOReader (this is the same as `adb logcat | grep KOReader`)

`adb logcat KOReader:I *:S` will print info or higher messages for KOReader.

######

<details>
  <summary>Here is a sneak peak of logging info messages:</summary>

```
--------- beginning of system
--------- beginning of main
12-27 20:11:43.799 31577 31622 I KOReader: try to load module libs/libkoreader-lfs.so
12-27 20:11:43.799 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libkoreader-lfs.so
12-27 20:11:43.800 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:43.801 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libkoreader-lfs.so
12-27 20:11:43.801 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:43.803 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:43.803 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libkoreader-lfs.so
12-27 20:11:43.809 31577 31622 I KOReader: external storage /storage/emulated/0
12-27 20:11:43.818 31577 31622 W KOReader:  cannot open translation file: l10n/es_ES/koreader.po
12-27 20:11:43.891 31577 31622 I KOReader: ffi.load blitbuffer
12-27 20:11:43.891 31577 31622 I KOReader: ffi.load ./libs/libblitbuffer.so
12-27 20:11:43.891 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/./libs/libblitbuffer.so
12-27 20:11:43.892 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/./libs/libblitbuffer.so
12-27 20:11:43.893 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:43.894 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:43.904 31577 31622 I KOReader: ffi.load SDL2
12-27 20:11:43.904 31577 31622 I KOReader: ffi.load SDL
12-27 20:11:44.123 31577 31622 I KOReader:  initializing for device Android
12-27 20:11:44.123 31577 31622 I KOReader:  framebuffer resolution: {
12-27 20:11:44.123 31577 31622 I KOReader:     ["h"] = 1920,
12-27 20:11:44.123 31577 31622 I KOReader:     ["w"] = 1080
12-27 20:11:44.123 31577 31622 I KOReader: }
12-27 20:11:44.125 31577 31622 I KOReader: ffi.load libs/libfreetype.so.6
12-27 20:11:44.125 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.126 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.127 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.128 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.176 31577 31622 I KOReader: try to load module common/serialize.so
12-27 20:11:44.176 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.177 31577 31622 I KOReader:          dl.dlopen - opening needed libluacompat52.so for /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.177 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libluacompat52.so
12-27 20:11:44.178 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.178 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libluacompat52.so
12-27 20:11:44.179 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.180 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.180 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libluacompat52.so
12-27 20:11:44.181 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.181 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.182 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.183 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.183 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.234 31577 31622 I KOReader: try to load module rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.234 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.235 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.236 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.236 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.237 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.237 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.254 31577 31622 I KOReader: try to load module common/socket/score.so
12-27 20:11:44.254 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/socket/score.so
12-27 20:11:44.255 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.256 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/socket/score.so
12-27 20:11:44.256 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.257 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.257 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/socket/score.so
12-27 20:11:44.263 31577 31622 I KOReader: try to load module common/mime/mcore.so
12-27 20:11:44.263 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/mime/mcore.so
12-27 20:11:44.264 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.264 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/mime/mcore.so
12-27 20:11:44.264 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.265 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.266 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/mime/mcore.so
12-27 20:11:44.269 31577 31622 I KOReader: try to load module common/ssl.so
12-27 20:11:44.269 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.270 31577 31622 I KOReader:          dl.dlopen - opening needed libssl.so.1.0.0 for /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.271 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.272 31577 31622 I KOReader:          dl.dlopen - opening needed libcrypto.so.1.0.0 for /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.272 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.276 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.276 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.278 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.278 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.280 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.280 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.282 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.282 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.284 31577 31622 I KOReader:          dl.dlopen - opening needed libcrypto.so.1.0.0 for /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.284 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.287 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.287 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.290 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.290 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.291 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.291 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.291 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.293 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.294 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.337 31577 31622 I KOReader: ffi.load libs/libmupdf.so
12-27 20:11:44.337 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.338 31577 31622 I KOReader:          dl.dlopen - opening needed libz.so.1 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.339 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.340 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.340 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.341 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.341 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.342 31577 31622 I KOReader:          dl.dlopen - opening needed libjpeg.so.8 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.342 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.343 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.343 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.344 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.345 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.345 31577 31622 I KOReader:          dl.dlopen - opening needed libfreetype.so.6 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.346 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.347 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.347 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.348 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.348 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.348 31577 31622 I KOReader:          dl.dlopen - opening needed libm.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.349 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libm.so
12-27 20:11:44.350 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libm.so
12-27 20:11:44.350 31577 31622 I KOReader:          dl.dlopen - opening needed liblog.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.350 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/liblog.so
12-27 20:11:44.351 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/liblog.so
12-27 20:11:44.351 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.352 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.353 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.355 31577 31622 I KOReader: ffi.load libs/libwrap-mupdf.so
12-27 20:11:44.355 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libwrap-mupdf.so
12-27 20:11:44.356 31577 31622 I KOReader:          dl.dlopen - opening needed libmupdf.so for /data/user/0/org.koreader.launcher/files/libs/libwrap-mupdf.so
12-27 20:11:44.357 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.358 31577 31622 I KOReader:          dl.dlopen - opening needed libz.so.1 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.358 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.359 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.359 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.360 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.361 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.361 31577 31622 I KOReader:          dl.dlopen - opening needed libjpeg.so.8 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.361 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.362 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.362 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.364 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.364 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.364 31577 31622 I KOReader:          dl.dlopen - opening needed libfreetype.so.6 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.364 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.365 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.365 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.367 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.367 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.367 31577 31622 I KOReader:          dl.dlopen - opening needed libm.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.367 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libm.so
12-27 20:11:44.368 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libm.so
12-27 20:11:44.369 31577 31622 I KOReader:          dl.dlopen - opening needed liblog.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.369 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/liblog.so
12-27 20:11:44.370 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/liblog.so
12-27 20:11:44.370 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.370 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.371 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.372 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.372 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libwrap-mupdf.so
12-27 20:11:44.372 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.373 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.530 31577 31622 I KOReader: get battery level 80
12-27 20:11:44.531 31577 31622 I KOReader:  Loading plugins from directory: plugins
12-27 20:11:44.531 31577 31622 I KOReader:  Plugin  plugins/SSH.koplugin/main.lua  has been disabled.
12-27 20:11:44.532 31577 31622 I KOReader:  Plugin  plugins/autofrontlight.koplugin/main.lua  has been disabled.
12-27 20:11:44.532 31577 31622 I KOReader:  Plugin  plugins/autosuspend.koplugin/main.lua  has been disabled.
12-27 20:11:44.533 31577 31622 I KOReader:  Plugin  plugins/hello.koplugin/main.lua  has been disabled.
12-27 20:11:44.533 31577 31622 I KOReader:  Plugin  plugins/keepalive.koplugin/main.lua  has been disabled.
12-27 20:11:44.534 31577 31622 I KOReader:  Plugin  plugins/kobolight.koplugin/main.lua  has been disabled.
12-27 20:11:44.535 31577 31622 I KOReader:  Plugin  plugins/timesync.koplugin/main.lua  has been disabled.
12-27 20:16:44.549 31577 31622 I KOReader: get battery level 81
```
</details>

######

<details>
  <summary>and here the same log but including all messages:</summary>

```
--------- beginning of system
--------- beginning of main
12-27 20:11:43.799 31577 31622 I KOReader: try to load module libs/libkoreader-lfs.so
12-27 20:11:43.799 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libkoreader-lfs.so
12-27 20:11:43.800 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:43.801 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libkoreader-lfs.so
12-27 20:11:43.801 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:43.803 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:43.803 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libkoreader-lfs.so
12-27 20:11:43.809 31577 31622 I KOReader: external storage /storage/emulated/0
12-27 20:11:43.818 31577 31622 W KOReader:  cannot open translation file: l10n/es_ES/koreader.po
12-27 20:11:43.891 31577 31622 I KOReader: ffi.load blitbuffer
12-27 20:11:43.891 31577 31622 I KOReader: ffi.load ./libs/libblitbuffer.so
12-27 20:11:43.891 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/./libs/libblitbuffer.so
12-27 20:11:43.892 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/./libs/libblitbuffer.so
12-27 20:11:43.893 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:43.894 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:43.904 31577 31622 I KOReader: ffi.load SDL2
12-27 20:11:43.904 31577 31622 I KOReader: ffi.load SDL
12-27 20:11:44.123 31577 31622 I KOReader:  initializing for device Android
12-27 20:11:44.123 31577 31622 I KOReader:  framebuffer resolution: {
12-27 20:11:44.123 31577 31622 I KOReader:     ["h"] = 1920,
12-27 20:11:44.123 31577 31622 I KOReader:     ["w"] = 1080
12-27 20:11:44.123 31577 31622 I KOReader: }
12-27 20:11:44.125 31577 31622 I KOReader: ffi.load libs/libfreetype.so.6
12-27 20:11:44.125 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.126 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.127 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.128 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.176 31577 31622 I KOReader: try to load module common/serialize.so
12-27 20:11:44.176 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.177 31577 31622 I KOReader:          dl.dlopen - opening needed libluacompat52.so for /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.177 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libluacompat52.so
12-27 20:11:44.178 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.178 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libluacompat52.so
12-27 20:11:44.179 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.180 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.180 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libluacompat52.so
12-27 20:11:44.181 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.181 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.182 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.183 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.183 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/serialize.so
12-27 20:11:44.234 31577 31622 I KOReader: try to load module rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.234 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.235 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.236 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.236 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.237 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.237 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/rocks/lib/lua/5.1/lpeg.so
12-27 20:11:44.254 31577 31622 I KOReader: try to load module common/socket/score.so
12-27 20:11:44.254 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/socket/score.so
12-27 20:11:44.255 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.256 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/socket/score.so
12-27 20:11:44.256 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.257 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.257 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/socket/score.so
12-27 20:11:44.263 31577 31622 I KOReader: try to load module common/mime/mcore.so
12-27 20:11:44.263 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/mime/mcore.so
12-27 20:11:44.264 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.264 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/mime/mcore.so
12-27 20:11:44.264 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.265 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.266 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/mime/mcore.so
12-27 20:11:44.269 31577 31622 I KOReader: try to load module common/ssl.so
12-27 20:11:44.269 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.270 31577 31622 I KOReader:          dl.dlopen - opening needed libssl.so.1.0.0 for /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.271 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.272 31577 31622 I KOReader:          dl.dlopen - opening needed libcrypto.so.1.0.0 for /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.272 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.276 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.276 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.278 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.278 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.280 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.280 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.282 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.282 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libssl.so.1.0.0
12-27 20:11:44.284 31577 31622 I KOReader:          dl.dlopen - opening needed libcrypto.so.1.0.0 for /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.284 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.287 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.287 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.290 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.290 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libcrypto.so.1.0.0
12-27 20:11:44.291 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library libluajit.so
12-27 20:11:44.291 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.291 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.293 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.294 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/common/ssl.so
12-27 20:11:44.337 31577 31622 I KOReader: ffi.load libs/libmupdf.so
12-27 20:11:44.337 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.338 31577 31622 I KOReader:          dl.dlopen - opening needed libz.so.1 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.339 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.340 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.340 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.341 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.341 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.342 31577 31622 I KOReader:          dl.dlopen - opening needed libjpeg.so.8 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.342 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.343 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.343 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.344 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.345 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.345 31577 31622 I KOReader:          dl.dlopen - opening needed libfreetype.so.6 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.346 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.347 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.347 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.348 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.348 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.348 31577 31622 I KOReader:          dl.dlopen - opening needed libm.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.349 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libm.so
12-27 20:11:44.350 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libm.so
12-27 20:11:44.350 31577 31622 I KOReader:          dl.dlopen - opening needed liblog.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.350 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/liblog.so
12-27 20:11:44.351 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/liblog.so
12-27 20:11:44.351 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.352 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.353 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.355 31577 31622 I KOReader: ffi.load libs/libwrap-mupdf.so
12-27 20:11:44.355 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libwrap-mupdf.so
12-27 20:11:44.356 31577 31622 I KOReader:          dl.dlopen - opening needed libmupdf.so for /data/user/0/org.koreader.launcher/files/libs/libwrap-mupdf.so
12-27 20:11:44.357 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.358 31577 31622 I KOReader:          dl.dlopen - opening needed libz.so.1 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.358 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.359 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.359 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.360 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.361 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libz.so.1
12-27 20:11:44.361 31577 31622 I KOReader:          dl.dlopen - opening needed libjpeg.so.8 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.361 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.362 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.362 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.364 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.364 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libjpeg.so.8
12-27 20:11:44.364 31577 31622 I KOReader:          dl.dlopen - opening needed libfreetype.so.6 for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.364 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.365 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.365 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.367 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.367 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libfreetype.so.6
12-27 20:11:44.367 31577 31622 I KOReader:          dl.dlopen - opening needed libm.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.367 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libm.so
12-27 20:11:44.368 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libm.so
12-27 20:11:44.369 31577 31622 I KOReader:          dl.dlopen - opening needed liblog.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.369 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/liblog.so
12-27 20:11:44.370 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/liblog.so
12-27 20:11:44.370 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.370 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.371 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.372 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /data/user/0/org.koreader.launcher/files/libs/libmupdf.so
12-27 20:11:44.372 31577 31622 I KOReader:          dl.dlopen - opening needed libc.so for /data/user/0/org.koreader.launcher/files/libs/libwrap-mupdf.so
12-27 20:11:44.372 31577 31622 I KOReader: dl.lua - dl.dlopen - library lname detected /system/lib/libc.so
12-27 20:11:44.373 31577 31622 I KOReader: dl.lua - sys_dlopen - loading library /system/lib/libc.so
12-27 20:11:44.458 31577 31622 V KOReader:  ImageWidget: _render'ing resources/icons/appbar.home.png 63 63
12-27 20:11:44.458 31577 31622 V KOReader:  renderImageData: using MuPDF
12-27 20:11:44.459 31577 31622 V KOReader:  Mupdf.renderImage true cdata<struct BlitBuffer8>: 0x9a88c240
12-27 20:11:44.459 31577 31622 V KOReader:  cache image|resources/icons/appbar.home.png|63|63
12-27 20:11:44.459 31577 31622 V KOReader:  ImageWidget: initial offsets 0 0
12-27 20:11:44.459 31577 31622 V KOReader:  ImageWidget: _render'ing resources/icons/appbar.plus.png 63 63
12-27 20:11:44.459 31577 31622 V KOReader:  renderImageData: using MuPDF
12-27 20:11:44.459 31577 31622 V KOReader:  Mupdf.renderImage true cdata<struct BlitBuffer8>: 0x9a88b158
12-27 20:11:44.459 31577 31622 V KOReader:  cache image|resources/icons/appbar.plus.png|63|63
12-27 20:11:44.459 31577 31622 V KOReader:  ImageWidget: initial offsets 0 0
12-27 20:11:44.477 31577 31622 V KOReader:  ImageWidget: _render'ing resources/icons/appbar.chevron.left.png
12-27 20:11:44.477 31577 31622 V KOReader:  renderImageData: using MuPDF
12-27 20:11:44.477 31577 31622 V KOReader:  Mupdf.renderImage true cdata<struct BlitBuffer8>: 0x9a8882b8
12-27 20:11:44.477 31577 31622 V KOReader:  RenderImage:scaleBlitBuffer: scaling
12-27 20:11:44.478 31577 31622 V KOReader:  cache image|resources/icons/appbar.chevron.left.png|||d
12-27 20:11:44.478 31577 31622 V KOReader:  ImageWidget: _render'ing resources/icons/appbar.chevron.right.png
12-27 20:11:44.478 31577 31622 V KOReader:  renderImageData: using MuPDF
12-27 20:11:44.478 31577 31622 V KOReader:  Mupdf.renderImage true cdata<struct BlitBuffer8>: 0x9a8899e8
12-27 20:11:44.478 31577 31622 V KOReader:  RenderImage:scaleBlitBuffer: scaling
12-27 20:11:44.479 31577 31622 V KOReader:  cache image|resources/icons/appbar.chevron.right.png|||d
12-27 20:11:44.479 31577 31622 V KOReader:  ImageWidget: _render'ing resources/icons/appbar.chevron.first.png
12-27 20:11:44.479 31577 31622 V KOReader:  renderImageData: using MuPDF
12-27 20:11:44.479 31577 31622 V KOReader:  Mupdf.renderImage true cdata<struct BlitBuffer8>: 0xaa20e1c0
12-27 20:11:44.479 31577 31622 V KOReader:  RenderImage:scaleBlitBuffer: scaling
12-27 20:11:44.480 31577 31622 V KOReader:  cache image|resources/icons/appbar.chevron.first.png|||d
12-27 20:11:44.480 31577 31622 V KOReader:  ImageWidget: _render'ing resources/icons/appbar.chevron.last.png
12-27 20:11:44.480 31577 31622 V KOReader:  renderImageData: using MuPDF
12-27 20:11:44.480 31577 31622 V KOReader:  Mupdf.renderImage true cdata<struct BlitBuffer8>: 0x9b39d3a0
12-27 20:11:44.480 31577 31622 V KOReader:  RenderImage:scaleBlitBuffer: scaling
12-27 20:11:44.481 31577 31622 V KOReader:  cache image|resources/icons/appbar.chevron.last.png|||d
12-27 20:11:44.481 31577 31622 V KOReader:  ImageWidget: _render'ing resources/icons/appbar.arrow.left.up.png
12-27 20:11:44.481 31577 31622 V KOReader:  renderImageData: using MuPDF
12-27 20:11:44.481 31577 31622 V KOReader:  Mupdf.renderImage true cdata<struct BlitBufferRGB24>: 0x9a871188
12-27 20:11:44.481 31577 31622 V KOReader:  RenderImage:scaleBlitBuffer: scaling
12-27 20:11:44.482 31577 31622 V KOReader:  cache image|resources/icons/appbar.arrow.left.up.png|||d
12-27 20:11:44.526 31577 31622 V KOReader:  setDirty via a func from widget all
12-27 20:11:44.526 31577 31622 V KOReader:  Getting list of dictionaries
12-27 20:11:44.526 31577 31622 V KOReader:  found 0 dictionaries
12-27 20:11:44.526 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua  is invalid, remove.
12-27 20:11:44.526 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.1  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.2  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.3  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.4  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.5  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.6  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.7  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.8  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/lookup_history.lua.old.9  is invalid, remove.
12-27 20:11:44.527 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.1  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.2  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.3  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.4  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.5  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.6  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.7  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.8  is invalid, remove.
12-27 20:11:44.528 31577 31622 V KOReader:  /storage/emulated/0/koreader/settings/wikipedia_history.lua.old.9  is invalid, remove.
12-27 20:11:44.530 31577 31622 I KOReader: get battery level 80
12-27 20:11:44.531 31577 31622 I KOReader:  Loading plugins from directory: plugins
12-27 20:11:44.531 31577 31622 I KOReader:  Plugin  plugins/SSH.koplugin/main.lua  has been disabled.
12-27 20:11:44.532 31577 31622 I KOReader:  Plugin  plugins/autofrontlight.koplugin/main.lua  has been disabled.
12-27 20:11:44.532 31577 31622 I KOReader:  Plugin  plugins/autosuspend.koplugin/main.lua  has been disabled.
12-27 20:11:44.533 31577 31622 I KOReader:  Plugin  plugins/hello.koplugin/main.lua  has been disabled.
12-27 20:11:44.533 31577 31622 I KOReader:  Plugin  plugins/keepalive.koplugin/main.lua  has been disabled.
12-27 20:11:44.534 31577 31622 I KOReader:  Plugin  plugins/kobolight.koplugin/main.lua  has been disabled.
12-27 20:11:44.535 31577 31622 I KOReader:  Plugin  plugins/timesync.koplugin/main.lua  has been disabled.
12-27 20:11:44.536 31577 31622 V KOReader:  show widget unknown
12-27 20:11:44.536 31577 31622 V KOReader:  setDirty nil from widget table: 0x9a9b6270 w/ NO region
12-27 20:11:44.536 31577 31622 V KOReader:  painting widget: table: 0x9adc9af8
12-27 20:11:44.584 31577 31622 V KOReader:  blitFrom 18 9 0 0 63 63
12-27 20:11:44.633 31577 31622 V KOReader:  blitFrom 999 9 0 0 63 63
12-27 20:11:44.756 31577 31622 V KOReader:  _refresh: Enqueued ui update for region 0 0 1080 1920
12-27 20:11:44.887 31577 31622 V KOReader:  input event => type: 4, code: 7(0), value: 1, time: 1545937904.887724
12-27 20:11:44.887 31577 31622 V KOReader:  Android application event 7
12-27 20:11:44.888 31577 31622 V KOReader:  input event => type: 4, code: 6(nil), value: 1, time: 1545937904.888024
12-27 20:11:44.888 31577 31622 V KOReader:  Android application event 6
12-27 20:11:52.269 31577 31622 V KOReader:  input event => type: 4, code: 12(5), value: 1, time: 1545937912.268897
12-27 20:11:52.269 31577 31622 V KOReader:  Android application event 12
12-27 20:11:52.271 31577 31622 V KOReader:  input event => type: 4, code: 13(6), value: 1, time: 1545937912.270817
12-27 20:11:52.271 31577 31622 V KOReader:  Android application event 13
12-27 20:11:57.036 31577 31622 V KOReader:  input event => type: 4, code: 7(0), value: 1, time: 1545937917.36804
12-27 20:11:57.037 31577 31622 V KOReader:  Android application event 7
12-27 20:16:44.549 31577 31622 I KOReader: get battery level 81
```
</details>

######

As you see there are a bunch of other messages than can be logged with LOGV in luajit-launcher (like everything in dl.lua), but this PR just cares about the frontend.


Other misc changes:

1. Do not log intent file path if we're running KOReader with the file manager
2. ~~Do not change default logger name until we start KOReader (aka: running reader.lua)~~