### PR TITLE
A few graphics fixes after #4541

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -40,35 +40,47 @@ local ReaderPaging = InputContainer:new{
 }
 
 function ReaderPaging:init()
-    if Device:hasKeyboard() or Device:hasKeys() then
-        self.key_events = {
-            GotoNextPage = {
-                {Input.group.PgFwd}, doc = "go to next page",
-                event = "PagingRel", args = 1 },
-            GotoPrevPage = {
-                {Input.group.PgBack}, doc = "go to previous page",
-                event = "PagingRel", args = -1 },
-
-            GotoFirst = {
-                {"1"}, doc = "go to start", event = "GotoPercent", args = 0},
-            Goto11 = {
-                {"2"}, doc = "go to 11%", event = "GotoPercent", args = 11},
-            Goto22 = {
-                {"3"}, doc = "go to 22%", event = "GotoPercent", args = 22},
-            Goto33 = {
-                {"4"}, doc = "go to 33%", event = "GotoPercent", args = 33},
-            Goto44 = {
-                {"5"}, doc = "go to 44%", event = "GotoPercent", args = 44},
-            Goto55 = {
-                {"6"}, doc = "go to 55%", event = "GotoPercent", args = 55},
-            Goto66 = {
-                {"7"}, doc = "go to 66%", event = "GotoPercent", args = 66},
-            Goto77 = {
-                {"8"}, doc = "go to 77%", event = "GotoPercent", args = 77},
-            Goto88 = {
-                {"9"}, doc = "go to 88%", event = "GotoPercent", args = 88},
-            GotoLast = {
-                {"0"}, doc = "go to end", event = "GotoPercent", args = 100},
+    self.key_events = {}
+    if Device:hasKeys() then
+        self.key_events.GotoNextPage = {
+            {Input.group.PgFwd}, doc = "go to next page",
+            event = "PagingRel", args = 1,
+        }
+        self.key_events.GotoPrevPage = {
+            {Input.group.PgBack}, doc = "go to previous page",
+            event = "PagingRel", args = -1,
+        }
+    end
+    if Device:hasKeyboard() then
+        self.key_events.GotoFirst = {
+            {"1"}, doc = "go to start", event = "GotoPercent", args = 0,
+        }
+        self.key_events.Goto11 = {
+            {"2"}, doc = "go to 11%", event = "GotoPercent", args = 11,
+        }
+        self.key_events.Goto22 = {
+            {"3"}, doc = "go to 22%", event = "GotoPercent", args = 22,
+        }
+        self.key_events.Goto33 = {
+            {"4"}, doc = "go to 33%", event = "GotoPercent", args = 33,
+        }
+        self.key_events.Goto44 = {
+            {"5"}, doc = "go to 44%", event = "GotoPercent", args = 44,
+        }
+        self.key_events.Goto55 = {
+            {"6"}, doc = "go to 55%", event = "GotoPercent", args = 55,
+        }
+        self.key_events.Goto66 = {
+            {"7"}, doc = "go to 66%", event = "GotoPercent", args = 66,
+        }
+        self.key_events.Goto77 = {
+            {"8"}, doc = "go to 77%", event = "GotoPercent", args = 77,
+        }
+        self.key_events.Goto88 = {
+            {"9"}, doc = "go to 88%", event = "GotoPercent", args = 88,
+        }
+        self.key_events.GotoLast = {
+            {"0"}, doc = "go to end", event = "GotoPercent", args = 100,
         }
     end
     self.number_of_pages = self.ui.document.info.number_of_pages

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -47,48 +47,61 @@ local ReaderRolling = InputContainer:new{
 }
 
 function ReaderRolling:init()
-    if Device:hasKeyboard() or Device:hasKeys() then
-        self.key_events = {
-            GotoNextView = {
-                { Input.group.PgFwd },
-                doc = "go to next view",
-                event = "GotoViewRel", args = 1
-            },
-            GotoPrevView = {
-                { Input.group.PgBack },
-                doc = "go to previous view",
-                event = "GotoViewRel", args = -1
-            },
-            MoveUp = {
-                { "Up" },
-                doc = "move view up",
-                event = "Panning", args = {0, -1}
-            },
-            MoveDown = {
-                { "Down" },
-                doc = "move view down",
-                event = "Panning", args = {0,  1}
-            },
-            GotoFirst = {
-                {"1"}, doc = "go to start", event = "GotoPercent", args = 0},
-            Goto11 = {
-                {"2"}, doc = "go to 11%", event = "GotoPercent", args = 11},
-            Goto22 = {
-                {"3"}, doc = "go to 22%", event = "GotoPercent", args = 22},
-            Goto33 = {
-                {"4"}, doc = "go to 33%", event = "GotoPercent", args = 33},
-            Goto44 = {
-                {"5"}, doc = "go to 44%", event = "GotoPercent", args = 44},
-            Goto55 = {
-                {"6"}, doc = "go to 55%", event = "GotoPercent", args = 55},
-            Goto66 = {
-                {"7"}, doc = "go to 66%", event = "GotoPercent", args = 66},
-            Goto77 = {
-                {"8"}, doc = "go to 77%", event = "GotoPercent", args = 77},
-            Goto88 = {
-                {"9"}, doc = "go to 88%", event = "GotoPercent", args = 88},
-            GotoLast = {
-                {"0"}, doc = "go to end", event = "GotoPercent", args = 100},
+    self.key_events = {}
+    if Device:hasKeys() then
+        self.key_events.GotoNextView = {
+            { Input.group.PgFwd },
+            doc = "go to next view",
+            event = "GotoViewRel", args = 1,
+        }
+        self.key_events.GotoPrevView = {
+            { Input.group.PgBack },
+            doc = "go to previous view",
+            event = "GotoViewRel", args = -1,
+        }
+    end
+    if Device:hasDPad() then
+        self.key_events.MoveUp = {
+            { "Up" },
+            doc = "move view up",
+            event = "Panning", args = {0, -1},
+        }
+        self.key_events.MoveDown = {
+            { "Down" },
+            doc = "move view down",
+            event = "Panning", args = {0,  1},
+        }
+    end
+    if Device:hasKeyboard() then
+        self.key_events.GotoFirst = {
+            {"1"}, doc = "go to start", event = "GotoPercent", args = 0,
+        }
+        self.key_events.Goto11 = {
+            {"2"}, doc = "go to 11%", event = "GotoPercent", args = 11,
+        }
+        self.key_events.Goto22 = {
+            {"3"}, doc = "go to 22%", event = "GotoPercent", args = 22,
+        }
+        self.key_events.Goto33 = {
+            {"4"}, doc = "go to 33%", event = "GotoPercent", args = 33,
+        }
+        self.key_events.Goto44 = {
+            {"5"}, doc = "go to 44%", event = "GotoPercent", args = 44,
+        }
+        self.key_events.Goto55 = {
+            {"6"}, doc = "go to 55%", event = "GotoPercent", args = 55,
+        }
+        self.key_events.Goto66 = {
+            {"7"}, doc = "go to 66%", event = "GotoPercent", args = 66,
+        }
+        self.key_events.Goto77 = {
+            {"8"}, doc = "go to 77%", event = "GotoPercent", args = 77,
+        }
+        self.key_events.Goto88 = {
+            {"9"}, doc = "go to 88%", event = "GotoPercent", args = 88,
+        }
+        self.key_events.GotoLast = {
+            {"0"}, doc = "go to end", event = "GotoPercent", args = 100,
         }
     end
 

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -198,6 +198,7 @@ function Button:onTapSelectButton()
             UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
             -- NOTE: This completely insane double repaint is needed to avoid cosmetic issues with FrameContainer's rounded corners on Text buttons...
             --       On the upside, we now actually get to *see* those rounded corners (as the highlight), where it was a simple square before.
+            -- NOTE: Yes, self[1] -> self.frame !
             if self.text then
                 self.frame.invert = true
                 UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -198,10 +198,9 @@ function Button:onTapSelectButton()
             UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
             -- NOTE: This completely insane double repaint is needed to avoid cosmetic issues with FrameContainer's rounded corners on Text buttons...
             --       On the upside, we now actually get to *see* those rounded corners (as the highlight), where it was a simple square before.
-            -- NOTE: Yes, self[1] -> self.frame !
+            -- NOTE: self[1] -> self.frame, if you're confused about what this does vs. onFocus/onUnfocus ;).
             if self.text then
-                self.frame.invert = true
-                UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
+                UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
             end
             UIManager:setDirty(nil, function()
                 return "fast", self[1].dimen
@@ -212,8 +211,7 @@ function Button:onTapSelectButton()
                 self[1].invert = false
                 UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
                 if self.text then
-                    self.frame.invert = false
-                    UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
+                    UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
                 end
                 UIManager:setDirty(nil, function()
                     return "fast", self[1].dimen

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -194,8 +194,10 @@ function Button:onTapSelectButton()
             self.callback()
         else
             self[1].invert = true
+            self.frame.invert = true
             -- For most of our buttons, we can't avoid that initial repaint...
             UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
+            UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
             UIManager:setDirty(nil, function()
                 return "fast", self[1].dimen
             end)
@@ -203,7 +205,9 @@ function Button:onTapSelectButton()
             UIManager:tickAfterNext(function()
                 self.callback()
                 self[1].invert = false
+                self.frame.invert = false
                 UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
+                UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
                 UIManager:setDirty(nil, function()
                     return "fast", self[1].dimen
                 end)

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -198,7 +198,7 @@ function Button:onTapSelectButton()
             UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
             -- NOTE: This completely insane double repaint is needed to avoid cosmetic issues with FrameContainer's rounded corners on Text buttons...
             --       On the upside, we now actually get to *see* those rounded corners (as the highlight), where it was a simple square before.
-            --       c.f., #4554 & #4551
+            --       c.f., #4554 & #4541
             -- NOTE: self[1] -> self.frame, if you're confused about what this does vs. onFocus/onUnfocus ;).
             if self.text then
                 UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -193,10 +193,11 @@ function Button:onTapSelectButton()
         if G_reader_settings:isFalse("flash_ui") then
             self.callback()
         else
-            self[1].invert = true
-            self.frame.invert = true
             -- For most of our buttons, we can't avoid that initial repaint...
+            self[1].invert = true
             UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
+            -- NOTE: This completely insane double repaint is needed to avoid cosmetic issues with FrameContainer's rounded corners on Text buttons...
+            self.frame.invert = true
             UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
             UIManager:setDirty(nil, function()
                 return "fast", self[1].dimen
@@ -205,8 +206,8 @@ function Button:onTapSelectButton()
             UIManager:tickAfterNext(function()
                 self.callback()
                 self[1].invert = false
-                self.frame.invert = false
                 UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
+                self.frame.invert = false
                 UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
                 UIManager:setDirty(nil, function()
                     return "fast", self[1].dimen

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -198,6 +198,7 @@ function Button:onTapSelectButton()
             UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
             -- NOTE: This completely insane double repaint is needed to avoid cosmetic issues with FrameContainer's rounded corners on Text buttons...
             --       On the upside, we now actually get to *see* those rounded corners (as the highlight), where it was a simple square before.
+            --       c.f., #4554 & #4551
             -- NOTE: self[1] -> self.frame, if you're confused about what this does vs. onFocus/onUnfocus ;).
             if self.text then
                 UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -197,8 +197,11 @@ function Button:onTapSelectButton()
             self[1].invert = true
             UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
             -- NOTE: This completely insane double repaint is needed to avoid cosmetic issues with FrameContainer's rounded corners on Text buttons...
-            self.frame.invert = true
-            UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
+            --       On the upside, we now actually get to *see* those rounded corners (as the highlight), where it was a simple square before.
+            if self.text then
+                self.frame.invert = true
+                UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
+            end
             UIManager:setDirty(nil, function()
                 return "fast", self[1].dimen
             end)
@@ -207,8 +210,10 @@ function Button:onTapSelectButton()
                 self.callback()
                 self[1].invert = false
                 UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
-                self.frame.invert = false
-                UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
+                if self.text then
+                    self.frame.invert = false
+                    UIManager:widgetRepaint(self.frame, self.frame.dimen.x, self.frame.dimen.y)
+                end
                 UIManager:setDirty(nil, function()
                     return "fast", self[1].dimen
                 end)

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -89,7 +89,7 @@ function ButtonTable:init()
         end
     end -- end for each button line
     self:addHorizontalSep(true, false, false)
-    if Device:hasKeys() then
+    if Device:hasDPad() then
         self.layout = self.buttons_layout
         self.layout[1][1]:onFocus()
         self.key_events.SelectByKeyPress = { {{"Press"}} }

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -772,7 +772,7 @@ function ConfigDialog:update()
             self.config_menubar,
         },
     }
-    --reset the focusmanager cursor
+    -- Reset the focusmanager cursor
     self.selected.y=#self.layout
     self.selected.x=self.panel_index
 
@@ -896,7 +896,7 @@ end
 
 function ConfigDialog:onSelect()
     self:getFocusItem():handleEvent(Event:new("TapSelect"))
-   return true
+    return true
 end
 
 return ConfigDialog

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -747,6 +747,8 @@ function ConfigDialog:init()
     if Device:hasKeys() then
         -- set up keyboard events
         self.key_events.Close = { {"Back"}, doc = "close config menu" }
+    end
+    if Device:hasDPad() then
         self.key_events.Select = { {"Press"}, doc = "select current menu item" }
     end
 end

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -34,7 +34,7 @@ function FocusManager:init()
     if not self.selected then
         self.selected = { x = 1, y = 1 }
     end
-    if Device:hasKeys() then
+    if Device:hasDPad() then
         self.key_events = {
             -- these will all generate the same event, just with different arguments
             FocusUp =    { {"Up"},    doc = "move focus up",    event = "FocusMove", args = {0, -1} },

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -34,6 +34,7 @@ function FocusManager:init()
     if not self.selected then
         self.selected = { x = 1, y = 1 }
     end
+
     if Device:hasDPad() then
         self.key_events = {
             -- these will all generate the same event, just with different arguments
@@ -84,7 +85,7 @@ function FocusManager:onFocusMove(args)
             self.layout[self.selected.y][self.selected.x]:handleEvent(Event:new("Focus"))
             -- trigger a fast repaint, this does not count toward a flashing eink resfresh
             -- TODO: is this really needed?
-            UIManager:setDirty(self.show_parent or self, "fast")
+            --UIManager:setDirty(self.show_parent or self, "fast")
             break
         end
     end

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -83,9 +83,10 @@ function FocusManager:onFocusMove(args)
             -- we found a different object to focus
             current_item:handleEvent(Event:new("Unfocus"))
             self.layout[self.selected.y][self.selected.x]:handleEvent(Event:new("Focus"))
-            -- trigger a fast repaint, this does not count toward a flashing eink resfresh
-            -- TODO: is this really needed?
-            --UIManager:setDirty(self.show_parent or self, "fast")
+            -- Trigger a fast repaint, this does not count toward a flashing eink refresh
+            -- NOTE: Ideally, we'd only have to repaint the specific subwidget we're highlighting,
+            --       but we may not know its exact coordinates, so, redraw the parent widget instead.
+            UIManager:setDirty(self.show_parent or self, "fast")
             break
         end
     end

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -373,7 +373,7 @@ function InputDialog:init()
     if self.allow_newline then -- remove any enter_callback
         self._input_widget.enter_callback = nil
     end
-    if Device:hasKeys() then
+    if Device:hasDPad() then
         --little hack to piggyback on the layout of the button_table to handle the new InputText
         table.insert(self.button_table.layout, 1, {self._input_widget})
     end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -150,20 +150,20 @@ if Device.isTouchDevice() or Device.hasDPad() then
         end
 
     end
-    if Device.hasKeys() then
+    if Device.hasDPad() then
         if not InputText.initEventListener then
             function InputText:initEventListener() end
         end
 
         function InputText:onFocus()
-            --Event called by the focusmanager
+            -- Event called by the focusmanager
             self.key_events.ShowKeyboard = { {"Press"}, doc = "show keyboard" }
             self:focus()
             return true
         end
 
         function InputText:onUnfocus()
-            --Event called by the focusmanager
+            -- Event called by the focusmanager
             self.key_events = {}
             self:unfocus()
             return true

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -813,6 +813,9 @@ function Menu:init()
         self.key_events.PrevPage = {
             {Input.group.PgBack}, doc = "goto previous page of the menu"
         }
+    end
+
+    if Device:hasDPad() then
         -- we won't catch presses to "Right", leave that to MenuItem.
         self.key_events.FocusRight = nil
         -- shortcut icon is not needed for touch device
@@ -826,7 +829,6 @@ function Menu:init()
             {"Right"}, doc = "hold  menu item"
         }
     end
-
 
     if #self.item_table > 0 then
         -- if the table is not yet initialized, this call
@@ -868,7 +870,7 @@ end
 
 function Menu:updatePageInfo(select_number)
     if self.item_group[1] then
-        if Device:hasKeys() then
+        if Device:hasDPad() then
             -- reset focus manager accordingly
             self.selected = { x = 1, y = select_number }
         end

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -51,8 +51,8 @@ function MultiInputDialog:init()
             padding = field.padding or nil,
             margin = field.margin or nil,
         }
-        if Device:hasKeys() then
-            --little hack to piggyback on the layout of the button_table to handle the new InputText
+        if Device:hasDPad() then
+            -- little hack to piggyback on the layout of the button_table to handle the new InputText
             table.insert(self.button_table.layout, #self.button_table.layout, {input_field[k]})
         end
         if field.description then
@@ -83,8 +83,8 @@ function MultiInputDialog:init()
         })
     end
 
-    if Device:hasKeys() then
-        --remove the not needed hack in inputdialog
+    if Device:hasDPad() then
+        -- remove the not needed hack in inputdialog
         table.remove(self.button_table.layout, 1)
     end
     -- Add same vertical space after than before InputText

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -74,7 +74,7 @@ function ScrollHtmlWidget:init()
         }
     end
 
-    if Device:hasKeyboard() or Device:hasKeys() then
+    if Device:hasKeys() then
         self.key_events = {
             ScrollDown = {{Input.group.PgFwd}, doc = "scroll down"},
             ScrollUp = {{Input.group.PgBack}, doc = "scroll up"},

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -97,7 +97,7 @@ function ScrollTextWidget:init()
             }
         end
     end
-    if Device:hasKeyboard() or Device:hasKeys() then
+    if Device:hasKeys() then
         self.key_events = {
             ScrollDown = {{Input.group.PgFwd}, doc = "scroll down"},
             ScrollUp = {{Input.group.PgBack}, doc = "scroll up"},

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -232,8 +232,10 @@ function VirtualKeyboard:init()
     self.umlautmode_keys = keyboard.umlautmode_keys
     self.height = Screen:scaleBySize(64 * #self.KEYS)
     self:initLayout(self.keyboard_layout)
-    if Device:hasKeys() then
+    if Device:hasDPad() then
         self.key_events.PressKey = { {"Press"}, doc = "select key" }
+    end
+    if Device:hasKeys() then
         self.key_events.Close = { {"Back"}, doc = "close keyboard" }
     end
 end


### PR DESCRIPTION
* Various FocusManager related tweaks to limit its usage to devices with a DPad, and prevent initial button highlights in Dialogs on devices where it makes no sense (i.e., those without a DPad. And even on DPad devices, I'm not even sure how we'd go about making one of those pop up anyway, because no Touch ;)!).
* One mysterious fix to text-only Buttons so that the flash_ui highlight always works, and always honors `FrameContainer`'s pill shape. (Before that, an unhighlight on a text button with a callback that didn't repaint anything [say, the find first/find last buttons in the Reader's search bar when you're already on the first/last match] would do a square black highlight, and a white pill-shaped unhighlight (leaving the black corners visible)).
The workaround makes *absolutely* no sense to me (as `self[1] -> self.frame`, AFAICT), but it works, and ensures all highlights/unhighlights are pill-shaped, so at least we're not doing maths for rounded corners for nothing ;).