### PR TITLE
Night mode: keep some images non-inverted

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -365,14 +365,22 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
     end
     -- TODO: self.buffer could be re-used when no page/layout/highlights
     -- change has been made, to avoid having crengine redraw the exact
-    -- same buffer.
-    -- And it could only change when some other methods from here are called
-    --local start_clock = os.clock()
-    self._drawn_images_count, self._drawn_images_surface_ratio = self._document:drawCurrentPage(self.buffer, self.render_color)
-    --print(string.format("CreDocument:drawCurrentView: Rendering took %9.3f ms", (os.clock() - start_clock) * 1000))
-    --start_clock = os.clock()
+    -- same buffer. And it could only change when some other methods
+    -- from here are called
+
+    -- If in night mode, ask crengine to invert all images, so they
+    -- get displayed in their original colors when the whole screen
+    -- is inverted by night mode
+    local invert_images = G_reader_settings:isTrue("night_mode")
+
+    -- local start_clock = os.clock()
+    self._drawn_images_count, self._drawn_images_surface_ratio =
+        self._document:drawCurrentPage(self.buffer, self.render_color, invert_images)
+    -- print(string.format("CreDocument:drawCurrentView: Rendering took %9.3f ms", (os.clock() - start_clock) * 1000))
+
+    -- start_clock = os.clock()
     target:blitFrom(self.buffer, x, y, 0, 0, rect.w, rect.h)
-    --print(string.format("CreDocument:drawCurrentView: Blitting took  %9.3f ms", (os.clock() - start_clock) * 1000))
+    -- print(string.format("CreDocument:drawCurrentView: Blitting took  %9.3f ms", (os.clock() - start_clock) * 1000))
 end
 
 function CreDocument:drawCurrentViewByPos(target, x, y, rect, pos)

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -298,12 +298,15 @@ end
 
 function FootnoteWidget:onClose()
     UIManager:close(self)
+    if self.close_callback then
+        self.close_callback(self.height)
+    end
     return true
 end
 
 function FootnoteWidget:onTapClose(arg, ges)
     if ges.pos:notIntersectWith(self.container.dimen) then
-        self:onClose()
+        UIManager:close(self)
         -- Allow ReaderLink to check if our dismiss tap
         -- was itself on another footnote, and display
         -- it. This avoids having to tap 2 times to
@@ -327,6 +330,7 @@ function FootnoteWidget:onSwipeFollow(arg, ges)
             return self.follow_callback()
         end
     elseif ges.direction == "south" or ges.direction == "east" then
+        UIManager:close(self)
         -- We can close with swipe down. If footnote is scrollable,
         -- this event will be eaten by ScrollHtmlWidget, and it will
         -- work only when started outside the footnote.
@@ -335,7 +339,6 @@ function FootnoteWidget:onSwipeFollow(arg, ges)
         if self.close_callback then
             self.close_callback(self.height)
         end
-        self:onClose()
         return true
     elseif ges.direction == "north" then
         -- no use for now

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -373,6 +373,13 @@ function ImageWidget:paintTo(bb, x, y)
     if self.dim then
         bb:dimRect(x, y, size.w, size.h)
     end
+    -- If in night mode, invert all rendered images, so the original is
+    -- displayed when the whole screen is inverted by night mode.
+    -- Except for our black & white icon files, that we want inverted
+    -- in night mode.
+    if not self.file and G_reader_settings:isTrue("night_mode") then
+        bb:invertRect(x, y, size.w, size.h)
+    end
 end
 
 -- This will normally be called by our WidgetContainer:free()


### PR DESCRIPTION
Have the code pre-invert some images when in night mode, so they get inverted back to normal by night mode.
This will allow images to be displayed normally in the following contexts:
- images in credocument pages
- images long-pressed in credocument and viewed in ImageViewer
- cover thumbnails in File browser and History
- full size covers when viewed in ImageViewer
- images in Wikipedia lookup results

There is still some issues when the lua blitter is used (Kobo, Kindle), where some images may be wrongly or not inverted, or messed up. No issue seen when the C blitter is used (Android, emulator). Discussed in #2571. Closes #2571.

Includes https://github.com/koreader/crengine/pull/276:
- DrawBuf: allow drawing images inverted (to be used in night mode)
- ldomXPointer::getRect(): adds adjusted=false parameter
- CSS: fix parsing of "! important" with spaces
- CSS: fix non-deterministic combinators
- Delay some style computations until needed https://github.com/koreader/crengine/pull/278

Also:
Footnote popups: fix link unhighlight when closing with keys. (Fix last item in https://github.com/koreader/koreader/issues/4840#issuecomment-476603558)