### PR TITLE
ButtonProgressWidget: grey buttons instead of black

### DIFF
--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -43,13 +43,15 @@ function ButtonProgressWidget:update()
     local button_margin = Size.margin.tiny
     local button_padding = Size.padding.button
     local button_bordersize = Size.border.button
-    local preselect
+    local preselect, background
     local button_width = math.floor(self.width / self.num_buttons) - 2*button_padding - 2*button_margin - 2*button_bordersize
     for i = 1, self.num_buttons do
         if self.position >= i then
             preselect = true
+            background = Blitbuffer.COLOR_GREY
         else
             preselect = false
+            background = Blitbuffer.COLOR_WHITE
         end
         local button = Button:new{
             text = "",
@@ -60,6 +62,7 @@ function ButtonProgressWidget:update()
             enabled = true,
             width = button_width,
             preselect = preselect,
+            background = background,
             text_font_face = self.font_face,
             text_font_size = self.font_size,
             callback = function()

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -43,26 +43,19 @@ function ButtonProgressWidget:update()
     local button_margin = Size.margin.tiny
     local button_padding = Size.padding.button
     local button_bordersize = Size.border.button
-    local preselect, background
     local button_width = math.floor(self.width / self.num_buttons) - 2*button_padding - 2*button_margin - 2*button_bordersize
     for i = 1, self.num_buttons do
-        if self.position >= i then
-            preselect = true
-            background = Blitbuffer.COLOR_GREY
-        else
-            preselect = false
-            background = Blitbuffer.COLOR_WHITE
-        end
+        local blackened = i <= self.position
         local button = Button:new{
             text = "",
             radius = 0,
-            margin = button_margin,
+            margin = blackened and 0 or button_margin, -- margin will be provided by FrameContainer below
             padding = button_padding,
             bordersize = button_bordersize,
             enabled = true,
             width = button_width,
-            preselect = preselect,
-            background = background,
+            preselect = blackened,
+            background = blackened and Blitbuffer.COLOR_GREY or Blitbuffer.COLOR_WHITE,
             text_font_face = self.font_face,
             text_font_size = self.font_size,
             callback = function()
@@ -75,6 +68,17 @@ function ButtonProgressWidget:update()
                 self.hold_callback(i)
             end,
         }
+        if blackened then
+            -- If we want no black border on grey squares:
+            button.frame.color = Blitbuffer.COLOR_GREY
+            -- Add back button margin
+            button = FrameContainer:new{
+                margin = button_margin,
+                padding = 0,
+                bordersize = 0,
+                button,
+            }
+        end
         table.insert(self.buttonprogress_content, button)
     end
 

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -19,6 +19,7 @@ local ButtonProgressWidget = InputContainer:new{
     enabled = true,
     num_buttons = 2,
     position = 1,
+    thin_grey_style = false, -- default to black
 }
 
 function ButtonProgressWidget:init()
@@ -42,20 +43,23 @@ function ButtonProgressWidget:update()
     self.buttonprogress_content:clear()
     local button_margin = Size.margin.tiny
     local button_padding = Size.padding.button
-    local button_bordersize = Size.border.button
+    local button_bordersize = self.thin_grey_style and Size.border.thin or Size.border.button
     local button_width = math.floor(self.width / self.num_buttons) - 2*button_padding - 2*button_margin - 2*button_bordersize
     for i = 1, self.num_buttons do
-        local blackened = i <= self.position
+        local highlighted = i <= self.position
+        local margin = button_margin
+        if self.thin_grey_style and highlighted then
+            margin = 0 -- moved outside button so it's not inverted
+        end
         local button = Button:new{
             text = "",
             radius = 0,
-            margin = blackened and 0 or button_margin, -- margin will be provided by FrameContainer below
+            margin = margin,
             padding = button_padding,
             bordersize = button_bordersize,
             enabled = true,
             width = button_width,
-            preselect = blackened,
-            background = blackened and Blitbuffer.COLOR_GREY or Blitbuffer.COLOR_WHITE,
+            preselect = highlighted,
             text_font_face = self.font_face,
             text_font_size = self.font_size,
             callback = function()
@@ -68,16 +72,17 @@ function ButtonProgressWidget:update()
                 self.hold_callback(i)
             end,
         }
-        if blackened then
-            -- If we want no black border on grey squares:
-            button.frame.color = Blitbuffer.COLOR_GREY
-            -- Add back button margin
-            button = FrameContainer:new{
-                margin = button_margin,
-                padding = 0,
-                bordersize = 0,
-                button,
-            }
+        if self.thin_grey_style then
+            button.frame.color = Blitbuffer.COLOR_GREY -- no black border around grey squares
+            if highlighted then
+                button.frame.background = Blitbuffer.COLOR_GREY
+                button = FrameContainer:new{ -- add margin back
+                    margin = button_margin,
+                    padding = 0,
+                    bordersize = 0,
+                    button,
+                }
+            end
         end
         table.insert(self.buttonprogress_content, button)
     end

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -503,6 +503,7 @@ function ConfigOption:init()
                     width = math.min(max_buttonprogress_width, buttonprogress_width),
                     height = option_height,
                     padding = 0,
+                    thin_grey_style = true,
                     font_face = item_font_face,
                     font_size = item_font_size,
                     num_buttons = #self.options[c].values,


### PR DESCRIPTION
May help with ghosting when closing bottom dialog, and fit better with the other grey toggles.
See https://github.com/koreader/koreader/pull/4691#issuecomment-468646394 and follow ups.

(To be merged or tried before/after release.)

It's actually far better in grey on my GloHD (because of the HW auto-flash, which leaves no ghosting at all):

<kbd>![image](https://user-images.githubusercontent.com/24273478/53664436-c754ce80-3c68-11e9-9251-fcaa5431c721.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/53664448-d045a000-3c68-11e9-98b9-fc776c6d19ac.png)</kbd>
