### PR TITLE
[UX] Gesture manager: add a little notification to the wifi on action

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -723,6 +723,11 @@ function ReaderGesture:gestureAction(action, ges)
         local NetworkMgr = require("ui/network/manager")
 
         if not NetworkMgr:isOnline() then
+            UIManager:show(InfoMessage:new{
+                text = _("Enabling wifi…"),
+                timeout = 1,
+            })
+
             -- NB Normal widgets should use NetworkMgr:promptWifiOn()
             -- This is specifically the toggle wifi action, so consent is implied.
             NetworkMgr:turnOnWifi()
@@ -747,6 +752,11 @@ function ReaderGesture:gestureAction(action, ges)
         local NetworkMgr = require("ui/network/manager")
 
         if not NetworkMgr:isOnline() then
+            UIManager:show(InfoMessage:new{
+                text = _("Enabling wifi…"),
+                timeout = 1,
+            })
+
             -- NB Normal widgets should use NetworkMgr:promptWifiOn()
             -- This is specifically the toggle wifi action, so consent is implied.
             NetworkMgr:turnOnWifi()


### PR DESCRIPTION
Fixes #4783.

Perhaps this should be done in NetworkManager instead.