### PR TITLE
Cloudstorage - Adding option to view unsupported files

### DIFF
--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -17,14 +17,20 @@ end
 function DropBox:downloadFile(item, password, path, close)
     local code_response = DropBoxApi:downloadFile(item.url, password, path)
     if code_response == 200 then
-        UIManager:show(ConfirmBox:new{
-            text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"),
-                path),
-            ok_callback = function()
-                close()
-                ReaderUI:showReader(path)
-            end
-        })
+        if G_reader_settings:readSetting("show_unsupported") then
+            UIManager:show(InfoMessage:new{
+                text = T(_("File saved to:\n%1"), path),
+            })
+        else
+            UIManager:show(ConfirmBox:new{
+                text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"),
+                    path),
+                ok_callback = function()
+                    close()
+                    ReaderUI:showReader(path)
+                end
+            })
+        end
     else
         UIManager:show(InfoMessage:new{
             text = T(_("Could not save file to:\n%1"), path),

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -17,7 +17,7 @@ end
 function DropBox:downloadFile(item, password, path, close)
     local code_response = DropBoxApi:downloadFile(item.url, password, path)
     if code_response == 200 then
-        if G_reader_settings:readSetting("show_unsupported") then
+        if G_reader_settings:isTrue("show_unsupported") then
             UIManager:show(InfoMessage:new{
                 text = T(_("File saved to:\n%1"), path),
             })

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -107,7 +107,8 @@ function DropBoxApi:listFolder(path, token)
                 type = tag,
             })
         --show only file with supported formats
-        elseif tag == "file" and DocumentRegistry:hasProvider(text) then
+        elseif tag == "file" and (DocumentRegistry:hasProvider(text)
+            or G_reader_settings:readSetting("show_unsupported")) then
             table.insert(dropbox_file, {
                 text = text,
                 url = files.path_display,

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -108,7 +108,7 @@ function DropBoxApi:listFolder(path, token)
             })
         --show only file with supported formats
         elseif tag == "file" and (DocumentRegistry:hasProvider(text)
-            or G_reader_settings:readSetting("show_unsupported")) then
+            or G_reader_settings:isTrue("show_unsupported")) then
             table.insert(dropbox_file, {
                 text = text,
                 url = files.path_display,

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -26,14 +26,20 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
         local file = io.open(path, "w")
         file:write(response)
         file:close()
-        UIManager:show(ConfirmBox:new{
-            text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"),
-                path),
-            ok_callback = function()
-                close()
-                ReaderUI:showReader(path)
-            end
-        })
+        if G_reader_settings:readSetting("show_unsupported") then
+            UIManager:show(InfoMessage:new{
+                text = T(_("File saved to:\n%1"), path),
+            })
+        else
+            UIManager:show(ConfirmBox:new{
+                text = T(_("File saved to:\n %1\nWould you like to read the downloaded book now?"),
+                    path),
+                ok_callback = function()
+                    close()
+                    ReaderUI:showReader(path)
+                end
+            })
+        end
     else
         UIManager:show(InfoMessage:new{
             text = T(_("Could not save file to:\n%1"), path),

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -26,7 +26,7 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
         local file = io.open(path, "w")
         file:write(response)
         file:close()
-        if G_reader_settings:readSetting("show_unsupported") then
+        if G_reader_settings:isTrue("show_unsupported") then
             UIManager:show(InfoMessage:new{
                 text = T(_("File saved to:\n%1"), path),
             })

--- a/frontend/apps/cloudstorage/ftpapi.lua
+++ b/frontend/apps/cloudstorage/ftpapi.lua
@@ -55,7 +55,7 @@ function FtpApi:listFolder(address_path, folder_path)
                 })
             --show only file with supported formats
             elseif extension  and (DocumentRegistry:hasProvider(item)
-                or G_reader_settings:readSetting("show_unsupported")) then
+                or G_reader_settings:isTrue("show_unsupported")) then
                 type = "file"
                 table.insert(ftp_file, {
                     text = file_name,

--- a/frontend/apps/cloudstorage/ftpapi.lua
+++ b/frontend/apps/cloudstorage/ftpapi.lua
@@ -54,7 +54,8 @@ function FtpApi:listFolder(address_path, folder_path)
                     type = type,
                 })
             --show only file with supported formats
-            elseif extension  and DocumentRegistry:hasProvider(item) then
+            elseif extension  and (DocumentRegistry:hasProvider(item)
+                or G_reader_settings:readSetting("show_unsupported")) then
                 type = "file"
                 table.insert(ftp_file, {
                     text = file_name,

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -17,14 +17,20 @@ end
 function WebDav:downloadFile(item, address, username, password, local_path, close)
     local code_response = WebDavApi:downloadFile(address .. WebDavApi:urlEncode( item.url ), username, password, local_path)
     if code_response == 200 then
-        UIManager:show(ConfirmBox:new{
-            text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
-                local_path),
-            ok_callback = function()
-                close()
-                ReaderUI:showReader(local_path)
-            end
-        })
+        if G_reader_settings:readSetting("show_unsupported") then
+            UIManager:show(InfoMessage:new{
+                text = T(_("File saved to:\n%1"), path),
+            })
+        else
+            UIManager:show(ConfirmBox:new{
+                text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
+                    local_path),
+                ok_callback = function()
+                    close()
+                    ReaderUI:showReader(local_path)
+                end
+            })
+        end
     else
         UIManager:show(InfoMessage:new{
             text = T(_("Could not save file to:\n%1"), local_path),

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -19,7 +19,7 @@ function WebDav:downloadFile(item, address, username, password, local_path, clos
     if code_response == 200 then
         if G_reader_settings:readSetting("show_unsupported") then
             UIManager:show(InfoMessage:new{
-                text = T(_("File saved to:\n%1"), path),
+                text = T(_("File saved to:\n%1"), local_path),
             })
         else
             UIManager:show(ConfirmBox:new{

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -17,7 +17,7 @@ end
 function WebDav:downloadFile(item, address, username, password, local_path, close)
     local code_response = WebDavApi:downloadFile(address .. WebDavApi:urlEncode( item.url ), username, password, local_path)
     if code_response == 200 then
-        if G_reader_settings:readSetting("show_unsupported") then
+        if G_reader_settings:isTrue("show_unsupported") then
             UIManager:show(InfoMessage:new{
                 text = T(_("File saved to:\n%1"), local_path),
             })

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -115,7 +115,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
                     })
                 end
             elseif item:find("<d:resourcetype/>") and (DocumentRegistry:hasProvider(item_name)
-                or G_reader_settings:readSetting("show_unsupported")) then
+                or G_reader_settings:isTrue("show_unsupported")) then
                 table.insert(webdav_file, {
                     text = item_name,
                     url = util.urlDecode( item_path ),

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -114,7 +114,8 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
                         type = "folder",
                     })
                 end
-            elseif item:find("<d:resourcetype/>") and DocumentRegistry:hasProvider(item_name) then
+            elseif item:find("<d:resourcetype/>") and (DocumentRegistry:hasProvider(item_name)
+                or G_reader_settings:readSetting("show_unsupported")) then
                 table.insert(webdav_file, {
                     text = item_name,
                     url = util.urlDecode( item_path ),


### PR DESCRIPTION
Option to show all files in cloudstorage also not supported by KOReader. We can also download any file.
To show all files in CS we need to enable option `Show unsupported files` in file manager (introducing in #5129)
Close: #5006 
![obraz](https://user-images.githubusercontent.com/22982594/61592721-59894f00-abd7-11e9-86f0-657744468a7a.png)
![obraz](https://user-images.githubusercontent.com/22982594/61592724-61e18a00-abd7-11e9-8b19-21c41bcc4dba.png)
![obraz](https://user-images.githubusercontent.com/22982594/61592728-673ed480-abd7-11e9-9ce8-92c44031e391.png)
