### PR TITLE
Simplify isWifiOn on Kobo

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -406,7 +406,22 @@ function Kobo:initNetworkManager(NetworkMgr)
     -- NOTE: Cheap-ass way of checking if WiFi seems to be enabled...
     --       Since the crux of the issues lies in race-y module unloading, this is perfectly fine for our usage.
     function NetworkMgr:isWifiOn()
-        return 0 == os.execute("lsmod | grep -q " .. (os.getenv("WIFI_MODULE") or "sdio_wifi_pwr"))
+        local fd = io.open("/proc/modules", "r")
+        if fd then
+            local lsmod = fd:read("*all")
+            fd:close()
+            -- lsmod is usually empty, unless WiFi or USB is enabled
+            -- We could alternatively check if lfs.attributes("/proc/sys/net/ipv4/conf/" .. os.getenv("INTERFACE"), "mode") == "directory"
+            -- c.f., also what Cervantes does via /sys/class/net/eth0/carrier to check if the interface is up.
+            -- That said, since we only care about whether *modules* are loaded, this does the job nicely.
+            if lsmod:len() > 0 then
+                local module = os.getenv("WIFI_MODULE") or "sdio_wifi_pwr"
+                if lsmod:find(module) then
+                    return true
+                end
+            end
+        end
+        return false
     end
 end
 


### PR DESCRIPTION
Don't fork for lsmod + grep, we can perfectly well parse /proc/modules
ourselves ;).

c.f., https://github.com/koreader/koreader/pull/5203#issuecomment-521277628