### PR TITLE
[fix, UX] Update kosync login/logout text

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -96,9 +96,16 @@ function KOSync:addToMainMenu(menu_items)
                 end,
                 keep_menu_open = true,
                 callback_func = function()
-                    return self.kosync_userkey and
-                        function() self:logout() end or
-                        function() self:login() end
+                    if self.kosync_userkey then
+                        return function(menu)
+                            self._menu_to_update = menu
+                            self:logout()
+                        end
+                    else
+                        return function(menu)
+                            self._menu_to_update = menu
+                            self:login()
+                        end
                 end,
             },
             {
@@ -328,6 +335,7 @@ function KOSync:doRegister(username, password)
     elseif status then
         self.kosync_username = username
         self.kosync_userkey = userkey
+        self._menu_to_update:updateItems()
         UIManager:show(InfoMessage:new{
             text = _("Registered to KOReader server."),
         })
@@ -363,6 +371,7 @@ function KOSync:doLogin(username, password)
     elseif status then
         self.kosync_username = username
         self.kosync_userkey = userkey
+        self._menu_to_update:updateItems()
         UIManager:show(InfoMessage:new{
             text = _("Logged in to KOReader server."),
         })
@@ -378,6 +387,7 @@ end
 function KOSync:logout()
     self.kosync_userkey = nil
     self.kosync_auto_sync = true
+    self._menu_to_update:updateItems()
     self:saveSettings()
 end
 

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -106,6 +106,7 @@ function KOSync:addToMainMenu(menu_items)
                             self._menu_to_update = menu
                             self:login()
                         end
+                    end
                 end,
             },
             {


### PR DESCRIPTION
As a side effect of <https://github.com/koreader/koreader/pull/4189> some menus have to manually trigger updates.

I'm not overly enthused with this solution but I couldn't think of anything better right now.

Fixes <https://github.com/koreader/koreader/issues/5224>.