### PR TITLE
Go Big or Go Home!

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -560,6 +560,7 @@ end
 function FileManager:goHome()
     local home_dir = G_reader_settings:readSetting("home_dir")
     if home_dir then
+        -- Jump to the first page if we're already home
         if self.file_chooser.path and home_dir == self.file_chooser.path then
             self.file_chooser:onGotoPage(1)
         else

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -560,7 +560,11 @@ end
 function FileManager:goHome()
     local home_dir = G_reader_settings:readSetting("home_dir")
     if home_dir then
-        self.file_chooser:changeToPath(home_dir)
+        if self.file_chooser.path and home_dir == self.file_chooser.path then
+            self.file_chooser:onGotoPage(1)
+        else
+            self.file_chooser:changeToPath(home_dir)
+        end
     else
         -- Try some sane defaults, depending on platform
         if Device:isKindle() then
@@ -576,7 +580,11 @@ function FileManager:goHome()
         end
 
         if home_dir then
-            self.file_chooser:changeToPath(home_dir)
+            if self.file_chooser.path and home_dir == self.file_chooser.path then
+                self.file_chooser:onGotoPage(1)
+            else
+                self.file_chooser:changeToPath(home_dir)
+            end
         else
             self:setHome()
         end

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -562,7 +562,24 @@ function FileManager:goHome()
     if home_dir then
         self.file_chooser:changeToPath(home_dir)
     else
-        self:setHome()
+        -- Try some sane defaults, depending on platform
+        if Device:isKindle() then
+            home_dir = "/mnt/us"
+        elseif Device:isKobo() then
+            home_dir = "/mnt/onboard"
+        elseif Device:isPocketBook() then
+            home_dir = "/mnt/ext1"
+        elseif Device:isCervantes() then
+            home_dir = "/mnt/public"
+        elseif Device:isAndroid() then
+            home_dir = "/sdcard/koreader"
+        end
+
+        if home_dir then
+            self.file_chooser:changeToPath(home_dir)
+        else
+            self:setHome()
+        end
     end
     return true
 end

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -577,7 +577,7 @@ function FileManager:goHome()
         elseif Device:isCervantes() then
             home_dir = "/mnt/public"
         elseif Device:isAndroid() then
-            home_dir = "/sdcard/koreader"
+            home_dir = "/sdcard"
         end
 
         if home_dir then


### PR DESCRIPTION
Make the Home button fallback to sane values in case no custom home directory is set (re #5154 ).
And if we're already home, make it jump to the first page.

(The QuickStart Guide properly introduces the long-press as the way to set defaults, so I'm not too torn up about mostly getting rid of that bit of QoL cuteness that may actually mean people wouldn't remember that long-presses are awesome in KOReader).