### PR TITLE
Properly account for MuPDF feeding us premultiplied alpha

### DIFF
--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -359,7 +359,8 @@ function ImageWidget:paintTo(bb, x, y)
         -- Only actually try to alpha-blend if the image really has an alpha channel...
         local bbtype = self._bb:getType()
         if bbtype == Blitbuffer.TYPE_BB8A or bbtype == Blitbuffer.TYPE_BBRGB32 then
-            bb:alphablitFrom(self._bb, x, y, self._offset_x, self._offset_y, size.w, size.h)
+            -- NOTE: MuPDF feeds us premultiplied alpha (and we don't care w/ GifLib, as alpha is all or nothing).
+            bb:pmulalphablitFrom(self._bb, x, y, self._offset_x, self._offset_y, size.w, size.h)
         else
             bb:blitFrom(self._bb, x, y, self._offset_x, self._offset_y, size.w, size.h)
         end

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -431,7 +431,8 @@ function TextBoxWidget:_renderImage(start_row_idx)
         -- With alpha-blending if the image contains an alpha channel
         local bbtype = image.bb:getType()
         if bbtype == Blitbuffer.TYPE_BB8A or bbtype == Blitbuffer.TYPE_BBRGB32 then
-            self._bb:alphablitFrom(image.bb, self.width - image.width, 0)
+            -- NOTE: MuPDF feeds us premultiplied alpha (and we don't care w/ GifLib, as alpha is all or nothing).
+            self._bb:pmulalphablitFrom(image.bb, self.width - image.width, 0)
         else
             self._bb:blitFrom(image.bb, self.width - image.width, 0)
         end


### PR DESCRIPTION
Note that in every current call site, alphablitFrom was used with pixmap data straight from MuPDF ;).
(Which means that, technically, alphablitFrom is now dead code).

Depends on https://github.com/koreader/koreader-base/pull/863

re: https://github.com/koreader/koreader/pull/4789#discussion_r266173207