### PR TITLE
Fix: Zsync -> Subscribe to book share crashes

### DIFF
--- a/plugins/zsync.koplugin/main.lua
+++ b/plugins/zsync.koplugin/main.lua
@@ -62,6 +62,11 @@ function ZSync:addToMainMenu(menu_items)
                     return self.filemq_server == nil
                 end,
                 callback = function()
+                    local NetworkMgr = require("ui/network/manager")
+                    if not NetworkMgr:isOnline() then
+                        NetworkMgr:promptWifiOn()
+                        return
+                    end
                     if not self.filemq_client then
                         self:subscribe()
                     else


### PR DESCRIPTION
Patch similar to PR #3086.
Same problem #2638 when tap Subscribe to book share.
"Zsync" -> "Subscribe to book share" crashes koreader if not connected to wifi

After this fix when koreader is offline after "Zsync" -> "Subscribe to book share" we are asked to enable wifi.