### PR TITLE
 [statistics] Remove conversion message on new installations 

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -159,6 +159,7 @@ files["spec/unit/*"].globals = {
 -- 631 - Line is too long
 ignore = {
     "211/__*",
+    "231/__",
     "631",
     "dummy",
 }

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -241,7 +241,7 @@ Do you want to create an empty database?
     else  -- first time convertion to sqlite database
         self.convert_to_db = true
         if not conn:exec("pragma table_info('book');") then
-            local filename_first_history, quickstart_filename, __
+            local filename_first_history, quickstart_filename, __ -- luacheck: ignore
             if #ReadHistory.hist == 1 then
                 filename_first_history = ReadHistory.hist[1]["text"]
                 local quickstart_path = require("ui/quickstart").quickstart_filename

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -241,7 +241,10 @@ Do you want to create an empty database?
     else  -- first time convertion to sqlite database
         self.convert_to_db = true
         if not conn:exec("pragma table_info('book');") then
-            if #ReadHistory.hist > 0 then
+            local filename_first_history = ReadHistory.hist[1]["text"]
+            local quickstart_path = require("ui/quickstart").quickstart_filename
+            local __, quickstart_filename = util.splitFilePathName(quickstart_path)
+            if #ReadHistory.hist > 1 or (#ReadHistory.hist == 1 and filename_first_history ~= quickstart_filename) then
                 local info = InfoMessage:new{
                     text =_([[
 New version of statistics plugin detected.

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -241,12 +241,12 @@ Do you want to create an empty database?
     else  -- first time convertion to sqlite database
         self.convert_to_db = true
         if not conn:exec("pragma table_info('book');") then
-            local filename_first_history = ""
+            local filename_first_history, quickstart_filename, __
             if #ReadHistory.hist == 1 then
                 filename_first_history = ReadHistory.hist[1]["text"]
+                local quickstart_path = require("ui/quickstart").quickstart_filename
+                __, quickstart_filename = util.splitFilePathName(quickstart_path)
             end
-            local quickstart_path = require("ui/quickstart").quickstart_filename
-            local __, quickstart_filename = util.splitFilePathName(quickstart_path)
             if #ReadHistory.hist > 1 or (#ReadHistory.hist == 1 and filename_first_history ~= quickstart_filename) then
                 local info = InfoMessage:new{
                     text =_([[

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -241,7 +241,7 @@ Do you want to create an empty database?
     else  -- first time convertion to sqlite database
         self.convert_to_db = true
         if not conn:exec("pragma table_info('book');") then
-            local filename_first_history, quickstart_filename, __ -- luacheck: ignore
+            local filename_first_history, quickstart_filename, __
             if #ReadHistory.hist == 1 then
                 filename_first_history = ReadHistory.hist[1]["text"]
                 local quickstart_path = require("ui/quickstart").quickstart_filename

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -241,7 +241,10 @@ Do you want to create an empty database?
     else  -- first time convertion to sqlite database
         self.convert_to_db = true
         if not conn:exec("pragma table_info('book');") then
-            local filename_first_history = ReadHistory.hist[1]["text"]
+            local filename_first_history = ""
+            if #ReadHistory.hist == 1 then
+                filename_first_history = ReadHistory.hist[1]["text"]
+            end
             local quickstart_path = require("ui/quickstart").quickstart_filename
             local __, quickstart_filename = util.splitFilePathName(quickstart_path)
             if #ReadHistory.hist > 1 or (#ReadHistory.hist == 1 and filename_first_history ~= quickstart_filename) then


### PR DESCRIPTION
After fresh KOReader installation we don't need information "Conversion complited." like that:
![1](https://user-images.githubusercontent.com/22982594/61369677-e909c780-a890-11e9-9e7d-77f8811710e6.png)

