### PR TITLE
CoverBrowser: speedup "View full size cover"

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -36,8 +36,10 @@ local action_strings = {
     toc = _("Table of contents"),
     bookmarks = _("Bookmarks"),
     reading_progress = _("Reading progress"),
-    book_info = _("Book information"),
     book_status = _("Book status"),
+    book_info = _("Book information"),
+    book_description = _("Book description"),
+    book_cover = _("Book cover"),
 
     history = _("History"),
     open_previous_document = _("Open previous document"),
@@ -321,8 +323,10 @@ function ReaderGesture:buildMenu(ges, default)
         { "toc", not self.is_docless},
         {"bookmarks", not self.is_docless},
         {"reading_progress", ReaderGesture.getReaderProgress ~= nil},
+        {"book_status", not self.is_docless},
         {"book_info", not self.is_docless},
-        {"book_status", not self.is_docless, true},
+        {"book_description", not self.is_docless},
+        {"book_cover", not self.is_docless, true},
 
         {"history", true},
         {"open_previous_document", true, true},
@@ -627,6 +631,33 @@ function ReaderGesture:gestureAction(action, ges)
         self.ui:handleEvent(Event:new("ShowHist"))
     elseif action == "book_info" then
         self.ui:handleEvent(Event:new("ShowBookInfo"))
+    elseif action == "book_description" then
+        local description = self.document:getProps().description
+        if description and description ~= "" then
+            local TextViewer = require("ui/widget/textviewer")
+            UIManager:show(TextViewer:new{
+                title = _("Book description:"),
+                text = description,
+            })
+        else
+            UIManager:show(InfoMessage:new{
+                text = _("No book description available."),
+            })
+        end
+    elseif action == "book_cover" then
+        local cover_bb = self.document:getCoverPageImage()
+        if cover_bb then
+            local ImageViewer = require("ui/widget/imageviewer")
+            UIManager:show(ImageViewer:new{
+                image = cover_bb,
+                with_title_bar = false,
+                fullscreen = true,
+            })
+        else
+            UIManager:show(InfoMessage:new{
+                text = _("No cover image available."),
+            })
+        end
     elseif action == "book_status" then
         self.ui:handleEvent(Event:new("ShowBookStatus"))
     elseif action == "page_jmp_fwd_10" then

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -177,6 +177,11 @@ function CreDocument:loadDocument(full_document)
     if not self._loaded then
         local only_metadata = full_document == false
         logger.dbg("CreDocument: loading document...")
+        if only_metadata then
+            -- Setting a default font before loading document
+            -- actually do prevent some crashes
+            self:setFontFace(self.default_font)
+        end
         if self._document:loadDocument(self.file, only_metadata) then
             self._loaded = true
             logger.dbg("CreDocument: loading done.")

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -391,9 +391,6 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
     if document then
         local pages
         if document.loadDocument then -- needed for crengine
-            -- Setting a default font before loading document
-            -- actually do prevent some crashes
-            document:setFontFace(document.default_font)
             if not document:loadDocument(false) then -- load only metadata
                 -- failed loading, calling other methods would segfault
                 loaded = false

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -1,6 +1,7 @@
 local DocumentRegistry = require("document/documentregistry")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local ImageViewer = require("ui/widget/imageviewer")
+local InfoMessage = require("ui/widget/infomessage")
 local Menu = require("ui/widget/menu")
 local TextViewer = require("ui/widget/textviewer")
 local UIManager = require("ui/uimanager")
@@ -127,7 +128,6 @@ function CoverMenu:updateItems(select_number)
                     UIManager:unschedule(self.items_update_action)
                     self.items_update_action = nil
                 end
-                local InfoMessage = require("ui/widget/infomessage")
                 UIManager:show(InfoMessage:new{
                     text = _("Start-up of background extraction job failed.\nPlease restart KOReader or your device.")
                 })
@@ -232,13 +232,22 @@ function CoverMenu:updateItems(select_number)
                         callback = function()
                             local document = DocumentRegistry:openDocument(file)
                             if document then
+                                if document.loadDocument then -- needed for crengine
+                                    document:loadDocument(false) -- load only metadata
+                                end
                                 local cover_bb = document:getCoverPageImage()
-                                local imgviewer = ImageViewer:new{
-                                    image = cover_bb,
-                                    with_title_bar = false,
-                                    fullscreen = true,
-                                }
-                                UIManager:show(imgviewer)
+                                if cover_bb then
+                                    local imgviewer = ImageViewer:new{
+                                        image = cover_bb,
+                                        with_title_bar = false,
+                                        fullscreen = true,
+                                    }
+                                    UIManager:show(imgviewer)
+                                else
+                                    UIManager:show(InfoMessage:new{
+                                        text = _("No cover image available."),
+                                    })
+                                end
                                 UIManager:close(self.file_dialog)
                                 DocumentRegistry:closeDocument(file)
                             end
@@ -352,13 +361,22 @@ function CoverMenu:onHistoryMenuHold(item)
             callback = function()
                 local document = DocumentRegistry:openDocument(file)
                 if document then
+                    if document.loadDocument then -- needed for crengine
+                        document:loadDocument(false) -- load only metadata
+                    end
                     local cover_bb = document:getCoverPageImage()
-                    local imgviewer = ImageViewer:new{
-                        image = cover_bb,
-                        with_title_bar = false,
-                        fullscreen = true,
-                    }
-                    UIManager:show(imgviewer)
+                    if cover_bb then
+                        local imgviewer = ImageViewer:new{
+                            image = cover_bb,
+                            with_title_bar = false,
+                            fullscreen = true,
+                        }
+                        UIManager:show(imgviewer)
+                    else
+                        UIManager:show(InfoMessage:new{
+                            text = _("No cover image available."),
+                        })
+                    end
                     UIManager:close(self.histfile_dialog)
                     DocumentRegistry:closeDocument(file)
                 end


### PR DESCRIPTION
It was doing a full document load to get the cover. It now does the faster "only metadata" load.
Also move the trick of setting a default font in CreDocument, so that all callers of `document:loadDocument(false)` benefit from it.
Prevent crash when no cover image is available (even if the cache says it has one, the file may have been updated and doesn't have it anymore).

Also:
Gesture manager: add actions: Book cover, Book description - as requested in https://github.com/koreader/koreader/issues/4727#issuecomment-472739389