### PR TITLE
Enable addNote button, by letting it edit highlight

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -974,7 +974,7 @@ function ReaderHighlight:exportToDocument(page, item)
 end
 
 function ReaderHighlight:addNote()
-    self:handleEvent(Event:new("AddNote"))
+    self.ui:handleEvent(Event:new("AddNote"))
     local page, index = self:saveHighlight()
     self:editHighlight(page, index)
     UIManager:close(self.edit_highlight_dialog)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -721,13 +721,8 @@ function ReaderHighlight:onHoldRelease()
                     },
                     {
                         text = _("Add Note"),
-                        enabled = true,
                         callback = function()
-                            local page, index = self:saveHighlight()
-                            if page and index then -- saveHighlight can return nil, nil
-                                self:editHighlight(page, index)
-                                UIManager:close(self.edit_highlight_dialog)
-                            end
+                            self:addNote()
                             self:onClose()
                         end,
                     },
@@ -979,7 +974,10 @@ function ReaderHighlight:exportToDocument(page, item)
 end
 
 function ReaderHighlight:addNote()
-    self:handleEvent(Event:new("addNote"))
+    self:handleEvent(Event:new("AddNote"))
+    local page, index = self:saveHighlight()
+    self:editHighlight(page, index)
+    UIManager:close(self.edit_highlight_dialog)
     logger.dbg("add Note")
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -721,9 +721,13 @@ function ReaderHighlight:onHoldRelease()
                     },
                     {
                         text = _("Add Note"),
-                        enabled = false,
+                        enabled = true,
                         callback = function()
-                            self:addNote()
+                            local page, index = self:saveHighlight()
+                            if page and index then -- saveHighlight can return nil, nil
+                                self:editHighlight(page, index)
+                                UIManager:close(self.edit_highlight_dialog)
+                            end
                             self:onClose()
                         end,
                     },
@@ -946,6 +950,7 @@ function ReaderHighlight:saveHighlight()
         if self.selected_text.pboxes then
             self:exportToDocument(page, hl_item)
         end
+        return page, #self.view.highlight.saved[page]
     end
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -974,11 +974,10 @@ function ReaderHighlight:exportToDocument(page, item)
 end
 
 function ReaderHighlight:addNote()
-    self.ui:handleEvent(Event:new("AddNote"))
     local page, index = self:saveHighlight()
     self:editHighlight(page, index)
     UIManager:close(self.edit_highlight_dialog)
-    logger.dbg("add Note")
+    self.ui:handleEvent(Event:new("AddNote"))
 end
 
 function ReaderHighlight:lookupWikipedia()


### PR DESCRIPTION
Reuses already existing highlight editing functionality, to enable "AddNote" in highlight menu. This basically does what was asked in #4115 #1095 