### PR TITLE
ConfigDialog: fix ButtonProgressWidget and some refreshes

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -643,6 +643,15 @@ function ReaderRolling:onUpdatePos()
         -- we have set above) to avoid multiple refreshes.
         return true
     end
+    -- Calling this now ensures the re-rendering is done by crengine
+    -- so the delayed updatePos() has good info and can reposition
+    -- the previous xpointer accurately:
+    self.ui.document:getCurrentPos()
+    -- Otherwise, _readMetadata() would do that, but the positionning
+    -- would not work as expected, for some reason (it worked
+    -- previously because of some bad setDirty() in ConfigDialog widgets
+    -- that were triggering a full repaint of crengine (so, the needed
+    -- rerendering) before updatePos() is called.
     UIManager:scheduleIn(0.1, function () self:updatePos() end)
     return true
 end

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -6,6 +6,7 @@ local Screen = Device.screen
 
 local KoptOptions = {
     prefix = 'kopt',
+    needs_redraw_on_change = true,
     {
         icon = "resources/icons/appbar.transform.rotate.right.large.png",
         options = {


### PR DESCRIPTION
This internal ButtonProgressWidget widget was behaving differently from all others (OptionTextItem, OptionIconItem and ToggleSwitch) by duplicating some code from ConfigDialog:onConfigChoose() instead of calling it directly. So, similar to:
https://github.com/koreader/koreader/blob/f637555d93a16d77b78140f3c18a16a2bcdb6d13/frontend/ui/widget/toggleswitch.lua#L191-L208


While making it similar to others, I noticed that onConfigChoose() did a full repaint, which was necessary for some settings to be applied (ie: Contrast) - or may be not, see below, but I don't know what did that then...
On CreDocument, this full repaint may cause some double drawing on config changes (ie: Margins, since #4691, drawing once after margin changes,and then re-positionning to previous xpointer).
So, make the need for full repaint a condition on KoptOptions.

These changes seem to make PDF and CRE settings behave all correctly. I'll still have to check on my Kobo.

But I'm still puzzled, mostly about how it works/worked with PDF.
Previously, we had a call in that ButtonProgressWidget: `UIManager:setDirty("all")`. It looks to me this is actually a no-op from UIManager point of view (where there is no mode provided like "full" or "ui") ! Or may be not in some situations?
So I don't know why removing it, or replacing it with a more localized `UIManager:setDirty(self.config, function() return "ui", widget.diment)` made contrast no more applied...

I'm pretty confident these change are fine for CreDocument, a bit less for PDF.
Changing contrast leads to the following log:
```
adjusted ges: tap
setDirty via a func from widget table: 0x4085d3f8
setDirty via a func from widget table: 0x4085d3f8
painting widget: table: 0x40dab098
_refresh: Enqueued fast update for region 163 514 424 32
update_mode: Update refresh mode fast to ui
_refresh: Enqueued ui update for region 163 514 424 32
setDirty via a func from widget table: 0x4085d3f8
setDirty via a func from widget table: 0x4085d3f8
_refresh: Enqueued partial update for region 0 0 600 610
setDirty partial from widget all w/ NO region
painting widget: ReaderUI
loading koptcontext from ./cache/8d22901f6040cb5e7cf1b7ffa9b3a684
painting widget: table: 0x40dab098
_refresh: Enqueued partial update for region 0 0 600 610
_refresh: Enqueued partial update for region 0 0 600 610
```
Previously:
```
adjusted ges: tap
AutoSuspend: onInputEvent
setDirty via a func from widget table: 0x41eb8bc8
painting widget: table: 0x40dd5650
_refresh: Enqueued ui update for region 163 514 424 32
setDirty nil from widget all w/ NO region
painting widget: ReaderUI
loading koptcontext from ./cache/f5078849f8b7e252f3d07136207b5e8b
painting widget: table: 0x40dd5650
no refresh got enqueued. Will do a partial full screen refresh, which might be inefficient
_refresh: Enqueued partial update for region 0 0 600 610
```
So, 3 instead of 1 "Enqueued partial update for region 0 0 600 610" - dunno if that means 3 EInk screen refreshes...

Pinging @NiLuJe for opinion.