### PR TITLE
Reorganize tap corner menu in Gesture Manager

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -256,20 +256,20 @@ function ReaderGesture:addToMainMenu(menu_items)
         text = _("Tap corner"),
         sub_item_table = {
             {
-                text = _("Tap top left corner"),
+                text_func = function() return actionTextFunc("tap_top_left_corner", _("Top left")) end,
                 enabled_func = function() return self.ges_mode == "gesture_reader" end,
                 sub_item_table = self:buildMenu("tap_top_left_corner", self.default_gesture["tap_top_left_corner"]),
             },
             {
-                text = _("Tap top right corner"),
+                text_func = function() return actionTextFunc("tap_top_right_corner", _("Top right")) end,
                 sub_item_table = self:buildMenu("tap_top_right_corner", self.default_gesture["tap_top_right_corner"]),
             },
             {
-                text = _("Tap bottom left corner"),
+                text_func = function() return actionTextFunc("tap_left_bottom_corner", _("Bottom left")) end,
                 sub_item_table = self:buildMenu("tap_left_bottom_corner", self.default_gesture["tap_left_bottom_corner"]),
             },
             {
-                text = _("Tap bottom right corner"),
+                text_func = function() return actionTextFunc("tap_right_bottom_corner", _("Bottom right")) end,
                 sub_item_table = self:buildMenu("tap_right_bottom_corner", self.default_gesture["tap_right_bottom_corner"]),
                 separator = true,
             },


### PR DESCRIPTION
Reorganize submenu tap corner like other submenus
Settings -> Tap and gestures -> Gesture manager -> Tap corner

Before:
![obraz](https://user-images.githubusercontent.com/22982594/64074958-50010580-ccb2-11e9-9ea4-6a69602f6f63.png)

After:
![obraz](https://user-images.githubusercontent.com/22982594/64074961-57c0aa00-ccb2-11e9-9f37-9c4afdc51eca.png)
