### PR TITLE
ConfigDialog: fix possible crash

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -356,7 +356,7 @@ function ConfigOption:init()
                 end
                 local default_option_name = self.config.config_options.prefix.."_"..self.options[c].name
                 local default_value = G_reader_settings:readSetting(default_option_name)
-                if default_value then
+                if default_value and self.options[c].values then
                     local val = default_value
                     local min_diff
                     if type(val) == "table" then


### PR DESCRIPTION
Fix possible crash introduced by #4805, when one has set a default for toggles that don't have 'values' in their definitions (possibly only Orientation).
Noticed by @NiLuJe, details in https://github.com/koreader/koreader-base/pull/878#issuecomment-476076439.