### PR TITLE
[fix, plugins] NewsDownloader: close document on go to folder

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -89,7 +89,9 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Go to news folder"),
                 callback = function()
                     local FileManager = require("apps/filemanager/filemanager")
-                    self.ui:onClose()
+                    if self.ui.document then
+                        self.ui:onClose()
+                    end
                     if FileManager.instance then
                         FileManager.instance:reinit(news_download_dir_path)
                     else

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -89,6 +89,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Go to news folder"),
                 callback = function()
                     local FileManager = require("apps/filemanager/filemanager")
+                    self.ui:onClose()
                     if FileManager.instance then
                         FileManager.instance:reinit(news_download_dir_path)
                     else


### PR DESCRIPTION
Same as https://github.com/koreader/koreader/pull/5063. Also see https://github.com/koreader/koreader/issues/5060#issuecomment-499416617.