### PR TITLE
Fix: incorrect chapter markers

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -911,6 +911,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
                 callback = function()
                     self.settings.disable_progress_bar = not self.settings.disable_progress_bar
+                    self:setTocMarkers()
                     self:refreshFooter()
                     if self.settings.progress_bar_separate_line then
                         self.ui:handleEvent(Event:new("SetPageBottomMargin", self.view.document.configurable.b_page_margin))
@@ -983,10 +984,11 @@ function ReaderFooter:genAllFooterText()
     return table.concat(info, separator)
 end
 
--- this method should never get called when footer is disabled
 function ReaderFooter:setTocMarkers(reset)
+    if self.settings.disable_progress_bar then return end
     if reset then
         self.progress_bar.ticks = nil
+        self.pages = self.view.document:getPageCount()
     end
     if self.settings.toc_markers then
         if self.progress_bar.ticks ~= nil then return end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -751,6 +751,7 @@ function ReaderRolling:onChangeViewMode()
     self.old_doc_height = self.ui.document.info.doc_height
     self.old_page = self.ui.document.info.number_of_pages
     self.ui:handleEvent(Event:new("UpdateToc"))
+    self.view.footer:setTocMarkers(true)
     if self.xpointer then
         self:_gotoXPointer(self.xpointer)
         -- Ensure a whole screen refresh is always enqueued


### PR DESCRIPTION
Close: #3778 

We have to set chapter markers in footer every time when screen geometry is changed.
Thanks @poire-z for: https://github.com/koreader/koreader/issues/3778#issuecomment-389967175