### PR TITLE
[UX] Keyboard popup: add Q and W

### DIFF
--- a/frontend/ui/data/keyboardlayouts/en_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/en_keyboard.lua
@@ -20,12 +20,16 @@ local _L_ = en_popup._L_
 local _l_ = en_popup._l_
 local _O_ = en_popup._O_
 local _o_ = en_popup._o_
+local _Q_ = en_popup._Q_
+local _q_ = en_popup._q_
 local _S_ = en_popup._S_
 local _s_ = en_popup._s_
 local _T_ = en_popup._T_
 local _t_ = en_popup._t_
 local _U_ = en_popup._U_
 local _u_ = en_popup._u_
+local _W_ = en_popup._W_
+local _w_ = en_popup._w_
 local _Z_ = en_popup._Z_
 local _z_ = en_popup._z_
 
@@ -37,8 +41,8 @@ return {
     keys = {
         -- first row
         {  --  1           2       3       4       5       6       7       8       9       10      11      12
-            { "Q",        "q",    "„",    "0",    "Й",    "й",    "?",    "!",    "Å",    "å",    "1",    "ª", },
-            { "W",        "w",    "!",    "1",    "Ц",    "ц",    "(",    "1",    "Ä",    "ä",    "2",    "º", },
+            { _Q_,        _q_,    "„",    "0",    "Й",    "й",    "?",    "!",    "Å",    "å",    "1",    "ª", },
+            { _W_,        _w_,    "!",    "1",    "Ц",    "ц",    "(",    "1",    "Ä",    "ä",    "2",    "º", },
             { _E_,        _e_,    _at,    "2",    "У",    "у",    ")",    "2",    "Ö",    "ö",    "3",    "¡", },
             { "R",        "r",    "#",    "3",    "К",    "к",    "~",    "3",    "ß",    "ß",    "4",    "¿", },
             { _T_,        _t_,    "+",    "=",    "Е",    "е",    "Ә",    "ә",    "À",    "à",    "5",    "¼", },

--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -227,6 +227,20 @@ return {
         "ɔ", -- open o, open-mid back rounded vowel IPA
         "ɒ", -- turned alpha, open back rounded vowel IPA
     },
+    _Q_ = {
+        "Q",
+        north = "[",
+        northeast = "{",
+        -- todo render q̃ correctly on key (not a problem in textbox?)
+        --east = {"q̃"}, -- Old/Middle French abbreviation of que
+    },
+    _q_ = {
+        "q",
+        north = "[",
+        northeast = "{",
+        -- todo render q̃ correctly on key (not a problem in textbox?)
+        --east = {"q̃"}, -- Old/Middle French abbreviation of que
+    },
     _S_ = {
         "S",
         north = "ẞ",
@@ -304,6 +318,20 @@ return {
         southwest = "ů",
         "ū",
         "ʌ", -- turned v, open-mid back unrounded vowel IPA
+    },
+    _W_ = {
+        "W",
+        north = "]",
+        northeast = "}",
+        northwest = "ʍ", -- inverted w, voiceless labial-velar approximant IPA
+        east = "Ƿ", -- wynn, Old English for /w/
+    },
+    _w_ = {
+        "w",
+        north = "]",
+        northeast = "}",
+        northwest = "ʍ", -- inverted w, voiceless labial-velar approximant IPA
+        east = "ƿ", -- wynn, Old English for /w/
     },
     _Z_ = {
         "Z",


### PR DESCRIPTION
Mainly for easy swipe access to `[]{}`.

<img width=45% src=https://user-images.githubusercontent.com/202757/56077963-9a0c4c00-5de2-11e9-8fae-1d51004813ee.png><img width=45% src=https://user-images.githubusercontent.com/202757/56077962-9a0c4c00-5de2-11e9-8c60-d96a83c2846d.png>
<img width=45% src=https://user-images.githubusercontent.com/202757/56077961-9a0c4c00-5de2-11e9-9e77-831d49e06b08.png><img width=45% src=https://user-images.githubusercontent.com/202757/56077960-9a0c4c00-5de2-11e9-809a-bd77947e83ca.png>



