### PR TITLE
Gesture manager: allow folder shortcuts as action in Reader

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -190,13 +190,24 @@ function FileManagerShortcuts:deleteFolderShortcut(item)
 end
 
 function FileManagerShortcuts:onShowFolderShortcutsDialog()
-    local fm_bookmark =  FileManagerShortcuts:new{
+    local fm_bookmark = self:new{
         title = _("Folder shortcuts"),
         show_parent = self.ui,
-        curr_path = self.ui.file_chooser.path,
+        curr_path = self.ui.file_chooser and self.ui.file_chooser.path or self.ui:getLastDirFile(),
         goFolder = function(folder)
             if folder ~= nil and lfs.attributes(folder, "mode") == "directory" then
-                self.ui.file_chooser:changeToPath(folder)
+                if self.ui.file_chooser then
+                    self.ui.file_chooser:changeToPath(folder)
+                else
+                    local FileManager = require("apps/filemanager/filemanager")
+
+                    self.ui:onClose()
+                    if FileManager.instance then
+                        FileManager.instance:reinit(folder)
+                    else
+                        FileManager:showFiles(folder)
+                    end
+                end
             end
         end,
     }

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -198,7 +198,7 @@ function FileManagerShortcuts:onShowFolderShortcutsDialog()
             if folder ~= nil and lfs.attributes(folder, "mode") == "directory" then
                 if self.ui.file_chooser then
                     self.ui.file_chooser:changeToPath(folder)
-                else
+                else -- called from Reader
                     local FileManager = require("apps/filemanager/filemanager")
 
                     self.ui:onClose()

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -315,7 +315,7 @@ function ReaderGesture:buildMenu(ges, default)
         {"clear_location_history", not self.is_docless, true},
 
         {"folder_up", self.is_docless},
-        {"folder_shortcuts", self.is_docless, true},
+        {"folder_shortcuts", true, true},
 
         { "toc", not self.is_docless},
         {"bookmarks", not self.is_docless},

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -13,6 +13,7 @@ local Event = require("ui/event")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local FileManagerHistory = require("apps/filemanager/filemanagerhistory")
 local FileManagerFileSearcher = require("apps/filemanager/filemanagerfilesearcher")
+local FileManagerShortcuts = require("apps/filemanager/filemanagershortcuts")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
@@ -333,6 +334,11 @@ function ReaderUI:init()
     })
     -- file searcher
     self:registerModule("filesearcher", FileManagerFileSearcher:new{
+        dialog = self.dialog,
+        ui = self,
+    })
+    -- folder shortcuts
+    self:registerModule("folder_shortcuts", FileManagerShortcuts:new{
         dialog = self.dialog,
         ui = self,
     })


### PR DESCRIPTION
Note that `self.ui:onClose()` properly closes open documents. There might be similar pieces of code around that don't do that.

Fixes #4755.