### PR TITLE
[UX] Keyboard popup: minor changes to S

### DIFF
--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -263,31 +263,30 @@ return {
     },
     _S_ = {
         "S",
-        north = "ẞ",
+        north = "ẞ", -- uppercase eszett
         northeast = "Ś",
-        northwest = "ſ",
+        northwest = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
         east = "Ŝ",
         west = "Š",
         south = "Ş",
         southeast = "$",
         southwest = "Ṣ",
-        "Σ",
-        "σ",
-        "ς",
+        "ſ", -- long s
+        "Σ", -- uppercase sigma
     },
     _s_ = {
         "s",
-        north = "ß",
+        north = "ß", -- lowercase eszett
         northeast = "ś",
-        northwest = "ſ",
+        northwest = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
         east = "ŝ",
         west = "š",
         south = "ş",
         southeast = "$",
         southwest = "ṣ",
-        "Σ",
-        "σ",
-        "ς",
+        "ſ", -- long s
+        "σ", -- lowercase sigma
+        "ς", -- lowercase word-end sigma
     },
     _T_ = {
         "T",


### PR DESCRIPTION
Split sigma into upper and lowercase to make room for esh.

![Screenshot_2019-04-14_09-29-50](https://user-images.githubusercontent.com/202757/56089793-abb02b00-5e98-11e9-96cc-cbcd32bf1d67.png)
![Screenshot_2019-04-14_09-30-01](https://user-images.githubusercontent.com/202757/56089794-abb02b00-5e98-11e9-96ac-db66452f502d.png)
