### PR TITLE
Revert "[feat, Kobo] Implement shutdown from suspend (#5280)"

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -341,12 +341,20 @@ function Input:handleKeyBoardEv(ev)
     end
 
     if keycode == "Power" then
+        --- @fixme This hacky Kobo code is also used by Cervantes and Sony.
+        -- Input is **not** the place where this should turn into "Resume".
         -- Kobo generates Power keycode only, we need to decide whether it's
         -- power-on or power-off ourselves.
-        if ev.value == EVENT_VALUE_KEY_PRESS then
-            return "PowerPress"
-        elseif ev.value == EVENT_VALUE_KEY_RELEASE then
-            return "PowerRelease"
+        if self.device.screen_saver_mode then
+            if ev.value == EVENT_VALUE_KEY_RELEASE then
+                return "Resume"
+            end
+        else
+            if ev.value == EVENT_VALUE_KEY_PRESS then
+                return "PowerPress"
+            elseif ev.value == EVENT_VALUE_KEY_RELEASE then
+                return "PowerRelease"
+            end
         end
     end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -109,19 +109,12 @@ function UIManager:init()
             end
         end
         self.event_handlers["PowerPress"] = function()
-            -- Always schedule power off.
-            -- Press the power button for 2+ seconds to shutdown directly from suspend.
             UIManager:scheduleIn(2, self.poweroff_action)
         end
         self.event_handlers["PowerRelease"] = function()
             if not self._entered_poweroff_stage then
                 UIManager:unschedule(self.poweroff_action)
-                -- resume if we were suspended
-                if Device.screen_saver_mode then
-                    self:resume()
-                else
-                    self:suspend()
-                end
+                self:suspend()
             end
         end
         -- Sleep Cover handling


### PR DESCRIPTION
This reverts commit cfa73be940e2468c353f5737a0e76f722362dcc6.

Cervantes and Sony secretly depend on hacky Kobo code.
Reported by @avsej, see <https://github.com/koreader/koreader/issues/2431#issuecomment-526925910>.

Closes <https://github.com/koreader/koreader/issues/5292>.