### PR TITLE
[Android] add Keep screen awake toggle

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -30,9 +30,9 @@ function Device:init()
             logger.dbg("Android application event", ev.code)
             if ev.code == C.APP_CMD_SAVE_STATE then
                 return "SaveState"
-            elseif ev.code == C.APP_CMD_GAINED_FOCUS then
-                this.device.screen:refreshFull()
-            elseif ev.code == C.APP_CMD_WINDOW_REDRAW_NEEDED then
+            elseif ev.code == C.APP_CMD_GAINED_FOCUS
+                or ev.code == C.APP_CMD_INIT_WINDOW
+                or ev.code == C.APP_CMD_WINDOW_REDRAW_NEEDED then
                 this.device.screen:refreshFull()
             end
         end,
@@ -58,6 +58,11 @@ function Device:init()
        ~= C.ACONFIGURATION_TOUCHSCREEN_NOTOUCH
     then
         self.isTouchDevice = yes
+    end
+
+    -- check if we disabled support for wakelocks
+    if G_reader_settings:isTrue("disable_android_wakelock") then
+        android.setWakeLock(false)
     end
 
     Generic.init(self)

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -125,6 +125,7 @@ else
 end
 if Device:isAndroid() then
     table.insert(common_settings.screen.sub_item_table, require("ui/elements/screen_fullscreen_menu_table"))
+    table.insert(common_settings.screen.sub_item_table, require("ui/elements/screen_keep_on_menu_table"))
 end
 
 if Device:hasKeys() then

--- a/frontend/ui/elements/screen_keep_on_menu_table.lua
+++ b/frontend/ui/elements/screen_keep_on_menu_table.lua
@@ -1,0 +1,24 @@
+local isAndroid, android = pcall(require, "android")
+local _ = require("gettext")
+
+if not isAndroid then return end
+
+local function isWakeLock()
+    return not G_reader_settings:isTrue("disable_android_wakelock")
+end
+
+local function setWakeLock(enable)
+    G_reader_settings:saveSetting("disable_android_wakelock", not enable)
+end
+
+return {
+    text = _("Keep screen on"),
+    checked_func = function()
+        return isWakeLock()
+    end,
+    callback = function()
+        local current = isWakeLock()
+        android.setWakeLock(not current)
+        setWakeLock(not current)
+    end,
+}


### PR DESCRIPTION
continuation of #4409 , which I managed to close somehow, sorry :p 

Fixes #2748
Fixes #4364
Related to #4430 #3567 #3517 

In *some* phones *some* runtime configuration changes will force a surfaceDestroyed (followed by surfaceCreate) without losing/regain focus, so we need to refresh the screen on APP_CMD_INIT_WINDOW too. This will help on further "black screen issues"

More info: https://developer.nvidia.com/fixing-common-android-lifecycle-issues-games

 