### PR TITLE
[UX] Gesture manager: add action - book status

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -36,6 +36,7 @@ local action_strings = {
     toc = _("Table of contents"),
     bookmarks = _("Bookmarks"),
     reading_progress = _("Reading progress"),
+    book_status = _("Book status"),
 
     history = _("History"),
     open_previous_document = _("Open previous document"),
@@ -149,6 +150,7 @@ function ReaderGesture:init()
         multiswipe_north_west = self.ges_mode == "gesture_reader" and "bookmarks" or "folder_shortcuts",
         multiswipe_north_south = self.ges_mode == "gesture_reader" and "nothing" or "folder_up",
         multiswipe_east_north = "history",
+        multiswipe_west_north = "book_status",
         multiswipe_east_south = "go_to",
         multiswipe_south_north = self.ges_mode == "gesture_reader" and "skim" or "nothing",
         multiswipe_south_east = self.ges_mode == "gesture_reader" and "toggle_reflow" or "nothing",
@@ -317,7 +319,8 @@ function ReaderGesture:buildMenu(ges, default)
 
         { "toc", not self.is_docless},
         {"bookmarks", not self.is_docless},
-        {"reading_progress", ReaderGesture.getReaderProgress ~= nil, true},
+        {"reading_progress", ReaderGesture.getReaderProgress ~= nil},
+        {"book_status", not self.is_docless, true},
 
         {"history", true},
         {"open_previous_document", true, true},
@@ -620,6 +623,8 @@ function ReaderGesture:gestureAction(action, ges)
         self.ui:handleEvent(Event:new("ShowBookmark"))
     elseif action == "history" then
         self.ui:handleEvent(Event:new("ShowHist"))
+    elseif action == "book_status" then
+        self.ui:handleEvent(Event:new("ShowBookStatus"))
     elseif action == "page_jmp_fwd_10" then
         self:pageUpdate(10)
     elseif action == "page_jmp_fwd_1" then

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -150,7 +150,7 @@ function ReaderGesture:init()
         multiswipe_north_west = self.ges_mode == "gesture_reader" and "bookmarks" or "folder_shortcuts",
         multiswipe_north_south = self.ges_mode == "gesture_reader" and "nothing" or "folder_up",
         multiswipe_east_north = "history",
-        multiswipe_west_north = "book_status",
+        multiswipe_west_north = self.ges_mode == "gesture_reader" and "book_status" or "nothing",
         multiswipe_east_south = "go_to",
         multiswipe_south_north = self.ges_mode == "gesture_reader" and "skim" or "nothing",
         multiswipe_south_east = self.ges_mode == "gesture_reader" and "toggle_reflow" or "nothing",

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -357,7 +357,7 @@ function ReaderGesture:buildMenu(ges, default)
         {"zoom_content", not self.is_docless},
         {"zoom_page", not self.is_docless, true},
 
-        {"wallabag_download", self.ui.wallabag ~= nil, true},
+        {"wallabag_download", self.ui.wallabag ~= nil},
     }
     local return_menu = {}
     -- add default action to the top of the submenu

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -31,7 +31,7 @@ function ReaderStatus:addToMainMenu(menu_items)
     menu_items.book_status = {
         text = _("Book status"),
         callback = function()
-            self:showStatus()
+            self:onShowBookStatus()
         end,
     }
 end
@@ -141,7 +141,7 @@ function ReaderStatus:openNextFile(next_file)
     end
 end
 
-function ReaderStatus:showStatus(before_show_callback)
+function ReaderStatus:onShowBookStatus(before_show_callback)
     local status_page = BookStatusWidget:new {
         thumbnail = self.document:getCoverPageImage(),
         props = self.document:getProps(),
@@ -154,6 +154,7 @@ function ReaderStatus:showStatus(before_show_callback)
     end
     status_page.dithered = true
     UIManager:show(status_page, "full")
+    return true
 end
 
 function ReaderStatus:onReadSettings(config)


### PR DESCRIPTION
Marking a document as "finished" is important for Wallabag (see, among others, #4737, #4271). Also it's an obvious missing action.

Default to left, up. That keeps with the fullscreen dialog gestures generally go up. Also it was still unassigned.