### PR TITLE
Add fine tune buttons to horizontal margins

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -64,6 +64,7 @@ Note that this may not be ensured under some conditions: in scroll mode, when a 
                 name = "h_page_margins",
                 name_text = S.H_PAGE_MARGINS,
                 buttonprogress = true,
+                fine_tune = true,
                 values = {
                     DCREREADER_CONFIG_H_MARGIN_SIZES_SMALL,
                     DCREREADER_CONFIG_H_MARGIN_SIZES_MEDIUM,

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -965,13 +965,28 @@ function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, 
             local value
             if direction == "-" then
                 value = self.configurable[name] or values[1]
-                value = value - 1
-                if value < 0 then
-                    value = 0
+                if type(value) == "table" then
+                    for i=1, #value do
+                        value[i] = value[i] - 1
+                        if value[i] < 0 then
+                            value[i] = 0
+                        end
+                    end
+                else
+                    value = value - 1
+                    if value < 0 then
+                        value = 0
+                    end
                 end
             else
                 value = self.configurable[name] or values[#values]
-                value = value + 1
+                if type(value) == "table" then
+                    for i=1, #value do
+                        value[i] = value[i] + 1
+                    end
+                else
+                    value = value + 1
+                end
             end
             self:onConfigChoice(name, value)
         end


### PR DESCRIPTION
Similar to top and bottom margins I add fine tune buttons to L/R margins.

Before: 
<img src=https://user-images.githubusercontent.com/22982594/64080043-a3457900-ccef-11e9-9a5a-376504b7353d.png width=70%>

After:
<img src=https://user-images.githubusercontent.com/22982594/64080046-a9d3f080-ccef-11e9-8883-e1f4dbec29ed.png width=70%>
