### PR TITLE
More robust Gyro toggle

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -948,7 +948,7 @@ function ReaderGesture:gestureAction(action, ges)
         self:onShowFLOnOff()
     elseif action == "toggle_gsensor" then
         G_reader_settings:flipNilOrFalse("input_ignore_gsensor")
-        Device:toggleGSensor()
+        Device:toggleGSensor(not G_reader_settings:isTrue("input_ignore_gsensor"))
         self:onGSensorToggle()
     elseif action == "toggle_page_flipping" then
         if not self.ui.document.info.has_pages then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -283,7 +283,7 @@ function Device:setDateTime(year, month, day, hour, min, sec) end
 function Device:saveSettings() end
 
 -- Device specific method for toggling the GSensor
-function Device:toggleGSensor() end
+function Device:toggleGSensor(toggle) end
 
 --[[
 prepare for application shutdown

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -703,7 +703,7 @@ function Input:toggleMiscEvNTX(toggle)
             self.handleMiscEv = self.handleMiscEvNTX
             self.isNTXAccelHooked = true
         end
-    else if toggle and toggle == false then
+    elseif toggle and toggle == false then
         -- Ignore Gyro events
         if self.isNTXAccelHooked then
             self.handleMiscEv = function() end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -696,14 +696,29 @@ function Input:handleMiscEvNTX(ev)
 end
 
 -- Allow toggling it at runtime
-function Input:toggleMiscEvNTX()
-    if self.isNTXAccelHooked then
-        self.handleMiscEv = function() end
+function Input:toggleMiscEvNTX(toggle)
+    if toggle and toggle == true then
+        -- Honor Gyro events
+        if not self.isNTXAccelHooked then
+            self.handleMiscEv = self.handleMiscEvNTX
+            self.isNTXAccelHooked = true
+        end
+    else if toggle and toggle == false then
+        -- Ignore Gyro events
+        if self.isNTXAccelHooked then
+            self.handleMiscEv = function() end
+            self.isNTXAccelHooked = false
+        end
     else
-        self.handleMiscEv = self.handleMiscEvNTX
-    end
+        -- Toggle it
+        if self.isNTXAccelHooked then
+            self.handleMiscEv = function() end
+        else
+            self.handleMiscEv = self.handleMiscEvNTX
+        end
 
-    self.isNTXAccelHooked = not self.isNTXAccelHooked
+        self.isNTXAccelHooked = not self.isNTXAccelHooked
+    end
 end
 
 -- helpers for touch event data management:

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -716,11 +716,11 @@ function Kobo:reboot()
     os.execute("reboot")
 end
 
-function Kobo:toggleGSensor()
+function Kobo:toggleGSensor(toggle)
     if self:canToggleGSensor() and self.input then
         -- Currently only supported on the Forma
         if self.misc_ntx_gsensor_protocol then
-            self.input:toggleMiscEvNTX()
+            self.input:toggleMiscEvNTX(toggle)
         end
     end
 end

--- a/frontend/ui/elements/screen_toggle_gsensor.lua
+++ b/frontend/ui/elements/screen_toggle_gsensor.lua
@@ -8,6 +8,6 @@ return {
     end,
     callback = function()
         G_reader_settings:flipNilOrFalse("input_ignore_gsensor")
-        Device:toggleGSensor()
+        Device:toggleGSensor(not G_reader_settings:isTrue("input_ignore_gsensor"))
     end,
 }

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -95,7 +95,7 @@ function UIManager:init()
         self.event_handlers["Suspend"] = function()
             -- Ignore the accelerometer (if that's not already the case) while we're alseep
             if G_reader_settings:nilOrFalse("input_ignore_gsensor") then
-                Device:toggleGSensor()
+                Device:toggleGSensor(false)
             end
             self:_beforeSuspend()
             Device:onPowerEvent("Suspend")
@@ -105,7 +105,7 @@ function UIManager:init()
             self:_afterResume()
             -- Stop ignoring the accelerometer (unless requested) when we wakeup
             if G_reader_settings:nilOrFalse("input_ignore_gsensor") then
-                Device:toggleGSensor()
+                Device:toggleGSensor(true)
             end
         end
         self.event_handlers["PowerPress"] = function()


### PR DESCRIPTION
Make sure it's off when we want it off, and on when we want it on.

The older racy behavior could lead to unexpected results after a quick succession of suspend/resume events.