### PR TITLE
[Android] kodev run android: show all errors

### DIFF
--- a/kodev
+++ b/kodev
@@ -626,7 +626,7 @@ TARGET:
                 # there's no adb run so we do this…
                 adb shell monkey -p org.koreader.launcher -c android.intent.category.LAUNCHER 1
                 assert_ret_zero $?
-                adb logcat KOReader:V luajit-launcher:V AndroidRuntime:E "*:S"
+                adb logcat KOReader:V luajit-launcher:V "*:E"
             } || echo "Failed to find adb in PATH to interact with Android device."
             ;;
         *)


### PR DESCRIPTION
It will introduce some minor noise, but too much stuff is simply not seen otherwise, for example:

*:E
```
02-09 12:45:53.359  2580  2609 E IconLoader: Unexpected null component name or activity info: ComponentInfo{org.koreader.launcher/org.koreader.launcher.MainActivity}, null
```

*:F
```
--------- beginning of system
--------- beginning of main
--------- beginning of crash
02-09 12:47:31.275  4985  5003 F libc    : /home/frans/src/kobo/koreader/base/thirdparty/filemq/build/i686-linux-android-debug/filemq-prefix/src/filemq/src/fmq_client.c:170: fmq_client_set_resync: assertion "self" failed
02-09 12:47:31.275  4985  5003 F libc    : Fatal signal 6 (SIGABRT), code -6 (SI_TKILL) in tid 5003 (Thread-37), pid 4985 (reader.launcher)
02-09 12:47:31.512  5085  5085 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
02-09 12:47:31.512  5085  5085 F DEBUG   : Build fingerprint: 'Android/sdk_phone_x86_64/generic_x86_64:9/PSR1.180720.012/4923214:userdebug/test-keys'
02-09 12:47:31.512  5085  5085 F DEBUG   : Revision: '0'
02-09 12:47:31.513  5085  5085 F DEBUG   : ABI: 'x86'
02-09 12:47:31.513  5085  5085 F DEBUG   : pid: 4985, tid: 5003, name: Thread-37  >>> org.koreader.launcher <<<
02-09 12:47:31.513  5085  5085 F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
02-09 12:47:31.513  5085  5085 F DEBUG   : Abort message: '/home/frans/src/kobo/koreader/base/thirdparty/filemq/build/i686-linux-android-debug/filemq-prefix/src/filemq/src/fmq_client.c:170: fmq_client_set_resync: assertion "self" failed'
02-09 12:47:31.513  5085  5085 F DEBUG   :     eax 00000000  ebx 00001379  ecx 0000138b  edx 00000006
02-09 12:47:31.513  5085  5085 F DEBUG   :     edi 00000000  esi 00000000
02-09 12:47:31.513  5085  5085 F DEBUG   :     ebp 33167a17  esp de3e9528  eip f70d8b59
02-09 12:47:31.515  5085  5085 F DEBUG   : 
02-09 12:47:31.515  5085  5085 F DEBUG   : backtrace:
02-09 12:47:31.515  5085  5085 F DEBUG   :     #00 pc 00000b59  [vdso:f70d8000] (__kernel_vsyscall+9)
02-09 12:47:31.515  5085  5085 F DEBUG   :     #01 pc 0001fc08  /system/lib/libc.so (syscall+40)
02-09 12:47:31.515  5085  5085 F DEBUG   :     #02 pc 000321f3  /system/lib/libc.so (abort+115)
02-09 12:47:31.515  5085  5085 F DEBUG   :     #03 pc 00032681  /system/lib/libc.so (__assert2+49)
02-09 12:47:31.515  5085  5085 F DEBUG   :     #04 pc 000046b0  /data/data/org.koreader.launcher/files/libs/libfmq.so.1
02-09 12:47:31.515  5085  5085 F DEBUG   :     #05 pc 00008e54  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #06 pc 00056a61  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #07 pc 0006ed92  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #08 pc 00006fc9  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #09 pc 00061f73  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #10 pc 00006fc9  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #11 pc 00061f73  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #12 pc 00006fc9  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #13 pc 0001c470  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so (lua_pcall+80)
02-09 12:47:31.515  5085  5085 F DEBUG   :     #14 pc 0000571a  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so (android_main+458)
02-09 12:47:31.515  5085  5085 F DEBUG   :     #15 pc 00070a38  /data/app/org.koreader.launcher-u3tYrWEK7wgvoJGvd1pTrA==/lib/x86/libluajit.so
02-09 12:47:31.515  5085  5085 F DEBUG   :     #16 pc 0009cce5  /system/lib/libc.so (__pthread_start(void*)+53)
02-09 12:47:31.515  5085  5085 F DEBUG   :     #17 pc 00033c1b  /system/lib/libc.so (__start_thread+75)
```