### PR TITLE
[UX] Gesture manager: add action - clear location history

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -31,6 +31,7 @@ local action_strings = {
     previous_location = _("Back to previous location"),
     latest_bookmark = _("Go to latest bookmark"),
     follow_nearest_link = _("Follow nearest link"),
+    clear_location_history = _("Clear location history"),
 
     toc = _("Table of contents"),
     bookmarks = _("Bookmarks"),
@@ -269,7 +270,8 @@ function ReaderGesture:buildMenu(ges, default)
         {"back", true},
         {"previous_location", not self.is_docless},
         {"latest_bookmark", not self.is_docless},
-        {"follow_nearest_link", not self.is_docless, true},
+        {"follow_nearest_link", not self.is_docless},
+        {"clear_location_history", not self.is_docless, true},
 
         {"folder_up", self.is_docless, true},
 
@@ -547,11 +549,13 @@ function ReaderGesture:gestureAction(action, ges)
     elseif action == "back" then
         self.ui:handleEvent(Event:new("Back"))
     elseif action == "previous_location" then
-        self.ui:handleEvent(Event:new("GoBackLink"))
+        self.ui:handleEvent(Event:new("GoBackLink", true)) -- show_notification_if_empty
     elseif action == "latest_bookmark" then
-        self.ui.link:onGoToLatestBookmark()
+        self.ui:handleEvent(Event:new("GoToLatestBookmark"))
     elseif action == "follow_nearest_link" then
         self.ui:handleEvent(Event:new("GoToPageLink", ges, false, G_reader_settings:isTrue("footnote_link_in_popup")))
+    elseif action == "clear_location_history" then
+        self.ui:handleEvent(Event:new("ClearLocationStack", true)) -- show_notification
     elseif action == "filemanager" then
         self.ui:onClose()
         self.ui:showFileManager()

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -444,7 +444,7 @@ function ReaderLink:onClearLocationStack(show_notification)
     self.location_stack = {}
     if show_notification then
         UIManager:show(Notification:new{
-            text = _("Location history cleared"),
+            text = _("Location history cleared."),
             timeout = 2,
         })
     end
@@ -632,7 +632,7 @@ function ReaderLink:onGoBackLink(show_notification_if_empty)
         return true
     elseif show_notification_if_empty then
         UIManager:show(Notification:new{
-            text = _("Location history is empty"),
+            text = _("Location history is empty."),
             timeout = 2,
         })
     end
@@ -653,7 +653,7 @@ function ReaderLink:onSwipe(arg, ges)
                 -- Make that gesture don't do anything, and show a Notification
                 -- so the user knows why
                 UIManager:show(Notification:new{
-                    text = _("Location history is empty"),
+                    text = _("Location history is empty."),
                     timeout = 2,
                 })
                 return true

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -278,7 +278,7 @@ This allows you to specify how much smaller or larger it should be relative to t
                 text = _("Clear location history?"),
                 ok_text = _("Clear"),
                 ok_callback = function()
-                    self.location_stack = {}
+                    self:onClearLocationStack()
                     touchmenu_instance:closeMenu()
                 end,
             })
@@ -438,6 +438,17 @@ function ReaderLink:addCurrentLocationToStack()
             xpointer = self.ui.rolling:getBookLocation(),
         })
     end
+end
+
+function ReaderLink:onClearLocationStack(show_notification)
+    self.location_stack = {}
+    if show_notification then
+        UIManager:show(Notification:new{
+            text = _("Location history cleared"),
+            timeout = 2,
+        })
+    end
+    return true
 end
 
 --- Goes to link.
@@ -613,12 +624,17 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
 end
 
 --- Goes back to previous location.
-function ReaderLink:onGoBackLink()
+function ReaderLink:onGoBackLink(show_notification_if_empty)
     local saved_location = table.remove(self.location_stack)
     if saved_location then
         logger.dbg("GoBack: restoring:", saved_location)
         self.ui:handleEvent(Event:new('RestoreBookLocation', saved_location))
         return true
+    elseif show_notification_if_empty then
+        UIManager:show(Notification:new{
+            text = _("Location history is empty"),
+            timeout = 2,
+        })
     end
 end
 


### PR DESCRIPTION
Also show notification when `previous_location` can't go back because the location stack is empty.
Ref https://github.com/koreader/koreader/issues/4687#issuecomment-468956892

(I've put it in the menu, not just after `Back to previous location`, but after all the others that put stuff into this location stack, as some kind of self documentation.)