### PR TITLE
Change default zoom mode & add warning message for fit page + scroll

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -9,6 +9,7 @@ local Device = require("device")
 local Geom = require("ui/geometry")
 local Event = require("ui/event")
 local ImageWidget = require("ui/widget/imagewidget")
+local InfoMessage = require("ui/widget/infomessage")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local ReaderDogear = require("apps/reader/modules/readerdogear")
 local ReaderFlipping = require("apps/reader/modules/readerflipping")
@@ -736,21 +737,16 @@ function ReaderView:onSetFullScreen(full_screen)
 end
 
 function ReaderView:onSetScrollMode(page_scroll)
-    local function initScrollPageStates()
-        self.page_scroll = page_scroll
-        self:recalculate()
-        self.ui:handleEvent(Event:new("InitScrollPageStates"))
+    if self.ui.document.info.has_pages and page_scroll and self.zoom_mode == "page" then
+        UIManager:show(InfoMessage:new{
+            text = _([[Continuous view (scroll mode) can lead to unexpected shifts when turning pages in combination with zooming to fit page.]]),
+            timeout = 5,
+        })
     end
 
-    if self.ui.document.info.has_pages then
-        self.ui.zooming:checkScrollZoomMode(initScrollPageStates, nil, page_scroll, _([[
-Change view mode to continuous?
-
-In combination with zoom to fit page, this can lead to unexpected shifts when turning pages.]]),
-            _("Change mode"))
-    else
-        initScrollPageStates()
-    end
+    self.page_scroll = page_scroll
+    self:recalculate()
+    self.ui:handleEvent(Event:new("InitScrollPageStates"))
 end
 
 function ReaderView:onReadSettings(config)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -736,9 +736,21 @@ function ReaderView:onSetFullScreen(full_screen)
 end
 
 function ReaderView:onSetScrollMode(page_scroll)
-    self.page_scroll = page_scroll
-    self:recalculate()
-    self.ui:handleEvent(Event:new("InitScrollPageStates"))
+    local function initScrollPageStates()
+        self.page_scroll = page_scroll
+        self:recalculate()
+        self.ui:handleEvent(Event:new("InitScrollPageStates"))
+    end
+
+    if self.ui.document.info.has_pages then
+        self.ui.zooming:checkScrollZoomMode(initScrollPageStates, nil, page_scroll, _([[
+Change view mode to continuous?
+
+In combination with zoom to fit page, this can lead to unexpected shifts when turning pages.]]),
+            _("Change mode"))
+    else
+        initScrollPageStates()
+    end
 end
 
 function ReaderView:onReadSettings(config)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -737,9 +737,12 @@ function ReaderView:onSetFullScreen(full_screen)
 end
 
 function ReaderView:onSetScrollMode(page_scroll)
-    if self.ui.document.info.has_pages and page_scroll and self.zoom_mode == "page" then
+    if self.ui.document.info.has_pages and page_scroll and self.ui.zooming.paged_modes[self.zoom_mode] then
         UIManager:show(InfoMessage:new{
-            text = _([[Continuous view (scroll mode) can lead to unexpected shifts when turning pages in combination with zooming to fit page.]]),
+            text = _([[
+Continuous view (scroll mode) works best with zoom to page width or zoom to content width.
+
+In combination with zoom to fit page, page height, content height or content, continuous view can cause unexpected shifts when turning pages.]]),
             timeout = 5,
         })
     end

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -16,7 +16,7 @@ local ReaderZooming = InputContainer:new{
     zoom = 1.0,
     -- default to nil so we can trigger ZoomModeUpdate events on start up
     zoom_mode = nil,
-    DEFAULT_ZOOM_MODE = "page",
+    DEFAULT_ZOOM_MODE = "pagewidth",
     current_page = 1,
     rotation = 0
 }

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -318,6 +318,27 @@ function ReaderZooming:getRegionalZoomCenter(pageno, pos)
     return zoom/(1 + 3*margin/zoom/page_size.w)
 end
 
+-- helper method to emit warnings against less desirable combinations
+function ReaderZooming:checkScrollZoomMode(callback, mode, page_scroll, text, ok_text)
+    mode = mode or self.zoom_mode
+    if page_scroll == nil then page_scroll = self.ui.view.page_scroll end
+
+    text = text or _([[
+Change zoom mode to fit page?
+
+In combination with continuous display (scroll mode), this can lead to unexpected shifts when turning pages.]])
+    ok_text = ok_text or _("Fit page")
+    if mode == "page" and page_scroll then
+        UIManager:show(ConfirmBox:new{
+            text = text,
+            ok_text = ok_text,
+            ok_callback = callback,
+        })
+    else
+        callback()
+    end
+end
+
 function ReaderZooming:setZoom()
     if not self.dimen then
         self.dimen = self.ui.dimen
@@ -338,20 +359,7 @@ function ReaderZooming:setZoomMode(mode)
         self.ui:handleEvent(Event:new("InitScrollPageStates"))
     end
 
-    if mode == "page" and self.ui.view.page_scroll then
-        UIManager:show(ConfirmBox:new{
-            text = _([[
-Change zoom mode to fit page?
-
-In combination with continuous display (scroll mode), this can lead to unexpected shifts when turning pages.]]),
-            ok_text = _("Fit page"),
-            ok_callback = function()
-                emitZoomEvents()
-            end,
-        })
-    else
-        emitZoomEvents()
-    end
+    self:checkScrollZoomMode(emitZoomEvents, mode)
 end
 
 function ReaderZooming:addToMainMenu(menu_items)

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -19,7 +19,13 @@ local ReaderZooming = InputContainer:new{
     zoom_mode = nil,
     DEFAULT_ZOOM_MODE = "pagewidth",
     current_page = 1,
-    rotation = 0
+    rotation = 0,
+    paged_modes = {
+        page = _("Zoom to fit page works best with page view."),
+        pageheight = _("Zoom to fit page height works best with page view."),
+        contentheight = _("Zoom to fit content height works best with page view."),
+        content = _("Zoom to fit content works best with page view."),
+    },
 }
 
 function ReaderZooming:init()
@@ -334,10 +340,12 @@ function ReaderZooming:genSetZoomModeCallBack(mode)
 end
 
 function ReaderZooming:setZoomMode(mode)
-    if mode == "page" and self.ui.view.page_scroll then
+    if self.ui.view.page_scroll and self.paged_modes[mode] then
         UIManager:show(InfoMessage:new{
-            text = _([[
-Zooming to fit page can lead to unexpected shifts when turning pages in combination with continuous display (scroll mode).]]),
+            text = T(_([[
+%1
+
+In combination with continuous view (scroll mode), this can cause unexpected vertical shifts when turning pages.]]), self.paged_modes[mode]),
             timeout = 5,
         })
     end

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -333,8 +333,25 @@ function ReaderZooming:genSetZoomModeCallBack(mode)
 end
 
 function ReaderZooming:setZoomMode(mode)
-    self.ui:handleEvent(Event:new("SetZoomMode", mode))
-    self.ui:handleEvent(Event:new("InitScrollPageStates"))
+    local function emitZoomEvents()
+        self.ui:handleEvent(Event:new("SetZoomMode", mode))
+        self.ui:handleEvent(Event:new("InitScrollPageStates"))
+    end
+
+    if mode == "page" and self.ui.view.page_scroll then
+        UIManager:show(ConfirmBox:new{
+            text = _([[
+Change zoom mode to fit page?
+
+In combination with continuous display (scroll mode), this can lead to unexpected shifts when turning pages.]]),
+            ok_text = _("Fit page"),
+            ok_callback = function()
+                emitZoomEvents()
+            end,
+        })
+    else
+        emitZoomEvents()
+    end
 end
 
 function ReaderZooming:addToMainMenu(menu_items)

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -83,8 +83,8 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
-        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", true))
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui.paging:onGotoPage(1)
         assert.is.same(1, readerui.paging.current_page)
         readerui.link:onTap(nil, {pos = {x = 250, y = 534}})

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -27,6 +27,7 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", false))
         readerui.paging:onGotoPage(1)
         readerui.link:onTap(nil, {pos = {x = 363, y = 585}})
@@ -39,6 +40,7 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", true))
         readerui.paging:onGotoPage(1)
         assert.is.same(1, readerui.paging.current_page)
@@ -66,6 +68,7 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", false))
         readerui.paging:onGotoPage(1)
         readerui.link:onTap(nil, {pos = {x = 363, y = 585}})
@@ -80,6 +83,7 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", true))
         readerui.paging:onGotoPage(1)
         assert.is.same(1, readerui.paging.current_page)
@@ -131,6 +135,7 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         assert.is.falsy(readerui.view.footer_visible)
         readerui.paging:onGotoPage(1)
         assert.is.same(1, readerui.paging.current_page)

--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -27,8 +27,8 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
-        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", false))
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui.paging:onGotoPage(1)
         readerui.link:onTap(nil, {pos = {x = 363, y = 585}})
         UIManager:run()
@@ -40,8 +40,8 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
-        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", true))
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui.paging:onGotoPage(1)
         assert.is.same(1, readerui.paging.current_page)
         readerui.link:onTap(nil, {pos = {x = 250, y = 534}})
@@ -68,8 +68,8 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
-        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", false))
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui.paging:onGotoPage(1)
         readerui.link:onTap(nil, {pos = {x = 363, y = 585}})
         UIManager:run()

--- a/spec/unit/readerview_spec.lua
+++ b/spec/unit/readerview_spec.lua
@@ -105,8 +105,8 @@ describe("Readerview module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
-        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", true))
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui.zooming:setZoomMode("page")
         local view = readerui.view
         local ctx = view:getViewContext()

--- a/spec/unit/readerview_spec.lua
+++ b/spec/unit/readerview_spec.lua
@@ -105,6 +105,7 @@ describe("Readerview module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_pdf),
         }
+        readerui:handleEvent(Event:new("SetZoomMode", "page"))
         readerui:handleEvent(Event:new("SetScrollMode", true))
         readerui.zooming:setZoomMode("page")
         local view = readerui.view


### PR DESCRIPTION
The alternative is to disable scroll mode by default, but the default combination of fit page + scroll is a bit odd.

Fixes #5166.

![Screenshot_2019-08-02_20-50-47](https://user-images.githubusercontent.com/202757/62392250-45463a00-b567-11e9-84e2-fe1f55ffce09.png)
