### PR TITLE
[UX] Keyboard O popup: add Ø

### DIFF
--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -186,6 +186,7 @@ return {
         west = "Õ",
         south = "Ǫ",
         southeast = "Œ",
+        southwest = "Ø",
         "Ō",
         "ɔ", -- open o, open-mid back rounded vowel IPA
         "ɒ", -- turned alpha, open back rounded vowel IPA
@@ -199,6 +200,7 @@ return {
         west = "õ",
         south = "ǫ",
         southeast = "œ",
+        southwest = "ø",
         "ō",
         "ɔ", -- open o, open-mid back rounded vowel IPA
         "ɒ", -- turned alpha, open back rounded vowel IPA


### PR DESCRIPTION
Danish/Norse and IPA close-mid front rounded vowel.

Requested by @gerhaher over in https://github.com/koreader/koreader/pull/4907#issuecomment-482784459

![Screenshot_2019-04-13_09-41-54](https://user-images.githubusercontent.com/202757/56076393-d8990b00-5dd0-11e9-91ed-8e1de6b92530.png)
![Screenshot_2019-04-13_09-42-05](https://user-images.githubusercontent.com/202757/56076394-d8990b00-5dd0-11e9-8803-e976c768b231.png)
