### PR TITLE
[UX] Treat inverse_reading_order as a proper setting

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -239,8 +239,8 @@ function ReaderPaging:addToMainMenu(menu_items)
         end,
         sub_item_table = page_overlap_menu,
     }
-    menu_items.read_from_right_to_left = {
-        text = _("Read from right to left"),
+    menu_items.invert_page_turn_gestures = {
+        text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
             self.inverse_reading_order = not self.inverse_reading_order

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -253,8 +253,6 @@ function ReaderPaging:addToMainMenu(menu_items)
                 ok_text = self.inverse_reading_order and _("Enable")
                     or _("Disable"),
                 ok_callback = function()
-                    self.inverse_reading_order = not self.inverse_reading_order
-                    self:setupTapTouchZones()
                     G_reader_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -247,14 +247,14 @@ function ReaderPaging:addToMainMenu(menu_items)
             self:setupTapTouchZones()
         end,
         hold_callback = function(touchmenu_instance)
-            self.inverse_reading_order = not self.inverse_reading_order
-            self:setupTapTouchZones()
             UIManager:show(ConfirmBox:new{
                 text = self.inverse_reading_order and _("Enable right to left reading by default?")
                     or _("Disable right to left reading by default?"),
                 ok_text = self.inverse_reading_order and _("Enable")
                     or _("Disable"),
                 ok_callback = function()
+                    self.inverse_reading_order = not self.inverse_reading_order
+                    self:setupTapTouchZones()
                     G_reader_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -357,14 +357,14 @@ function ReaderRolling:addToMainMenu(menu_items)
             self:setupTouchZones()
         end,
         hold_callback = function(touchmenu_instance)
-            self.inverse_reading_order = not self.inverse_reading_order
-            self:setupTouchZones()
             UIManager:show(ConfirmBox:new{
                 text = self.inverse_reading_order and _("Enable right to left reading by default?")
                     or _("Disable right to left reading by default?"),
                 ok_text = self.inverse_reading_order and _("Enable")
                     or _("Disable"),
                 ok_callback = function()
+                    self.inverse_reading_order = not self.inverse_reading_order
+                    self:setupTouchZones()
                     G_reader_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -349,8 +349,8 @@ end
 
 function ReaderRolling:addToMainMenu(menu_items)
     --- @fixme Repeated code with ReaderPaging read from left to right.
-    menu_items.read_from_right_to_left = {
-        text = _("Read from right to left"),
+    menu_items.invert_page_turn_gestures = {
+        text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
             self.inverse_reading_order = not self.inverse_reading_order

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -363,8 +363,6 @@ function ReaderRolling:addToMainMenu(menu_items)
                 ok_text = self.inverse_reading_order and _("Enable")
                     or _("Disable"),
                 ok_callback = function()
-                    self.inverse_reading_order = not self.inverse_reading_order
-                    self:setupTouchZones()
                     G_reader_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -37,7 +37,6 @@ local order = {
         "highlight_options",
     },
     setting = {
-        "read_from_right_to_left",
         -- common settings
         -- those that don't exist will simply be skipped during menu gen
         "frontlight", -- if Device:hasFrontlight()
@@ -70,6 +69,7 @@ local order = {
         "enable_back_history",
         "android_volume_keys",
         "----------------------------",
+        "invert_page_turn_gestures",
         "invert_page_turn_buttons",
     },
     network = {


### PR DESCRIPTION
This is supported by ReaderPaging and ReaderRolling, but the menu entry was only shown in ReaderPaging.

Hold now sets the global default.

Fixes <https://github.com/koreader/koreader/issues/4983>.
Fixes <https://github.com/koreader/koreader/issues/4089>. 