### PR TITLE
[fix] ReadSettings Inverse reading order

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -180,10 +180,8 @@ function ReaderPaging:onReadSettings(config)
     self.flipping_zoom_mode = config:readSetting("flipping_zoom_mode") or "page"
     self.flipping_scroll_mode = config:readSetting("flipping_scroll_mode") or false
     self.inverse_reading_order = config:readSetting("inverse_reading_order")
-    if self.inverse_reading_order == nil and G_reader_settings:has("inverse_reading_order") then
+    if self.inverse_reading_order == nil then
         self.inverse_reading_order = G_reader_settings:isTrue("inverse_reading_order")
-    else
-        self.inverse_reading_order = false
     end
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -188,11 +188,10 @@ function ReaderRolling:onReadSettings(config)
     if self.show_overlap_enable == nil then
         self.show_overlap_enable = DSHOWOVERLAP
     end
+
     self.inverse_reading_order = config:readSetting("inverse_reading_order")
-    if self.inverse_reading_order == nil and G_reader_settings:has("inverse_reading_order") then
+    if self.inverse_reading_order == nil then
         self.inverse_reading_order = G_reader_settings:isTrue("inverse_reading_order")
-    else
-        self.inverse_reading_order = false
     end
 
     -- This self.visible_pages may not be the current nb of visible pages


### PR DESCRIPTION
`self.inverse_reading_order == nil and G_reader_settings:has("inverse_reading_order")` could easily be false, which would then incorrectly turn the setting off.

Fixes <https://github.com/koreader/koreader/issues/5346>.