### PR TITLE
Various ui fixes: file sizes in History, pages read/left in CoverBrowser

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -355,11 +355,7 @@ function ReaderRolling:onTapBackward()
 end
 
 function ReaderRolling:onSwipe(_, ges)
-    if ges.direction == "north" then
-        self:onGotoViewRel(1)
-    elseif ges.direction == "south" then
-        self:onGotoViewRel(-1)
-    elseif ges.direction == "west" then
+    if ges.direction == "west" then
         if self.inverse_reading_order then
             self:onGotoViewRel(-1)
         else

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -1,6 +1,7 @@
 local DataStorage = require("datastorage")
 local DocSettings = require("docsettings")
 local dump = require("dump")
+local getFriendlySize = require("util").getFriendlySize
 local joinPath = require("ffi/util").joinPath
 local lfs = require("libs/libkoreader-lfs")
 local realpath = require("ffi/util").realpath
@@ -13,11 +14,13 @@ local ReadHistory = {
 }
 
 local function buildEntry(input_time, input_file)
+    local file_exists = lfs.attributes(input_file, "mode") == "file"
     return {
         time = input_time,
         text = input_file:gsub(".*/", ""),
         file = realpath(input_file) or input_file, -- keep orig file path of deleted files
-        dim = lfs.attributes(input_file, "mode") ~= "file", -- "dim", as expected by Menu
+        dim = not file_exists, -- "dim", as expected by Menu
+        mandatory = file_exists and getFriendlySize(lfs.attributes(input_file, "size") or 0),
         callback = function()
             local ReaderUI = require("apps/reader/readerui")
             ReaderUI:showReader(input_file)

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -13,6 +13,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
+local Math = require("optmath")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local RightContainer = require("ui/widget/container/rightcontainer")
 local Size = require("ui/size")
@@ -364,7 +365,14 @@ function ListMenuItem:update()
                 end
             elseif percent_finished then
                 if pages then
-                    pages_str = T(_("%1 % of %2 pages"), math.floor(100*percent_finished), pages)
+                    if BookInfoManager:getSetting("show_pages_read_as_progress") then
+                        pages_str = T(_("page %1 of %2"), Math.round(percent_finished*pages), pages)
+                    else
+                        pages_str = T(_("%1 % of %2 pages"), math.floor(100*percent_finished), pages)
+                    end
+                    if BookInfoManager:getSetting("show_pages_left_in_progress") then
+                        pages_str = T(_("%1, %2 to read"), pages_str, Math.round(pages-percent_finished*pages), pages)
+                    end
                 else
                     pages_str = string.format("%d %%", math.floor(100*percent_finished))
                 end

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -295,6 +295,30 @@ function CoverBrowser:addToMainMenu(menu_items)
                         end,
                     },
                     {
+                        text = _("Show number of pages read instead of progress %"),
+                        checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,
+                        callback = function()
+                            if BookInfoManager:getSetting("show_pages_read_as_progress") then
+                                BookInfoManager:saveSetting("show_pages_read_as_progress", false)
+                            else
+                                BookInfoManager:saveSetting("show_pages_read_as_progress", true)
+                            end
+                            self:refreshFileManagerInstance()
+                        end,
+                    },
+                    {
+                        text = _("Show number of pages left to read"),
+                        checked_func = function() return BookInfoManager:getSetting("show_pages_left_in_progress") end,
+                        callback = function()
+                            if BookInfoManager:getSetting("show_pages_left_in_progress") then
+                                BookInfoManager:saveSetting("show_pages_left_in_progress", false)
+                            else
+                                BookInfoManager:saveSetting("show_pages_left_in_progress", true)
+                            end
+                            self:refreshFileManagerInstance()
+                        end,
+                    },
+                    {
                         text = _("Append series metadata to authors"),
                         checked_func = function() return BookInfoManager:getSetting("append_series_to_authors") end,
                         callback = function()


### PR DESCRIPTION
#### ReaderRolling: remove swipe north/south
Fix some conflict on Android where a swipe north from the bottom to show system buttons (to exit or swith apps) would cause a page change. These gestures have never been available in ReaderPaging, so it shouldn't be a big loss. https://github.com/koreader/koreader/issues/4326#issuecomment-437668418. Closes #4326.

#### History: show files sizes, as File browser does
See https://github.com/koreader/koreader/issues/4266#issuecomment-428994659. Closes #4266.

#### CoverBrowser: options to show pages read/left as progress
See https://github.com/koreader/koreader/issues/4436#issuecomment-450652619. Closes #4436.

2 independant options, that can make sense independantly (and easier to do than a `Show progress as >` menu with a subitem for each combination of % / pages read / pages left):

<kbd>![image](https://user-images.githubusercontent.com/24273478/50571452-a1679680-0dab-11e9-9a67-4c8fb0160fc8.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/50571470-04592d80-0dac-11e9-82a7-4488c5ed0934.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/50571472-1509a380-0dac-11e9-84b5-cec02e527cbf.png)</kbd>

Originally and still the default:
<kbd>![image](https://user-images.githubusercontent.com/24273478/50571496-6f0a6900-0dac-11e9-866f-7226d63c91a4.png)</kbd>

(Of course, it takes more room to display pages left, so less room for book titles)

