### PR TITLE
[fix] PdfDocument: Hash collision

### DIFF
--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -154,7 +154,7 @@ function PdfDocument:getUsedBBox(pageno)
 end
 
 function PdfDocument:getPageLinks(pageno)
-    local hash = "pgubbox|"..self.file.."|"..self.reflowable_font_size.."|"..pageno
+    local hash = "pglinks|"..self.file.."|"..self.reflowable_font_size.."|"..pageno
     local cached = Cache:check(hash)
     if cached then
         return cached.links


### PR DESCRIPTION
A typo introduced in <https://github.com/koreader/koreader/pull/5282>.

This might resolve <https://github.com/koreader/koreader/issues/5323>, fixes <https://github.com/koreader/koreader/issues/5327>.