### PR TITLE
Random bug triage!

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -210,6 +210,15 @@ local PocketBook624 = PocketBook:new{
     emu_events_dev = "/var/dev/shm/emu_events",
 }
 
+-- PocketBook Basic Touch 2
+local PocketBook625 = PocketBook:new{
+    isTouchDevice = yes,
+    hasKeys = yes,
+    hasFrontlight = no,
+    display_dpi = 166,
+    emu_events_dev = "/var/dev/shm/emu_events",
+}
+
 -- PocketBook Touch Lux
 local PocketBook623 = PocketBook:new{
     isTouchDevice = yes,
@@ -280,6 +289,8 @@ elseif codename == "PocketBook 623" then
     return PocketBook623
 elseif codename == "PocketBook 630" then
     return PocketBook630
+elseif codename == "PB625" then
+    return PocketBook625
 elseif codename == "PB740" then
     return PocketBook740
 elseif codename == "PocketBook Color Lux" then

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -124,7 +124,7 @@ function NetworkMgr:getWifiMenuTable()
         enabled_func = function() return Device:isAndroid() or Device:isCervantes() or Device:isKindle() or Device:isKobo() or Device:isSonyPRSTUX() end,
         checked_func = function() return NetworkMgr:isWifiOn() end,
         callback = function(touchmenu_instance)
-            local wifi_status = NetworkMgr:isWifiOn()
+            local wifi_status = NetworkMgr:isWifiOn() and NetworkMgr:isConnected()
             local complete_callback = function()
                 -- notify touch menu to update item check state
                 touchmenu_instance:updateItems()
@@ -272,6 +272,16 @@ function NetworkMgr:showNetworkMenu(complete_callback)
         if network_list == nil then
             UIManager:show(InfoMessage:new{text = err})
             return
+        end
+        -- NOTE: Fairly hackish workaround for #4387,
+        --       rescan if the first scan appeared to yield an empty list.
+        -- FIXME: This *might* be an issue better handled in lj-wpaclient...
+        if (table.getn(network_list) == 0) then
+            network_list, err = self:getNetworkList()
+            if network_list == nil then
+                UIManager:show(InfoMessage:new{text = err})
+                return
+            end
         end
         UIManager:show(require("ui/widget/networksetting"):new{
             network_list = network_list,


### PR DESCRIPTION
* Detect the PocketBook Basic Touch 2 (fix #4366)
* Workaround a few WiFi corner-cases on some Kobo devices (i.e., make the 'Wi-Fi connection' menu less stupid) (fix #4387)