### PR TITLE
[Android] Enforce LZMA2 1MB chunk size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ androidupdate: all
 	# in runtime luajit-launcher's libluajit.so will be loaded
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
 	# make android update apk
-	cd $(INSTALL_DIR)/koreader && 7z a -l -m0=lzma2 -mx=1 \
+	cd $(INSTALL_DIR)/koreader && 7z a -l -m0=lzma2 -mx=1 -mc=1M \
 		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).7z * \
 		-x!resources/fonts -x!resources/icons/src -x!spec
 	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) $(if $(KODEBUG), debug, release) ANDROID_APPNAME=KOReader ANDROID_VERSION=$(ANDROID_VERSION) ANDROID_NAME=$(ANDROID_NAME) ANDROID_FLAVOR=$(ANDROID_FLAVOR)


### PR DESCRIPTION
According to the manual:

> If you don't specify ChunkSize, LZMA2 sets it to max(DictionarySize, min(256M, max(1M, DictionarySize * 4))).

From my understanding the dictionary should be only 64 kB with the `-mx=1` flag, but memory usage on Android suggests we end up with something larger. Enforcing a 1MB chunk size seems to prevent the problem, while mostly keeping the faster LZMA2 decompression advantage.

Cf. <https://github.com/koreader/android-luajit-launcher/issues/16#issuecomment-520588236>.

<hr>

@pazos Could you double check if I didn't accidentally make a mistake with the Android profiling? :-)