### PR TITLE
[Kobo/Cervantes] Always use setBrightness to set the brightness

### DIFF
--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -131,11 +131,7 @@ end
 
 function CervantesPowerD:setIntensityHW(intensity)
     if self.fl == nil then return end
-    if self.fl_warmth == nil then
-        self.fl:setBrightness(intensity)
-    else
-        self.fl:setNaturalBrightness(intensity, self.fl_warmth)
-    end
+    self.fl:setBrightness(intensity)
     self.hw_intensity = intensity
     -- Now that we have set intensity, we need to let BasePowerD
     -- know about possibly changed frontlight state (if we came

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -232,11 +232,7 @@ end
 
 function KoboPowerD:setIntensityHW(intensity)
     if self.fl == nil then return end
-    if self.fl_warmth == nil then
-        self.fl:setBrightness(intensity)
-    else
-        self.fl:setNaturalBrightness(intensity, self.fl_warmth)
-    end
+    self.fl:setBrightness(intensity)
     self.hw_intensity = intensity
     -- Now that we have set intensity, we need to let BasePowerD
     -- know about possibly changed frontlight state (if we came


### PR DESCRIPTION
sysfs_light handles every case sanely already, no need to be cute ;).

This prevents always setting the warmth when setting the FL on NL
devices with a mixer, because, besides being useless, it's also slow
(lua does mmap'ed io, so every handle requires an fstat + mmap).

It was subtly affecting the fluidity of the toggle ramp, and much less
subtly wreaking havoc on #5373 ;).

KA1 owners might want to investigate keeping the fds around one way or
another, like we do for the fl ioctl, to alleviate the overhead of doing
that for not one but three or four fds...
I won't be doing that, since I lack the hardware to test it, and FL+NL
stuff is pain.