### PR TITLE
Add missing parentheses

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -406,7 +406,7 @@ function Kobo:initNetworkManager(NetworkMgr)
     -- NOTE: Cheap-ass way of checking if WiFi seems to be enabled...
     --       Since the crux of the issues lies in race-y module unloading, this is perfectly fine for our usage.
     function NetworkMgr:isWifiOn()
-        return 0 == os.execute("lsmod | grep -q " .. os.getenv("WIFI_MODULE") or "sdio_wifi_pwr")
+        return 0 == os.execute("lsmod | grep -q " .. (os.getenv("WIFI_MODULE") or "sdio_wifi_pwr"))
     end
 end
 


### PR DESCRIPTION
Prevents a crash when the WIFI_MODULE environment variable is not
defined.