### PR TITLE
[fix] VirtualKeyboard: always fall back to en (like it used to)

### DIFF
--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -506,9 +506,8 @@ local lang_to_keyboard_layout = {
 }
 
 function VirtualKeyboard:init()
-    local lang = G_reader_settings:readSetting("language") or "en"
-    if lang == "C" then lang = "en" end
-    local keyboard_layout = lang_to_keyboard_layout[lang]
+    local lang = G_reader_settings:readSetting("language")
+    local keyboard_layout = lang_to_keyboard_layout[lang] or lang_to_keyboard_layout["en"]
     local keyboard = require("ui/data/keyboardlayouts/" .. keyboard_layout)
     self.KEYS = keyboard.keys
     self.shiftmode_keys = keyboard.shiftmode_keys


### PR DESCRIPTION
Fixes #4899.