### PR TITLE
PocketBook 626 new codename

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -342,7 +342,8 @@ elseif codename == "PocketBook 624" then
     return PocketBook624
 elseif codename == "PB625" then
     return PocketBook625
-elseif codename == "PB626" or codename == "PocketBook 626" then
+elseif codename == "PB626" or codename == "PB626(2)-TL3" or
+    codename == "PocketBook 626" then
     return PocketBook626
 elseif codename == "PB627" then
     return PocketBook627


### PR DESCRIPTION
Similar to #4474

PocketBook Touch Lux 3 (626) seems to have a new codename with the latest firmware (mine is FR626.5.14.1228 released on 20170718_143341)