### PR TITLE
Make sure the AutoWarmth feature will never try to turn the light back

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -240,7 +240,12 @@ function KoboPowerD:setWarmth(warmth)
         self:calculateAutoWarmth()
     end
     self.fl_warmth = warmth or self.fl_warmth
-    self.fl:setWarmth(self.fl_warmth)
+    -- Don't turn the light back on on legacy NaturalLight devices just for the sake of setting the warmth!
+    -- That's because we can only set warmth independently of brightness on devices with a mixer.
+    -- On older ones, calling setWarmth *will* actually set the brightness, too!
+    if self.device:hasNaturalLightMixer() or self:isFrontlightOnHW() then
+        self.fl:setWarmth(self.fl_warmth)
+    end
 end
 
 -- Sets fl_warmth according to current hour and max_warmth_hour


### PR DESCRIPTION
on if it's off.
Because, on the KA1, since setting the warmth *has* to set the
brightness, it could ;).

Patch only actually needed on Kobo, as all Cervantes devices with warmth
support have a mixer, which mean they *can* set the warmth without
affecting the brightness ;).