### PR TITLE
Adds "Enable back history" menu item

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -190,6 +190,15 @@ if Device:hasKeys() then
                     },
                 },
             },
+            {
+                text = _("Enable back history"),
+                checked_func = function()
+                    return G_reader_settings:nilOrTrue("enable_back_history")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrTrue("enable_back_history")
+                end,
+            },
         }
     }
 end


### PR DESCRIPTION
For a hidden setting already present (added in #3862) and used in [frontend/apps/reader/modules/readerback.lua](https://github.com/koreader/koreader/blob/master/frontend/apps/reader/modules/readerback.lua)
Only shown, as the whole Navigation> submenu, on devices with keys.
See https://github.com/koreader/koreader/issues/4421#issuecomment-451175347