### PR TITLE
[CI] CircleCI: save test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           command: .ci/after_success.sh
       # by storing the test results CircleCI automatically distributes tests based on execution time
       - store_test_results:
-          path: koreader-emulator-x86_64-linux-gnu/koreader/junit-test-results.xml
+          path: koreader-emulator-x86_64-linux-gnu/koreader
       # CircleCI doesn't make the test results available as artifacts (October 2017)
       - store_artifacts:
           path: koreader-emulator-x86_64-linux-gnu/koreader/junit-test-results.xml


### PR DESCRIPTION
It should be a path to a directory, not a file.

https://circleci.com/docs/2.0/configuration-reference/#store_test_results

> Path (absolute, or relative to your working_directory) to directory containing subdirectories of JUnit XML or Cucumber JSON test metadata files

Perhaps the file needs to be named results.xml. We'll see.