### PR TITLE
Gesture manager: fix actions: Book cover, Book description

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -195,6 +195,7 @@ function BookInfo:show(file, book_props)
 end
 
 function BookInfo:onShowBookInfo()
+    if not self.document then return end
     -- Get them directly from ReaderUI's doc_settings
     local doc_props = self.ui.doc_settings:readSetting("doc_props")
     -- Make a copy, so we don't add "pages" to the original doc_props
@@ -205,6 +206,41 @@ function BookInfo:onShowBookInfo()
     end
     book_props.pages = self.ui.doc_settings:readSetting("doc_pages")
     self:show(self.document.file, book_props)
+end
+
+function BookInfo:onShowBookDescription()
+    if not self.document then return end
+    local description = self.document:getProps().description
+    if description and description ~= "" then
+        -- Description may (often in EPUB, but not always) or may not (rarely
+        -- in PDF) be HTML.
+        description = util.htmlToPlainTextIfHtml(description)
+        local TextViewer = require("ui/widget/textviewer")
+        UIManager:show(TextViewer:new{
+            title = _("Book description:"),
+            text = description,
+        })
+    else
+        UIManager:show(InfoMessage:new{
+            text = _("No book description available."),
+        })
+    end
+end
+
+function BookInfo:onShowBookCover()
+    if not self.document then return end
+    local cover_bb = self.document:getCoverPageImage()
+    if cover_bb then
+        UIManager:show(ImageViewer:new{
+            image = cover_bb,
+            with_title_bar = false,
+            fullscreen = true,
+        })
+    else
+        UIManager:show(InfoMessage:new{
+            text = _("No cover image available."),
+        })
+    end
 end
 
 return BookInfo

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -632,32 +632,9 @@ function ReaderGesture:gestureAction(action, ges)
     elseif action == "book_info" then
         self.ui:handleEvent(Event:new("ShowBookInfo"))
     elseif action == "book_description" then
-        local description = self.document:getProps().description
-        if description and description ~= "" then
-            local TextViewer = require("ui/widget/textviewer")
-            UIManager:show(TextViewer:new{
-                title = _("Book description:"),
-                text = description,
-            })
-        else
-            UIManager:show(InfoMessage:new{
-                text = _("No book description available."),
-            })
-        end
+        self.ui:handleEvent(Event:new("ShowBookDescription"))
     elseif action == "book_cover" then
-        local cover_bb = self.document:getCoverPageImage()
-        if cover_bb then
-            local ImageViewer = require("ui/widget/imageviewer")
-            UIManager:show(ImageViewer:new{
-                image = cover_bb,
-                with_title_bar = false,
-                fullscreen = true,
-            })
-        else
-            UIManager:show(InfoMessage:new{
-                text = _("No cover image available."),
-            })
-        end
+        self.ui:handleEvent(Event:new("ShowBookCover"))
     elseif action == "book_status" then
         self.ui:handleEvent(Event:new("ShowBookStatus"))
     elseif action == "page_jmp_fwd_10" then


### PR DESCRIPTION
Code removed from ReaderGesture and put into BookInfo where it belongs, so we can just use Events - I added that a bit too quickly as part of #4792.

Also convert description to plain text to not show HTML tags. Reported at https://github.com/koreader/koreader/issues/4727#issuecomment-473274913