### PR TITLE
[fix] Prevent crash when no page boxes

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1048,10 +1048,12 @@ function KoptInterface:getPageBoxesFromPositions(doc, pageno, ppos0, ppos1)
         local spos0 = self:nativeToReflowPosTransform(doc, pageno, ppos0)
         local spos1 = self:nativeToReflowPosTransform(doc, pageno, ppos1)
         local page_boxes = self:getReflowedTextBoxes(doc, pageno)
+        if not page_boxes then return end
         local text_boxes = self:getTextFromBoxes(page_boxes, spos0, spos1)
         return text_boxes.boxes
     else
         local page_boxes = self:getTextBoxes(doc, pageno)
+        if not page_boxes then return end
         local text_boxes = self:getTextFromBoxes(page_boxes, ppos0, ppos1)
         return text_boxes.boxes
     end

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1048,12 +1048,18 @@ function KoptInterface:getPageBoxesFromPositions(doc, pageno, ppos0, ppos1)
         local spos0 = self:nativeToReflowPosTransform(doc, pageno, ppos0)
         local spos1 = self:nativeToReflowPosTransform(doc, pageno, ppos1)
         local page_boxes = self:getReflowedTextBoxes(doc, pageno)
-        if not page_boxes then return end
+        if not page_boxes then
+            logger.warn("KoptInterface: missing page_boxes")
+            return
+        end
         local text_boxes = self:getTextFromBoxes(page_boxes, spos0, spos1)
         return text_boxes.boxes
     else
         local page_boxes = self:getTextBoxes(doc, pageno)
-        if not page_boxes then return end
+        if not page_boxes then
+            logger.warn("KoptInterface: missing page_boxes")
+            return
+        end
         local text_boxes = self:getTextFromBoxes(page_boxes, ppos0, ppos1)
         return text_boxes.boxes
     end


### PR DESCRIPTION
Can occur with invalid page numbers, for example by changing the font size in a reflowable MuPDF document.

Discussion in <https://github.com/koreader/koreader/pull/5282#issuecomment-526842921>.