### PR TITLE
Allow setting a fine-tuned font size as default

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1062,7 +1062,6 @@ end
 -- Tweaked variant used with the fine_tune variant of buttonprogress (direction can only be "-" or "+")
 -- NOTE: This sets the defaults to the *current* value, as the -/+ buttons have no fixed value ;).
 function ConfigDialog:onMakeFineTuneDefault(name, name_text, values, labels, direction)
-    print("ConfigDialog:onMakeFineTuneDefault:", name, name_text, values, labels, direction)
     local display_value = self.configurable[name] or direction == "-" and labels[1] or labels[#labels]
 
     UIManager:show(ConfirmBox:new{
@@ -1074,9 +1073,6 @@ function ConfigDialog:onMakeFineTuneDefault(name, name_text, values, labels, dir
         ok_text = T(_("Set default")),
         ok_callback = function()
             name = self.config_options.prefix.."_"..name
-            print("name:", name)
-            print("configurable[name]", self.configurable[name])
-            print("display_value", display_value)
             G_reader_settings:saveSetting(name, display_value)
             self:update()
             UIManager:setDirty(self, function()

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1062,33 +1062,33 @@ end
 -- Tweaked variant used with the fine_tune variant of buttonprogress (direction can only be "-" or "+")
 -- NOTE: This sets the defaults to the *current* value, as the -/+ buttons have no fixed value ;).
 function ConfigDialog:onMakeFineTuneDefault(name, name_text, values, labels, direction)
-    local display_value = self.configurable[name] or direction == "-" and labels[1] or labels[#labels]
+    local current_value = self.configurable[name] or direction == "-" and labels[1] or labels[#labels]
 
-    local printable_value
+    local display_value
     -- known table value, make it pretty
     if name == "h_page_margins" then
-            printable_value = T(_([[
+            display_value = T(_([[
 
   left:  %1
   right: %2
 ]]),
-        display_value[1], display_value[2])
-    elseif type(display_value) == "table" then
-        printable_value = dump(display_value)
+        current_value[1], current_value[2])
+    elseif type(current_value) == "table" then
+        display_value = dump(current_value)
     else
-        printable_value = display_value
+        display_value = current_value
     end
 
     UIManager:show(ConfirmBox:new{
         text = T(
             _("Set default %1 to %2?"),
             (name_text or ""),
-            printable_value
+            display_value
         ),
         ok_text = T(_("Set default")),
         ok_callback = function()
             name = self.config_options.prefix.."_"..name
-            G_reader_settings:saveSetting(name, display_value)
+            G_reader_settings:saveSetting(name, current_value)
             self:update()
             UIManager:setDirty(self, function()
                 return "ui", self.dialog_frame.dimen

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1062,6 +1062,7 @@ end
 -- Tweaked variant used with the fine_tune variant of buttonprogress (direction can only be "-" or "+")
 -- NOTE: This sets the defaults to the *current* value, as the -/+ buttons have no fixed value ;).
 function ConfigDialog:onMakeFineTuneDefault(name, name_text, values, labels, direction)
+    print("ConfigDialog:onMakeFineTuneDefault:", name, name_text, values, labels, direction)
     local display_value = self.configurable[name] or direction == "-" and labels[1] or labels[#labels]
 
     UIManager:show(ConfirmBox:new{
@@ -1073,7 +1074,10 @@ function ConfigDialog:onMakeFineTuneDefault(name, name_text, values, labels, dir
         ok_text = T(_("Set default")),
         ok_callback = function()
             name = self.config_options.prefix.."_"..name
-            G_reader_settings:saveSetting(name, self.configurable[name])
+            print("name:", name)
+            print("configurable[name]", self.configurable[name])
+            print("display_value", display_value)
+            G_reader_settings:saveSetting(name, display_value)
             self:update()
             UIManager:setDirty(self, function()
                 return "ui", self.dialog_frame.dimen

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1064,11 +1064,26 @@ end
 function ConfigDialog:onMakeFineTuneDefault(name, name_text, values, labels, direction)
     local display_value = self.configurable[name] or direction == "-" and labels[1] or labels[#labels]
 
+    local printable_value
+    -- known table value, make it pretty
+    if name == "h_page_margins" then
+            printable_value = T(_([[
+
+  left:  %1
+  right: %2
+]]),
+        display_value[1], display_value[2])
+    elseif type(display_value) == "table" then
+        printable_value = dump(display_value)
+    else
+        printable_value = display_value
+    end
+
     UIManager:show(ConfirmBox:new{
         text = T(
             _("Set default %1 to %2?"),
             (name_text or ""),
-            display_value
+            printable_value
         ),
         ok_text = T(_("Set default")),
         ok_callback = function()

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -210,9 +210,20 @@ function ToggleSwitch:onTapSelect(arg, gev)
 end
 
 function ToggleSwitch:onHoldSelect(arg, gev)
+    print("Called ToggleSwitch:onHoldSelect:", arg, gev)
+    print("name:", self.name)
+    print("name_text:", self.name_text)
+    print("val:", self.values or self.args)
+    print("toggle:", self.toggle)
     local position = self:calculatePosition(gev)
-    self.config:onMakeDefault(self.name, self.name_text,
-                    self.values or self.args, self.toggle, position)
+    print("pos:", position)
+    if self.name == "font_fine_tune" then
+        self.config:onMakeFineTuneDefault("font_size", _("Font Size"),
+                        self.values or self.args, self.toggle, position == 1 and "-" or "+")
+    else
+        self.config:onMakeDefault(self.name, self.name_text,
+                        self.values or self.args, self.toggle, position)
+    end
     return true
 end
 

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -210,13 +210,7 @@ function ToggleSwitch:onTapSelect(arg, gev)
 end
 
 function ToggleSwitch:onHoldSelect(arg, gev)
-    print("Called ToggleSwitch:onHoldSelect:", arg, gev)
-    print("name:", self.name)
-    print("name_text:", self.name_text)
-    print("val:", self.values or self.args)
-    print("toggle:", self.toggle)
     local position = self:calculatePosition(gev)
-    print("pos:", position)
     if self.name == "font_fine_tune" then
         self.config:onMakeFineTuneDefault("font_size", _("Font Size"),
                         self.values or self.args, self.toggle, position == 1 and "-" or "+")

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -212,6 +212,7 @@ end
 function ToggleSwitch:onHoldSelect(arg, gev)
     local position = self:calculatePosition(gev)
     if self.name == "font_fine_tune" then
+        --- @note Ugly hack for the only widget that uses a dual toggle for fine-tuning (others prefer a buttonprogress)
         self.config:onMakeFineTuneDefault("font_size", _("Font Size"),
                         self.values or self.args, self.toggle, position == 1 and "-" or "+")
     else


### PR DESCRIPTION
And a couple bugfix this unearthed:

* Always set the default as the *current* value, no matter what (by chance, this was not an issue for margins).
* Don't crash on the hold gesture in the -/+ buttons for the horizontal margins (regression since #5303).