### PR TITLE
Set font size for menu items

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -149,8 +149,6 @@ function FileManagerMenu:setUpdateItemTable()
                         title_text =  _("Items per page"),
                         callback = function(spin)
                             G_reader_settings:saveSetting("items_per_page", spin.value)
-                            --after changing items per page we reset the font size of item and set it as default
-                            G_reader_settings:saveSetting("items_font_size", math.floor(24 - ((spin.value - 6)/ 18) * 10 ))
                             self.ui:onRefresh()
                         end
                     }

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -172,7 +172,7 @@ function FileManagerMenu:setUpdateItemTable()
                         value_max = 72,
                         default_value = default_font_size,
                         ok_text = _("Set size"),
-                        title_text =  _("Max font size for item"),
+                        title_text =  _("Maximum font size for item"),
                         callback = function(spin)
                             G_reader_settings:saveSetting("items_font_size", spin.value)
                             self.ui:onRefresh()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -126,31 +126,62 @@ function FileManagerMenu:setUpdateItemTable()
         checked_func = function() return self.ui.file_chooser.show_unsupported end,
         callback = function() self.ui:toggleUnsupportedFiles() end
     }
-    self.menu_items.items_per_page = {
-        text = _("Items per page"),
-        help_text = _([[This sets the number of items per page in:
+    self.menu_items.items = {
+        text = _("Items"),
+        sub_item_table = {
+            {
+                text = _("Items per page"),
+                help_text = _([[This sets the number of items per page in:
 - File browser and history in 'classic' display mode
 - File and directory selection
 - Table of contents
 - Bookmarks list]]),
-        keep_menu_open = true,
-        callback = function()
-            local SpinWidget = require("ui/widget/spinwidget")
-            local curr_items = G_reader_settings:readSetting("items_per_page") or 14
-            local items = SpinWidget:new{
-                width = Screen:getWidth() * 0.6,
-                value = curr_items,
-                value_min = 6,
-                value_max = 24,
-                ok_text = _("Set items"),
-                title_text =  _("Items per page"),
-                callback = function(spin)
-                    G_reader_settings:saveSetting("items_per_page", spin.value)
-                    self.ui:onRefresh()
+                keep_menu_open = true,
+                callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local curr_items = G_reader_settings:readSetting("items_per_page") or 14
+                    local items = SpinWidget:new{
+                        width = Screen:getWidth() * 0.6,
+                        value = curr_items,
+                        value_min = 6,
+                        value_max = 24,
+                        ok_text = _("Set items"),
+                        title_text =  _("Items per page"),
+                        callback = function(spin)
+                            G_reader_settings:saveSetting("items_per_page", spin.value)
+                            --after changing items per page we reset the font size of item and set it as default
+                            G_reader_settings:saveSetting("items_font_size", math.floor(24 - ((spin.value - 6)/ 18) * 10 ))
+                            self.ui:onRefresh()
+                        end
+                    }
+                    UIManager:show(items)
+                end
+            },
+            {
+                text = _("Font size"),
+                keep_menu_open = true,
+                callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local curr_items = G_reader_settings:readSetting("items_per_page") or 14
+                    local default_font_size = math.floor(24 - ((curr_items - 6)/ 18) * 10 )
+                    local curr_font_size = G_reader_settings:readSetting("items_font_size") or default_font_size
+                    local items_font = SpinWidget:new{
+                        width = Screen:getWidth() * 0.6,
+                        value = curr_font_size,
+                        value_min = 10,
+                        value_max = 72,
+                        default_value = default_font_size,
+                        ok_text = _("Set size"),
+                        title_text =  _("Max font size for item"),
+                        callback = function(spin)
+                            G_reader_settings:saveSetting("items_font_size", spin.value)
+                            self.ui:onRefresh()
+                        end
+                    }
+                    UIManager:show(items_font)
                 end
             }
-            UIManager:show(items)
-        end
+        }
     }
     self.menu_items.sort_by = self.ui:getSortingMenuTable()
     self.menu_items.reverse_sorting = {

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -13,7 +13,7 @@ local order = {
         "filemanager_display_mode",
         "show_hidden_files",
         "show_unsupported_files",
-        "items_per_page",
+        "items",
         "----------------------------",
         "sort_by",
         "reverse_sorting",

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -929,8 +929,8 @@ function Menu:updateItems(select_number)
     end
     --font size between 12 and 18 for better matching
     local infont_size = math.floor(18 - (self.perpage - 6) / 3)
-    --font size between 14 and 24 for better matching
-    local font_size = math.floor(24 - ((self.perpage - 6)/ 18) * 10 )
+    --default font size between 14 and 24 for better matching
+    local font_size = G_reader_settings:readSetting("items_font_size") or math.floor(24 - ((self.perpage - 6)/ 18) * 10 )
 
     for c = 1, math.min(self.perpage, #self.item_table) do
         -- calculate index in item_table


### PR DESCRIPTION
Ref: #4757
This PR add option to changing the font size of items in menu widget (filemanger in classic mode, TOC) in single line mode.
Close: #4757

![obraz](https://user-images.githubusercontent.com/22982594/61950999-e81f1700-afaf-11e9-9980-05a776aec2fb.png)
![obraz](https://user-images.githubusercontent.com/22982594/61951095-2fa5a300-afb0-11e9-952e-3e3cda71a912.png)
![obraz](https://user-images.githubusercontent.com/22982594/61951455-4a2c4c00-afb1-11e9-9cd7-d3dc6a0c10d6.png)
![obraz](https://user-images.githubusercontent.com/22982594/61951481-5d3f1c00-afb1-11e9-9d73-52a62b926856.png)

 
