### PR TITLE
[fix, Android] hasEinkScreen function in eink_opt_menu_table

### DIFF
--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -25,7 +25,7 @@ local eink_settings_table = {
     },
 }
 
-if Device.hasEinkScreen then
+if Device:hasEinkScreen() then
     table.insert(eink_settings_table.sub_item_table, 1, require("ui/elements/refresh_menu_table"))
 end
 


### PR DESCRIPTION
Follow-up to #4557. Ten-second fixes are never a good idea.
This hides the E Ink settings menu properly again.