### PR TITLE
PicDocument: Pass a copy of image_bb in getCoverPageImage()

### DIFF
--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -43,7 +43,7 @@ end
 function PicDocument:getCoverPageImage()
     local first_page = self._document:openPage(1)
     if first_page.image_bb then
-        return first_page.image_bb
+        return first_page.image_bb:copy()
     end
     return nil
 end

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -438,7 +438,7 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
                         scale_factor = math.min(spec_max_cover_w / cbb_w, spec_max_cover_h / cbb_h)
                         cbb_w = math.min(math.floor(cbb_w * scale_factor)+1, spec_max_cover_w)
                         cbb_h = math.min(math.floor(cbb_h * scale_factor)+1, spec_max_cover_h)
-                        cover_bb = RenderImage:scaleBlitBuffer(cover_bb, cbb_w, cbb_h)
+                        cover_bb = RenderImage:scaleBlitBuffer(cover_bb, cbb_w, cbb_h, true)
                     end
                     dbrow.cover_w = cbb_w
                     dbrow.cover_h = cbb_h


### PR DESCRIPTION
Avoids a use-after-free in mupdf.scaleBlitBuffer

Fix koreader/koreader-base#821

Thanks for the hint, @poire-z ;).