### PR TITLE
[fix, chore] Abstract filename logic in util.getSafeFilename()

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -616,7 +616,7 @@ function ReaderLink:onGoToExternalLink(link_url)
         -- wikipedia page saved as epub, full of wikipedia links, it's
         -- too easy to click on links when wanting to change page...)
         -- But first check if this wikipedia article has been saved as EPUB
-        local epub_filename = util.replaceInvalidChars(wiki_page:gsub("_", " ")) .. "."..string.upper(wiki_lang)..".epub"
+        local epub_filename = util.getSafeFilename(wiki_page:gsub("_", " ")) .. "."..string.upper(wiki_lang)..".epub"
         local epub_fullpath
         -- either in current book directory
         local last_file = G_reader_settings:readSetting("lastfile")

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -329,7 +329,7 @@ function DictQuickLookup:update()
                         local lang = self.lang or self.wiki_languages_copy[1]
                         -- Just to be safe (none of the invalid chars, except ':' for uninteresting
                         -- Portal: or File: wikipedia pages, should be in lookup_word)
-                        local cleaned_lookupword = util.replaceInvalidChars(self.lookupword:gsub("_", " "))
+                        local cleaned_lookupword = util.getSafeFilename(self.lookupword:gsub("_", " "))
                         local filename = cleaned_lookupword .. "."..string.upper(lang)..".epub"
                         -- Find a directory to save file into
                         local dir

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -479,9 +479,8 @@ end
 function OPDSBrowser:downloadFile(item, format, remote_url)
     -- download to user selected directory or last opened dir
     local download_dir = self.getCurrentDownloadDir()
-    local file_system = util.getFilesystemType(download_dir)
-    item.author = util.getSafeFilename(item.author)
-    item.title = util.getSafeFilename(item.title)
+    item.author = util.getSafeFilename(item.author, download_dir)
+    item.title = util.getSafeFilename(item.title, download_dir)
     local local_path = download_dir .. "/" .. item.author .. ' - ' .. item.title .. "." .. string.lower(format)
     local_path = util.fixUtf8(local_path, "_")
 

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -480,13 +480,8 @@ function OPDSBrowser:downloadFile(item, format, remote_url)
     -- download to user selected directory or last opened dir
     local download_dir = self.getCurrentDownloadDir()
     local file_system = util.getFilesystemType(download_dir)
-    if file_system == "vfat" or file_system == "fuse.fsp" then
-        item.author = util.replaceInvalidChars(item.author)
-        item.title = util.replaceInvalidChars(item.title)
-    else
-        item.author = util.replaceSlashChar(item.author)
-        item.title = util.replaceSlashChar(item.title)
-    end
+    item.author = util.getSafeFilename(item.author)
+    item.title = util.getSafeFilename(item.title)
     local local_path = download_dir .. "/" .. item.author .. ' - ' .. item.title .. "." .. string.lower(format)
     local_path = util.fixUtf8(local_path, "_")
 

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -479,9 +479,8 @@ end
 function OPDSBrowser:downloadFile(item, format, remote_url)
     -- download to user selected directory or last opened dir
     local download_dir = self.getCurrentDownloadDir()
-    item.author = util.getSafeFilename(item.author, download_dir)
-    item.title = util.getSafeFilename(item.title, download_dir)
-    local local_path = download_dir .. "/" .. item.author .. ' - ' .. item.title .. "." .. string.lower(format)
+    local filename = util.getSafeFilename(item.author .. " - " .. item.title .. "." .. string.lower(format), download_dir)
+    local local_path = download_dir .. "/" .. filename
     local_path = util.fixUtf8(local_path, "_")
 
     local function download()

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -500,7 +500,6 @@ function util.getSafeFilename(str, path, limit)
     filename = util.fixUtf8(filename, "")
 
     if suffix and suffix ~= "" then
-    error(suffix)
         safe_filename = replaceFunc(filename) .. "." .. replaceFunc(suffix)
     else
         safe_filename = replaceFunc(filename)

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -262,7 +262,7 @@ end
 function NewsDownloader:processAtom(feeds, limit, download_full_article, include_images)
     local feed_output_dir = string.format("%s%s/",
                                           news_download_dir_path,
-                                          util.replaceInvalidChars(getFeedTitle(feeds.feed.title)))
+                                          util.getSafeFilename(getFeedTitle(feeds.feed.title)))
     if not lfs.attributes(feed_output_dir, "mode") then
         lfs.mkdir(feed_output_dir)
     end
@@ -281,7 +281,7 @@ end
 
 function NewsDownloader:processRSS(feeds, limit, download_full_article, include_images)
     local feed_output_dir = ("%s%s/"):format(
-        news_download_dir_path, util.replaceInvalidChars(util.htmlEntitiesToUtf8(feeds.rss.channel.title)))
+        news_download_dir_path, util.getSafeFilename(util.htmlEntitiesToUtf8(feeds.rss.channel.title)))
     if not lfs.attributes(feed_output_dir, "mode") then
         lfs.mkdir(feed_output_dir)
     end
@@ -307,7 +307,7 @@ local function parseDate(dateTime)
 end
 
 local function getTitleWithDate(feed)
-    local title = util.replaceInvalidChars(getFeedTitle(feed.title))
+    local title = util.getSafeFilename(getFeedTitle(feed.title))
     if feed.updated then
        title = parseDate(feed.updated) .. title
     elseif feed.pubDate then

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -24,7 +24,7 @@ local T = FFIUtil.template
 local Screen = require("device").screen
 
 -- constants
-local article_id_preffix = "[w-id_"
+local article_id_prefix = "[w-id_"
 local article_id_postfix = "] "
 local failed, skipped, downloaded = 1, 2, 3
 
@@ -297,8 +297,8 @@ end
 function Wallabag:download(article)
     local skip_article = false
     local item_url = "/api/entries/" .. article.id .. "/export.epub"
-    local title = util.replaceInvalidChars(article.title)
-    local local_path = self.directory .. article_id_preffix .. article.id .. article_id_postfix .. title:sub(1,30) .. ".epub"
+    local title = util.getSafeFilename(article.title)
+    local local_path = self.directory .. article_id_prefix .. article.id .. article_id_postfix .. title .. ".epub"
     logger.dbg("Wallabag: DOWNLOAD: id: ", article.id)
     logger.dbg("Wallabag: DOWNLOAD: title: ", article.title)
     logger.dbg("Wallabag: DOWNLOAD: filename: ", local_path)
@@ -571,17 +571,17 @@ end
 function Wallabag:getArticleID( path )
     -- extract the Wallabag ID from the file name
     local offset = self.directory:len() + 2 -- skip / and advance to the next char
-    local preffix_len = article_id_preffix:len()
-    if path:sub( offset , offset + preffix_len - 1 ) ~= article_id_preffix then
-        logger.warn("Wallabag: getArticleID: no match! ", path:sub( offset , offset + preffix_len - 1 ) )
+    local prefix_len = article_id_prefix:len()
+    if path:sub( offset , offset + prefix_len - 1 ) ~= article_id_prefix then
+        logger.warn("Wallabag: getArticleID: no match! ", path:sub( offset , offset + prefix_len - 1 ) )
         return
     end
-    local endpos = path:find( article_id_postfix, offset + preffix_len )
+    local endpos = path:find( article_id_postfix, offset + prefix_len )
     if endpos == nil then
         logger.warn("Wallabag: getArticleID: no match! " )
         return
     end
-    local id = path:sub( offset + preffix_len, endpos - 1 )
+    local id = path:sub( offset + prefix_len, endpos - 1 )
     return id
 end
 


### PR DESCRIPTION
Fixes https://github.com/koreader/koreader/issues/5025

The OPDS browser was doing some fancier stuff in a way that should be abstracted away in util (because it applies anywhere files will be saved):

https://github.com/koreader/koreader/blob/eace8d25c1cbf9bd13e98220098494e8fb63c18f/frontend/ui/widget/opdsbrowser.lua#L482-L491