### PR TITLE
[Desktop]: Open writable font dir in FM, toggle between system+user and user fonts, fix openLink on mac...

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -49,6 +49,9 @@ function ReaderFont:init()
     end
     -- build face_table for menu
     self.face_table = {}
+    if Device:isDesktop() then
+        table.insert(self.face_table, require("ui/elements/font_settings"):getMenuTable())
+    end
     local face_list = cre.getFontFaces()
     for k,v in ipairs(face_list) do
         table.insert(self.face_table, {

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -40,6 +40,9 @@ local Device = {
     canToggleGSensor = no,
     canToggleMassStorage = no,
     canUseWAL = yes, -- requires mmap'ed I/O on the target FS
+    canRestart = yes,
+    canReboot = no,
+    canPowerOff = no,
 
     -- use these only as a last resort. We should abstract the functionality
     -- and have device dependent implementations in the corresponting
@@ -53,9 +56,7 @@ local Device = {
     isSonyPRSTUX = no,
     isSDL = no,
     isEmulator = no,
-    canRestart = yes,
-    canReboot = no,
-    canPowerOff = no,
+    isDesktop = no,
 
     -- some devices have part of their screen covered by the bezel
     viewport = nil,

--- a/frontend/document/canvascontext.lua
+++ b/frontend/document/canvascontext.lua
@@ -37,6 +37,7 @@ The following key is required for a device object:
 function CanvasContext:init(device)
     self.screen = device.screen
     self.isAndroid = device.isAndroid
+    self.isDesktop = device.isDesktop
     self.isKindle = device.isKindle
     self.should_restrict_JIT = device.should_restrict_JIT
     self:setColorRenderingEnabled(device.screen.isColorEnabled())

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -65,6 +65,8 @@ end
 local function getExternalFontDir()
     if CanvasContext.isAndroid() then
         return ANDROID_FONT_DIR
+    elseif CanvasContext.isDesktop() then
+        return require("frontend/ui/elements/font_settings"):getPath()
     else
         return os.getenv("EXT_FONT_DIR")
     end

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -1,0 +1,81 @@
+local Device = require("device")
+local logger = require("logger")
+local util = require("util")
+local _ = require("gettext")
+
+--[[ Font settings for desktop linux and mac ]]--
+
+local function getUserDir()
+    return os.getenv("HOME").."/.local/share/fonts"
+end
+
+-- System fonts are common in linux
+local function getSystemDir()
+    local path = "/usr/share/fonts"
+    if util.pathExists(path) then
+        return path
+    else
+        -- mac doesn't use ttf fonts
+        return nil
+    end
+end
+
+local function usesSystemFonts()
+    return G_reader_settings:isTrue("system_fonts")
+end
+
+local function openFontDir()
+    local user_dir = getUserDir()
+    local openable = util.pathExists(user_dir)
+    if not openable then
+        logger.info("Font path not found, making one in ", user_dir)
+        openable = util.makePath(user_dir)
+    end
+    if not openable then
+        logger.warn("Unable to create the folder ", user_dir)
+        return
+    end
+    if Device:canOpenLink() then
+        Device:openLink(user_dir)
+    end
+end
+
+local FontSettings = {}
+
+function FontSettings:getPath()
+    if usesSystemFonts() then
+        local system_path = getSystemDir()
+        if system_path ~= nil then
+            return getUserDir()..";"..system_path
+        end
+    end
+    return getUserDir()
+end
+
+function FontSettings:getMenuTable()
+    return {
+        text = _("Font settings"),
+        separator = true,
+        sub_item_table = {
+            {
+                text = _("Enable system fonts"),
+                checked_func = usesSystemFonts,
+                callback = function()
+                    G_reader_settings:saveSetting("system_fonts", not usesSystemFonts())
+                    local UIManager = require("ui/uimanager")
+                    local InfoMessage = require("ui/widget/infomessage")
+                    UIManager:show(InfoMessage:new{
+                        text = _("This will take effect on next restart.")
+                    })
+                end,
+            },
+            {
+                text = _("Open fonts folder"),
+                keep_menu_open = true,
+                callback = openFontDir,
+            },
+        }
+    }
+end
+
+return FontSettings

--- a/platform/appimage/AppRun
+++ b/platform/appimage/AppRun
@@ -10,9 +10,6 @@ cd "${KOREADER_DIR}" || exit
 # export load library path
 export LD_LIBRARY_PATH=${KOREADER_DIR}/libs:$LD_LIBRARY_PATH
 
-# export external font directory
-export EXT_FONT_DIR="${HOME}/.fonts"
-
 RETURN_VALUE=85
 
 if [ $# -eq 0 ]; then

--- a/platform/debian/koreader.sh
+++ b/platform/debian/koreader.sh
@@ -23,10 +23,6 @@ cd "${KOREADER_DIR}" || exit
 # export load library path
 export LD_LIBRARY_PATH=${KOREADER_DIR}/libs:$LD_LIBRARY_PATH
 
-# export external font directory
-export EXT_FONT_DIR="${HOME}/.config/koreader/fonts"
-[ ! -d "${EXT_FONT_DIR}" ] && mkdir -pv "${EXT_FONT_DIR}"
-
 RETURN_VALUE=85
 while [ $RETURN_VALUE -eq 85 ]; do
     ./reader.lua "${ARGS}"


### PR DESCRIPTION
~~I enabled it on the emulator just to test (I needed to export EXT_FONT_DIR =~/.local/share/fonts)~~

~~The emulator should be removed since we cannot grant it is linux.~~

~~The user has a menu to switch from its own set of fonts (~/.local/share/fonts) and system fonts (/usr/share/fonts). If the user chooses her/his own fonts she/he can open it on the file manager (via xdg-open).~~

~~It seems a bit hacky but works really well.~~

~~The user can toggle system fonts. The toggle just creates or deletes a symbolic link to /usr/share/fonts in a folder inside our EXT_FONT_DIR.~~

Thanks to @poire-z and @Frenzie for the hints!

**to-do**:
- ~~place the new submenu somewhere.~~
- ~~remove the emulator from isDesktopLinux.~~
- ~~enable "open dir in fm" just if "xdg-open" exists.~~
- ~~infomessage saying "changes will apply after a restart (not true, changes will apply on the next cr3 document loaded, but that is harder to explain :man_facepalming:~~ )
- ~~more sanity checks ¿?~~

Fixes #5093 