### PR TITLE
bump crengine: adds DOCX and FB3 support

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -111,7 +111,7 @@ function CreDocument:init()
     -- same way, and are kept as-is for when a previously opened document
     -- requests one of them.
     self.default_css = "./data/epub.css"
-    if file_type == "fb2" then
+    if file_type == "fb2" or file_type == "fb3" then
         self.default_css = "./data/fb2.css"
     end
 
@@ -850,9 +850,11 @@ function CreDocument:register(registry)
     registry:addProvider("azw", "application/vnd.amazon.mobi8-ebook", self, 90)
     registry:addProvider("chm", "application/vnd.ms-htmlhelp", self, 90)
     registry:addProvider("doc", "application/msword", self, 90)
+    registry:addProvider("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", self, 90)
     registry:addProvider("epub", "application/epub+zip", self, 100)
     registry:addProvider("fb2", "application/fb2", self, 90)
     registry:addProvider("fb2.zip", "application/zip", self, 90)
+    registry:addProvider("fb3", "application/fb3", self, 90)
     registry:addProvider("htm", "text/html", self, 100)
     registry:addProvider("html", "text/html", self, 100)
     registry:addProvider("htm.zip", "application/zip", self, 100)


### PR DESCRIPTION
Includes:
- (Upstream) Unified cache for chars and glyph's indexes https://github.com/koreader/crengine/pull/314
- (Upstream) Glyph caching: optional use of hash table instead of a linked list
- (Upstream) Adds docx and fb3 support
- Update hardcoded elements list and stylesheets
- DocX: build a HTML DOM instead of a FB2 DOM
- Text: allow wrap after '/' and '-' https://github.com/koreader/crengine/pull/316
- Text: with Harfbuzz, split measurement on text node change
- Clear fonts on load and re-rendering