### PR TITLE
Fix: set custom screen DPI

### DIFF
--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -20,7 +20,7 @@ local function setDPI(_dpi)
     Device:setScreenDPI(_dpi)
 end
 
-local function spinWidgetSetDPI()
+local function spinWidgetSetDPI(touchmenu_instance)
     local SpinWidget = require("ui/widget/spinwidget")
     local UIManager = require("ui/uimanager")
     local items = SpinWidget:new{
@@ -35,8 +35,7 @@ local function spinWidgetSetDPI()
         callback = function(spin)
             G_reader_settings:saveSetting("custom_screen_dpi", spin.value)
             setDPI(spin.value)
-            local Event = require("ui/event")
-            UIManager:broadcastEvent(Event:new("UpdateTouchMenu"))
+            touchmenu_instance:updateItems()
         end
     }
     UIManager:show(items)
@@ -127,15 +126,15 @@ return {
                 local _dpi, _custom = dpi(), custom()
                 return _custom and _dpi == _custom
             end,
-            callback = function()
+            callback = function(touchmenu_instance)
                 if custom() then
                     setDPI(custom() or dpi_auto)
                 else
-                    spinWidgetSetDPI()
+                    spinWidgetSetDPI(touchmenu_instance)
                 end
             end,
-            hold_callback = function()
-                spinWidgetSetDPI()
+            hold_callback = function(touchmenu_instance)
+                spinWidgetSetDPI(touchmenu_instance)
             end,
         },
     }

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -553,10 +553,6 @@ function TouchMenu:_recalculatePageLayout()
     self.page_num = math.ceil(#self.item_table / self.perpage)
 end
 
-function TouchMenu:onUpdateTouchMenu()
-    self:updateItems()
-end
-
 function TouchMenu:updateItems()
     local old_dimen = self.dimen and self.dimen:copy()
     self:_recalculatePageLayout()


### PR DESCRIPTION
Settings -> Screen -> Screen DPI
When custom DPI is not set we see ugly information with %1:

![obraz](https://user-images.githubusercontent.com/22982594/62354906-2ff0f180-b50e-11e9-9e34-33853f2bd2fe.png)
This PR should fix it and replace input widget with spin widget.

Before:
![obraz](https://user-images.githubusercontent.com/22982594/62354995-64fd4400-b50e-11e9-9634-e3bd1cee0baa.png)

After:

![obraz](https://user-images.githubusercontent.com/22982594/62355018-70e90600-b50e-11e9-8d47-a40f2cf1cf8b.png)

![obraz](https://user-images.githubusercontent.com/22982594/62355111-a5f55880-b50e-11e9-8df7-9a37c128c24f.png)

![obraz](https://user-images.githubusercontent.com/22982594/62355124-ad1c6680-b50e-11e9-99bc-dcc9a94eb1b9.png)

