### PR TITLE
A few minor fixes after #4847

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -263,6 +263,21 @@ function FileManagerMenu:setUpdateItemTable()
             end,
         })
     end
+    if not Device.should_restrict_JIT then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            text = _("Disable use of the C blitter"),
+            enabled_func = function()
+                local lfs = require("libs/libkoreader-lfs")
+                return lfs.attributes("libs/libblitbuffer.so", "mode") == "file"
+            end,
+            checked_func = function()
+                return G_reader_settings:isTrue("dev_no_c_blitter")
+            end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("dev_no_c_blitter")
+            end,
+        })
+    end
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),
         callback = function()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -265,7 +265,7 @@ function FileManagerMenu:setUpdateItemTable()
     end
     if not Device.should_restrict_JIT then
         table.insert(self.menu_items.developer_options.sub_item_table, {
-            text = _("Disable use of the C blitter"),
+            text = _("Disable C blitter"),
             enabled_func = function()
                 local lfs = require("libs/libkoreader-lfs")
                 return lfs.attributes("libs/libblitbuffer.so", "mode") == "file"

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -260,6 +260,10 @@ function FileManagerMenu:setUpdateItemTable()
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_startup_no_fbdepth")
+                local InfoMessage = require("ui/widget/infomessage")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
             end,
         })
     end
@@ -275,6 +279,10 @@ function FileManagerMenu:setUpdateItemTable()
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_no_c_blitter")
+                local InfoMessage = require("ui/widget/infomessage")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
             end,
         })
     end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -560,16 +560,19 @@ end
 
 -- only call this function after document is fully loaded
 function ReaderFooter:_updateFooterText(force_repaint)
-    self.footer_text:setText(self:genFooterText())
+    local text = self:genFooterText()
+    if text then
+        self.footer_text:setText(self:genFooterText())
+    end
     if self.settings.disable_progress_bar then
-        if self.has_no_mode then
+        if self.has_no_mode or not text then
             self.text_width = 0
         else
             self.text_width = self.footer_text:getSize().w
         end
         self.progress_bar.width = 0
     else
-        if self.has_no_mode then
+        if self.has_no_mode or not text then
             self.text_width = 0
         else
             self.text_width = self.footer_text:getSize().w + self.text_left_margin

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -640,7 +640,16 @@ function ReaderFooter:applyFooterMode(mode)
     -- 10 for wifi status
     if mode ~= nil then self.mode = mode end
     self.view.footer_visible = (self.mode ~= MODE.off)
-    if not self.view.footer_visible or self.settings.all_at_once then return end
+
+    -- If all-at-once is enabled, just hide, but the text will keep being processed...
+    if self.settings.all_at_once then
+        return
+    end
+    -- We're not in all-at-once mode, disable text generation entirely when we're hidden
+    if not self.view.footer_visible then
+        self.genFooterText = footerTextGeneratorMap.empty
+        return
+    end
 
     local mode_name = MODE_INDEX[self.mode]
     if not self.settings[mode_name] or self.has_no_mode then

--- a/frontend/ui/widget/fixedtextwidget.lua
+++ b/frontend/ui/widget/fixedtextwidget.lua
@@ -10,7 +10,7 @@ local FixedTextWidget = TextWidget:new{}
 
 function FixedTextWidget:getSize()
     local tsize = RenderText:sizeUtf8Text(0, Screen:getWidth(), self.face, self.text, true, self.bold)
-    if not tsize then
+    if tsize.x == 0 then
         return Geom:new{}
     end
     self._length = tsize.x

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -43,7 +43,7 @@ local TextWidget = Widget:new{
 
 function TextWidget:updateSize()
     local tsize = RenderText:sizeUtf8Text(0, self.max_width and self.max_width or Screen:getWidth(), self.face, self.text, true, self.bold)
-    if not tsize then
+    if tsize.x == 0 then
         self._length = 0
     else
         -- As text length includes last glyph pen "advance" (for positionning

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -3,11 +3,8 @@ A.dl.library_path = A.dl.library_path .. ":" .. A.dir .. "/libs"
 A.log_name = 'KOReader'
 
 local ffi = require("ffi")
+local dummy = require("ffi/posix_h")
 local C = ffi.C
-ffi.cdef[[
-    char *getenv(const char *name);
-    int putenv(const char *envvar);
-]]
 
 -- check uri of the intent that starts this application
 local file = A.getIntent()

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -23,7 +23,7 @@ A.execute("chmod", "755", "./tar")
 A.execute("chmod", "755", "./zsync")
 
 -- set TESSDATA_PREFIX env var
-C.putenv("TESSDATA_PREFIX=/sdcard/koreader/data")
+C.setenv("TESSDATA_PREFIX", "/sdcard/koreader/data", 1)
 
 -- create fake command-line arguments
 arg = {"-d", file or "/sdcard"}

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -9,7 +9,7 @@ export LD_LIBRARY_PATH="/usr/local/Kobo"
 # Reset PWD, and clear up our own custom stuff from the env while we're there, otherwise, USBMS may become very wonky on newer FW...
 # shellcheck disable=SC2164
 cd /
-unset OLDPWD EXT_FONT_DIR TESSDATA_PREFIX FROM_NICKEL STARDICT_DATA_DIR LC_ALL
+unset OLDPWD EXT_FONT_DIR TESSDATA_PREFIX FROM_NICKEL STARDICT_DATA_DIR LC_ALL KO_NO_CBB
 
 # Ensures fmon will restart. Note that we don't have to worry about reaping this, nickel kills on-animator.sh on start.
 (

--- a/reader.lua
+++ b/reader.lua
@@ -34,6 +34,24 @@ if lang_locale then
     _.changeLang(lang_locale)
 end
 
+-- Make the C blitter optional (ffi/blitbuffer.lua will check that env var)
+local ffi = require("ffi")
+local dummy = require("ffi/posix_h")
+local C = ffi.C
+if G_reader_settings:isTrue("dev_no_c_blitter") then
+    if ffi.os == "Windows" then
+        C._putenv("KO_NO_CBB=true")
+    else
+        C.putenv("KO_NO_CBB=true")
+    end
+else
+    if ffi.os == "Windows" then
+        C._putenv("KO_NO_CBB=false")
+    else
+        C.putenv("KO_NO_CBB=false")
+    end
+end
+
 local Device = require("device")
 local dpi_override = G_reader_settings:readSetting("screen_dpi")
 if dpi_override ~= nil then

--- a/reader.lua
+++ b/reader.lua
@@ -42,13 +42,13 @@ if G_reader_settings:isTrue("dev_no_c_blitter") then
     if ffi.os == "Windows" then
         C._putenv("KO_NO_CBB=true")
     else
-        C.putenv("KO_NO_CBB=true")
+        C.setenv("KO_NO_CBB", "true", 1)
     end
 else
     if ffi.os == "Windows" then
         C._putenv("KO_NO_CBB=false")
     else
-        C.putenv("KO_NO_CBB=false")
+        C.unsetenv("KO_NO_CBB")
     end
 end
 

--- a/setupkoenv.lua
+++ b/setupkoenv.lua
@@ -8,13 +8,10 @@ package.cpath =
 
 -- set search path for 'ffi.load()'
 local ffi = require("ffi")
-ffi.cdef[[
-    char *getenv(const char *name);
-    int putenv(const char *envvar);
-    int _putenv(const char *envvar);
-]]
+local dummy = require("ffi/posix_h")
+local C = ffi.C
 if ffi.os == "Windows" then
-    ffi.C._putenv("PATH=libs;common;")
+    C._putenv("PATH=libs;common;")
 end
 local ffi_load = ffi.load
 -- patch ffi.load for thirdparty luajit libraries


### PR DESCRIPTION
* Add a toggle to disable the C blitter in the Dev menu (depends on https://github.com/koreader/koreader-base/pull/882) (never shown if the JIT is disabled, grayed out if the C blitter is not installed)
* Fix a few sizeUtf8Text call sites that were doing a nil check in order to account for the new return type.
* Tweak statusbar handling to avoid spurious sizeUtf8Text warnings when it's hidden, and unify its behavior between being hidden via toggle, and hidden on book open (at least when all-at-once is not enabled).