### PR TITLE
[fix] Makefile: declare all phonies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,4 +501,4 @@ static-check:
 doc:
 	make -C doc
 
-.PHONY: test doc
+.PHONY: all clean doc test update


### PR DESCRIPTION
It's generally working as expected at the moment because you're unlikely to have a file named `clean`. But if you were to create a file named `all` or `clean` you could have a pretty difficult time figuring out why nothing's happening anymore.

Pointed out by https://github.com/mrtazz/checkmake which I ran out of sheer curiosity.