### PR TITLE
Go back to "UI" refreshes in the FM

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -160,7 +160,7 @@ function FileManager:init()
     function file_chooser:onPathChanged(path)  -- luacheck: ignore
         FileManager.instance.path_text:setText(truncatePath(filemanagerutil.abbreviate(path)))
         UIManager:setDirty(FileManager.instance, function()
-            return "partial", FileManager.instance.path_text.dimen, FileManager.instance.dithered
+            return "ui", FileManager.instance.path_text.dimen, FileManager.instance.dithered
         end)
         return true
     end

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -101,7 +101,7 @@ function CoverMenu:updateItems(select_number)
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
-        return "partial", refresh_dimen, self.show_parent.dithered
+        return "ui", refresh_dimen, self.show_parent.dithered
     end)
 
     -- As additionally done in FileChooser:updateItems()


### PR DESCRIPTION
Going with partial ends up being problematic on REAGL devices in a
number of different ways.

On Kindle (at least pre EPDCv2), it's slightly flickery because of the
whitespace and the boldface (I assume), probably combined with the need to make it FULL.
On Kobo, it's slow when anything else tries to queue an update (i.e.,
flashing the chevrons).
Which is a non-issue on the Forma because then it's fast when using
pageturns to navigate, but, still :D.

The obvious downside is we lose the automatic flash after n refresh,
which is potentially annoying on older, non-reagl devices.
It's not really an issue on REAGL devices, especially on EPDCv2.