### PR TITLE
android bump - kotlin/haptic/timeout

### DIFF
--- a/frontend/ui/elements/screen_android.lua
+++ b/frontend/ui/elements/screen_android.lua
@@ -1,6 +1,7 @@
 local isAndroid, android = pcall(require, "android")
 local Device = require("device")
 local Geom = require("ui/geometry")
+local ffi = require("ffi")
 local logger = require("logger")
 local _ = require("gettext")
 local Input = Device.input
@@ -9,19 +10,18 @@ local T = require("ffi/util").template
 
 if not isAndroid then return end
 
+local system = ffi.C.AKEEP_SCREEN_ON_DISABLED
+local screenOn = ffi.C.AKEEP_SCREEN_ON_ENABLED
+local needs_wakelocks = android.needsWakelocks()
+
 -- custom timeouts (in milliseconds)
-local timeout_custom1 = 30 * 1000
-local timeout_custom2 = 60 * 1000
-local timeout_custom3 = 2 * 60 * 1000
-local timeout_custom4 = 5 * 60 * 1000
-local timeout_custom5 = 10 * 60 * 1000
-local timeout_custom6 = 15 * 60 * 1000
+local timeout_custom1 = 2 * 60 * 1000
+local timeout_custom2 = 5 * 60 * 1000
+local timeout_custom3 = 10 * 60 * 1000
+local timeout_custom4 = 15 * 60 * 1000
+local timeout_custom5 = 20 * 60 * 1000
+local timeout_custom6 = 25 * 60 * 1000
 local timeout_custom7 = 30 * 60 * 1000
-
-local timeout_system = 0    -- same as system (do nothing!)
-local timeout_disabled = -1 -- disable timeout using wakelocks
-
-local can_modify_timeout = not android.needsWakelocks()
 
 local function humanReadableTimeout(timeout)
     local sec = timeout / 1000
@@ -32,13 +32,35 @@ local function humanReadableTimeout(timeout)
     end
 end
 
+local function canModifyTimeout(timeout)
+    if needs_wakelocks then return false end
+    if timeout == system or timeout == screenOn then
+        return true
+    else
+        return android.settings.canWrite()
+    end
+end
+
 local function timeoutEquals(timeout)
-    return timeout == android.getScreenOffTimeout()
+    return timeout == android.timeout.get()
 end
 
 local function saveAndApplyTimeout(timeout)
     G_reader_settings:saveSetting("android_screen_timeout", timeout)
-    android.setScreenOffTimeout(timeout)
+    android.timeout.set(timeout)
+end
+
+local function requestWriteSettings()
+    local UIManager = require("ui/uimanager")
+    local ConfirmBox = require("ui/widget/confirmbox")
+    UIManager:show(ConfirmBox:new{
+        text = _("Allow KOReader to modify system settings?\n\nYou will be prompted with a permission management screen. You'll need to give KOReader permission and then restart the program."),
+        ok_text = _("Allow"),
+        ok_callback = function()
+            UIManager:scheduleIn(1, function() UIManager:quit() end)
+            android.settings.requestWritePermission()
+        end,
+    })
 end
 
 local ScreenHelper = {}
@@ -93,66 +115,77 @@ end
 
 -- timeout menu table
 function ScreenHelper:getTimeoutMenuTable()
-    return {
-        text = _("Screen Timeout"),
-        sub_item_table = {
+    local t = {
             {
                 text = _("Use system settings"),
-                enabled_func = function() return can_modify_timeout end,
-                checked_func = function() return timeoutEquals(timeout_system) end,
-                callback = function() saveAndApplyTimeout(timeout_system) end
+                enabled_func = function() return canModifyTimeout(system) end,
+                checked_func = function() return timeoutEquals(system) end,
+                callback = function() saveAndApplyTimeout(system) end
             },
             {
                 text = humanReadableTimeout(timeout_custom1),
-                enabled_func = function() return can_modify_timeout end,
+                enabled_func = function() return canModifyTimeout(timeout_custom1) end,
                 checked_func = function() return timeoutEquals(timeout_custom1) end,
                 callback = function() saveAndApplyTimeout(timeout_custom1) end
             },
             {
                 text = humanReadableTimeout(timeout_custom2),
-                enabled_func = function() return can_modify_timeout end,
+                enabled_func = function() return canModifyTimeout(timeout_custom2) end,
                 checked_func = function() return timeoutEquals(timeout_custom2) end,
                 callback = function() saveAndApplyTimeout(timeout_custom2) end
             },
             {
                 text = humanReadableTimeout(timeout_custom3),
-                enabled_func = function() return can_modify_timeout end,
+                enabled_func = function() return canModifyTimeout(timeout_custom3) end,
                 checked_func = function() return timeoutEquals(timeout_custom3) end,
                 callback = function() saveAndApplyTimeout(timeout_custom3) end
             },
             {
                 text = humanReadableTimeout(timeout_custom4),
-                enabled_func = function() return can_modify_timeout end,
+                enabled_func = function() return canModifyTimeout(timeout_custom4) end,
                 checked_func = function() return timeoutEquals(timeout_custom4) end,
                 callback = function() saveAndApplyTimeout(timeout_custom4) end
             },
             {
                 text = humanReadableTimeout(timeout_custom5),
-                enabled_func = function() return can_modify_timeout end,
+                enabled_func = function() return canModifyTimeout(timeout_custom5) end,
                 checked_func = function() return timeoutEquals(timeout_custom5) end,
                 callback = function() saveAndApplyTimeout(timeout_custom5) end
             },
             {
                 text = humanReadableTimeout(timeout_custom6),
-                enabled_func = function() return can_modify_timeout end,
+                enabled_func = function() return canModifyTimeout(timeout_custom6) end,
                 checked_func = function() return timeoutEquals(timeout_custom6) end,
                 callback = function() saveAndApplyTimeout(timeout_custom6) end
             },
             {
                 text = humanReadableTimeout(timeout_custom7),
-                enabled_func = function() return can_modify_timeout end,
+                enabled_func = function() return canModifyTimeout(timeout_custom7) end,
                 checked_func = function() return timeoutEquals(timeout_custom7) end,
                 callback = function() saveAndApplyTimeout(timeout_custom7) end
             },
             {
                 text = _("Keep screen on"),
-                enabled_func = function() return can_modify_timeout end,
-                checked_func = function() return timeoutEquals(timeout_disabled) end,
-                callback = function() saveAndApplyTimeout(timeout_disabled) end
+                enabled_func = function() return canModifyTimeout(screenOn) end,
+                checked_func = function() return timeoutEquals(screenOn) end,
+                callback = function() saveAndApplyTimeout(screenOn) end
             },
         }
+
+    if not android.settings.canWrite() then
+        table.insert(t, 1, {
+            text = _("Allow system settings override"),
+            enabled_func = function() return not android.settings.canWrite() end,
+            checked_func = function() return android.settings.canWrite() end,
+            callback = function() requestWriteSettings() end,
+            separator = true,
+        })
+    end
+
+    return {
+        text = _("Screen Timeout"),
+        sub_item_table = t
     }
 end
-
 
 return ScreenHelper


### PR DESCRIPTION
Visible changes:

- KOReader icon on start & friendly e-ink spinner, authored by @ColinKinloch

![ezgif-3-83c30eeb53a4](https://user-images.githubusercontent.com/975883/66245223-c0b19c80-e70c-11e9-9990-9db05faed88b.gif)

- Safer and more verbose WRITE_SETTINGS permissions: 

![ezgif-2-91e834e26ff3](https://user-images.githubusercontent.com/975883/66262881-781be100-e7e9-11e9-83b3-2bc12e279a88.gif)

Under the hood: 

- Migration to Kotlin (everything except the test activity and the e-ink methods to refresh the screen):
	+ Safety against null pointer exceptions (It can still be triggered from JNI)
	+ Less boilerplate code.
	+ Usually easier to read and more expresive.
	
- More responsive garbage collector:
	+ avoid leaking activity context
	+ slightly more memory usage on average (~1MB) but with the hability to free some memory on-demand (2-3MB)

- Removed wakelock permissions.

Fixes #5374 
Requires https://github.com/koreader/android-luajit-launcher/pull/193