### PR TITLE
[build] Bump base to make ninja the default CMake generator when available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: frenzie/koappimage:0.1.3
+      - image: frenzie/koappimage:0.1.4
         environment:
           EMULATE_READER: 1
           # this is for shellcheck 0.4.5 and lower; can be removed for 0.4.6


### PR DESCRIPTION
The difference for builds from scratch is negligible, but for rebuilds (i.e., for us hackers & the CI here in front) it should bring a speed improvement.

Automatic fallback to Make when Ninja is not available, or override with `USE_MAKE=1`.

You can (theoretically) choose your own generator with a sensible combination of `CMAKE_FLAGS` and `CMAKE_MAKE_PROGRAM`.

I also added `MAKE_FLAGS` and `NINJA_FLAGS`. That way you can easily pass `MAKE_FLAGS=-n` or `NINJA_FLAGS=-n` for a dry run, for example.

To switch you might have to run something like `make dist-clean USE_MAKE=1`.

Cf. https://github.com/koreader/koreader-base/pull/861, https://github.com/koreader/koreader-base/pull/862 and https://github.com/koreader/virdevenv/pull/34/files