### PR TITLE
[Kobo/Cervantes] Prefer using the ioctl over sysfs when setting the FL.

### DIFF
--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -71,6 +71,14 @@ function CervantesPowerD:init()
                     self.device.frontlight_settings[key] = val
                 end
             end
+            -- If this device has a mixer, we can use the ioctl for brightness control, as it's much lower latency.
+            if self.device:hasNaturalLightMixer() then
+                local kobolight = require("ffi/kobolight")
+                local ok, light = pcall(kobolight.open)
+                if ok then
+                    self.device.frontlight_settings.frontlight_ioctl = light
+                end
+            end
             self.fl = SysfsLight:new(self.device.frontlight_settings)
             self.fl_warmth = 0
             self:_syncLightOnStart()

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -126,14 +126,14 @@ function KoboPowerD:init()
                 end
             end
             -- Does this device's NaturalLight use a custom scale?
-            self.fl_warmth_min = self.device.frontlight_settings["nl_min"] or self.fl_warmth_min
-            self.fl_warmth_max = self.device.frontlight_settings["nl_max"] or self.fl_warmth_max
+            self.fl_warmth_min = self.device.frontlight_settings.nl_min or self.fl_warmth_min
+            self.fl_warmth_max = self.device.frontlight_settings.nl_max or self.fl_warmth_max
             -- If this device has a mixer, we can use the ioctl for brightness control, as it's much lower latency.
             if self.device:hasNaturalLightMixer() then
                 local kobolight = require("ffi/kobolight")
                 local ok, light = pcall(kobolight.open)
                 if ok then
-                    self.device.frontlight_settings["frontlight_ioctl"] = light
+                    self.device.frontlight_settings.frontlight_ioctl = light
                 end
             end
             self.fl = SysfsLight:new(self.device.frontlight_settings)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -128,6 +128,14 @@ function KoboPowerD:init()
             -- Does this device's NaturalLight use a custom scale?
             self.fl_warmth_min = self.device.frontlight_settings["nl_min"] or self.fl_warmth_min
             self.fl_warmth_max = self.device.frontlight_settings["nl_max"] or self.fl_warmth_max
+            -- If this device has a mixer, we can use the ioctl for brightness control, as it's much lower latency.
+            if self.device:hasNaturalLightMixer() then
+                local kobolight = require("ffi/kobolight")
+                local ok, light = pcall(kobolight.open)
+                if ok then
+                    self.device.frontlight_settings["frontlight_ioctl"] = light
+                end
+            end
             self.fl = SysfsLight:new(self.device.frontlight_settings)
             self.fl_warmth = 0
             self:_syncKoboLightOnStart()
@@ -314,7 +322,7 @@ function KoboPowerD:turnOffFrontlightHW()
         for i = 1,5 do
             self:_setIntensity(math.floor(self.fl_intensity - ((self.fl_intensity / 5) * i)))
             -- NOTE: We generally don't need to sleep when using sysfs as a backend...
-            if not self.device:hasNaturalLight() then
+            if self.device:hasNaturalLight() and not self.device:hasNaturalLightMixer() then
                 if (i < 5) then
                     util.usleep(35 * 1000)
                 end
@@ -351,7 +359,7 @@ function KoboPowerD:turnOnFrontlightHW()
     util.runInSubProcess(function()
         for i = 1,5 do
             self:_setIntensity(math.ceil(self.fl_min + ((self.fl_intensity / 5) * i)))
-            if not self.device:hasNaturalLight() then
+            if self.device:hasNaturalLight() and not self.device:hasNaturalLightMixer() then
                 if (i < 5) then
                     util.usleep(35 * 1000)
                 end

--- a/frontend/device/sysfs_light.lua
+++ b/frontend/device/sysfs_light.lua
@@ -10,6 +10,7 @@ local SysfsLight = {
     frontlight_red = nil,
     frontlight_green = nil,
     frontlight_mixer = nil,
+    frontlight_ioctl = nil,
     nl_min = nil,
     nl_max = nil,
     nl_inverted = nil,
@@ -69,7 +70,12 @@ function SysfsLight:setNaturalBrightness(brightness, warmth)
         -- Honor the device's scale, which may not be [0...100] (f.g., it's [0...10] on the Forma) ;).
         warmth = math.floor(warmth / self.nl_max)
         if set_brightness then
-            self:_write_value(self.frontlight_white, brightness)
+            -- Prefer the ioctl, as it's much lower latency.
+            if self.frontlight_ioctl then
+                self.frontlight_ioctl:setBrightness(brightness)
+            else
+                self:_write_value(self.frontlight_white, brightness)
+            end
         end
         -- And it may be inverted... (cold is nl_max, warm is nl_min)
         if set_warmth then


### PR DESCRIPTION
It's much lower latency (re #5373).

We can do so on NL devices with a mixer.