### PR TITLE
[fix] FileManagerShortcuts: prevent interference with general Menu class

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -208,7 +208,6 @@ end
 function FileManagerShortcuts:onShowFolderShortcutsDialog()
     self.fm_bookmark = Menu:new{
         title = _("Folder shortcuts"),
-        item_table = self.shortcuts,
         show_parent = self.ui,
         width = Screen:getWidth(),
         height = Screen:getHeight(),


### PR DESCRIPTION
The widget system doesn't really do multi-inheritance as well as it should at the moment. Instead of diving into the internals with release upcoming, this commit rewrites the shortcuts to behave better.

Also fixes an older bug in that changing the friendly name didn't actually do anything on first adding a shortcut.

Fixes #4763.