### PR TITLE
Fix "fonts test HTML document" styles

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -383,6 +383,16 @@ function ReaderFont:buildFontsTestDocument()
 <html>
 <head>
 <title>%s</title>
+<style>
+section > title {
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+  page-break-before: always;
+  margin-bottom: 0.5em;
+}
+a { color: black; }
+</style>
 </head>
 <body>
 <section id="list"><title>%s</title></section>


### PR DESCRIPTION
This little hidden feature (introduced in #3941) needed some update after we made htm.css obsolete and
use epub.css instead.