### PR TITLE
Fix Color rendering toggle not toggable

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -236,6 +236,7 @@ end
 
 function ReaderPaging:onColorRenderingUpdate()
     self.ui.document:updateColorRendering()
+    UIManager:setDirty(self.view.dialog, "partial")
 end
 
 --[[

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -738,6 +738,7 @@ end
 
 function ReaderRolling:onColorRenderingUpdate()
     self.ui.document:updateColorRendering()
+    UIManager:setDirty(self.view.dialog, "partial")
 end
 
 --[[

--- a/frontend/ui/elements/screen_color_menu_table.lua
+++ b/frontend/ui/elements/screen_color_menu_table.lua
@@ -9,7 +9,7 @@ return {
     enabled_func = Screen.isColorScreen,
     checked_func = Screen.isColorEnabled,
     callback = function()
-        local new_val = Screen.isColorEnabled()
+        local new_val = not Screen.isColorEnabled()
         CanvasContext:setColorRenderingEnabled(new_val)
         G_reader_settings:saveSetting("color_rendering", new_val)
         UIManager:broadcastEvent(Event:new("ColorRenderingUpdate"))


### PR DESCRIPTION
Fix #4832, indeed broken by some late change in #4580.
Also refresh screen when toggling (which was no more happening probably since we have more localized refreshes for menu).