### PR TITLE
[Kobo] Restart KOReader after a crash

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -304,6 +304,22 @@ function FileManagerMenu:setUpdateItemTable()
             end,
         })
     end
+    --- @note Currently, only Kobo has a fancy crash display (#5328)
+    if Device:isKobo() then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            text = _("Always abort on crash"),
+            checked_func = function()
+                return G_reader_settings:isTrue("dev_abort_on_crash")
+            end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("dev_abort_on_crash")
+                local InfoMessage = require("ui/widget/infomessage")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
+            end,
+        })
+    end
     if not Device.should_restrict_JIT then
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Disable C blitter"),

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -232,7 +232,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         ./fbink -q -c -B GRAY9 -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039
-        ./fbink -q -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3' -O
+        ./fbink -q -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # Cue a lemming's faceplant sound effect!
 
         # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -197,6 +197,8 @@ if [ -e crash.log ]; then
 fi
 
 CRASH_COUNT=0
+CRASH_TS=0
+CRASH_PREV_TS=0
 # Because we *want* an initial fbdepth pass ;).
 RETURN_VALUE=85
 while [ $RETURN_VALUE -ne 0 ]; do
@@ -215,6 +217,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
     if [ $RETURN_VALUE -ne 0 ] && [ $RETURN_VALUE -ne 85 ]; then
         # Increment the crash counter
         CRASH_COUNT=$((CRASH_COUNT + 1))
+        CRASH_TS=$(date +'%s')
         echo "!!!!" >>crash.log 2>&1
         echo "Hu oh, something went awry... (Crash n°${CRASH_COUNT}: $(date +'%x @ %X'))" >>crash.log 2>&1
         if [ $CRASH_COUNT -le 5 ]; then
@@ -237,10 +240,12 @@ while [ $RETURN_VALUE -ne 0 ]; do
         ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!
 
-        # Pause a bit if it's the first crash, so that it actually has a chance of getting noticed ;).
-        if [ $CRASH_COUNT -eq 1 ]; then
+        # Pause a bit if it's the first crash in a while, so that it actually has a chance of getting noticed ;).
+        if [ $((CRASH_TS - CRASH_PREV_TS)) -ge 5 ]; then
             sleep 2
         fi
+        # Cycle the last crash timestamp
+        CRASH_PREV_TS=${CRASH_TS}
 
         # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...
         if [ $CRASH_COUNT -gt 5 ]; then

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -257,7 +257,8 @@ while [ $RETURN_VALUE -ne 0 ]; do
         if [ ${CRASH_COUNT} -eq 1 ]; then
             # NOTE: We don't actually care about what read read, we're just using it as a fancy sleep ;).
             #       i.e., we pause either until the 15s timeout, or until the user touches the screen.
-            read -t 15 < /dev/input/event1
+            # shellcheck disable=SC2039
+            read -r -t 15 </dev/input/event1
         fi
         # Cycle the last crash timestamp
         CRASH_PREV_TS=${CRASH_TS}

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -219,7 +219,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         CRASH_COUNT=$((CRASH_COUNT + 1))
         CRASH_TS=$(date +'%s')
         # Reset it to a first crash if it's been a while since our last crash...
-        if [ $((CRASH_TS - CRASH_PREV_TS)) -ge 12 ]; then
+        if [ $((CRASH_TS - CRASH_PREV_TS)) -ge 20 ]; then
             CRASH_COUNT=1
         fi
 
@@ -232,6 +232,10 @@ while [ $RETURN_VALUE -ne 0 ]; do
         bombMargin=$((viewWidth/30))
         # With a little notice at the top of the screen, on a big gray screen of death ;).
         ./fbink -q -b -c -B GRAY9 -m -y 1 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
+        if [ ${CRASH_COUNT} -eq 1 ]; then
+            # Warn that we're waiting on a tap to continue...
+            ./fbink -q -b -O -m -y 2 "Tap the screen to continue!"
+        fi
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039
         ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
@@ -251,7 +255,9 @@ while [ $RETURN_VALUE -ne 0 ]; do
 
         # Pause a bit if it's the first crash in a while, so that it actually has a chance of getting noticed ;).
         if [ ${CRASH_COUNT} -eq 1 ]; then
-            sleep 6
+            # NOTE: We don't actually care about what read read, we're just using it as a fancy sleep ;).
+            #       i.e., we pause either until the 15s timeout, or until the user touches the screen.
+            read -t 15 < /dev/input/event1
         fi
         # Cycle the last crash timestamp
         CRASH_PREV_TS=${CRASH_TS}

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -235,10 +235,11 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # Show a fancy bomb on screen
         viewWidth=600
         viewHeight=800
-        eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight | tr '\n' ';')"
-        # Given the (mostly) identical AR across all Kobos, a fraction of the *width* usually leaves us with something right above the center of the screen, so it doesn't clash with the boot progress bar ;)
-        bombHeight=$((viewWidth/2 + viewWidth/4))
-        bombMargin=$((viewWidth/30))
+        FONTH=16
+        eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
+        # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
+        bombHeight=$((viewHeight/2 + viewHeight/15))	# ~56.7%
+        bombMargin=$((FONTH + FONTH/2))			# 1.5 lines
         # With a little notice at the top of the screen, on a big gray screen of death ;).
         ./fbink -q -b -c -B GRAY9 -m -y 1 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         if [ ${CRASH_COUNT} -eq 1 ]; then
@@ -250,7 +251,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
-        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + viewWidth/20)),left=$((bombMargin / 2)),right=$((bombMargin / 2)),size=6 "${crashLog}"
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + FONTH*2)),left=$((viewWidth/60)),right=$((viewWidth/60)),px=$((viewHeight/64)) "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -228,6 +228,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # Given the (mostly) identical AR across all Kobos, a fraction of the *width* usually leaves us with something right above the center of the screen, so it doesn't clash with the boot progress bar ;)
         bombHeight=$((viewWidth/2 + viewWidth/4))
         bombMargin=$((viewWidth/30))
+        # With a little notice at the bottom of the screen (same line as KFMon)
         ./fbink -q -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -250,7 +250,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
-        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + bombMargin)),left=$((bombMargin / 2)),right=$((bombMargin / 2)),size=6 "${crashLog}"
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + viewWidth/20)),left=$((bombMargin / 2)),right=$((bombMargin / 2)),size=6 "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -251,7 +251,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
-        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + FONTH*2)),left=$((viewWidth/60)),right=$((viewWidth/60)),px=$((viewHeight/64)) "${crashLog}"
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + FONTH*2 + FONTH/2)),left=$((viewWidth/60)),right=$((viewWidth/60)),px=$((viewHeight/64)) "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -43,7 +43,7 @@ ko_update_check() {
             ./fbink -q -y -6 -pm "Update successful :)"
             ./fbink -q -y -5 -pm "KOReader will start momentarily . . ."
         else
-            # Huh ho...
+            # Uh oh...
             ./fbink -q -y -6 -pmh "Update failed :("
             ./fbink -q -y -5 -pm "KOReader may fail to function properly!"
         fi
@@ -155,7 +155,7 @@ case "${ORIG_FB_BPP}" in
     16) ;;
     32) ;;
     *)
-        # Hu oh? Don't do anything...
+        # Uh oh? Don't do anything...
         unset ORIG_FB_BPP
         ;;
 esac
@@ -256,7 +256,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # Cue a lemming's faceplant sound effect!
 
         echo "!!!!" >>crash.log 2>&1
-        echo "Hu oh, something went awry... (Crash n°${CRASH_COUNT}: $(date +'%x @ %X'))" >>crash.log 2>&1
+        echo "Uh oh, something went awry... (Crash n°${CRASH_COUNT}: $(date +'%x @ %X'))" >>crash.log 2>&1
         if [ $CRASH_COUNT -lt 5 ] && [ "${ALWAYS_ABORT}" = "false" ]; then
             echo "Attempting to restart KOReader . . ." >>crash.log 2>&1
             echo "!!!!" >>crash.log 2>&1

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -237,6 +237,11 @@ while [ $RETURN_VALUE -ne 0 ]; do
         ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!
 
+        # Pause a bit if it's the first crash, so that it actually has a chance of getting noticed ;).
+        if [ $CRASH_COUNT -eq 1 ]; then
+            sleep 2
+        fi
+
         # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...
         if [ $CRASH_COUNT -gt 5 ]; then
             echo "Too many consecutive crashes, aborting . . ." >>crash.log 2>&1

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -218,6 +218,10 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # Increment the crash counter
         CRASH_COUNT=$((CRASH_COUNT + 1))
         CRASH_TS=$(date +'%s')
+        # Reset it to a first crash if it's been a while since our last crash...
+        if [ $((CRASH_TS - CRASH_PREV_TS)) -ge 12 ]; then
+            CRASH_COUNT=1
+        fi
 
         # Show a fancy bomb on screen
         viewWidth=600
@@ -240,20 +244,20 @@ while [ $RETURN_VALUE -ne 0 ]; do
 
         echo "!!!!" >>crash.log 2>&1
         echo "Hu oh, something went awry... (Crash n°${CRASH_COUNT}: $(date +'%x @ %X'))" >>crash.log 2>&1
-        if [ $CRASH_COUNT -le 5 ]; then
+        if [ $CRASH_COUNT -lt 5 ]; then
             echo "Attempting to restart KOReader . . ." >>crash.log 2>&1
             echo "!!!!" >>crash.log 2>&1
         fi
 
         # Pause a bit if it's the first crash in a while, so that it actually has a chance of getting noticed ;).
-        if [ $((CRASH_TS - CRASH_PREV_TS)) -ge 5 ]; then
-            sleep 2
+        if [ ${CRASH_COUNT} -eq 1 ]; then
+            sleep 6
         fi
         # Cycle the last crash timestamp
         CRASH_PREV_TS=${CRASH_TS}
 
         # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...
-        if [ $CRASH_COUNT -gt 5 ]; then
+        if [ $CRASH_COUNT -ge 5 ]; then
             echo "Too many consecutive crashes, aborting . . ." >>crash.log 2>&1
             echo "!!!! ! !!!!" >>crash.log 2>&1
             break

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -232,7 +232,8 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # shellcheck disable=SC2039
         ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # And then print the tail end of the log on the bottom of the screen...
-        tail -n 20 crash.log | ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + bombMargin)),size=6
+        crashLog="$(tail -n 25 crash.log)"
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + bombMargin)),left=$((bombMargin / 2)),right=$((bombMargin / 2)),size=6 "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -238,8 +238,9 @@ while [ $RETURN_VALUE -ne 0 ]; do
         FONTH=16
         eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
         # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
-        bombHeight=$((viewHeight/2 + viewHeight/15))	# ~56.7%
-        bombMargin=$((FONTH + FONTH/2))		# 1.5 lines
+        # Height @ ~56.7%, w/ a margin worth 1.5 lines
+        bombHeight=$((viewHeight/2 + viewHeight/15))
+        bombMargin=$((FONTH + FONTH/2))
         # With a little notice at the top of the screen, on a big gray screen of death ;).
         ./fbink -q -b -c -B GRAY9 -m -y 1 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         if [ ${CRASH_COUNT} -eq 1 ]; then
@@ -252,7 +253,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
         # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
-        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + FONTH*2 + FONTH/2)),left=$((viewWidth/60)),right=$((viewWidth/60)),px=$((viewHeight/64)) "${crashLog}"
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + FONTH * 2 + FONTH/2)),left=$((viewWidth/60)),right=$((viewWidth/60)),px=$((viewHeight/64)) "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -229,10 +229,12 @@ while [ $RETURN_VALUE -ne 0 ]; do
         bombHeight=$((viewWidth/2 + viewWidth/4))
         bombMargin=$((viewWidth/30))
         # With a little notice at the bottom of the screen (same line as KFMon), on a big gray screen of death ;).
-        ./fbink -q -c -B GRAY9 -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
+        ./fbink -q -b -c -B GRAY9 -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039
-        ./fbink -q -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
+        ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
+        # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
+        ./fbink -q -f -s top=0,left=0
         # Cue a lemming's faceplant sound effect!
 
         # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -228,10 +228,10 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # Given the (mostly) identical AR across all Kobos, a fraction of the *width* usually leaves us with something right above the center of the screen, so it doesn't clash with the boot progress bar ;)
         bombHeight=$((viewWidth/2 + viewWidth/4))
         bombMargin=$((viewWidth/30))
-        ./fbink -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
+        ./fbink -q -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039
-        ./fbink -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
+        ./fbink -q -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # Cue a lemming's faceplant sound effect!
 
         # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -232,7 +232,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # shellcheck disable=SC2039
         ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # And then print the tail end of the log on the bottom of the screen...
-        crashLog="$(tail -n 25 crash.log)"
+        crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
         ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + bombMargin)),left=$((bombMargin / 2)),right=$((bombMargin / 2)),size=6 "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s top=0,left=0

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -239,7 +239,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
         # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
         bombHeight=$((viewHeight/2 + viewHeight/15))	# ~56.7%
-        bombMargin=$((FONTH + FONTH/2))			# 1.5 lines
+        bombMargin=$((FONTH + FONTH/2))		# 1.5 lines
         # With a little notice at the top of the screen, on a big gray screen of death ;).
         ./fbink -q -b -c -B GRAY9 -m -y 1 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         if [ ${CRASH_COUNT} -eq 1 ]; then
@@ -251,6 +251,7 @@ while [ $RETURN_VALUE -ne 0 ]; do
         ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
+        # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
         ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight/2 + FONTH*2 + FONTH/2)),left=$((viewWidth/60)),right=$((viewWidth/60)),px=$((viewHeight/64)) "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s top=0,left=0

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -228,11 +228,11 @@ while [ $RETURN_VALUE -ne 0 ]; do
         # Given the (mostly) identical AR across all Kobos, a fraction of the *width* usually leaves us with something right above the center of the screen, so it doesn't clash with the boot progress bar ;)
         bombHeight=$((viewWidth/2 + viewWidth/4))
         bombMargin=$((viewWidth/30))
-        # With a little notice at the bottom of the screen (same line as KFMon)
-        ./fbink -q -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
+        # With a little notice at the bottom of the screen (same line as KFMon), on a big gray screen of death ;).
+        ./fbink -q -c -B GRAY9 -m -y -5 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039
-        ./fbink -q -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
+        ./fbink -q -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3' -O
         # Cue a lemming's faceplant sound effect!
 
         # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...


### PR DESCRIPTION
Because getting booted back to Nickel is mildly annoying ;).

(Keeps track of crashes to avoid getting stuck in boot loops).