### PR TITLE
Some Wi-Fi tweaks

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -154,7 +154,7 @@ function Device:onPowerEvent(ev)
                 local UIManager = require("ui/uimanager")
                 UIManager:unschedule(self.suspend)
                 local network_manager = require("ui/network/manager")
-                if network_manager.wifi_was_on and G_reader_settings:nilOrTrue("auto_restore_wifi") then
+                if network_manager.wifi_was_on and G_reader_settings:isTrue("auto_restore_wifi") then
                     network_manager:restoreWifiAsync()
                 end
                 self:resume()

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -24,7 +24,7 @@ function NetworkMgr:init()
     end
 
     self.wifi_was_on = G_reader_settings:isTrue("wifi_was_on")
-    if self.wifi_was_on and G_reader_settings:nilOrTrue("auto_restore_wifi") then
+    if self.wifi_was_on and G_reader_settings:isTrue("auto_restore_wifi") then
         self:restoreWifiAsync()
     end
 end
@@ -194,9 +194,9 @@ end
 function NetworkMgr:getRestoreMenuTable()
     return {
         text = _("Automatically restore Wi-Fi connection after resume"),
-        checked_func = function() return G_reader_settings:nilOrTrue("auto_restore_wifi") end,
+        checked_func = function() return G_reader_settings:isTrue("auto_restore_wifi") end,
         enabled_func = function() return Device:isKobo() or Device:isCervantes() end,
-        callback = function() G_reader_settings:flipNilOrTrue("auto_restore_wifi") end,
+        callback = function() G_reader_settings:flipNilOrFalse("auto_restore_wifi") end,
     }
 end
 

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -5,6 +5,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local LuaSettings = require("luasettings")
 local UIManager = require("ui/uimanager")
 local ffiutil = require("ffi/util")
+local logger = require("logger")
 local _ = require("gettext")
 local T = ffiutil.template
 
@@ -15,6 +16,13 @@ function NetworkMgr:readNWSettings()
 end
 
 function NetworkMgr:init()
+    -- On Kobo, kill WiFi if NetworkMgr:isWifiOn() and NOT NetworkMgr:isConnected()
+    -- (i.e., if the launcher left the WiFi in an inconsistent state: modules loaded, but no route to gateway).
+    if Device:isKobo() and self:isWifiOn() and not self:isConnected() then
+        logger.info("Kobo WiFi: Left in an inconsistent state by launcher!")
+        self:turnOffWifi()
+    end
+
     self.wifi_was_on = G_reader_settings:isTrue("wifi_was_on")
     if self.wifi_was_on and G_reader_settings:nilOrTrue("auto_restore_wifi") then
         self:restoreWifiAsync()

--- a/spec/unit/network_manager_spec.lua
+++ b/spec/unit/network_manager_spec.lua
@@ -44,6 +44,12 @@ describe("network_manager module", function()
                 self:turnOnWifi()
                 self:obtainIP()
             end
+            function NetworkMgr:isWifiOn()
+                return turn_on_wifi_called == 1 and true or false
+            end
+            function NetworkMgr:isConnected()
+                return self:ifWifiOn()
+            end
         end
     end)
 

--- a/spec/unit/network_manager_spec.lua
+++ b/spec/unit/network_manager_spec.lua
@@ -6,6 +6,7 @@ describe("network_manager module", function()
     local release_ip_called
 
     local function clearState()
+        G_reader_settings:saveSetting("auto_restore_wifi", true)
         turn_on_wifi_called = 0
         turn_off_wifi_called = 0
         obtain_ip_called = 0
@@ -43,12 +44,6 @@ describe("network_manager module", function()
             function NetworkMgr:restoreWifiAsync()
                 self:turnOnWifi()
                 self:obtainIP()
-            end
-            function NetworkMgr:isWifiOn()
-                return turn_on_wifi_called == 1 and true or false
-            end
-            function NetworkMgr:isConnected()
-                return self:ifWifiOn()
             end
         end
     end)


### PR DESCRIPTION
* On Kobo, try to avoid booting in an inconsistent state ("Wi-Fi connection" checked, because the modules are loaded, but no actual network connection, for whatever reason).
* Don't enable auto_restore_wifi by default.