### PR TITLE
wifi: try to connect to known network before listing

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -160,7 +160,7 @@ function Cervantes:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOnWifi(complete_callback)
         logger.info("Cervantes: enabling WiFi")
         os.execute("./enable-wifi.sh")
-        self:showNetworkMenu(complete_callback)
+        self:reconnectOrShowNetworkMenu(complete_callback)
     end
     NetworkMgr:setWirelessBackend("wpa_supplicant", {ctrl_interface = "/var/run/wpa_supplicant/eth0"})
     function NetworkMgr:obtainIP()


### PR DESCRIPTION
Iterate over available networks ordered by signal power, and check if we
can connect to saved SSIDs. If we can, then skip network list dialog.