### PR TITLE
Fix footer with no_mode and disabled progress bar

### DIFF
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -504,7 +504,7 @@ function ReaderTypeset:onSetPageMargins(margins, refresh_callback)
     local top = Screen:scaleBySize(margins[2])
     local right = Screen:scaleBySize(margins[3])
     local bottom
-    if self.view.footer.has_no_mode or self.view.footer.reclaim_height then
+    if self.view.footer.reclaim_height then
         bottom = Screen:scaleBySize(margins[4])
     else
         bottom = Screen:scaleBySize(margins[4]) + self.view.footer:getHeight()


### PR DESCRIPTION
I found several problems with proper showing footer (or margins) when enable/disable progress bar (or mode with empty items) after KO start. 