### PR TITLE
[fix] End of document - go to file browser: swap openFileBrowser() close/open order

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -118,10 +118,10 @@ end
 
 function ReaderStatus:openFileBrowser()
     local FileManager = require("apps/filemanager/filemanager")
+    self.ui:onClose()
     if not FileManager.instance then
         self.ui:showFileManager()
     end
-    self.ui:onClose()
     self.document = nil
 end
 


### PR DESCRIPTION
Fixes #5060.

Cf. https://github.com/koreader/koreader/blob/89e002f2367079cefd445e1719c1715dccedd65b/frontend/apps/reader/modules/readermenu.lua#L42-L50 and https://github.com/koreader/koreader/blob/89e002f2367079cefd445e1719c1715dccedd65b/frontend/apps/reader/readerui.lua#L711-L718