### PR TITLE
[feat] Update check

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -21,7 +21,7 @@ local Device = Generic:new{
     display_dpi = android.lib.AConfiguration_getDensity(android.app.config),
     hasClipboard = yes,
     hasColorScreen = yes,
-    hasOTAUpdates = yes,
+    hasOTAUpdates = no,
 }
 
 function Device:init()

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -21,6 +21,7 @@ local Device = Generic:new{
 
 local AppImage = Device:new{
     model = "AppImage",
+    hasOTAUpdates = yes,
 }
 
 local Emulator = Device:new{

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -8,7 +8,6 @@ local UIManager = require("ui/uimanager")
 local Version = require("version")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
-local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
@@ -170,8 +169,8 @@ function OTAManager:checkUpdate()
             for line in update_info:lines() do
                 i = i + 1
                 if i == 1 then
-                    link = self:getOTAServer() .. line
-                    dummy, ota_package = util.splitFilePathName(line)
+                    ota_package = line
+                    link = self:getOTAServer() .. ota_package
                 end
             end
         else


### PR DESCRIPTION
The concept is quite simple: stick a file on the OTA server named
something like `koreader-appimage-latest-stable` (by analogy with
`koreader-cervantes-latest-stable.zsync`), which contains nothing
but a filename.

The difference with the zsync update is that the link is then launched
in the user's browser (AppImage) or DownloadManager (Android, not yet
implemented).