### PR TITLE
[fix] Try to make screensaver settings slightly less error-prone

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -175,7 +175,11 @@ function ReaderMenu:setUpdateItemTable()
             text = _("Screensaver"),
             sub_item_table = require("ui/elements/screensaver_menu"),
         }
-        table.remove(self.menu_items.screensaver.sub_item_table, 9)
+        local table_len = #self.menu_items.screensaver.sub_item_table
+        --- @todo Make this less prone to being messed up by screensaver menu changes, for example with MenuSorter.
+        if self.menu_items.screensaver.sub_item_table[table_len].text == ss_book_settings.text then
+            table.remove(self.menu_items.screensaver.sub_item_table, table_len)
+        end
         table.insert(self.menu_items.screensaver.sub_item_table, ss_book_settings)
     end
 
@@ -348,10 +352,11 @@ end
 
 function ReaderMenu:onCloseDocument()
     if Device:supportsScreensaver() then
-        -- Remove the 9th item we added (which cleans up references to document
+        --- @todo Make this less prone to being messed up by screensaver menu changes, for example with MenuSorter.
+        -- Remove the item we added (which cleans up references to document
         -- and doc_settings embedded in functions)
         local screensaver_sub_item_table = require("ui/elements/screensaver_menu")
-        table.remove(screensaver_sub_item_table, 9)
+        table.remove(screensaver_sub_item_table, #screensaver_sub_item_table)
     end
 end
 


### PR DESCRIPTION
Regression inadvertently caused by #5369.

With the way this is constructed, this is almost guaranteed to happen.

Fixes #5459.