### PR TITLE
File manager - adding option to view unsupported files

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -129,6 +129,7 @@ function FileManager:init()
 
     local g_show_hidden = G_reader_settings:readSetting("show_hidden")
     local show_hidden = g_show_hidden == nil and DSHOWHIDDENFILES or g_show_hidden
+    local show_unsupported = G_reader_settings:readSetting("show_unsupported")
     local file_chooser = FileChooser:new{
         -- remember to adjust the height when new item is added to the group
         path = self.root_path,
@@ -143,6 +144,7 @@ function FileManager:init()
         is_borderless = true,
         has_close_button = true,
         perpage = G_reader_settings:readSetting("items_per_page"),
+        show_unsupported = show_unsupported,
         file_filter = function(filename)
             if DocumentRegistry:hasProvider(filename) then
                 return true
@@ -274,7 +276,7 @@ function FileManager:init()
             {
                 {
                     text = _("Open with…"),
-                    enabled = lfs.attributes(file, "mode") == "file"
+                    enabled = lfs.attributes(file, "mode") == "file" and DocumentRegistry:getProviders(file) ~= nil
                         and #(DocumentRegistry:getProviders(file)) > 1,
                     callback = function()
                         UIManager:close(self.file_dialog)
@@ -523,6 +525,11 @@ end
 function FileManager:toggleHiddenFiles()
     self.file_chooser:toggleHiddenFiles()
     G_reader_settings:saveSetting("show_hidden", self.file_chooser.show_hidden)
+end
+
+function FileManager:toggleUnsupportedFiles()
+    self.file_chooser:toggleUnsupportedFiles()
+    G_reader_settings:saveSetting("show_unsupported", self.file_chooser.show_unsupported)
 end
 
 function FileManager:setCollate(collate)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -121,6 +121,11 @@ function FileManagerMenu:setUpdateItemTable()
         checked_func = function() return self.ui.file_chooser.show_hidden end,
         callback = function() self.ui:toggleHiddenFiles() end
     }
+    self.menu_items.show_unsupported_files = {
+        text = _("Show unsupported files"),
+        checked_func = function() return self.ui.file_chooser.show_unsupported end,
+        callback = function() self.ui:toggleUnsupportedFiles() end
+    }
     self.menu_items.items_per_page = {
         text = _("Items per page"),
         help_text = _([[This sets the number of items per page in:

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -12,6 +12,7 @@ local order = {
     filemanager_settings = {
         "filemanager_display_mode",
         "show_hidden_files",
+        "show_unsupported_files",
         "items_per_page",
         "----------------------------",
         "sort_by",

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -71,7 +71,7 @@ function FileChooser:init()
                                                     attr = attributes})
                             end
                         elseif attributes.mode == "file" then
-                            if self.file_filter == nil or self.file_filter(filename) then
+                            if self.file_filter == nil or self.file_filter(filename) or self.show_unsupported then
                                 local percent_finished = 0
                                 if self.collate == "percent_unopened_first" or self.collate == "percent_unopened_last" then
                                     if DocSettings:hasSidecarFile(filename) then
@@ -328,6 +328,11 @@ end
 
 function FileChooser:toggleHiddenFiles()
     self.show_hidden = not self.show_hidden
+    self:refreshPath()
+end
+
+function FileChooser:toggleUnsupportedFiles()
+    self.show_unsupported = not self.show_unsupported
     self:refreshPath()
 end
 


### PR DESCRIPTION
New option to show all files (also not supported by KOReader) in file manager. Default this option is disabled.
Close: #3578 

Screenshots:

![obraz](https://user-images.githubusercontent.com/22982594/61580228-c1746280-ab0f-11e9-9c3f-7bf02009b580.png)

![obraz](https://user-images.githubusercontent.com/22982594/61580224-b7eafa80-ab0f-11e9-93fa-755137171f4a.png)

![obraz](https://user-images.githubusercontent.com/22982594/61580244-f08ad400-ab0f-11e9-9dba-a456e3c0a8ee.png)






