### PR TITLE
cre landscape view: adds 1 page / 2 pages toggable 

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -207,7 +207,7 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     -- showing menu...). We might want to cache these boxes per page (and
     -- clear that cache when page layout change or highlights are added
     -- or removed).
-    local cur_page, cur_page2, cur_scroll_top, cur_scroll_bottom
+    local cur_view_top, cur_view_bottom
     local pos = self.view:screenToPageTransform(ges.pos)
     for page, _ in pairs(self.view.highlight.saved) do
         local items = self.view.highlight.saved[page]
@@ -216,37 +216,22 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
                 local pos0, pos1 = items[i].pos0, items[i].pos1
                 -- document:getScreenBoxesFromPositions() is expensive, so we
                 -- first check this item is on current page
-                local is_in_view = false
-                if self.view.view_mode == "page" then
-                    if not cur_page then
-                        cur_page = self.ui.document:getPageFromXPointer(self.ui.document:getXPointer())
-                        if self.ui.document:getVisiblePageCount() > 1 then
-                            cur_page2 = cur_page + 1
-                        end
-                    end
-                    local page0 = self.ui.document:getPageFromXPointer(pos0)
-                    local page1 = self.ui.document:getPageFromXPointer(pos1)
-                    local start_page = math.min(page0, page1)
-                    local end_page = math.max(page0, page1)
-                    if start_page <= cur_page and end_page >= cur_page then
-                        is_in_view = true
-                    elseif cur_page2 and start_page <= cur_page2 and end_page >= cur_page2 then
-                        is_in_view = true
-                    end
-                else
-                    if not cur_scroll_top then
-                        cur_scroll_top = self.ui.document:getPosFromXPointer(self.ui.document:getXPointer())
-                        cur_scroll_bottom = cur_scroll_top + self.ui.dimen.h
-                    end
-                    local spos0 = self.ui.document:getPosFromXPointer(pos0)
-                    local spos1 = self.ui.document:getPosFromXPointer(pos1)
-                    local start_pos = math.min(spos0, spos1)
-                    local end_pos = math.max(spos0, spos1)
-                    if start_pos <= cur_scroll_bottom and end_pos >= cur_scroll_top then
-                        is_in_view = true
+                if not cur_view_top then
+                    -- Even in page mode, it's safer to use pos and ui.dimen.h
+                    -- than pages' xpointers pos, even if ui.dimen.h is a bit
+                    -- larger than pages' heights
+                    cur_view_top = self.ui.document:getCurrentPos()
+                    if self.view.view_mode == "page" and self.ui.document:getVisiblePageCount() > 1 then
+                        cur_view_bottom = cur_view_top + 2 * self.ui.dimen.h
+                    else
+                        cur_view_bottom = cur_view_top + self.ui.dimen.h
                     end
                 end
-                if is_in_view then
+                local spos0 = self.ui.document:getPosFromXPointer(pos0)
+                local spos1 = self.ui.document:getPosFromXPointer(pos1)
+                local start_pos = math.min(spos0, spos1)
+                local end_pos = math.max(spos0, spos1)
+                if start_pos <= cur_view_bottom and end_pos >= cur_view_top then
                     local boxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1, true) -- get_segments=true
                     if boxes then
                         for index, box in pairs(boxes) do

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1062,9 +1062,15 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
         UIManager:setDirty(self.dialog, "ui")
         close_callback = function(footnote_height)
             -- remove this highlight (actually all) on close
+            local highlight_page = self.ui.document:getCurrentPage()
             local clear_highlight = function()
                 self.ui.document:highlightXPointer()
-                UIManager:setDirty(self.dialog, "ui")
+                -- Only refresh if we stayed on the same page, otherwise
+                -- this could remove too early a marker on the target page
+                -- after this footnote is followed
+                if self.ui.document:getCurrentPage() == highlight_page then
+                    UIManager:setDirty(self.dialog, "ui")
+                end
             end
             if footnote_height then
                 -- If the link was hidden by the footnote popup,

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -418,10 +418,21 @@ function CreDocument:getScreenPositionFromXPointer(xp)
     local doc_y, doc_x = self:getPosFromXPointer(xp)
     local top_y = self:getCurrentPos()
     local screen_y = doc_y - top_y
+    local screen_x = doc_x + doc_margins["left"]
     if self._view_mode == self.PAGE_VIEW_MODE then
+        if self:getVisiblePageCount() > 1 then
+            -- Correct coordinates if on the 2nd page in 2-pages mode
+            local next_page = self:getCurrentPage() + 1
+            if next_page <= self:getPageCount() then
+                local next_top_y = self._document:getPageStartY(next_page)
+                if doc_y >= next_top_y then
+                    screen_y = doc_y - next_top_y
+                    screen_x = screen_x + self._document:getPageOffsetX(next_page)
+                end
+            end
+        end
         screen_y = screen_y + doc_margins["top"] + self:getHeaderHeight()
     end
-    local screen_x = doc_x + doc_margins["left"]
     -- Just as getPosFromXPointer() does, we return y first and x second,
     -- as callers most often just need the y
     return screen_y, screen_x

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -190,11 +190,12 @@ end
 function CreDocument:render()
     -- load document before rendering
     self:loadDocument()
-    -- set visible page count in landscape
-    if math.max(CanvasContext:getWidth(), CanvasContext:getHeight()) / CanvasContext:getDPI()
-        < DCREREADER_TWO_PAGE_THRESHOLD then
-        self:setVisiblePageCount(1)
-    end
+    -- This is now configurable and done by ReaderRolling:
+    -- -- set visible page count in landscape
+    -- if math.max(CanvasContext:getWidth(), CanvasContext:getHeight()) / CanvasContext:getDPI()
+    --     < DCREREADER_TWO_PAGE_THRESHOLD then
+    --     self:setVisiblePageCount(1)
+    -- end
     logger.dbg("CreDocument: rendering document...")
     self._document:renderDocument()
     self.info.doc_height = self._document:getFullHeight()

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -280,6 +280,11 @@ function CreDocument:getWordFromPosition(pos)
             w = 20, h = 20,
         }
     end
+    if text_range then
+        -- add xpointers if found, might be useful for across pages highlighting
+        wordbox.pos0 = text_range.pos0
+        wordbox.pos1 = text_range.pos1
+    end
     return wordbox
 end
 

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -29,7 +29,32 @@ local CreOptions = {
                 current_func = function() return Device.screen:getScreenMode() end,
                 event = "ChangeScreenMode",
                 name_text_hold_callback = optionsutil.showValues,
-            }
+            },
+            {
+                name = "visible_pages",
+                name_text = S.TWO_PAGES,
+                toggle = {S.OFF, S.ON},
+                values = {1, 2},
+                default_value = 1,
+                args = {1, 2},
+                default_arg = 1,
+                event = "SetVisiblePages",
+                current_func = function()
+                    -- If not in landscape mode, shows "1" as selected
+                    if Device.screen:getScreenMode() ~= "landscape" then
+                        return 1
+                    end
+                    -- if we return nil, ConfigDialog will pick the one from the
+                    -- configurable as if we hadn't provided this 'current_func'
+                end,
+                enabled_func = function(configurable)
+                    return Device.screen:getScreenMode() == "landscape" and
+                        optionsutil.enableIfEquals(configurable, "view_mode", 0) -- "page"
+                end,
+                name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[In landscape mode, you can choose to display one or two pages of the book on the screen.
+Note that this may not be ensured under some conditions: in scroll mode, when a very big font size is used, or on devices with a very low aspect ratio.]]),
+            },
         }
     },
     {

--- a/frontend/ui/data/strings.lua
+++ b/frontend/ui/data/strings.lua
@@ -3,6 +3,7 @@ local _ = require("gettext")
 local S = {}
 
 S.SCREEN_MODE = _("Orientation")
+S.TWO_PAGES = _("Two Pages")
 S.PAGE_CROP = _("Page Crop")
 S.FULL_SCREEN = _("Full Screen")
 S.SCROLL_MODE = _("Scroll Mode")

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -849,6 +849,7 @@ Do you want to prune cache of removed books?]]
             },
             text_widget
         })
+        info.movable[1][1]._size = nil -- reset HorizontalGroup size
         info.movable:setMovedOffset(orig_moved_offset)
         info:paintTo(Screen.bb, 0,0)
         local d = info.movable[1].dimen

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -81,8 +81,13 @@ function CoverMenu:updateItems(select_number)
     self:_updateItemsBuildUI()
 
     -- Set the local variables with the things we know
-    current_path = self.path
-    current_cover_specs = self.cover_specs
+    -- These are used only by extractBooksInDirectory(), which should
+    -- use the cover_specs set for FileBrowser, and not those from History.
+    -- Hopefully, we get self.path=nil when called fro History
+    if self.path then
+        current_path = self.path
+        current_cover_specs = self.cover_specs
+    end
 
     -- As done in Menu:updateItems()
     self:updatePageInfo(select_number)


### PR DESCRIPTION
Fix a few small issues, and introduce a new toggle in the Orientation bottom config menu:

<kbd>![2pagesb](https://user-images.githubusercontent.com/24273478/54278808-bf176000-4593-11e9-8aa0-d09cfb8ce48c.png)</kbd>

Note: 2-pages view was the default for landscape for some users depending on their device resolution and selected dpi, and was not toggable. So I guess a few people will discover this existing nice feature of crengine, that I find really cute.

See individual commit messages for details.

Added fixes for CoverBrowser issues detailed in #4778. Closes #4778.

Also:
bump crengine https://github.com/koreader/crengine/pull/270
- docToWindowPoint(): adds fitToPage parameter
- 2-pages mode: add and fix some functions
- 2-pages mode: tweak middle margin sizing
- Text rendering: fix words stuck when hyphenating on italic

bump base https://github.com/koreader/koreader-base/pull/850
- cre.cpp: add a few functions useful with 2-pages mode
- cre.cpp: fix docToWindowRect() to get truncated segments for lines split onto 2 pages, for highlights and links
- Bump CMake minimum version to 3.5.1 https://github.com/koreader/koreader-base/pull/849

