### PR TITLE
avoid hard-coded path

### DIFF
--- a/kodev
+++ b/kodev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSION=$(git describe HEAD)

--- a/platform/debian/koreader.sh
+++ b/platform/debian/koreader.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export LC_ALL="en_US.UTF-8"
 
 # writable storage: ${HOME}/.config/koreader.
@@ -15,7 +15,7 @@ else
 fi
 
 # working directory of koreader
-KOREADER_DIR="/usr/lib/koreader"
+KOREADER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/koreader"
 
 # we're always starting from our working directory
 cd "${KOREADER_DIR}" || exit


### PR DESCRIPTION
Although the current hard-coded paths work on debian, they may fail on many other distros. Other distros may pack koreader based on the released deb file. I personally have problem using current script on nixos, as it does not use the paths `/bin/bash` and `/usr/lib/`.