### PR TITLE
Image viewer use the whole screen

### DIFF
--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -390,7 +390,9 @@ function ImageViewer:update()
     if progress_container then
         table.insert(frame_elements, progress_container)
     end
-    table.insert(frame_elements, button_container)
+    if self._show_buttons then
+        table.insert(frame_elements, button_container)
+    end
 
     self.main_frame = FrameContainer:new{
         radius = not self.fullscreen and 8 or nil,
@@ -455,6 +457,7 @@ function ImageViewer:onTap(_, ges)
     if self.caption_tap_area and ges.pos:intersectWith(self.caption_tap_area.dimen) then
         self.caption_visible = not self.caption_visible
         self:update()
+        return true
     end
     if self._images_list then
         -- If it's a list of image (e.g. animated gifs), tap each size to navigate

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -81,7 +81,7 @@ local ImageViewer = InputContainer:new{
     _image_wg = nil,
     _images_list = nil,
     _images_list_disposable = nil,
-    
+
     -- buttons state
     _show_buttons = false,
 }
@@ -340,7 +340,7 @@ function ImageViewer:update()
     -- if no buttons are shown, use the full screen
     local max_image_h = img_container_h
     local max_image_w = self.width
-    
+
     -- Otherwise, add paddings
     if not self._show_buttons then
         max_image_h = img_container_h - self.image_padding*2

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -216,7 +216,7 @@ function ImageViewer:update()
             button_table,
         }
         button_table_size = button_table:getSize().h
-    end						   
+    end
 
     -- height available to our image
     local img_container_h = self.height - button_table_size


### PR DESCRIPTION
As proposed in #5444, when open an image, it is shown using the whole screen. User can toggle the buttons by tapping the bottom quarter. Tapping other area will close the image.

If it is a list of image (e.g. animated gifs), then the above does not applied.