### PR TITLE
Fix tap for top menu occasionally not working

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -77,7 +77,10 @@ function FileManagerMenu:initGesListener()
                 ratio_x = DTAP_ZONE_MENU.x, ratio_y = DTAP_ZONE_MENU.y,
                 ratio_w = DTAP_ZONE_MENU.w, ratio_h = DTAP_ZONE_MENU.h,
             },
-            overrides = { "rolling_swipe", "paging_swipe", },
+            overrides = {
+                "rolling_swipe",
+                "paging_swipe",
+            },
             handler = function(ges) return self:onSwipeShowMenu(ges) end,
         },
     })

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -44,7 +44,10 @@ function ReaderConfig:initGesListener()
                 ratio_x = DTAP_ZONE_CONFIG.x, ratio_y = DTAP_ZONE_CONFIG.y,
                 ratio_w = DTAP_ZONE_CONFIG.w, ratio_h = DTAP_ZONE_CONFIG.h,
             },
-            overrides = { 'tap_forward', 'tap_backward', },
+            overrides = {
+                "tap_forward",
+                "tap_backward",
+            },
             handler = function() return self:onTapShowConfigMenu() end,
         },
         {
@@ -54,7 +57,10 @@ function ReaderConfig:initGesListener()
                 ratio_x = DTAP_ZONE_CONFIG.x, ratio_y = DTAP_ZONE_CONFIG.y,
                 ratio_w = DTAP_ZONE_CONFIG.w, ratio_h = DTAP_ZONE_CONFIG.h,
             },
-            overrides = { "rolling_swipe", "paging_swipe", },
+            overrides = {
+                "rolling_swipe",
+                "paging_swipe",
+            },
             handler = function(ges) return self:onSwipeShowConfigMenu(ges) end,
         },
         {
@@ -64,7 +70,10 @@ function ReaderConfig:initGesListener()
                 ratio_x = DTAP_ZONE_CONFIG.x, ratio_y = DTAP_ZONE_CONFIG.y,
                 ratio_w = DTAP_ZONE_CONFIG.w, ratio_h = DTAP_ZONE_CONFIG.h,
             },
-            overrides = { "rolling_pan", "paging_pan", },
+            overrides = {
+                "rolling_pan",
+                "paging_pan",
+            },
             handler = function(ges) return self:onSwipeShowConfigMenu(ges) end,
         },
     })

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -252,7 +252,9 @@ function ReaderFooter:setupTouchZones()
             screen_zone = footer_screen_zone,
             handler = function(ges) return self:onTapFooter(ges) end,
             overrides = {
-                'tap_forward', 'tap_backward', 'readerconfigmenu_tap',
+                "tap_forward",
+                "tap_backward",
+                "readerconfigmenu_tap",
             },
         },
         {
@@ -260,7 +262,9 @@ function ReaderFooter:setupTouchZones()
             ges = "hold",
             screen_zone = footer_screen_zone,
             handler = function() return self:onHoldFooter() end,
-            overrides = {'readerhighlight_hold'},
+            overrides = {
+                "readerhighlight_hold",
+            },
         },
     })
 end

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -589,7 +589,7 @@ function ReaderGesture:setupGesture(ges, action)
         if self.is_docless then
             overrides = { 'filemanager_tap' }
         else
-            overrides = { 'readerfooter_tap', }
+            overrides = { 'readerfooter_tap' }
         end
     elseif ges == "tap_left_bottom_corner" then
         ges_type = "tap"
@@ -600,7 +600,7 @@ function ReaderGesture:setupGesture(ges, action)
         if self.is_docless then
             overrides = { 'filemanager_tap' }
         else
-            overrides = { 'readerfooter_tap', 'filemanager_tap' }
+            overrides = { 'readerfooter_tap' }
         end
     elseif ges == "two_finger_swipe_west" then
         ges_type = "two_finger_swipe"

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -587,9 +587,13 @@ function ReaderGesture:setupGesture(ges, action)
             ratio_w = 0.1, ratio_h = 0.1,
         }
         if self.is_docless then
-            overrides = { 'filemanager_tap' }
+            overrides = {
+                "filemanager_tap",
+            }
         else
-            overrides = { 'readerfooter_tap' }
+            overrides = {
+                "readerfooter_tap",
+            }
         end
     elseif ges == "tap_left_bottom_corner" then
         ges_type = "tap"
@@ -598,9 +602,13 @@ function ReaderGesture:setupGesture(ges, action)
             ratio_w = 0.1, ratio_h = 0.1,
         }
         if self.is_docless then
-            overrides = { 'filemanager_tap' }
+            overrides = {
+                "filemanager_tap",
+            }
         else
-            overrides = { 'readerfooter_tap' }
+            overrides = {
+                "readerfooter_tap",
+            }
         end
     elseif ges == "two_finger_swipe_west" then
         ges_type = "two_finger_swipe"
@@ -635,9 +643,14 @@ function ReaderGesture:setupGesture(ges, action)
         direction = {northeast = true, northwest = true, southeast = true, southwest = true}
         distance = "short"
         if self.is_docless then
-            overrides = { 'filemanager_tap' }
+            overrides = {
+                "filemanager_tap",
+            }
         else
-            overrides = { 'rolling_swipe', 'paging_swipe' }
+            overrides = {
+                "rolling_swipe",
+                "paging_swipe",
+            }
         end
 
     else return

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -35,7 +35,12 @@ function ReaderHighlight:setupTouchZones()
             screen_zone = {
                 ratio_x = 0, ratio_y = 0, ratio_w = 1, ratio_h = 1,
             },
-            overrides = { 'tap_forward', 'tap_backward', 'readermenu_tap', 'readerconfigmenu_tap', },
+            overrides = {
+                "tap_forward",
+                "tap_backward",
+                "readermenu_tap",
+                "readerconfigmenu_tap",
+            },
             handler = function(ges) return self:onTap(nil, ges) end
         },
         {

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -97,7 +97,10 @@ function ReaderMenu:onReaderReady()
                 ratio_x = DTAP_ZONE_MENU.x, ratio_y = DTAP_ZONE_MENU.y,
                 ratio_w = DTAP_ZONE_MENU.w, ratio_h = DTAP_ZONE_MENU.h,
             },
-            overrides = { 'tap_forward', 'tap_backward', },
+            overrides = {
+                "tap_forward",
+                "tap_backward",
+            },
             handler = function(ges) return self:onTapShowMenu(ges) end,
         },
         {
@@ -107,7 +110,10 @@ function ReaderMenu:onReaderReady()
                 ratio_x = DTAP_ZONE_MENU.x, ratio_y = DTAP_ZONE_MENU.y,
                 ratio_w = DTAP_ZONE_MENU.w, ratio_h = DTAP_ZONE_MENU.h,
             },
-            overrides = { "rolling_swipe", "paging_swipe", },
+            overrides = {
+                "rolling_swipe",
+                "paging_swipe",
+            },
             handler = function(ges) return self:onSwipeShowMenu(ges) end,
         },
         {
@@ -117,7 +123,10 @@ function ReaderMenu:onReaderReady()
                 ratio_x = DTAP_ZONE_MENU.x, ratio_y = DTAP_ZONE_MENU.y,
                 ratio_w = DTAP_ZONE_MENU.w, ratio_h = DTAP_ZONE_MENU.h,
             },
-            overrides = { "rolling_pan", "paging_pan", },
+            overrides = {
+                "rolling_pan",
+                "paging_pan",
+            },
             handler = function(ges) return self:onSwipeShowMenu(ges) end,
         },
     })

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -97,6 +97,7 @@ function ReaderMenu:onReaderReady()
                 ratio_x = DTAP_ZONE_MENU.x, ratio_y = DTAP_ZONE_MENU.y,
                 ratio_w = DTAP_ZONE_MENU.w, ratio_h = DTAP_ZONE_MENU.h,
             },
+            overrides = { 'tap_forward', 'tap_backward', },
             handler = function(ges) return self:onTapShowMenu(ges) end,
         },
         {

--- a/plugins/kobolight.koplugin/main.lua
+++ b/plugins/kobolight.koplugin/main.lua
@@ -64,7 +64,10 @@ function KoboLight:setupTouchZones()
             ges = "swipe",
             screen_zone = swipe_zone,
             handler = function(ges) return self:onSwipe(nil, ges) end,
-            overrides = { 'paging_swipe', 'rolling_swipe', },
+            overrides = {
+                "paging_swipe",
+                "rolling_swipe",
+            },
         },
         {
             -- dummy zone to disable reader panning
@@ -72,7 +75,10 @@ function KoboLight:setupTouchZones()
             ges = "pan",
             screen_zone = swipe_zone,
             handler = function(ges) return true end,
-            overrides = { 'paging_pan', 'rolling_pan', },
+            overrides = {
+                "paging_pan",
+                "rolling_pan",
+            },
         },
         {
             -- dummy zone to disable reader panning
@@ -80,7 +86,9 @@ function KoboLight:setupTouchZones()
             ges = "pan_release",
             screen_zone = swipe_zone,
             handler = function(ges) return true end,
-            overrides = { 'paging_pan_release', },
+            overrides = {
+                "paging_pan_release",
+            },
         },
     })
     if with_natural_light then
@@ -90,7 +98,10 @@ function KoboLight:setupTouchZones()
             ges = "swipe",
             screen_zone = swipe_zone_warmth,
             handler = function(ges) return self:onSwipeWarmth(nil, ges) end,
-            overrides = { 'paging_swipe', 'rolling_swipe', },
+            overrides = {
+                "paging_swipe",
+                "rolling_swipe",
+            },
         },
         {
             -- dummy zone to disable reader panning
@@ -98,7 +109,10 @@ function KoboLight:setupTouchZones()
             ges = "pan",
             screen_zone = swipe_zone_warmth,
             handler = function(ges) return true end,
-            overrides = { 'paging_pan', 'rolling_pan', },
+            overrides = {
+                "paging_pan",
+                "rolling_pan",
+            },
         },
         {
             -- dummy zone to disable reader panning
@@ -106,7 +120,9 @@ function KoboLight:setupTouchZones()
             ges = "pan_release",
             screen_zone = swipe_zone_warmth,
             handler = function(ges) return true end,
-            overrides = { 'paging_pan_release', },
+            overrides = {
+                "paging_pan_release",
+            },
         },
         })
     end


### PR DESCRIPTION
It was missing some ordering hints to have it always precede taps to change page.
(Somehow noticed only when we reached > 32 gestures registered, which may have introduced some shuffling, while previously the addition order was somehow preserved...)
Details and observations in #4856. Closes #4856.