### PR TITLE
MovableContainer: avoid refresh glitches on close

### DIFF
--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -147,6 +147,9 @@ function MovableContainer:_moveBy(dx, dy, restrict_to_screen)
                 self._moved_offset_y = screen_h - self._orig_y - self.dimen.h
             end
         end
+        -- Ensure the offsets are integers, to avoid refresh area glitches
+        self._moved_offset_x = Math.round(self._moved_offset_x)
+        self._moved_offset_y = Math.round(self._moved_offset_y)
         -- if not restrict_to_screen, we don't need to check anything:
         -- we trust gestures' position and distances: if we started with our
         -- finger on widget, and moved our finger to screen border, a part


### PR DESCRIPTION
The MovableContainer's contained widget may not have integer position/dimen (which should probably be fixed in those that don't ensure that), and our maths could eventually make them even more shifted by fractional parts.
In the end, when closing the widget, the refresh code may miss painting/cleaning 1px and leave a border of the widget on the screen.

Eg, on a sufficiently large resolution, moving this InfoMessage to the screen right border, then back:

<kbd>![image](https://user-images.githubusercontent.com/24273478/60129617-b7bc4100-9795-11e9-8d24-f2218b0e2803.png)</kbd>

On tap elsewhere to close it:

<kbd>![image](https://user-images.githubusercontent.com/24273478/60129722-f05c1a80-9795-11e9-93f6-8b9bf0f1fc11.png)</kbd>

So, @NiLuJe , don't remove the following as long as we haven't make sure there's no fractional x/y/w/h from any widget :)

https://github.com/koreader/koreader/blob/fca51757af6dace42d72163816ca12b52a2ee3aa/frontend/ui/uimanager.lua#L938-L944

Because even with that, when the x/w or y/h may both be shifted by fractional parts, we might be in a off-by-twos situation :)
