### PR TITLE
Cervantes tweaks

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -66,8 +66,11 @@ local Cervantes4 = Cervantes:new{
     display_dpi = 300,
     hasNaturalLight = yes,
     frontlight_settings = {
-        frontlight_white = "/sys/class/backlight/lm3630a_ledb",
-        frontlight_red = "/sys/class/backlight/lm3630a_leda",
+        frontlight_white = "/sys/class/backlight/mxc_msp430_fl.0/brightness",
+        frontlight_mixer = "/sys/class/backlight/lm3630a_led/color",
+        nl_min = 0,
+        nl_max = 10,
+        nl_inverted = true,
     },
 }
 

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -21,6 +21,14 @@ local function isConnected()
     return carrier
 end
 
+local function isMassStorageSupported()
+    -- we rely on 3rd party package for that. It should be installed as part of KOReader prerequisites,
+    local safemode_version = io.open("/usr/share/safemode/version", "rb")
+    if not safemode_version then return false end
+    safemode_version:close()
+    return true
+end
+
 local Cervantes = Generic:new{
     model = "Cervantes",
     isCervantes = yes,
@@ -32,6 +40,9 @@ local Cervantes = Generic:new{
     touch_probe_ev_epoch_time = true,
     hasOTAUpdates = yes,
     hasKeys = yes,
+
+    -- do we support usb mass storage?
+    canToggleMassStorage = function() return isMassStorageSupported() end,
 
     -- all devices, except the original Cervantes Touch, have frontlight
     hasFrontlight = yes,

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -30,6 +30,7 @@ local Device = {
     hasColorScreen = no,
     hasBGRFrameBuffer = no,
     canToggleGSensor = no,
+    canToggleMassStorage = no,
 
     -- use these only as a last resort. We should abstract the functionality
     -- and have device dependent implementations in the corresponting

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -21,6 +21,22 @@ if Device:hasFrontlight() then
     }
 end
 
+if Device:canToggleMassStorage() then
+    local MassStorage = require("ui/elements/mass_storage")
+
+    -- mass storage settings
+    common_settings.mass_storage_settings = {
+        text = _("USB mass storage"),
+        sub_item_table = MassStorage:getSettingsMenuTable()
+    }
+
+    -- mass storage actions
+    common_settings.mass_storage_actions = {
+        text = _("Start USB storage"),
+        callback = function() MassStorage:start() end,
+    }
+end
+
 if Device:setDateTime() then
     common_settings.time = {
         text = _("Time and date"),

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -39,6 +39,7 @@ local order = {
         "time",
         "battery",
         "gesture",
+        "mass_storage_settings",
     },
     network = {
         "network_wifi",
@@ -95,6 +96,7 @@ local order = {
         "open_last_document",
         "----------------------------",
         "system_statistics",
+        "mass_storage_actions",
         "----------------------------",
         "ota_update", -- if Device:hasOTAUpdates()
         "version",

--- a/frontend/ui/elements/mass_storage.lua
+++ b/frontend/ui/elements/mass_storage.lua
@@ -1,0 +1,54 @@
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+
+local MassStorage = {}
+
+-- if required a popup will ask before entering mass storage mode
+function MassStorage:requireConfirmation()
+    return not G_reader_settings:isTrue("mass_storage_confirmation_disabled")
+end
+
+-- mass storage settings menu
+function MassStorage:getSettingsMenuTable()
+    return {
+        {
+            text = _("Disable confirmation popup"),
+            checked_func = function() return not self:requireConfirmation() end,
+            callback = function()
+                G_reader_settings:saveSetting("mass_storage_confirmation_disabled", self:requireConfirmation())
+            end,
+        },
+    }
+end
+
+-- mass storage actions
+function MassStorage:getActionsMenuTable()
+    return {
+        {
+            text = _("Start USB storage"),
+            callback = function()
+                self:start()
+            end,
+        },
+    }
+end
+
+-- exit KOReader and start mass storage mode.
+function MassStorage:start()
+    if self:requireConfirmation() then
+        local ConfirmBox = require("ui/widget/confirmbox")
+        UIManager:show(ConfirmBox:new{
+            text = _("Share storage via USB?\n"),
+            ok_text = _("Share"),
+            ok_callback = function()
+                UIManager:quit()
+                UIManager._exit_code = 86
+            end,
+        })
+    else
+        UIManager:quit()
+        UIManager._exit_code = 86
+    end
+end
+
+return MassStorage

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -61,6 +61,7 @@ local order = {
         "time",
         "battery",
         "gesture",
+        "mass_storage_settings",
     },
     network = {
         "network_wifi",
@@ -119,6 +120,7 @@ local order = {
         "book_info",
         "----------------------------",
         "system_statistics",
+        "mass_storage_actions",
         "----------------------------",
         "ota_update", -- if Device:hasOTAUpdates()
         "version",

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -90,6 +90,11 @@ RETURN_VALUE="${RESTART_KOREADER}"
 
 # Loop forever until KOReader requests a normal exit.
 while [ "${RETURN_VALUE}" -ge "${RESTART_KOREADER}" ]; do
+
+    # move dictionaries from external storage to koreader private partition.
+    find /mnt/public/dict -type f -exec mv -v \{\} /mnt/private/koreader/data/dict \; 2>/dev/null
+
+    # run KOReader
     ./reader.lua "${args}" >>crash.log 2>&1
     RETURN_VALUE=$?
 

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -30,7 +30,7 @@ fi
     #SPINNER="▌ ▛ ▀ ▜ ▐ ▟ ▄ ▙"
     while :; do
         for spin in ${SPINNER}; do
-            usleep 500000
+            usleep 500000 2>/dev/null || sleep 0.5
             # NOTE: Throw stderr to the void because I'm cheating w/ U+FFFD for a blank character,
             #       which FBInk replaces by a blank, but not before shouting at us on stderr ;).
             ./fbink -q -y -7 -pmh "${ZSYNC_MESSAGE} ${spin}" 2>/dev/null


### PR DESCRIPTION
* Move Cervantes 4 to frontlight mixer, like Kobo Forma and Kobo Clara HD.
* Fix waiting spinner (fallback to sleep in devices where usleep is not present)
* USB storage support for KOReader, using a thirdparty tool.
* Allow installation of dicts from the external partition.

I  don't want to spend time building safemode as part of koreader so I made a runtime check. USB storage settings and actions are only displayed on devices if 3rd party tools are recent enough to work with KO.

Once this PR is merged I will update the tool and write specific instructions to enable mass storage on mobileread :+1: 

pinging @avsej for feedback (specially about frontlight/natural light changes),