### PR TITLE
[fix, Android] Set executable bit

### DIFF
--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -15,6 +15,13 @@ end
 -- run koreader patch before koreader startup
 pcall(dofile, "/sdcard/koreader/patch.lua")
 
+-- Set proper permission for binaries.
+--- @todo Take care of this on extraction instead.
+-- Cf. <https://github.com/koreader/koreader/issues/5347#issuecomment-529476693>.
+android.execute("chmod", "755", "./sdcv")
+android.execute("chmod", "755", "./tar")
+android.execute("chmod", "755", "./zsync")
+
 -- set TESSDATA_PREFIX env var
 C.setenv("TESSDATA_PREFIX", "/sdcard/koreader/data", 1)
 


### PR DESCRIPTION
Partially reverts d2536d8b7e9474bd7748b199d1f01a53f332942a.

Fixes <https://github.com/koreader/koreader/issues/5347>.