### PR TITLE
Joplin support

### DIFF
--- a/plugins/evernote.koplugin/JoplinClient.lua
+++ b/plugins/evernote.koplugin/JoplinClient.lua
@@ -1,0 +1,140 @@
+local json = require("json")
+local http = require('socket.http')
+local ltn12 = require('ltn12')
+local socket = require('socket')
+local url = require('socket.url')
+
+local JoplinClient =  {
+    server_ip = "localhost",
+    server_port = 41184,
+    auth_token = ""
+}
+
+function JoplinClient:new(o)
+    o = o or {}
+    self.__index = self
+    setmetatable(o, self)
+    return o
+end
+
+function JoplinClient:_makeRequest(url, method, request_body)
+    local sink = {}
+    local source = {}
+    local request_body = json.encode(request_body)
+    local source = ltn12.source.string(request_body)
+    http.request{
+        url = url,
+        method = method,
+        sink = ltn12.sink.table(sink),
+        source = source,
+        headers = {["Content-Length"] = #request_body,
+            ["Content-Type"] = "application/json"}
+    }
+
+    if not sink[1] then
+        error("No response from Joplin Server") 
+    end
+
+    local response = json.decode(sink[1])
+
+    if response["error"] then
+        error(response["error"])
+    end
+
+    return response
+end
+
+function JoplinClient:ping()
+    local sink = {}
+
+    http.request{
+        url =  "http://"..self.server_ip..":"..self.server_port.."/ping",
+        method = "GET",
+        sink = ltn12.sink.table(sink)
+    }
+
+    if sink[1] == "JoplinClipperServer" then 
+        return true
+    else 
+        return false
+    end
+end
+
+--@return if successful returns id of found note
+function JoplinClient:findNoteByTitle(title, notebook_id)
+    local url =  "http://"..self.server_ip..":"..self.server_port.."/notes?".."token="..self.auth_token.."&fields=id,title,parent_id"
+
+    local notes = self:_makeRequest(url, "GET")
+
+    for _, note in pairs(notes) do
+        if note["title"] == title then
+            if notebook_id == nil or note["parent_id"] == notebook_id then
+                return note["id"]
+            end
+        end
+    end
+
+    return false
+
+end
+
+--@return if successful returns id of found notebook (folder)
+function JoplinClient:findNotebookByTitle(title)
+    local url =  "http://"..self.server_ip..":"..self.server_port.."/folders?".."token="..self.auth_token.."&".."query="..title
+
+    local folders = self:_makeRequest(url, "GET") 
+
+    for _, folder in pairs(folders) do
+        if folder["title"] == title then
+            return folder["id"]
+        end
+    end
+
+    return false
+end
+
+--@return if successful returns id of created notebook (folder)
+function JoplinClient:createNotebook(title, created_time)
+    local request_body = {["title"] = title,
+        ["created_time"] = created_time
+    }
+
+    local url =  "http://"..self.server_ip..":"..self.server_port.."/folders?".."token="..self.auth_token
+    local response = self:_makeRequest(url, "POST", request_body)
+
+    return response["id"]
+end
+
+
+--@return if successful returns id of created note
+function JoplinClient:createNote(title, note, parent_id, created_time)
+    local request_body = {["title"] = title,
+            ["body"] = note, 
+            ["parent_id"] = parent_id,
+            ["created_time"] = created_time
+    }
+    local url =  "http://"..self.server_ip..":"..self.server_port.."/notes?".."token="..self.auth_token
+    local response = self:_makeRequest(url, "POST", request_body)
+
+    return response["id"]
+end
+
+--@return if successful returns true
+function JoplinClient:updateNote(note_id, note, title, parent_id)
+    local request_body = {
+        ["body"] = note
+    }
+    if title then 
+        request_body["title"] = title 
+    end
+
+    if parent_id then
+        request_body["parent_id"] = parent_id
+    end
+
+    local url = "http://"..self.server_ip..":"..self.server_port.."/notes/"..note_id.."?token="..self.auth_token
+    local response = self:_makeRequest(url, "PUT", request_body)
+    return response["id"]
+end
+
+return JoplinClient

--- a/plugins/evernote.koplugin/JoplinClient.lua
+++ b/plugins/evernote.koplugin/JoplinClient.lua
@@ -1,8 +1,6 @@
 local json = require("json")
 local http = require('socket.http')
 local ltn12 = require('ltn12')
-local socket = require('socket')
-local url = require('socket.url')
 
 local JoplinClient =  {
     server_ip = "localhost",
@@ -19,26 +17,27 @@ end
 
 function JoplinClient:_makeRequest(url, method, request_body)
     local sink = {}
-    local source = {}
-    local request_body = json.encode(request_body)
-    local source = ltn12.source.string(request_body)
+    local request_body_json = json.encode(request_body)
+    local source = ltn12.source.string(request_body_json)
     http.request{
         url = url,
         method = method,
         sink = ltn12.sink.table(sink),
         source = source,
-        headers = {["Content-Length"] = #request_body,
-            ["Content-Type"] = "application/json"}
+        headers = {
+            ["Content-Length"] = #request_body_json,
+            ["Content-Type"] = "application/json"
+        }
     }
 
     if not sink[1] then
-        error("No response from Joplin Server") 
+        error("No response from Joplin Server")
     end
 
     local response = json.decode(sink[1])
 
     if response.error then
-        error(response["error"])
+        error(response.error)
     end
 
     return response
@@ -53,9 +52,9 @@ function JoplinClient:ping()
         sink = ltn12.sink.table(sink)
     }
 
-    if sink[1] == "JoplinClipperServer" then 
+    if sink[1] == "JoplinClipperServer" then
         return true
-    else 
+    else
         return false
     end
 end
@@ -67,9 +66,9 @@ function JoplinClient:findNoteByTitle(title, notebook_id)
     local notes = self:_makeRequest(url, "GET")
 
     for _, note in pairs(notes) do
-        if note["title"] == title then
-            if notebook_id == nil or note["parent_id"] == notebook_id then
-                return note["id"]
+        if note.title == title then
+            if notebook_id == nil or note.parent_id == notebook_id then
+                return note.id
             end
         end
     end
@@ -82,11 +81,11 @@ end
 function JoplinClient:findNotebookByTitle(title)
     local url =  "http://"..self.server_ip..":"..self.server_port.."/folders?".."token="..self.auth_token.."&".."query="..title
 
-    local folders = self:_makeRequest(url, "GET") 
+    local folders = self:_makeRequest(url, "GET")
 
     for _, folder in pairs(folders) do
-        if folder["title"] == title then
-            return folder["id"]
+        if folder.title== title then
+            return folder.id
         end
     end
 
@@ -95,46 +94,43 @@ end
 
 -- If successful returns id of created notebook (folder).
 function JoplinClient:createNotebook(title, created_time)
-    local request_body = {["title"] = title,
-        ["created_time"] = created_time
+    local request_body = {
+        title = title,
+        created_time = created_time
     }
 
     local url =  "http://"..self.server_ip..":"..self.server_port.."/folders?".."token="..self.auth_token
     local response = self:_makeRequest(url, "POST", request_body)
 
-    return response["id"]
+    return response.id
 end
 
 
 -- If successful returns id of created note.
 function JoplinClient:createNote(title, note, parent_id, created_time)
-    local request_body = {["title"] = title,
-            ["body"] = note, 
-            ["parent_id"] = parent_id,
-            ["created_time"] = created_time
+    local request_body = {
+            title = title,
+            body = note,
+            parent_id = parent_id,
+            created_time = created_time
     }
     local url =  "http://"..self.server_ip..":"..self.server_port.."/notes?".."token="..self.auth_token
     local response = self:_makeRequest(url, "POST", request_body)
 
-    return response["id"]
+    return response.id
 end
 
 -- If successful returns id of updated note.
 function JoplinClient:updateNote(note_id, note, title, parent_id)
     local request_body = {
-        ["body"] = note
+        body = note,
+        title = title,
+        parent_id = parent_id
     }
-    if title then 
-        request_body["title"] = title 
-    end
-
-    if parent_id then
-        request_body["parent_id"] = parent_id
-    end
 
     local url = "http://"..self.server_ip..":"..self.server_port.."/notes/"..note_id.."?token="..self.auth_token
     local response = self:_makeRequest(url, "PUT", request_body)
-    return response["id"]
+    return response.id
 end
 
 return JoplinClient

--- a/plugins/evernote.koplugin/JoplinClient.lua
+++ b/plugins/evernote.koplugin/JoplinClient.lua
@@ -37,7 +37,7 @@ function JoplinClient:_makeRequest(url, method, request_body)
 
     local response = json.decode(sink[1])
 
-    if response["error"] then
+    if response.error then
         error(response["error"])
     end
 
@@ -60,7 +60,7 @@ function JoplinClient:ping()
     end
 end
 
---@return if successful returns id of found note
+-- If successful returns id of found note.
 function JoplinClient:findNoteByTitle(title, notebook_id)
     local url =  "http://"..self.server_ip..":"..self.server_port.."/notes?".."token="..self.auth_token.."&fields=id,title,parent_id"
 
@@ -78,7 +78,7 @@ function JoplinClient:findNoteByTitle(title, notebook_id)
 
 end
 
---@return if successful returns id of found notebook (folder)
+-- If successful returns id of found notebook (folder).
 function JoplinClient:findNotebookByTitle(title)
     local url =  "http://"..self.server_ip..":"..self.server_port.."/folders?".."token="..self.auth_token.."&".."query="..title
 
@@ -93,7 +93,7 @@ function JoplinClient:findNotebookByTitle(title)
     return false
 end
 
---@return if successful returns id of created notebook (folder)
+-- If successful returns id of created notebook (folder).
 function JoplinClient:createNotebook(title, created_time)
     local request_body = {["title"] = title,
         ["created_time"] = created_time
@@ -106,7 +106,7 @@ function JoplinClient:createNotebook(title, created_time)
 end
 
 
---@return if successful returns id of created note
+-- If successful returns id of created note.
 function JoplinClient:createNote(title, note, parent_id, created_time)
     local request_body = {["title"] = title,
             ["body"] = note, 
@@ -119,7 +119,7 @@ function JoplinClient:createNote(title, note, parent_id, created_time)
     return response["id"]
 end
 
---@return if successful returns true
+-- If successful returns id of updated note.
 function JoplinClient:updateNote(note_id, note, title, parent_id)
     local request_body = {
         ["body"] = note

--- a/plugins/evernote.koplugin/JoplinClient.lua
+++ b/plugins/evernote.koplugin/JoplinClient.lua
@@ -1,6 +1,6 @@
 local json = require("json")
-local http = require('socket.http')
-local ltn12 = require('ltn12')
+local http = require("socket.http")
+local ltn12 = require("ltn12")
 
 local JoplinClient =  {
     server_ip = "localhost",

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -241,7 +241,7 @@ For Windows: netsh interface portproxy add listeningaddress:0.0.0.0 listeningpor
 
 For Linux: $socat tcp-listen:41185,reuseaddr,fork tcp:localhost:41184
 
-For more info visit https://github.com/koreader/koreader/wiki/Evernote-export.]])
+For more information, please visit https://github.com/koreader/koreader/wiki/Evernote-export.]])
                             ,DataStorage:getDataDir())
                             })
                         end

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -36,6 +36,10 @@ function EvernoteExporter:init()
     self.evernote_username = settings.username or ""
     self.evernote_token = settings.token
     self.notebook_guid = settings.notebook
+    self.joplin_IP = settings.joplin_IP or "localhost"
+    self.joplin_port = settings.joplin_port or 41184
+    self.joplin_token = settings.joplin_token -- or your token
+    self.joplin_notebook_guid = settings.joplin_notebook_guid or nil
     self.html_export = settings.html_export or false
     if self.html_export then
         self.txt_export = false
@@ -288,6 +292,11 @@ function EvernoteExporter:saveSettings()
         notebook = self.notebook_guid,
         html_export = self.html_export,
         txt_export = self.txt_export,
+        joplin_IP = self.joplin_IP,
+        joplin_port = self.joplin_port,
+        joplin_token = self.joplin_token,
+        joplin_notebook_guid = self.joplin_notebook_guid,
+        joplin_export = self.joplin_export
     }
     G_reader_settings:saveSetting("evernote", settings)
 end

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -126,7 +126,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Export to Joplin ") ,
+                text = _("Joplin") ,
                 checked_func = function() return self.joplin_export end,
                 sub_item_table ={
                     {
@@ -180,7 +180,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                         end
                     },
                     {
-                        text = "Set authorization token",
+                        text = _("Set authorization token"),
                         keep_menu_open = true,
                         callback = function()
                             local MultiInputDialog = require("ui/widget/multiinputdialog")
@@ -206,7 +206,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                                             callback = function()
                                                 local auth_field = auth_dialog:getFields()
                                                 --TODO do a check on auth string
-                                                self.joplin_token = auth_field[1] -- "41fb4a57758bbdfea75fcde1b7999469fc568ad9e6efc821683180278458d0d2e6c4a1ec2f85bfe73a3edfec096d963964e92308a4a394f017795928a7569288"
+                                                self.joplin_token = auth_field[1]
                                                 self:saveSettings()
                                                 UIManager:close(auth_dialog)
                                             end
@@ -672,16 +672,10 @@ function EvernoteExporter:exportBooknotesToJoplin(client, title, booknotes)
         end
     end
 
-    local ok
-
     if note_guid then
-        ok = client:updateNote(note_guid, note)
+        client:updateNote(note_guid, note)
     else 
-        ok = client:createNote(title, note, self.joplin_notebook_guid)
-    end
-
-    if not ok then
-        error("Server didn't respond to update or create post query, token error?")
+        client:createNote(title, note, self.joplin_notebook_guid)
     end
 
 end

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -201,7 +201,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                                             end
                                         },
                                         {
-                                            text = _("OK"),
+                                            text = _("Set token"),
                                             callback = function()
                                                 local auth_field = auth_dialog:getFields()
                                                 self.joplin_token = auth_field[1]

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -44,8 +44,8 @@ function EvernoteExporter:init()
     self.html_export = settings.html_export or false
     self.joplin_export = settings.joplin_export or false
     self.txt_export = settings.txt_export or false
-    --TODO is this if block necessarry? nowhere in the code they are assigned both true
-    --do they check against external modifications to settings file?
+    ---@todo Is this if block necessarry? Nowhere in the code they are assigned both true.
+    --Do they check against external modifications to settings file?
 
     if self.html_export then
         self.txt_export = false
@@ -162,7 +162,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                                                 local ip = fields[1]
                                                 local port = tonumber(fields[2])
                                                 if ip ~= "" then 
-                                                    --TODO better checks for ip and port
+                                                    ---@todo Do better checks for ip and port.
                                                     if port and port < 65355 then 
                                                         self.joplin_IP = ip
                                                     end
@@ -205,7 +205,6 @@ function EvernoteExporter:addToMainMenu(menu_items)
                                             text = _("OK"),
                                             callback = function()
                                                 local auth_field = auth_dialog:getFields()
-                                                --TODO do a check on auth string
                                                 self.joplin_token = auth_field[1]
                                                 self:saveSettings()
                                                 UIManager:close(auth_dialog)
@@ -239,7 +238,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
 
 To use Joplin you must enable port forwarding via socat or similar program.
 
-For more info visit github.com/koreader/wiki/Evernote-export. ]])
+For more info visit https://github.com/koreader/koreader/wiki/Evernote-export.]])
                             ,DataStorage:getDataDir())
                             })
                         end
@@ -521,8 +520,8 @@ function EvernoteExporter:exportClippings(clippings)
             server_port = self.joplin_port,
             auth_token = self.joplin_token
         }
-        --TODO also check if user deleted our notebook, in that case note
-        -- will endup in random folder in Joplin
+        ---@todo Check if user deleted our notebook, in that case note
+        -- will end up in random folder in Joplin.
         if not self.joplin_notebook_guid then
             self.joplin_notebook_guid = joplin_client:createNotebook(self.notebook_name) 
             self:saveSettings()
@@ -681,7 +680,7 @@ function EvernoteExporter:exportBooknotesToJoplin(client, title, booknotes)
         end
 
         for _, clipping in ipairs(chapter) do
-            -- TODO do something to prettify epoch time, write it
+            ---@todo Do something to prettify epoch time, write it.
             note = note .. clipping.text .. "\n * * *\n"
         end
     end

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -233,7 +233,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                         keep_menu_open = true,
                         callback = function()
                             UIManager:show(InfoMessage:new{
-                                text = T(_([[You can manually enter your auth token by saving empty field, editing evernote.joplin_token field in %1/settings.reader.lua and restarting KOReader.
+                                text = T(_([[You can enter your auth token on your computer by saving an empty token. Then quit KOReader, edit the evernote.joplin_token field in %1/settings.reader.lua after creating a backup, and restart KOReader once you're done.
 
 To export to Joplin, you must forward the IP and port used by this plugin to the localhost:port on which Joplin is listening. This can be done with socat or a similar program. For example:
 

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -233,9 +233,13 @@ function EvernoteExporter:addToMainMenu(menu_items)
                         keep_menu_open = true,
                         callback = function()
                             UIManager:show(InfoMessage:new{
-                                text = T(_([[You can manually enter your auth token by editing %1/settings.reader.lua.
+                                text = T(_([[You can manually enter your auth token by saving empty field, editing evernote.joplin_token field in %1/settings.reader.lua and restarting KOReader.
 
-To use Joplin you must enable port forwarding via socat or similar program.
+To use Joplin you must enable port forwarding from your computers local IP:port this plugin uses to localhost:port that Joplin is listening via socat or similar program. For example:
+
+For Windows: netsh interface portproxy add listeningaddress:0.0.0.0 listeningport:41185 connectaddress:localhost connectport:41184
+
+For Linux: $socat tcp-listen:41185,reuseaddr,fork tcp:localhost:41184
 
 For more info visit https://github.com/koreader/koreader/wiki/Evernote-export.]])
                             ,DataStorage:getDataDir())
@@ -502,7 +506,7 @@ end
 function EvernoteExporter:exportClippings(clippings)
     local client = nil
     local exported_stamp
-    local joplin_client = nil
+    local joplin_client
     if not (self.html_export or self.txt_export or self.joplin_export) then
         client = require("EvernoteClient"):new{
             domain = self.evernote_domain,

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -38,14 +38,14 @@ function EvernoteExporter:init()
     self.evernote_token = settings.token
     self.notebook_guid = settings.notebook
     self.joplin_IP = settings.joplin_IP or "localhost"
-    self.joplin_port = settings.joplin_port or 41184
+    self.joplin_port = settings.joplin_port or 41185
     self.joplin_token = settings.joplin_token -- or your token
     self.joplin_notebook_guid = settings.joplin_notebook_guid or nil
     self.html_export = settings.html_export or false
     self.joplin_export = settings.joplin_export or false
     self.txt_export = settings.txt_export or false
     --TODO is this if block necessarry? nowhere in the code they are assigned both true
-    --do they check against external modifications to ettings file?
+    --do they check against external modifications to settings file?
 
     if self.html_export then
         self.txt_export = false
@@ -186,7 +186,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                             local MultiInputDialog = require("ui/widget/multiinputdialog")
                             local auth_dialog
                             auth_dialog = MultiInputDialog:new{
-                                title = _("Set authorization token from Joplin\n->WebClipper Settings"),
+                                title = _("Set authorization token for Joplin"),
                                 fields = {
                                     {
                                         text = self.joplin_token,
@@ -228,6 +228,20 @@ function EvernoteExporter:addToMainMenu(menu_items)
                                 self.txt_export = false
                             end
                             self:saveSettings()
+                        end
+                    },
+                    {
+                        text = _("Help"),
+                        keep_menu_open = true,
+                        callback = function()
+                            UIManager:show(InfoMessage:new{
+                                text = T(_([[You can manually enter your auth token by editing %1/settings.reader.lua.
+
+To use Joplin you must enable port forwarding via socat or similar program.
+
+For more info visit github.com/koreader/wiki/Evernote-export. ]])
+                            ,DataStorage:getDataDir())
+                            })
                         end
                     }
                 }

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -50,7 +50,7 @@ function EvernoteExporter:init()
     if self.html_export then
         self.txt_export = false
         self.joplin_export = false
-    elseif self.txt_export then 
+    elseif self.txt_export then
         self.joplin_export = false
     end
 
@@ -70,8 +70,8 @@ function EvernoteExporter:isDocless()
 end
 
 function EvernoteExporter:readyToExport()
-    return self.evernote_token ~= nil or 
-            self.html_export ~= false or 
+    return self.evernote_token ~= nil or
+            self.html_export ~= false or
             self.txt_export ~= false or
             self.joplin_export ~= false
 end
@@ -130,7 +130,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                 checked_func = function() return self.joplin_export end,
                 sub_item_table ={
                     {
-                        text = _("Set Joplin IP and Port"), 
+                        text = _("Set Joplin IP and Port"),
                         keep_menu_open = true,
                         callback = function()
                             local MultiInputDialog = require("ui/widget/multiinputdialog")
@@ -161,12 +161,11 @@ function EvernoteExporter:addToMainMenu(menu_items)
                                                 local fields = url_dialog:getFields()
                                                 local ip = fields[1]
                                                 local port = tonumber(fields[2])
-                                                if ip ~= "" then 
-                                                    ---@todo Do better checks for ip and port.
-                                                    if port and port < 65355 then 
+                                                if ip ~= "" then
+                                                    if port and port < 65355 then
                                                         self.joplin_IP = ip
+                                                        self.joplin_port = port
                                                     end
-                                                    self.joplin_port = port
                                                     self:saveSettings()
                                                 end
                                                 UIManager:close(url_dialog)
@@ -283,8 +282,8 @@ For more info visit https://github.com/koreader/koreader/wiki/Evernote-export.]]
                 callback = function()
                     self.html_export = not self.html_export
                     if self.html_export then
-                        self.txt_export = false 
-                        self.joplin_export = false 
+                        self.txt_export = false
+                        self.joplin_export = false
                     end
                     self:saveSettings()
                 end
@@ -295,8 +294,8 @@ For more info visit https://github.com/koreader/koreader/wiki/Evernote-export.]]
                 callback = function()
                     self.txt_export = not self.txt_export
                     if self.txt_export then
-                        self.html_export = false 
-                        self.joplin_export = false 
+                        self.html_export = false
+                        self.joplin_export = false
                     end
                     self:saveSettings()
                 end
@@ -503,7 +502,7 @@ end
 function EvernoteExporter:exportClippings(clippings)
     local client = nil
     local exported_stamp
-    if not (self.html_export or self.txt_export or self.joplin_export) then 
+    if not (self.html_export or self.txt_export or self.joplin_export) then
         client = require("EvernoteClient"):new{
             domain = self.evernote_domain,
             authToken = self.evernote_token,
@@ -523,7 +522,7 @@ function EvernoteExporter:exportClippings(clippings)
         ---@todo Check if user deleted our notebook, in that case note
         -- will end up in random folder in Joplin.
         if not self.joplin_notebook_guid then
-            self.joplin_notebook_guid = joplin_client:createNotebook(self.notebook_name) 
+            self.joplin_notebook_guid = joplin_client:createNotebook(self.notebook_name)
             self:saveSettings()
         end
     else
@@ -680,14 +679,14 @@ function EvernoteExporter:exportBooknotesToJoplin(client, title, booknotes)
         end
 
         for _, clipping in ipairs(chapter) do
-            ---@todo Do something to prettify epoch time, write it.
+            note = note .. os.date("%Y-%m-%d %H:%M:%S \n", clipping.time)
             note = note .. clipping.text .. "\n * * *\n"
         end
     end
 
     if note_guid then
         client:updateNote(note_guid, note)
-    else 
+    else
         client:createNote(title, note, self.joplin_notebook_guid)
     end
 

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -45,7 +45,7 @@ function EvernoteExporter:init()
     self.joplin_export = settings.joplin_export or false
     self.txt_export = settings.txt_export or false
     --- @todo Is this if block necessarry? Nowhere in the code they are assigned both true.
-    --Do they check against external modifications to settings file?
+    -- Do they check against external modifications to settings file?
 
     if self.html_export then
         self.txt_export = false

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -44,7 +44,7 @@ function EvernoteExporter:init()
     self.html_export = settings.html_export or false
     self.joplin_export = settings.joplin_export or false
     self.txt_export = settings.txt_export or false
-    ---@todo Is this if block necessarry? Nowhere in the code they are assigned both true.
+    --- @todo Is this if block necessarry? Nowhere in the code they are assigned both true.
     --Do they check against external modifications to settings file?
 
     if self.html_export then

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -502,6 +502,7 @@ end
 function EvernoteExporter:exportClippings(clippings)
     local client = nil
     local exported_stamp
+    local joplin_client = nil
     if not (self.html_export or self.txt_export or self.joplin_export) then
         client = require("EvernoteClient"):new{
             domain = self.evernote_domain,

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -516,4 +516,24 @@ function EvernoteExporter:exportBooknotesToTXT(title, booknotes)
     end
 end
 
+function EvernoteExporter:exportBooknotesToJoplin(client, title, booknotes)
+    local note_guid = client:findNoteByTitle(title, self.joplin_notebook_guid)
+    local note = ""
+    for _, chapter in ipairs(booknotes) do
+        if chapter.title then
+            note = note .. "\n\t*" .. chapter.title .. "*\n\n * * *"
+        end
+
+        for _, clipping in ipairs(chapter) do
+            -- TODO do something to prettify epoch time, write it
+            note = note .. clipping.text .. "\n * * *\n"
+        end
+    end
+    if note_guid then
+        client:updateNote(note_guid, note)
+    else 
+        client:createNote(title, note, self.joplin_notebook_guid)
+    end
+end
+
 return EvernoteExporter

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -235,7 +235,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                             UIManager:show(InfoMessage:new{
                                 text = T(_([[You can manually enter your auth token by saving empty field, editing evernote.joplin_token field in %1/settings.reader.lua and restarting KOReader.
 
-To use Joplin you must enable port forwarding from your computers local IP:port this plugin uses to localhost:port that Joplin is listening via socat or similar program. For example:
+To export to Joplin, you must forward the IP and port used by this plugin to the localhost:port on which Joplin is listening. This can be done with socat or a similar program. For example:
 
 For Windows: netsh interface portproxy add listeningaddress:0.0.0.0 listeningport:41185 connectaddress:localhost connectport:41184
 


### PR DESCRIPTION
adds joplin support https://github.com/koreader/koreader/issues/5086

Changes
-adds a submenu to evernote menu 
   - -Joplin
      |-Set IP and port
      |-Set authorization token
      |-Export to Joplin
      |-Help

-adds EvernoteExporter:exportBooknotesToJoplin()
-adds JoplinClient.lua
-modifies html_export, txt_export and joplin_export flags to work with each other. (eg if user selects one others deactivated)

Because joplin only listens on localhost, [see diccussion on joplin forums, ](https://discourse.joplinapp.org/t/clipper-api-listens-only-localhost-requesting-to-include-local-addresses/3560)  user needs to port forward on computer. To do that :
on linux `$socat tcp-listen:41185,reuseaddr,fork tcp:localhost:41184`
on windows `netsh interface portproxy add listeningaddress:0.0.0.0 listeningport:41185 connectaddress:localhost connectport:41184`
If you think this is too hacky, feel free to close this PR.  I can add all this into wiki in case someone may want to use Joplin.