### PR TITLE
[UX] VirtualKeyPopup: respond to hold & pan release

### DIFF
--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -131,12 +131,6 @@ function VirtualKey:init()
                     range = self.dimen,
                 },
             },
-            SwipeKey = {
-                GestureRange:new{
-                    ges = "swipe",
-                    range = self.dimen,
-                },
-            },
             HoldReleaseKey = {
                 GestureRange:new{
                     ges = "hold_release",
@@ -146,6 +140,12 @@ function VirtualKey:init()
             PanReleaseKey = {
                 GestureRange:new{
                     ges = "pan_release",
+                    range = self.dimen,
+                },
+            },
+            SwipeKey = {
+                GestureRange:new{
+                    ges = "swipe",
                     range = self.dimen,
                 },
             },
@@ -318,6 +318,8 @@ function VirtualKeyPopup:init()
 
                 if v == key_char_orig then
                     virtual_key[1].background = Blitbuffer.COLOR_LIGHT_GRAY
+                    virtual_key.onHoldReleaseKey = function() end
+                    virtual_key.onPanReleaseKey = function() end
                 end
 
                 table.insert(group, virtual_key)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -318,8 +318,16 @@ function VirtualKeyPopup:init()
 
                 if v == key_char_orig then
                     virtual_key[1].background = Blitbuffer.COLOR_LIGHT_GRAY
-                    virtual_key.onHoldReleaseKey = function() end
-                    virtual_key.onPanReleaseKey = function() end
+
+                    -- restore ability to hold/pan release on central key after opening popup
+                    virtual_key._keyOrigHoldPanHandler = function()
+                        virtual_key.onHoldReleaseKey = virtual_key._onHoldReleaseKey
+                        virtual_key.onPanReleaseKey = virtual_key._onPanReleaseKey
+                    end
+                    virtual_key._onHoldReleaseKey = virtual_key.onHoldReleaseKey
+                    virtual_key.onHoldReleaseKey = virtual_key._keyOrigHoldPanHandler
+                    virtual_key._onPanReleaseKey = virtual_key.onPanReleaseKey
+                    virtual_key.onPanReleaseKey = virtual_key._keyOrigHoldPanHandler
                 end
 
                 table.insert(group, virtual_key)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -137,6 +137,18 @@ function VirtualKey:init()
                     range = self.dimen,
                 },
             },
+            HoldReleaseKey = {
+                GestureRange:new{
+                    ges = "hold_release",
+                    range = self.dimen,
+                },
+            },
+            PanReleaseKey = {
+                GestureRange:new{
+                    ges = "pan_release",
+                    range = self.dimen,
+                },
+            },
         }
     end
     self.flash_keyboard = G_reader_settings:readSetting("flash_keyboard") ~= false
@@ -219,6 +231,9 @@ function VirtualKey:onSwipeKey(arg, ges)
     return true
 end
 
+VirtualKey.onHoldReleaseKey = VirtualKey.onTapSelect
+VirtualKey.onPanReleaseKey = VirtualKey.onTapSelect
+
 function VirtualKey:invert(invert, hold)
     if invert then
         self[1].inner_bordersize = self.focused_bordersize
@@ -298,8 +313,8 @@ function VirtualKeyPopup:init()
                     key_chars = key_chars,
                     width = parent_key.width,
                     height = parent_key.height,
-                    hold_callback = nil,
                 }
+                virtual_key.hold_callback = nil
 
                 if v == key_char_orig then
                     virtual_key[1].background = Blitbuffer.COLOR_LIGHT_GRAY


### PR DESCRIPTION
As suggested by @poire-z in https://github.com/koreader/koreader/pull/4886#discussion_r273569802

This is actually much better than before.

It subtly changes the behavior of every key this way, but I don't think that's a bad thing.