### PR TITLE
[Android] use the same tag for all logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ androidupdate: all
 	cd $(INSTALL_DIR)/koreader && 7z a -l -m0=lzma2 -mx=1 \
 		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).7z * \
 		-x!resources/fonts -x!resources/icons/src -x!spec
-	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) $(if $(KODEBUG), debug, release) ANDROID_VERSION=$(ANDROID_VERSION) ANDROID_NAME=$(ANDROID_NAME) ANDROID_FLAVOR=$(ANDROID_FLAVOR)
+	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) $(if $(KODEBUG), debug, release) ANDROID_APPNAME=KOReader ANDROID_VERSION=$(ANDROID_VERSION) ANDROID_NAME=$(ANDROID_NAME) ANDROID_FLAVOR=$(ANDROID_FLAVOR)
 	cp $(ANDROID_LAUNCHER_DIR)/bin/NativeActivity.apk \
 		koreader-android-$(MACHINE)-$(VERSION).apk
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -141,8 +141,7 @@ function Device:retrieveNetworkInfo()
 end
 
 function Device:exit()
-    android.log_name = 'luajit-launcher'
-    android.LOGI("Finishing luajit launcher main activity");
+    android.LOGI("Finishing main activity");
     android.lib.ANativeActivity_finish(android.app.activity)
 end
 

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -1,6 +1,5 @@
 local A = require("android")
 A.dl.library_path = A.dl.library_path .. ":" .. A.dir .. "/libs"
-A.log_name = 'KOReader'
 
 local ffi = require("ffi")
 local dummy = require("ffi/posix_h")
@@ -17,7 +16,7 @@ end
 -- run koreader patch before koreader startup
 pcall(dofile, "/sdcard/koreader/patch.lua")
 
--- set proper permission for sdcv
+-- set proper permission for binaries
 A.execute("chmod", "755", "./sdcv")
 A.execute("chmod", "755", "./tar")
 A.execute("chmod", "755", "./zsync")


### PR DESCRIPTION
get android logger tag from application name ("KOReader")

~~debug logging can be enabled using developer options like in other platforms.~~

requires https://github.com/koreader/android-luajit-launcher/pull/136 & bumping that module