### PR TITLE
Fix: Crash toggleswitch when args are empty

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -535,7 +535,7 @@ function ConfigOption:init()
                     enabled = enabled,
                     row_count = row_count,
                     callback = function(arg)
-                        if self.options[c].args[arg] == "⋮" then
+                        if self.options[c].toggle[arg] == "⋮" then
                             self.config:onConfigMoreChoose(self.options[c].values, self.options[c].name,
                                 self.options[c].event, arg, self.options[c].name_text, self.options[c].delay_repaint, self.options[c].more_options_param)
                         end

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -195,7 +195,7 @@ function ToggleSwitch:onTapSelect(arg, gev)
     end
     if gev then
         local position = self:calculatePosition(gev)
-        if self.args[position] ~= "⋮" then
+        if self.toggle[position] ~= "⋮" then
             self:togglePosition(position, true)
         else
             self:togglePosition(position, false)
@@ -218,7 +218,7 @@ function ToggleSwitch:onTapSelect(arg, gev)
     end
     --]]
     self.callback(self.position)
-    if self.args[self.position] ~= "⋮" then
+    if self.toggle[self.position] ~= "⋮" then
         self.config:onConfigChoose(self.values, self.name,
             self.event, self.args, self.events, self.position, self.delay_repaint)
         UIManager:setDirty(self.config, function()
@@ -230,7 +230,7 @@ end
 
 function ToggleSwitch:onHoldSelect(arg, gev)
     local position = self:calculatePosition(gev)
-    if self.args[position] == "⋮" then
+    if self.toggle[position] == "⋮" then
         return true
     end
     if self.name == "font_fine_tune" then


### PR DESCRIPTION
Fix: #5434 