### PR TITLE
Add percentage read (and other book information) to sleep message

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -174,6 +174,7 @@ function Screensaver:setMessage()
     end
     self.input_dialog = InputDialog:new{
         title = "Screensaver message",
+        description = _("The message to be displayed by the screensaver. The following escape sequences may be used in the message:\n  %p percentage read\n  %c current page number\n  %t total number of pages\n  %T title"),
         input = screensaver_message,
         buttons = {
             {
@@ -384,10 +385,10 @@ end
 
 function Screensaver:expandSpecial(message, fallback)
     -- Expand special character sequences in given message. Use fallback string if there is no document instance
-    -- %p percentage read, with percent sign
+    -- %p percentage read
     -- %c current page
     -- %t total pages
-    -- %dt document title
+    -- %T document title
 
     local ret = message
 
@@ -402,10 +403,10 @@ function Screensaver:expandSpecial(message, fallback)
         ret = string.gsub(ret, "%%t", totalpages)
 
         local percent = math.floor(((currentpage * 100) / totalpages) + 0.5)
-        ret = string.gsub(ret, "%%p", percent .. "%%")
+        ret = string.gsub(ret, "%%p", percent)
 
         local props = doc:getProps()
-        ret = string.gsub(ret, "%%dt", props.title)
+        ret = string.gsub(ret, "%%T", props.title)
     else
         ret = fallback
     end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -174,7 +174,7 @@ function Screensaver:setMessage()
     end
     self.input_dialog = InputDialog:new{
         title = "Screensaver message",
-        description = _("The message to be displayed by the screensaver. The following escape sequences may be used in the message:\n  %p percentage read\n  %c current page number\n  %t total number of pages\n  %T title"),
+        description = _("Enter the message to be displayed by the screensaver. The following escape sequences can be used:\n  %p percentage read\n  %c current page number\n  %t total number of pages\n  %T title"),
         input = screensaver_message,
         buttons = {
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -349,9 +349,14 @@ function Screensaver:show(event, fallback_message)
         if screensaver_message == nil and prefix ~= "" then
             screensaver_message = G_reader_settings:readSetting("screensaver_message")
         end
+
+        local fallback = fallback_message or default_screensaver_message
         if screensaver_message == nil then
-            screensaver_message = fallback_message or default_screensaver_message
+            screensaver_message = fallback
+        else
+            screensaver_message = self:expandSpecial(screensaver_message, fallback)
         end
+
         widget = InfoMessage:new{
             text = screensaver_message,
             readonly = true,
@@ -375,6 +380,38 @@ function Screensaver:show(event, fallback_message)
         self.left_msg.dithered = true
         UIManager:show(self.left_msg, "full")
     end
+end
+
+function Screensaver:expandSpecial(message, fallback)
+    -- Expand special character sequences in given message. Use fallback string if there is no document instance
+    -- %p percentage read, with percent sign
+    -- %c current page
+    -- %t total pages
+    -- %dt document title
+
+    local ret = message
+
+    local lastfile = G_reader_settings:readSetting("lastfile")
+    local doc = DocumentRegistry:openDocument(lastfile)
+    local instance = require("apps/reader/readerui"):_getRunningInstance()
+    if instance ~= nil then
+        local currentpage = instance.view.state.page
+        ret = string.gsub(ret, "%%c", currentpage)
+
+        local totalpages = doc:getPageCount()
+        ret = string.gsub(ret, "%%t", totalpages)
+
+        local percent = math.floor(((currentpage * 100) / totalpages) + 0.5)
+        ret = string.gsub(ret, "%%p", percent .. "%%")
+
+        local props = doc:getProps()
+        ret = string.gsub(ret, "%%dt", props.title)
+    else
+        ret = fallback
+    end
+    doc:close()
+
+    return ret
 end
 
 function Screensaver:close()


### PR DESCRIPTION
This is one feature I miss from the stock Kobo firmware, the ability to see the percentage read on the screen while the device is asleep. I know I can see the book status but it's not quite the same.

I thought a good way to do it would be to create escape sequences that the user can put in their screensaver text. I've modified screensaver.lua to use %p for percentage read. While I was at it I added %c and %t for current and total pages respectively, and %dt for document title.

Attached is a picture of the screen of my Kobo Aura One sleeping...

![IMG_20190718_093423](https://user-images.githubusercontent.com/52647914/61422734-9509ec00-a93f-11e9-93e4-0202877a1f2a.jpg)
