### PR TITLE
[fix] ReaderGesture: don't crash without custom gestures

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -12,7 +12,6 @@ local UIManager = require("ui/uimanager")
 local T = require("ffi/util").template
 local _ = require("gettext")
 local logger = require("logger")
-local util = require("util")
 
 local default_gesture = {
     tap_right_bottom_corner = "nothing",

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -211,8 +211,10 @@ local multiswipes = {
     "west south",
 }
 
-for k, v in pairs(custom_multiswipes_table) do
-    table.insert(multiswipes, v)
+if custom_multiswipes_table then
+    for k, v in pairs(custom_multiswipes_table) do
+        table.insert(multiswipes, v)
+    end
 end
 
 function ReaderGesture:buildMultiswipeMenu()


### PR DESCRIPTION
Silly oversight in https://github.com/koreader/koreader/pull/4644.