### PR TITLE
[cervantes] automatically restore wifi connection

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -170,6 +170,7 @@ function Cervantes:initNetworkManager(NetworkMgr)
         os.execute("./release-ip.sh")
     end
     function NetworkMgr:restoreWifiAsync()
+        os.execute("./restore-wifi-async.sh")
     end
     function NetworkMgr:isWifiOn()
         return 1 == isConnected()

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -187,7 +187,7 @@ function NetworkMgr:getRestoreMenuTable()
     return {
         text = _("Automatically restore Wi-Fi connection after resume"),
         checked_func = function() return G_reader_settings:nilOrTrue("auto_restore_wifi") end,
-        enabled_func = function() return Device:isKobo() end,
+        enabled_func = function() return Device:isKobo() or Device:isCervantes() end,
         callback = function() G_reader_settings:flipNilOrTrue("auto_restore_wifi") end,
     }
 end

--- a/platform/cervantes/restore-wifi-async.sh
+++ b/platform/cervantes/restore-wifi-async.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+RunWpaCli() {
+    ./luajit <<EOF
+    require("setupkoenv")
+    local DataStorage = require("datastorage")
+    local LuaSettings = require("luasettings")
+
+    local settings = LuaSettings:open(DataStorage:getSettingsDir().."/network.lua")
+    local cli = io.popen("wpa_cli -g /var/run/wpa_supplicant/eth0 > /dev/null", "w")
+    local idx = 0
+    for ssid, network in pairs(settings.data) do
+        cli:write("add_network\n")
+        cli:write("set_network " .. tostring(idx) .. " ssid \"" .. ssid .. "\"\n")
+        cli:write("set_network " .. tostring(idx) .. " psk \"" .. network["password"] .. "\"\n")
+        cli:write("enable_network " .. tostring(idx) .. "\n")
+        idx = idx + 1
+    end
+    cli:close()
+EOF
+}
+
+RestoreWifi() {
+    echo "[$(date)] restore-wifi-async.sh: Restarting WiFi"
+    ./enable-wifi.sh
+    RunWpaCli
+    ./obtain-ip.sh
+    echo "[$(date)] restore-wifi-async.sh: Restarted WiFi"
+}
+
+RestoreWifi &


### PR DESCRIPTION
Fixes #4422 

The patch runs shell script and pipes known networks from `settings/network.lua` to `wpa_cli` executable.