### PR TITLE
WIP: [Android] Boox NovaPro sys natural backlight support

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -112,8 +112,11 @@ local BooxNovaPro = Device:new{
     hasNaturalLight = yes,
     hasLightLevelFallback = no,
     frontlight_settings = {
-        frontlight_white = "/sys/class/backlight/white",
-        frontlight_red = "/sys/class/backlight/warm",
+        frontlight_white = "/sys/class/backlight/white/brightness",
+        frontlight_mixer = "/sys/class/backlight/warm/brightness",
+        nl_min = 0, nl_max = 1,
+        fl_warmth_min = 0, fl_warmth_max = 250,
+        fl_min = 0, fl_max = 250,
         bl_power_off = nil,
         bl_power_on = nil,
     },
@@ -212,6 +215,10 @@ function Device:init()
     local last_value = G_reader_settings:readSetting("fl_last_level")
     if type(last_value) == "number" and last_value >= 0 then
         Device:setScreenBrightness(last_value)
+    end
+
+    if self:hasNaturalLight() and self.frontlight_settings and self.frontlight_settings.frontlight_mixer then
+        self.hasNaturalLightMixer = yes
     end
 
     Generic.init(self)

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -132,8 +132,6 @@ function Device:init()
                 or ev.code == C.APP_CMD_INIT_WINDOW
                 or ev.code == C.APP_CMD_WINDOW_REDRAW_NEEDED then
                 this.device.screen:_updateWindow()
-            elseif ev.code == C.APP_CMD_PAUSE then
-                self.powerd:beforeSuspend()
             elseif ev.code == C.APP_CMD_RESUME then
                 EXTERNAL_DICTS_AVAILABILITY_CHECKED = false
                 if external_dict_when_back_callback then

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -110,6 +110,7 @@ local Device = Generic:new{
 local BooxNovaPro = Device:new{
     model = "Onyx_Boox_NovaPro",
     hasNaturalLight = yes,
+    hasLightLevelFallback = no,
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/white",
         frontlight_red = "/sys/class/backlight/warm",

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -113,6 +113,8 @@ local BooxNovaPro = Device:new{
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/white",
         frontlight_red = "/sys/class/backlight/warm",
+        bl_power_off = nil,
+        bl_power_on = nil,
     },
 }
 

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -1,17 +1,139 @@
 local BasePowerD = require("device/generic/powerd")
+local PluginShare = require("pluginshare")
+local SysfsLight = require("device/sysfs_light")
 local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
     fl_min = 0, fl_max = 25,
+    fl_warmth_min = 0, fl_warmth_max = 100,
     fl_intensity = 10,
+    fl = nil,
+    fl_warmth = nil,
+    auto_warmth = false,
+    max_warmth_hour = 23,
 }
 
+function AndroidPowerD:init()
+    self.hw_intensity = 20
+    self.initial_is_fl_on = true
+    self.autowarmth_job_running = false
+
+    if self.device:hasNaturalLight() then
+        local nl_config = G_reader_settings:readSetting("natural_light_config")
+        if nl_config then
+            for key,val in pairs(nl_config) do
+                self.device.frontlight_settings[key] = val
+            end
+        end
+        -- Does this device's NaturalLight use a custom scale?
+        self.fl_warmth_min = self.device.frontlight_settings["nl_min"] or self.fl_warmth_min
+        self.fl_warmth_max = self.device.frontlight_settings["nl_max"] or self.fl_warmth_max
+        self.fl = SysfsLight:new(self.device.frontlight_settings)
+        self.fl_warmth = 0
+        --- @todo Sync sysfs backlight?
+    end
+end
+
+function AndroidPowerD:saveSettings()
+    if self.device:hasNaturalLight() then
+        local cur_intensity = self.fl_intensity
+        local cur_is_fl_on = self.is_fl_on
+        local cur_warmth = self.fl_warmth
+        local cur_auto_warmth = self.auto_warmth
+        local cur_max_warmth_hour = self.max_warmth_hour
+        -- Save intensity to koreader settings
+        G_reader_settings:saveSetting("frontlight_intensity", cur_intensity)
+        G_reader_settings:saveSetting("is_frontlight_on", cur_is_fl_on)
+        if cur_warmth ~= nil then
+            G_reader_settings:saveSetting("frontlight_warmth", cur_warmth)
+            G_reader_settings:saveSetting("frontlight_auto_warmth", cur_auto_warmth)
+            G_reader_settings:saveSetting("frontlight_max_warmth_hour", cur_max_warmth_hour)
+        end
+    end
+end
+
 function AndroidPowerD:frontlightIntensityHW()
-    return math.floor(android.getScreenBrightness() / 255 * self.fl_max)
+    if self.fl == nil then
+        return math.floor(android.getScreenBrightness() / 255 * self.fl_max)
+    else
+        return self.hw_intensity
+    end
+end
+
+function AndroidPowerD:isFrontlightOnHW()
+    return self.hw_intensity > 0
 end
 
 function AndroidPowerD:setIntensityHW(intensity)
-    android.setScreenBrightness(math.floor(255 * intensity / self.fl_max))
+    if self.device:hasNaturalLight() then
+        if self.fl_warmth == nil then
+            self.fl:setBrightness(intensity)
+        else
+            self.fl:setNaturalBrightness(intensity, self.fl_warmth)
+        end
+        self.hw_intensity = intensity
+        self:_decideFrontlightState()
+    else
+        android.setScreenBrightness(math.floor(255 * intensity / self.fl_max))
+    end
+end
+
+function AndroidPowerD:setWarmth(warmth)
+    if self.fl == nil then return end
+    if not warmth and self.auto_warmth then
+        self.calculateAutoWarmth()
+    end
+    self.fl_warmth = warmth or self.fl_warmth
+    if self.device:hasNaturalLightMixer() or self:isFrontlightOnHW() then
+        self.fl:setWarmth(self.fl_warmth)
+    end
+end
+
+-- Sets fl_warmth according to current hour and max_warmth_hour
+-- and starts background job if necessary.
+function AndroidPowerD:calculateAutoWarmth()
+    local current_time = os.date("%H") + os.date("%M")/60
+    local max_hour = self.max_warmth_hour
+    local diff_time = max_hour - current_time
+    if diff_time < 0 then
+        diff_time = diff_time + 24
+    end
+    if diff_time < 12 then
+        -- We are before bedtime. Use a slower progression over 5h.
+        self.fl_warmth = math.max(20 * (5 - diff_time), 0)
+    elseif diff_time > 22 then
+        -- Keep warmth at maximum for two hours after bedtime.
+        self.fl_warmth = 100
+    else
+        -- Between 2-4h after bedtime, return to zero.
+        self.fl_warmth = math.max(100 - 50 * (22 - diff_time), 0)
+    end
+    self.fl_warmth = math.floor(self.fl_warmth + 0.5)
+    -- Make sure sysfs_light actually picks that new value up without an explicit setWarmth call...
+    -- This avoids having to bypass the ramp-up on resume w/ an explicit setWarmth call on devices where brightness & warmth
+    -- are linked (i.e., when there's no mixer) ;).
+    -- NOTE: A potentially saner solution would be to ditch the internal sysfs_light current_* values,
+    --       and just pass it a pointer to this powerd instance, so it has access to fl_warmth & hw_intensity.
+    --       It seems harmless enough for warmth, but brightness might be a little trickier because of the insanity
+    --       that is hw_intensity handling because we can't actually *read* the frontlight status...
+    --       (Technically, we could, on Mk. 7 devices, but we don't,
+    --       because this is already messy enough without piling on special cases.)
+    if self.fl then
+        self.fl.current_warmth = self.fl_warmth
+    end
+    -- Enable background job for setting Warmth, if not already done.
+    if not self.autowarmth_job_running then
+        table.insert(PluginShare.backgroundJobs, {
+                         when = 180,
+                         repeated = true,
+                         executable = function()
+                             if self.auto_warmth then
+                                 self:setWarmth()
+                             end
+                         end,
+        })
+        self.autowarmth_job_running = true
+    end
 end
 
 function AndroidPowerD:getCapacityHW()
@@ -20,6 +142,28 @@ end
 
 function AndroidPowerD:isChargingHW()
     return android.isCharging()
+end
+
+function AndroidPowerD:beforeSuspend()
+    if self.fl == nil then return end
+    self.fl_was_on = self.is_fl_on
+    self:turnOffFrontlight()
+end
+
+function AndroidPowerD:afterResume()
+    if self.fl == nil then return end
+    -- Don't bother if the light was already off on suspend
+    if not self.fl_was_on then return end
+    -- Update AutoWarmth state
+    if self.fl_warmth ~= nil and self.auto_warmth then
+        self:calculateAutoWarmth()
+        -- And we need an explicit setWarmth if the device has a mixer, because turnOn won't touch the warmth on those ;).
+        if self.device:hasNaturalLightMixer() then
+            self:setWarmth(self.fl_warmth)
+        end
+    end
+    -- Turn the frontlight back on
+    self:turnOnFrontlight()
 end
 
 return AndroidPowerD

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -61,7 +61,14 @@ function AndroidPowerD:frontlightIntensityHW()
 end
 
 function AndroidPowerD:isFrontlightOnHW()
-    return self.hw_intensity > 0
+    if self.device:hanNaturalLight() then
+        local white = self.fl:_get_light_value(self.fl.frontlight_white) or 0
+        local green = self.fl:_get_light_value(self.fl.frontlight_green) or 0
+        local red = self.fl:_get_light_value(self.fl.frontlight_red) or 0
+        return (white + green + red) > 0
+    else
+        return self.hw_intensity > 0
+    end
 end
 
 function AndroidPowerD:setIntensityHW(intensity)

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -28,6 +28,8 @@ function AndroidPowerD:init()
         -- Does this device's NaturalLight use a custom scale?
         self.fl_warmth_min = self.device.frontlight_settings["nl_min"] or self.fl_warmth_min
         self.fl_warmth_max = self.device.frontlight_settings["nl_max"] or self.fl_warmth_max
+        self.fl_min = self.device.frontlight_settings["fl_min"] or self.fl_min
+        self.fl_max = self.device.frontlight_settings["fl_max"] or self.fl_max
         self.fl = SysfsLight:new(self.device.frontlight_settings)
         self.fl_warmth = 0
         --- @todo Sync sysfs backlight?
@@ -61,7 +63,11 @@ function AndroidPowerD:frontlightIntensityHW()
 end
 
 function AndroidPowerD:isFrontlightOnHW()
-    if self.device:hasNaturalLight() then
+    if self.device:hasNaturalLightMixer() then
+        local white = self.fl:_get_light_value(self.fl.frontlight_white) or 0
+        local mixer = self.fl:_get_light_value(self.fl.frontlight_mixer) or 0
+        return (white + mixer) > 0
+    elseif self.device:hasNaturalLight() then
         local white = self.fl:_get_light_value(self.fl.frontlight_white) or 0
         local green = self.fl:_get_light_value(self.fl.frontlight_green) or 0
         local red = self.fl:_get_light_value(self.fl.frontlight_red) or 0

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -61,7 +61,7 @@ function AndroidPowerD:frontlightIntensityHW()
 end
 
 function AndroidPowerD:isFrontlightOnHW()
-    if self.device:hanNaturalLight() then
+    if self.device:hasNaturalLight() then
         local white = self.fl:_get_light_value(self.fl.frontlight_white) or 0
         local green = self.fl:_get_light_value(self.fl.frontlight_green) or 0
         local red = self.fl:_get_light_value(self.fl.frontlight_red) or 0
@@ -149,12 +149,6 @@ end
 
 function AndroidPowerD:isChargingHW()
     return android.isCharging()
-end
-
-function AndroidPowerD:beforeSuspend()
-    if self.fl == nil then return end
-    self.fl_was_on = self.is_fl_on
-    self:turnOffFrontlight()
 end
 
 function AndroidPowerD:afterResume()

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -153,8 +153,7 @@ end
 
 function AndroidPowerD:afterResume()
     if self.fl == nil then return end
-    -- Don't bother if the light was already off on suspend
-    if not self.fl_was_on then return end
+    self:_decideFrontlightState()
     -- Update AutoWarmth state
     if self.fl_warmth ~= nil and self.auto_warmth then
         self:calculateAutoWarmth()

--- a/frontend/device/sysfs_light.lua
+++ b/frontend/device/sysfs_light.lua
@@ -54,7 +54,7 @@ dbg:guard(SysfsLight, 'setWarmth',
                      "Wrong warmth value given!")
           end)
 
-function SysfsLight:_brightness_to_raw(brightness, warmth, exponent, gain, offest)
+function SysfsLight:_brightness_to_raw(brightness, warmth, exponent, gain, offset)
     -- On Nickel, the values for white/red/green are roughly linearly dependent
     -- on the 4th root of brightness and warmth.
     return gain * math.pow(brightness * warmth, exponent) + offset

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -949,4 +949,13 @@ function util.stringEndsWith(str, ending)
    return ending == "" or str:sub(-#ending) == ending
 end
 
+-- Clamps value between min and max
+-- @param value number: number to clamp
+-- @param min number: minimum value
+-- @param max number: maximum value
+-- @return number: min if it is larger than value or max if it is smaller than value else value
+function util.clamp(value, min, max)
+    return math.min(math.max(value, min), max)
+end
+
 return util


### PR DESCRIPTION
I recently bought a Boox Nova Pro (Android eInk device).
It doesn't respect the android system brightness settings.
It has two frontlight types white and orange at `/sys/class/backlight/white/brightness` and `/sys/class/backlight/warm/brightness` respectively.
Much of the code in this merge request is copied from the kobo frontend.
I feel much of the auto warmth code should be move to the generic frontend.
Any pointers on how this code could be improved would be appreciated.

`white/device/uevent` and `warm/device/uevent` contain:
```
DRIVER=lm3630a_bl
OF_NAME=lm3630a
OF_FULLNAME=/i2c@ff140000/lm3630a@38
OF_COMPATIBLE_0=onyx,lm3630a
OF_COMPATIBLE_N=1
MODALIAS=i2c:lm3630a
```

https://github.com/torvalds/linux/blob/master/Documentation/ABI/stable/sysfs-class-backlight
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/video/backlight/lm3630a_bl.c
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/video/backlight/backlight.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5331)
<!-- Reviewable:end -->
