### PR TITLE
Stricter WiFi callback

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -143,7 +143,6 @@ function NetworkMgr:getWifiMenuTable()
                     UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
                 else
                     -- Check that the connection attempt was actually successful...
-                    local NetworkMgr = require("ui/network/manager")
                     if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
                         UIManager:broadcastEvent(Event:new("NetworkConnected"))
                     elseif NetworkMgr:isWifiOn() and not NetworkMgr:isConnected() then
@@ -158,7 +157,6 @@ function NetworkMgr:getWifiMenuTable()
                         --       Kobo: Yes please.
                         --       Cervantes: Loads/unloads module, probably could use it like Kobo.
                         --       Kindle: Probably could use it, if only because leaving Wireless on is generally a terrible idea on Kindle.
-                        local Device = require("device")
                         if Device:isKobo() or Device:isCervantes() or Device:isKindle() then
                             NetworkMgr:turnOffWifi()
                         end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -156,8 +156,10 @@ function NetworkMgr:getWifiMenuTable()
                         --       Sony: Doesn't play with modules, don't do it
                         --       Kobo: Yes please.
                         --       Cervantes: Loads/unloads module, probably could use it like Kobo.
-                        --       Kindle: Probably could use it, if only because leaving Wireless on is generally a terrible idea on Kindle.
-                        if Device:isKobo() or Device:isCervantes() or Device:isKindle() then
+                        --       Kindle: Probably could use it, if only because leaving Wireless on is generally a terrible idea on Kindle,
+                        --               except that we defer to lipc, and the callback is simply delayed by 1s,
+                        --               we can't be sure the system will actually have finished bringing WiFi up by then...
+                        if Device:isKobo() or Device:isCervantes() then
                             NetworkMgr:turnOffWifi()
                         end
                         touchmenu_instance:updateItems()

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -142,7 +142,17 @@ function NetworkMgr:getWifiMenuTable()
                 if wifi_status then
                     UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
                 else
-                    UIManager:broadcastEvent(Event:new("NetworkConnected"))
+                    -- Check that the connection attempt was actually successful...
+                    local NetworkMgr = require("ui/network/manager")
+                    if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
+                        UIManager:broadcastEvent(Event:new("NetworkConnected"))
+                    elseif NetworkMgr:isWifiOn() and not NetworkMgr:isConnected() then
+                        -- Don't leave WiFi in an inconsistent state if the connection failed (i.e., unload modules on Kobo).
+                        self.wifi_was_on = false
+                        G_reader_settings:saveSetting("wifi_was_on", false)
+                        NetworkMgr:turnOffWifi()
+                        touchmenu_instance:updateItems()
+                    end
                 end
             end
             if wifi_status then

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -150,7 +150,18 @@ function NetworkMgr:getWifiMenuTable()
                         -- Don't leave WiFi in an inconsistent state if the connection failed (i.e., unload modules on Kobo).
                         self.wifi_was_on = false
                         G_reader_settings:saveSetting("wifi_was_on", false)
-                        NetworkMgr:turnOffWifi()
+                        -- NOTE: Limit that to only a few platforms, as it might be overkill on some devices.
+                        --       The intent being to unload kernel modules, and make a subsequent turnOnWifi behave sanely.
+                        --       PB: netagent, no idea what it does, but it's not using this codepath anyway (!hasWifiToggle)
+                        --       Android: definitely shouldn't do it.
+                        --       Sony: Doesn't play with modules, don't do it
+                        --       Kobo: Yes please.
+                        --       Cervantes: Loads/unloads module, probably could use it like Kobo.
+                        --       Kindle: Probably could use it, if only because leaving Wireless on is generally a terrible idea on Kindle.
+                        local Device = require("device")
+                        if Device:isKobo() or Device:isCervantes() or Device:isKindle() then
+                            NetworkMgr:turnOffWifi()
+                        end
                         touchmenu_instance:updateItems()
                     end
                 end


### PR DESCRIPTION
Double-checks that the connection was successful, and forcefully kills WiFi if it didn't, to avoid leaving stuff in an inconsistent state.

Should fix #2183