### PR TITLE
[UX] Gesture manager: add Exit and Restart action and a few gestures

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -714,10 +714,9 @@ function ReaderGesture:multiswipeAction(multiswipe_directions, ges)
     if not self.multiswipes_enabled then return end
     local gesture_manager = G_reader_settings:readSetting(self.ges_mode)
     local multiswipe_gesture_name = "multiswipe_"..self:safeMultiswipeName(multiswipe_directions)
-    for gesture, action in pairs(gesture_manager) do
-        if gesture == multiswipe_gesture_name then
-            return self:gestureAction(action, ges)
-        end
+    local action = gesture_manager[multiswipe_gesture_name]
+    if action and action ~= "nothing" then
+        return self:gestureAction(action, ges)
     end
 end
 

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -377,7 +377,7 @@ function ReaderGesture:buildMultiswipeMenu()
     end
 
     for i=1, #multiswipes do
-        separator = false
+        local separator = false
         if i < #multiswipes and multiswipes[i+1] == true then
             separator = true
         end

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -196,6 +196,7 @@ function ReaderGesture:addToMainMenu(menu_items)
             {
                 text = _("Multiswipe recorder"),
                 enabled_func = function() return self.multiswipes_enabled end,
+                keep_menu_open = true,
                 callback = function(touchmenu_instance)
                     local multiswipe_recorder
                     multiswipe_recorder = InputDialog:new{
@@ -231,6 +232,7 @@ function ReaderGesture:addToMainMenu(menu_items)
                                         custom_multiswipes:addTableItem("multiswipes", recorded_multiswipe)
                                         -- TODO implement some nicer method in TouchMenu than this ugly hack for updating the menu
                                         touchmenu_instance.item_table[3] = self:genMultiswipeSubmenu()
+                                        touchmenu_instance:updateItems()
                                         UIManager:close(multiswipe_recorder)
                                     end,
                                 },


### PR DESCRIPTION
Reference https://github.com/koreader/koreader/issues/4687#issuecomment-469054113
Also:
- add and show some separators in the gestures list
- fix gesture removal, and also remove it from settings
- add missing east west east
- add 6 remaining of the 8 knob 3/4 rotations
- add 3 easy knob full rotation (down + east + west)

These 3/4 or full knob rotations are really practical for stuff you don't want to do by error, but still easy to do when needed. Some may appeal more to left-handed persons.

<kbd>![image](https://user-images.githubusercontent.com/24273478/53731935-93ea8d80-3e7c-11e9-84cc-a71a560eeeda.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/53731941-9c42c880-3e7c-11e9-8f60-c0c165f536f9.png)</kbd>
(I let the "Zoom to fit" ones consecutive)

I did not let in these ones in yellow, because the drawing is really ambiguous:
<kbd>![image](https://user-images.githubusercontent.com/24273478/53731980-be3c4b00-3e7c-11e9-8637-0169ade17134.png)</kbd>

@Frenzie: removing a gesture updated the current menu, but when going up and back, we were still seeing it. Also, it was not removed from the settings, so it was still active!

I think it needs another check somewhere to remove from settings any gesture that is referenced in none of the default or custom list (and to clean up the one recorded and played with and removed before this fix).
Dunno where you'd want to have that in your code.

Also, another thing: would be nice if the gestures settings would not include the gestures mapped to "nothing". We would then have something in settings.reader.lua a little shorted than:
```
    ["gesture_reader"] = {
        ["multiswipe_north_south_north"] = "prev_chapter",
        ["multiswipe_east_north_west"] = "zoom_contentwidth",
        ["multiswipe_southeast_northeast"] = "follow_nearest_link",
        ["multiswipe_east_north"] = "history",
        ["multiswipe_east_west_east"] = "nothing",
        ["multiswipe_south_west_north_east"] = "nothing",
        ["short_diagonal_swipe"] = "full_refresh",
        ["multiswipe_west_east"] = "previous_location",
        ["multiswipe_south_west"] = "show_frontlight_dialog",
        ["tap_right_bottom_corner"] = "nothing",
        ["multiswipe_east_south"] = "go_to",
        ["multiswipe_north_east"] = "toc",
        ["multiswipe_north_west"] = "bookmarks",
        ["multiswipe_southwest_northwest"] = "nothing",
        ["multiswipe_north_south"] = "nothing",
        ["multiswipe_west_north_east"] = "nothing",
        ["multiswipe_east_west"] = "latest_bookmark",
        ["multiswipe_west_south"] = "back",
        ["multiswipe"] = "nothing",
        ["multiswipe_northeast_southeast"] = "nothing",
        ["multiswipe_east_south_west"] = "nothing",
        ["multiswipe_north_west_south"] = "nothing",
        ["multiswipe_south_north"] = "skim",
        ["multiswipe_north_east_south"] = "nothing",
        ["multiswipe_east_north_west_east"] = "zoom_pagewidth",
        ["multiswipe_northwest_southwest"] = "nothing",
        ["multiswipe_south_east_north"] = "zoom_contentheight",
        ["multiswipe_south_north_south"] = "next_chapter",
        ["tap_left_bottom_corner"] = "toggle_frontlight",
        ["multiswipe_west_north"] = "nothing",
        ["multiswipe_south_west_north"] = "nothing",
        ["multiswipe_south_east_north_south"] = "zoom_pageheight",
        ["multiswipe_west_south_east_north"] = "nothing",
        ["multiswipe_west_south_east"] = "nothing",
        ["multiswipe_east_south_west_north"] = "full_refresh",
        ["multiswipe_south_east"] = "toggle_reflow",
        ["multiswipe_south_east_north_west"] = "nothing",
        ["multiswipe_west_east_west"] = "open_previous_document"
    },
```
