### PR TITLE
Links menu and handling tweaks

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -31,6 +31,7 @@ local action_strings = {
     previous_location = _("Back to previous location"),
     latest_bookmark = _("Go to latest bookmark"),
     follow_nearest_link = _("Follow nearest link"),
+    follow_nearest_internal_link = _("Follow nearest internal link"),
     clear_location_history = _("Clear location history"),
 
     toc = _("Table of contents"),
@@ -361,6 +362,7 @@ function ReaderGesture:buildMenu(ges, default)
         {"previous_location", not self.is_docless},
         {"latest_bookmark", not self.is_docless},
         {"follow_nearest_link", not self.is_docless},
+        {"follow_nearest_internal_link", not self.is_docless},
         {"clear_location_history", not self.is_docless, true},
 
         {"folder_up", self.is_docless},
@@ -747,6 +749,8 @@ function ReaderGesture:gestureAction(action, ges)
         self.ui:handleEvent(Event:new("GoToLatestBookmark"))
     elseif action == "follow_nearest_link" then
         self.ui:handleEvent(Event:new("GoToPageLink", ges, false, G_reader_settings:isTrue("footnote_link_in_popup")))
+    elseif action == "follow_nearest_internal_link" then
+        self.ui:handleEvent(Event:new("GoToPageLink", ges, true, G_reader_settings:isTrue("footnote_link_in_popup")))
     elseif action == "clear_location_history" then
         self.ui:handleEvent(Event:new("ClearLocationStack", true)) -- show_notification
     elseif action == "filemanager" then

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -948,7 +948,8 @@ function KoptInterface:getLinkFromPosition(doc, pageno, pos)
                 w = link.x1 - link.x0 + len,
                 h = link.y1 - link.y0 + len,
             }
-            if _inside_box(pos, lbox) and link.page then
+            -- Allow external links, with link.uri instead of link.page
+            if _inside_box(pos, lbox) then -- and link.page then
                 return link, lbox
             end
         end

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -22,6 +22,10 @@ local ButtonDialogTitle = InputContainer:new{
     title_face = Font:getFace("x_smalltfont"),
     title_padding = Size.padding.large,
     title_margin = Size.margin.title,
+    use_info_style = false, -- set to true to have the same look as ConfirmBox
+    info_face = Font:getFace("infofont"),
+    info_padding = Size.padding.default,
+    info_margin = Size.margin.default,
     buttons = nil,
     tap_close_callback = nil,
     dismissable = true, -- set to false if any button callback is required
@@ -55,13 +59,13 @@ function ButtonDialogTitle:init()
                 VerticalGroup:new{
                     align = "center",
                     FrameContainer:new{
-                        padding = self.title_padding,
-                        margin = self.title_margin,
+                        padding = self.use_info_style and self.info_padding or self.title_padding,
+                        margin = self.use_info_style and self.info_margin or self.title_margin,
                         bordersize = 0,
                         TextBoxWidget:new{
                             text = self.title,
                             width = Screen:getWidth() * 0.8 ,
-                            face = self.title_face,
+                            face = self.use_info_style and self.info_face or self.title_face,
                             alignment = self.title_align or "left",
                         },
                     },


### PR DESCRIPTION
Follow up to #4863, see discussion there (so, I removed the External link action menu, and as a compensation, I allowed external links on swipe :).

- Removed "Swipe to follow first link on page" menu item and handling code, as it feels not really as practical as "Swipe to follow nearest link".
- Removed recently added "External link action", as we can just always present a popup with the url and the available actions.
- Generic handling of these actions in onGoToExternalLink(), so they are proposed on the Wikipedia lookup popup too.
- Allow external link on PDF documents (previously, only internal links were handled).
- Have "Ignore external links on tap" available on all document types.
- Added "Ignore external links on swipe" (default to true, the current behaviour).
- Added multiswipe gesture "Follow nearest internal link" (the existing "Follow nearest link" now follows the nearest external or internal link)
- ButtonDialogTitle: added an option to look a bit more alike ConfirmBoxes.
- Footnote popups: fix link unhighlight when tap on external link.

I'm not really fond of the switch for Wikipedia popup from the ConfirmBox & MultiConfirmBox to this ButtonDialogTitle, but I guess I'll get used to it (the removal of the Info icon make more room for the article title, so I guess it's good).

<kbd>![image](https://user-images.githubusercontent.com/24273478/55398664-665f3580-5549-11e9-911c-ebf5e3052081.png)</kbd>

For all Wikipedia or external links, the popup will be the same, with just added buttons depending on what's possible/available:

![image](https://user-images.githubusercontent.com/24273478/55398795-b6d69300-5549-11e9-9a4e-c3ae846ef0b0.png)

![image](https://user-images.githubusercontent.com/24273478/55398813-c35aeb80-5549-11e9-8044-6e8510c23534.png)

![image](https://user-images.githubusercontent.com/24273478/55398864-dd94c980-5549-11e9-9d7c-71e167844b73.png)

![image](https://user-images.githubusercontent.com/24273478/55398884-e9808b80-5549-11e9-9031-e58f65705c4e.png)

![image](https://user-images.githubusercontent.com/24273478/55398970-1896fd00-554a-11e9-946b-1f7ee7f93a5a.png)

![image](https://user-images.githubusercontent.com/24273478/55398990-29477300-554a-11e9-9d04-22a8cf0416f0.png)




