### PR TITLE
Set actual model names on PB devices

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -23,18 +23,18 @@ local Kobo = Generic:new{
     model = "Kobo",
     isKobo = yes,
     isTouchDevice = yes, -- all of them are
-    hasBGRFrameBuffer = yes, -- True when >16bpp
+    hasBGRFrameBuffer = yes, -- True when >16bpp (i.e., on current FW)
     hasOTAUpdates = yes,
 
     -- most Kobos have X/Y switched for the touch screen
     touch_switch_xy = true,
     -- most Kobos have also mirrored X coordinates
     touch_mirrored_x = true,
-    -- enforce protrait mode on Kobos:
+    -- enforce portrait mode on Kobos
     isAlwaysPortrait = yes,
     -- the internal storage mount point users can write to
     internal_storage_mount_point = "/mnt/onboard/",
-    -- currently only Aura One has coloured frontlight
+    -- currently only the Aura One and Forma have coloured frontlights
     hasNaturalLight = no,
 }
 

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -157,6 +157,7 @@ end
 
 -- PocketBook InkPad
 local PocketBook840 = PocketBook:new{
+    model = "PBInkPad",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -166,6 +167,7 @@ local PocketBook840 = PocketBook:new{
 
 -- PocketBook Lux 4
 local PocketBook627 = PocketBook:new{
+    model = "PBLux4",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -173,8 +175,9 @@ local PocketBook627 = PocketBook:new{
     emu_events_dev = "/var/dev/shm/emu_events",
 }
 
--- PocketBook HD Touch
+-- PocketBook Touch HD
 local PocketBook631 = PocketBook:new{
+    model = "PBTouchHD631",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -184,6 +187,7 @@ local PocketBook631 = PocketBook:new{
 
 -- PocketBook Touch HD Plus
 local PocketBook632 = PocketBook:new{
+    model = "PBTouchHDPlus",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -194,6 +198,7 @@ local PocketBook632 = PocketBook:new{
 
 -- PocketBook Lux 3
 local PocketBook626 = PocketBook:new{
+    model = "PBLux3",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -203,6 +208,7 @@ local PocketBook626 = PocketBook:new{
 
 -- PocketBook Basic Touch
 local PocketBook624 = PocketBook:new{
+    model = "PBBasicTouch",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = no,
@@ -212,6 +218,7 @@ local PocketBook624 = PocketBook:new{
 
 -- PocketBook Basic Touch 2
 local PocketBook625 = PocketBook:new{
+    model = "PBBasicTouch2",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = no,
@@ -221,6 +228,7 @@ local PocketBook625 = PocketBook:new{
 
 -- PocketBook Touch Lux
 local PocketBook623 = PocketBook:new{
+    model = "PBTouchLux",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -230,6 +238,7 @@ local PocketBook623 = PocketBook:new{
 
 -- PocketBook InkPad 3
 local PocketBook740 = PocketBook:new{
+    model = "PBInkPad3",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -238,8 +247,9 @@ local PocketBook740 = PocketBook:new{
     emu_events_dev = "/var/dev/shm/emu_events",
 }
 
--- PocketBook HD Touch
+-- PocketBook Touch HD
 local PocketBook630 = PocketBook:new{
+    model = "PBTouchHD630",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -249,6 +259,7 @@ local PocketBook630 = PocketBook:new{
 
 -- PocketBook Aqua 2
 local PocketBook641 = PocketBook:new{
+    model = "PBAqua2",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -258,6 +269,7 @@ local PocketBook641 = PocketBook:new{
 
 -- PocketBook Color Lux
 local PocketBookColorLux = PocketBook:new{
+    model = "PBColorLux",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -177,7 +177,7 @@ local PocketBook627 = PocketBook:new{
 
 -- PocketBook Touch HD
 local PocketBook631 = PocketBook:new{
-    model = "PBTouchHD631",
+    model = "PBTouchHD",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -247,9 +247,9 @@ local PocketBook740 = PocketBook:new{
     emu_events_dev = "/var/dev/shm/emu_events",
 }
 
--- PocketBook Touch HD
+-- PocketBook Sense
 local PocketBook630 = PocketBook:new{
-    model = "PBTouchHD630",
+    model = "PBSense",
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,


### PR DESCRIPTION
Not that we ever use it anywhere on PB, it basically just makes logs prettier ;).