### PR TITLE
Eliminate ghosting on eInk when showing an image ScreenSaver

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -187,8 +187,10 @@ function Device:onPowerEvent(ev)
             self.orig_rotation_mode = self.screen:getRotationMode()
             self.screen:setRotationMode(0)
 
-            -- If we're using a screensaver mode that shows an image, flash the screen to white first, to eliminate ghosting.
-            if G_reader_settings:readSetting("screensaver_type") == "cover" or
+            -- On eInk, if we're using a screensaver mode that shows an image,
+            -- flash the screen to white first, to eliminate ghosting.
+            if self:hasEinkScreen() and
+               G_reader_settings:readSetting("screensaver_type") == "cover" or
                G_reader_settings:readSetting("screensaver_type") == "random_image" or
                G_reader_settings:readSetting("screensaver_type") == "image_file" then
                 self.screen:clear(self.screen:getScreenWidth(), self.screen:getScreenHeight())

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -176,7 +176,7 @@ function Device:onPowerEvent(ev)
             logger.dbg("Already in screen saver mode, suspending...")
             self:rescheduleSuspend()
         end
-    -- else we we not in screensaver mode
+    -- else we were not in screensaver mode
     elseif ev == "Power" or ev == "Suspend" then
         self.powerd:beforeSuspend()
         local UIManager = require("ui/uimanager")
@@ -186,6 +186,12 @@ function Device:onPowerEvent(ev)
         if G_reader_settings:readSetting("screensaver_type") ~= "message" then
             self.orig_rotation_mode = self.screen:getRotationMode()
             self.screen:setRotationMode(0)
+
+            -- If we're using a screensaver mode that shows an image, flash the screen to white first, to eliminate ghosting.
+            if G_reader_settings:readSetting("screensaver_type") ~= "disable" then
+                self.screen:clear(self.screen:getScreenWidth(), self.screen:getScreenHeight())
+                self.screen:refreshFull()
+            end
         else
             -- nil it, in case user switched ScreenSaver modes during our lifetime.
             self.orig_rotation_mode = nil

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -188,7 +188,9 @@ function Device:onPowerEvent(ev)
             self.screen:setRotationMode(0)
 
             -- If we're using a screensaver mode that shows an image, flash the screen to white first, to eliminate ghosting.
-            if G_reader_settings:readSetting("screensaver_type") ~= "disable" then
+            if G_reader_settings:readSetting("screensaver_type") == "cover" or
+               G_reader_settings:readSetting("screensaver_type") == "random_image" or
+               G_reader_settings:readSetting("screensaver_type") == "image_file" then
                 self.screen:clear(self.screen:getScreenWidth(), self.screen:getScreenHeight())
                 self.screen:refreshFull()
             end


### PR DESCRIPTION
By flashing to a white screen first.

Depends on https://github.com/koreader/koreader-base/pull/814