### PR TITLE
Make sure we only pass a single IP to ping

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -314,9 +314,9 @@ function Device:retrieveNetworkInfo()
             -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles...
             local pingok
             if self:isKindle() and self:hasKeyboard() then
-                pingok = os.execute("ping -q -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
+                pingok = os.execute("ping -q -c 2 `ip r | grep default | tail -n 1 | cut -d ' ' -f 3` > /dev/null")
             else
-                pingok = os.execute("ping -q -w 3 -c 2 `ip r | grep default | cut -d ' ' -f 3` > /dev/null")
+                pingok = os.execute("ping -q -w 3 -c 2 `ip r | grep default | tail -n 1 | cut -d ' ' -f 3` > /dev/null")
             end
             if pingok == 0 then
                 result = result .. "Gateway ping successful"

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -107,13 +107,28 @@ if Device:setDateTime() then
 end
 
 if Device:isKobo() then
-    common_settings.sleepcover = {
-        text = _("Ignore sleepcover events"),
+    common_settings.ignore_sleepcover = {
+        text = _("Ignore all sleepcover events"),
         checked_func = function()
             return G_reader_settings:isTrue("ignore_power_sleepcover")
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("ignore_power_sleepcover")
+            G_reader_settings:flipFalse("ignore_open_sleepcover")
+            UIManager:show(InfoMessage:new{
+                text = _("This will take effect on next restart."),
+            })
+        end
+    }
+
+    common_settings.ignore_open_sleepcover = {
+        text = _("Ignore sleepcover wakeup events"),
+        checked_func = function()
+            return G_reader_settings:isTrue("ignore_open_sleepcover")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("ignore_open_sleepcover")
+            G_reader_settings:flipFalse("ignore_power_sleepcover")
             UIManager:show(InfoMessage:new{
                 text = _("This will take effect on next restart."),
             })

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -40,7 +40,8 @@ local order = {
         "time",
         "battery",
         "autosuspend",
-        "sleepcover",
+        "ignore_sleepcover",
+        "ignore_open_sleepcover",
         "mass_storage_settings",
     },
     navigation = {

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -60,7 +60,8 @@ local order = {
         "time",
         "battery",
         "autosuspend",
-        "sleepcover",
+        "ignore_sleepcover",
+        "ignore_open_sleepcover",
         "mass_storage_settings",
     },
     navigation = {

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -104,9 +104,9 @@ function NetworkMgr:isConnected()
         -- `-c1` try only once; `-w2` wait 2 seconds
         -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles...
         if Device:isKindle() and Device:hasKeyboard() then
-            return 0 == os.execute([[ping -c1 $(/sbin/route -n | awk '$4 == "UG" {print $2}')]])
+            return 0 == os.execute([[ping -c1 $(/sbin/route -n | awk '$4 == "UG" {print $2}' | tail -n 1)]])
         else
-            return 0 == os.execute([[ping -c1 -w2 $(/sbin/route -n | awk '$4 == "UG" {print $2}')]])
+            return 0 == os.execute([[ping -c1 -w2 $(/sbin/route -n | awk '$4 == "UG" {print $2}' | tail -n 1)]])
         end
     end
 end

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -229,7 +229,7 @@ function CoverMenu:updateItems(select_number)
                 local orig_purge_callback = orig_buttons[1][3].callback
                 orig_buttons[1][3].callback = function()
                     -- Wipe the cache
-                    if self.cover_info_cache[file] then
+                    if self.cover_info_cache and self.cover_info_cache[file] then
                         self.cover_info_cache[file] = nil
                     end
                     -- And then purge the sidecar folder as expected
@@ -242,7 +242,7 @@ function CoverMenu:updateItems(select_number)
                         text_func = function()
                             -- If the book has a cache entry, it means it has a sidecar file, and it *may* have the info we need.
                             local status
-                            if self.cover_info_cache[file] then
+                            if self.cover_info_cache and self.cover_info_cache[file] then
                                 local _, _, c_status = unpack(self.cover_info_cache[file])
                                 status = c_status
                             end
@@ -256,7 +256,7 @@ function CoverMenu:updateItems(select_number)
                         enabled = true,
                         callback = function()
                             local status
-                            if self.cover_info_cache[file] then
+                            if self.cover_info_cache and self.cover_info_cache[file] then
                                 local c_pages, c_percent_finished, c_status = unpack(self.cover_info_cache[file])
                                 status = c_status == "complete" and "reading" or "complete"
                                 -- Update the cache, even if it had a nil status before
@@ -368,7 +368,7 @@ function CoverMenu:updateItems(select_number)
                         enabled = bookinfo and true or false,
                         callback = function()
                             -- Wipe the cache
-                            if self.cover_info_cache[file] then
+                            if self.cover_info_cache and self.cover_info_cache[file] then
                                 self.cover_info_cache[file] = nil
                             end
                             BookInfoManager:deleteBookInfo(file)


### PR DESCRIPTION
For some mysterious reason, I have a duplicate default gateway on my
Forma, one with no metrics, and a proper one.
This ensures we pick the proper one.

I'm fairly sure this is temporary insanity on the part of my device,
but, still, it can't hurt.

`route -n`:
```
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         192.168.0.1     0.0.0.0         UG    0      0        0 eth0
0.0.0.0         192.168.0.1     0.0.0.0         UG    208    0        0 eth0
192.168.0.0     0.0.0.0         255.255.255.0   U     208    0        0 eth0
```

`ip r`:
```
default via 192.168.0.1 dev eth0
default via 192.168.0.1 dev eth0  metric 208
192.168.0.0/24 dev eth0  src 192.168.0.49  metric 208
```