### PR TITLE
cre: fix 2 footnotes issues

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -419,8 +419,7 @@ This only works with footnotes that have specific attributes set by the publishe
 *[role~="doc-rearnote"]
 {
     -cr-hint: footnote-inpage;
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
+    margin: 0 !important;
 }
                 ]],
             },
@@ -439,8 +438,7 @@ This only works with footnotes that have specific attributes set by the publishe
 *[role~="doc-rearnote"]
 {
     -cr-hint: footnote-inpage;
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
+    margin: 0 !important;
     font-size: 80% !important;
 }
                 ]],
@@ -453,8 +451,7 @@ This only works with footnotes that have specific attributes set by the publishe
                 css = [[
 ol.references > li {
     -cr-hint: footnote-inpage;
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
+    margin: 0 !important;
 }
 /* hide backlinks */
 ol.references > li > .noprint { display: none; }
@@ -468,8 +465,7 @@ ol.references > li > .mw-cite-backlink { display: none; }
                 css = [[
 ol.references > li {
     -cr-hint: footnote-inpage;
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
+    margin: 0 !important;
     font-size: 80% !important;
 }
 /* hide backlinks */
@@ -488,11 +484,10 @@ ol.references > li > .mw-cite-backlink { display: none; }
 Show footnotes with classic class names at the bottom of pages.
 This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
                 css = [[
-.footnote, .note, .note1, .ntb
+.footnote, .note, .note1, .ntb, .ntb-txt, .ntb-txt-j
 {
     -cr-hint: footnote-inpage;
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
+    margin: 0 !important;
 }
                 ]],
             },
@@ -503,11 +498,10 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
 Show footnotes with classic classname at the bottom of pages.
 This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
                 css = [[
-.footnote, .note, .note1, .ntb
+.footnote, .note, .note1, .ntb, .ntb-txt, .ntb-txt-j
 {
     -cr-hint: footnote-inpage;
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
+    margin: 0 !important;
     font-size: 80% !important;
 }
                 ]],

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -174,6 +174,11 @@ function FootnoteWidget:init()
     --   <div>abc<br anyattr="anyvalue"/>def</div> : 3 lines, empty line in between
     -- Remove any attribute, let a <br/> be a plain <br/>
     self.html = self.html:gsub([[<br[^>]*>]], [[<br/>]])
+    -- Elements with a id= attribute get a line above them (by some internal MuPDF
+    -- code, possibly generate_anchor() in html-layout.c).
+    -- Working around it with the following does not work: *[id] {margin-top: -1em;}
+    -- So, just rename the id= attribute, as we don't follow links in this popup.
+    self.html = self.html:gsub([[(<[^>]* )[iI][dD]=]], [[%1disabledID=]])
 
     -- We may use a font size a bit smaller than the document one (because
     -- footnotes are usually smaller, and because NotoSans is a bit on the


### PR DESCRIPTION
- Popup footnotes: workaround strange behaviour of MuPDF which is adding some unwanted margin above elements with an `id=` attribute. See https://github.com/koreader/koreader/issues/5015#issuecomment-492221431
- In-page footnotes: also remove any left and right margin, to keep footnotes aligned with the main text. See https://github.com/koreader/koreader/issues/5015#issuecomment-492184113
Also add 2 classnames (witnessed in quite a few recent french books) to the list of classic classnames.

Also bump crengine for:
- CSS: fix parsing of multi classnames and attributes selectors https://github.com/koreader/crengine/pull/288