### PR TITLE
TOC: baseline align chapter name and page number, adds some style tweaks

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -327,6 +327,7 @@ function ReaderToc:onShowToc()
         height = Screen:getHeight(),
         cface = Font:getFace("x_smallinfofont"),
         single_line = true,
+        align_baselines = true,
         perpage = G_reader_settings:readSetting("items_per_page") or 14,
         line_color = require("ffi/blitbuffer").COLOR_WHITE,
         on_close_ges = {

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -21,10 +21,31 @@ local CssTweaks = {
             css = [[body { margin: 0 !important; }]],
         },
         {
-            id = "margin_all_0";
-            title = _("Ignore all publisher margins"),
-            priority = 2,
-            css = [[* { margin: 0 !important; }]],
+            title = _("Ignore margins and paddings"),
+            {
+                id = "margin_horizontal_all_0";
+                title = _("Ignore all horizontal margins"),
+                priority = 2,
+                css = [[* { margin-left: 0 !important; margin-right: 0 !important; }]],
+            },
+            {
+                id = "margin_vertical_all_0";
+                title = _("Ignore all vertical margins"),
+                priority = 2,
+                css = [[* { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+            },
+            {
+                id = "padding_horizontal_all_0";
+                title = _("Ignore all horizontal paddings"),
+                priority = 2,
+                css = [[* { padding-left: 0 !important; padding-right: 0 !important; }]],
+            },
+            {
+                id = "padding_vertical_all_0";
+                title = _("Ignore all vertical paddings"),
+                priority = 2,
+                css = [[* { padding-top: 0 !important; padding-bottom: 0 !important; }]],
+            },
             separator = true,
         },
         {

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -17,6 +17,7 @@ local HorizontalSpan = require("ui/widget/horizontalspan")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LeftContainer = require("ui/widget/container/leftcontainer")
+local Math = require("optmath")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local RenderText = require("ui/rendertext")
 local RightContainer = require("ui/widget/container/rightcontainer")
@@ -139,6 +140,9 @@ local MenuItem = InputContainer:new{
     shortcut_style = "square",
     _underline_container = nil,
     linesize = Size.line.medium,
+    single_line = false,
+    -- Align text & mandatory baselines (only when single_line=true)
+    align_baselines = false,
 }
 
 function MenuItem:init()
@@ -218,6 +222,22 @@ function MenuItem:init()
             bold = self.bold,
             fgcolor = self.dim and Blitbuffer.COLOR_DARK_GRAY or nil,
         }
+        if self.align_baselines then
+            local name_baseline = item_name:getBaseline()
+            local mandatory_baseline = mandatory_widget:getBaseline()
+            local baselines_diff = Math.round(name_baseline - mandatory_baseline)
+            if baselines_diff > 0 then
+                mandatory_widget = VerticalGroup:new{
+                    VerticalSpan:new{width = baselines_diff},
+                    mandatory_widget,
+                }
+            elseif baselines_diff < 0 then
+                item_name = VerticalGroup:new{
+                    VerticalSpan:new{width = -baselines_diff},
+                    item_name,
+                }
+            end
+        end
     else
         while true do
             -- Free previously made widgets to avoid memory leaks
@@ -946,6 +966,7 @@ function Menu:updateItems(select_number)
                 menu = self,
                 linesize = self.linesize,
                 single_line = self.single_line,
+                align_baselines = self.align_baselines,
                 line_color = self.line_color,
             }
             table.insert(self.item_group, item_tmp)

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -79,6 +79,11 @@ function TextWidget:getSize()
     }
 end
 
+function TextWidget:getBaseline()
+    self:updateSize()
+    return self._baseline_h
+end
+
 function TextWidget:setText(text)
     self.text = text
     self:updateSize()


### PR DESCRIPTION
In the TOC, baseline align chapter name and page number, which makes it a bit prettier.
Before:
<kbd>![toc_before](https://user-images.githubusercontent.com/24273478/61561380-2330c000-aa6f-11e9-9bdd-b10f91b4622c.png)</kbd>
After:
<kbd>![toc_after](https://user-images.githubusercontent.com/24273478/61561389-275cdd80-aa6f-11e9-96b4-c85939fee581.png)</kbd>

Add a few style tweaks to ignore all horizontal margins _only_ or all vertical margins _only_ instead of _all_ margins - and the same for paddings for books that wrongly use paddings for that effect.