### PR TITLE
[fix] ReaderUI Pass self in open with cancel callback

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -448,7 +448,7 @@ function ReaderUI:showReader(file, provider)
                         doc_settings:close()
                         self:showReaderCoroutine(file, provider)
                     end,
-                    cancel_callback = self.showFileManager,
+                    cancel_callback = function() self:showFileManager() end,
                 })
         else
             self:showReaderCoroutine(file, provider)


### PR DESCRIPTION
I added a call to self in ReaderUI:showFileManager() in #4720, breaking this singular reference that wasn't passing self.

Reported on Gitter by @ptrm, see https://gitter.im/koreader/koreader?at=5c81465725e4e24c072f1a00