### PR TITLE
cre: fix position and page number after window resize

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -665,17 +665,20 @@ function ReaderRolling:onRedrawCurrentView()
 end
 
 function ReaderRolling:onSetDimensions(dimen)
-    -- This is called during reader initialization, where
-    -- we don't need to do much. But it may be called after,
-    -- when resizing the window on SDL, where we need to
-    -- do a bit more
-    if self.ui.postReaderCallback == nil then -- ReaderUI:init() done
+    if self.ui.postReaderCallback ~= nil then
+        -- ReaderUI:init() not yet done: just set document dimensions
+        self.ui.document:setViewDimen(Screen:getSize())
+        -- (what's done in the following else is done elsewhere by
+        -- the initialization code)
+    else
+        -- Initialization done: we are called on orientation change
+        -- or on window resize (SDL, Android possibly).
         -- We need to temporarily re-enable internal history as crengine
         -- uses it to reposition after resize
         self.ui.document:enableInternalHistory(true)
-    end
-    self.ui.document:setViewDimen(Screen:getSize())
-    if self.ui.postReaderCallback == nil then -- ReaderUI:init() done
+        -- Set document dimensions
+        self.ui.document:setViewDimen(Screen:getSize())
+        -- Re-setup previous position
         self:onChangeViewMode()
         self:onUpdatePos()
         -- Re-disable internal history, with required redraw
@@ -685,17 +688,11 @@ function ReaderRolling:onSetDimensions(dimen)
 end
 
 function ReaderRolling:onChangeScreenMode(mode, rotation)
-    -- We need to temporarily re-enable internal history as crengine
-    -- uses it to reposition after resize
-    self.ui.document:enableInternalHistory(true)
-    -- Flag it as interactive so we can properly swap to Inverted orientations (we usurp the second argument, which usually means rotation)
+    -- Flag it as interactive so we can properly swap to Inverted orientations
+    -- (we usurp the second argument, which usually means rotation)
     self.ui:handleEvent(Event:new("SetScreenMode", mode, rotation or true))
-    self.ui.document:setViewDimen(Screen:getSize())
-    self:onChangeViewMode()
-    self:onUpdatePos()
-    -- Re-disable internal history, with required redraw
-    self.ui.document:enableInternalHistory(false)
-    self:onRedrawCurrentView()
+    -- (This had the above ReaderRolling:onSetDimensions() called to resize
+    -- document dimensions and keep up with current position)
 end
 
 function ReaderRolling:onColorRenderingUpdate()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -665,7 +665,23 @@ function ReaderRolling:onRedrawCurrentView()
 end
 
 function ReaderRolling:onSetDimensions(dimen)
+    -- This is called during reader initialization, where
+    -- we don't need to do much. But it may be called after,
+    -- when resizing the window on SDL, where we need to
+    -- do a bit more
+    if self.ui.postReaderCallback == nil then -- ReaderUI:init() done
+        -- We need to temporarily re-enable internal history as crengine
+        -- uses it to reposition after resize
+        self.ui.document:enableInternalHistory(true)
+    end
     self.ui.document:setViewDimen(Screen:getSize())
+    if self.ui.postReaderCallback == nil then -- ReaderUI:init() done
+        self:onChangeViewMode()
+        self:onUpdatePos()
+        -- Re-disable internal history, with required redraw
+        self.ui.document:enableInternalHistory(false)
+        self:onRedrawCurrentView()
+    end
 end
 
 function ReaderRolling:onChangeScreenMode(mode, rotation)


### PR DESCRIPTION
Just copied the code from the next function ReaderRolling:onChangeScreenMode into ReaderRolling:onSetDimensions with some conditionals to not have it before init() is done.
Seems to fix position, footer, toc...
Not super sure about the whole events chain and order, but it seems to work without issue, even on my Kobo when just rotating.
Pinging @NiLuJe - might be there's just a few lines to add around there to fix https://github.com/koreader/koreader/issues/4752#issuecomment-470708895