### PR TITLE
bump crengine, fix a few cre scroll mode issues

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -207,10 +207,7 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     -- showing menu...). We might want to cache these boxes per page (and
     -- clear that cache when page layout change or highlights are added
     -- or removed).
-    local cur_page
-    -- In scroll mode, we'll need to check for highlights in previous or next
-    -- page too as some parts of them may be displayed
-    local neighbour_pages = self.view.view_mode ~= "page" and 1 or 0
+    local cur_page, cur_scroll_top, cur_scroll_bottom
     local pos = self.view:screenToPageTransform(ges.pos)
     for page, _ in pairs(self.view.highlight.saved) do
         local items = self.view.highlight.saved[page]
@@ -222,17 +219,32 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
                 local pos0, pos1 = items[i].pos0, items[i].pos1
                 -- document:getScreenBoxesFromPositions() is expensive, so we
                 -- first check this item is on current page
-                local page0 = self.ui.document:getPageFromXPointer(pos0)
-                local page1 = self.ui.document:getPageFromXPointer(pos1)
-                local start_page = math.min(page0, page1)
-                local end_page = math.max(page0, page1)
-                -- In scroll mode, we may be displaying cur_page and cur_page+1, so
-                -- we have to check the highlight start_page is <= cur_page+1.
-                -- Same thinking with highlight's end_page >= cur_page-1 as we may
-                -- be displaying a part of cur_page-1.
-                -- (A highlight starting on cur_page-17 and ending on cur_page+13 is
-                -- a highlight to consider)
-                if start_page <= cur_page + neighbour_pages and end_page >= cur_page - neighbour_pages then
+                local is_in_view = false
+                if self.view_mode == "page" then
+                    if not cur_page then
+                        cur_page = self.ui.document:getPageFromXPointer(self.ui.document:getXPointer())
+                    end
+                    local page0 = self.ui.document:getPageFromXPointer(pos0)
+                    local page1 = self.ui.document:getPageFromXPointer(pos1)
+                    local start_page = math.min(page0, page1)
+                    local end_page = math.max(page0, page1)
+                    if start_page <= cur_page and end_page >= cur_page then
+                        is_in_view = true
+                    end
+                else
+                    if not cur_scroll_top then
+                        cur_scroll_top = self.ui.document:getPosFromXPointer(self.ui.document:getXPointer())
+                        cur_scroll_bottom = cur_scroll_top + self.ui.dimen.h
+                    end
+                    local spos0 = self.ui.document:getPosFromXPointer(pos0)
+                    local spos1 = self.ui.document:getPosFromXPointer(pos1)
+                    local start_pos = math.min(spos0, spos1)
+                    local end_pos = math.max(spos0, spos1)
+                    if start_pos <= cur_scroll_bottom and end_pos >= cur_scroll_top then
+                        is_in_view = true
+                    end
+                end
+                if is_in_view then
                     local boxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1, true) -- get_segments=true
                     if boxes then
                         for index, box in pairs(boxes) do

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -200,10 +200,19 @@ function CreDocument:render()
     end
     logger.dbg("CreDocument: rendering document...")
     self._document:renderDocument()
-    if not self.info.has_pages then
+    self.info.doc_height = self._document:getFullHeight()
+    self.been_rendered = true
+    logger.dbg("CreDocument: rendering done.")
+end
+
+function CreDocument:_readMetadata()
+    Document._readMetadata(self) -- will grab/update self.info.number_of_pages
+    if self.been_rendered then
+        -- getFullHeight() would crash if the document is not
+        -- yet rendered
         self.info.doc_height = self._document:getFullHeight()
     end
-    logger.dbg("CreDocument: rendering done.")
+    return true
 end
 
 function CreDocument:close()


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/264:
- Fix text selection in some tables
- Add known HTML attributes to avoid cache issues
- Make existing context.AddLine() and pb_flag clearer

cre.cpp https://github.com/koreader/koreader-base/pull/834:
- gotoPos(): allow scrolling after end of document (to avoid not seeing the last line of a document that would be hidden by the footer bar). Will help fixing https://github.com/koreader/koreader/issues/4650

cre scroll mode: fix highlights not shown when small pages

cre scroll mode: fix last line of book hidden by footer (closes #4650) and some other issues related to new document height (when switching font size or layout) never being updated until book reload. Might fix #4328.
