### PR TITLE
Added choice of default action when highlighting

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -522,7 +522,7 @@ function ReaderHighlight:onHoldRelease()
     end
 
     if self.selected_text then
-        default_action_when_highlighting = G_reader_settings:readSetting("default_highlight_action")
+        local default_action_when_highlighting = G_reader_settings:readSetting("default_highlight_action")
         if default_action_when_highlighting == nil or default_action_when_highlighting == "ask" then
             logger.dbg("show highlight dialog")
             local highlight_buttons = {

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -523,8 +523,7 @@ function ReaderHighlight:onHoldRelease()
 
     if self.selected_text then
         local default_highlight_action = G_reader_settings:readSetting("default_highlight_action")
-        if default_highlight_action == nil or default_highlight_action == "ask" then
-            logger.dbg("show highlight dialog")
+        if not default_highlight_action then
             local highlight_buttons = {
                 {
                     {

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -521,98 +521,110 @@ function ReaderHighlight:onHoldRelease()
         end
     end
     if self.selected_text then
-        logger.dbg("show highlight dialog")
-        local highlight_buttons = {
-            {
-                {
-                    text = _("Highlight"),
-                    callback = function()
-                        self:saveHighlight()
-                        self:onClose()
-                    end,
-                },
-                {
-                    text = _("Add Note"),
-                    enabled = false,
-                    callback = function()
-                        self:addNote()
-                        self:onClose()
-                    end,
-                },
-            },
-            {
-                {
-                    text = "Copy",
-                    enabled = Device:hasClipboard(),
-                    callback = function()
-                        Device.input.setClipboardText(self.selected_text.text)
-                    end,
-                },
-                {
-                    text = _("View HTML"),
-                    enabled = not self.ui.document.info.has_pages,
-                    callback = function()
-                        self:viewSelectionHTML()
-                    end,
-                },
-            },
-            {
-                {
-                    text = _("Wikipedia"),
-                    callback = function()
-                        UIManager:scheduleIn(0.1, function()
-                            self:lookupWikipedia()
-                            -- We don't call self:onClose(), we need the highlight
-                            -- to still be there, as we may Highlight it from the
-                            -- dict lookup widget
-                        end)
-                    end,
-                },
-                {
-                    text = _("Dictionary"),
-                    callback = function()
-                        self:onHighlightDictLookup()
-                        -- We don't call self:onClose(), same reason as above
-                    end,
-                },
-            },
-            {
-                {
-                    text = _("Translate"),
-                    callback = function()
-                        self:translate(self.selected_text)
-                        -- We don't call self:onClose(), so one can still see
-                        -- the highlighted text when moving the translated
-                        -- text window, and also if NetworkMgr:promptWifiOn()
-                        -- is needed, so the user can just tap again on this
-                        -- button and does not need to select the text again.
-                    end,
-                },
-                {
-                    text = _("Search"),
-                    callback = function()
-                        self:onHighlightSearch()
-                        UIManager:close(self.highlight_dialog)
-                    end,
-                },
-            },
-        }
-        if self.selected_link ~= nil then
-            table.insert(highlight_buttons, { -- for now, a single button in an added row
-                {
-                    text = _("Follow Link"),
-                    callback = function()
-                        self.ui.link:onGotoLink(self.selected_link)
-                        self:onClose()
-                    end,
-                },
-            })
-        end
-        self.highlight_dialog = ButtonDialog:new{
-            buttons = highlight_buttons,
-            tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,
-        }
-        UIManager:show(self.highlight_dialog)
+	default_highlight_action = G_reader_settings:readSetting("default_highlight_action")
+	if default_highlight_action == "ask" or default_highlight_action == nil then
+		logger.dbg("show highlight dialog")
+		local highlight_buttons = {
+		    {
+		        {
+		            text = _("Highlight"),
+		            callback = function()
+		                self:saveHighlight()
+		                self:onClose()
+		            end,
+		        },
+		        {
+		            text = _("Add Note"),
+		            enabled = false,
+		            callback = function()
+		                self:addNote()
+		                self:onClose()
+		            end,
+		        },
+		    },
+		    {
+		        {
+		            text = "Copy",
+		            enabled = Device:hasClipboard(),
+		            callback = function()
+		                Device.input.setClipboardText(self.selected_text.text)
+		            end,
+		        },
+		        {
+		            text = _("View HTML"),
+		            enabled = not self.ui.document.info.has_pages,
+		            callback = function()
+		                self:viewSelectionHTML()
+		            end,
+		        },
+		    },
+		    {
+		        {
+		            text = _("Wikipedia"),
+		            callback = function()
+		                UIManager:scheduleIn(0.1, function()
+		                    self:lookupWikipedia()
+		                    -- We don't call self:onClose(), we need the highlight
+		                    -- to still be there, as we may Highlight it from the
+		                    -- dict lookup widget
+		                end)
+		            end,
+		        },
+		        {
+		            text = _("Dictionary"),
+		            callback = function()
+		                self:onHighlightDictLookup()
+		                -- We don't call self:onClose(), same reason as above
+		            end,
+		        },
+		    },
+		    {
+		        {
+		            text = _("Translate"),
+		            callback = function()
+		                self:translate(self.selected_text)
+		                -- We don't call self:onClose(), so one can still see
+		                -- the highlighted text when moving the translated
+		                -- text window, and also if NetworkMgr:promptWifiOn()
+		                -- is needed, so the user can just tap again on this
+		                -- button and does not need to select the text again.
+		            end,
+		        },
+		        {
+		            text = _("Search"),
+		            callback = function()
+		                self:onHighlightSearch()
+		                UIManager:close(self.highlight_dialog)
+		            end,
+		        },
+		    },
+		}
+		if self.selected_link ~= nil then
+		    table.insert(highlight_buttons, { -- for now, a single button in an added row
+		        {
+		            text = _("Follow Link"),
+		            callback = function()
+		                self.ui.link:onGotoLink(self.selected_link)
+		                self:onClose()
+		            end,
+		        },
+		    })
+		end
+		self.highlight_dialog = ButtonDialog:new{
+		    buttons = highlight_buttons,
+		    tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,
+		}
+		UIManager:show(self.highlight_dialog)
+	elseif default_highlight_action == "highlight" then
+                self:saveHighlight()
+		self:onClose()
+	elseif default_highlight_action == "translate" then
+		self:translate(self.selected_text)
+		self:onClose()
+	elseif default_highlight_action == "wikipedia" then
+		self:lookupWikipedia()
+		self:onClose()
+	end
     elseif self.selected_word then
         self:lookup(self.selected_word, self.selected_link)
         self.selected_word = nil

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -520,99 +520,112 @@ function ReaderHighlight:onHoldRelease()
             self:onHoldPan(nil, {pos=self.hold_ges_pos})
         end
     end
+
     if self.selected_text then
-        logger.dbg("show highlight dialog")
-        local highlight_buttons = {
-            {
+        default_action_when_highlighting = G_reader_settings:readSetting("default_highlight_action")
+        if default_action_when_highlighting == nil or default_action_when_highlighting == "ask" then
+            logger.dbg("show highlight dialog")
+            local highlight_buttons = {
                 {
-                    text = _("Highlight"),
-                    callback = function()
-                        self:saveHighlight()
-                        self:onClose()
-                    end,
+                    {
+                        text = _("Highlight"),
+                        callback = function()
+                            self:saveHighlight()
+                            self:onClose()
+                        end,
+                    },
+                    {
+                        text = _("Add Note"),
+                        enabled = false,
+                        callback = function()
+                            self:addNote()
+                            self:onClose()
+                        end,
+                    },
                 },
                 {
-                    text = _("Add Note"),
-                    enabled = false,
-                    callback = function()
-                        self:addNote()
-                        self:onClose()
-                    end,
-                },
-            },
-            {
-                {
-                    text = "Copy",
-                    enabled = Device:hasClipboard(),
-                    callback = function()
-                        Device.input.setClipboardText(self.selected_text.text)
-                    end,
-                },
-                {
-                    text = _("View HTML"),
-                    enabled = not self.ui.document.info.has_pages,
-                    callback = function()
-                        self:viewSelectionHTML()
-                    end,
-                },
-            },
-            {
-                {
-                    text = _("Wikipedia"),
-                    callback = function()
-                        UIManager:scheduleIn(0.1, function()
-                            self:lookupWikipedia()
-                            -- We don't call self:onClose(), we need the highlight
-                            -- to still be there, as we may Highlight it from the
-                            -- dict lookup widget
-                        end)
-                    end,
+                    {
+                        text = "Copy",
+                        enabled = Device:hasClipboard(),
+                        callback = function()
+                            Device.input.setClipboardText(self.selected_text.text)
+                        end,
+                    },
+                    {
+                        text = _("View HTML"),
+                        enabled = not self.ui.document.info.has_pages,
+                        callback = function()
+                            self:viewSelectionHTML()
+                        end,
+                    },
                 },
                 {
-                    text = _("Dictionary"),
-                    callback = function()
-                        self:onHighlightDictLookup()
-                        -- We don't call self:onClose(), same reason as above
-                    end,
+                    {
+                        text = _("Wikipedia"),
+                        callback = function()
+                            UIManager:scheduleIn(0.1, function()
+                                self:lookupWikipedia()
+                                -- We don't call self:onClose(), we need the highlight
+                                -- to still be there, as we may Highlight it from the
+                                -- dict lookup widget
+                            end)
+                        end,
+                    },
+                    {
+                        text = _("Dictionary"),
+                        callback = function()
+                            self:onHighlightDictLookup()
+                            -- We don't call self:onClose(), same reason as above
+                        end,
+                    },
                 },
-            },
-            {
                 {
-                    text = _("Translate"),
-                    callback = function()
-                        self:translate(self.selected_text)
-                        -- We don't call self:onClose(), so one can still see
-                        -- the highlighted text when moving the translated
-                        -- text window, and also if NetworkMgr:promptWifiOn()
-                        -- is needed, so the user can just tap again on this
-                        -- button and does not need to select the text again.
-                    end,
+                    {
+                        text = _("Translate"),
+                        callback = function()
+                            self:translate(self.selected_text)
+                            -- We don't call self:onClose(), so one can still see
+                            -- the highlighted text when moving the translated
+                            -- text window, and also if NetworkMgr:promptWifiOn()
+                            -- is needed, so the user can just tap again on this
+                            -- button and does not need to select the text again.
+                        end,
+                    },
+                    {
+                        text = _("Search"),
+                        callback = function()
+                            self:onHighlightSearch()
+                            UIManager:close(self.highlight_dialog)
+                        end,
+                    },
                 },
-                {
-                    text = _("Search"),
-                    callback = function()
-                        self:onHighlightSearch()
-                        UIManager:close(self.highlight_dialog)
-                    end,
-                },
-            },
-        }
-        if self.selected_link ~= nil then
-            table.insert(highlight_buttons, { -- for now, a single button in an added row
-                {
-                    text = _("Follow Link"),
-                    callback = function()
-                        self.ui.link:onGotoLink(self.selected_link)
-                        self:onClose()
-                    end,
-                },
-            })
+            }
+            if self.selected_link ~= nil then
+                table.insert(highlight_buttons, { -- for now, a single button in an added row
+                    {
+                        text = _("Follow Link"),
+                        callback = function()
+                            self.ui.link:onGotoLink(self.selected_link)
+                            self:onClose()
+                        end,
+                    },
+                })
+            end
+            self.highlight_dialog = ButtonDialog:new{
+                buttons = highlight_buttons,
+                tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,
+            }
+            UIManager:show(self.highlight_dialog)
+        elseif default_action_when_highlighting == "highlight" then
+            self:saveHighlight()
+            self:onClose()
+        elseif default_action_when_highlighting == "translate" then
+            self:translate(self.selected_text)
+            self:onClose()
+        elseif default_action_when_highlighting == "wikipedia" then
+            self:lookupWikipedia()
+            self:onClose()
         end
-        self.highlight_dialog = ButtonDialog:new{
-            buttons = highlight_buttons,
-            tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,
-        }
-        UIManager:show(self.highlight_dialog)
     elseif self.selected_word then
         self:lookup(self.selected_word, self.selected_link)
         self.selected_word = nil

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -522,8 +522,8 @@ function ReaderHighlight:onHoldRelease()
     end
 
     if self.selected_text then
-        local default_action_when_highlighting = G_reader_settings:readSetting("default_highlight_action")
-        if default_action_when_highlighting == nil or default_action_when_highlighting == "ask" then
+        local default_highlight_action = G_reader_settings:readSetting("default_highlight_action")
+        if default_highlight_action == nil or default_highlight_action == "ask" then
             logger.dbg("show highlight dialog")
             local highlight_buttons = {
                 {
@@ -616,13 +616,13 @@ function ReaderHighlight:onHoldRelease()
                 tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,
             }
             UIManager:show(self.highlight_dialog)
-        elseif default_action_when_highlighting == "highlight" then
+        elseif default_highlight_action == "highlight" then
             self:saveHighlight()
             self:onClose()
-        elseif default_action_when_highlighting == "translate" then
+        elseif default_highlight_action == "translate" then
             self:translate(self.selected_text)
             self:onClose()
-        elseif default_action_when_highlighting == "wikipedia" then
+        elseif default_highlight_action == "wikipedia" then
             self:lookupWikipedia()
             self:onClose()
         end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -521,110 +521,98 @@ function ReaderHighlight:onHoldRelease()
         end
     end
     if self.selected_text then
-	default_highlight_action = G_reader_settings:readSetting("default_highlight_action")
-	if default_highlight_action == "ask" or default_highlight_action == nil then
-		logger.dbg("show highlight dialog")
-		local highlight_buttons = {
-		    {
-		        {
-		            text = _("Highlight"),
-		            callback = function()
-		                self:saveHighlight()
-		                self:onClose()
-		            end,
-		        },
-		        {
-		            text = _("Add Note"),
-		            enabled = false,
-		            callback = function()
-		                self:addNote()
-		                self:onClose()
-		            end,
-		        },
-		    },
-		    {
-		        {
-		            text = "Copy",
-		            enabled = Device:hasClipboard(),
-		            callback = function()
-		                Device.input.setClipboardText(self.selected_text.text)
-		            end,
-		        },
-		        {
-		            text = _("View HTML"),
-		            enabled = not self.ui.document.info.has_pages,
-		            callback = function()
-		                self:viewSelectionHTML()
-		            end,
-		        },
-		    },
-		    {
-		        {
-		            text = _("Wikipedia"),
-		            callback = function()
-		                UIManager:scheduleIn(0.1, function()
-		                    self:lookupWikipedia()
-		                    -- We don't call self:onClose(), we need the highlight
-		                    -- to still be there, as we may Highlight it from the
-		                    -- dict lookup widget
-		                end)
-		            end,
-		        },
-		        {
-		            text = _("Dictionary"),
-		            callback = function()
-		                self:onHighlightDictLookup()
-		                -- We don't call self:onClose(), same reason as above
-		            end,
-		        },
-		    },
-		    {
-		        {
-		            text = _("Translate"),
-		            callback = function()
-		                self:translate(self.selected_text)
-		                -- We don't call self:onClose(), so one can still see
-		                -- the highlighted text when moving the translated
-		                -- text window, and also if NetworkMgr:promptWifiOn()
-		                -- is needed, so the user can just tap again on this
-		                -- button and does not need to select the text again.
-		            end,
-		        },
-		        {
-		            text = _("Search"),
-		            callback = function()
-		                self:onHighlightSearch()
-		                UIManager:close(self.highlight_dialog)
-		            end,
-		        },
-		    },
-		}
-		if self.selected_link ~= nil then
-		    table.insert(highlight_buttons, { -- for now, a single button in an added row
-		        {
-		            text = _("Follow Link"),
-		            callback = function()
-		                self.ui.link:onGotoLink(self.selected_link)
-		                self:onClose()
-		            end,
-		        },
-		    })
-		end
-		self.highlight_dialog = ButtonDialog:new{
-		    buttons = highlight_buttons,
-		    tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,
-		}
-		UIManager:show(self.highlight_dialog)
-	elseif default_highlight_action == "highlight" then
-                self:saveHighlight()
-		self:onClose()
-	elseif default_highlight_action == "translate" then
-		self:translate(self.selected_text)
-		self:onClose()
-	elseif default_highlight_action == "wikipedia" then
-		self:lookupWikipedia()
-		self:onClose()
-	end
+        logger.dbg("show highlight dialog")
+        local highlight_buttons = {
+            {
+                {
+                    text = _("Highlight"),
+                    callback = function()
+                        self:saveHighlight()
+                        self:onClose()
+                    end,
+                },
+                {
+                    text = _("Add Note"),
+                    enabled = false,
+                    callback = function()
+                        self:addNote()
+                        self:onClose()
+                    end,
+                },
+            },
+            {
+                {
+                    text = "Copy",
+                    enabled = Device:hasClipboard(),
+                    callback = function()
+                        Device.input.setClipboardText(self.selected_text.text)
+                    end,
+                },
+                {
+                    text = _("View HTML"),
+                    enabled = not self.ui.document.info.has_pages,
+                    callback = function()
+                        self:viewSelectionHTML()
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Wikipedia"),
+                    callback = function()
+                        UIManager:scheduleIn(0.1, function()
+                            self:lookupWikipedia()
+                            -- We don't call self:onClose(), we need the highlight
+                            -- to still be there, as we may Highlight it from the
+                            -- dict lookup widget
+                        end)
+                    end,
+                },
+                {
+                    text = _("Dictionary"),
+                    callback = function()
+                        self:onHighlightDictLookup()
+                        -- We don't call self:onClose(), same reason as above
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Translate"),
+                    callback = function()
+                        self:translate(self.selected_text)
+                        -- We don't call self:onClose(), so one can still see
+                        -- the highlighted text when moving the translated
+                        -- text window, and also if NetworkMgr:promptWifiOn()
+                        -- is needed, so the user can just tap again on this
+                        -- button and does not need to select the text again.
+                    end,
+                },
+                {
+                    text = _("Search"),
+                    callback = function()
+                        self:onHighlightSearch()
+                        UIManager:close(self.highlight_dialog)
+                    end,
+                },
+            },
+        }
+        if self.selected_link ~= nil then
+            table.insert(highlight_buttons, { -- for now, a single button in an added row
+                {
+                    text = _("Follow Link"),
+                    callback = function()
+                        self.ui.link:onGotoLink(self.selected_link)
+                        self:onClose()
+                    end,
+                },
+            })
+        end
+        self.highlight_dialog = ButtonDialog:new{
+            buttons = highlight_buttons,
+            tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,
+        }
+        UIManager:show(self.highlight_dialog)
     elseif self.selected_word then
         self:lookup(self.selected_word, self.selected_link)
         self.selected_word = nil

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -317,6 +317,48 @@ common_settings.document = {
 
             }
         },
+        {
+            text = _("Default action when highlighting"),
+            sub_item_table = {
+                {
+                    text = _("Default(show menu)"),
+                    checked_func = function()
+                        local setting = G_reader_settings:readSetting("default_highlight_action")
+                        return setting == "ask" or setting == nil
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "ask")
+                    end,
+                },
+                {
+                    text = _("Highlight"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "highlight"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "highlight")
+                    end,
+                },
+                {
+                    text = _("Translate"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "translate"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "translate")
+                    end,
+                },
+                {
+                    text = _("Wikipedia"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "wikipedia"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "wikipedia")
+                    end,
+                },
+            }
+        },
     },
 }
 common_settings.language = Language:getLangMenuTable()

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -318,16 +318,15 @@ common_settings.document = {
             }
         },
         {
-            text = _("Default action when highlighting"),
+            text = _("Highlight action"),
             sub_item_table = {
                 {
-                    text = _("Default(show menu)"),
+                    text = _("Ask with popup dialog"),
                     checked_func = function()
-                        local setting = G_reader_settings:readSetting("default_highlight_action")
-                        return setting == "ask" or setting == nil
+                        return G_reader_settings:readSetting("default_highlight_action") == nil
                     end,
                     callback = function()
-                        G_reader_settings:saveSetting("default_highlight_action", "ask")
+                        G_reader_settings:saveSetting("default_highlight_action", nil)
                     end,
                 },
                 {

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -315,7 +315,49 @@ common_settings.document = {
                     end,
                 },
 
-            }
+            }		
+        },        
+	{
+            text = _("Action on highlight"),
+            sub_item_table = {
+                {
+                    text = _("Default"),
+                    checked_func = function()
+                        local setting = G_reader_settings:readSetting("default_highlight_action")
+                        return setting == "ask" or setting == nil
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "ask")
+                    end,
+                },
+                {
+                    text = _("Highlight"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "highlight"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "highlight")
+                    end,
+                },
+                {
+                    text = _("Translate"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "translate"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "translate")
+                    end,
+                },
+                {
+                    text = _("Check wikipedia"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "wikipedia"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "wikipedia")
+                    end,
+                },
+            }		
         },
     },
 }

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -323,7 +323,7 @@ common_settings.document = {
                 {
                     text = _("Ask with popup dialog"),
                     checked_func = function()
-                        return G_reader_settings:readSetting("default_highlight_action") == nil
+                        return G_reader_settings:nilOrFalse('default_highlight_action')
                     end,
                     callback = function()
                         G_reader_settings:saveSetting("default_highlight_action", nil)

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -315,49 +315,7 @@ common_settings.document = {
                     end,
                 },
 
-            }		
-        },        
-	{
-            text = _("Action on highlight"),
-            sub_item_table = {
-                {
-                    text = _("Default"),
-                    checked_func = function()
-                        local setting = G_reader_settings:readSetting("default_highlight_action")
-                        return setting == "ask" or setting == nil
-                    end,
-                    callback = function()
-                        G_reader_settings:saveSetting("default_highlight_action", "ask")
-                    end,
-                },
-                {
-                    text = _("Highlight"),
-                    checked_func = function()
-                        return G_reader_settings:readSetting("default_highlight_action") == "highlight"
-                    end,
-                    callback = function()
-                        G_reader_settings:saveSetting("default_highlight_action", "highlight")
-                    end,
-                },
-                {
-                    text = _("Translate"),
-                    checked_func = function()
-                        return G_reader_settings:readSetting("default_highlight_action") == "translate"
-                    end,
-                    callback = function()
-                        G_reader_settings:saveSetting("default_highlight_action", "translate")
-                    end,
-                },
-                {
-                    text = _("Check wikipedia"),
-                    checked_func = function()
-                        return G_reader_settings:readSetting("default_highlight_action") == "wikipedia"
-                    end,
-                    callback = function()
-                        G_reader_settings:saveSetting("default_highlight_action", "wikipedia")
-                    end,
-                },
-            }		
+            }
         },
     },
 }

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -323,7 +323,7 @@ common_settings.document = {
                 {
                     text = _("Ask with popup dialog"),
                     checked_func = function()
-                        return G_reader_settings:nilOrFalse('default_highlight_action')
+                        return G_reader_settings:nilOrFalse("default_highlight_action")
                     end,
                     callback = function()
                         G_reader_settings:saveSetting("default_highlight_action", nil)


### PR DESCRIPTION
This resolves #4480. Adds `Action on highlight` subsection in `Document>` menu, that allows for using default action when user highlights multiple words.