### PR TITLE
android: add support for 3rd party dictionary apps

### DIFF
--- a/frontend/device/android/dictionaries.lua
+++ b/frontend/device/android/dictionaries.lua
@@ -1,0 +1,15 @@
+return { --[[ supported android dictionary applications.
+
+Most of them should support Intent.ACTION_SEND, Intent.ACTION_SEARCH or
+Intent.ACTION_PROCESS_TEXT. Some applications implement their custom intents. ]]--
+
+    { "Aard2", "Aard2", false, "itkach.aard2", "aard2" },
+    { "Alpus", "Alpus", false, "com.ngcomputing.fora.android", "search" },
+    { "ColorDict", "ColorDict", false, "com.socialnmobile.colordict", "colordict" },
+    { "Fora", "Fora Dict", false, "com.ngc.fora", "search" },
+    { "GoldenFree", "GoldenDict Free", false, "mobi.goldendict.android.free", "send" },
+    { "GoldenPro", "GoldenDict Pro", false, "mobi.goldendict.android.pro", "send" },
+    { "Kiwix", "Kiwix", false, "org.kiwix.kiwixmobile", "text" },
+    { "Mdict", "Mdict", false, "cn.mdict", "send" },
+    { "QuickDic", "QuickDic", false, "de.reimardoeffinger.quickdic", "quickdic" },
+}

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -71,6 +71,7 @@ local Device = {
 
     canOpenLink = no,
     openLink = no,
+    canExternalDictLookup = no,
 }
 
 function Device:new(o)


### PR DESCRIPTION
Added support for Aard2, Alpus, Colordict, Fora, Goldendict, Kiwix, Mdict and Quickdic.

Goldendict Pro is untested. The Free version works fine.

All credits to @poire-z, who did most of the job in https://github.com/koreader/koreader/issues/2333#issuecomment-502010311

**how to add support for new dictionary apps ?**

1. find a target dict app (already installed, configured and ready to work)
2. find its package name (using an app like "Package Names Viewer")
3. try generic actions in this order: picker-share -> picker-send -> picker-text.
4. hopefully the application is available as an option to open the query.
5. try again removing the "picker-", It should open your dictionary without questions.

You might need to look at the app AndroidManifest.xml and find the kind of intents that the application handles.

Requires https://github.com/koreader/android-luajit-launcher/pull/156
Fixes #3496
Fixes #5039
