### PR TITLE
[feat] plugins/Wallabag: add ability to set a list of tags to ignore

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -187,13 +187,10 @@ function Wallabag:addToMainMenu(menu_items)
                     },
                     {
                         text_func = function()
-                            local tags
-                            if not self.ignore_tags then
-                                tags = ""
-                            else
-                                tags = self.ignore_tags
+                            if not self.ignore_tags or self.ignore_tags == "" then
+                                return _("Ignore tags")
                             end
-                            return T(_("Ignore tags (%1)"), tags)
+                            return T(_("Ignore tags (%1)"), self.ignore_tags)
                         end,
                         keep_menu_open = true,
                         callback = function(touchmenu_instance)


### PR DESCRIPTION
A new setting has been adding allowing to set a comma separated list of
tags to ignore.

Entries with either of these tags will be skipped by the client when
fetching the list of articles to download. Extra articles will be
fetched from the server to make up for the skipped articles, ensuring to
meet the target number of articles.

This can be used to ignore some articles that are known to not be readable in koreader: videos, binaries,.. As long as they are correctly tagged on the server. 
Another use case could be, once the ability to tag an entry in the client has been added, to ignore some entries and not download them again.

Most of the code (for the UI) was copied from the existing `filter_tag` setting. 