### PR TITLE
bump crengine and others, adds HTML extended debug view

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -705,6 +705,7 @@ function ReaderHighlight:viewSelectionHTML(debug_view)
                     table.insert(buttons_table, {button})
                 end
             end
+            local next_debug_text
             local next_debug_view = debug_view + 1
             if next_debug_view == 1 then
                 next_debug_text = _("Switch to debug view")

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -782,6 +782,11 @@ function CreDocument:setStatusLineProp(prop)
     self._document:setStringProperty("window.status.line", prop)
 end
 
+function CreDocument:setBackgroundImage(img_path) -- use nil to unset
+    logger.dbg("CreDocument: set background image", img_path)
+    self._document:setBackgroundImage(img_path)
+end
+
 function CreDocument:findText(pattern, origin, reverse, caseInsensitive)
     logger.dbg("CreDocument: find text", pattern, origin, reverse, caseInsensitive)
     return self._document:findText(


### PR DESCRIPTION
Bump crengine https://github.com/koreader/crengine/pull/305 :
- View HTML: option to show text unicode codepoints
- Fix attribute parsing: decode &-encoded chars
- Text: allow wrap after more unicode spaces and hyphen (Closes #5191)
- Fix: no left hanging when hanging punctuation disabled
- lvtextfm.cpp: more comments, some formatting cleanup
- Optimize background image drawing
- CSS: fix background-image file path resolution

Bump harfbuzz to 2.6.0 https://github.com/koreader/koreader-base/pull/917
Bump luasec to 0.8.1 https://github.com/koreader/koreader-base/pull/949

cre.cpp: https://github.com/koreader/koreader-base/pull/950
Adds `setBackgroundImage()` proxy function to crengine facility to set background textures (this is unrelated to the background-image CSS fixes).
No frontend code (yet) to select such an image (dunno if we should provide some free samples, let the user put his ones in styletweaks/ and build a menu for easy selection - or just use a a FileChooser).
For those interested to see, just add some of the tx_*.jpg files from https://github.com/koreader/crengine/tree/master/android/res/drawable in your koreader root directory, and add something like that:
```diff
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -122,6 +122,7 @@ function ReaderTypeset:onReadSettings(config)
         self.nightmode_images = (global == nil or global == 1) and 1 or 0
     end
     self:toggleNightmodeImages(self.nightmode_images)
+    self.ui.document:setBackgroundImage("tx_old_book.jpg")
 end

 function ReaderTypeset:onSaveSettings()
```

<kbd>![image](https://user-images.githubusercontent.com/24273478/63211666-ad198a80-c0fa-11e9-94e0-b04708b9b070.png)</kbd>
(This is totaly unbearable on eInk - at least on my Kobo GloHD, which doesn't really like grey -, but it may be interesting on Android.)

View HTML: adds a 3rd view (extended debug view), showing the unicode codepoint of each char and crengine rendereing methods.
<kbd>![image](https://user-images.githubusercontent.com/24273478/63211656-907d5280-c0fa-11e9-8105-1620cde67639.png)</kbd>
(might be only useful to me, but I need the first debug view without all that).