### PR TITLE
[feat, UX] Gesture manager: add support for diagonal swipes

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -92,7 +92,9 @@ local default_multiswipes = {
 }
 local multiswipes = {}
 local multiswipes_info_text = _([[
-Multiswipes allow you to perform complex gestures built up out of multiple straight swipes.]])
+Multiswipes allow you to perform complex gestures built up out of multiple swipe directions, never losing touch with the screen.
+
+These advanced gestures consist of either straight swipes or diagonal swipes. To ensure accuracy, they can't be mixed.]])
 
 function ReaderGesture:init()
     if not Device:isTouchDevice() then return end
@@ -388,16 +390,17 @@ function ReaderGesture:createSubMenu(text, action, ges, separator)
 end
 
 local multiswipe_to_arrow = {
-    east = "↦",
-    west = "↤",
-    north = "↥",
-    south = "↧",
+    east = "➡",
+    west = "⬅",
+    north = "⬆",
+    south = "⬇",
+    northeast = "⬉", -- @TODO swap back, see https://github.com/koreader/koreader/issues/4707
+    northwest = "⬈", -- @TODO swap back, see https://github.com/koreader/koreader/issues/4707
+    southeast = "⬊",
+    southwest = "⬋",
 }
 function ReaderGesture:friendlyMultiswipeName(multiswipe)
-    for k, v in pairs(multiswipe_to_arrow) do
-        multiswipe = multiswipe:gsub(k, v)
-    end
-    return multiswipe
+    return multiswipe:gsub("%S+", multiswipe_to_arrow)
 end
 
 function ReaderGesture:safeMultiswipeName(multiswipe)


### PR DESCRIPTION
NB The north east and north west arrows are swapped, see https://github.com/koreader/koreader/issues/4707

![screenshot_2019-03-02_13-49-36](https://user-images.githubusercontent.com/202757/53682039-227ed380-3cf2-11e9-9cc8-2832a66e03ca.png)
![screenshot_2019-03-02_13-49-53](https://user-images.githubusercontent.com/202757/53682040-227ed380-3cf2-11e9-9e5f-2813c6ad19a9.png)
