### PR TITLE
README: remove Ubuntu Touch and add screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 [![Latest release][release-badge]](https://github.com/koreader/koreader/releases/)
 
 
-KOReader is a document viewer application, originally created for Kindle
-e-ink readers. It currently runs on Kindle, Kobo, PocketBook, Ubuntu Touch
-and Android devices. Developers can also run a KOReader emulator
-for development purposes on desktop PCs with Linux, Windows and
-Mac OSX.
+KOReader is a document viewer primarily targeting e-ink readers.
+It runs on Cervantes, Kindle, Kobo, PocketBook and Android devices.
+Developers can also run a KOReader emulator on desktop PCs with Linux or Mac OS X.
+
+[![screenshot-footnotes](https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes-thumbnail.png)](https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes.png)
 
 Main features for users
 -----------------------
 
 * supports multi-format documents including:
-  * paged fixed-layout formats: PDF, DjVu, CBT, and CBZ
+  * Fixed paged formats: PDF, DjVu, CBT, and CBZ
   * reflowable e-book formats: ePub, fb2, mobi, doc, chm and plain text
   * scanned PDF/DjVu documents can also be reflowed with built-in K2pdfopt
 * use StarDict dictionaries / Wikipedia to lookup words

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ KOReader is a document viewer primarily targeting e-ink readers.
 It runs on Cervantes, Kindle, Kobo, PocketBook and Android devices.
 Developers can also run a KOReader emulator on desktop PCs with Linux or Mac OS X.
 
-[![screenshot-footnotes](https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes-thumbnail.png)](https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes.png)
+<a href="https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes.png"><img src="https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes-thumbnail.png" alt="" width="200px"></a>
 
 Main features for users
 -----------------------
 
 * supports multi-format documents including:
-  * Fixed paged formats: PDF, DjVu, CBT, and CBZ
+  * fixed page formats: PDF, DjVu, CBT, and CBZ
   * reflowable e-book formats: ePub, fb2, mobi, doc, chm and plain text
   * scanned PDF/DjVu documents can also be reflowed with built-in K2pdfopt
 * use StarDict dictionaries / Wikipedia to lookup words

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ KOReader is a document viewer primarily targeting e-ink readers.
 It runs on Cervantes, Kindle, Kobo, PocketBook and Android devices.
 Developers can also run a KOReader emulator on desktop PCs with Linux or Mac OS X.
 
+<a href="https://github.com/koreader/koreader-artwork/raw/master/koreader-menu.png"><img src="https://github.com/koreader/koreader-artwork/raw/master/koreader-menu-thumbnail.png" alt="" width="200px"></a>
 <a href="https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes.png"><img src="https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes-thumbnail.png" alt="" width="200px"></a>
 
 Main features for users

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Developers can also run a KOReader emulator on desktop PCs with Linux or Mac OS 
 
 <a href="https://github.com/koreader/koreader-artwork/raw/master/koreader-menu.png"><img src="https://github.com/koreader/koreader-artwork/raw/master/koreader-menu-thumbnail.png" alt="" width="200px"></a>
 <a href="https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes.png"><img src="https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes-thumbnail.png" alt="" width="200px"></a>
+<a href="https://github.com/koreader/koreader-artwork/raw/master/koreader-dictionary.png"><img src="https://github.com/koreader/koreader-artwork/raw/master/koreader-dictionary-thumbnail.png" alt="" width="200px"></a>
 
 Main features for users
 -----------------------


### PR DESCRIPTION
The Ubuntu Touch build has been broken for three years and since I have no way to test I can't fix it.

References #4904.