### PR TITLE
fullscreen toggle for Jelly Bean devices

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -181,8 +181,8 @@ if Device:isAndroid() then
         }
     end
 
-    -- fullscreen toggle on devices with compatible fullscreen methods (apis 14-16)
-    if Device.firmware_rev <= 16 then
+    -- fullscreen toggle on devices with compatible fullscreen methods (apis 14-18)
+    if Device.firmware_rev < 19 then
         common_settings.fullscreen = {
             text = _("Fullscreen"),
             checked_func = function() return android.isFullscreen() end,

--- a/frontend/ui/elements/screen_android.lua
+++ b/frontend/ui/elements/screen_android.lua
@@ -2,6 +2,7 @@ local isAndroid, android = pcall(require, "android")
 local Device = require("device")
 local Geom = require("ui/geometry")
 local logger = require("logger")
+local _ = require("gettext")
 local Input = Device.input
 local Screen = Device.screen
 
@@ -9,8 +10,23 @@ if not isAndroid then return end
 
 local ScreenHelper = {}
 
--- toggle android status bar visibility
 function ScreenHelper:toggleFullscreen()
+    local api = Device.firmware_rev
+
+    if api < 19 and api >= 17 then
+        Device:toggleFullscreen()
+        local UIManager = require("ui/uimanager")
+        local InfoMessage = require("ui/widget/infomessage")
+        UIManager:show(InfoMessage:new{
+            text = _("This will take effect on next restart.")
+        })
+    elseif api < 17 then
+        self:toggleFullscreenLegacy()
+    end
+end
+
+-- toggle android status bar visibility -- Legacy function for Apis 14 - 16
+function ScreenHelper:toggleFullscreenLegacy()
     -- toggle android status bar visibility
     local is_fullscreen = android.isFullscreen()
     android.setFullscreen(not is_fullscreen)

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -12,7 +12,6 @@ if file ~= nil then
     A.LOGI("intent file path " .. file)
 end
 
--- (Disabled, since we hide navbar on start now no need for this hack)
 -- run koreader patch before koreader startup
 pcall(dofile, "/sdcard/koreader/patch.lua")
 


### PR DESCRIPTION
Work in progress: 

Things work but the new viewport is not changed without reloading current app (I mean the reader or the file manager). 
Move the old toggleFullscreen for apis 14-16 to device/android/device.lua?

requires https://github.com/koreader/android-luajit-launcher/pull/148
fixes #4794