### PR TITLE
Fix: conflict horizontal edge gesture with link swipe

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -953,6 +953,9 @@ function ReaderGesture:setupGesture(ges, action)
             "paging_swipe",
             "rolling_swipe",
         }
+        overrides_horizontal_edge = {
+            "swipe_link"
+        }
         overrides_pan = {
             "paging_swipe",
             "rolling_swipe",

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -952,9 +952,15 @@ function ReaderGesture:setupGesture(ges, action)
         overrides_vertical_edge = {
             "paging_swipe",
             "rolling_swipe",
+            "readermenu_swipe",
+            "readerconfigmenu_swipe",
         }
         overrides_horizontal_edge = {
-            "swipe_link"
+            "swipe_link",
+            "paging_swipe",
+            "rolling_swipe",
+            "readermenu_swipe",
+            "readerconfigmenu_swipe",
         }
         overrides_pan = {
             "paging_swipe",

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -45,6 +45,10 @@ function ReaderLink:init()
                     ratio_x = 0, ratio_y = 0,
                     ratio_w = 1, ratio_h = 1,
                 },
+                overrides = {
+                    "paging_swipe",
+                    "rolling_swipe"
+                },
                 handler = function(ges) return self:onSwipe(_, ges) end,
             },
         })

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -6,8 +6,6 @@ local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
-local Geom = require("ui/geometry")
-local GestureRange = require("ui/gesturerange")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LinkBox = require("ui/widget/linkbox")
@@ -26,7 +24,30 @@ local ReaderLink = InputContainer:new{
 
 function ReaderLink:init()
     if Device:isTouchDevice() then
-        self:initGesListener()
+        self.ui:registerTouchZones({
+            {
+                id = "tap_link",
+                ges = "tap",
+                screen_zone = {
+                    ratio_x = 0, ratio_y = 0,
+                    ratio_w = 1, ratio_h = 1,
+                },
+                overrides = {
+                    "tap_forward",
+                    "tap_backward",
+                },
+                handler = function(ges) return self:onTap(_, ges) end,
+            },
+            {
+                id = "swipe_link",
+                ges = "swipe",
+                screen_zone = {
+                    ratio_x = 0, ratio_y = 0,
+                    ratio_w = 1, ratio_h = 1,
+                },
+                handler = function(ges) return self:onSwipe(_, ges) end,
+            },
+        })
     end
     self.ui:registerPostInitCallback(function()
         self.ui.menu:registerToMainMenu(self)
@@ -46,33 +67,6 @@ end
 function ReaderLink:onReadSettings(config)
     -- called when loading new document
     self.location_stack = {}
-end
-
-function ReaderLink:initGesListener()
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            Tap = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = Geom:new{
-                        x = 0, y = 0,
-                        w = Screen:getWidth(),
-                        h = Screen:getHeight()
-                    }
-                }
-            },
-            Swipe = {
-                GestureRange:new{
-                    ges = "swipe",
-                    range = Geom:new{
-                        x = 0, y = 0,
-                        w = Screen:getWidth(),
-                        h = Screen:getHeight(),
-                    }
-                }
-            },
-        }
-    end
 end
 
 local function isTapToFollowLinksOn()
@@ -372,13 +366,6 @@ function ReaderLink:showLinkBox(link, allow_footnote_popup)
         end
     elseif link and link.xpointer ~= "" then -- credocument
         return self:onGotoLink(link, false, allow_footnote_popup)
-    end
-end
-
-function ReaderLink:onSetDimensions(dimen)
-    -- update listening according to new screen dimen
-    if Device:isTouchDevice() then
-        self:initGesListener()
     end
 end
 


### PR DESCRIPTION
See: #5186 

> Horizontal left edge gesture gets in conflict with the other left swipe. I have 'Swipe to follow nearest link' enabled, so every time there is a link on the page my bottom/top left edge swipe follows that link instead.