### PR TITLE
[fix] GetText: guard against empty strings in translation

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -137,18 +137,18 @@ local function addTranslation(msgctxt, msgid, msgstr, n)
             if not GetText.context[msgctxt][msgid] then
                 GetText.context[msgctxt][msgid] = {}
             end
-            GetText.context[msgctxt][msgid][n] = unescaped_string
+            GetText.context[msgctxt][msgid][n] = unescaped_string ~= "" and unescaped_string or nil
         else
-            GetText.context[msgctxt][msgid] = unescaped_string
+            GetText.context[msgctxt][msgid] = unescaped_string ~= "" and unescaped_string or nil
         end
     else
         if n then
             if not GetText.translation[msgid] then
                 GetText.translation[msgid] = {}
             end
-            GetText.translation[msgid][n] = unescaped_string
+            GetText.translation[msgid][n] = unescaped_string ~= "" and unescaped_string or nil
         else
-            GetText.translation[msgid] = unescaped_string
+            GetText.translation[msgid] = unescaped_string ~= "" and unescaped_string or nil
         end
     end
 end

--- a/spec/unit/gettext_spec.lua
+++ b/spec/unit/gettext_spec.lua
@@ -96,6 +96,7 @@ describe("GetText module", function()
     local GetText
     local test_po_nl, test_po_ru
     local test_po_none, test_po_simple
+    local test_po_many
 
     setup(function()
         require("commonrequire")


### PR DESCRIPTION
Fixes <https://github.com/koreader/koreader/issues/5293>.