### PR TITLE
[fix, UX] ReaderFooter: Don't hide progressbar if it's the only ticked option

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -210,7 +210,7 @@ function ReaderFooter:init()
     self[1] = self.footer_positioner
 
     self.mode = G_reader_settings:readSetting("reader_footer_mode") or self.mode
-    if self.has_no_mode then
+    if self.has_no_mode and self.settings.disable_progress_bar then
         self.mode = MODE.off
         self.view.footer_visible = false
         self:resetLayout()

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -594,8 +594,25 @@ describe("Readerfooter module", function()
         local footer = readerui.view.footer
 
         assert.truthy(footer.has_no_mode)
-        assert.falsy(readerui.view.footer_visible)
+        assert.truthy(readerui.view.footer_visible)
         assert.is.same(15, footer:getHeight())
+    end)
+
+    it("should disable footer when all modes + progressbar are disabled", function()
+        local sample_epub = "spec/front/unit/data/juliet.epub"
+        purgeDir(DocSettings:getSidecarDir(sample_epub))
+        os.remove(DocSettings:getHistoryPath(sample_epub))
+        UIManager:quit()
+
+        G_reader_settings:saveSetting("reader_footer_mode", 1)
+        G_reader_settings:saveSetting("footer", {disable_progress_bar = true})
+        local readerui = ReaderUI:new{
+            document = DocumentRegistry:openDocument(sample_epub),
+        }
+        local footer = readerui.view.footer
+
+        assert.truthy(footer.has_no_mode)
+        assert.falsy(readerui.view.footer_visible)
     end)
 
     it("should disable footer if settings.disabled is true", function()


### PR DESCRIPTION
Fixes #3914.

Cf. #3056.