### PR TITLE
bump crengine: hyphenation, kerning and epub.css fixes

### DIFF
--- a/spec/unit/readerrolling_spec.lua
+++ b/spec/unit/readerrolling_spec.lua
@@ -201,7 +201,7 @@ describe("Readerrolling module", function()
             local ReaderView = require("apps/reader/modules/readerview")
             local saved_handler = ReaderView.onPageUpdate
             ReaderView.onPageUpdate = function(_self)
-                assert.are.same(6, _self.ui.document:getPageCount())
+                assert.are.same(7, _self.ui.document:getPageCount())
             end
             local test_book = "spec/front/unit/data/sample.txt"
             require("docsettings"):open(test_book):purge()


### PR DESCRIPTION
Includes:
- Freetype kerning: fix possible unstable rendering https://github.com/koreader/crengine/pull/291
- Hyphenation: fix one-letter patterns, update French.pattern https://github.com/koreader/crengine/pull/290 Thanks @cramoisi 
- Hyphenation: update French.pattern https://github.com/koreader/crengine/pull/292
- epub.css: add style for empty-line (used on text files) https://github.com/koreader/crengine/pull/293
    Closes #5042 