### PR TITLE
[fix, Kobo] Don't crash trying to sync frontlight with Nickel.

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -168,7 +168,7 @@ function KoboPowerD:saveSettings()
         local cur_intensity = self.fl_intensity
         -- If we're shutting down straight from suspend then the frontlight won't
         -- be turned on but we still want to save its state.
-        local cur_is_fl_on = self.is_fl_on or self.fl_was_on
+        local cur_is_fl_on = self.is_fl_on or self.fl_was_on or false
         local cur_warmth = self.fl_warmth
         local cur_auto_warmth = self.auto_warmth
         local cur_max_warmth_hour = self.max_warmth_hour

--- a/spec/unit/nickel_conf_spec.lua
+++ b/spec/unit/nickel_conf_spec.lua
@@ -183,5 +183,60 @@ FrontLightLevel=15
                           fd:read("*a"))
             fd:close()
         end)
+
+        it("should not crash on nil values for regular users", function()
+            local fn = os.tmpname()
+            local fd = io.open(fn, "w")
+            fd:write([[
+[PowerOptions]
+foo=bar
+[OtherThing]
+bar=baz
+]])
+            fd:close()
+
+            NickelConf._set_kobo_conf_path(fn)
+            NickelConf.frontLightLevel.set()
+            NickelConf.frontLightState.set()
+
+            fd = io.open(fn, "r")
+            assert.Equals([[
+[PowerOptions]
+foo=bar
+[OtherThing]
+bar=baz
+]], fd:read("*a"))
+            fd:close()
+            os.remove(fn)
+        end)
+        
+        it("should crash on nil values in debug mode", function()
+            local dbg = require("dbg")
+            dbg:turnOn()
+            NickelConf = package.reload("device/kobo/nickel_conf")
+            local fn = os.tmpname()
+            local fd = io.open(fn, "w")
+            fd:write([[
+[PowerOptions]
+foo=bar
+[OtherThing]
+bar=baz
+]])
+            fd:close()
+
+            NickelConf._set_kobo_conf_path(fn)
+            assert.has_error(function() NickelConf.frontLightLevel.set() end)
+            assert.has_error(function() NickelConf.frontLightState.set() end)
+
+            fd = io.open(fn, "r")
+            assert.Equals([[
+[PowerOptions]
+foo=bar
+[OtherThing]
+bar=baz
+]], fd:read("*a"))
+            fd:close()
+            os.remove(fn)
+        end)
     end)
 end)

--- a/spec/unit/nickel_conf_spec.lua
+++ b/spec/unit/nickel_conf_spec.lua
@@ -209,7 +209,7 @@ bar=baz
             fd:close()
             os.remove(fn)
         end)
-        
+
         it("should crash on nil values in debug mode", function()
             local dbg = require("dbg")
             dbg:turnOn()


### PR DESCRIPTION
When reasonably possible, the program should only crash in debug mode.

Adds a couple of extra unit tests to prevent regressions and adds docs.

Fixes <https://github.com/koreader/koreader/issues/5356>.