### PR TITLE
[fix] Add keyboard layout to filemanager menu

### DIFF
--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -38,6 +38,7 @@ local order = {
         -- end common settings
     },
     device = {
+        "keyboard_layout",
         "time",
         "battery",
         "autosuspend",


### PR DESCRIPTION
Overlooked in <https://github.com/koreader/koreader/pull/5318>.