### PR TITLE
[fix] TimeVal: add dbg:guard against incorrect subtraction order

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -195,7 +195,7 @@ end
 
 function GestureDetector:isSwipe(slot)
     if not self.first_tevs[slot] or not self.last_tevs[slot] then return end
-    local tv_diff = self.first_tevs[slot].timev - self.last_tevs[slot].timev
+    local tv_diff = self.last_tevs[slot].timev - self.first_tevs[slot].timev
     if (tv_diff.sec == 0) and (tv_diff.usec < self.SWIPE_INTERVAL) then
         local x_diff = self.last_tevs[slot].x - self.first_tevs[slot].x
         local y_diff = self.last_tevs[slot].y - self.first_tevs[slot].y

--- a/frontend/ui/timeval.lua
+++ b/frontend/ui/timeval.lua
@@ -13,6 +13,7 @@ A simple module to module to compare and do arithmetic with time values.
     local tv_duration_seconds_float = tv_duration.sec + tv_duration.usec/1000000
 ]]
 
+local dbg = require("dbg")
 local util = require("ffi/util")
 
 --[[--
@@ -109,6 +110,12 @@ function TimeVal:__sub(time_b)
 
     return diff
 end
+
+dbg:guard(TimeVal, '__sub',
+          function(self, time_b)
+              assert(self.sec > time_b.sec or (self.sec == time_b.sec and self.usec >= time_b.usec),
+                     "Subtract the first timeval from the latest, not vice versa.")
+          end)
 
 function TimeVal:__add(time_b)
     local sum = TimeVal:new{}

--- a/spec/unit/timeval_spec.lua
+++ b/spec/unit/timeval_spec.lua
@@ -1,0 +1,34 @@
+describe("TimeVal module", function()
+    local TimeVal, dbg, dbg_on
+    setup(function()
+        require("commonrequire")
+        TimeVal = require("ui/timeval")
+        dbg = require("dbg")
+        dbg_on = dbg.is_on
+    end)
+
+    after_each(function()
+        if dbg_on then
+            dbg:turnOn()
+        else
+            dbg:turnOff()
+        end
+    end)
+
+    it("should subtract", function()
+        local timev1 = TimeVal:new{ sec = 5, usec = 5000}
+        local timev2 = TimeVal:new{ sec = 10, usec = 6000}
+
+        assert.is.same({sec = 5,usec = 1000}, timev2 - timev1)
+        assert.is.same({sec = -5,usec = -1000}, timev1 - timev2)
+    end)
+
+    it("should guard against reverse subtraction logic", function()
+        dbg:turnOn()
+        TimeVal = package.reload("ui/timeval")
+        local timev1 = TimeVal:new{ sec = 5, usec = 5000}
+        local timev2 = TimeVal:new{ sec = 10, usec = 5000}
+
+        assert.has.errors(function() return timev1 - timev2 end)
+    end)
+end)


### PR DESCRIPTION
In principle, any negative subtraction result should be caused by a logical error. Cf. https://github.com/koreader/koreader/pull/4666#discussion_r260772668

@poire-z @NiLuJe Of course it could also be made into a more forgiving logger.warn, or nothing at all if there are legitimate cases where the result could be negative.