### PR TITLE
cre: allow text selection/highlighting across pages

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -289,16 +289,7 @@ end
 --- Check if a xpointer to <a> node really points to itself
 function ReaderLink:isXpointerCoherent(a_xpointer)
     -- Get screen coordinates of xpointer
-    local doc_margins = self.ui.document:getPageMargins()
-    local header_height = self.ui.document:getHeaderHeight() -- top full status bar (0 when bottom mini bar used)
-    local doc_y, doc_x = self.ui.document:getPosFromXPointer(a_xpointer)
-    local top_y = self.ui.document:getCurrentPos()
-    -- (strange, but using doc_margins.top is accurate even in scroll mode)
-    local screen_y = doc_y - top_y
-    if self.view.view_mode == "page" then
-        screen_y = screen_y + doc_margins["top"] + header_height
-    end
-    local screen_x = doc_x + doc_margins["left"]
+    local screen_y, screen_x = self.ui.document:getScreenPositionFromXPointer(a_xpointer)
     -- Get again link and a_xpointer from this position
     local re_link_xpointer, re_a_xpointer = self.ui.document:getLinkFromPosition({x = screen_x, y = screen_y}) -- luacheck: no unused
     -- We should get the same a_xpointer. If not, crengine has messed up

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -475,14 +475,8 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
     if marker_xp and marker_setting then
         -- Show a mark on left side of screen to give a visual feedback of
         -- where xpointer target is (and remove if after 1s)
-        local doc_y = self.ui.document:getPosFromXPointer(marker_xp)
-        local top_y = self.ui.document:getCurrentPos()
-        local screen_y = doc_y - top_y
+        local screen_y = self.ui.document:getScreenPositionFromXPointer(marker_xp)
         local doc_margins = self.ui.document:getPageMargins()
-        local header_height = self.ui.document:getHeaderHeight() -- top full status bar (0 when bottom mini bar used)
-        if self.view.view_mode == "page" then
-            screen_y = screen_y + doc_margins["top"] + header_height
-        end
         local marker_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0)
         -- Make it 4/5 of left margin wide (and bigger when huge margin)
         local marker_w = math.floor(math.max(doc_margins["left"] - Screen:scaleBySize(5), doc_margins["left"] * 4/5))


### PR DESCRIPTION
Follow up on an initial idea and experimentations by @Galunid in https://github.com/koreader/koreader/issues/4496#issuecomment-455821393)

Panning to the bottom right corner (or top left corner) switches to scroll mode and scroll the page forward (resp. backward) 1/3rd of the screen.
One has to pan out of the corner to continue selection.
Panning again to that corner scrolls another 1/3rd of screen.
Page mode and initial page are restored when highlighting or dismissing the highlight dialog, and a little marker is shown at where selection was started so one does not get lost after all that scrolling and restoring.

Closes #4496. Closes #1575. Closes #2071. Related #4533.