### PR TITLE
Add highlight editing buttons

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -449,7 +449,7 @@ function ReaderBookmark:updateBookmark(item)
             self.bookmarks[i].page = item.updated_highlight.pos0
             self.bookmarks[i].pos0 = item.updated_highlight.pos0
             self.bookmarks[i].pos1 = item.updated_highlight.pos1
-            self.bookmarks[i].text = item.updated_highlight.text
+            self.bookmarks[i].notes = item.updated_highlight.notes
             self.bookmarks[i].datetime = item.updated_highlight.datetime
             self:onSaveSettings()
         end

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -446,8 +446,8 @@ end
 function ReaderBookmark:updateBookmark(item)
     for i=1, #self.bookmarks do
         if item.datetime == self.bookmarks[i].datetime and item.page == self.bookmarks[i].page then
-            page = self.ui.document:getPageFromXPointer(item.updated_highlight.pos0)
-            new_text = item.updated_highlight.text
+            local page = self.ui.document:getPageFromXPointer(item.updated_highlight.pos0)
+            local new_text = item.updated_highlight.text
             self.bookmarks[i].page = item.updated_highlight.pos0
             self.bookmarks[i].pos0 = item.updated_highlight.pos0
             self.bookmarks[i].pos1 = item.updated_highlight.pos1

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -446,10 +446,16 @@ end
 function ReaderBookmark:updateBookmark(item)
     for i=1, #self.bookmarks do
         if item.datetime == self.bookmarks[i].datetime and item.page == self.bookmarks[i].page then
+            page = self.ui.document:getPageFromXPointer(item.updated_highlight.pos0)
+            new_text = item.updated_highlight.text
             self.bookmarks[i].page = item.updated_highlight.pos0
             self.bookmarks[i].pos0 = item.updated_highlight.pos0
             self.bookmarks[i].pos1 = item.updated_highlight.pos1
-            self.bookmarks[i].notes = item.updated_highlight.notes
+            self.bookmarks[i].notes = item.updated_highlight.text
+            self.bookmarks[i].text = T(_("Page %1 %2 @ %3"),
+                                        page,
+                                        new text,
+                                        item.updated_highlight.datetime)
             self.bookmarks[i].datetime = item.updated_highlight.datetime
             self:onSaveSettings()
         end

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -443,6 +443,19 @@ function ReaderBookmark:removeBookmark(item)
     logger.warn("removeBookmark: full scan search didn't find bookmark")
 end
 
+function ReaderBookmark:updateBookmark(item)
+    for i=1, #self.bookmarks do
+        if item.datetime == self.bookmarks[i].datetime and item.page == self.bookmarks[i].page then
+            self.bookmarks[i].page = item.updated_highlight.pos0
+            self.bookmarks[i].pos0 = item.updated_highlight.pos0
+            self.bookmarks[i].pos1 = item.updated_highlight.pos1
+            self.bookmarks[i].text = item.updated_highlight.text
+            self.bookmarks[i].datetime = item.updated_highlight.datetime
+            self:onSaveSettings()
+        end
+    end
+end
+
 function ReaderBookmark:renameBookmark(item, from_highlight)
     if from_highlight then
         -- Called by ReaderHighlight:editHighlight, we need to find the bookmark

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -452,9 +452,8 @@ function ReaderBookmark:updateBookmark(item)
             self.bookmarks[i].pos0 = item.updated_highlight.pos0
             self.bookmarks[i].pos1 = item.updated_highlight.pos1
             self.bookmarks[i].notes = item.updated_highlight.text
-            self.bookmarks[i].text = T(_("Page %1 %2 @ %3"),
-                                        page,
-                                        new text,
+            self.bookmarks[i].text = T(_("Page %1 %2 @ %3"), page,
+                                        new_text,
                                         item.updated_highlight.datetime)
             self.bookmarks[i].datetime = item.updated_highlight.datetime
             self:onSaveSettings()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -248,7 +248,7 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     end
 end
 
-function ReaderHighlight:updateHighlight(page, index, side, direction, move_char)
+function ReaderHighlight:updateHighlight(page, index, side, direction, move_by_char)
     if self.ui.document.info.has_pages then -- we do this only if it's epub file
         return
     end
@@ -260,7 +260,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction, move_char
     if side == 0 then -- we move from pos0
         if direction == 1 then -- move highlight to the right
             local updated_highlight_beginning
-            if move_char then
+            if move_by_char then
                 updated_highlight_beginning = self.ui.document:getNextVisibleChar(highlight_beginning)
             else
                 updated_highlight_beginning = self.ui.document:getNextVisibleWordStart(highlight_beginning)
@@ -270,7 +270,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction, move_char
             end
          else -- move highlight to the left
             local updated_highlight_beginning
-            if move_char then
+            if move_by_char then
                 updated_highlight_beginning = self.ui.document:getPrevVisibleChar(highlight_beginning)
             else
                 updated_highlight_beginning = self.ui.document:getPrevVisibleWordStart(highlight_beginning)
@@ -282,7 +282,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction, move_char
     else -- we move from pos1
         if direction == 1 then
             local updated_highlight_end
-            if move_char then
+            if move_by_char then
                 updated_highlight_end = self.ui.document:getNextVisibleChar(highlight_end)
             else
                 updated_highlight_end = self.ui.document:getNextVisibleWordEnd(highlight_end)
@@ -292,7 +292,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction, move_char
             end
         else
             local updated_highlight_end
-            if move_char then
+            if move_by_char then
                 updated_highlight_end = self.ui.document:getPrevVisibleChar(highlight_end)
             else
                 updated_highlight_end = self.ui.document:getPrevVisibleWordEnd(highlight_end)
@@ -345,7 +345,6 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
                     self:updateHighlight(page, index, 0, -1, false)
                 end,
                 hold_callback = function()
-                    logger.dbg("detected hold!!")
                     self:updateHighlight(page, index, 0, -1, true)
                     return true
                 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -257,7 +257,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction, move_by_c
     local highlight_time = highlight.datetime
     local highlight_beginning = highlight.pos0
     local highlight_end = highlight.pos1
-    if side == 0 then -- we move from pos0
+    if side == 0 then -- we move pos0
         if direction == 1 then -- move highlight to the right
             local updated_highlight_beginning
             if move_by_char then
@@ -279,8 +279,8 @@ function ReaderHighlight:updateHighlight(page, index, side, direction, move_by_c
                 self.view.highlight.saved[page][index].pos0 = updated_highlight_beginning
             end
         end
-    else -- we move from pos1
-        if direction == 1 then
+    else -- we move pos1
+        if direction == 1 then -- move highlight to the right
             local updated_highlight_end
             if move_by_char then
                 updated_highlight_end = self.ui.document:getNextVisibleChar(highlight_end)
@@ -290,7 +290,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction, move_by_c
             if updated_highlight_end then
                 self.view.highlight.saved[page][index].pos1 = updated_highlight_end
             end
-        else
+        else -- move highlight to the left
             local updated_highlight_end
             if move_by_char then
                 updated_highlight_end = self.ui.document:getPrevVisibleChar(highlight_end)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -254,6 +254,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction)
     end
 
     local highlight = self.view.highlight.saved[page][index]
+    local highlight_time = highlight.datetime
     local highlight_beginning = highlight.pos0
     local highlight_end = highlight.pos1
     if side == 0 then -- we move from pos0
@@ -281,6 +282,17 @@ function ReaderHighlight:updateHighlight(page, index, side, direction)
             end
         end
     end
+
+    local new_beginning = self.view.highlight.saved[page][index].pos0
+    local new_end = self.view.highlight.saved[page][index].pos1
+    local new_text = self.ui.document:getTextFromXPointers(new_beginning, new_end)
+    self.view.highlight.saved[page][index].text = new_text
+    local new_highlight = self.view.highlight.saved[page][index]
+    self.ui.bookmark:updateBookmark({
+        page = highlight_beginning,
+        datetime = highlight_time,
+        updated_highlight = new_highlight
+    }, true)
     UIManager:setDirty(self.dialog, "ui")
 end
 
@@ -966,7 +978,6 @@ function ReaderHighlight:deleteHighlight(page, i, bookmark_item)
 end
 
 function ReaderHighlight:editHighlight(page, i)
-    logger.info("edit highlight", page, i)
     local item = self.view.highlight.saved[page][i]
     self.ui.bookmark:renameBookmark({
         page = self.ui.document.info.has_pages and page or item.pos0,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -285,9 +285,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction)
 end
 
 function ReaderHighlight:onShowHighlightDialog(page, index)
-    if not self.ui.document.info.has_pages then
-        self.edit_highlight_dialog = ButtonDialog:new{
-            buttons = {
+    buttons = {
                 {
                     {
                         text = _("Delete"),
@@ -305,60 +303,41 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
                         end,
                     },
                 },
-                {
-                    {
-                        text = _("◁⇱"),
-                        callback = function()
-                            self:updateHighlight(page, index, 0, -1)
-                        end,
-                    },
-                    {
-                        text = _("⇱▷"),
-                        callback = function()
-                            self:updateHighlight(page, index, 0, 1)
-                        end,
-                    },
-                },
-                {
-                    {
-                        text = _("◁⇲"),
-                        callback = function()
-                            self:updateHighlight(page, index, 1, -1)
-                        end,
-                    },
-                    {
-                        text = _("⇲▷"),
-                        callback = function()
-                            self:updateHighlight(page, index, 1, 1)
-                        end,
-                    },
-                }
-            },
-        }
-    else
-        self.edit_highlight_dialog = ButtonDialog:new{
-            buttons = {
-                {
-                    {
-                        text = _("Delete"),
-                        callback = function()
-                            self:deleteHighlight(page, index)
-                            -- other part outside of the dialog may be dirty
-                            UIManager:close(self.edit_highlight_dialog, "ui")
-                        end,
-                    },
-                    {
-                        text = _("Edit"),
-                        callback = function()
-                            self:editHighlight(page, index)
-                            UIManager:close(self.edit_highlight_dialog)
-                        end,
-                    },
-                },
-            },
-        }
+             }
 
+    if not self.ui.document.info.has_pages then
+        table.insert(buttons, {
+                        {
+                            text = _("◁⇱"),
+                            callback = function()
+                                self:updateHighlight(page, index, 0, -1)
+                            end,
+                        },
+                        {
+                            text = _("⇱▷"),
+                            callback = function()
+                                self:updateHighlight(page, index, 0, 1)
+                            end,
+                        },
+                    })
+        table.insert(buttons, {
+                        {
+                            text = _("◁⇲"),
+                            callback = function()
+                                self:updateHighlight(page, index, 1, -1)
+                            end,
+                        },
+                        {
+                            text = _("⇲▷"),
+                            callback = function()
+                                self:updateHighlight(page, index, 1, 1)
+                            end,
+                        },
+                    })
     end
+    self.edit_highlight_dialog = ButtonDialog:new{
+        buttons = buttons
+    }
     UIManager:show(self.edit_highlight_dialog)
     return true
 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -248,6 +248,31 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     end
 end
 
+function ReaderHighlight:updateHighlight(page, index, move_from_beginning, dir)
+    local highlight = self.view.highlight.saved[page][index]
+    local highlight_beginning = highlight.pos0
+    local highlight_end = highlight.pos1
+    if move_from_beginning then
+        if dir == 1 then
+            local updated_highlight = self.ui.document:getNextVisibleWordEnd(highlight_beginning)
+            self.view.highlight.saved[page][index].pos0 = updated_highlight
+        else
+            local updated_highlight = self.ui.document:getPrevVisibleWordEnd(highlight_beginning)
+            self.view.highlight.saved[page][index].pos0 = updated_highlight
+        end
+    else
+        if dir == 1 then
+            local updated_highlight = self.ui.document:getNextVisibleWordEnd(highlight_end)
+            self.view.highlight.saved[page][index].pos1 = updated_highlight
+        else
+            local updated_highlight = self.ui.document:getPrevVisibleWordEnd(highlight_end)
+            self.view.highlight.saved[page][index].pos1 = updated_highlight
+        end
+    end
+    UIManager:setDirty(self.dialog, "ui")
+--    self.ui.document:clearSelection() -- do we really need this?
+end
+
 function ReaderHighlight:onShowHighlightDialog(page, index)
     self.edit_highlight_dialog = ButtonDialog:new{
         buttons = {
@@ -268,6 +293,34 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
                     end,
                 },
             },
+            {
+                {
+                    text = _("<<"),
+                    callback = function()
+                        self:updateHighlight(page, index, true, -1)
+                    end,
+                },
+                {
+                    text = _(">>"),
+                    callback = function()
+                        self:updateHighlight(page, index, true, 1)
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("<"),
+                    callback = function()
+                        self:updateHighlight(page, index, false, -1)
+                    end,
+                },
+                {
+                    text = _(">"),
+                    callback = function()
+                        self:updateHighlight(page, index, false, 1)
+                    end,
+                },
+            }
         },
     }
     UIManager:show(self.edit_highlight_dialog)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -285,55 +285,80 @@ function ReaderHighlight:updateHighlight(page, index, side, direction)
 end
 
 function ReaderHighlight:onShowHighlightDialog(page, index)
-    self.edit_highlight_dialog = ButtonDialog:new{
-        buttons = {
-            {
+    if not self.ui.document.info.has_pages then
+        self.edit_highlight_dialog = ButtonDialog:new{
+            buttons = {
                 {
-                    text = _("Delete"),
-                    callback = function()
-                        self:deleteHighlight(page, index)
-                        -- other part outside of the dialog may be dirty
-                        UIManager:close(self.edit_highlight_dialog, "ui")
-                    end,
+                    {
+                        text = _("Delete"),
+                        callback = function()
+                            self:deleteHighlight(page, index)
+                            -- other part outside of the dialog may be dirty
+                            UIManager:close(self.edit_highlight_dialog, "ui")
+                        end,
+                    },
+                    {
+                        text = _("Edit"),
+                        callback = function()
+                            self:editHighlight(page, index)
+                            UIManager:close(self.edit_highlight_dialog)
+                        end,
+                    },
                 },
                 {
-                    text = _("Edit"),
-                    callback = function()
-                        self:editHighlight(page, index)
-                        UIManager:close(self.edit_highlight_dialog)
-                    end,
+                    {
+                        text = _("◁⇱"),
+                        callback = function()
+                            self:updateHighlight(page, index, 0, -1)
+                        end,
+                    },
+                    {
+                        text = _("⇱▷"),
+                        callback = function()
+                            self:updateHighlight(page, index, 0, 1)
+                        end,
+                    },
+                },
+                {
+                    {
+                        text = _("◁⇲"),
+                        callback = function()
+                            self:updateHighlight(page, index, 1, -1)
+                        end,
+                    },
+                    {
+                        text = _("⇲▷"),
+                        callback = function()
+                            self:updateHighlight(page, index, 1, 1)
+                        end,
+                    },
+                }
+            },
+        }
+    else
+        self.edit_highlight_dialog = ButtonDialog:new{
+            buttons = {
+                {
+                    {
+                        text = _("Delete"),
+                        callback = function()
+                            self:deleteHighlight(page, index)
+                            -- other part outside of the dialog may be dirty
+                            UIManager:close(self.edit_highlight_dialog, "ui")
+                        end,
+                    },
+                    {
+                        text = _("Edit"),
+                        callback = function()
+                            self:editHighlight(page, index)
+                            UIManager:close(self.edit_highlight_dialog)
+                        end,
+                    },
                 },
             },
-            {
-                {
-                    text = _("◁⇱"),
-                    callback = function()
-                        self:updateHighlight(page, index, 0, -1)
-                    end,
-                },
-                {
-                    text = _("⇱▷"),
-                    callback = function()
-                        self:updateHighlight(page, index, 0, 1)
-                    end,
-                },
-            },
-            {
-                {
-                    text = _("◁⇲"),
-                    callback = function()
-                        self:updateHighlight(page, index, 1, -1)
-                    end,
-                },
-                {
-                    text = _("⇲▷"),
-                    callback = function()
-                        self:updateHighlight(page, index, 1, 1)
-                    end,
-                },
-            }
-        },
-    }
+        }
+
+    end
     UIManager:show(self.edit_highlight_dialog)
     return true
 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -286,54 +286,52 @@ end
 
 function ReaderHighlight:onShowHighlightDialog(page, index)
     local buttons = {
-                {
-                    {
-                        text = _("Delete"),
-                        callback = function()
-                            self:deleteHighlight(page, index)
-                            -- other part outside of the dialog may be dirty
-                            UIManager:close(self.edit_highlight_dialog, "ui")
-                        end,
-                    },
-                    {
-                        text = _("Edit"),
-                        callback = function()
-                            self:editHighlight(page, index)
-                            UIManager:close(self.edit_highlight_dialog)
-                        end,
-                    },
-                },
-             }
+        {
+            {
+                text = _("Delete"),
+                callback = function()
+                    self:deleteHighlight(page, index)
+                    -- other part outside of the dialog may be dirty
+                    UIManager:close(self.edit_highlight_dialog, "ui")
+                end,
+            },
+            {
+                text = _("Edit"),
+                callback = function()
+                    self:editHighlight(page, index)
+                    UIManager:close(self.edit_highlight_dialog)
+                end,
+            },
+        }
+    }
 
     if not self.ui.document.info.has_pages then
         table.insert(buttons, {
-                        {
-                            text = _("◁⇱"),
-                            callback = function()
-                                self:updateHighlight(page, index, 0, -1)
-                            end,
-                        },
-                        {
-                            text = _("⇱▷"),
-                            callback = function()
-                                self:updateHighlight(page, index, 0, 1)
-                            end,
-                        },
-                    })
-        table.insert(buttons, {
-                        {
-                            text = _("◁⇲"),
-                            callback = function()
-                                self:updateHighlight(page, index, 1, -1)
-                            end,
-                        },
-                        {
-                            text = _("⇲▷"),
-                            callback = function()
-                                self:updateHighlight(page, index, 1, 1)
-                            end,
-                        },
-                    })
+            {
+                text = _("◁⇱"),
+                callback = function()
+                    self:updateHighlight(page, index, 0, -1)
+                end,
+            },
+            {
+                text = _("⇱▷"),
+                callback = function()
+                    self:updateHighlight(page, index, 0, 1)
+                end,
+            },
+            {
+                text = _("◁⇲"),
+                callback = function()
+                    self:updateHighlight(page, index, 1, -1)
+                end,
+            },
+            {
+                text = _("⇲▷"),
+                callback = function()
+                    self:updateHighlight(page, index, 1, 1)
+                end,
+            }
+        })
     end
     self.edit_highlight_dialog = ButtonDialog:new{
         buttons = buttons

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -248,29 +248,40 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     end
 end
 
-function ReaderHighlight:updateHighlight(page, index, move_from_beginning, dir)
+function ReaderHighlight:updateHighlight(page, index, side, direction)
+    if self.ui.document.info.has_pages then -- we do this only if it's epub file
+        return
+    end
+
     local highlight = self.view.highlight.saved[page][index]
     local highlight_beginning = highlight.pos0
     local highlight_end = highlight.pos1
-    if move_from_beginning then
-        if dir == 1 then
-            local updated_highlight = self.ui.document:getNextVisibleWordEnd(highlight_beginning)
-            self.view.highlight.saved[page][index].pos0 = updated_highlight
-        else
-            local updated_highlight = self.ui.document:getPrevVisibleWordEnd(highlight_beginning)
-            self.view.highlight.saved[page][index].pos0 = updated_highlight
+    if side == 0 then -- we move from pos0
+        if direction == 1 then -- move highlight to the right
+            local updated_highlight = self.ui.document:getNextVisibleWordStart(highlight_beginning)
+            if updated_highlight then -- in theory crengine could return nil
+                self.view.highlight.saved[page][index].pos0 = updated_highlight
+            end
+         else -- move highlight to the left
+            local updated_highlight = self.ui.document:getPrevVisibleWordStart(highlight_beginning)
+            if updated_highlight then
+                self.view.highlight.saved[page][index].pos0 = updated_highlight
+            end
         end
-    else
-        if dir == 1 then
+    else -- we move from pos1
+        if direction == 1 then
             local updated_highlight = self.ui.document:getNextVisibleWordEnd(highlight_end)
-            self.view.highlight.saved[page][index].pos1 = updated_highlight
+            if updated_highlight then
+                self.view.highlight.saved[page][index].pos1 = updated_highlight
+            end
         else
             local updated_highlight = self.ui.document:getPrevVisibleWordEnd(highlight_end)
-            self.view.highlight.saved[page][index].pos1 = updated_highlight
+            if updated_highlight then
+                self.view.highlight.saved[page][index].pos1 = updated_highlight
+            end
         end
     end
     UIManager:setDirty(self.dialog, "ui")
---    self.ui.document:clearSelection() -- do we really need this?
 end
 
 function ReaderHighlight:onShowHighlightDialog(page, index)
@@ -295,29 +306,29 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
             },
             {
                 {
-                    text = _("<<"),
+                    text = _("◁⇱"),
                     callback = function()
-                        self:updateHighlight(page, index, true, -1)
+                        self:updateHighlight(page, index, 0, -1)
                     end,
                 },
                 {
-                    text = _(">>"),
+                    text = _("⇱▷"),
                     callback = function()
-                        self:updateHighlight(page, index, true, 1)
+                        self:updateHighlight(page, index, 0, 1)
                     end,
                 },
             },
             {
                 {
-                    text = _("<"),
+                    text = _("◁⇲"),
                     callback = function()
-                        self:updateHighlight(page, index, false, -1)
+                        self:updateHighlight(page, index, 1, -1)
                     end,
                 },
                 {
-                    text = _(">"),
+                    text = _("⇲▷"),
                     callback = function()
-                        self:updateHighlight(page, index, false, 1)
+                        self:updateHighlight(page, index, 1, 1)
                     end,
                 },
             }

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -285,7 +285,7 @@ function ReaderHighlight:updateHighlight(page, index, side, direction)
 end
 
 function ReaderHighlight:onShowHighlightDialog(page, index)
-    buttons = {
+    local buttons = {
                 {
                     {
                         text = _("Delete"),

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -258,26 +258,26 @@ function ReaderHighlight:updateHighlight(page, index, side, direction)
     local highlight_end = highlight.pos1
     if side == 0 then -- we move from pos0
         if direction == 1 then -- move highlight to the right
-            local updated_highlight = self.ui.document:getNextVisibleWordStart(highlight_beginning)
-            if updated_highlight then -- in theory crengine could return nil
-                self.view.highlight.saved[page][index].pos0 = updated_highlight
+            local updated_highlight_beginning = self.ui.document:getNextVisibleWordStart(highlight_beginning)
+            if updated_highlight_beginning then -- in theory crengine could return nil
+                self.view.highlight.saved[page][index].pos0 = updated_highlight_beginning
             end
          else -- move highlight to the left
-            local updated_highlight = self.ui.document:getPrevVisibleWordStart(highlight_beginning)
-            if updated_highlight then
-                self.view.highlight.saved[page][index].pos0 = updated_highlight
+            local updated_highlight_beginning = self.ui.document:getPrevVisibleWordStart(highlight_beginning)
+            if updated_highlight_beginning then
+                self.view.highlight.saved[page][index].pos0 = updated_highlight_beginning
             end
         end
     else -- we move from pos1
         if direction == 1 then
-            local updated_highlight = self.ui.document:getNextVisibleWordEnd(highlight_end)
-            if updated_highlight then
-                self.view.highlight.saved[page][index].pos1 = updated_highlight
+            local updated_highlight_end = self.ui.document:getNextVisibleWordEnd(highlight_end)
+            if updated_highlight_end then
+                self.view.highlight.saved[page][index].pos1 = updated_highlight_end
             end
         else
-            local updated_highlight = self.ui.document:getPrevVisibleWordEnd(highlight_end)
-            if updated_highlight then
-                self.view.highlight.saved[page][index].pos1 = updated_highlight
+            local updated_highlight_end = self.ui.document:getPrevVisibleWordEnd(highlight_end)
+            if updated_highlight_end then
+                self.view.highlight.saved[page][index].pos1 = updated_highlight_end
             end
         end
     end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -444,6 +444,10 @@ function CreDocument:getTextFromXPointer(xp)
     end
 end
 
+function CreDocument:getTextFromXPointers(pos0, pos1)
+    return self._document:getTextFromXPointers(pos0, pos1)
+end
+
 function CreDocument:getHTMLFromXPointer(xp, flags, from_final_parent)
     if xp then
         return self._document:getHTMLFromXPointer(xp, flags, from_final_parent)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -306,6 +306,14 @@ function CreDocument:getScreenBoxesFromPositions(pos0, pos1, get_segments)
     return line_boxes
 end
 
+function CreDocument:getNextVisibleWordEnd(pos0, pos1)
+    return self._document:nextVisibleWordEnd(pos0, pos1)
+end
+
+function CreDocument:getPrevVisibleWordEnd(pos0, pos1)
+    return self._document:prevVisibleWordEnd(pos0, pos1)
+end
+
 function CreDocument:drawCurrentView(target, x, y, rect, pos)
     if self.buffer and (self.buffer.w ~= rect.w or self.buffer.h ~= rect.h) then
         self.buffer:free()

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -322,6 +322,14 @@ function CreDocument:getPrevVisibleWordEnd(xp)
     return self._document:getPrevVisibleWordEnd(xp)
 end
 
+function CreDocument:getPrevVisibleChar(xp)
+    return self._document:getPrevVisibleChar(xp)
+end
+
+function CreDocument:getNextVisibleChar(xp)
+    return self._document:getNextVisibleChar(xp)
+end
+
 function CreDocument:drawCurrentView(target, x, y, rect, pos)
     if self.buffer and (self.buffer.w ~= rect.w or self.buffer.h ~= rect.h) then
         self.buffer:free()

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -306,12 +306,20 @@ function CreDocument:getScreenBoxesFromPositions(pos0, pos1, get_segments)
     return line_boxes
 end
 
-function CreDocument:getNextVisibleWordEnd(pos0, pos1)
-    return self._document:nextVisibleWordEnd(pos0, pos1)
+function CreDocument:getNextVisibleWordStart(xp)
+    return self._document:getNextVisibleWordStart(xp)
 end
 
-function CreDocument:getPrevVisibleWordEnd(pos0, pos1)
-    return self._document:prevVisibleWordEnd(pos0, pos1)
+function CreDocument:getNextVisibleWordEnd(xp)
+    return self._document:getNextVisibleWordEnd(xp)
+end
+
+function CreDocument:getPrevVisibleWordStart(xp)
+    return self._document:getPrevVisibleWordStart(xp)
+end
+
+function CreDocument:getPrevVisibleWordEnd(xp)
+    return self._document:getPrevVisibleWordEnd(xp)
 end
 
 function CreDocument:drawCurrentView(target, x, y, rect, pos)

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -102,6 +102,13 @@ function Button:init()
                     range = self.dimen,
                 },
                 doc = "Hold Button",
+            },
+            -- Safe-guard for when used inside a MovableContainer
+            HoldReleaseSelectButton = {
+                GestureRange:new{
+                    ges = "hold_release",
+                    range = self.dimen,
+                },
             }
         }
     end
@@ -238,6 +245,18 @@ function Button:onHoldSelectButton()
         self:onInput(self.hold_input_func())
     end
     return true
+end
+
+function Button:onHoldReleaseSelectButton()
+    -- Safe-guard for when used inside a MovableContainer,
+    -- which would handle HoldRelease and process it like
+    -- a Hold if we wouldn't return true here
+    if self.enabled and self.hold_callback then
+        return true
+    elseif self.hold_input or type(self.hold_input_func) == "function" then
+        return true
+    end
+    return false
 end
 
 return Button

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -53,6 +53,7 @@ function ButtonTable:init()
                 text = btn_entry.text,
                 enabled = btn_entry.enabled,
                 callback = btn_entry.callback,
+                hold_callback = btn_entry.hold_callback,
                 width = (self.width - sizer_space)/column_cnt,
                 max_width = (self.width - sizer_space)/column_cnt - 2*self.sep_width - 2*self.padding,
                 bordersize = 0,


### PR DESCRIPTION
This allows user to move highlight end/beginning using buttons that appear after pressing on the highlight.
**Screenshot:**
![image](https://user-images.githubusercontent.com/10298730/52573860-51a0d400-2e1b-11e9-94a2-a65ab3bba2bf.png)
This should be merged after https://github.com/koreader/koreader-base/pull/808

Close #4555. Close #975. Provides a solution for #4134 and https://github.com/koreader/koreader/pull/4267#issuecomment-429926765