### PR TITLE
Git ignore .directory files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_*
 ._*
+*.directory
 *.swp
 *.swo
 *.un~


### PR DESCRIPTION
They're created by Dolphin by default to store per-directory view settings.