### PR TITLE
Page overlap menu (cre): set nb of overlap lines

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -100,8 +100,9 @@ function ReaderHighlight:genHighlightDrawerMenu()
     end
     return {
         {
-            text_func = function()
-                return self.view.highlight.disabled and _("Enable") or _("Disable")
+            text = _("Allow highlighting"),
+            checked_func = function()
+                return not self.view.highlight.disabled
             end,
             callback = function()
                 self.view.highlight.disabled = not self.view.highlight.disabled
@@ -109,6 +110,7 @@ function ReaderHighlight:genHighlightDrawerMenu()
             hold_callback = function(touchmenu_instance)
                 self:makeDefault(not self.view.highlight.disabled)
             end,
+            separator = true,
         },
         get_highlight_style("lighten"),
         get_highlight_style("underscore"),

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -187,18 +187,21 @@ function ReaderPaging:addToMainMenu(menu_items)
     -- The difference between the two menus is only the enabled func.
     local page_overlap_menu = {
         {
-            text_func = function()
-                return self.show_overlap_enable and _("Disable") or _("Enable")
+            text = _("Page overlap"),
+            checked_func = function()
+                return self.show_overlap_enable
             end,
             callback = function()
                 self.show_overlap_enable = not self.show_overlap_enable
                 if not self.show_overlap_enable then
                     self.view:resetDimArea()
                 end
-            end
+            end,
+            separator = true,
         },
     }
-    for _, menu_entry in ipairs(self.view:genOverlapStyleMenu()) do
+    local overlap_enabled_func = function() return self.show_overlap_enable end
+    for _, menu_entry in ipairs(self.view:genOverlapStyleMenu(overlap_enabled_func)) do
         table.insert(page_overlap_menu, menu_entry)
     end
     menu_items.page_overlap = {

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -841,11 +841,12 @@ local page_overlap_styles = {
     dim = _("Gray out"),
 }
 
-function ReaderView:genOverlapStyleMenu()
+function ReaderView:genOverlapStyleMenu(overlap_enabled_func)
     local view = self
     local get_overlap_style = function(style)
         return {
             text = page_overlap_styles[style],
+            enabled_func = overlap_enabled_func,
             checked_func = function()
                 return view.page_overlap_style == style
             end,


### PR DESCRIPTION
Make the existing setting (introduced in #3870) tunable with a menu item.
Also make the Page overlap and Highlight menus (with pdf or cre) items grayed out when disabled, and use a checkbox instead of the strange Enable/Disable.

<kbd>![image](https://user-images.githubusercontent.com/24273478/52126934-f3ad0900-2630-11e9-9368-acefe064985a.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/52126957-032c5200-2631-11e9-976b-b1089cbb5cb5.png)</kbd>
