### PR TITLE
Cleanup multiline translatable strings, adds one paragraph tweak

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -233,8 +233,8 @@ function ReaderDictionary:addToMainMenu(menu_items)
                 keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_(
-[[If you'd like to change the order in which dictionaries are queried (and their results displayed), you can:
+                        text = T(_([[
+If you'd like to change the order in which dictionaries are queried (and their results displayed), you can:
 - move all dictionary directories out of %1.
 - move them back there, one by one, in the order you want them to be used.]]), self.data_dir)
                     })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -354,8 +354,8 @@ function ReaderHighlight:onHoldPan(_, ges)
     UIManager:setDirty(self.dialog, "ui")
 end
 
-local info_message_ocr_text = _(
-[[No OCR results or no language data.
+local info_message_ocr_text = _([[
+No OCR results or no language data.
 
 KOReader has a build-in OCR engine for recognizing words in scanned PDF and DjVu documents. In order to use OCR in scanned pages, you need to install tesseract trained data for your document language.
 

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -167,7 +167,8 @@ function ReaderLink:addToMainMenu(menu_items)
                     G_reader_settings:saveSetting("swipe_to_jump_to_latest_bookmark",
                         not isSwipeToJumpToLatestBookmarkEnabled())
                 end,
-                help_text = _([[Swipe to the left to go the most recently bookmarked page.
+                help_text = _([[
+Swipe to the left to go the most recently bookmarked page.
 This can be useful to quickly swipe back and forth between what you are reading and some reference page (for example notes, a map or a characters list).
 If any of the other Swipe to follow link options is enabled, this will work only when the current page contains no link.]]),
             },
@@ -199,7 +200,8 @@ If any of the other Swipe to follow link options is enabled, this will work only
                 G_reader_settings:saveSetting("tap_ignore_external_links",
                     not isTapIgnoreExternalLinksEnabled())
             end,
-            help_text = _([[Ignore taps on external links. Useful with Wikipedia EPUBs to make page turning easier.
+            help_text = _([[
+Ignore taps on external links. Useful with Wikipedia EPUBs to make page turning easier.
 You can still follow them from the dictionary window or the selection menu after holding on them.]]),
             separator = true,
         })

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -340,8 +340,8 @@ function ReaderStyleTweak:init()
         end,
         hold_callback = function()
             UIManager:show(InfoMessage:new{
-                text = _(
-[[Style tweaks allow changing small parts of book styles (including the publisher/embedded styles) to make visual adjustments or disable unwanted publisher layout choices.
+                text = _([[
+Style tweaks allow changing small parts of book styles (including the publisher/embedded styles) to make visual adjustments or disable unwanted publisher layout choices.
 
 Some tweaks may be useful with some books, while resulting in undesirable effects with others.
 

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -248,8 +248,8 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                         home_dir = home_dir:gsub("^(.-)/*$", "%1") -- remove trailing slash
                         if home_dir and lfs.attributes(home_dir, "mode") == "directory" then
                             local wikipedia_dir = home_dir.."/Wikipedia"
-                            local text = _(
-[[Wikipedia articles can be saved as an EPUB for more comfortable reading.
+                            local text = _([[
+Wikipedia articles can be saved as an EPUB for more comfortable reading.
 
 You can select an existing directory, or use a default directory named "Wikipedia" in your reader's home directory.
 

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -193,6 +193,23 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
     {
         title = _("Paragraphs"),
         {
+            id = "paragraph_web_browser_style";
+            title = _("Generic web browser paragraph style"),
+            description = _([[
+Display paragraphs as browsers do, in full-block style without indentation or justification, discarding KOReader's book paragraph style.
+This might be needed with some documents that expect this style as the default, and only use CSS when it needs to diverge from this default.]]),
+            priority = -1,
+            css = [[
+p {
+    text-align: left;
+    text-indent: 0;
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+            ]],
+            separator = true,
+        },
+        {
             id = "paragraph_no_indent";
             title = _("No indentation on first paragraph line"),
             description = _("Do not indent the first line of paragraphs."),
@@ -325,14 +342,14 @@ width: 100% !important;
             {
                 title = _("About alternative TOC"),
                 info_text = _([[
-An alternative table of content can be built with a long-press on the "Table of content" menu item.
+An alternative table of contents can be built with a long-press on the "Table of contents" menu item.
 
 The TOC will be built from document headings <H1> to <H6>. Some of these can be ignored with the tweaks available here.
 If the document contains no headings, or all are ignored, the alternative TOC will be built from document fragments and will point to the start of each individual HTML file in the EPUB.
 
 Hints can be set to other non-heading elements in a user style tweak, so they can be used as TOC items. Since this would be quite book-specific, please see the final tweak for some examples.
 
-After applying these tweaks, the alternative TOC needs to be rebuilt by long-pressing "Table of content" twice: once to restore the original TOC, and once to build the alternative TOC again.]]),
+After applying these tweaks, the alternative TOC needs to be rebuilt by long-pressing "Table of contents" twice: once to restore the original TOC, and once to build the alternative TOC again.]]),
                 separator = true,
             },
             {

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -93,8 +93,8 @@ function optionsutil.showValuesMargins(configurable, option)
     end
     if not default then
         UIManager:show(InfoMessage:new{
-            text = T(_(
-[[%1:
+            text = T(_([[
+%1:
 Current value: %2
   left: %3
   top: %4
@@ -112,8 +112,8 @@ Default value: not set]]),
             end
         end
         UIManager:show(InfoMessage:new{
-            text = T(_(
-[[%1:
+            text = T(_([[
+%1:
 Current value: %2
   left: %3
   top: %4

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -17,8 +17,8 @@ local language = G_reader_settings:readSetting("language") or "en"
 local version = Version:getNormalizedCurrentVersion()
 local rev = Version:getCurrentRevision()
 
-local quickstart_guide = T(_(
-[[# KOReader Quickstart Guide
+local quickstart_guide = T(_([[
+# KOReader Quickstart Guide
 
 Welcome to KOReader.
 

--- a/frontend/ui/widget/hyphenationlimits.lua
+++ b/frontend/ui/widget/hyphenationlimits.lua
@@ -144,8 +144,8 @@ function HyphenationLimitsWidget:update()
         CloseButton:new{ window = self, padding_top = Size.margin.title, },
     }
 
-    local hyph_into_text = _(
-[[Set minimum length before hyphenation occurs.
+    local hyph_into_text = _([[
+Set minimum length before hyphenation occurs.
 These settings will apply to all books with any hyphenation dictionary.
 'Use language defaults' resets them.]])
     local hyph_info = FrameContainer:new{

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -675,8 +675,8 @@ function BookInfoManager:extractBooksInDirectory(path, cover_specs)
     local Trapper = require("ui/trapper")
     local Screen = require("device").screen
 
-    local go_on = Trapper:confirm(_(
-[[This will extract metadata and cover images for books in current directory.
+    local go_on = Trapper:confirm(_([[
+This will extract metadata and cover images for books in current directory.
 Once extraction has started, you can abort at any moment by tapping on the screen.
 
 Cover images will be saved with the adequate size for the current display mode.
@@ -688,16 +688,16 @@ This extraction may take time and use some battery power: you may wish to keep y
         return
     end
 
-    local recursive = Trapper:confirm(_(
-[[Do you want to extract book information for books in sub-directories too?]]
+    local recursive = Trapper:confirm(_([[
+Do you want to extract book information for books in sub-directories too?]]
     ), _("Here only"), _("Here and under"))
 
-    local refresh_existing = Trapper:confirm(_(
-[[Do you want to refresh metadata and covers that have already been extracted?]]
+    local refresh_existing = Trapper:confirm(_([[
+Do you want to refresh metadata and covers that have already been extracted?]]
     ), _("Don't refresh"), _("Refresh"))
 
-    local prune = Trapper:confirm(_(
-[[If you have removed many books, or have renamed some directories, it is good to remove them from the cache database.
+    local prune = Trapper:confirm(_([[
+If you have removed many books, or have renamed some directories, it is good to remove them from the cache database.
 
 Do you want to prune cache of removed books?]]
     ), _("Don't prune"), _("Prune"))

--- a/plugins/goodreads.koplugin/main.lua
+++ b/plugins/goodreads.koplugin/main.lua
@@ -83,8 +83,8 @@ function Goodreads:updateSettings()
     local text_top
     local hint_bottom
     local text_bottom
-    local text_info = _(
-[[How to generate a key and a secret key:
+    local text_info = _([[
+How to generate a key and a secret key:
 
 1. Go to https://www.goodreads.com/user/sign_up and create an account
 2. Register for a development key on the following page: https://www.goodreads.com/user/sign_in?rd=true

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -218,8 +218,8 @@ function ReaderStatistics:checkInitDatabase()
     if self.convert_to_db then      -- if conversion to sqlite was doing earlier
         if not conn:exec("pragma table_info('book');") then
             UIManager:show(ConfirmBox:new{
-                text = T(_(
-[[Cannot open database in %1.
+                text = T(_([[
+Cannot open database in %1.
 The database may have been moved or deleted.
 Do you want to create an empty database?
 ]]),
@@ -243,8 +243,8 @@ Do you want to create an empty database?
         if not conn:exec("pragma table_info('book');") then
             if #ReadHistory.hist > 0 then
                 local info = InfoMessage:new{
-                    text =_(
-[[New version of statistics plugin detected.
+                    text =_([[
+New version of statistics plugin detected.
 Statistics data needs to be converted into the new database format.
 This may take a few minutes.
 Please wait…

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -481,8 +481,8 @@ function TextEditor:editFile(file_path, readonly)
                         return false, T(_("Failed saving file: %1"), err)
                     end
                 end
-                local save_anyway = Trapper:confirm(T(_(
-[[Lua syntax check failed:
+                local save_anyway = Trapper:confirm(T(_([[
+Lua syntax check failed:
 
 %1
 
@@ -502,8 +502,8 @@ Do you really want to save to this file?
                     return false, false -- no need for more InfoMessage
                 end
             else -- If content is empty, propose to delete the file
-                local delete_file = Trapper:confirm(T(_(
-[[Text content is empty.
+                local delete_file = Trapper:confirm(T(_([[
+Text content is empty.
 Do you want to keep this file as empty, or do you prefer to delete it?
 
 %1]]), file_path), _("Keep empty file"), _("Delete file"))

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -603,8 +603,8 @@ function Wallabag:setFilterTag(touchmenu_instance)
 end
 
 function Wallabag:editServerSettings()
-    local text_info = T(_(
-[[Enter the details of your Wallabag server and account.
+    local text_info = T(_([[
+Enter the details of your Wallabag server and account.
 
 Client ID and client secret are long strings so you might prefer to save the empty settings and edit the config file directly in your installation directory:
 %1/wallabag.lua


### PR DESCRIPTION
Thanks to https://github.com/koreader/koreader-misc/pull/24, revert #4132

Adds "Generic web browser paragraph style" style tweak:

<kbd><img src="https://user-images.githubusercontent.com/24273478/51846050-209faa00-2319-11e9-84be-4cb5ad4c301f.png" width=400></kbd>
