### PR TITLE
Fix: hold left corner doesn't work properly

### DIFF
--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -250,7 +250,9 @@ function Button:onHoldSelectButton()
     elseif type(self.hold_input_func) == "function" then
         self:onInput(self.hold_input_func(), true)
     end
-    return true
+    if self.readonly ~= true then
+        return true
+    end
 end
 
 function Button:onHoldReleaseSelectButton()


### PR DESCRIPTION
Close: #5174 
Hold gesture was eaten by a hidden `return button`.
https://github.com/koreader/koreader/blob/2dd29f6ab14f30c0ccdefa63d18fbf0281dd909a/frontend/ui/widget/menu.lua#L719-L727