### PR TITLE
Better align toggleswitch in configdialog

### DIFF
--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -73,7 +73,15 @@ function ToggleSwitch:init()
         w = item_width,
         h = item_height,
     }
+    local diff_one_step = item_width - (frame_inner_width / self.n_pos - 2*item_border_size)
+    local diff = 0
     for i = 1, #self.toggle do
+        diff = diff + diff_one_step
+        if diff >= 1 then
+            -- One pixel narrower to better align the entire widget
+            center_dimen.w = item_width - math.floor(diff)
+            diff = diff - math.floor(diff)
+        end
         local text = self.toggle[i]
         local face = Font:getFace(self.font_face, self.font_size)
         local txt_width = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text, true, true).x

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -78,7 +78,7 @@ function ToggleSwitch:init()
         local real_item_width = item_width
         item_width_to_add = item_width_to_add + item_width_adjust
         if item_width_to_add >= 1 then
-            -- One pixel narrower to better align the entire widget
+            -- One pixel wider to better align the entire widget
             real_item_width = item_width + math.floor(item_width_to_add)
             item_width_to_add = item_width_to_add - math.floor(item_width_to_add)
         end

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -65,39 +65,36 @@ function ToggleSwitch:init()
     local item_padding = Size.padding.default -- only used to check if text truncate needed
     local item_border_size = Size.border.thin
     local frame_inner_width = self.width - 2*self.toggle_frame.padding - 2* self.toggle_frame.bordersize
-    -- We'll need to adjust items width and distribute the accumulated fractional part to some
-    -- of them for proper visual alignment
     local item_width_real = frame_inner_width / self.n_pos - 2*item_border_size
-    local item_width = math.ceil(item_width_real)
-    local item_width_adjust = item_width - item_width_real
-    local item_height = self.height / self.row_count
+    local item_width = math.floor(item_width_real)
+    local item_width_adjust = item_width_real - item_width
     -- Note: the height provided by ConfigDialog might be smaller than needed,
     -- it gets too thin if we account for padding & border
-    local center_dimen = Geom:new{
-        w = item_width,
-        h = item_height,
-    }
-    --local diff_one_step = item_width - (frame_inner_width / self.n_pos - 2*item_border_size)
+    local item_height = self.height / self.row_count
     local item_width_to_add = 0
     for i = 1, #self.toggle do
+        local real_item_width = item_width
         item_width_to_add = item_width_to_add + item_width_adjust
         if item_width_to_add >= 1 then
             -- One pixel narrower to better align the entire widget
-            center_dimen.w = item_width - math.floor(item_width_to_add)
+            real_item_width = item_width + math.floor(item_width_to_add)
             item_width_to_add = item_width_to_add - math.floor(item_width_to_add)
         end
         local text = self.toggle[i]
         local face = Font:getFace(self.font_face, self.font_size)
         local txt_width = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text, true, true).x
-        if  txt_width > item_width - item_padding then
-            text = RenderText:truncateTextByWidth(text, face, item_width - item_padding, true, true)
+        if  txt_width > real_item_width - item_padding then
+            text = RenderText:truncateTextByWidth(text, face, real_item_width - item_padding, true, true)
         end
         local label = ToggleLabel:new{
             text = text,
             face = face,
         }
         local content = CenterContainer:new{
-            dimen = center_dimen,
+            dimen = Geom:new{
+                w = real_item_width,
+                h = item_height,
+            },
             label,
         }
         local button = FrameContainer:new{
@@ -111,7 +108,6 @@ function ToggleSwitch:init()
         }
         table.insert(self.toggle_content[math.ceil(i / self.n_pos)], button)
     end
-
     self.toggle_frame[1] = self.toggle_content
     self[1] = self.toggle_frame
     self.dimen = Geom:new(self.toggle_frame:getSize())

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -65,6 +65,8 @@ function ToggleSwitch:init()
     local item_padding = Size.padding.default -- only used to check if text truncate needed
     local item_border_size = Size.border.thin
     local frame_inner_width = self.width - 2*self.toggle_frame.padding - 2* self.toggle_frame.bordersize
+    -- We'll need to adjust items width and distribute the accumulated fractional part to some
+    -- of them for proper visual alignment
     local item_width_real = frame_inner_width / self.n_pos - 2*item_border_size
     local item_width = math.floor(item_width_real)
     local item_width_adjust = item_width_real - item_width

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -65,7 +65,11 @@ function ToggleSwitch:init()
     local item_padding = Size.padding.default -- only used to check if text truncate needed
     local item_border_size = Size.border.thin
     local frame_inner_width = self.width - 2*self.toggle_frame.padding - 2* self.toggle_frame.bordersize
-    local item_width = math.ceil(frame_inner_width / self.n_pos - 2*item_border_size)
+    -- We'll need to adjust items width and distribute the accumulated fractional part to some
+    -- of them for proper visual alignment
+    local item_width_real = frame_inner_width / self.n_pos - 2*item_border_size
+    local item_width = math.ceil(item_width_real)
+    local item_width_adjust = item_width - item_width_real
     local item_height = self.height / self.row_count
     -- Note: the height provided by ConfigDialog might be smaller than needed,
     -- it gets too thin if we account for padding & border
@@ -73,14 +77,14 @@ function ToggleSwitch:init()
         w = item_width,
         h = item_height,
     }
-    local diff_one_step = item_width - (frame_inner_width / self.n_pos - 2*item_border_size)
-    local diff = 0
+    --local diff_one_step = item_width - (frame_inner_width / self.n_pos - 2*item_border_size)
+    local item_width_to_add = 0
     for i = 1, #self.toggle do
-        diff = diff + diff_one_step
-        if diff >= 1 then
+        item_width_to_add = item_width_to_add + item_width_adjust
+        if item_width_to_add >= 1 then
             -- One pixel narrower to better align the entire widget
-            center_dimen.w = item_width - math.floor(diff)
-            diff = diff - math.floor(diff)
+            center_dimen.w = item_width - math.floor(item_width_to_add)
+            item_width_to_add = item_width_to_add - math.floor(item_width_to_add)
         end
         local text = self.toggle[i]
         local face = Font:getFace(self.font_face, self.font_size)


### PR DESCRIPTION
See: https://github.com/koreader/koreader/pull/5375#issuecomment-533561559

Before (align `View mode` `Render mode` `Zoom`):
![ver2](https://user-images.githubusercontent.com/22982594/65508433-78a2a680-ded0-11e9-9d23-94c472e1df0c.png)

After (align `View mode` `Render mode` `Zoom`):
![ver1](https://user-images.githubusercontent.com/22982594/65508411-6e80a800-ded0-11e9-9d6e-121a646b743a.png)
