### PR TITLE
EPUB: more support for RTL documents

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -169,12 +169,12 @@ h1 + h6, h2 + h6, h3 + h6, h4 + h6, h5 + h6 { page-break-before: avoid !importan
             {
                 title = _("About text direction"),
                 info_text = _([[
-Documents in languages like arabic or hebrew are to be rendered Right-To-Left. This does not only affects text layout, but also list items bullets and numbers (put on the right) and table layout (cells laid from right to left).
+Languages like Arabic or Hebrew use right-to-left writing systems (Right-To-Left or RTL). This doesn't only affect text layout, but also list item bullets and numbers, which have to be put on the right side of the page, as well as tables, where the cells are laid out from right to left.
 
-Usually, the publisher has set the appropriate tags to force such rendering - but if he hasn't, or if you're reading plain text documents, you may want to manually enable it with these tweaks.
-Note that in the absence of such specifications KOReader will try to detect the language of each paragraph and set the approppriate rendering per paragraph.
+Usually, the publisher will have set the appropriate tags to enable RTL rendering. But if these are missing, or if you're reading plain text documents, you may want to manually enable RTL with these tweaks.
+Note that in the absence of such specifications, KOReader will try to detect the language of each paragraph to set the appropriate rendering per paragraph.
 
-You may also want to enable, in top menu → Gear → Navigation →, Invert page turn taps and swipes.]]),
+You may also want to enable, in the top menu → Gear → Navigation →, Invert page turn taps and swipes.]]),
                 separator = true,
             },
             {

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -179,7 +179,7 @@ You may also want to enable, in the top menu → Gear → Navigation →, Invert
             },
             {
                 id = "body_direction_rtl",
-                title = _("Set document direction to RTL (Right-to-Left)"),
+                title = _("Document direction RTL"),
                 css = [[body { direction: rtl !important; }]],
                 priority = 2, -- so it overrides the LTR one below
             },
@@ -201,7 +201,7 @@ You may also want to enable, in the top menu → Gear → Navigation →, Invert
             },
             {
                 id = "body_direction_ltr",
-                title = _("Set document direction to LTR (Left-to-Right)"),
+                title = _("Document direction LTR"),
                 css = [[body { direction: ltr !important; }]],
             },
         },

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -178,7 +178,7 @@ You may also want to enable, in top menu → Gear → Navigation →, Invert pag
                 separator = true,
             },
             {
-                id = "dir_html_rtl",
+                id = "body_direction_rtl",
                 title = _("Set document direction to RTL (Right-to-Left)"),
                 css = [[body { direction: rtl !important; }]],
                 priority = 2, -- so it overrides the LTR one below
@@ -200,7 +200,7 @@ You may also want to enable, in top menu → Gear → Navigation →, Invert pag
                 separator = true,
             },
             {
-                id = "dir_html_ltr",
+                id = "body_direction_ltr",
                 title = _("Set document direction to LTR (Left-to-Right)"),
                 css = [[body { direction: ltr !important; }]],
             },

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -161,7 +161,48 @@ h1 + h6, h2 + h6, h3 + h6, h4 + h6, h5 + h6 { page-break-before: avoid !importan
                 id = "headings_align_center",
                 title = _("Center headings"),
                 css = [[h1, h2, h3, h4, h5, h6 { text-align: center !important; }]],
-                priority = 3, -- so it overrides the ones above
+                priority = 4, -- so it overrides the ones above
+            },
+        },
+        {
+            title = _("Text direction"),
+            {
+                title = _("About text direction"),
+                info_text = _([[
+Documents in languages like arabic or hebrew are to be rendered Right-To-Left. This does not only affects text layout, but also list items bullets and numbers (put on the right) and table layout (cells laid from right to left).
+
+Usually, the publisher has set the appropriate tags to force such rendering - but if he hasn't, or if you're reading plain text documents, you may want to manually enable it with these tweaks.
+Note that in the absence of such specifications KOReader will try to detect the language of each paragraph and set the approppriate rendering per paragraph.
+
+You may also want to enable, in top menu → Gear → Navigation →, Invert page turn taps and swipes.]]),
+                separator = true,
+            },
+            {
+                id = "dir_html_rtl",
+                title = _("Set document direction to RTL (Right-to-Left)"),
+                css = [[body { direction: rtl !important; }]],
+                priority = 2, -- so it overrides the LTR one below
+            },
+            {
+                id = "text_align_most_right",
+                title = _("Right align most text"),
+                description = _("Enforce right alignment of text in common text elements."),
+                -- Includes H1..H6 as this is probably most useful for RTL readers
+                css = [[body, p, li, h1, h2, h3, h4, h5, h6 { text-align: right !important; }]],
+                priority = 3, -- so it overrides the ones from Text alignment
+            },
+            {
+                id = "text_align_all_right",
+                title = _("Right align all elements"),
+                description = _("Enforce right alignment of text in all elements."),
+                css = [[* { text-align: right !important; }]],
+                priority = 3, -- so it overrides the ones from Text alignment
+                separator = true,
+            },
+            {
+                id = "dir_html_ltr",
+                title = _("Set document direction to LTR (Left-to-Right)"),
+                css = [[body { direction: ltr !important; }]],
             },
         },
         {
@@ -280,7 +321,7 @@ This might be needed with some documents that expect this style as the default, 
             priority = -1,
             css = [[
 p {
-    text-align: left;
+    text-align: start;
     text-indent: 0;
     margin-top: 1em;
     margin-bottom: 1em;


### PR DESCRIPTION
bump crengine: enhanced RTL block rendering. Includes:
- Re-enable: Use the same FT load flags in HB as in FT https://github.com/koreader/crengine/pull/311
- Avoid redundant calls to getStyle() https://github.com/koreader/crengine/pull/312
- CSS: parse and store "direction:"
- Enhanced block rendering: handle RTL direction
- Enhanced block rendering: handle RTL tables
- Pagesplitting: account for lines' text direction
- CSS: add support for more pseudo-classes
- epub.css: a few updates for RTL documents
- Fix LVDocView::getBookmark() which could be slow or wrong https://github.com/koreader/crengine/pull/313

Add a few style tweaks useful to RTL readers.

Wikipedia Save as EPUB: build proper RTL documents from persian, arabic, hebrew (and others) Wikipedia articles.

Screenshots in https://github.com/koreader/crengine/pull/312