### PR TITLE
[i18n, feat] Add basic context (msgctxt) support

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -21,9 +21,9 @@ function GetText_mt.__call(gettext, ...)
     end
     if argc == 2 then
         -- gettext.dgettext
-        local context = select(1, ...)
+        local domain = select(1, ...)
         local string = select(2, ...)
-        return gettext.context[context] and gettext.context[context][string] or string
+        return gettext.domain[domain] and gettext.domain[domain][string] or string
     end
     --if argc == 3 then -- gettext.ngettext end
     --if argc == 4 then -- gettext.dngettext end
@@ -49,7 +49,7 @@ end
 -- we only implement a sane subset for now
 
 function GetText_mt.__index.changeLang(new_lang)
-    GetText.context = {}
+    GetText.domain = {}
     GetText.translation = {}
     GetText.current_lang = "C"
 
@@ -77,10 +77,10 @@ function GetText_mt.__index.changeLang(new_lang)
             if data.msgid and data.msgstr and data.msgstr ~= "" then
                 local unescaped_string = string.gsub(data.msgstr, "\\(.)", c_escape)
                 if data.msgctxt and data.msgctxt ~= "" then
-                    if not GetText.context[data.msgctxt] then
-                        GetText.context[data.msgctxt] = {}
+                    if not GetText.domain[data.msgctxt] then
+                        GetText.domain[data.msgctxt] = {}
                     end
-                    GetText.context[data.msgctxt][data.msgid] = unescaped_string
+                    GetText.domain[data.msgctxt][data.msgid] = unescaped_string
                 else
                     GetText.translation[data.msgid] = unescaped_string
                 end

--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -75,13 +75,14 @@ function GetText_mt.__index.changeLang(new_lang)
         local line = po:read("*l")
         if line == nil or line == "" then
             if data.msgid and data.msgstr and data.msgstr ~= "" then
+                local unescaped_string = string.gsub(data.msgstr, "\\(.)", c_escape)
                 if data.msgctxt and data.msgctxt ~= "" then
                     if not GetText.context[data.msgctxt] then
                         GetText.context[data.msgctxt] = {}
                     end
-                    GetText.context[data.msgctxt][data.msgid] = string.gsub(data.msgstr, "\\(.)", c_escape)
+                    GetText.context[data.msgctxt][data.msgid] = unescaped_string
                 else
-                    GetText.translation[data.msgid] = string.gsub(data.msgstr, "\\(.)", c_escape)
+                    GetText.translation[data.msgid] = unescaped_string
                 end
             end
             -- stop at EOF:

--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -101,7 +101,7 @@ function GetText_mt.__index.changeLang(new_lang)
 end
 
 function GetText_mt.__index.pgettext(msgctxt, msgstr)
-    return GetText.context[msgctxt] and GetText.msgctxt[context][msgstr] or msgstr
+    return GetText.context[msgctxt] and GetText.context[msgctxt][msgstr] or msgstr
 end
 
 setmetatable(GetText, GetText_mt)

--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -101,7 +101,7 @@ function GetText_mt.__index.changeLang(new_lang)
 end
 
 function GetText_mt.__index.pgettext(msgctxt, msgstr)
-    return GetText.context[msgctxt] and gettext.msgctxt[context][msgstr] or msgstr
+    return GetText.context[msgctxt] and GetText.msgctxt[context][msgstr] or msgstr
 end
 
 setmetatable(GetText, GetText_mt)

--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -21,9 +21,9 @@ function GetText_mt.__call(gettext, ...)
     end
     if argc == 2 then
         -- gettext.dgettext
-        local domain = select(1, ...)
+        local context = select(1, ...)
         local string = select(2, ...)
-        return gettext.domain[domain] and gettext.domain[domain][string] or string
+        return gettext.context[context] and gettext.context[context][string] or string
     end
     --if argc == 3 then -- gettext.ngettext end
     --if argc == 4 then -- gettext.dngettext end
@@ -49,7 +49,7 @@ end
 -- we only implement a sane subset for now
 
 function GetText_mt.__index.changeLang(new_lang)
-    GetText.domain = {}
+    GetText.context = {}
     GetText.translation = {}
     GetText.current_lang = "C"
 
@@ -77,10 +77,10 @@ function GetText_mt.__index.changeLang(new_lang)
             if data.msgid and data.msgstr and data.msgstr ~= "" then
                 local unescaped_string = string.gsub(data.msgstr, "\\(.)", c_escape)
                 if data.msgctxt and data.msgctxt ~= "" then
-                    if not GetText.domain[data.msgctxt] then
-                        GetText.domain[data.msgctxt] = {}
+                    if not GetText.context[data.msgctxt] then
+                        GetText.context[data.msgctxt] = {}
                     end
-                    GetText.domain[data.msgctxt][data.msgid] = unescaped_string
+                    GetText.context[data.msgctxt][data.msgid] = unescaped_string
                 else
                     GetText.translation[data.msgid] = unescaped_string
                 end

--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -12,21 +12,8 @@ local GetText_mt = {
     __index = {}
 }
 
-function GetText_mt.__call(gettext, ...)
-    local argc = select("#", ...)
-    if argc == 1 then
-        -- gettext.gettext
-        local string = select(1, ...)
-        return gettext.translation[string] or string
-    end
-    if argc == 2 then
-        -- gettext.dgettext
-        local context = select(1, ...)
-        local string = select(2, ...)
-        return gettext.context[context] and gettext.context[context][string] or string
-    end
-    --if argc == 3 then -- gettext.ngettext end
-    --if argc == 4 then -- gettext.dngettext end
+function GetText_mt.__call(gettext, msgstr)
+    return gettext.translation[msgstr] or msgstr
 end
 
 local function c_escape(what)
@@ -111,6 +98,10 @@ function GetText_mt.__index.changeLang(new_lang)
         end
     end
     GetText.current_lang = new_lang
+end
+
+function GetText_mt.__index.pgettext(msgctxt, msgstr)
+    return GetText.context[msgctxt] and gettext.msgctxt[context][msgstr] or msgstr
 end
 
 setmetatable(GetText, GetText_mt)


### PR DESCRIPTION
References https://github.com/koreader/koreader/issues/5232

Given an entry in the PO file like the following:

```
msgctxt "systemstat"
msgid "    Total"
msgstr "Totaal"
```

It can be addressed using:

```lua
_("systemstat", "    Total")
```

This allows to distinguish between separate instances of the same string, for example "Pages" meaning "Number of pages" and "Pages" meaning "Display of pages".

Extraction of this code pattern is not yet implemented by nightswatcher. xgettext didn't yet support Lua back in 2013 when all this was first added to the program, but now it does. Therefore it might make the most sense to replace the current Python extraction script with xgettext itself.

By default it only understands gettext.dgettext(), but that can be addressed by passing some extra command line arguments, for example:

```
xgettext -l lua -c --keyword=_:1c,2 *.lua
```