### PR TITLE
Footnote popups: fix crash when used on some links

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1114,7 +1114,9 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
             if not self:onTap(arg, ges) then
                 -- If we did tap on another link, onTap has already cleared our
                 -- highlight. If not, call close_callback to unhighlight it.
-                close_callback(footnote_height)
+                if close_callback then -- not set if xpointer not coherent
+                    close_callback(footnote_height)
+                end
             end
         end,
         dialog = self.dialog,

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -688,6 +688,8 @@ function ReaderRolling:onChangeViewMode()
     self.ui:handleEvent(Event:new("UpdateToc"))
     if self.xpointer then
         self:_gotoXPointer(self.xpointer)
+        -- Ensure a whole screen refresh is always enqueued
+        UIManager:setDirty(self.view.dialog, "partial")
     else
         table.insert(self.ui.postInitCallback, function()
             self:_gotoXPointer(self.xpointer)


### PR DESCRIPTION
Fix crash when dismissing the popup when the link was detected as "not coherent". See https://github.com/koreader/koreader/issues/4840#issuecomment-476603558. Close #4840.

Also includes:
ReaderRolling: proper refresh when toggling scroll/page mode 
When toggling between scroll and page modes multiple times, _gotoXPointer() could find the xpointer to be already positionned and avoid calling setDirty() (so not enqueuing a whole screen refresh). But the page will be slightly moved to account for the top margin disappearing. We need that whole screen refresh in such cases, so ensure one is enqueued.
Issue probably introduced by the refresh optimisations from #4793.