### PR TITLE
set panning rate default based on hasEinkScreen

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -21,11 +21,11 @@ local Device = Generic:new{
     hasDPad = no,
     isAndroid = yes,
     hasEinkScreen = function() return android.isEink() end,
+    hasColorScreen = function() return not android.isEink() end,
     hasFrontlight = yes,
     firmware_rev = android.app.activity.sdkVersion,
     display_dpi = android.lib.AConfiguration_getDensity(android.app.config),
     hasClipboard = yes,
-    hasColorScreen = yes,
     hasOTAUpdates = canUpdateApk,
     --[[
     Disable jit on some modules on android to make koreader on Android more stable.

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -111,7 +111,7 @@ function Device:init()
     self.screen.isBGRFrameBuffer = self.hasBGRFrameBuffer
 
     local low_pan_rate = G_reader_settings:readSetting("low_pan_rate")
-    self.screen.low_pan_rate = (low_pan_rate == nil) or low_pan_rate
+    self.screen.low_pan_rate = low_pan_rate or self.hasEinkScreen()
 
     logger.info("initializing for device", self.model)
     logger.info("framebuffer resolution:", self.screen:getSize())


### PR DESCRIPTION
in Android, where we support both e-ink/normal screens, hasColorScreen depends on hasEinkScreen.

Fixes #4667 