### PR TITLE
Fixed Wallabag plugin's parsing of wrong API url.

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -341,7 +341,7 @@ end
 -- filepath: downloads the file if provided, returns JSON otherwise
 function Wallabag:callAPI( method, apiurl, headers, body, filepath )
     local request, sink = {}, {}
-    local parsed = url.parse(apiurl)
+    local parsed = url.parse(self.server_url)
     request["url"] = self.server_url .. apiurl
     request["method"] = method
     if filepath ~= "" then


### PR DESCRIPTION
The Wallabag plugin's callAPI() method was attempting to parse the user supplied
URL for the Wallabag API. Unfortunately, the parse was silently failing since
the variable apiurl did not contain a complete URL. The scheme of the parsed
URL (always nil) was then used to select either http or https (default). The
result being https was always selected, regardless of the user supplied setting.

The parsed URL was switched to the variable server_url instead of apiurl but the
behavior resulting in the default selection of https when parsing fails was left
unchanged.