### PR TITLE
Assorted minor tweaks

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -82,7 +82,7 @@ function OTAManager:getOTAModel()
     elseif Device:isCervantes() then
         return "cervantes"
     elseif Device:isKindle() then
-        if Device:isTouchDevice() then
+        if Device:isTouchDevice() or Device.model == "Kindle4" then
             if self:_isKindleWarioOrMore() then
                 return "kindlepw2"
             else

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -228,6 +228,20 @@ function InputContainer:onKeyPress(key)
     end
 end
 
+-- NOTE: Currently a verbatim copy of onKeyPress ;).
+function InputContainer:onKeyRepeat(key)
+    for name, seq in pairs(self.key_events) do
+        if not seq.is_inactive then
+            for _, oneseq in ipairs(seq) do
+                if key:match(oneseq) then
+                    local eventname = seq.event or name
+                    return self:handleEvent(Event:new(eventname, seq.args, key))
+                end
+            end
+        end
+    end
+end
+
 function InputContainer:onGesture(ev)
     for _, tzone in ipairs(self._ordered_touch_zones) do
         if tzone.gs_range:match(ev) and tzone.handler(ev) then


### PR DESCRIPTION
* WiFi handling on Kindle (fix #4472)
* Crappy attempt at handling key repeat for the Forma pageturn buttons
* Fix long-standing OTA inconsistencies on Kindle so that OTAManager picks the right binaries (Massive oversight on my part there -_-") (re #4497).
   * Use the proper binaries (kindle5 -> kindle) on the K4
   * Use the proper binaries (kindlepw2) on every Kindle since the PW2. 