### PR TITLE
Style tweaks: split in-page footnotes tweaks

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -326,54 +326,115 @@ This is just an example, that will need to be adapted into a user style tweak.]]
             },
         },
         {
-            id = "epub_footnote-inpage";
-            title = _("Show EPUB footnotes in pages"),
-            description = _([[
-Show footnotes text at the bottom of pages that contain links to them.
+            title = _("In-page footnotes"),
+            {
+                id = "footnote-inpage_epub";
+                title = _("In-page EPUB footnotes"),
+                description = _([[
+Show EPUB footnotes text at the bottom of pages that contain links to them.
 This only works with footnotes that have specific attributes set by the publisher.]]),
-            css = [[
-/* EPUB attributes: */
-*[type~="note"], *[type~="footnote"],
+                css = [[
+*[type~="note"],
+*[type~="footnote"],
 *[type~="rearnote"],
-*[role~="doc-note"], *[role~="doc-footnote"],
-*[role~="doc-rearnote"],
-/* Wikipedia EPUBs footnotes: */
-ol.references > li,
-/* Classic footnotes class names: */
-.footnote, .note, .note1
+*[role~="doc-note"],
+*[role~="doc-footnote"],
+*[role~="doc-rearnote"]
 {
     -cr-hint: footnote-inpage;
     margin-top: 0 !important;
     margin-bottom: 0 !important;
 }
-/* Wikipedia EPUBs: hide backlinks */
-ol.references > li > .noprint { display: none; }
-            ]],
-        },
-        {
-            id = "epub_footnote-inpage_smaller";
-            title = _("Show smaller EPUB footnotes in pages"),
-            description = _([[Decrease font size of footnotes text displayed in pages.]]),
-            -- Include the whole content of previous style, so toggling this one is enough
-            css = [[
-/* EPUB attributes: */
-*[type~="note"], *[type~="footnote"],
+                ]],
+            },
+            {
+                id = "footnote-inpage_epub_smaller";
+                title = _("In-page EPUB footnotes (smaller)"),
+                description = _([[
+Show EPUB footnotes text at the bottom of pages that contain links to them.
+This only works with footnotes that have specific attributes set by the publisher.]]),
+                css = [[
+*[type~="note"],
+*[type~="footnote"],
 *[type~="rearnote"],
-*[role~="doc-note"], *[role~="doc-footnote"],
-*[role~="doc-rearnote"],
-/* Wikipedia EPUBs footnotes: */
-ol.references > li,
-/* Classic footnotes class names: */
-.footnote, .note, .note1
+*[role~="doc-note"],
+*[role~="doc-footnote"],
+*[role~="doc-rearnote"]
 {
     -cr-hint: footnote-inpage;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
     font-size: 80% !important;
+}
+                ]],
+                separator = true,
+            },
+            {
+                id = "footnote-inpage_wikipedia";
+                title = _("In-page Wikipedia footnotes"),
+                description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
+                css = [[
+ol.references > li {
+    -cr-hint: footnote-inpage;
     margin-top: 0 !important;
     margin-bottom: 0 !important;
 }
-/* Wikipedia EPUBs: hide backlinks */
+/* hide backlinks */
 ol.references > li > .noprint { display: none; }
-            ]],
+ol.references > li > .mw-cite-backlink { display: none; }
+                ]],
+            },
+            {
+                id = "footnote-inpage_wikipedia_smaller";
+                title = _("In-page Wikipedia footnotes (smaller)"),
+                description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
+                css = [[
+ol.references > li {
+    -cr-hint: footnote-inpage;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    font-size: 80% !important;
+}
+/* hide backlinks */
+ol.references > li > .noprint { display: none; }
+ol.references > li > .mw-cite-backlink { display: none; }
+                ]],
+                separator = true,
+            },
+            -- We can add other classic class names to the 2 following
+            -- tweaks (except when named 'calibreN', as the N number is
+            -- usually random across books).
+            {
+                id = "footnote-inpage_classic_classnames";
+                title = _("In-page classic classname footnotes"),
+                description = _([[
+Show footnotes with classic class names at the bottom of pages.
+This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
+                css = [[
+.footnote, .note, .note1, .ntb
+{
+    -cr-hint: footnote-inpage;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+}
+                ]],
+            },
+            {
+                id = "footnote-inpage_classic_classnames_smaller";
+                title = _("In-page classic classname footnotes (smaller)"),
+                description = _([[
+Show footnotes with classic classname at the bottom of pages.
+This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
+                css = [[
+.footnote, .note, .note1, .ntb
+{
+    -cr-hint: footnote-inpage;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    font-size: 80% !important;
+}
+                ]],
+            },
         },
         {
             id = "epub_switch_show_case";

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -944,6 +944,14 @@ a.newwikinonexistent {
 ul, ol {
     margin-left: 0em;
 }
+/* OL in Wikipedia pages may inherit their style-type from a wrapping div,
+ * ensure they fallback to decimal with inheritance */
+body {
+    list-style-type: decimal;
+}
+ol.references {
+    list-style-type: inherit;
+}
 /* show a box around image thumbnails */
 div.thumb {
     border: dotted 1px black;


### PR DESCRIPTION
Will include a bump for crengine, which includes https://github.com/koreader/crengine/pull/250
- CSS: avoid publisher's !important from overriding ours (see https://github.com/koreader/koreader/issues/4196#issuecomment-451016032)
- In-page footnotes: fix vertical position when full status bar (closes #4444)
- In-page footnotes: avoid duplicated footnotes on same page
- In-page footnotes: fix ignored link in nested tags
- In-page footnotes: gather links in table cells
- In-page footnotes: fix page splitting edge cases

Split the In-page footnotes tweak into 3 distinct ones, mainly because I want the 3rd one with classic class names to be disabled'able, while keeping the others, in case these classic class names are not used for footnotes.

<kbd>![image](https://user-images.githubusercontent.com/24273478/50739933-03c6f980-11e7-11e9-9d0f-63af211a499e.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/50739939-1b9e7d80-11e7-11e9-8aba-79e38e077068.png)</kbd>

![image](https://user-images.githubusercontent.com/24273478/50739946-2822d600-11e7-11e9-957d-49b5f19d44d4.png)
![image](https://user-images.githubusercontent.com/24273478/50739949-340e9800-11e7-11e9-9622-037aeeb73131.png)
![image](https://user-images.githubusercontent.com/24273478/50739951-3e309680-11e7-11e9-8291-34d3824c2a80.png)

Rewording suggestions welcome.

Also fix footnotes list-style-type in Wikipedia EPUBs, which may have been wrong (but it was less visibile when following page links because of the little black marker, or showing them in popup footnotes where the number/letter is not shown).
The indeed can be specified like this:
<kbd>![image](https://user-images.githubusercontent.com/24273478/50739973-b5662a80-11e7-11e9-8e19-ad33655e16b6.png)</kbd>
And this allows the different numbering to be displayed correctly:
<kbd>![image](https://user-images.githubusercontent.com/24273478/50737019-ebde7e00-11c4-11e9-931c-a13c3c35fa6e.png)</kbd>

There are also pages that specifiy it differently (for footnotes numbered a,b,c..), which [work in the web pages](https://fr.wikipedia.org/wiki/Saint-Empire_romain_germanique), but unfortunatly styles seem broken in the API returned HTML, so we get:
<kbd>![image](https://user-images.githubusercontent.com/24273478/50739994-2a396480-11e8-11e9-8c0a-348586348870.png)</kbd>
Nothing we can do till wikipedia fixes their stuff (https://en.wikipedia.org/wiki/Help:Footnotes#Footnotes:_predefined_groups https://phabricator.wikimedia.org/T198021)