### PR TITLE
[UX] add inverse reading order to gesture manager

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -240,14 +240,6 @@ function ReaderGesture:initGesture()
     G_reader_settings:saveSetting(self.ges_mode, gesture_manager)
 end
 
-function ReaderGesture:onReSetupGesture()
-    local gesture_manager = G_reader_settings:readSetting(self.ges_mode)
-    for gesture, action in pairs(gesture_manager) do
-        self:setupGesture(gesture, action)
-    end
-    return true
-end
-
 function ReaderGesture:genMultiswipeSubmenu()
     return {
         text = _("Multiswipe"),
@@ -1368,7 +1360,7 @@ function ReaderGesture:gestureAction(action, ges)
     elseif action == "toggle_bookmark" then
         self.ui:handleEvent(Event:new("ToggleBookmark"))
     elseif action == "toggle_inverse_reading_order" then
-        self.ui:handleEvent(Event:new("ToggleReadingOrder"))
+        self:onToggleReadingOrder()
     elseif action == "toggle_frontlight" then
         -- when using frontlight system settings
         if lightFrontlight() then
@@ -1572,6 +1564,22 @@ function ReaderGesture:onGSensorToggle()
     UIManager:show(Notification:new{
         text = new_text,
         timeout = 1.0,
+    })
+    return true
+end
+
+function ReaderGesture:onToggleReadingOrder()
+    local document_module = self.ui.document.info.has_pages and self.ui.paging or self.ui.rolling
+    document_module.inverse_reading_order = not document_module.inverse_reading_order
+    document_module:setupTouchZones()
+    -- Needed to reset the touch zone overrides
+    local gesture_manager = G_reader_settings:readSetting(self.ges_mode)
+    for gesture, action in pairs(gesture_manager) do
+        self:setupGesture(gesture, action)
+    end
+    UIManager:show(Notification:new{
+        text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
+        timeout = 2.5,
     })
     return true
 end

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -240,6 +240,13 @@ function ReaderGesture:initGesture()
     G_reader_settings:saveSetting(self.ges_mode, gesture_manager)
 end
 
+function ReaderGesture:onReSetupGesture()
+    local gesture_manager = G_reader_settings:readSetting(self.ges_mode)
+    for gesture, action in pairs(gesture_manager) do
+        self:setupGesture(gesture, action)
+    end
+end
+
 function ReaderGesture:genMultiswipeSubmenu()
     return {
         text = _("Multiswipe"),

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -1578,7 +1578,7 @@ function ReaderGesture:onToggleReadingOrder()
         self:setupGesture(gesture, action)
     end
     UIManager:show(Notification:new{
-        text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
+        text = document_module.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,
     })
     return true

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -245,6 +245,7 @@ function ReaderGesture:onReSetupGesture()
     for gesture, action in pairs(gesture_manager) do
         self:setupGesture(gesture, action)
     end
+    return true
 end
 
 function ReaderGesture:genMultiswipeSubmenu()

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -80,6 +80,7 @@ local action_strings = {
     toggle_bookmark = _("Toggle bookmark"),
     toggle_page_flipping = _("Toggle page flipping"),
     toggle_reflow = _("Toggle reflow"),
+    toggle_inverse_reading_order = _("Toggle page turn direction"),
 
     zoom_contentwidth = _("Zoom to fit content width"),
     zoom_contentheight = _("Zoom to fit content height"),
@@ -723,6 +724,7 @@ function ReaderGesture:buildMenu(ges, default)
         {"toggle_bookmark", not self.is_docless, true},
         {"toggle_page_flipping", not self.is_docless, true},
         {"toggle_reflow", not self.is_docless, true},
+        {"toggle_inverse_reading_order", not self.is_docless, true},
         {"zoom_contentwidth", not self.is_docless},
         {"zoom_contentheight", not self.is_docless},
         {"zoom_pagewidth", not self.is_docless},
@@ -1357,6 +1359,8 @@ function ReaderGesture:gestureAction(action, ges)
         end
     elseif action == "toggle_bookmark" then
         self.ui:handleEvent(Event:new("ToggleBookmark"))
+    elseif action == "toggle_inverse_reading_order" then
+        self.ui:handleEvent(Event:new("ToggleReadingOrder"))
     elseif action == "toggle_frontlight" then
         -- when using frontlight system settings
         if lightFrontlight() then

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -1026,6 +1026,7 @@ function ReaderPaging:onToggleReadingOrder()
         text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,
     })
+    return true
 end
 
 return ReaderPaging

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -1022,6 +1022,8 @@ end
 function ReaderPaging:onToggleReadingOrder()
     self.inverse_reading_order = not self.inverse_reading_order
     self:setupTapTouchZones()
+    -- Needed to reset the touch zone overrides
+    self.ui:handleEvent(Event:new("ReSetupGesture"))
     UIManager:show(Notification:new{
         text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -4,6 +4,7 @@ local Event = require("ui/event")
 local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Math = require("optmath")
+local Notification = require("ui/widget/notification")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
@@ -241,8 +242,7 @@ function ReaderPaging:addToMainMenu(menu_items)
         text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
-            self.inverse_reading_order = not self.inverse_reading_order
-            self:setupTapTouchZones()
+            self:onToggleReadingOrder()
         end,
         hold_callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
@@ -1017,6 +1017,15 @@ function ReaderPaging:onGotoPrevChapter()
         self:onGotoPage(new_page)
     end
     return true
+end
+
+function ReaderPaging:onToggleReadingOrder()
+    self.inverse_reading_order = not self.inverse_reading_order
+    self:setupTapTouchZones()
+    UIManager:show(Notification:new{
+        text = _((self.inverse_reading_order and "RTL" or "LTR") .. " page direction."),
+        timeout = 2.5,
+    })
 end
 
 return ReaderPaging

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -1023,7 +1023,7 @@ function ReaderPaging:onToggleReadingOrder()
     self.inverse_reading_order = not self.inverse_reading_order
     self:setupTapTouchZones()
     UIManager:show(Notification:new{
-        text = _((self.inverse_reading_order and "RTL" or "LTR") .. " page direction."),
+        text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,
     })
 end

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -4,7 +4,6 @@ local Event = require("ui/event")
 local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Math = require("optmath")
-local ReaderGesture = require("apps/reader/modules/readergesture")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
@@ -242,7 +241,7 @@ function ReaderPaging:addToMainMenu(menu_items)
         text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
-            ReaderGesture:onToggleReadingOrder()
+            self.ui:handleEvent(Event:new("ToggleReadingOrder"))
         end,
         hold_callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -4,7 +4,7 @@ local Event = require("ui/event")
 local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Math = require("optmath")
-local Notification = require("ui/widget/notification")
+local ReaderGesture = require("apps/reader/modules/readergesture")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
@@ -242,7 +242,7 @@ function ReaderPaging:addToMainMenu(menu_items)
         text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
-            self:onToggleReadingOrder()
+            ReaderGesture:onToggleReadingOrder()
         end,
         hold_callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
@@ -1016,18 +1016,6 @@ function ReaderPaging:onGotoPrevChapter()
         self.ui.link:addCurrentLocationToStack()
         self:onGotoPage(new_page)
     end
-    return true
-end
-
-function ReaderPaging:onToggleReadingOrder()
-    self.inverse_reading_order = not self.inverse_reading_order
-    self:setupTapTouchZones()
-    -- Needed to reset the touch zone overrides
-    self.ui:handleEvent(Event:new("ReSetupGesture"))
-    UIManager:show(Notification:new{
-        text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
-        timeout = 2.5,
-    })
     return true
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1032,7 +1032,7 @@ function ReaderRolling:onToggleReadingOrder()
     self.inverse_reading_order = not self.inverse_reading_order
     self:setupTouchZones()
     UIManager:show(Notification:new{
-        text = _((self.inverse_reading_order and "RTL" or "LTR") .. " page direction."),
+        text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,
     })
 end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1031,6 +1031,8 @@ end
 function ReaderRolling:onToggleReadingOrder()
     self.inverse_reading_order = not self.inverse_reading_order
     self:setupTouchZones()
+    -- Needed to reset the touch zone overrides
+    self.ui:handleEvent(Event:new("ReSetupGesture"))
     UIManager:show(Notification:new{
         text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1035,6 +1035,7 @@ function ReaderRolling:onToggleReadingOrder()
         text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,
     })
+    return true
 end
 
 return ReaderRolling

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -3,6 +3,7 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local Notification = require("ui/widget/notification")
 local ProgressWidget = require("ui/widget/progresswidget")
 local ReaderPanning = require("apps/reader/modules/readerpanning")
 local TimeVal = require("ui/timeval")
@@ -367,8 +368,7 @@ function ReaderRolling:addToMainMenu(menu_items)
         text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
-            self.inverse_reading_order = not self.inverse_reading_order
-            self:setupTouchZones()
+            self:onToggleReadingOrder()
         end,
         hold_callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
@@ -1026,6 +1026,15 @@ function ReaderRolling:showEngineProgress(percent)
         -- some progress callback for will generate a full
         -- screen refresh.
     end
+end
+
+function ReaderRolling:onToggleReadingOrder()
+    self.inverse_reading_order = not self.inverse_reading_order
+    self:setupTouchZones()
+    UIManager:show(Notification:new{
+        text = _((self.inverse_reading_order and "RTL" or "LTR") .. " page direction."),
+        timeout = 2.5,
+    })
 end
 
 return ReaderRolling

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -4,7 +4,6 @@ local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local ProgressWidget = require("ui/widget/progresswidget")
-local ReaderGesture = require("apps/reader/modules/readergesture")
 local ReaderPanning = require("apps/reader/modules/readerpanning")
 local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
@@ -368,7 +367,7 @@ function ReaderRolling:addToMainMenu(menu_items)
         text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
-            ReaderGesture:onToggleReadingOrder()
+            self.ui:handleEvent(Event:new("ToggleReadingOrder"))
         end,
         hold_callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -3,8 +3,8 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local Notification = require("ui/widget/notification")
 local ProgressWidget = require("ui/widget/progresswidget")
+local ReaderGesture = require("apps/reader/modules/readergesture")
 local ReaderPanning = require("apps/reader/modules/readerpanning")
 local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
@@ -368,7 +368,7 @@ function ReaderRolling:addToMainMenu(menu_items)
         text = _("Invert page turn taps and swipes"),
         checked_func = function() return self.inverse_reading_order end,
         callback = function()
-            self:onToggleReadingOrder()
+            ReaderGesture:onToggleReadingOrder()
         end,
         hold_callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
@@ -1026,18 +1026,6 @@ function ReaderRolling:showEngineProgress(percent)
         -- some progress callback for will generate a full
         -- screen refresh.
     end
-end
-
-function ReaderRolling:onToggleReadingOrder()
-    self.inverse_reading_order = not self.inverse_reading_order
-    self:setupTouchZones()
-    -- Needed to reset the touch zone overrides
-    self.ui:handleEvent(Event:new("ReSetupGesture"))
-    UIManager:show(Notification:new{
-        text = self.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
-        timeout = 2.5,
-    })
-    return true
 end
 
 return ReaderRolling


### PR DESCRIPTION
before you merge, i am not very familiar with lua so a few points;

i was not sure what to put here just followed the flow.
```lua
 {"toggle_inverse_reading_order", not self.is_docless, true},
```

is there a way to abstract the code from `readerrolling` and `readerpaging` to avoid duplication?

---

when testing this i came across a very weird related bug that i can not figure out.

on startup of the reader i can change the page turn direction using any gesture.

once the page turn direction was changed in the current session (of crengine) i cannot change it via the corresponding corner gesture.

 i can't go from RTL -> LTR using the right corners,
nor from LTR -> RTL using the top left corner,
nor either way using the bottom left corner.
(all once the page turn direction was changed in the current session)

however other gestures (short diagonal swipe) always work.

