### PR TITLE
Restart KOReader after update

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -49,6 +49,7 @@ local ota_channels = {
 local function showRestartMessage()
     UIManager:show(ConfirmBox:new{
         text = _("KOReader will be updated on next restart.\nWould you like to restart now?"),
+        ok_text = _("Restart"),
         ok_callback = function()
             local savequit_caller = nil
             local save_quit = function()

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -51,7 +51,7 @@ local function showRestartMessage()
         text = _("KOReader will be updated on next restart.\nWould you like to restart now?"),
         ok_text = _("Restart"),
         ok_callback = function()
-            local savequit_caller = nil
+            local savequit_caller
             local save_quit = function()
                 Device:saveSettings()
                 UIManager:quit()


### PR DESCRIPTION
Adding the option to restart KOReader after update.
Close: #5144

Before:
![obraz](https://user-images.githubusercontent.com/22982594/62011081-db4b2080-b173-11e9-9c2d-e47fc668711d.png)
After:
![obraz](https://user-images.githubusercontent.com/22982594/62011089-fcac0c80-b173-11e9-8781-8e1682fd8985.png)

