### PR TITLE
bump crengine: count nb of images drawn & others

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -323,7 +323,7 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
     -- change has been made, to avoid having crengine redraw the exact
     -- same buffer.
     -- And it could only change when some other methods from here are called
-    self._document:drawCurrentPage(self.buffer, self.render_color)
+    self._drawn_images_count, self._drawn_images_surface_ratio = self._document:drawCurrentPage(self.buffer, self.render_color)
     target:blitFrom(self.buffer, x, y, 0, 0, rect.w, rect.h)
 end
 

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -402,6 +402,11 @@ function Document:drawPage(target, x, y, rect, pageno, zoom, rotation, gamma, re
         rect.w, rect.h)
 end
 
+function Document:getDrawnImagesStatistics()
+    -- For now, only set by CreDocument in CreDocument:drawCurrentView()
+    return self._drawn_images_count, self._drawn_images_surface_ratio
+end
+
 function Document:getPageText(pageno)
     -- is this worth caching? not done yet.
     local page = self._document:openPage(pageno)


### PR DESCRIPTION
Includes:
- Update french hyphenation pattern https://github.com/koreader/crengine/pull/255
- epub.css: update style for 'blockquote' https://github.com/koreader/crengine/pull/256
- DrawBuf: count nb of images and surface drawn https://github.com/koreader/crengine/pull/256
- base/cre.cpp drawCurrentPage(): returns nb of images and % of buffer surface used when drawing images https://github.com/koreader/koreader-base/pull/802

Adds Document:getDrawnImagesStatistics() to help deciding if refresh with (possibly costly) dithering should be used (on devices with HW dithering capabilities) with CreDocument: when a page contains enough images to benefit from it. See https://github.com/koreader/koreader/pull/4541 , https://github.com/koreader/koreader/pull/4541#issuecomment-459947281.