### PR TITLE
[i18n] Switch `make pot` to xgettext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,15 +462,15 @@ pocketbook-toolchain:
 # for gettext
 DOMAIN=koreader
 TEMPLATE_DIR=l10n/templates
-KOREADER_MISC_TOOL=../koreader-misc
-XGETTEXT_BIN=$(KOREADER_MISC_TOOL)/gettext/lua_xgettext.py
+XGETTEXT_BIN=xgettext
 
 pot:
 	mkdir -p $(TEMPLATE_DIR)
-	$(XGETTEXT_BIN) reader.lua `find frontend -iname "*.lua"` \
+	$(XGETTEXT_BIN) --from-code=utf-8 --keyword=C_:1c,2 \
+		reader.lua `find frontend -iname "*.lua"` \
 		`find plugins -iname "*.lua"` \
 		`find tools -iname "*.lua"` \
-		> $(TEMPLATE_DIR)/$(DOMAIN).pot
+		-o $(TEMPLATE_DIR)/$(DOMAIN).pot
 	# push source file to Transifex
 	$(MAKE) -i -C l10n bootstrap
 	$(MAKE) -C l10n push

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -14,7 +14,7 @@ local C_ = _.pgettext
 
 local CssTweaks = {
     {
-        title = C_("Menu|StyleTweaks|", "Pages"),
+        title = C_("StyleTweaksCategory", "Pages"),
         {
             id = "margin_body_0";
             title = _("Ignore publisher page margins"),

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -10,10 +10,11 @@ They may have the following optional attributes:
 ]]
 
 local _ = require("gettext")
+local C_ = _.pgettext
 
 local CssTweaks = {
     {
-        title = _("Pages"),
+        title = C_("Menu|StyleTweaks|", "Pages"),
         {
             id = "margin_body_0";
             title = _("Ignore publisher page margins"),

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -14,7 +14,7 @@ local C_ = _.pgettext
 
 local CssTweaks = {
     {
-        title = C_("StyleTweaksCategory", "Pages"),
+        title = C_("Style tweaks category", "Pages"),
         {
             id = "margin_body_0";
             title = _("Ignore publisher page margins"),


### PR DESCRIPTION
This introduces context to our strings to differentiate them when necessary.

The syntax chosen is `C_()`, following [glib](https://developer.gnome.org/glib/2.28/glib-I18N.html#C-:CAPS).

```lua
local _ = require("gettext")
local C_ = _.pgettext

C_("Menu|StyleTweaks|", "Pages")
```

Closes #5232.