### PR TITLE
A few Kobo input tweaks

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 local default_gesture = {
     tap_right_bottom_corner = "nothing",
-    tap_left_bottom_corner = Device.hasFrontlight() and "toggle_frontlight" or "nothing",
+    tap_left_bottom_corner = Device:hasFrontlight() and "toggle_frontlight" or "nothing",
     short_diagonal_swipe = "full_refresh",
 }
 
@@ -70,7 +70,8 @@ function ReaderGesture:buildMenu(ges, default)
         {_("Reading progress"), "reading_progress", ReaderGesture.getReaderProgress ~= nil},
         {_("Full screen refresh"), "full_refresh", true},
         {_("Night mode"), "night_mode", true},
-        {_("Toggle frontlight"), "toggle_frontlight", Device.hasFrontlight()},
+        {_("Toggle frontlight"), "toggle_frontlight", Device:hasFrontlight()},
+        {_("Toggle accelerometer"), "toggle_gsensor", Device:canToggleGSensor()},
     }
     local return_menu = {}
     -- add default action to the top of the submenu
@@ -190,15 +191,18 @@ function ReaderGesture:gestureAction(action)
         UIManager:setDirty("all", "full")
     elseif action == "bookmarks" then
         self.ui:handleEvent(Event:new("ShowBookmark"))
-    elseif action =="page_update_up10" then
+    elseif action == "page_update_up10" then
         self:pageUpdate(10)
-    elseif action =="page_update_down10" then
+    elseif action == "page_update_down10" then
         self:pageUpdate(-10)
-    elseif action =="folder_up" then
+    elseif action == "folder_up" then
         self.ui.file_chooser:changeToPath(string.format("%s/..", self.ui.file_chooser.path))
-    elseif action =="toggle_frontlight" then
+    elseif action == "toggle_frontlight" then
         Device:getPowerDevice():toggleFrontlight()
         self:onShowFLOnOff()
+    elseif action == "toggle_gsensor" then
+        G_reader_settings:flipNilOrFalse("input_ignore_gsensor")
+        Device:toggleGSensor()
     end
     return true
 end

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -203,6 +203,7 @@ function ReaderGesture:gestureAction(action)
     elseif action == "toggle_gsensor" then
         G_reader_settings:flipNilOrFalse("input_ignore_gsensor")
         Device:toggleGSensor()
+        self:onGSensorToggle()
     end
     return true
 end
@@ -229,6 +230,21 @@ function ReaderGesture:onShowFLOnOff()
         new_text = _("Frontlight is on.")
     else
         new_text = _("Frontlight is off.")
+    end
+    UIManager:show(Notification:new{
+        text = new_text,
+        timeout = 1.0,
+    })
+    return true
+end
+
+function ReaderGesture:onGSensorToggle()
+    local Notification = require("ui/widget/notification")
+    local new_text
+    if G_reader_settings:isTrue("input_ignore_gsensor") then
+        new_text = _("Accelerometer rotation events will now be ignored.")
+    else
+        new_text = _("Accelerometer rotation events will now be honored.")
     end
     UIManager:show(Notification:new{
         text = new_text,

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -85,7 +85,7 @@ end
 
 -- Toggle GSensor
 function Device:toggleGSensor()
-    if self:canToggleGSensor and self.input then
+    if self:canToggleGSensor() and self.input then
         -- Currently only supported on the Forma
         if self.misc_ntx_gsensor_protocol then
             self.input:toggleMiscEvNTX()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -81,6 +81,9 @@ function Device:invertButtons()
                 self.input.event_map[key] = "RPgFwd"
             end
         end
+
+        -- NOTE: We currently leave self.input.rotation_map alone,
+        --       which will definitely yield fairly stupid mappings in Landscape...
     end
 end
 
@@ -121,8 +124,7 @@ function Device:init()
 
     -- Handle button mappings shenanigans
     if self:hasKeys() then
-        local inverted_buttons = G_reader_settings:readSetting("input_invert_page_turn_keys")
-        if inverted_buttons then
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") then
             self:invertButtons()
         end
     end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -27,6 +27,7 @@ local Device = {
     hasClipboard = no,
     hasColorScreen = no,
     hasBGRFrameBuffer = no,
+    canToggleGSensor = no,
 
     -- use these only as a last resort. We should abstract the functionality
     -- and have device dependent implementations in the corresponting
@@ -78,6 +79,16 @@ function Device:invertButtons()
             elseif value == "RPgBack" then
                 self.input.event_map[key] = "RPgFwd"
             end
+        end
+    end
+end
+
+-- Toggle GSensor
+function Device:toggleGSensor()
+    if self:canToggleGSensor and self.input then
+        -- Currently only supported on the Forma
+        if self.misc_ntx_gsensor_protocol then
+            self.input:toggleMiscEvNTX()
         end
     end
 end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -67,7 +67,7 @@ end
 
 -- Inverts PageTurn button mappings
 function Device:invertButtons()
-    if self.hasKeys() and self.input and self.input.event_map then
+    if self:hasKeys() and self.input and self.input.event_map then
         for key, value in pairs(self.input.event_map) do
             if value == "LPgFwd" then
                 self.input.event_map[key] = "LPgBack"

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -117,7 +117,7 @@ function Device:init()
             {x = 0 - self.viewport.x, y = 0 - self.viewport.y})
     end
 
-    -- Handle mapping shenanigans, like button inversion on the Forma
+    -- Handle button mappings shenanigans
     if self:hasKeys() then
         local inverted_buttons = G_reader_settings:readSetting("input_invert_buttons")
         if inverted_buttons then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -83,16 +83,6 @@ function Device:invertButtons()
     end
 end
 
--- Toggle GSensor
-function Device:toggleGSensor()
-    if self:canToggleGSensor() and self.input then
-        -- Currently only supported on the Forma
-        if self.misc_ntx_gsensor_protocol then
-            self.input:toggleMiscEvNTX()
-        end
-    end
-end
-
 function Device:init()
     assert(self ~= nil)
     if not self.screen then
@@ -242,6 +232,9 @@ function Device:setDateTime(year, month, day, hour, min, sec) end
 
 -- Device specific method if any setting needs being saved
 function Device:saveSettings() end
+
+-- Device specific method for toggling the GSensor
+function Device:toggleGSensor() end
 
 --[[
 prepare for application shutdown

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -67,6 +67,7 @@ function Device:new(o)
 end
 
 -- Inverts PageTurn button mappings
+-- NOTE: For ref. on Kobo, stored by Nickel in the [Reading] section as invertPageTurnButtons=true
 function Device:invertButtons()
     if self:hasKeys() and self.input and self.input.event_map then
         for key, value in pairs(self.input.event_map) do

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -130,7 +130,7 @@ function Device:init()
 
     -- Handle button mappings shenanigans
     if self:hasKeys() then
-        local inverted_buttons = G_reader_settings:readSetting("input_invert_buttons")
+        local inverted_buttons = G_reader_settings:readSetting("input_invert_page_turn_keys")
         if inverted_buttons then
             self:invertButtons()
         end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -65,6 +65,23 @@ function Device:new(o)
     return o
 end
 
+-- Inverts PageTurn button mappings
+function Device:invertButtons()
+    if self.hasKeys() and self.input and self.input.event_map then
+        for key, value in pairs(self.input.event_map) do
+            if value == "LPgFwd" then
+                self.input.event_map[key] = "LPgBack"
+            elseif value == "LPgBack" then
+                self.input.event_map[key] = "LPgFwd"
+            elseif value == "RPgFwd" then
+                self.input.event_map[key] = "RPgBack"
+            elseif value == "RPgBack" then
+                self.input.event_map[key] = "RPgFwd"
+            end
+        end
+    end
+end
+
 function Device:init()
     assert(self ~= nil)
     if not self.screen then
@@ -98,6 +115,14 @@ function Device:init()
         self.input:registerEventAdjustHook(
             self.input.adjustTouchTranslate,
             {x = 0 - self.viewport.x, y = 0 - self.viewport.y})
+    end
+
+    -- Handle mapping shenanigans, like button inversion on the Forma
+    if self:hasKeys() then
+        local inverted_buttons = G_reader_settings:readSetting("input_invert_buttons")
+        if inverted_buttons then
+            self:invertButtons()
+        end
     end
 end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -659,6 +659,16 @@ function Input:handleMiscEvNTX(ev)
     end
 end
 
+-- Allow toggling it at runtime
+function Input:toggleMiscEvNTX()
+    if self.isNTXAccelHooked then
+        self.handleMiscEv = function() end
+    else
+        self.handleMiscEv = self.handleMiscEvNTX
+    end
+
+    self.isNTXAccelHooked = not self.isNTXAccelHooked
+end
 
 -- helpers for touch event data management:
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -715,6 +715,10 @@ function Input:isEvKeyPress(ev)
     return ev.value == EVENT_VALUE_KEY_PRESS
 end
 
+function Input:isEvKeyRepeat(ev)
+    return ev.value == EVENT_VALUE_KEY_REPEAT
+end
+
 function Input:isEvKeyRelease(ev)
     return ev.value == EVENT_VALUE_KEY_RELEASE
 end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -223,9 +223,8 @@ local KoboFrost = Kobo:new{
     },
 }
 
-local probeEvEpochTime
--- this function will update itself after the first touch event
-probeEvEpochTime = function(self, ev)
+-- This function will update itself after the first touch event
+local probeEvEpochTimeFunc = function(self, ev)
     print("probeEvEpochTime: ev.time.sec:", ev.time.sec)
     local now = TimeVal:now()
     -- This check should work as long as main UI loop is not blocked for more
@@ -241,6 +240,7 @@ probeEvEpochTime = function(self, ev)
         probeEvEpochTime = function(_, _) end
     end
 end
+local probeEvEpochTime
 
 function Kobo:init()
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
@@ -292,6 +292,9 @@ function Kobo:init()
     -- fake_events is only used for usb plug event so far
     -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status
     self.input.open("fake_events")
+
+    -- Reset probeEvEpochTime to its default state to make sure the testsuite is in a sane state, as the tests are not sandboxed.
+    probeEvEpochTime = probeEvEpochTimeFunc
 
     if not self.needsTouchScreenProbe() then
         self:initEventAdjustHooks()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -282,13 +282,6 @@ function Kobo:init()
         }
     }
 
-    -- Handle mapping shenanigans, like button inversion on the Forma
-    local inverted_buttons = G_reader_settings:readSetting("input_invert_buttons")
-    if inverted_buttons then
-        self.input.event_map[193] = "RPgFwd"
-        self.input.event_map[194] = "RPgBack"
-    end
-
     Generic.init(self)
 
     -- When present, event2 is the raw accelerometer data (3-Axis Orientation/Motion Detection)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -207,6 +207,7 @@ local KoboFrost = Kobo:new{
     model = "Kobo_frost",
     hasFrontlight = yes,
     hasKeys = yes,
+    canToggleGSensor = yes,
     touch_snow_protocol = true,
     misc_ntx_gsensor_protocol = true,
     display_dpi = 300,
@@ -431,6 +432,7 @@ function Kobo:initEventAdjustHooks()
     -- Accelerometer on the Forma
     if self.misc_ntx_gsensor_protocol then
         self.input.handleMiscEv = self.input.handleMiscEvNTX
+        self.input.isNTXAccelHooked = true
     end
 end
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -271,7 +271,7 @@ function Kobo:init()
             SleepCover = function(ev)
                 if self.input:isEvKeyPress(ev) then
                     return "SleepCoverClosed"
-                elseif self.input:isEvKeyRelease(ev)
+                elseif self.input:isEvKeyRelease(ev) then
                     return "SleepCoverOpened"
                 end
             end,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -431,8 +431,13 @@ function Kobo:initEventAdjustHooks()
 
     -- Accelerometer on the Forma
     if self.misc_ntx_gsensor_protocol then
-        self.input.handleMiscEv = self.input.handleMiscEvNTX
-        self.input.isNTXAccelHooked = true
+        local ignore_gsensor = G_reader_settings:readSetting("input_ignore_gsensor")
+        if not ignore_gsensor then
+            self.input.handleMiscEv = self.input.handleMiscEvNTX
+            self.input.isNTXAccelHooked = true
+        else
+            self.input.isNTXAccelHooked = false
+        end
     end
 end
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -225,15 +225,13 @@ local KoboFrost = Kobo:new{
 
 -- This function will update itself after the first touch event
 local probeEvEpochTime
-local probeEvEpochTimeFunc = function(self, ev)
-    print("probeEvEpochTime (Default): ev.time.sec:", ev.time.sec)
+probeEvEpochTime = function(self, ev)
     local now = TimeVal:now()
     -- This check should work as long as main UI loop is not blocked for more
     -- than 10 minute before handling the first touch event.
     if ev.time.sec <= now.sec - 600 then
         -- time is seconds since boot, force it to epoch
         probeEvEpochTime = function(_, _ev)
-            print("probeEvEpochTime (!epoch)")
             _ev.time = TimeVal:now()
         end
         ev.time = now
@@ -293,9 +291,6 @@ function Kobo:init()
     -- fake_events is only used for usb plug event so far
     -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status
     self.input.open("fake_events")
-
-    -- Reset probeEvEpochTime to its default state to make sure the testsuite is in a sane state, as the tests are not sandboxed.
-    probeEvEpochTime = probeEvEpochTimeFunc
 
     if not self.needsTouchScreenProbe() then
         self:initEventAdjustHooks()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -688,6 +688,15 @@ function Kobo:reboot()
     os.execute("reboot")
 end
 
+function Kobo:toggleGSensor()
+    if self:canToggleGSensor() and self.input then
+        -- Currently only supported on the Forma
+        if self.misc_ntx_gsensor_protocol then
+            self.input:toggleMiscEvNTX()
+        end
+    end
+end
+
 -------------- device probe ------------
 
 local codename = Kobo:getCodeName()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -271,7 +271,7 @@ function Kobo:init()
             SleepCover = function(ev)
                 if self.input:isEvKeyPress(ev) then
                     return "SleepCoverClosed"
-                else
+                elseif self.input:isEvKeyRelease(ev)
                     return "SleepCoverOpened"
                 end
             end,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -431,12 +431,11 @@ function Kobo:initEventAdjustHooks()
 
     -- Accelerometer on the Forma
     if self.misc_ntx_gsensor_protocol then
-        local ignore_gsensor = G_reader_settings:readSetting("input_ignore_gsensor")
-        if not ignore_gsensor then
+        if G_reader_settings:isTrue("input_ignore_gsensor") then
+            self.input.isNTXAccelHooked = false
+        else
             self.input.handleMiscEv = self.input.handleMiscEvNTX
             self.input.isNTXAccelHooked = true
-        else
-            self.input.isNTXAccelHooked = false
         end
     end
 end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -226,6 +226,7 @@ local KoboFrost = Kobo:new{
 local probeEvEpochTime
 -- this function will update itself after the first touch event
 probeEvEpochTime = function(self, ev)
+    print("probeEvEpochTime: ev.time.sec:", ev.time.sec)
     local now = TimeVal:now()
     -- This check should work as long as main UI loop is not blocked for more
     -- than 10 minute before handling the first touch event.

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -224,14 +224,16 @@ local KoboFrost = Kobo:new{
 }
 
 -- This function will update itself after the first touch event
+local probeEvEpochTime
 local probeEvEpochTimeFunc = function(self, ev)
-    print("probeEvEpochTime: ev.time.sec:", ev.time.sec)
+    print("probeEvEpochTime (Default): ev.time.sec:", ev.time.sec)
     local now = TimeVal:now()
     -- This check should work as long as main UI loop is not blocked for more
     -- than 10 minute before handling the first touch event.
     if ev.time.sec <= now.sec - 600 then
         -- time is seconds since boot, force it to epoch
         probeEvEpochTime = function(_, _ev)
+            print("probeEvEpochTime (!epoch)")
             _ev.time = TimeVal:now()
         end
         ev.time = now
@@ -240,7 +242,6 @@ local probeEvEpochTimeFunc = function(self, ev)
         probeEvEpochTime = function(_, _) end
     end
 end
-local probeEvEpochTime
 
 function Kobo:init()
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -282,6 +282,13 @@ function Kobo:init()
         }
     }
 
+    -- Handle mapping shenanigans, like button inversion on the Forma
+    local inverted_buttons = G_reader_settings:readSetting("input_invert_buttons")
+    if inverted_buttons then
+        self.input.event_map[193] = "RPgFwd"
+        self.input.event_map[194] = "RPgBack"
+    end
+
     Generic.init(self)
 
     -- When present, event2 is the raw accelerometer data (3-Axis Orientation/Motion Detection)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -377,7 +377,7 @@ function Kobo:initNetworkManager(NetworkMgr)
     -- NOTE: Cheap-ass way of checking if WiFi seems to be enabled...
     --       Since the crux of the issues lies in race-y module unloading, this is perfectly fine for our usage.
     function NetworkMgr:isWifiOn()
-        return 0 == os.execute("lsmod | grep -q sdio_wifi_pwr")
+        return 0 == os.execute("lsmod | grep -q " .. os.getenv("WIFI_MODULE") or "sdio_wifi_pwr")
     end
 end
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -207,6 +207,7 @@ if Device:hasKeys() then
                 end,
                 callback = function()
                     G_reader_settings:flipNilOrFalse("input_invert_buttons")
+                    Device:invertButtons()
                 end,
             },
         }

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -203,10 +203,10 @@ if Device:hasKeys() then
                 text = _("Invert PageTurn Buttons"),
                 enabled_func = function() return Device:hasKeys() end,
                 checked_func = function()
-                    return G_reader_settings:nilOrTrue("input_invert_buttons")
+                    return G_reader_settings:isTrue("input_invert_buttons")
                 end,
                 callback = function()
-                    G_reader_settings:flipNilOrTrue("input_invert_buttons")
+                    G_reader_settings:flipNilOrFalse("input_invert_buttons")
                 end,
             },
         }

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -199,6 +199,16 @@ if Device:hasKeys() then
                     G_reader_settings:flipNilOrTrue("enable_back_history")
                 end,
             },
+            {
+                text = _("Invert PageTurn Buttons"),
+                enabled_func = return Device:hasKeys() end,
+                checked_func = function()
+                    return G_reader_settings:nilOrTrue("input_invert_buttons")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrTrue("input_invert_buttons")
+                end,
+            },
         }
     }
 end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -201,7 +201,7 @@ if Device:hasKeys() then
             },
             {
                 text = _("Invert PageTurn Buttons"),
-                enabled_func = return Device:hasKeys() end,
+                enabled_func = function() return Device:hasKeys() end,
                 checked_func = function()
                     return G_reader_settings:nilOrTrue("input_invert_buttons")
                 end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -110,10 +110,11 @@ common_settings.screen = {
     sub_item_table = {
         require("ui/elements/screen_dpi_menu_table"),
         require("ui/elements/screen_eink_opt_menu_table"),
-        require("ui/elements/menu_activate"),
-        require("ui/elements/screen_disable_double_tap_table"),
         require("ui/elements/flash_ui"),
         require("ui/elements/flash_keyboard"),
+        require("ui/elements/menu_activate"),
+        require("ui/elements/screen_disable_double_tap_table"),
+        require("ui/elements/screen_toggle_gsensor"),
     },
 }
 if Screen.isColorScreen() then

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -110,8 +110,6 @@ common_settings.screen = {
     sub_item_table = {
         require("ui/elements/screen_dpi_menu_table"),
         require("ui/elements/screen_eink_opt_menu_table"),
-        require("ui/elements/flash_ui"),
-        require("ui/elements/flash_keyboard"),
         require("ui/elements/menu_activate"),
         require("ui/elements/screen_disable_double_tap_table"),
         require("ui/elements/screen_toggle_gsensor"),

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -112,9 +112,11 @@ common_settings.screen = {
         require("ui/elements/screen_eink_opt_menu_table"),
         require("ui/elements/menu_activate"),
         require("ui/elements/screen_disable_double_tap_table"),
-        require("ui/elements/screen_toggle_gsensor"),
     },
 }
+if Device:canToggleGSensor() then
+    table.insert(common_settings.screen.sub_item_table, require("ui/elements/screen_toggle_gsensor"))
+end
 if Screen.isColorScreen() then
     table.insert(common_settings.screen.sub_item_table, 3, require("ui/elements/screen_color_menu_table"))
     common_settings.screen.sub_item_table[3].separator = true
@@ -199,13 +201,12 @@ if Device:hasKeys() then
                 end,
             },
             {
-                text = _("Invert PageTurn Buttons"),
-                enabled_func = function() return Device:hasKeys() end,
+                text = _("Invert page turn buttons"),
                 checked_func = function()
-                    return G_reader_settings:isTrue("input_invert_buttons")
+                    return G_reader_settings:isTrue("input_invert_page_turn_keys")
                 end,
                 callback = function()
-                    G_reader_settings:flipNilOrFalse("input_invert_buttons")
+                    G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
                     Device:invertButtons()
                 end,
             },

--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -13,6 +13,8 @@ local eink_settings_table = {
                 G_reader_settings:saveSetting("low_pan_rate", Screen.low_pan_rate)
             end,
         },
+        require("ui/elements/flash_ui"),
+        require("ui/elements/flash_keyboard"),
         {
             text = _("Avoid mandatory black flashes in UI"),
             checked_func = function() return G_reader_settings:isTrue("avoid_flashing_ui") end,
@@ -20,7 +22,6 @@ local eink_settings_table = {
                 G_reader_settings:flipNilOrFalse("avoid_flashing_ui")
             end,
         },
-
     },
 }
 

--- a/frontend/ui/elements/screen_toggle_gsensor.lua
+++ b/frontend/ui/elements/screen_toggle_gsensor.lua
@@ -1,0 +1,13 @@
+local _ = require("gettext")
+
+return {
+    text = _("Ignore accelerometer rotation events"),
+    enabled_func = function() return Device:canToggleGSensor() end,
+    checked_func = function()
+        return G_reader_settings:isTrue("input_ignore_gsensor")
+    end,
+    callback = function()
+        G_reader_settings:flipNilOrFalse("input_ignore_gsensor")
+        Device:toggleGSensor()
+    end,
+}

--- a/frontend/ui/elements/screen_toggle_gsensor.lua
+++ b/frontend/ui/elements/screen_toggle_gsensor.lua
@@ -1,3 +1,4 @@
+local Device = require("device")
 local _ = require("gettext")
 
 return {

--- a/frontend/ui/elements/screen_toggle_gsensor.lua
+++ b/frontend/ui/elements/screen_toggle_gsensor.lua
@@ -3,7 +3,6 @@ local _ = require("gettext")
 
 return {
     text = _("Ignore accelerometer rotation events"),
-    enabled_func = function() return Device:canToggleGSensor() end,
     checked_func = function()
         return G_reader_settings:isTrue("input_ignore_gsensor")
     end,

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -80,7 +80,7 @@ describe("device module", function()
             kobo_dev:init()
             local Screen = kobo_dev.screen
 
-            kobo_dev.touch_probe_ev_epoch_time = false
+            kobo_dev.touch_probe_ev_epoch_time = nil
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             assert.truthy(kobo_dev:needsTouchScreenProbe())
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
@@ -94,11 +94,13 @@ describe("device module", function()
                 type = EV_ABS,
                 code = ABS_X,
                 value = y,
+                time = TimeVal:now(),
             }
             local ev_y = {
                 type = EV_ABS,
                 code = ABS_Y,
                 value = Screen:getWidth()-x,
+                time = TimeVal:now(),
             }
 
             kobo_dev.input:eventAdjustHook(ev_x)
@@ -110,7 +112,7 @@ describe("device module", function()
 
             -- reset eventAdjustHook
             kobo_dev.input.eventAdjustHook = function() end
-            kobo_dev.touch_probe_ev_epoch_time = true
+            kobo_dev.touch_probe_ev_epoch_time = nil
         end)
 
         it("should setup eventAdjustHooks properly for trilogy with non-epoch ev time", function()
@@ -125,6 +127,7 @@ describe("device module", function()
             kobo_dev:init()
             local Screen = kobo_dev.screen
 
+            kobo_dev.touch_probe_ev_epoch_time = true
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             local x, y = Screen:getWidth()-5, 10
             local EV_ABS = 3
@@ -144,7 +147,8 @@ describe("device module", function()
                 time = {sec = 1000}
             }
 
-            assert.truthy(kobo_dev.touch_probe_ev_epoch_time)
+            -- This gets nil'ed in every case since #4450
+            assert.falsy(touch_probe_ev_epoch_time)
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
             kobo_dev:touchScreenProbe()
 

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -82,6 +82,7 @@ describe("device module", function()
 
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             assert.truthy(kobo_dev:needsTouchScreenProbe())
+            -- This gets reset to nil during Kobo:init() since #4450
             assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
             kobo_dev:touchScreenProbe()
@@ -130,6 +131,7 @@ describe("device module", function()
 
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             assert.truthy(kobo_dev:needsTouchScreenProbe())
+            -- This gets reset to nil during Kobo:init() since #4450
             assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
             kobo_dev:touchScreenProbe()
             local x, y = Screen:getWidth()-5, 10

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -148,7 +148,7 @@ describe("device module", function()
             kobo_dev.input:eventAdjustHook(ev_x)
             kobo_dev.input:eventAdjustHook(ev_y)
             local cur_sec = TimeVal:now().sec
-            assert.truthy(cur_sec - ev_x.time.sec < 10)
+            --assert.truthy(cur_sec - ev_x.time.sec < 10)
             assert.truthy(cur_sec - ev_y.time.sec < 10)
 
             kobo_dev.input.eventAdjustHook = function() end

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -145,10 +145,15 @@ describe("device module", function()
                 time = {sec = 1000}
             }
 
+            print("ev_x.time.sec:", ev_x.time.sec)
+            print("ev_y.time.sec:", ev_y.time.sec)
             kobo_dev.input:eventAdjustHook(ev_x)
             kobo_dev.input:eventAdjustHook(ev_y)
             local cur_sec = TimeVal:now().sec
-            --assert.truthy(cur_sec - ev_x.time.sec < 10)
+            print("cur_sec:", cur_sec)
+            print("ev_x.time.sec:", ev_x.time.sec)
+            print("ev_y.time.sec:", ev_y.time.sec)
+            assert.truthy(cur_sec - ev_x.time.sec < 10)
             assert.truthy(cur_sec - ev_y.time.sec < 10)
 
             kobo_dev.input.eventAdjustHook = function() end

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -111,7 +111,6 @@ describe("device module", function()
 
             -- reset eventAdjustHook
             kobo_dev.input.eventAdjustHook = function() end
-            kobo_dev.touch_probe_ev_epoch_time = nil
         end)
 
         it("should setup eventAdjustHooks properly for trilogy with non-epoch ev time", function()
@@ -126,15 +125,13 @@ describe("device module", function()
             kobo_dev:init()
             local Screen = kobo_dev.screen
 
-            -- This got nil'ed during init() since #4450
-            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
-            kobo_dev.touch_probe_ev_epoch_time = true
             assert.is.same("Kobo_trilogy", kobo_dev.model)
+            assert.truthy(kobo_dev:needsTouchScreenProbe())
+            kobo_dev:touchScreenProbe()
             local x, y = Screen:getWidth()-5, 10
             local EV_ABS = 3
             local ABS_X = 00
             local ABS_Y = 01
-            -- mirror x, then switch_xy
             local ev_x = {
                 type = EV_ABS,
                 code = ABS_X,
@@ -147,10 +144,6 @@ describe("device module", function()
                 value = y,
                 time = {sec = 1000}
             }
-
-            assert.truthy(kobo_dev.touch_probe_ev_epoch_time)
-            G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
-            kobo_dev:touchScreenProbe()
 
             kobo_dev.input:eventAdjustHook(ev_x)
             kobo_dev.input:eventAdjustHook(ev_y)

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -66,7 +66,7 @@ describe("device module", function()
             assert.is.same("Kobo_dahlia", kobo_dev.model)
         end)
 
-        it("should setup eventAdjustHooks properly for input in trilogy", function()
+        it("should setup eventAdjustHooks properly for trilogy with non-epoch ev time", function()
             os.getenv.invokes(function(key)
                 if key == "PRODUCT" then
                     return "trilogy"
@@ -76,52 +76,6 @@ describe("device module", function()
             end)
 
             package.loaded['device/kobo/device'] = nil
-            local kobo_dev = require("device/kobo/device")
-            kobo_dev:init()
-            local Screen = kobo_dev.screen
-
-            assert.is.same("Kobo_trilogy", kobo_dev.model)
-            assert.truthy(kobo_dev:needsTouchScreenProbe())
-            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
-            G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
-            kobo_dev:touchScreenProbe()
-            local x, y = Screen:getWidth()-5, 10
-            local EV_ABS = 3
-            local ABS_X = 00
-            local ABS_Y = 01
-            -- mirror x, then switch_xy
-            local ev_x = {
-                type = EV_ABS,
-                code = ABS_X,
-                value = y,
-                time = TimeVal:now(),
-            }
-            local ev_y = {
-                type = EV_ABS,
-                code = ABS_Y,
-                value = Screen:getWidth()-x,
-                time = TimeVal:now(),
-            }
-
-            kobo_dev.input:eventAdjustHook(ev_x)
-            kobo_dev.input:eventAdjustHook(ev_y)
-            assert.is.same(x, ev_y.value)
-            assert.is.same(ABS_X, ev_y.code)
-            assert.is.same(y, ev_x.value)
-            assert.is.same(ABS_Y, ev_x.code)
-
-            -- reset eventAdjustHook
-            kobo_dev.input.eventAdjustHook = function() end
-        end)
-
-        it("should setup eventAdjustHooks properly for trilogy with non-epoch ev time", function()
-            os.getenv.invokes(function(key)
-                if key == "PRODUCT" then
-                    return "trilogy"
-                else
-                    return osgetenv(key)
-                end
-            end)
             local kobo_dev = require("device/kobo/device")
             kobo_dev:init()
             local Screen = kobo_dev.screen
@@ -158,6 +112,53 @@ describe("device module", function()
             assert.truthy(cur_sec - ev_x.time.sec < 10)
             assert.truthy(cur_sec - ev_y.time.sec < 10)
 
+            kobo_dev.input.eventAdjustHook = function() end
+        end)
+
+        it("should setup eventAdjustHooks properly for input in trilogy", function()
+            os.getenv.invokes(function(key)
+                if key == "PRODUCT" then
+                    return "trilogy"
+                else
+                    return osgetenv(key)
+                end
+            end)
+
+            local kobo_dev = require("device/kobo/device")
+            kobo_dev:init()
+            local Screen = kobo_dev.screen
+
+            assert.is.same("Kobo_trilogy", kobo_dev.model)
+            assert.truthy(kobo_dev:needsTouchScreenProbe())
+            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
+            G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
+            kobo_dev:touchScreenProbe()
+            local x, y = Screen:getWidth()-5, 10
+            local EV_ABS = 3
+            local ABS_X = 00
+            local ABS_Y = 01
+            -- mirror x, then switch_xy
+            local ev_x = {
+                type = EV_ABS,
+                code = ABS_X,
+                value = y,
+                time = TimeVal:now(),
+            }
+            local ev_y = {
+                type = EV_ABS,
+                code = ABS_Y,
+                value = Screen:getWidth()-x,
+                time = TimeVal:now(),
+            }
+
+            kobo_dev.input:eventAdjustHook(ev_x)
+            kobo_dev.input:eventAdjustHook(ev_y)
+            assert.is.same(x, ev_y.value)
+            assert.is.same(ABS_X, ev_y.code)
+            assert.is.same(y, ev_x.value)
+            assert.is.same(ABS_Y, ev_x.code)
+
+            -- reset eventAdjustHook
             kobo_dev.input.eventAdjustHook = function() end
         end)
 

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -148,7 +148,7 @@ describe("device module", function()
             }
 
             -- This gets nil'ed in every case since #4450
-            assert.falsy(touch_probe_ev_epoch_time)
+            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
             kobo_dev:touchScreenProbe()
 

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -149,14 +149,9 @@ describe("device module", function()
                 time = {sec = 1000}
             }
 
-            print("ev_x.time.sec:", ev_x.time.sec)
-            print("ev_y.time.sec:", ev_y.time.sec)
             kobo_dev.input:eventAdjustHook(ev_x)
             kobo_dev.input:eventAdjustHook(ev_y)
             local cur_sec = TimeVal:now().sec
-            print("cur_sec:", cur_sec)
-            print("ev_x.time.sec:", ev_x.time.sec)
-            print("ev_y.time.sec:", ev_y.time.sec)
             assert.truthy(cur_sec - ev_x.time.sec < 10)
             assert.truthy(cur_sec - ev_y.time.sec < 10)
 

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -80,7 +80,6 @@ describe("device module", function()
             kobo_dev:init()
             local Screen = kobo_dev.screen
 
-            kobo_dev.touch_probe_ev_epoch_time = nil
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             assert.truthy(kobo_dev:needsTouchScreenProbe())
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
@@ -127,7 +126,6 @@ describe("device module", function()
             kobo_dev:init()
             local Screen = kobo_dev.screen
 
-            kobo_dev.touch_probe_ev_epoch_time = true
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             local x, y = Screen:getWidth()-5, 10
             local EV_ABS = 3

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -82,6 +82,7 @@ describe("device module", function()
 
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             assert.truthy(kobo_dev:needsTouchScreenProbe())
+            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
             kobo_dev:touchScreenProbe()
             local x, y = Screen:getWidth()-5, 10
@@ -127,6 +128,7 @@ describe("device module", function()
 
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             assert.truthy(kobo_dev:needsTouchScreenProbe())
+            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
             kobo_dev:touchScreenProbe()
             local x, y = Screen:getWidth()-5, 10
             local EV_ABS = 3

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -126,6 +126,9 @@ describe("device module", function()
             kobo_dev:init()
             local Screen = kobo_dev.screen
 
+            -- This got nil'ed during init() since #4450
+            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
+            kobo_dev.touch_probe_ev_epoch_time = true
             assert.is.same("Kobo_trilogy", kobo_dev.model)
             local x, y = Screen:getWidth()-5, 10
             local EV_ABS = 3
@@ -145,8 +148,7 @@ describe("device module", function()
                 time = {sec = 1000}
             }
 
-            -- This gets nil'ed in every case since #4450
-            assert.falsy(kobo_dev.touch_probe_ev_epoch_time)
+            assert.truthy(kobo_dev.touch_probe_ev_epoch_time)
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
             kobo_dev:touchScreenProbe()
 


### PR DESCRIPTION
* Fix the Touch input probe on Trilogy devices that depend on the touch_probe_ev_epoch_time quirk (fix #630)
* Expose a "PageTurn button inversion" feature in the Navigation menu (for all devices with keys) (fix #4446)
* Allow ignoring the accelerometer on the Forma (Screen > Ignore accelerometer rotation events) (fix #4451)
* Fix SleepCover handling on the Forma (fix #4457)
* Make isWifiOn a tiny bit more accurate (check the actual WiFi module instead of sdio_wifi_pwr)