### PR TITLE
[fix] GestureDetector: add PANINTERVAL

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -401,8 +401,8 @@ function ReaderPaging:onPan(_, ges)
             self.view:PanningStart(-ges.relative.x, -ges.relative.y)
         end
     elseif ges.direction == "north" or ges.direction == "south" then
-        self:onPanningRel(self.last_pan_relative_y - ges.relative.y)
-        self.last_pan_relative_y = ges.relative.y
+        self:onPanningRel(self.last_pan_relative_y - ges.relative_delayed.y)
+        self.last_pan_relative_y = ges.relative_delayed.y
     end
     return true
 end

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -401,8 +401,12 @@ function ReaderPaging:onPan(_, ges)
             self.view:PanningStart(-ges.relative.x, -ges.relative.y)
         end
     elseif ges.direction == "north" or ges.direction == "south" then
-        self:onPanningRel(self.last_pan_relative_y - ges.relative_delayed.y)
-        self.last_pan_relative_y = ges.relative_delayed.y
+        local relative_type = "relative"
+        if self.ui.gesture and self.ui.gesture.multiswipes_enabled then
+            relative_type = "relative_delayed"
+        end
+        self:onPanningRel(self.last_pan_relative_y - ges[relative_type].y)
+        self.last_pan_relative_y = ges[relative_type].y
     end
     return true
 end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -422,9 +422,9 @@ end
 function ReaderRolling:onPan(_, ges)
     if self.view.view_mode == "scroll" then
         if ges.direction == "north" then
-            self:_gotoPos(self.current_pos + ges.distance)
+            self:_gotoPos(self.current_pos + ges.distance_delayed)
         elseif ges.direction == "south" then
-            self:_gotoPos(self.current_pos - ges.distance)
+            self:_gotoPos(self.current_pos - ges.distance_delayed)
         end
     end
     return true

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -421,10 +421,14 @@ end
 
 function ReaderRolling:onPan(_, ges)
     if self.view.view_mode == "scroll" then
+        local distance_type = "distance"
+        if self.ui.gesture and self.ui.gesture.multiswipes_enabled then
+            distance_type = "distance_delayed"
+        end
         if ges.direction == "north" then
-            self:_gotoPos(self.current_pos + ges.distance_delayed)
+            self:_gotoPos(self.current_pos + ges[distance_type])
         elseif ges.direction == "south" then
-            self:_gotoPos(self.current_pos - ges.distance_delayed)
+            self:_gotoPos(self.current_pos - ges[distance_type])
         end
     end
     return true

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -500,6 +500,7 @@ function GestureDetector:handlePan(tev)
             pos = nil,
             direction = pan_direction,
             distance = pan_distance,
+            distance_delayed = 0,
             time = tev.timev,
         }
 
@@ -512,8 +513,7 @@ function GestureDetector:handlePan(tev)
         if not ((tv_diff.sec == 0) and (tv_diff.usec < self.PAN_DELAYED_INTERVAL)) then
             pan_ev.relative_delayed.x = tev.x - self.first_tevs[slot].x
             pan_ev.relative_delayed.y = tev.y - self.first_tevs[slot].y
-        else
-            pan_ev.distance = 0
+            pan_ev.distance_delayed = pan_distance
         end
 
         pan_ev.pos = Geom:new{

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -540,6 +540,7 @@ function GestureDetector:handlePan(tev)
 
         -- wait a little while to start actually panning to reduce the potential
         -- for panning on swipe (e.g., for the menu or for multiswipe)
+        local tv_diff = self.first_tevs[slot].timev - self.last_tevs[slot].timev
         if (tv_diff.sec == 0) and (tv_diff.usec < self.PAN_INTERVAL) then
             pan_ev.relative = {
                 x = 0,

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -53,7 +53,7 @@ local GestureDetector = {
     DOUBLE_TAP_INTERVAL = 300 * 1000,
     TWO_FINGER_TAP_DURATION = 300 * 1000,
     HOLD_INTERVAL = 500 * 1000,
-    PAN_DELAYED_INTERVAL = 200 * 1000,
+    PAN_DELAYED_INTERVAL = 500 * 1000,
     SWIPE_INTERVAL = 900 * 1000,
     -- pinch/spread direction table
     DIRECTION_TABLE = {
@@ -196,7 +196,7 @@ end
 
 function GestureDetector:isSwipe(slot)
     if not self.first_tevs[slot] or not self.last_tevs[slot] then return end
-    local tv_diff = self.first_tevs[slot].timev - self.last_tevs[slot].timev
+    local tv_diff = self.last_tevs[slot].timev - self.first_tevs[slot].timev
     if (tv_diff.sec == 0) and (tv_diff.usec < self.SWIPE_INTERVAL) then
         local x_diff = self.last_tevs[slot].x - self.first_tevs[slot].x
         local y_diff = self.last_tevs[slot].y - self.first_tevs[slot].y
@@ -483,7 +483,7 @@ function GestureDetector:handlePan(tev)
         return self:handleTwoFingerPan(tev)
     else
         local pan_direction, pan_distance = self:getPath(slot)
-        local tv_diff = self.first_tevs[slot].timev - self.last_tevs[slot].timev
+        local tv_diff = self.last_tevs[slot].timev - self.first_tevs[slot].timev
 
         local pan_ev = {
             ges = "pan",

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -53,6 +53,7 @@ local GestureDetector = {
     DOUBLE_TAP_INTERVAL = 300 * 1000,
     TWO_FINGER_TAP_DURATION = 300 * 1000,
     HOLD_INTERVAL = 500 * 1000,
+    PAN_INTERVAL = 300 * 1000,
     SWIPE_INTERVAL = 900 * 1000,
     -- pinch/spread direction table
     DIRECTION_TABLE = {
@@ -535,6 +536,15 @@ function GestureDetector:handlePan(tev)
                     [2] = pan_ev,
                 }
             end
+        end
+
+        -- wait a little while to start actually panning to reduce the potential
+        -- for panning on swipe (e.g., for the menu or for multiswipe)
+        if (tv_diff.sec == 0) and (tv_diff.usec < self.PAN_INTERVAL) then
+            pan_ev.relative = {
+                x = 0,
+                y = 0,
+            }
         end
 
         return pan_ev

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -507,7 +507,7 @@ function GestureDetector:handlePan(tev)
         pan_ev.relative.x = tev.x - self.first_tevs[slot].x
         pan_ev.relative.y = tev.y - self.first_tevs[slot].y
 
-        -- delayed pan, used where to reduce potential activation of panning
+        -- delayed pan, used where necessary to reduce potential activation of panning
         -- when swiping is intended (e.g., for the menu or for multiswipe)
         if not ((tv_diff.sec == 0) and (tv_diff.usec < self.PAN_DELAYED_INTERVAL)) then
             pan_ev.relative_delayed.x = tev.x - self.first_tevs[slot].x

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -53,7 +53,7 @@ local GestureDetector = {
     DOUBLE_TAP_INTERVAL = 300 * 1000,
     TWO_FINGER_TAP_DURATION = 300 * 1000,
     HOLD_INTERVAL = 500 * 1000,
-    PAN_DELAYED_INTERVAL = 300 * 1000,
+    PAN_DELAYED_INTERVAL = 200 * 1000,
     SWIPE_INTERVAL = 900 * 1000,
     -- pinch/spread direction table
     DIRECTION_TABLE = {


### PR DESCRIPTION
This properly fixes the long-standing complaint that swiping to open
the menu could unintentionally trigger some light panning. With the
introduction of multiswipes, this problem has become more noticeable.