### PR TITLE
cre: adds in-page footnotes and alternative TOC hints tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -430,6 +430,26 @@ You can enable individual tweaks on this book with a tap, or view more details a
                 end,
                 separator = item.separator,
             })
+        elseif item.info_text then -- informative menu item
+            table.insert(menu, {
+                text = item.title or "### undefined menu title ###",
+                -- No check box.
+                -- Show the info text when either tap or hold
+                keep_menu_open = true,
+                callback = function()
+                    UIManager:show(InfoMessage:new{
+                        text = item.info_text,
+                        face = Font:getFace(item.smaller_font and "x_smallinfofont" or "smallinfofont"),
+                    })
+                end,
+                hold_callback = function()
+                    UIManager:show(InfoMessage:new{
+                        text = item.info_text,
+                        face = Font:getFace(item.smaller_font and "x_smallinfofont" or "smallinfofont"),
+                    })
+                end,
+                separator = item.separator,
+            })
         else
             table.insert(menu, {
                 text = item.if_empty_menu_title or _("This section is empty"),

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -134,7 +134,7 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
             id = "paragraph_no_indent";
             title = _("No indentation on first paragraph line"),
             description = _("Do not indent the first line of paragraphs."),
-            css = [[p + p { text-indent: 0 !important; }]],
+            css = [[p { text-indent: 0 !important; }]],
         },
         {
             id = "paragraph_indent";
@@ -162,7 +162,7 @@ body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
             id = "paragraph_no_whitespace";
             title = _("No spacing between paragraphs"),
             description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
-            css = [[p, li { margin: 0 !important; }]],
+            css = [[p, li { margin-top: 0 !important; margin-bottom: 0 !important; }]],
         },
     },
     {
@@ -259,6 +259,122 @@ width: 100% !important;
     },
     {
         title = _("Miscellaneous"),
+        {
+            title = _("Alternative TOC hints"),
+            {
+                title = _("About alternative TOC"),
+                smaller_font = true,
+                info_text = _([[
+An alternative table of content can be built with a long-press on the "Table of content" menu item.
+
+It will be built from document headings <H1> to <H6>. Some of these can be ignored with the tweaks available here.
+If the document contains no heading, or all are ignored, the alternative TOC will be built from the document fragments, to point to the start of each individual HTML file in the EPUB.
+
+Hints can be set to other non-heading elements, for them to be used as TOC items, in some user style tweaks (as they would be quite book-specific, see last tweak here for some examples).
+
+After applying these tweaks, it is needed to re-build the alternative TOC by long-pressing "Table of content" twice (once to restore the original TOC, once to build again the alternative TOC).]]),
+                separator = true,
+            },
+            {
+                id = "alt_toc_ignore_h_all";
+                title = _("Ignore all <H1> to <H6>"),
+                css = [[h1, h2, h3, h4, h5, h6 { -cr-hint: toc-ignore; }]],
+            },
+            {
+                id = "alt_toc_ignore_h1";
+                title = _("Ignore <H1>"),
+                css = [[h1 { -cr-hint: toc-ignore; }]],
+            },
+            {
+                id = "alt_toc_ignore_h2";
+                title = _("Ignore <H2>"),
+                css = [[h2 { -cr-hint: toc-ignore; }]],
+            },
+            {
+                id = "alt_toc_ignore_h3";
+                title = _("Ignore <H3>"),
+                css = [[h3 { -cr-hint: toc-ignore; }]],
+            },
+            {
+                id = "alt_toc_ignore_h4";
+                title = _("Ignore <H4>"),
+                css = [[h4 { -cr-hint: toc-ignore; }]],
+            },
+            {
+                id = "alt_toc_ignore_h5";
+                title = _("Ignore <H5>"),
+                css = [[h5 { -cr-hint: toc-ignore; }]],
+            },
+            {
+                id = "alt_toc_ignore_h6";
+                title = _("Ignore <H6>"),
+                css = [[h6 { -cr-hint: toc-ignore; }]],
+                separator = true,
+            },
+            {
+                id = "alt_toc_level_example";
+                title = _("Example of book specific TOC hints"),
+                description = _([[
+If headings or document fragments do not give a usable TOC, you may inspect the HTML and look for elements that contain chapter titles, and set hints to their class names.
+This is just an example, that will need to be adapted in a user style tweak.]]),
+                css = [[
+.book_n    { -cr-hint: toc-level1; }
+.part_n    { -cr-hint: toc-level2; }
+.chap_tit  { -cr-hint: toc-level3; }
+.chap_tit1 { -cr-hint: toc-level3; }
+                ]],
+            },
+        },
+        {
+            id = "epub_footnote-inpage";
+            title = _("Show EPUB footnotes in pages"),
+            description = _([[
+Show footnotes text at the bottom of pages that contain links to them.
+This only works with footnotes that have specific attributes set by the publisher.]]),
+            css = [[
+/* EPUB attributes: */
+*[type~="note"], *[type~="footnote"],
+*[type~="rearnote"],
+*[role~="doc-note"], *[role~="doc-footnote"],
+*[role~="doc-rearnote"],
+/* Wikipedia EPUBs footnotes: */
+ol.references > li,
+/* Classic footnotes class names: */
+.footnote, .note, .note1
+{
+    -cr-hint: footnote-inpage;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+}
+/* Wikipedia EPUBs: hide backlinks */
+ol.references > li > .noprint { display: none; }
+            ]],
+        },
+        {
+            id = "epub_footnote-inpage_smaller";
+            title = _("Show smaller EPUB footnotes in pages"),
+            description = _([[Decrease font size of footnotes text displayed in pages.]]),
+            -- Include the whole content of previous style, so toggling this one is enough
+            css = [[
+/* EPUB attributes: */
+*[type~="note"], *[type~="footnote"],
+*[type~="rearnote"],
+*[role~="doc-note"], *[role~="doc-footnote"],
+*[role~="doc-rearnote"],
+/* Wikipedia EPUBs footnotes: */
+ol.references > li,
+/* Classic footnotes class names: */
+.footnote, .note, .note1
+{
+    -cr-hint: footnote-inpage;
+    font-size: 80% !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+}
+/* Wikipedia EPUBs: hide backlinks */
+ol.references > li > .noprint { display: none; }
+            ]],
+        },
         {
             id = "epub_switch_show_case";
             title = _("Toggle alternative EPUB content"),

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -267,12 +267,12 @@ width: 100% !important;
                 info_text = _([[
 An alternative table of content can be built with a long-press on the "Table of content" menu item.
 
-It will be built from document headings <H1> to <H6>. Some of these can be ignored with the tweaks available here.
-If the document contains no heading, or all are ignored, the alternative TOC will be built from the document fragments, to point to the start of each individual HTML file in the EPUB.
+The TOC will be built from document headings <H1> to <H6>. Some of these can be ignored with the tweaks available here.
+If the document contains no headings, or all are ignored, the alternative TOC will be built from document fragments and will point to the start of each individual HTML file in the EPUB.
 
-Hints can be set to other non-heading elements, for them to be used as TOC items, in some user style tweaks (as they would be quite book-specific, see last tweak here for some examples).
+Hints can be set to other non-heading elements in a user style tweak, so they can be used as TOC items. Since this would be quite book-specific, please see the final tweak for some examples.
 
-After applying these tweaks, it is needed to re-build the alternative TOC by long-pressing "Table of content" twice (once to restore the original TOC, once to build again the alternative TOC).]]),
+After applying these tweaks, the alternative TOC needs to be rebuilt by long-pressing "Table of content" twice: once to restore the original TOC, and once to build the alternative TOC again.]]),
                 separator = true,
             },
             {
@@ -315,8 +315,8 @@ After applying these tweaks, it is needed to re-build the alternative TOC by lon
                 id = "alt_toc_level_example";
                 title = _("Example of book specific TOC hints"),
                 description = _([[
-If headings or document fragments do not give a usable TOC, you may inspect the HTML and look for elements that contain chapter titles, and set hints to their class names.
-This is just an example, that will need to be adapted in a user style tweak.]]),
+If headings or document fragments do not result in a usable TOC, you can inspect the HTML and look for elements that contain chapter titles. Then you can set hints to their class names.
+This is just an example, that will need to be adapted into a user style tweak.]]),
                 css = [[
 .book_n    { -cr-hint: toc-level1; }
 .part_n    { -cr-hint: toc-level2; }


### PR DESCRIPTION
Adds 2 tweaks to allow displaying footnotes at the bottom of pages, like it's done in some printed books. This will work only with books with correctly specified footnotes with the adequate EPUB attributes, and with Wikipedia EPUBs. But users may be able to activate them for other books with some user style tweaks.
Details and some sample pages screenshots in https://github.com/koreader/crengine/pull/249

<kbd>![image](https://user-images.githubusercontent.com/24273478/50574984-b1a36400-0df3-11e9-8d2d-1291d539e48b.png)</kbd>
Not sure if we should keep the `.footnote, .note, .note1` extra, it might be wrong with some books, but it adds a bit of documentation on how one could do that in his user style tweaks.


Adds a few tweaks to control the build of the alternative TOC, and a bit of documentation about this alternative TOC feature.
It's a bit crowded with what looks like quite not useful tweaks, but when you get a crappy EPUB you're gonna spend a few days or weeks with, all these could be helpful.
With some user style tweaks, one may be able to build a usable TOC for some badly formatted or converted books.

<kbd>![image](https://user-images.githubusercontent.com/24273478/50575017-65a4ef00-0df4-11e9-84b6-f5aa90053a79.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/50575027-92590680-0df4-11e9-8a5b-6416689dde6e.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/50575033-a1d84f80-0df4-11e9-8404-bd9c4e55de71.png)</kbd>

One can also make footnote popups works in books where they would not be detected, or where there would be too many false detection, with a specific user style tweak:
<kbd>![image](https://user-images.githubusercontent.com/24273478/50575082-30999c00-0df6-11e9-9049-d32500255be5.png)</kbd>


Will need a crengine and a (small) base bumps.

Also fixes 2 paragraphs tweaks (see https://github.com/koreader/koreader/pull/4358#issuecomment-450639586).