### PR TITLE
Fix shutdown action on Kobo

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -709,7 +709,7 @@ function Kobo:saveSettings()
 end
 
 function Kobo:powerOff()
-    os.execute("poweroff")
+    os.execute("poweroff -f")
 end
 
 function Kobo:reboot()


### PR DESCRIPTION
Bypass init, like Nickel does.
Otherwise, some devices either deadlock or panic.