### PR TITLE
[fix] Pass plain link to link:onGotoLink

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -861,7 +861,8 @@ function ReaderHighlight:onHoldRelease()
                     {
                         text = _("Follow Link"),
                         callback = function()
-                            self.ui.link:onGotoLink(self.selected_link)
+                            local link = self.selected_link.link or self.selected_link
+                            self.ui.link:onGotoLink(link)
                             self:onClose()
                         end,
                     },

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -457,8 +457,9 @@ function DictQuickLookup:update()
                             UIManager:close(self)
                             self:lookupWikipedia()
                         else
+                            local link = self.selected_link.link or self.selected_link
+                            self.ui.link:onGotoLink(link)
                             self:onClose()
-                            self.ui.link:onGotoLink(self.selected_link)
                         end
                     end,
                 },


### PR DESCRIPTION
Internal links carry more baggage than external ones.

See <https://github.com/koreader/koreader/pull/5282#issuecomment-526813719>.