### PR TITLE
[fix] Gesture manager: send TapForward event for page forward

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -474,7 +474,7 @@ function ReaderGesture:gestureAction(action)
     elseif action == "page_jmp_fwd_10" then
         self:pageUpdate(10)
     elseif action == "page_jmp_fwd_1" then
-        self:pageUpdate(1)
+        self.ui:handleEvent(Event:new("TapForward"))
     elseif action == "page_jmp_back_10" then
         self:pageUpdate(-10)
     elseif action == "page_jmp_back_1" then


### PR DESCRIPTION
Otherwise you can get rather unexpected results in paged media and scroll mode.

Workaround suggested by @NiLuJe here: https://github.com/koreader/koreader/pull/4570#discussion_r258693835