### PR TITLE
[sdl] Add support arrow key for next/prev page

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -405,7 +405,7 @@ function ReaderPaging:onPan(_, ges)
         if self.ui.gesture and self.ui.gesture.multiswipes_enabled then
             relative_type = "relative_delayed"
         end
-        --this is only use when mouse wheel is used
+        -- this is only used when mouse wheel is used
         if ges.mousewheel_direction and not self.view.page_scroll then
             self:onGotoViewRel(-1 * ges.mousewheel_direction)
         else

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -8,7 +8,6 @@ local ReaderPanning = require("apps/reader/modules/readerpanning")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
-local Input = Device.input
 local Screen = Device.screen
 local T = require("ffi/util").template
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -57,12 +57,12 @@ function ReaderRolling:init()
     self.key_events = {}
     if Device:hasKeys() then
         self.key_events.GotoNextView = {
-            { Input.group.PgFwd },
+            { {"RPgFwd", "LPgFwd", "Right" } },
             doc = "go to next view",
             event = "GotoViewRel", args = 1,
         }
         self.key_events.GotoPrevView = {
-            { Input.group.PgBack },
+            { { "RPgBack", "LPgBack", "Left" } },
             doc = "go to previous view",
             event = "GotoViewRel", args = -1,
         }
@@ -446,6 +446,9 @@ function ReaderRolling:onPan(_, ges)
         elseif ges.direction == "south" then
             self:_gotoPos(self.current_pos - ges[distance_type])
         end
+    --this is only use when mouse wheel is used
+    elseif ges.mousewheel_direction and self.view.view_mode == "page" then
+        UIManager:broadcastEvent(Event:new("GotoViewRel", -1 * ges.mousewheel_direction))
     end
     return true
 end
@@ -629,8 +632,11 @@ function ReaderRolling:onGotoViewRel(diff)
 end
 
 function ReaderRolling:onPanning(args, _)
-    if self.view.view_mode ~= "scroll" then return end
     local _, dy = unpack(args)
+    if self.view.view_mode ~= "scroll" then
+        UIManager:broadcastEvent(Event:new("GotoViewRel", dy))
+        return
+    end
     self:_gotoPos(self.current_pos + dy * self.panning_steps.normal)
     self.xpointer = self.ui.document:getXPointer()
     return true

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -118,6 +118,7 @@ function Device:init()
                         },
                         pos = pos,
                         time = timev,
+                        mousewheel_direction = scrolled_y,
                     }
                     local fake_ges_release = {
                         ges = "pan_release",
@@ -130,7 +131,6 @@ function Device:init()
                     }
                     local fake_pan_ev = Event:new("Pan", nil, fake_ges)
                     local fake_release_ev = Event:new("Gesture", fake_ges_release)
-
                     if scrolled_y == down then
                         fake_ges.direction = "north"
                         UIManager:broadcastEvent(fake_pan_ev)


### PR DESCRIPTION
Close: #4997 
This PR add support arrow key and mouse scroll wheel for next/previous page.

- Document in page mode:

PageDown, Arrow down, Arrow right - go to next page
PageUp, Arrow up, arrow left - go to prev page
Mouse scroll wheel down - go to next page
Mouse scroll wheel up - go to prev page

- Document in scroll mode:

PageDown, Arrow right - go to next page
PageUp, Arrow, arrow left - go to prev page
Arrow down - scroll document down
Arrow up - scroll document up
Mouse scroll wheel down - scroll document down
Mouse scroll wheel up - scroll document up



