### PR TITLE
CRe margins: hide bottom menu on change

### DIFF
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -71,7 +71,7 @@ function ReaderTypeset:onReadSettings(config)
         G_reader_settings:readSetting("copt_b_page_margin") or
         DCREREADER_CONFIG_B_MARGIN_SIZES_LARGE
     self.unscaled_margins = { h_margins[1], t_margin, h_margins[2], b_margin }
-    self:onSetPageMargins(self.unscaled_margins, true)
+    self:onSetPageMargins(self.unscaled_margins)
     self.sync_t_b_page_margins = config:readSetting("copt_sync_t_b_page_margins") or
         G_reader_settings:readSetting("copt_sync_t_b_page_margins") or 0
     self.sync_t_b_page_margins = self.sync_t_b_page_margins == 1 and true or false
@@ -349,32 +349,32 @@ function ReaderTypeset:makeDefaultStyleSheet(css, text, touchmenu_instance)
     })
 end
 
-function ReaderTypeset:onSetPageHorizMargins(h_margins)
+function ReaderTypeset:onSetPageHorizMargins(h_margins, refresh_callback)
     self.unscaled_margins = { h_margins[1], self.unscaled_margins[2], h_margins[2], self.unscaled_margins[4] }
-    self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins))
+    self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins, refresh_callback))
 end
 
-function ReaderTypeset:onSetPageTopMargin(t_margin)
+function ReaderTypeset:onSetPageTopMargin(t_margin, refresh_callback)
     self.unscaled_margins = { self.unscaled_margins[1], t_margin, self.unscaled_margins[3], self.unscaled_margins[4] }
     if self.sync_t_b_page_margins then
         self.unscaled_margins[4] = t_margin
         -- Let ConfigDialog know so it can update it on screen and have it saved on quit
         self.ui.document.configurable.b_page_margin = t_margin
     end
-    self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins))
+    self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins, refresh_callback))
 end
 
-function ReaderTypeset:onSetPageBottomMargin(b_margin)
+function ReaderTypeset:onSetPageBottomMargin(b_margin, refresh_callback)
     self.unscaled_margins = { self.unscaled_margins[1], self.unscaled_margins[2], self.unscaled_margins[3], b_margin }
     if self.sync_t_b_page_margins then
         self.unscaled_margins[2] = b_margin
         -- Let ConfigDialog know so it can update it on screen and have it saved on quit
         self.ui.document.configurable.t_page_margin = b_margin
     end
-    self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins))
+    self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins, refresh_callback))
 end
 
-function ReaderTypeset:onSyncPageTopBottomMargins(toggle)
+function ReaderTypeset:onSyncPageTopBottomMargins(toggle, refresh_callback)
     self.sync_t_b_page_margins = not self.sync_t_b_page_margins
     if self.sync_t_b_page_margins then
         -- Adjust current top and bottom margins if needed
@@ -389,12 +389,16 @@ function ReaderTypeset:onSyncPageTopBottomMargins(toggle)
             self.ui.document.configurable.t_page_margin = mean_margin
             self.ui.document.configurable.b_page_margin = mean_margin
             self.unscaled_margins = { self.unscaled_margins[1], mean_margin, self.unscaled_margins[3], mean_margin }
-            self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins))
+            self.ui:handleEvent(Event:new("SetPageMargins", self.unscaled_margins, refresh_callback))
+            refresh_callback = nil
         end
+    end
+    if refresh_callback then
+        refresh_callback()
     end
 end
 
-function ReaderTypeset:onSetPageMargins(margins, silent)
+function ReaderTypeset:onSetPageMargins(margins, refresh_callback)
     local left = Screen:scaleBySize(margins[1])
     local top = Screen:scaleBySize(margins[2])
     local right = Screen:scaleBySize(margins[3])
@@ -406,16 +410,19 @@ function ReaderTypeset:onSetPageMargins(margins, silent)
     end
     self.ui.document:setPageMargins(left, top, right, bottom)
     self.ui:handleEvent(Event:new("UpdatePos"))
-    if not silent then
+    if refresh_callback then
         -- Show a toast on set, with the unscaled & scaled values
         UIManager:show(InfoMessage:new{
             text = T(_([[
     Margins set to:
+
     horizontal: %1 (%2px)
     top: %3 (%4px)
-    bottom: %5 (%6px)]]),
+    bottom: %5 (%6px)
+
+    Tap to dismiss.]]),
             margins[1], left, margins[2], top, margins[4], bottom),
-            timeout = 4,
+            dismiss_callback = refresh_callback,
         })
     end
     return true

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -89,6 +89,7 @@ Note that this may not be ensured under some conditions: in scroll mode, when a 
                     DCREREADER_CONFIG_H_MARGIN_SIZES_X_HUGE,
                     DCREREADER_CONFIG_H_MARGIN_SIZES_XX_HUGE,
                 },
+                delay_repaint = true,
                 name_text_hold_callback = optionsutil.showValuesHMargins,
             },
             {
@@ -97,9 +98,10 @@ Note that this may not be ensured under some conditions: in scroll mode, when a 
                 toggle = {S.OFF, S.ON},
                 values = {0, 1},
                 default_value = 0,
+                event = "SyncPageTopBottomMargins",
                 args = {false, true},
                 default_arg = false,
-                event = "SyncPageTopBottomMargins",
+                delay_repaint = true,
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Keep top and bottom margins synchronized.
 - 'off' allows different top and bottom margins.
@@ -137,6 +139,7 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                     DCREREADER_CONFIG_T_MARGIN_SIZES_X_HUGE,
                     DCREREADER_CONFIG_T_MARGIN_SIZES_XX_HUGE,
                 },
+                delay_repaint = true,
                 name_text_hold_callback = optionsutil.showValues,
             },
             {
@@ -169,6 +172,7 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                     DCREREADER_CONFIG_B_MARGIN_SIZES_X_HUGE,
                     DCREREADER_CONFIG_B_MARGIN_SIZES_XX_HUGE,
                 },
+                delay_repaint = true,
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[In the top menu → Settings → Status bar, you can choose whether the bottom margin applies from the bottom of the screen, or from above the status bar.]]),
             },

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -68,6 +68,9 @@ function InputContainer:paintTo(bb, x, y)
     if self[1] == nil then
         return
     end
+    if self.skip_paint then
+        return
+    end
 
     if not self.dimen then
         local content_size = self[1]:getSize()

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -202,7 +202,7 @@ function ToggleSwitch:onTapSelect(arg, gev)
     end
     --]]
     self.config:onConfigChoose(self.values, self.name,
-                    self.event, self.args, self.events, self.position)
+                    self.event, self.args, self.events, self.position, self.delay_repaint)
     UIManager:setDirty(self.config, function()
         return "ui", self.dimen
     end)


### PR DESCRIPTION
So we can immediately see how's the bottom margin:

<kbd>![margins_tap_dismiss](https://user-images.githubusercontent.com/24273478/57060154-aa646800-6cb8-11e9-8922-6a107d68b324.gif)</kbd>

(As proposed in https://github.com/koreader/koreader/pull/4945#issuecomment-488571117)