### PR TITLE
A few assorted tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -207,7 +207,7 @@ end
     UpdatePos event is used to tell ReaderRolling to update pos.
 --]]
 function ReaderFont:onChangeSize(direction, font_delta)
-    local delta = direction == "decrease" and -1 or 1
+    local delta = direction == "decrease" and -0.5 or 0.5
     if font_delta then
         self.font_size = self.font_size + font_delta * delta
     else

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -124,8 +124,6 @@ local KoboSnow = Kobo:new{
     touch_mirrored_x = false,
     touch_probe_ev_epoch_time = true,
     display_dpi = 265,
-    -- the bezel covers the top 11 pixels:
-    viewport = Geom:new{x=0, y=11, w=1080, h=1429},
     hasNaturalLight = yes,
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/lm3630a_ledb",
@@ -141,8 +139,6 @@ local KoboSnowRev2 = Kobo:new{
     hasFrontlight = yes,
     touch_snow_protocol = true,
     display_dpi = 265,
-    -- the bezel covers the top 11 pixels:
-    viewport = Geom:new{x=0, y=11, w=1080, h=1429},
     hasNaturalLight = yes,
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/lm3630a_ledb",

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -153,8 +153,6 @@ local KoboStar = Kobo:new{
     touch_probe_ev_epoch_time = true,
     touch_phoenix_protocol = true,
     display_dpi = 212,
-    -- the bezel covers 1-2 pixels on each side:
-    viewport = Geom:new{x=1, y=0, w=756, h=1024},
 }
 
 -- Kobo Aura second edition, Rev 2:
@@ -165,8 +163,6 @@ local KoboStarRev2 = Kobo:new{
     touch_probe_ev_epoch_time = true,
     touch_phoenix_protocol = true,
     display_dpi = 212,
-    -- the bezel covers 1-2 pixels on each side:
-    viewport = Geom:new{x=1, y=0, w=756, h=1024},
 }
 
 -- Kobo Glo HD:

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -138,6 +138,18 @@ if Device:isCervantes() or Device:isKobo() or Device:isSDL() or Device:isSonyPRS
     }
 end
 
+if Device:isKobo() then
+    common_settings.sleepcover = {
+        text = _("Ignore sleepcover events"),
+        checked_func = function()
+            return G_reader_settings:isTrue("ignore_power_sleepcover")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("ignore_power_sleepcover")
+        end
+    }
+end
+
 common_settings.night_mode = {
     text = _("Night mode"),
     checked_func = function() return G_reader_settings:readSetting("night_mode") end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -106,6 +106,38 @@ if Device:setDateTime() then
     }
 end
 
+if Device:isCervantes() or Device:isKobo() or Device:isSDL() or Device:isSonyPRSTUX() then
+    common_settings.autosuspend = {
+        text = _("Autosuspend timeout"),
+        enabled_func = function()
+            -- NOTE: Pilfered from frontend/pluginloader.lua
+            local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
+            return plugins_disabled["autosuspend"] ~= true
+        end,
+        callback = function()
+            local SpinWidget = require("ui/widget/spinwidget")
+            local curr_items = G_reader_settings:readSetting("auto_suspend_timeout_seconds") or 60*60
+            local autosuspend_spin = SpinWidget:new {
+                width = Screen:getWidth() * 0.6,
+                value = curr_items / 60,
+                value_min = 5,
+                value_max = 240,
+                value_hold_step = 15,
+                ok_text = _("Set timeout"),
+                title_text = _("Timeout in minutes"),
+                callback = function(autosuspend_spin)
+                    G_reader_settings:saveSetting("auto_suspend_timeout_seconds", autosuspend_spin.value * 60)
+                    -- NOTE: Will only take effect after a restart, as we don't have a method to set this live...
+                    UIManager:show(InfoMessage:new{
+                        text = _("This will take effect on next restart."),
+                    })
+                end
+            }
+            UIManager:show(autosuspend_spin)
+        end
+    }
+end
+
 common_settings.night_mode = {
     text = _("Night mode"),
     checked_func = function() return G_reader_settings:readSetting("night_mode") end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -106,38 +106,6 @@ if Device:setDateTime() then
     }
 end
 
-if Device:isCervantes() or Device:isKobo() or Device:isSDL() or Device:isSonyPRSTUX() then
-    common_settings.autosuspend = {
-        text = _("Autosuspend timeout"),
-        enabled_func = function()
-            -- NOTE: Pilfered from frontend/pluginloader.lua
-            local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
-            return plugins_disabled["autosuspend"] ~= true
-        end,
-        callback = function()
-            local SpinWidget = require("ui/widget/spinwidget")
-            local curr_items = G_reader_settings:readSetting("auto_suspend_timeout_seconds") or 60*60
-            local autosuspend_spin = SpinWidget:new {
-                width = Screen:getWidth() * 0.6,
-                value = curr_items / 60,
-                value_min = 5,
-                value_max = 240,
-                value_hold_step = 15,
-                ok_text = _("Set timeout"),
-                title_text = _("Timeout in minutes"),
-                callback = function(autosuspend_spin)
-                    G_reader_settings:saveSetting("auto_suspend_timeout_seconds", autosuspend_spin.value * 60)
-                    -- NOTE: Will only take effect after a restart, as we don't have a method to set this live...
-                    UIManager:show(InfoMessage:new{
-                        text = _("This will take effect on next restart."),
-                    })
-                end
-            }
-            UIManager:show(autosuspend_spin)
-        end
-    }
-end
-
 if Device:isKobo() then
     common_settings.sleepcover = {
         text = _("Ignore sleepcover events"),

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -39,6 +39,7 @@ local order = {
     device = {
         "time",
         "battery",
+        "autosuspend",
         "mass_storage_settings",
     },
     navigation = {

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -40,6 +40,7 @@ local order = {
         "time",
         "battery",
         "autosuspend",
+        "sleepcover",
         "mass_storage_settings",
     },
     navigation = {

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -60,6 +60,7 @@ local order = {
         "time",
         "battery",
         "autosuspend",
+        "sleepcover",
         "mass_storage_settings",
     },
     navigation = {

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -59,6 +59,7 @@ local order = {
     device = {
         "time",
         "battery",
+        "autosuspend",
         "mass_storage_settings",
     },
     navigation = {

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -157,7 +157,7 @@ end
 function RenderText:sizeUtf8Text(x, width, face, text, kerning, bold)
     if not text then
         logger.warn("sizeUtf8Text called without text");
-        return
+        return { x = 0, y_top = 0, y_bottom = 0 }
     end
 
     -- may still need more adaptive pen placement when kerning,


### PR DESCRIPTION
* Ignore the accelerometer when sleeping on Kobo (avoids spurious refreshes).
* Allow setting the autosuspend timeout from the UI (Gear > Device)
* Allow toggling the sleepcover from the UI (Gear > Device)
* Enable full granularity in most common font sizes in CRe (depends on https://github.com/koreader/koreader-base/pull/881 for actual effect).
* Don't crash when sizeUtf8Text is called on a nil (#4845)
* Remove viewport on the H2O², as there isn't actually one in effect (#4834)
* Remove viewport on the Aura SE (I'm going to chalk 1-2px on the side to personal preference).