### PR TITLE
Fix: don't create sidecar file when indexing pdf documents

### DIFF
--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -1,6 +1,7 @@
 local Cache = require("cache")
 local CacheItem = require("cacheitem")
 local CanvasContext = require("document/canvascontext")
+local DocSettings = require("docsettings")
 local Document = require("document/document")
 local DrawContext = require("ffi/drawcontext")
 local logger = require("logger")
@@ -64,9 +65,12 @@ function PdfDocument:convertKoptToReflowableFontSize(font_size)
         return font_size * default_font_size
     end
 
-    local docsettings = require("docsettings"):open(self.file)
-    local size = docsettings:readSetting("kopt_font_size")
-    docsettings:close()
+    local size
+    if DocSettings:hasSidecarFile(self.file) then
+        local doc_settings = DocSettings:open(self.file)
+        size = doc_settings:readSetting("kopt_font_size")
+        doc_settings:close()
+    end
     if size then
         return size * default_font_size
     elseif G_reader_settings:readSetting("kopt_font_size") then


### PR DESCRIPTION
Fix issue 2) at #5383. Closes #5383.