### PR TITLE
Dict lookups: have them always interruptible

### DIFF
--- a/frontend/ui/trapper.lua
+++ b/frontend/ui/trapper.lua
@@ -314,8 +314,9 @@ Notes and limitations:
 3) We need a @{ui.widget.trapwidget|TrapWidget} or @{ui.widget.infomessage|InfoMessage},
    that, as a modal, will catch any @{ui.event|Tap event} happening during
    `cmd` execution. This can be an existing already displayed widget, or
-   provided as a string (a new TrapWidget will be created). If nil, an invisible
-   TrapWidget will be used instead.
+   provided as a string (a new TrapWidget will be created). If nil, true or false,
+   an invisible TrapWidget will be used instead (if nil or true, the event will be
+   resent; if false, the event will not be resent).
 
 If we really need to have more control, we would need to use `select()` via `ffi`
 or do low level non-blocking reading on the file descriptor.
@@ -324,7 +325,7 @@ collect indefinitely, the best option would be to compile any `timeout.c`
 and use it as a wrapper.
 
 @string cmd shell `cmd` to execute and get output from
-@param trap_widget_or_string already shown widget, string or nil
+@param trap_widget_or_string already shown widget, string, or nil, true or false
 @treturn boolean completed (`true` if not interrupted, `false` if dismissed)
 @treturn string output of command
 ]]
@@ -358,10 +359,15 @@ function Trapper:dismissablePopen(cmd, trap_widget_or_string)
             UIManager:show(trap_widget)
             UIManager:forceRePaint()
         else
-            -- Use an invisible TrapWidget that resend event
+            -- Use an invisible TrapWidget that resend event, but not if
+            -- trap_widget_or_string is false (rather than nil or true)
+            local resend_event = true
+            if trap_widget_or_string == false then
+                resend_event = false
+            end
             trap_widget = TrapWidget:new{
                 text = nil,
-                resend_event = true,
+                resend_event = resend_event,
             }
             UIManager:show(trap_widget)
             own_trap_widget_invisible = true
@@ -472,11 +478,12 @@ Notes and limitations:
 4) We need a @{ui.widget.trapwidget|TrapWidget} or @{ui.widget.infomessage|InfoMessage},
    that, as a modal, will catch any @{ui.event|Tap event} happening during
    `cmd` execution. This can be an existing already displayed widget, or
-   provided as a string (a new TrapWidget will be created). If nil, an invisible
-   TrapWidget will be used instead.
+   provided as a string (a new TrapWidget will be created). If nil, true or false,
+   an invisible TrapWidget will be used instead (if nil or true, the event will be
+   resent; if false, the event will not be resent).
 
 @function task lua function to execute and get return values from
-@param trap_widget_or_string already shown widget, string or nil
+@param trap_widget_or_string already shown widget, string, or nil, true or false
 @boolean task_returns_simple_string[opt=false] true if task returns a single string
 @treturn boolean completed (`true` if not interrupted, `false` if dismissed)
 @return ... return values of task
@@ -504,10 +511,15 @@ function Trapper:dismissableRunInSubprocess(task, trap_widget_or_string, task_re
             UIManager:show(trap_widget)
             UIManager:forceRePaint()
         else
-            -- Use an invisible TrapWidget that resend event
+            -- Use an invisible TrapWidget that resend event, but not if
+            -- trap_widget_or_string is false (rather than nil or true)
+            local resend_event = true
+            if trap_widget_or_string == false then
+                resend_event = false
+            end
             trap_widget = TrapWidget:new{
                 text = nil,
-                resend_event = true,
+                resend_event = resend_event,
             }
             UIManager:show(trap_widget)
             own_trap_widget_invisible = true

--- a/frontend/ui/widget/trapwidget.lua
+++ b/frontend/ui/widget/trapwidget.lua
@@ -115,16 +115,13 @@ function TrapWidget:_dismissAndResent(evtype, ev)
     self.dismiss_callback()
     UIManager:close(self)
     if self.resend_event and evtype and ev then
-        -- XXX There may be timing problems that could cause crashes, as we
+        -- There may be some timing issues that could cause crashes, as we
         -- use nextTick, if the dismiss_callback uses UIManager:scheduleIn()
         -- or has set up some widget that may catch that event while not being
         -- yet fully initialiazed.
-        -- It happened mostly when I had some bug somewhere, and it was a quite
+        -- (It happened mostly when I had some bug somewhere, and it was a quite
         -- reliable sign of a bug somewhere, but the stacktrace was unrelated
-        -- to the bug location.
-        -- Fix to avoid crashes: in GestureRange:match(), check that self.range()
-        -- does not return nil before using it:
-        --   if not range or not range:contains(gs.pos) then return false
+        -- to the bug location.)
         UIManager:nextTick(function() UIManager:handleInputEvent(Event:new(evtype, ev)) end)
     end
     return true

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -255,7 +255,10 @@ function Wikipedia:loadPage(text, lang, page_type, plain)
             error(self.dismissed_error_code) -- "Interrupted by user"
         end
     else
-        local timeout, maxtime = 10, 60
+        -- Smaller timeout than when we have a trap_widget because we are
+        -- blocking without one (but 20s may be needed to fetch the main HTML
+        -- page of big articles when making an EPUB).
+        local timeout, maxtime = 20, 60
         success, content = getUrlContent(built_url, timeout, maxtime)
     end
     if not success then


### PR DESCRIPTION
They should be now interruptible when fuzzy search is disabled, and on Android.
See https://github.com/koreader/koreader/issues/5151 and https://github.com/koreader/koreader/issues/3588#issuecomment-357467866.
Closes #5151. 
(Tested on my Android 6 phone, hope they work as well on other android versions, with hopefully correct shells.)

Also increase the timeout when downloading Wikipedia HTML, needed when making an EPUB out of https://zh.wikipedia.org/wiki/%E4%B8%AD%E5%8D%8E%E4%BA%BA%E6%B0%91%E5%85%B1%E5%92%8C%E5%9B%BD).