### PR TITLE
[Android]: Open files from intent

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -2,6 +2,7 @@ local Generic = require("device/generic/device")
 local _, android = pcall(require, "android")
 local ffi = require("ffi")
 local C = ffi.C
+local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 local function yes() return true end
@@ -34,6 +35,13 @@ function Device:init()
                 this.device.screen:refreshFull()
             elseif ev.code == C.APP_CMD_WINDOW_REDRAW_NEEDED then
                 this.device.screen:refreshFull()
+            elseif ev.code == C.APP_CMD_RESUME then
+                local new_file = android.getIntent()
+                if new_file ~= nil and lfs.attributes(new_file, "mode") == "file" then
+                    logger.warn("Loading new file from intent: " .. new_file)
+                    local ReaderUI = require("apps/reader/readerui")
+                    ReaderUI:doShowReader(new_file)
+                end
             end
         end,
         hasClipboardText = function()

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -10,25 +10,7 @@ ffi.cdef[[
 ]]
 
 -- check uri of the intent that starts this application
-local file = A.jni:context(A.app.activity.vm, function(JNI)
-    local uri = JNI:callObjectMethod(
-        JNI:callObjectMethod(
-            A.app.activity.clazz,
-            "getIntent",
-            "()Landroid/content/Intent;"
-        ),
-        "getData",
-        "()Landroid/net/Uri;"
-    )
-    if uri ~= nil then
-        local path = JNI:callObjectMethod(
-            uri,
-            "getPath",
-            "()Ljava/lang/String;"
-        )
-        return JNI:to_string(path)
-    end
-end)
+local file = A.getIntent()
 
 if file ~= nil then
     A.LOGI("intent file path " .. file)


### PR DESCRIPTION
Related to https://github.com/koreader/koreader/issues/4441
Requires https://github.com/koreader/android-luajit-launcher/pull/89

Fix open files from intent once KOReader is running (android 2.3 to 7.1). Check if file exists before open it.