### PR TITLE
[fix, UX] Common menu & info menu: switch to dofile

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -158,7 +158,7 @@ function FileManagerMenu:setUpdateItemTable()
         }
     end
     -- insert common settings
-    for id, common_setting in pairs(require("ui/elements/common_settings_menu_table")) do
+    for id, common_setting in pairs(dofile("frontend/ui/elements/common_settings_menu_table.lua")) do
         self.menu_items[id] = common_setting
     end
 
@@ -275,7 +275,7 @@ function FileManagerMenu:setUpdateItemTable()
         end
     }
     -- insert common info
-    for id, common_setting in pairs(require("ui/elements/common_info_menu_table")) do
+    for id, common_setting in pairs(dofile("frontend/ui/elements/common_info_menu_table.lua")) do
         self.menu_items[id] = common_setting
     end
     self.menu_items.exit_menu = {

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -132,7 +132,7 @@ function ReaderMenu:setUpdateItemTable()
 
     -- settings tab
     -- insert common settings
-    for id, common_setting in pairs(require("ui/elements/common_settings_menu_table")) do
+    for id, common_setting in pairs(dofile("frontend/ui/elements/common_settings_menu_table.lua")) do
         self.menu_items[id] = common_setting
     end
     -- insert DjVu render mode submenu just before the last entry (show advanced)
@@ -176,7 +176,7 @@ function ReaderMenu:setUpdateItemTable()
     }
     -- main menu tab
     -- insert common info
-    for id, common_setting in pairs(require("ui/elements/common_info_menu_table")) do
+    for id, common_setting in pairs(dofile("frontend/ui/elements/common_info_menu_table.lua")) do
         self.menu_items[id] = common_setting
     end
 


### PR DESCRIPTION
Require is kept in memory, including the modifications made to it by MenuSorter. This can cause trouble when switching between the FileManager and Reader.

Fixes #4703.