### PR TITLE
Honor the alpha channel in our icon for the About popup

### DIFF
--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -45,7 +45,8 @@ common_info.about = {
     callback = function()
         UIManager:show(InfoMessage:new{
             text = T(_("KOReader %1\n\nA document viewer for E Ink devices.\n\nLicensed under Affero GPL v3. All dependencies are free software.\n\nhttp://koreader.rocks/"), version),
-            icon_file = "resources/ko-icon.png"
+            icon_file = "resources/ko-icon.png",
+            alpha = true,
         })
     end
 }

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -58,6 +58,7 @@ local InfoMessage = InputContainer:new{
     -- Whether the icon should be shown. If it is false, self.image will be ignored.
     show_icon = true,
     icon_file = nil, -- use this file instead of "resources/info-i.png"
+    alpha = false, -- does that icon have an alpha channel?
     dismiss_callback = function() end,
 }
 
@@ -91,11 +92,13 @@ function InfoMessage:init()
                 image = self.image,
                 width = self.image_width,
                 height = self.image_height,
+                alpha = self.alpha,
             }
         else
             image_widget = ImageWidget:new{
                 file = self.icon_file or "resources/info-i.png",
                 scale_for_dpi = true,
+                alpha = self.alpha,
             }
         end
     else


### PR DESCRIPTION
It ends up with a black background otherwise.
(Old regression that dates back to my alpha shenanigans a few months
ago)