### PR TITLE
Fix partial refresh when coming out of ScreenSaver in landscape

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -161,11 +161,11 @@ function Device:onPowerEvent(ev)
                     network_manager:restoreWifiAsync()
                 end
                 self:resume()
-                require("ui/screensaver"):close()
                 -- restore to previous rotation mode, if need be.
                 if self.orig_rotation_mode then
                     self.screen:setRotationMode(self.orig_rotation_mode)
                 end
+                require("ui/screensaver"):close()
                 if self:needsScreenRefreshAfterResume() then
                     UIManager:scheduleIn(1, function() self.screen:refreshFull() end)
                 end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -408,7 +408,7 @@ function Screensaver:close()
     elseif screensaver_delay == "disable" or screensaver_delay == nil then
         logger.dbg("close screensaver")
         if self.left_msg then
-            UIManager:close(self.left_msg)
+            UIManager:close(self.left_msg, "full")
             self.left_msg = nil
         end
     else


### PR DESCRIPTION
When we rotate to show a screensaver, restore original rotation *before* closing the ScreenSaver window.

And ensure closing the ScreenSaver *always* triggers a full update, no matter the settings.

Fix #4621