### PR TITLE
open unsupported documents as text

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -293,8 +293,8 @@ function FileManager:init()
             {
                 {
                     text = _("Open with…"),
-                    enabled = lfs.attributes(file, "mode") == "file" and DocumentRegistry:getProviders(file) ~= nil
-                        and #(DocumentRegistry:getProviders(file)) > 1,
+                    enabled = lfs.attributes(file, "mode") == "file" and (DocumentRegistry:getProviders(file) == nil
+                        or #(DocumentRegistry:getProviders(file)) > 1),
                     callback = function()
                         UIManager:close(self.file_dialog)
                         self:showSetProviderButtons(file, FileManager.instance, ReaderUI)

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -447,7 +447,7 @@ function ReaderUI:showReader(file, provider)
         return
     end
 
-    if not DocumentRegistry:hasProvider(file) then
+    if not DocumentRegistry:hasProvider(file) and provider == nil then
         UIManager:show(InfoMessage:new{
             text = T(_("File '%1' is not supported."), file)
         })

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -56,8 +56,16 @@ end
 function DocumentRegistry:hasProvider(file)
     local filename_suffix = string.lower(util.getFileNameSuffix(file))
 
-    if self.filetype_provider[filename_suffix] then
+    local filetype_provider = G_reader_settings:readSetting("provider") or {}
+    if self.filetype_provider[filename_suffix] or filetype_provider[filename_suffix] then
         return true
+    end
+    local DocSettings = require("docsettings")
+    if DocSettings:hasSidecarFile(file) then
+        local doc_settings_provider = DocSettings:open(file):readSetting("provider")
+        if doc_settings_provider then
+            return true
+        end
     end
     return false
 end
@@ -96,6 +104,12 @@ function DocumentRegistry:getProvider(file)
 
         -- highest weighted provider
         return providers[1].provider
+    else
+        for _, provider in ipairs(self.providers) do
+            if provider.extension == "txt" then
+                return provider.provider
+            end
+        end
     end
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -402,8 +402,7 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             provider = provider.provider
             table.insert(radio_buttons, {
                 {
-                    -- @translators %1 is the provider name, such as Cool Reader Engine or MuPDF.
-                    text = T(_("%1 ~Unsupported"), provider.provider_name),
+                    text = provider.provider_name,
                     checked = DocumentRegistry:getProvider(file) == provider,
                     provider = provider,
                 },
@@ -413,7 +412,8 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
         local provider = DocumentRegistry:getProvider(file)
         table.insert(radio_buttons, {
             {
-                text = provider.provider_name .. _(" ~Unsupported"),
+                -- @translators %1 is the provider name, such as Cool Reader Engine or MuPDF.
+                text = T(_("%1 ~Unsupported"), provider.provider_name),
                 checked = true,
                 provider = provider,
             },

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -395,17 +395,27 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
     local buttons = {}
     local radio_buttons = {}
     local providers = DocumentRegistry:getProviders(file)
-
-    for ___, provider in ipairs(providers) do
-        -- we have no need for extension, mimetype, weights, etc. here
-        provider = provider.provider
+    if providers ~= nil then
+        for ___, provider in ipairs(providers) do
+            -- we have no need for extension, mimetype, weights, etc. here
+            provider = provider.provider
+            table.insert(radio_buttons, {
+                {
+                    text = provider.provider_name,
+                    checked = DocumentRegistry:getProvider(file) == provider,
+                    provider = provider,
+                },
+            })
+        end
+    else
+        local provider = DocumentRegistry:getProvider(file)
         table.insert(radio_buttons, {
             {
-                text = provider.provider_name,
-                checked = DocumentRegistry:getProvider(file) == provider,
+                text = provider.provider_name .. _(" ~Unsupported"),
+                checked = true,
                 provider = provider,
             },
-        })
+         })
     end
 
     table.insert(buttons, {

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -428,15 +428,6 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             end,
         },
         {
-            text = _("Reset default"),
-            enabled = filetype_provider[filename_suffix] ~= nil,
-            callback = function()
-                filetype_provider[filename_suffix] = nil
-                G_reader_settings:saveSetting("provider", filetype_provider)
-                UIManager:close(self.set_provider_dialog)
-            end,
-        },
-        {
             text = _("Open"),
             is_enter_default = true,
             callback = function()
@@ -479,6 +470,19 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             end,
         },
     })
+
+    if filetype_provider[filename_suffix] ~= nil then
+        table.insert(buttons, {
+           {
+               text = _("Reset default"),
+                callback = function()
+                    filetype_provider[filename_suffix] = nil
+                    G_reader_settings:saveSetting("provider", filetype_provider)
+                    UIManager:close(self.set_provider_dialog)
+                end,
+            },
+        })
+    end
 
     self.set_provider_dialog = OpenWithDialog:new{
         title = T(_("Open %1 with:"), filename_pure),

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -394,6 +394,7 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
 
     local buttons = {}
     local radio_buttons = {}
+    local filetype_provider = G_reader_settings:readSetting("provider") or {}
     local providers = DocumentRegistry:getProviders(file)
     if providers ~= nil then
         for ___, provider in ipairs(providers) do
@@ -422,6 +423,15 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
         {
             text = _("Cancel"),
             callback = function()
+                UIManager:close(self.set_provider_dialog)
+            end,
+        },
+        {
+            text = _("Reset Default"),
+            enabled = filetype_provider[filename_suffix] ~= nil,
+            callback = function()
+                filetype_provider[filename_suffix] = nil
+                G_reader_settings:saveSetting("provider", filetype_provider)
                 UIManager:close(self.set_provider_dialog)
             end,
         },

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -402,7 +402,7 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             provider = provider.provider
             table.insert(radio_buttons, {
                 {
-                    -- @translators %1 is the provider name, in this case Cool Reader Engine
+                    -- @translators %1 is the provider name, such as Cool Reader Engine or MuPDF.
                     text = T(_("%1 ~Unsupported"), provider.provider_name),
                     checked = DocumentRegistry:getProvider(file) == provider,
                     provider = provider,

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -417,7 +417,7 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
                 checked = true,
                 provider = provider,
             },
-         })
+        })
     end
 
     table.insert(buttons, {

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -402,7 +402,8 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             provider = provider.provider
             table.insert(radio_buttons, {
                 {
-                    text = provider.provider_name,
+                    -- @translators %1 is the provider name, in this case Cool Reader Engine
+                    text = T(_("%1 ~Unsupported"), provider.provider_name),
                     checked = DocumentRegistry:getProvider(file) == provider,
                     provider = provider,
                 },
@@ -427,7 +428,7 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             end,
         },
         {
-            text = _("Reset Default"),
+            text = _("Reset default"),
             enabled = filetype_provider[filename_suffix] ~= nil,
             callback = function()
                 filetype_provider[filename_suffix] = nil


### PR DESCRIPTION
This ~~is a working POC / hack to~~ allow opening unsupported files as txt, for example .lua files.
this can be very helpful when having oddly named files. 
it might be a good idea to allow all providers on this list?

this only triggers via the open with menu, not by directly clicking the item, unless setting the provider as a default.

this probably needs proper integration but i am not 100% sure exactly how the `DocumentRegistry` works and don't want to mess things up.

~~once this works i would like to add a way to clear already set providers from settings.~~
 
![FileManager_2019-Oct-17_015418](https://user-images.githubusercontent.com/38916402/66981236-2264f580-f081-11e9-8d79-a2d2535d0b8c.png)
