### PR TITLE
Try harder to find an FBInk binary on Kindle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ kindleupdate: all
 	ln -sf ../$(KINDLE_DIR)/launchpad $(INSTALL_DIR)/
 	ln -sf ../../$(KINDLE_DIR)/koreader.sh $(INSTALL_DIR)/koreader
 	ln -sf ../../$(KINDLE_DIR)/libkohelper.sh $(INSTALL_DIR)/koreader
+	ln -sf ../../../../$(KINDLE_DIR)/libkohelper.sh $(INSTALL_DIR)/extensions/koreader/bin
 	ln -sf ../../$(COMMON_DIR)/spinning_zsync $(INSTALL_DIR)/koreader
 	# create new package
 	cd $(INSTALL_DIR) && pwd && \
@@ -366,7 +367,7 @@ debianupdate: all
 sony-prstuxupdate: all
 	# ensure that the binaries were built for ARM
 	file $(INSTALL_DIR)/koreader/luajit | grep ARM || exit 1
-	# remove old package if any	
+	# remove old package if any
 	rm -f koreader-sony-prstux-$(MACHINE)-$(VERSION).zip
 	# Sony PRSTUX launching scripts
 	cp $(SONY_PRSTUX_DIR)/*.sh $(INSTALL_DIR)/koreader

--- a/platform/kindle/extensions/koreader/bin/koreader-ext.sh
+++ b/platform/kindle/extensions/koreader/bin/koreader-ext.sh
@@ -4,9 +4,6 @@
 #
 ##
 
-# KOReader's working directory
-KOREADER_DIR="/mnt/us/koreader"
-
 # Load our helper functions...
 if [ -f "./bin/libkohelper.sh" ]; then
     # shellcheck source=/dev/null

--- a/platform/kindle/extensions/koreader/bin/koreader-ext.sh
+++ b/platform/kindle/extensions/koreader/bin/koreader-ext.sh
@@ -8,9 +8,9 @@
 KOREADER_DIR="/mnt/us/koreader"
 
 # Load our helper functions...
-if [ -f "${KOREADER_DIR}/libkohelper.sh" ]; then
+if [ -f "./bin/libkohelper.sh" ]; then
     # shellcheck source=/dev/null
-    . "${KOREADER_DIR}/libkohelper.sh"
+    . "./bin/libkohelper.sh"
 else
     echo "Can't source helper functions, aborting!"
     exit 1

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -18,9 +18,9 @@ fi
 ## Check if we have an FBInk binary available somewhere...
 # Default to something that won't horribly blow up...
 FBINK_BIN="true"
-for my_dir in koreader linkss/bin linkfonts/bin libkh/bin usbnet/bin ; do
+for my_dir in koreader linkss/bin linkfonts/bin libkh/bin usbnet/bin; do
     my_fbink="/mnt/us/${my_dir}/fbink"
-    if [ -x "${my_fbink}" ] ; then
+    if [ -x "${my_fbink}" ]; then
         FBINK_BIN="${my_fbink}"
         # Got it!
         break
@@ -29,7 +29,7 @@ done
 
 has_fbink() {
     # Because the fallback is the "true" binary/shell built-in ;).
-    if [ "${FBINK_BIN}" != "true" ] ; then
+    if [ "${FBINK_BIN}" != "true" ]; then
         # Got it!
         return 0
     fi
@@ -63,7 +63,7 @@ eips_print_bottom_centered() {
 
     # NOTE: FBInk will handle the padding. FBInk's default font is square, not tall like eips,
     #       so we compensate by tweaking the baseline ;). This matches the baseline we use on Kobo, too.
-    if has_fbink ; then
+    if has_fbink; then
         ${FBINK_BIN} -qpm -y $((-4 - kh_eips_y_shift_up)) "${kh_eips_string}"
     else
         # Crappy fallback

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -15,7 +15,28 @@ else
 fi
 
 # Adapted from libkh[5]
-FBINK_BIN="/mnt/us/koreader/fbink"
+## Check if we have an FBInk binary available somewhere...
+# Default to something that won't horribly blow up...
+FBINK_BIN="true"
+for my_dir in koreader linkss/bin linkfonts/bin libkh/bin usbnet/bin ; do
+    my_fbink="/mnt/us/${my_dir}/fbink"
+    if [ -x "${my_fbink}" ] ; then
+        FBINK_BIN="${my_fbink}"
+        # Got it!
+        break
+    fi
+done
+
+has_fbink() {
+    # Because the fallback is the "true" binary/shell built-in ;).
+    if [ "${FBINK_BIN}" != "true" ] ; then
+        # Got it!
+        return 0
+    fi
+
+    # If we got this far, we don't have fbink installed
+    return 1
+}
 
 # NOTE: Yeah, the name becomes a bit of a lie now that we're exclusively using FBInk ;p.
 eips_print_bottom_centered() {
@@ -36,11 +57,16 @@ eips_print_bottom_centered() {
     # Sleep a tiny bit to workaround the logic in the 'new' (K4+) eInk controllers that tries to bundle updates,
     # otherwise it may drop part of our messages because of other screen updates from KUAL...
     # Unless we really don't want to sleep, for special cases...
-    if [ ! -n "${EIPS_NO_SLEEP}" ]; then
+    if [ -z "${EIPS_NO_SLEEP}" ]; then
         usleep 150000 # 150ms
     fi
 
     # NOTE: FBInk will handle the padding. FBInk's default font is square, not tall like eips,
     #       so we compensate by tweaking the baseline ;). This matches the baseline we use on Kobo, too.
-    ${FBINK_BIN} -qpm -y $((-4 - kh_eips_y_shift_up)) "${kh_eips_string}"
+    if has_fbink ; then
+        ${FBINK_BIN} -qpm -y $((-4 - kh_eips_y_shift_up)) "${kh_eips_string}"
+    else
+        # Crappy fallback
+        eips 0 0 "${kh_eips_string}" >/dev/null
+    fi
 }

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -18,7 +18,7 @@ fi
 ## Check if we have an FBInk binary available somewhere...
 # Default to something that won't horribly blow up...
 FBINK_BIN="true"
-for my_dir in koreader linkss/bin linkfonts/bin libkh/bin usbnet/bin; do
+for my_dir in libkh/bin koreader linkss/bin linkfonts/bin usbnet/bin; do
     my_fbink="/mnt/us/${my_dir}/fbink"
     if [ -x "${my_fbink}" ]; then
         FBINK_BIN="${my_fbink}"


### PR DESCRIPTION
Otherwise, using the KUAL extension can get a bit tricky if KOReader has
been removed.

(Same logic as in libkh5, except we prefer our own build, and there's a
shitty eips fallback in case all hell broke loose and even libkh is
gone).

That said, if libkh is gone on a FW 5.x, you're in serious trouble :D.

Re #5110