### PR TITLE
[wip]: android: (re)enable downloads using full apks

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -21,7 +21,7 @@ local Device = Generic:new{
     display_dpi = android.lib.AConfiguration_getDensity(android.app.config),
     hasClipboard = yes,
     hasColorScreen = yes,
-    hasOTAUpdates = no,
+    hasOTAUpdates = yes,
 }
 
 function Device:init()

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -224,7 +224,7 @@ function OTAManager:fetchAndProcessUpdate()
                     if isAndroid then
                         -- download the package if not present.
                         if android.download(link, ota_package) then
-                            android.notification(T(_("File %1 is already downloaded"), ota_package))
+                            android.notification(T(_("The file %1 already exists."), ota_package))
                         else
                             android.notification(T(_("Downloading %1"), ota_package))
                         end


### PR DESCRIPTION
Requires https://github.com/koreader/android-luajit-launcher/pull/122

#### to-do:

- make hasOTAUpdate false for Fdroid.
~~- better name for "koreader-latest.apk".~~


#### won't fix:
- opening the apk when downloaded, it is a hell, requires special permissions, a file provider on Nougat+, probably breaks our target api, requiring api24+, forcing us to request permissions at runtime instead of install time...

- display a notification when the file is downloaded, because it can't be translated.

#### preview:
![untitled](https://user-images.githubusercontent.com/975883/53212393-0e2d3d80-3645-11e9-818e-79005ea57dfe.gif)
