### PR TITLE
migrate from lzma to zip file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,11 +346,24 @@ androidupdate: all
 	-rm $(ANDROID_LAUNCHER_DIR)/assets/module/koreader-*
 	# in runtime luajit-launcher's libluajit.so will be loaded
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
-	# make android update apk
-	cd $(INSTALL_DIR)/koreader && 7z a -l -m0=lzma2 -mx=1 \
-		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).7z * \
-		-x!resources/fonts -x!resources/icons/src -x!spec
-	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) $(if $(KODEBUG), debug, release) ANDROID_APPNAME=KOReader ANDROID_VERSION=$(ANDROID_VERSION) ANDROID_NAME=$(ANDROID_NAME) ANDROID_FLAVOR=$(ANDROID_FLAVOR)
+
+        # assets are compressed manually and stored inside the APK.
+	cd $(INSTALL_DIR)/koreader && zip -r9 \
+		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).zip * \
+		--exclude=*resources/fonts* \
+		--exclude=*resources/icons/src* \
+		--exclude=*share/man* \
+		--exclude=*spec* \
+		--exclude=*COPYING* \
+		--exclude=*README.md*
+
+	# make the android APK
+	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) $(if $(KODEBUG), debug, release) \
+		ANDROID_APPNAME=KOReader \
+		ANDROID_VERSION=$(ANDROID_VERSION) \
+		ANDROID_NAME=$(ANDROID_NAME) \
+		ANDROID_FLAVOR=$(ANDROID_FLAVOR)
+
 	cp $(ANDROID_LAUNCHER_DIR)/bin/NativeActivity.apk \
 		koreader-android-$(ANDROID_ARCH)$(KODEDUG_SUFFIX)-$(VERSION).apk
 

--- a/kodev
+++ b/kodev
@@ -9,15 +9,7 @@ fi
 
 # Default Android build to arm.
 ANDROID_ARCH="${ANDROID_ARCH:-arm}"
-if [ -z "${ANDROID_FULL_ARCH}" ]; then
-    if [ "${ANDROID_ARCH}" = "arm" ]; then
-        ANDROID_FULL_ARCH_APK="${ANDROID_FULL_ARCH_APK:-arm-linux-androideabi}"
-    elif [ "${ANDROID_ARCH}" = "x86" ]; then
-        ANDROID_FULL_ARCH_APK="${ANDROID_FULL_ARCH_APK:-i686-linux-android}"
-    else
-        ANDROID_FULL_ARCH_APK="${ANDROID_ARCH}"
-    fi
-fi
+
 # Default to Android 4.0+; required for NDK 15 but with a custom NDK the strict minimum is 9.
 NDKABI=${NDKABI:-14}
 export NDKABI
@@ -625,7 +617,7 @@ TARGET:
                 # uninstall existing package to make sure *everything* is gone from memory
                 # no assert_ret_zero; uninstall is allowed to fail if there's nothing to uninstall
                 adb uninstall "org.koreader.launcher"
-                adb install "koreader-android-${ANDROID_FULL_ARCH_APK}${KODEBUG_SUFFIX}-${VERSION}.apk"
+                adb install "koreader-android-${ANDROID_ARCH}${KODEBUG_SUFFIX}-${VERSION}.apk"
                 assert_ret_zero $?
                 # there's no adb run so we do this…
                 adb shell monkey -p org.koreader.launcher -c android.intent.category.LAUNCHER 1

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -1,33 +1,29 @@
-local A = require("android")
-A.dl.library_path = A.dl.library_path .. ":" .. A.dir .. "/libs"
+local android = require("android")
+android.dl.library_path = android.dl.library_path .. ":" .. android.dir .. "/libs"
 
 local ffi = require("ffi")
 local dummy = require("ffi/posix_h")
 local C = ffi.C
 
 -- check uri of the intent that starts this application
-local file = A.getIntent()
+local file = android.getIntent()
 
 if file ~= nil then
-    A.LOGI("intent file path " .. file)
+    android.LOGI("intent file path " .. file)
 end
 
 -- run koreader patch before koreader startup
 pcall(dofile, "/sdcard/koreader/patch.lua")
 
--- set proper permission for binaries
-A.execute("chmod", "755", "./sdcv")
-A.execute("chmod", "755", "./tar")
-A.execute("chmod", "755", "./zsync")
-
 -- set TESSDATA_PREFIX env var
 C.setenv("TESSDATA_PREFIX", "/sdcard/koreader/data", 1)
 
 -- create fake command-line arguments
-if A.isDebuggable() then
+-- luacheck: ignore 121
+if android.isDebuggable() then
     arg = {"-d", file or "/sdcard"}
 else
     arg = {file or "/sdcard"}
 end
 
-dofile(A.dir.."/reader.lua")
+dofile(android.dir.."/reader.lua")


### PR DESCRIPTION
Requires https://github.com/koreader/android-luajit-launcher/pull/174 ~~and https://github.com/koreader/android-luajit-launcher/pull/175~~

The main benefit of having the libraries outside the zip file is that they will be installed when installing the application instead of copying them on the first run (it could save a few seconds)

**Edit:** I'm leaving the libs thingy for the future.