### PR TITLE
WIP: Profiles plugin

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -86,6 +86,8 @@ local action_strings = {
     cycle_highlight_action = _("Cycle highlight action"),
     cycle_highlight_style = _("Cycle highlight style"),
     wallabag_download = _("Wallabag retrieval"),
+    load_next_profile = _("Load next profile"),
+    load_previous_profile = _("Load previous profile"),
 }
 
 local custom_multiswipes_path = DataStorage:getSettingsDir().."/multiswipes.lua"
@@ -491,6 +493,8 @@ function ReaderGesture:buildMenu(ges, default)
         {"cycle_highlight_action", not self.is_docless},
         {"cycle_highlight_style", not self.is_docless},
         {"wallabag_download", self.ui.wallabag ~= nil},
+        {"load_next_profile", self.ui.profiles ~= nil},
+        {"load_previous_profile", self.ui.profiles ~= nil},
     }
     local return_menu = {}
     -- add default action to the top of the submenu
@@ -1053,6 +1057,10 @@ function ReaderGesture:gestureAction(action, ges)
         self.ui:handleEvent(Event:new("CycleHighlightAction"))
     elseif action == "cycle_highlight_style" then
         self.ui:handleEvent(Event:new("CycleHighlightStyle"))
+    elseif action == "load_next_profile" then
+        self.ui:handleEvent(Event:new("LoadNextProfile"))
+    elseif action == "load_previous_profile" then
+        self.ui:handleEvent(Event:new("LoadPreviousProfile"))
     end
     return true
 end

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -89,6 +89,7 @@ local order = {
         "news_downloader",
         "send2ebook",
         "text_editor",
+        "profiles",
         "----------------------------",
         "more_plugins",
         "plugin_management",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -112,6 +112,7 @@ local order = {
         "news_downloader",
         "send2ebook",
         "text_editor",
+        "profiles",
         "----------------------------",
         "more_plugins",
         "plugin_management",

--- a/plugins/profiles.koplugin/_meta.lua
+++ b/plugins/profiles.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = 'profiles',
+    fullname = _("Profiles"),
+    description = _([[This plugin allows combining multiple settings to make switchable 'profiles'.]]),
+}

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -1,0 +1,83 @@
+local DataStorage = require("datastorage")
+local Event = require("ui/event")
+local FFIUtil = require("ffi/util")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+local logger = require("logger")
+local T = FFIUtil.template
+
+local Profiles = WidgetContainer:new{
+    name = "profiles",
+}
+
+local last_profile = 1
+local number_of_profiles = 2
+
+function Profiles:init()
+    logger.info("Profiles:init()")
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function Profiles:addToMainMenu(menu_items)
+    logger.info("Profiles:addToMainMenu")
+    menu_items.profiles = {
+        text = _("Profiles"),
+        sub_item_table = {
+            {
+                text = _("Profile 1"),
+                keep_menu_open = true,
+                callback = function()
+                    -- Profile configuration via GUI not yet implemented
+                    logger.dbg("Profile 1 menu callback")
+                end,
+            },
+            {
+                text = _("Profile 2"),
+                keep_menu_open = true,
+                callback = function()
+                    -- Profile configuration via GUI not yet implemented
+                    logger.dbg("Profile 2 menu callback")
+                end,
+            },
+            {
+                text = _("Load next profile"),
+                callback = function()
+                    self.ui:handleEvent(Event:new("LoadNextProfile"))
+                end,
+            },
+            {
+                text = _("Load previous profile"),
+                callback = function()
+                    self.ui:handleEvent(Event:new("LoadPreviousProfile"))
+                end,
+            },
+        },
+    }
+end
+
+function Profiles:loadProfile(profile_number)
+    local profile_path = T(_("%1/profiles/profile_%2.lua"), DataStorage:getFullDataDir(), profile_number)
+    logger.dbg("Executing profile file", profile_path)
+    local ok, err = xpcall(dofile, debug.traceback, profile_path)
+    if not ok then
+        logger.dbg("Problem executing profile:", err)
+    end
+end
+
+function Profiles:onLoadNextProfile()
+    last_profile = last_profile + 1
+    if last_profile > number_of_profiles then
+        last_profile = 1
+    end
+    self:loadProfile(last_profile)
+end
+
+function Profiles:onLoadPreviousProfile()
+    last_profile = last_profile - 1
+    if last_profile <= 0 then
+        last_profile = 1
+    end
+    self:loadProfile(last_profile)
+end
+
+return Profiles

--- a/plugins/profiles.koplugin/profile_1.lua
+++ b/plugins/profiles.koplugin/profile_1.lua
@@ -1,0 +1,14 @@
+local Device = require("device")
+local Screen = require("device").screen
+local UIManager = require("ui/uimanager")
+
+local night_mode = G_reader_settings:isTrue("night_mode")
+if night_mode then
+    Screen:toggleNightMode()
+    UIManager:setDirty("all", "full")
+    G_reader_settings:saveSetting("night_mode", false)
+end
+
+local powerd = Device:getPowerDevice()
+powerd:setIntensity(16)
+powerd:setWarmth(30)

--- a/plugins/profiles.koplugin/profile_2.lua
+++ b/plugins/profiles.koplugin/profile_2.lua
@@ -1,0 +1,14 @@
+local Device = require("device")
+local Screen = require("device").screen
+local UIManager = require("ui/uimanager")
+
+local night_mode = G_reader_settings:isTrue("night_mode")
+if not night_mode then
+    Screen:toggleNightMode()
+    UIManager:setDirty("all", "full")
+    G_reader_settings:saveSetting("night_mode", true)
+end
+
+local powerd = Device:getPowerDevice()
+powerd:setIntensity(1)
+powerd:setWarmth(100)


### PR DESCRIPTION
I've been thinking about how, depending on whether it's day or night, I adjust a number of settings, but I usually end up with one of two states:

Setting | Dark | Light
--------- | ------ | -----
Frontlight Brightness | 1 | 16
Frontlight Warmth | 100 | 30
Night Mode | On | Off
Font Contrast | Higher | Low

My idea to make this more convenient is as follows.
* The user is able to configure two (possibly more) "profiles".
* With a UI similar to the gesture configuration UI, the user can choose multiple settings (with values) to add to the profile.
* Loading a profile simply sets the chosen settings to the selected values (After setting the settings, KOReader doesn't need to remember which profile was loaded, and the user can adjust the settings as usual).
* An action to toggle (or cycle) between profiles could be made available, so a gesture can toggle between profiles.

Would probably also solve some other issues, such as #1427 & #5019.

So far, this is a proof-of-concept which allows you to use gestures to "cycle through profiles" (execute one of two lua files). At the moment, the "profiles" are hand-written scripts (copy them into koreader/profiles/ to use them): It doesn't have a GUI to select desired settings and values yet.

Remarks
I thought about trying to hook into the gesture manager's actions, as a way to have a selection of relevant actions available instead of arbitrary code execution. However, actions are too limited for my use case, as they don't allow you to select custom values (e.g. there's a "toggle frontlight" action, but there's no "set frontlight intensity to _x_", nor support in the GUI for choosing _x_. Similarly, there's a "toggle night mode", but no "turn night mode _on_", etc.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5079)
<!-- Reviewable:end -->
