### PR TITLE
Support for exporting annotations/bookmark renames 

### DIFF
--- a/plugins/evernote.koplugin/clip.lua
+++ b/plugins/evernote.koplugin/clip.lua
@@ -226,7 +226,7 @@ function MyClipping:getImage(image)
     end
 end
 
-function MyClipping:parseHighlight(highlights, book)
+function MyClipping:parseHighlight(highlights, bookmarks, book)
     --DEBUG("book", book.file)
     for page, items in pairs(highlights) do
         for _, item in ipairs(items) do
@@ -235,6 +235,12 @@ function MyClipping:parseHighlight(highlights, book)
             clipping.sort = "highlight"
             clipping.time = self:getTime(item.datetime or "")
             clipping.text = self:getText(item.text)
+            for _, bookmark in pairs(bookmarks) do
+                if bookmark.datetime == item.datetime and bookmark.text then
+                    local tmp = string.gsub(bookmark.text, "Page %d+ ", "")
+                    clipping.text = string.gsub(tmp, " @ %d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d", "")
+                end
+            end
             if item.text == "" and item.pos0 and item.pos1 and
                     item.pos0.x and item.pos0.y and
                     item.pos1.x and item.pos1.y then
@@ -281,7 +287,7 @@ function MyClipping:parseHistoryFile(clippings, history_file, doc_file)
             title = title,
             author = author,
         }
-        self:parseHighlight(stored.highlight, clippings[title])
+        self:parseHighlight(stored.highlight, stored.bookmarks, clippings[title])
     end
 end
 
@@ -312,7 +318,7 @@ function MyClipping:parseCurrentDoc(view)
         title = title,
         author = author,
     }
-    self:parseHighlight(view.highlight.saved, clippings[title])
+    self:parseHighlight(view.highlight.saved, view.ui.bookmark.bookmarks, clippings[title])
 
     return clippings
 end

--- a/plugins/evernote.koplugin/clip.lua
+++ b/plugins/evernote.koplugin/clip.lua
@@ -287,7 +287,7 @@ function MyClipping:parseHistoryFile(clippings, history_file, doc_file)
             title = title,
             author = author,
         }
-        self:parseHighlight(stored.highlight, stored.bookmarks, clippings[title])
+        self:parseHighlight(stored.highlight, stored.bookmarks, clippings.title)
     end
 end
 
@@ -318,7 +318,7 @@ function MyClipping:parseCurrentDoc(view)
         title = title,
         author = author,
     }
-    self:parseHighlight(view.highlight.saved, view.ui.bookmark.bookmarks, clippings[title])
+    self:parseHighlight(view.highlight.saved, view.ui.bookmark.bookmarks, clippings.title)
 
     return clippings
 end


### PR DESCRIPTION
see https://github.com/koreader/koreader/issues/5408

parseHighlight now must be called with both highlight and bookmarks fields of sidecar file. If bookmarks field have edited text field on it, it removes page and time info from text, saves edited version as clipping.text. 

I tried to making it work only with bookmarks or highlight but both fields lacks necessary data (pboxes, page info for example) and didn't want to fill them with duplicate info.

Also when a highlights borders are changed bookmarks.text field gets rewritten. I think there will also be issues with that later.