### PR TITLE
PocketBook: implement Wi-Fi connection toggling

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -98,7 +98,7 @@ function NetworkMgr:beforeWifiAction(callback)
  end
 
 function NetworkMgr:isConnected()
-    if Device:isAndroid() or Device:isCervantes() then
+    if Device:isAndroid() or Device:isCervantes() or Device:isPocketBook() then
         return self:isWifiOn()
     else
         -- `-c1` try only once; `-w2` wait 2 seconds


### PR DESCRIPTION
Partially resolves #4747. Will enable switching Wi-Fi on/off in the menu and getting the network status. However, a new Wi-Fi session lasts ~100 seconds and then terminates automatically, apparently, to save the energy. I believe it can be prolonged by some networking activity. Also it is not shut down if the auto suspension is disabled.