### PR TITLE
Minor auto_restore_wifi tweaks

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -187,6 +187,7 @@ function Device:onPowerEvent(ev)
                 local network_manager = require("ui/network/manager")
                 if network_manager.wifi_was_on and G_reader_settings:isTrue("auto_restore_wifi") then
                     network_manager:restoreWifiAsync()
+                    network_manager:scheduleConnectivityCheck()
                 end
                 self:resume()
                 -- restore to previous rotation mode, if need be.

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -401,24 +401,6 @@ function Kobo:initNetworkManager(NetworkMgr)
 
     function NetworkMgr:restoreWifiAsync()
         os.execute("./restore-wifi-async.sh")
-
-        -- Make sure we eventually send a NetworkConnected event, as a few things rely on it (KOSync, c.f. #5109).
-        local UIManager = require("ui/uimanager")
-        local function connectivityCheck(iter)
-            -- Give up after a while...
-            if iter > 4 then
-                return
-            end
-
-            if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
-                local Event = require("ui/event")
-                UIManager:broadcastEvent(Event:new("NetworkConnected"))
-            else
-                UIManager:scheduleIn(5, connectivityCheck(iter + 1), end)
-            end
-        end
-
-        UIManager:scheduleIn(5, connectivityCheck(1), end)
     end
 
     -- NOTE: Cheap-ass way of checking if WiFi seems to be enabled...

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -401,6 +401,24 @@ function Kobo:initNetworkManager(NetworkMgr)
 
     function NetworkMgr:restoreWifiAsync()
         os.execute("./restore-wifi-async.sh")
+
+        -- Make sure we eventually send a NetworkConnected event, as a few things rely on it (KOSync, c.f. #5109).
+        local UIManager = require("ui/uimanager")
+        local function connectivityCheck(iter)
+            -- Give up after a while...
+            if iter > 4 then
+                return
+            end
+
+            if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
+                local Event = require("ui/event")
+                UIManager:broadcastEvent(Event:new("NetworkConnected"))
+            else
+                UIManager:scheduleIn(5, connectivityCheck(iter + 1), end)
+            end
+        end
+
+        UIManager:scheduleIn(5, connectivityCheck(1), end)
     end
 
     -- NOTE: Cheap-ass way of checking if WiFi seems to be enabled...

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -26,15 +26,23 @@ function NetworkMgr:connectivityCheck(iter)
         local Event = require("ui/event")
         UIManager:broadcastEvent(Event:new("NetworkConnected"))
         logger.info("WiFi successfully restored!")
+        return true
+    else
+        return false
     end
 end
 
 function NetworkMgr:scheduleConnectivityCheck()
     UIManager:scheduleIn(5, function()
-        NetworkMgr:connectivityCheck(1)
-        if not (NetworkMgr:isWifiOn() and NetworkMgr:isConnected()) then
+        if not NetworkMgr:connectivityCheck(1) then
             UIManager:scheduleIn(5, function()
-                NetworkMgr:connectivityCheck(2)
+                if not NetworkMgr:connectivityCheck(2) then
+                    UIManager:scheduleIn(5, function()
+                        if not NetworkMgr:connectivityCheck(3) then
+                            UIManager:scheduleIn(5, NetworkMgr:connectivityCheck(4))
+                        end
+                    end)
+                end
             end)
         end
     end)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -16,12 +16,7 @@ function NetworkMgr:readNWSettings()
 end
 
 -- Used after restoreWifiAsync() to make sure we eventually send a NetworkConnected event, as a few things rely on it (KOSync, c.f. #5109).
-function NetworkMgr:connectivityCheck(iter)
-    -- Give up after a while...
-    if iter > 4 then
-        return
-    end
-
+function NetworkMgr:connectivityCheck()
     if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
         local Event = require("ui/event")
         UIManager:broadcastEvent(Event:new("NetworkConnected"))
@@ -33,13 +28,13 @@ function NetworkMgr:connectivityCheck(iter)
 end
 
 function NetworkMgr:scheduleConnectivityCheck()
-    UIManager:scheduleIn(5, function()
-        if not NetworkMgr:connectivityCheck(1) then
-            UIManager:scheduleIn(5, function()
-                if not NetworkMgr:connectivityCheck(2) then
-                    UIManager:scheduleIn(5, function()
-                        if not NetworkMgr:connectivityCheck(3) then
-                            UIManager:scheduleIn(5, NetworkMgr:connectivityCheck(4))
+    UIManager:scheduleIn(3, function()
+        if not NetworkMgr:connectivityCheck() then
+            UIManager:scheduleIn(3, function()
+                if not NetworkMgr:connectivityCheck() then
+                    UIManager:scheduleIn(3, function()
+                        if not NetworkMgr:connectivityCheck() then
+                            UIManager:scheduleIn(3, NetworkMgr:connectivityCheck())
                         end
                     end)
                 end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -122,12 +122,23 @@ function NetworkMgr:isConnected()
     if Device:isAndroid() or Device:isCervantes() or Device:isPocketBook() then
         return self:isWifiOn()
     else
+        -- Pull the default gateway first, so we don't even try to ping anything if there isn't one...
+        local default_gw
+        local std_out = io.popen([[/sbin/route -n | awk '$4 == "UG" {print $2}' | tail -n 1]], "r")
+        if std_out then
+            default_gw = std_out:read("*all")
+            std_out:close()
+            if not default_gw or default_gw == "" then
+                return false
+            end
+        end
+
         -- `-c1` try only once; `-w2` wait 2 seconds
         -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles...
         if Device:isKindle() and Device:hasKeyboard() then
-            return 0 == os.execute([[ping -c1 $(/sbin/route -n | awk '$4 == "UG" {print $2}' | tail -n 1)]])
+            return 0 == os.execute("ping -c1 " .. default_gw)
         else
-            return 0 == os.execute([[ping -c1 -w2 $(/sbin/route -n | awk '$4 == "UG" {print $2}' | tail -n 1)]])
+            return 0 == os.execute("ping -c1 -w2 " .. default_gw)
         end
     end
 end

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -22,7 +22,7 @@ unset OLDPWD EXT_FONT_DIR TESSDATA_PREFIX FROM_NICKEL STARDICT_DATA_DIR LC_ALL K
 # Make sure we kill the WiFi first, because nickel apparently doesn't like it if it's up... (cf. #1520)
 # NOTE: That check is possibly wrong on PLATFORM == freescale (because I don't know if the sdio_wifi_pwr module exists there), but we don't terribly care about that.
 if lsmod | grep -q sdio_wifi_pwr; then
-    killall udhcpc default.script wpa_supplicant 2>/dev/null
+    killall restore-wifi-async.sh udhcpc default.script wpa_supplicant 2>/dev/null
     [ "${WIFI_MODULE}" != "8189fs" ] && [ "${WIFI_MODULE}" != "8192es" ] && wlarm_le -i "${INTERFACE}" down
     ifconfig "${INTERFACE}" down
     # NOTE: Kobo's busybox build is weird. rmmod appears to be modprobe in disguise, defaulting to the -r flag...

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -22,7 +22,7 @@ unset OLDPWD EXT_FONT_DIR TESSDATA_PREFIX FROM_NICKEL STARDICT_DATA_DIR LC_ALL K
 # Make sure we kill the WiFi first, because nickel apparently doesn't like it if it's up... (cf. #1520)
 # NOTE: That check is possibly wrong on PLATFORM == freescale (because I don't know if the sdio_wifi_pwr module exists there), but we don't terribly care about that.
 if lsmod | grep -q sdio_wifi_pwr; then
-    killall restore-wifi-async.sh udhcpc default.script wpa_supplicant 2>/dev/null
+    killall restore-wifi-async.sh enable-wifi.sh obtain-ip.sh udhcpc default.script wpa_supplicant 2>/dev/null
     [ "${WIFI_MODULE}" != "8189fs" ] && [ "${WIFI_MODULE}" != "8192es" ] && wlarm_le -i "${INTERFACE}" down
     ifconfig "${INTERFACE}" down
     # NOTE: Kobo's busybox build is weird. rmmod appears to be modprobe in disguise, defaulting to the -r flag...

--- a/platform/kobo/restore-wifi-async.sh
+++ b/platform/kobo/restore-wifi-async.sh
@@ -2,8 +2,25 @@
 
 RestoreWifi() {
     echo "[$(date)] restore-wifi-async.sh: Restarting WiFi"
+
     ./enable-wifi.sh
+
+    # Much like we do in the UI, ensure wpa_supplicant did its job properly, first.
+    # Pilfered from https://github.com/shermp/Kobo-UNCaGED/pull/21 ;)
+    wpac_timeout=0
+    while ! wpa_cli status | grep -q "wpa_state=COMPLETED"; do
+        # If wpa_supplicant hasn't connected within 10 seconds, assume it never will, and tear down WiFi
+        if [ ${wpac_timeout} -ge 40 ]; then
+            echo "[$(date)] restore-wifi-async.sh: Failed to connect to preferred AP!"
+            ./disable-wifi.sh
+            return 1
+        fi
+        usleep 250000
+        wpac_timeout=$(( wpac_timeout + 1 ))
+    done
+
     ./obtain-ip.sh
+
     echo "[$(date)] restore-wifi-async.sh: Restarted WiFi"
 }
 

--- a/platform/kobo/restore-wifi-async.sh
+++ b/platform/kobo/restore-wifi-async.sh
@@ -16,7 +16,7 @@ RestoreWifi() {
             return 1
         fi
         usleep 250000
-        wpac_timeout=$(( wpac_timeout + 1 ))
+        wpac_timeout=$((wpac_timeout + 1))
     done
 
     ./obtain-ip.sh


### PR DESCRIPTION
* Attempt to make it send a NetworkConnected event, eventually (may help w/ #5109)
* Made sure it wouldn't interfere with nickel startup in case it's still running when we exit (which reliably happens if we crash on startup)
* Tweaked the Kobo variant to check if wpa_supplicant managed to connect before attempting to acquire an IP, and to tear down the modules if it didn't ("inspired" from @shermp's https://github.com/shermp/Kobo-UNCaGED/pull/21 ;)).