### PR TITLE
android: add support for different screen timeout setups

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -167,9 +167,14 @@ function Device:init()
         self.isTouchDevice = yes
     end
 
-    -- check if we enabled support for wakelocks
-    if G_reader_settings:isTrue("enable_android_wakelock") or android.needsWakelocks() then
-        android.setWakeLock(true)
+    -- check if we enabled support for custom timeouts (including wakelocks)
+    if android.needsWakelocks() then
+        android.setScreenOffTimeout(-1)
+    else
+        local timeout = G_reader_settings:readSetting("android_screen_timeout")
+        if timeout ~= nil and timeout ~= 0 then
+            android.setScreenOffTimeout(timeout)
+        end
     end
 
     -- check if we disable fullscreen support

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -172,14 +172,8 @@ if Device:isAndroid() then
     local isAndroid, android = pcall(require, "android")
     if not isAndroid then return end
 
-    -- keep screen on toggle on devices which don't need wakelocks always enabled.
-    if not android.needsWakelocks() then
-        common_settings.keep_screen_on = {
-            text = _("Keep screen on"),
-            checked_func = function() return G_reader_settings:isTrue("enable_android_wakelock") end,
-            callback = function() require("ui/elements/screen_android"):toggleWakelock() end,
-        }
-    end
+    -- screen timeout options, disabled if device needs wakelocks.
+    common_settings.screen_timeout = require("ui/elements/screen_android"):getTimeoutMenuTable()
 
     -- fullscreen toggle on devices with compatible fullscreen methods (apis 14-18)
     if Device.firmware_rev < 19 then

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -71,7 +71,7 @@ local order = {
         "----------------------------",
         "screen_toggle_gsensor",
         "----------------------------",
-        "keep_screen_on",
+        "screen_timeout",
         "fullscreen",
     },
     taps_and_gestures = {

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -90,7 +90,7 @@ local order = {
         "----------------------------",
         "screen_toggle_gsensor",
         "----------------------------",
-        "keep_screen_on",
+        "screen_timeout",
         "fullscreen",
     },
     taps_and_gestures = {

--- a/frontend/ui/elements/screen_android.lua
+++ b/frontend/ui/elements/screen_android.lua
@@ -5,8 +5,41 @@ local logger = require("logger")
 local _ = require("gettext")
 local Input = Device.input
 local Screen = Device.screen
+local T = require("ffi/util").template
 
 if not isAndroid then return end
+
+-- custom timeouts (in milliseconds)
+local timeout_custom1 = 30 * 1000
+local timeout_custom2 = 60 * 1000
+local timeout_custom3 = 2 * 60 * 1000
+local timeout_custom4 = 5 * 60 * 1000
+local timeout_custom5 = 10 * 60 * 1000
+local timeout_custom6 = 15 * 60 * 1000
+local timeout_custom7 = 30 * 60 * 1000
+
+local timeout_system = 0    -- same as system (do nothing!)
+local timeout_disabled = -1 -- disable timeout using wakelocks
+
+local can_modify_timeout = not android.needsWakelocks()
+
+local function humanReadableTimeout(timeout)
+    local sec = timeout / 1000
+    if sec >= 120 then
+        return T(_("%1 minutes"), sec / 60)
+    else
+        return T(_("%1 seconds"), sec)
+    end
+end
+
+local function timeoutEquals(timeout)
+    return timeout == android.getScreenOffTimeout()
+end
+
+local function saveAndApplyTimeout(timeout)
+    G_reader_settings:saveSetting("android_screen_timeout", timeout)
+    android.setScreenOffTimeout(timeout)
+end
 
 local ScreenHelper = {}
 
@@ -58,11 +91,68 @@ function ScreenHelper:toggleFullscreenLegacy()
     end
 end
 
--- toggle android wakelock support
-function ScreenHelper:toggleWakelock()
-    local is_wakelock = G_reader_settings:isTrue("enable_android_wakelock")
-    android.setWakeLock(not is_wakelock)
-    G_reader_settings:saveSetting("enable_android_wakelock", not is_wakelock)
+-- timeout menu table
+function ScreenHelper:getTimeoutMenuTable()
+    return {
+        text = _("Screen Timeout"),
+        sub_item_table = {
+            {
+                text = _("Use system settings"),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_system) end,
+                callback = function() saveAndApplyTimeout(timeout_system) end
+            },
+            {
+                text = humanReadableTimeout(timeout_custom1),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_custom1) end,
+                callback = function() saveAndApplyTimeout(timeout_custom1) end
+            },
+            {
+                text = humanReadableTimeout(timeout_custom2),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_custom2) end,
+                callback = function() saveAndApplyTimeout(timeout_custom2) end
+            },
+            {
+                text = humanReadableTimeout(timeout_custom3),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_custom3) end,
+                callback = function() saveAndApplyTimeout(timeout_custom3) end
+            },
+            {
+                text = humanReadableTimeout(timeout_custom4),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_custom4) end,
+                callback = function() saveAndApplyTimeout(timeout_custom4) end
+            },
+            {
+                text = humanReadableTimeout(timeout_custom5),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_custom5) end,
+                callback = function() saveAndApplyTimeout(timeout_custom5) end
+            },
+            {
+                text = humanReadableTimeout(timeout_custom6),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_custom6) end,
+                callback = function() saveAndApplyTimeout(timeout_custom6) end
+            },
+            {
+                text = humanReadableTimeout(timeout_custom7),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_custom7) end,
+                callback = function() saveAndApplyTimeout(timeout_custom7) end
+            },
+            {
+                text = _("Keep screen on"),
+                enabled_func = function() return can_modify_timeout end,
+                checked_func = function() return timeoutEquals(timeout_disabled) end,
+                callback = function() saveAndApplyTimeout(timeout_disabled) end
+            },
+        }
+    }
 end
+
 
 return ScreenHelper


### PR DESCRIPTION
requires https://github.com/koreader/android-luajit-launcher/pull/160
fixes #4604

### normal device:
![1](https://user-images.githubusercontent.com/975883/61789636-79a65180-ae15-11e9-9c4d-8911a22ac319.png)

### device that needs wakelocks:
![2](https://user-images.githubusercontent.com/975883/61789649-80cd5f80-ae15-11e9-9555-eb6ec70eca64.png)
