### PR TITLE
[fix, lang] ReaderGesture: toggle highlight action to cycle

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -78,7 +78,7 @@ local action_strings = {
 
     folder_up = _("Folder up"),
     folder_shortcuts = _("Folder shortcuts"),
-    toggle_highlight_action = _("Toggle highlight action"),
+    cycle_highlight_action = _("Cycle highlight action"),
     wallabag_download = _("Wallabag retrieval"),
 }
 
@@ -362,7 +362,7 @@ function ReaderGesture:buildMenu(ges, default)
         {"zoom_column", not self.is_docless},
         {"zoom_content", not self.is_docless},
         {"zoom_page", not self.is_docless, true},
-        {"toggle_highlight_action", not self.is_docless},
+        {"cycle_highlight_action", not self.is_docless},
         {"wallabag_download", self.ui.wallabag ~= nil},
     }
     local return_menu = {}
@@ -804,7 +804,7 @@ function ReaderGesture:gestureAction(action, ges)
         self.ui:handleEvent(Event:new("SetZoomMode", "page"))
     elseif action == "wallabag_download" then
         self.ui:handleEvent(Event:new("SynchronizeWallabag"))
-    elseif action == "toggle_highlight_action" then
+    elseif action == "cycle_highlight_action" then
         self.ui:handleEvent(Event:new("CycleHighlightAction"))
     end
     return true


### PR DESCRIPTION
I overlooked this until I noticed it on Transifex today.

See https://github.com/koreader/koreader/pull/4791#discussion_r265546245

Also changing the internal name because for something that's only been in one or two nightlies there's no point in prematurely introducing legacy settings.