### PR TITLE
Bump crengine: cache and text fixes, use utf8proc

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -220,7 +220,7 @@ function ReaderRolling:onCloseDocument()
 end
 
 function ReaderRolling:onCheckDomStyleCoherence()
-    if self.ui.document:isBuiltDomStale() then
+    if self.ui.document and self.ui.document:isBuiltDomStale() then
         UIManager:show(ConfirmBox:new{
             text = _("Styles have changed in such a way that fully reloading the document may be needed for a correct rendering.\nDo you want to reload the document?"),
             ok_callback = function()

--- a/spec/unit/readertoc_spec.lua
+++ b/spec/unit/readertoc_spec.lua
@@ -1,23 +1,19 @@
 describe("Readertoc module", function()
-    local DocumentRegistry, Event, ReaderUI, DEBUG
+    local DocumentRegistry, ReaderUI, DEBUG
     local readerui, toc, toc_max_depth, title
 
     setup(function()
         require("commonrequire")
         DocumentRegistry = require("document/documentregistry")
-        Event = require("ui/event")
         ReaderUI = require("apps/reader/readerui")
         DEBUG = require("dbg")
 
         local sample_epub = "spec/front/unit/data/juliet.epub"
-
         readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
         -- reset book to first page
         readerui.rolling:onGotoPage(0)
-        readerui.document:setSpaceCondensing(75)
-        readerui:handleEvent(Event:new("ChangeScreenMode", "portrait"))
         toc = readerui.toc
     end)
 


### PR DESCRIPTION
Bump crengine:
- Ensure text decoration (underline) is continued over word gaps https://github.com/koreader/crengine/pull/286
- Invalidate TOC page numbers on rendering change (details in #4972)
- Ensure reproducible cache files when same rendering settings (details in #4972)
- Use utf8proc for string uppercase/lowercase/capitalize https://github.com/koreader/crengine/pull/287
- LVBlockWriteStream: workaround to exclude fatal error

Bump base https://github.com/koreader/koreader-base/pull/915
Thirdparty: adds utf8proc 2.3.0 (libutf8proc.so.2)
For use by crengine, for now mostly for more complete and accurate text-transform: uppercase/lowercase/capitalize.

Also revert test tweak (in #4972 / 27ddd6f) to workaround an issue with cre cache that should be solved by this crengine bump.

Also: cre: fix possible crash when switching books too fast
Noticable with "End of document action > Open next file", and holding PgDn in a directory full of single page html files.