### PR TITLE
Add fine tune in line spacing

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -249,6 +249,12 @@ Note that your selected font size is not affected by this setting.]]),
                 default_pos = 7,
                 default_value = DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM,
                 more_options = true,
+                more_options_param = {
+                  value_min = 70,
+                  value_max = 130,
+                  value_step = 1,
+                  value_hold_step = 5,
+                },
                 event = "SetLineSpace",
                 args = {
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_X_TINY,

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -248,6 +248,7 @@ Note that your selected font size is not affected by this setting.]]),
                 },
                 default_pos = 7,
                 default_value = DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM,
+                more_options = true,
                 event = "SetLineSpace",
                 args = {
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_X_TINY,

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -22,6 +22,7 @@ local ButtonProgressWidget = InputContainer:new{
     default_position = nil,
     thin_grey_style = false, -- default to black
     fine_tune = false, -- no -/+ buttons on the extremities by default
+    more_options = false, -- no "⋮" button
 }
 
 function ButtonProgressWidget:init()
@@ -49,6 +50,9 @@ function ButtonProgressWidget:update()
     local buttons_count = self.num_buttons
     if self.fine_tune then
        buttons_count = buttons_count + 2
+    end
+    if self.more_options then
+        buttons_count = buttons_count + 1
     end
     local button_width = math.floor(self.width / buttons_count) - 2*button_padding - 2*button_margin - 2*button_bordersize
 
@@ -162,6 +166,35 @@ function ButtonProgressWidget:update()
             no_focus = true,
             hold_callback = function()
                 self.hold_callback("+")
+            end,
+        }
+        if self.thin_grey_style then
+            button.frame.color = Blitbuffer.COLOR_DARK_GRAY
+        end
+        table.insert(self.buttonprogress_content, button)
+    end
+    -- More option button on the right
+    if self.more_options then
+        local margin = button_margin * 6
+        local extra_border_size = 0
+        local button = Button:new{
+            text = "⋮",
+            radius = 0,
+            margin = margin,
+            padding = button_padding,
+            bordersize = button_bordersize + extra_border_size,
+            enabled = true,
+            width = button_width - 2*extra_border_size,
+            preselect = false,
+            text_font_face = self.font_face,
+            text_font_size = self.font_size,
+            callback = function()
+                self.callback("⋮")
+                self:update()
+            end,
+            no_focus = true,
+            hold_callback = function()
+                self.hold_callback("⋮")
             end,
         }
         if self.thin_grey_style then

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -33,6 +33,9 @@ local SpinWidget = InputContainer:new{
     value_hold_step = 4,
     ok_text = _("OK"),
     cancel_text = _("Cancel"),
+    -- extra button on bottom
+    custom_text = nil,
+    callback_custom = nil,
     -- set this to see extra default button
     default_value = nil,
     default_text = _("Use default"),
@@ -140,6 +143,20 @@ function SpinWidget:update()
                 end,
             },
         })
+    end
+        if self.custom_text then
+            table.insert(buttons,{
+                {
+                    text = self.custom_text,
+                    callback = function()
+                        if self.callback_custom then
+                            self.value = value_widget:getValue()
+                            self.callback_custom(self)
+                        end
+                        self:onClose()
+                    end,
+                },
+            })
     end
 
     local ok_cancel_buttons = ButtonTable:new{

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -34,8 +34,8 @@ local SpinWidget = InputContainer:new{
     ok_text = _("OK"),
     cancel_text = _("Cancel"),
     -- extra button on bottom
-    custom_text = nil,
-    callback_custom = nil,
+    extra_text = nil,
+    extra_callback = nil,
     -- set this to see extra default button
     default_value = nil,
     default_text = _("Use default"),
@@ -144,14 +144,14 @@ function SpinWidget:update()
             },
         })
     end
-        if self.custom_text then
+        if self.extra_text then
             table.insert(buttons,{
                 {
-                    text = self.custom_text,
+                    text = self.extra_text,
                     callback = function()
-                        if self.callback_custom then
+                        if self.extra_callback then
                             self.value = value_widget:getValue()
-                            self.callback_custom(self)
+                            self.extra_callback(self)
                         end
                         self:onClose()
                     end,


### PR DESCRIPTION
See: https://github.com/koreader/koreader/issues/5312#issuecomment-528506421
Progress widget has a new extra button `⋮` that triggers SpinWidget. 

<img src=https://user-images.githubusercontent.com/22982594/64880841-7bdc9d80-d659-11e9-8cde-e0d3204493c8.png width=70%>

<img src=https://user-images.githubusercontent.com/22982594/64880857-8303ab80-d659-11e9-831d-8e1473855add.png width=70%>

<img src=https://user-images.githubusercontent.com/22982594/64880866-89922300-d659-11e9-92e9-5f32a4b6142d.png width=70%>

