### PR TITLE
add basic support for android eink refreshes on some rockchip devices

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -13,6 +13,7 @@ local Device = Generic:new{
     hasKeys = yes,
     hasDPad = no,
     isAndroid = yes,
+    hasEinkScreen = android.isEink(),
     hasFrontlight = yes,
     firmware_rev = android.app.activity.sdkVersion,
     display_dpi = android.lib.AConfiguration_getDensity(android.app.config),

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -25,6 +25,7 @@ local Device = {
     hasFrontlight = no,
     needsTouchScreenProbe = no,
     hasClipboard = yes, -- generic internal clipboard on all devices
+    hasEinkScreen = yes,
     hasColorScreen = no,
     hasBGRFrameBuffer = no,
     canToggleGSensor = no,

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -15,6 +15,7 @@ local Device = Generic:new{
     isTouchDevice = yes,
     needsScreenRefreshAfterResume = no,
     hasColorScreen = yes,
+    hasEinkScreen = no,
 }
 
 local AppImage = Device:new{
@@ -24,6 +25,7 @@ local AppImage = Device:new{
 local Emulator = Device:new{
     model = "Emulator",
     isEmulator = yes,
+    hasEinkScreen = yes,
     hasFrontlight = yes,
 }
 

--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -25,8 +25,7 @@ local eink_settings_table = {
     },
 }
 
--- TODO reactivate if someone reverse engineers Android E Ink stuff
-if not Device:isAndroid() then
+if Device.hasEinkScreen then
     table.insert(eink_settings_table.sub_item_table, 1, require("ui/elements/refresh_menu_table"))
 end
 


### PR DESCRIPTION
Supported devices:

- Boyue T61 and *some* clones
- Boyue T62 and *some* clones
- Onyx C67
- Energy Sistem (which are in fact Boyue T62 clones). Was tested on a energy pro 4.

Others may work with the same controller too, but are disabled by default.

Requires https://github.com/koreader/koreader-base/pull/798
Requires https://github.com/koreader/android-luajit-launcher/pull/96

Fixes #4373 
Fixes #1613 (supported devices will show the "full refresh rate" option under eink settings. Others won't)

Related #4228 (need to add support for this specific device to work)
