### PR TITLE
Fix inconvenient InputText behavior with hint text and devices having touchscreen

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -434,7 +434,11 @@ function InputText:addChars(chars)
     if self.readonly or not self:isTextEditable(true) then
         return
     end
+
     self.is_text_edited = true
+    if #self.charlist == 0 then -- widget text is empty or a hint text is displayed
+        self.charpos = 1 -- move cursor to the first position
+    end
     table.insert(self.charlist, self.charpos, chars)
     self.charpos = self.charpos + #util.splitToChars(chars)
     self:initTextBox(table.concat(self.charlist), true)


### PR DESCRIPTION
Dear KOReader developers,

I want to ask you to consider below pull request about improving `InputText` widget behavior.

Because `addChars()` function did not consider if hint text is displayed or not, it could ignore the character input if the carat is not at the beginning of the hint text. If an user uses touchscreen device, he or she can place a carat at the middle of a text.

-- Before change
![Before](https://i.imgur.com/9V6hWHv.gif)

As in the example above, if I placed the carat in the middle of a hint text and clicked a key, that key was just ignored and the carat is moved to the beginning of text. Subsequent key click was processed because the carat is at the beginning of text.

I think that there are at least two solutions:

❌ Make the widget tap handler function just moves the carat to the beginning of text if the widget is displaying a hint text, regardless of the position user had tapped.
      🤔 It seemed somewhat complicated, for knowing if the hint text is displaying or not.

✔️ In the `addChars()` function, if the actual text (`self.charlist`) is empty, move the carat to the front then process remaining adding characters job.

-- After change
![After](https://i.imgur.com/N1frdMR.gif)

With the change, the keyboard type is handled without omission and regardless of carat position!

Please consider this request. Thank you.
