### PR TITLE
Minor networking fixes on legacy Kindles

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -312,10 +312,11 @@ function Device:retrieveNetworkInfo()
         end
         if os.execute("ip r | grep -q default") == 0 then
             -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles...
+            local pingok = 1
             if self:isKindle() and self:hasKeyboard() then
-                local pingok = os.execute("ping -q -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
+                pingok = os.execute("ping -q -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
             else
-                local pingok = os.execute("ping -q -w 3 -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
+                pingok = os.execute("ping -q -w 3 -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
             end
             if pingok == 0 then
                 result = result .. "Gateway ping successful"

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -312,7 +312,7 @@ function Device:retrieveNetworkInfo()
         end
         if os.execute("ip r | grep -q default") == 0 then
             -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles...
-            local pingok = 1
+            local pingok
             if self:isKindle() and self:hasKeyboard() then
                 pingok = os.execute("ping -q -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
             else

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -311,7 +311,12 @@ function Device:retrieveNetworkInfo()
             std_out:close()
         end
         if os.execute("ip r | grep -q default") == 0 then
-            local pingok = os.execute("ping -q -w 3 -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
+            -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles...
+            if self:isKindle() and self:hasKeyboard() then
+                local pingok = os.execute("ping -q -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
+            else
+                local pingok = os.execute("ping -q -w 3 -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
+            end
             if pingok == 0 then
                 result = result .. "Gateway ping successful"
             else

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -32,14 +32,18 @@ local function isWifiUp()
         status = lipc_handle:get_int_property("com.lab126.wifid", "enable") or 0
         lipc_handle:close()
     else
-        -- NOTE: Pilfered from Cervantes, c.f., #4380
-        --       Possibly race-y, if we're extremely unlucky and lipc drops WiFi between our open and our read...
-        --       But then, if we're here, it's because we failed to acquire an lipc handle,
-        --       so it's likely we've failed to do that earlier when trying to toggle WiFi, too...
-        local file = io.open("/sys/class/net/wlan0/carrier", "rb")
-        if not file then return 0 end
-        status = tonumber(file:read("*all")) or 0
-        file:close()
+        local std_out = io.popen("lipc-get-prop -i com.lab126.wifid enable", "r")
+        if std_out then
+            local result = std_out:read("*all")
+            std_out:close()
+            if result then
+                return tonumber(result)
+            else
+                return 0
+            end
+        else
+            return 0
+        end
     end
     return status
 end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -13,6 +13,11 @@ local function kindleEnableWifi(toggle)
     if lipc_handle then
         lipc_handle:set_int_property("com.lab126.cmd", "wirelessEnable", toggle)
         lipc_handle:close()
+    else
+        -- No liblipclua on FW < 5.x ;)
+        -- Always kill 3G first...
+        os.execute("lipc-set-prop -i com.lab126.wan enable 0")
+        os.execute("lipc-set-prop -i com.lab126.wifid enable " .. toggle)
     end
 end
 

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -92,6 +92,8 @@ end
 function KindlePowerD:toggleSuspend()
     if self.lipc_handle then
         self.lipc_handle:set_int_property("com.lab126.powerd", "powerButton", 1)
+    else
+        os.execute("powerd_test -p")
     end
 end
 

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -102,7 +102,12 @@ function NetworkMgr:isConnected()
         return self:isWifiOn()
     else
         -- `-c1` try only once; `-w2` wait 2 seconds
-        return 0 == os.execute([[ping -c1 -w2 $(/sbin/route -n | awk '$4 == "UG" {print $2}')]])
+        -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles...
+        if Device:isKindle() and Device:hasKeyboard() then
+            return 0 == os.execute([[ping -c1 $(/sbin/route -n | awk '$4 == "UG" {print $2}')]])
+        else
+            return 0 == os.execute([[ping -c1 -w2 $(/sbin/route -n | awk '$4 == "UG" {print $2}')]])
+        end
     end
 end
 


### PR DESCRIPTION
By having viable fallbacks when we can't open a Lua lipc handle, and by dealing with really really old busybox builds.

Fix #5058