### PR TITLE
If zsync eats dirt during an OTA update, allow to fallback to a full download

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -177,7 +177,7 @@ function OTAManager:fetchAndProcessUpdate()
                             os.execute("./fbink -q -y -7 -pm ' '  ' '")
                         end
                         UIManager:show(MultiConfirmBox:new{
-                            text = _("Failed to update KOReader.\n\nYou can:\nCancel, keeping temporary files intact.\nRetry the update process but this time, with a full download.\nAbort and cleanup all temporary files."),
+                            text = _("Failed to update KOReader.\n\nYou can:\nCancel, keeping temporary files.\nRetry the update process with a full download.\nAbort and cleanup all temporary files."),
                             choice1_text = _("Retry"),
                             choice1_callback = function()
                                 UIManager:show(InfoMessage:new{

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -177,7 +177,7 @@ function OTAManager:fetchAndProcessUpdate()
                             os.execute("./fbink -q -y -7 -pm ' '  ' '")
                         end
                         UIManager:show(MultiConfirmBox:new{
-                            text = _("Failed to update KOReader.\nYou can:\nCancel, keeping temporary files intact.\nRetry the update process but this time, with a full download.\nAbort and cleanup all temporary files."),
+                            text = _("Failed to update KOReader.\n\nYou can:\nCancel, keeping temporary files intact.\nRetry the update process but this time, with a full download.\nAbort and cleanup all temporary files."),
                             choice1_text = _("Retry"),
                             choice1_callback = function()
                                 UIManager:show(InfoMessage:new{

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -180,6 +180,10 @@ function OTAManager:fetchAndProcessUpdate()
                             text = _("Failed to update KOReader.\nYou can:\nCancel, keeping temporary files intact.\nRetry the update process but this time, with a full download.\nAbort and cleanup all temporary files."),
                             choice1_text = _("Retry"),
                             choice1_callback = function()
+                                UIManager:show(InfoMessage:new{
+                                    text = _("Downloading may take several minutes…"),
+                                    timeout = 3,
+                                })
                                 -- Clear the installed package, as well as the complete/incomplete update download
                                 os.execute("rm " .. self.installed_package)
                                 os.execute("rm " .. self.updated_package .. "*")
@@ -271,7 +275,7 @@ function OTAManager:_buildLocalPackage()
 end
 
 function OTAManager:zsync(full_dl)
-    if self:_buildLocalPackage() == 0 then
+    if full_dl or self:_buildLocalPackage() == 0 then
         local zsync_wrapper = "zsync"
         -- With visual feedback if supported...
         if self.can_pretty_print then

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -1,7 +1,14 @@
 #!/bin/sh
 
+# Figure out whether that's a delta or a full download given the number of arguments passed...
+if [ $# -lt 7 ] ; then
+    ZSYNC_MESSAGE="Downloading update data"
+else
+    ZSYNC_MESSAGE="Computing zsync delta"
+fi
+
 # Small zsync wrapper so we can get a pretty spinner while it works...
-./fbink -q -y -7 -pmh 'Computing zsync delta !'
+./fbink -q -y -7 -pmh "${ZSYNC_MESSAGE} !"
 # Clear any potential leftover from the local OTA tarball creation.
 ./fbink -q -y -6 -pm ' '
 
@@ -26,7 +33,7 @@
             usleep 500000
             # NOTE: Throw stderr to the void because I'm cheating w/ U+FFFD for a blank character,
             #       which FBInk replaces by a blank, but not before shouting at us on stderr ;).
-            ./fbink -q -y -7 -pmh "Computing zsync delta ${spin}" 2>/dev/null
+            ./fbink -q -y -7 -pmh "${ZSYNC_MESSAGE} ${spin}" 2>/dev/null
         done
     done
 ) &

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Figure out whether that's a delta or a full download given the number of arguments passed...
-if [ $# -lt 7 ] ; then
+if [ $# -lt 7 ]; then
     ZSYNC_MESSAGE="Downloading update data"
 else
     ZSYNC_MESSAGE="Computing zsync delta"


### PR DESCRIPTION
Fix #4429 (and by "fix", I mean "workaround' ;p).

Basically gives the user another choice on failure, one that'll download the full OTA package.
Prevents leaving users in the lurch in case zsync goes wonky again, like in #4429 ;).