### PR TITLE
NewsDownloader: Skip re-downloading files which already exist

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -321,11 +321,16 @@ end
 function NewsDownloader:downloadFeed(feed, feed_output_dir, include_images)
     local link = getFeedLink(feed.link)
     local news_dl_path = ("%s%s%s"):format(feed_output_dir,
-                                               getTitleWithDate(feed),
-                                               file_extension)
-    logger.dbg("NewsDownloader: News file will be stored to :", news_dl_path)
+                                           getTitleWithDate(feed),
+                                           file_extension)
 
-    DownloadBackend:download(link, news_dl_path, include_images)
+    local file_mode = lfs.attributes(news_dl_path, "mode")
+    if file_mode == "file" then
+        logger.dbg("NewsDownloader:", news_dl_path, "already exists. Skipping")
+    else
+        logger.dbg("NewsDownloader: News file will be stored to :", news_dl_path)
+        DownloadBackend:download(link, news_dl_path, include_images)
+    end
 end
 
 function NewsDownloader:createFromDescription(feed, context, feed_output_dir)


### PR DESCRIPTION
Fixes #5005

Results from re-running "Download news" should be as before, except when the
article content has changed between runs, but the title has not and an updated
date has not been given in the feed. User can force it to re-download an
article by manually deleting the file then running "Download news".