### PR TITLE
[fix, UX] GestureDetector: fix multiswipe length detection

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -517,7 +517,6 @@ function GestureDetector:handlePan(tev)
                     ["slot"] = slot,
                 },
             }
-            pan_direction = self:getPath(slot, false, fake_first_tev)
         end
 
         local msd_direction, msd_distance = self:getPath(slot, true, fake_first_tev)

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -520,21 +520,20 @@ function GestureDetector:handlePan(tev)
             pan_direction = self:getPath(slot, false, fake_first_tev)
         end
 
-        if msd_cnt == 0
-           or pan_direction ~= msd_direction_prev
-        then
-            local msd_direction, msd_distance = self:getPath(slot, true, fake_first_tev)
+        local msd_direction, msd_distance = self:getPath(slot, true, fake_first_tev)
 
-            if msd_distance > self.MULTISWIPE_THRESHOLD
-               and (msd_cnt == 0
-                    or not pan_direction:match(msd_direction_prev))
-            then
-                if msd_direction ~= msd_direction_prev then
-                    self.multiswipe_directions[msd_cnt+1] = {
-                        [1] = msd_direction,
-                        [2] = pan_ev,
-                    }
-                end
+        if msd_distance > self.MULTISWIPE_THRESHOLD then
+            if msd_direction ~= msd_direction_prev then
+                self.multiswipe_directions[msd_cnt+1] = {
+                    [1] = msd_direction,
+                    [2] = pan_ev,
+                }
+            -- update ongoing swipe direction to the new maximum
+            else
+                self.multiswipe_directions[msd_cnt] = {
+                    [1] = msd_direction,
+                    [2] = pan_ev,
+                }
             end
         end
 

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -519,6 +519,7 @@ function GestureDetector:handlePan(tev)
             }
         end
 
+        -- the first time fake_first_tev is nil, so self.first_tevs is automatically used instead
         local msd_direction, msd_distance = self:getPath(slot, true, fake_first_tev)
 
         if msd_distance > self.MULTISWIPE_THRESHOLD then


### PR DESCRIPTION
Reported by @poire-z, cf. https://github.com/koreader/koreader/pull/4640#issuecomment-466544922

<hr>

Apparently it's natural for me to make the second swipe slightly longer than the first, so I never noticed a logic issue. I did notice that it seemed slightly harder to make 4-swipe multiswipes than I expected it to be, but those are not necessarily easy gestures to make.

The problem was that I needed to prevent obviously silly gestures like `west west west east`. In ignoring such duplication, what I accidentally did can be illustrated in the following `west east` multiswipe:

![path819](https://user-images.githubusercontent.com/202757/53290761-04bce600-37a9-11e9-88cd-5aee3b1581fa.png)

So what you see there is that at point X, the first direction in the multiswipe is detected. Every further movement west was ignored, meaning that the following swipe east could still end up as a relatively western movement overall.

By simply updating the current multiswipe slot in case of the same direction, both problems are prevented. We'll never get the same direction twice, and X moves over to where it's supposed to be on the left.