### PR TITLE
[fix, lang] Swipe to show footnotes in popup setting text

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -227,8 +227,9 @@ You can still follow them from the dictionary window or the selection menu after
         -- Swipe section
         menu_items.follow_links.sub_item_table[8].separator = nil
         table.insert(menu_items.follow_links.sub_item_table, 9, {
-            text = _("Show footnotes in popup"),
+            text = _("Swipe to show footnotes in popup"),
             checked_func = isSwipeLinkFootnotePopupEnabled,
+            enabled_func = isSwipeToFollowNearestLinkEnabled,
             callback = function()
                 G_reader_settings:saveSetting("swipe_link_footnote_popup",
                     not isSwipeLinkFootnotePopupEnabled())


### PR DESCRIPTION
Duplicate with the tap to show footnotes text, reported on https://www.mobileread.com/forums/showthread.php?p=3798627