### PR TITLE
A few minor fixes after #4541

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -218,7 +218,7 @@ function ReaderView:paintTo(bb, x, y)
     self.dialog.dithered = nil
     -- For KOpt, let the user choose.
     if self.ui.document.info.has_pages then
-        if self.document.configurable.hw_dithering == 1 then
+        if self.ui.document.is_pic or self.document.configurable.hw_dithering == 1 then
             self.dialog.dithered = true
         end
     else

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -218,6 +218,7 @@ function ReaderView:paintTo(bb, x, y)
     self.dialog.dithered = nil
     -- For KOpt, let the user choose.
     if self.ui.document.info.has_pages then
+        -- Also enforce dithering in PicDocument
         if self.ui.document.is_pic or self.document.configurable.hw_dithering == 1 then
             self.dialog.dithered = true
         end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -206,7 +206,7 @@ local KoboNova = Kobo:new{
 -- NOTE: For the FL, assume brightness is WO, and actual_brightness is RO!
 --       i.e., we could have a real KoboPowerD:frontlightIntensityHW() by reading actual_brightness ;).
 -- NOTE: Rotation events *may* not be enabled if Nickel has never been brought up in that power cycle.
---       Not sure, as I don't use KSM.
+--       i.e., this will affect KSM users.
 --       c.f., https://github.com/koreader/koreader/pull/4414#issuecomment-449652335
 --       There's also a CM_ROTARY_ENABLE command, but which seems to do as much nothing as the STATUS one...
 local KoboFrost = Kobo:new{

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -205,6 +205,10 @@ local KoboNova = Kobo:new{
 --       no matter the rotation we were started from (c.f., platform/kobo/koreader.sh).
 -- NOTE: For the FL, assume brightness is WO, and actual_brightness is RO!
 --       i.e., we could have a real KoboPowerD:frontlightIntensityHW() by reading actual_brightness ;).
+-- NOTE: Rotation events *may* not be enabled if Nickel has never been brought up in that power cycle.
+--       Not sure, as I don't use KSM.
+--       c.f., https://github.com/koreader/koreader/pull/4414#issuecomment-449652335
+--       There's also a CM_ROTARY_ENABLE command, but which seems to do as much nothing as the STATUS one...
 local KoboFrost = Kobo:new{
     model = "Kobo_frost",
     hasFrontlight = yes,

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -53,7 +53,7 @@ function ScreenSaverWidget:update()
     self[1] = self.main_frame
     UIManager:setDirty(self, function()
         local update_region = self.main_frame.dimen
-        return "partial", update_region
+        return "full", update_region
     end)
 end
 
@@ -83,7 +83,7 @@ end
 
 function ScreenSaverWidget:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "partial", self.main_frame.dimen
+        return "full", self.main_frame.dimen
     end)
     return true
 end


### PR DESCRIPTION
* Enforce Dithering in PicDocument
* Flash when closing ScreenSaver
* Mention that Forma rotation events won't work when launched via KSM, because apparently Nickel requests them somehow during boot.

Thanks to @ptrm for quickly noticing all those in #4541 ;).