### PR TITLE
[chore, CI] Ensure no whitespace between gettext() call and string

### DIFF
--- a/.ci/check.sh
+++ b/.ci/check.sh
@@ -28,7 +28,7 @@ if [ "${tab_detected}" ]; then
     exit 1
 fi
 
-newline_split=$(grep -Pzo "(_|gettext)\(\\n(\s)?\[\[" --include \*.lua --exclude={dateparser.lua,xml.lua} --recursive {reader,setupkoenv,datastorage}.lua frontend plugins spec || true)
+newline_split=$(grep -Pzo "(_|gettext)\((\n|\s)('|\"|\[\[)" --include \*.lua --exclude={dateparser.lua,xml.lua} --recursive {reader,setupkoenv,datastorage}.lua frontend plugins spec || true)
 if [ "${newline_split}" ]; then
     echo -e "\\n${ANSI_RED}Warning: whitespace detected between gettext() call and string."
     echo "${newline_split}"

--- a/.ci/check.sh
+++ b/.ci/check.sh
@@ -23,8 +23,15 @@ fi
 
 tab_detected=$(grep -P "\\t" --include \*.lua --exclude={dateparser.lua,xml.lua} --recursive {reader,setupkoenv,datastorage}.lua frontend plugins spec || true)
 if [ "${tab_detected}" ]; then
-    echo -e "\\n${ANSI_RED}Error TAB character detected"
+    echo -e "\\n${ANSI_RED}Warning: tab character detected. Please use spaces."
     echo "${tab_detected}"
+    exit 1
+fi
+
+newline_split=$(grep -Pzo "(_|gettext)\(\\n(\s)?\[\[" --include \*.lua --exclude={dateparser.lua,xml.lua} --recursive {reader,setupkoenv,datastorage}.lua frontend plugins spec || true)
+if [ "${newline_split}" ]; then
+    echo -e "\\n${ANSI_RED}Warning: whitespace detected between gettext() call and string."
+    echo "${newline_split}"
     exit 1
 fi
 

--- a/.ci/check.sh
+++ b/.ci/check.sh
@@ -28,7 +28,7 @@ if [ "${tab_detected}" ]; then
     exit 1
 fi
 
-newline_split=$(grep -Pzo "(_|gettext)\((\n|\s)('|\"|\[\[)" --include \*.lua --exclude={dateparser.lua,xml.lua} --recursive {reader,setupkoenv,datastorage}.lua frontend plugins spec || true)
+newline_split=$(grep -Pzo "(_|gettext)\((\n|\s)+('|\"|\[\[)" --include \*.lua --exclude={dateparser.lua,xml.lua} --recursive {reader,setupkoenv,datastorage}.lua frontend plugins spec || true)
 if [ "${newline_split}" ]; then
     echo -e "\\n${ANSI_RED}Warning: whitespace detected between gettext() call and string."
     echo "${newline_split}"


### PR DESCRIPTION
Follow-up to https://github.com/koreader/koreader/pull/4524

The regex in the Python wasn't actually picking up on that style of writing it at all, because it's not only ugly, but also so counter-intuitive that I overlooked to test for and add support for it.

```
_(
[[
```

It'd be easy to fix up the Python regex a little, and perhaps I will,
but either way it makes more sense to automatically enforce this as a coding standard.