### PR TITLE
ConfigDialog: remove gray underline on text items

### DIFF
--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -75,7 +75,9 @@ function ButtonProgressWidget:update()
         if self.thin_grey_style then
             button.frame.color = Blitbuffer.COLOR_DARK_GRAY -- no black border around gray squares
             if highlighted then
-                button.frame.background = Blitbuffer.COLOR_DARK_GRAY
+                -- The button and its frame background will be inverted,
+                -- so invert the color we want so it gets inverted back
+                button.frame.background = Blitbuffer.COLOR_DARK_GRAY:invert()
                 button = FrameContainer:new{ -- add margin back
                     margin = button_margin,
                     padding = 0,

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -391,7 +391,7 @@ function ConfigOption:init()
                             underline_padding = padding_button,
                             padding_left = d > 1 and horizontal_half_padding,
                             padding_right = d < #self.options[c].item_text and horizontal_half_padding,
-                            color = d == current_item and enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_WHITE,
+                            color = d == current_item and (enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY) or Blitbuffer.COLOR_WHITE,
                             enabled = enabled,
                         }
                     else
@@ -410,7 +410,7 @@ function ConfigOption:init()
                             underline_padding = -padding_button,
                             padding_left = d > 1 and horizontal_half_padding,
                             padding_right = d < #self.options[c].item_text and horizontal_half_padding,
-                            color = d == current_item and enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_WHITE,
+                            color = d == current_item and (enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY) or Blitbuffer.COLOR_WHITE,
                             enabled = enabled,
                         }
                     end
@@ -448,7 +448,7 @@ function ConfigOption:init()
                         underline_padding = -padding_button,
                         padding_left = d > 1 and horizontal_half_padding,
                         padding_right = d < #self.options[c].item_icons and horizontal_half_padding,
-                        color = d == current_item and enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_WHITE,
+                        color = d == current_item and (enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY) or Blitbuffer.COLOR_WHITE,
                         enabled = enabled,
                     }
                     option_items[d] = option_item


### PR DESCRIPTION
Fix small issue in #4789 gray refactoring. See https://github.com/koreader/koreader/pull/4789#issuecomment-473034847