### PR TITLE
TextWidget: small refactoring, better handle max_width

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -50,10 +50,6 @@ local function restoreScreenMode()
     end
 end
 
-local function truncatePath(text)
-    return FileChooser:truncatePath(text)
-end
-
 local FileManager = InputContainer:extend{
     title = _("KOReader"),
     root_path = lfs.currentdir(),
@@ -110,7 +106,9 @@ function FileManager:init()
 
     self.path_text = TextWidget:new{
         face = Font:getFace("xx_smallinfofont"),
-        text = truncatePath(filemanagerutil.abbreviate(self.root_path)),
+        text = filemanagerutil.abbreviate(self.root_path),
+        max_width = Screen:getWidth() - 2*Size.padding.small,
+        truncate_left = true,
     }
 
     self.banner = FrameContainer:new{
@@ -177,7 +175,7 @@ function FileManager:init()
     self.focused_file = nil -- use it only once
 
     function file_chooser:onPathChanged(path)  -- luacheck: ignore
-        FileManager.instance.path_text:setText(truncatePath(filemanagerutil.abbreviate(path)))
+        FileManager.instance.path_text:setText(filemanagerutil.abbreviate(path))
         UIManager:setDirty(FileManager.instance, function()
             return "ui", FileManager.instance.path_text.dimen, FileManager.instance.dithered
         end)

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -263,8 +263,7 @@ function RenderText:renderUtf8Text(dest_bb, x, baseline, face, text, kerning, bo
     return pen_x
 end
 
-local ellipsis, space = "…", " "
-local ellipsis_width, space_width
+local ellipsis = "…"
 --- Returns a substring of a given text that meets the maximum width (in pixels)
 -- restriction with ellipses (…) at the end if required.
 --
@@ -273,23 +272,13 @@ local ellipsis_width, space_width
 -- @int width maximum width in pixels
 -- @bool[opt=false] kerning whether the text should be measured with kerning
 -- @bool[opt=false] bold whether the text should be measured as bold
--- @bool[opt=false] prepend_space whether a space should be prepended to the text
 -- @treturn string
 -- @see getSubTextByWidth
-function RenderText:truncateTextByWidth(text, face, max_width, kerning, bold, prepend_space)
-    if not ellipsis_width then
-        ellipsis_width = self:sizeUtf8Text(0, max_width, face, ellipsis).x
-    end
-    if not space_width then
-        space_width = self:sizeUtf8Text(0, max_width, face, space).x
-    end
-    local new_txt_width = max_width - ellipsis_width - space_width
+function RenderText:truncateTextByWidth(text, face, max_width, kerning, bold)
+    local ellipsis_width = self:sizeUtf8Text(0, max_width, face, ellipsis, false, bold).x
+    local new_txt_width = max_width - ellipsis_width
     local sub_txt = self:getSubTextByWidth(text, face, new_txt_width, kerning, bold)
-    if prepend_space then
-        return space.. sub_txt .. ellipsis
-    else
-        return sub_txt .. ellipsis .. space
-    end
+    return sub_txt .. ellipsis
 end
 
 return RenderText

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -459,7 +459,6 @@ function Screensaver:addOverlayMessage(widget, text)
     local Font = require("ui/font")
     local FrameContainer = require("ui/widget/container/framecontainer")
     local OverlapGroup = require("ui/widget/overlapgroup")
-    local RenderText = require("ui/rendertext")
     local RightContainer = require("ui/widget/container/rightcontainer")
     local Size = require("ui/size")
     local TextBoxWidget = require("ui/widget/textboxwidget")
@@ -468,15 +467,13 @@ function Screensaver:addOverlayMessage(widget, text)
     local face = Font:getFace("infofont")
     local screen_w, screen_h = Screen:getWidth(), Screen:getHeight()
 
-    local textw
+    local textw = TextWidget:new{
+        text = text,
+        face = face,
+    }
     -- Don't make our message reach full screen width
-    local tsize = RenderText:sizeUtf8Text(0, screen_w, face, text)
-    if tsize.x < screen_w * 0.9 then
-        textw = TextWidget:new{
-            text = text,
-            face = face,
-        }
-    else -- if text too wide, use TextBoxWidget for multi lines display
+    if textw:getWidth() > screen_w * 0.9 then
+        -- Text too wide: use TextBoxWidget for multi lines display
         textw = TextBoxWidget:new{
             text = text,
             face = face,

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -18,7 +18,6 @@ local IconButton = require("ui/widget/iconbutton")
 local ImageWidget = require("ui/widget/imagewidget")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
-local RenderText = require("ui/rendertext")
 local RightContainer = require("ui/widget/container/rightcontainer")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
@@ -208,7 +207,11 @@ function ConfigOption:init()
             local face = Font:getFace(name_font_face, name_font_size)
             local txt_width = 0
             if text ~= nil then
-                txt_width = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text).x
+                local tmp = TextWidget:new{
+                    text = text,
+                    face = face,
+                }
+                txt_width = tmp:getWidth()
             end
             max_option_name_width = math.max(max_option_name_width, txt_width)
         end
@@ -265,16 +268,12 @@ function ConfigOption:init()
                 local name_text_max_width = name_widget_width - default_option_hpadding - 2*padding_small
                 local text = self.options[c].name_text
                 local face = Font:getFace(name_font_face, name_font_size)
-                local width_name_text = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text).x
-                if width_name_text > name_text_max_width then
-                    text = RenderText:truncateTextByWidth(text, face, name_text_max_width)
-                end
-
                 local option_name_container = RightContainer:new{
                     dimen = Geom:new{ w = name_widget_width, h = option_height},
                 }
                 local option_name = Button:new{
                     text = text,
+                    max_width = name_text_max_width,
                     bordersize = 0,
                     face = face,
                     enabled = enabled,
@@ -436,13 +435,10 @@ function ConfigOption:init()
                     else
                         local text = self.options[c].item_text[d]
                         local face = Font:getFace(item_font_face, item_font_size)
-                        local width_item_text = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text).x
-                        if max_item_text_width < width_item_text then
-                            text = RenderText:truncateTextByWidth(text, face, max_item_text_width)
-                        end
                         option_item = OptionTextItem:new{
                             TextWidget:new{
                                 text = text,
+                                max_width = max_item_text_width,
                                 face = face,
                                 fgcolor = enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
                             },

--- a/frontend/ui/widget/fixedtextwidget.lua
+++ b/frontend/ui/widget/fixedtextwidget.lua
@@ -1,29 +1,25 @@
 local TextWidget = require("ui/widget/textwidget")
-local RenderText = require("ui/rendertext")
 local Geom = require("ui/geometry")
-local Screen = require("device").screen
 
 --[[
 FixedTextWidget
 --]]
 local FixedTextWidget = TextWidget:new{}
 
-function FixedTextWidget:getSize()
-    local tsize = RenderText:sizeUtf8Text(0, Screen:getWidth(), self.face, self.text, true, self.bold)
-    if tsize.x == 0 then
-        return Geom:new{}
-    end
-    self._length = tsize.x
+function FixedTextWidget:updateSize()
+    TextWidget.updateSize(self)
+    -- Only difference from TextWidget:
+    -- no vertical padding, baseline is height
     self._height = self.face.size
-    return Geom:new{
-        w = self._length,
-        h = self._height,
-    }
+    self._baseline_h = self.face.size
 end
 
-function FixedTextWidget:paintTo(bb, x, y)
-    RenderText:renderUtf8Text(bb, x, y+self._height, self.face, self.text, true, self.bold,
-                self.fgcolor)
+function FixedTextWidget:getSize()
+    self:updateSize()
+    if self._length == 0 then
+        return Geom:new{}
+    end
+    return TextWidget.getSize(self)
 end
 
 return FixedTextWidget

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -108,7 +108,6 @@ local LineWidget = require("ui/widget/linewidget")
 local MovableContainer = require("ui/widget/container/movablecontainer")
 local MultiConfirmBox = require("ui/widget/multiconfirmbox")
 local Notification = require("ui/widget/notification")
-local RenderText = require("ui/rendertext")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local TextWidget = require("ui/widget/textwidget")
@@ -211,15 +210,6 @@ function InputDialog:init()
     end
 
     -- Title & description
-    local title_width = RenderText:sizeUtf8Text(0, self.width,
-            self.title_face, self.title, true).x
-    if title_width > self.width then
-        local indicator = "  >> "
-        local indicator_w = RenderText:sizeUtf8Text(0, self.width,
-                self.title_face, indicator, true).x
-        self.title = RenderText:getSubTextByWidth(self.title, self.title_face,
-                self.width - indicator_w, true) .. indicator
-    end
     self.title_widget = FrameContainer:new{
         padding = self.title_padding,
         margin = self.title_margin,
@@ -227,7 +217,7 @@ function InputDialog:init()
         TextWidget:new{
             text = self.title,
             face = self.title_face,
-            width = self.width,
+            max_width = self.width,
         }
     }
     self.title_bar = LineWidget:new{

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -235,7 +235,7 @@ function KeyValueItem:init()
     end
     key_widget:setMaxWidth(key_w)
 
-    -- For debugging positionning:
+    -- For debugging positioning:
     -- value_widget = FrameContainer:new{ padding=0, margin=0, bordersize=1, value_widget }
 
     self[1] = FrameContainer:new{

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1002,7 +1002,7 @@ end
 --]]
 function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch)
     if self.menu_title and new_title then
-        self.menu_title.text = new_title
+        self.menu_title:setText(new_title)
     end
 
     if itemnumber == nil then

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -25,7 +25,6 @@ local Font = require("ui/font")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
-local RenderText = require("ui/rendertext")
 local Size = require("ui/size")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
@@ -120,12 +119,7 @@ function NumberPickerWidget:paintWidget()
         width = self.screen_height * 0.01
     }
     local value = self.value
-    if self.value_table then
-        local text_width = RenderText:sizeUtf8Text(0, self.width, self.spinner_face, self.value, true, true).x
-        if self.width < text_width then
-            value = RenderText:truncateTextByWidth(self.value, self.spinner_face, self.width,true, true)
-        end
-    else
+    if not self.value_table then
         value = string.format(self.precision, value)
     end
 
@@ -185,9 +179,10 @@ function NumberPickerWidget:paintWidget()
         text = value,
         bordersize = 0,
         padding = 0,
-        text_font_face = self.spinner_face_font,
-        text_font_size = self.spinner_face_size,
+        text_font_face = self.spinner_face.font,
+        text_font_size = self.spinner_face.orig_size,
         width = self.width,
+        max_width = self.width,
         callback = callback_input,
     }
     return VerticalGroup:new{

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -12,7 +12,6 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local OverlapGroup = require("ui/widget/overlapgroup")
-local RenderText = require("ui/rendertext")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
@@ -33,20 +32,12 @@ local SortTitleWidget = VerticalGroup:new{
 function SortTitleWidget:init()
     self.close_button = CloseButton:new{ window = self }
     local btn_width = self.close_button:getSize().w
-    local title_txt_width = RenderText:sizeUtf8Text(
-                                0, self.width, self.tface, self.title).x
-    local show_title_txt
-    if self.width < (title_txt_width + btn_width) then
-        show_title_txt = RenderText:truncateTextByWidth(
-                            self.title, self.tface, self.width-btn_width)
-    else
-        show_title_txt = self.title
-    end
     -- title and close button
     table.insert(self, OverlapGroup:new{
         dimen = { w = self.width },
         TextWidget:new{
-            text = show_title_txt,
+            text = self.title,
+            max_width = self.width - btn_width,
             face = self.tface,
         },
         self.close_button,
@@ -124,10 +115,6 @@ function SortItemWidget:init()
 
     local frame_padding = Size.padding.default
     local frame_internal_width = self.width - frame_padding * 2
-    local text_rendered = RenderText:sizeUtf8Text(0, self.width, self.tface, self.text).x
-    if text_rendered > frame_internal_width then
-        self.text = RenderText:truncateTextByWidth(self.text, self.tface, frame_internal_width)
-    end
 
     self[1] = FrameContainer:new{
         padding = 0,
@@ -139,6 +126,7 @@ function SortItemWidget:init()
             },
             TextWidget:new{
                 text = self.text,
+                max_width = frame_internal_width,
                 face = self.tface,
             }
         },

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -12,7 +12,6 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local NumberPickerWidget = require("ui/widget/numberpickerwidget")
 local OverlapGroup = require("ui/widget/overlapgroup")
-local RenderText = require("ui/rendertext")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local TextWidget = require("ui/widget/textwidget")
@@ -90,24 +89,16 @@ function SpinWidget:update()
 
     local close_button = CloseButton:new{ window = self, padding_top = Size.margin.title, }
     local btn_width = close_button:getSize().w + Size.padding.default * 2
-    local title_txt_width = RenderText:sizeUtf8Text(
-        0, self.width, self.title_face, self.title_text).x
-    local show_title_txt
-    if self.width < (title_txt_width + btn_width) then
-        show_title_txt = RenderText:truncateTextByWidth(
-            self.title_text, self.title_face, self.width - btn_width)
-    else
-        show_title_txt = self.title_text
-    end
+
     local value_title = FrameContainer:new{
         padding = Size.padding.default,
         margin = Size.margin.title,
         bordersize = 0,
         TextWidget:new{
-            text = show_title_txt,
+            text = self.title_text,
+            max_width = self.width - btn_width,
             face = self.title_face,
             bold = true,
-            width = self.width,
         },
     }
     local value_line = LineWidget:new{

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -14,7 +14,6 @@ local GestureRange = require("ui/gesturerange")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local FrameContainer = require("ui/widget/container/framecontainer")
-local RenderText = require("ui/rendertext")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
@@ -27,10 +26,6 @@ local ToggleLabel = TextWidget:new{
     bgcolor = Blitbuffer.COLOR_WHITE,
     fgcolor = Blitbuffer.COLOR_BLACK,
 }
-
-function ToggleLabel:paintTo(bb, x, y)
-    RenderText:renderUtf8Text(bb, x, y+self._baseline_h, self.face, self.text, true, self.bold, self.fgcolor)
-end
 
 local ToggleSwitch = InputContainer:new{
     width = Screen:scaleBySize(216),
@@ -84,13 +79,10 @@ function ToggleSwitch:init()
         end
         local text = self.toggle[i]
         local face = Font:getFace(self.font_face, self.font_size)
-        local txt_width = RenderText:sizeUtf8Text(0, Screen:getWidth(), face, text, true, true).x
-        if  txt_width > real_item_width - item_padding then
-            text = RenderText:truncateTextByWidth(text, face, real_item_width - item_padding, true, true)
-        end
         local label = ToggleLabel:new{
             text = text,
             face = face,
+            max_width = real_item_width - item_padding,
         }
         local content = CenterContainer:new{
             dimen = Geom:new{

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -19,7 +19,6 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
-local RenderText = require("ui/rendertext")
 local RightContainer = require("ui/widget/container/rightcontainer")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
@@ -87,9 +86,6 @@ function TouchMenuItem:init()
     -- FrameContainer default paddings minus the checked widget width
     local text_max_width = self.dimen.w - 2*Size.padding.default - checked_widget:getSize().w
     local text = getMenuText(self.item)
-    if RenderText:sizeUtf8Text(0, Screen:getWidth(), self.face, text, true).x > text_max_width then
-        text = RenderText:truncateTextByWidth(text, self.face, text_max_width, true)
-    end
     self.item_frame = FrameContainer:new{
         width = self.dimen.w,
         bordersize = 0,
@@ -102,6 +98,7 @@ function TouchMenuItem:init()
             },
             TextWidget:new{
                 text = text,
+                max_width = text_max_width,
                 fgcolor = item_enabled ~= false and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
                 face = self.face,
             },

--- a/frontend/ui/widget/trapwidget.lua
+++ b/frontend/ui/widget/trapwidget.lua
@@ -18,7 +18,6 @@ local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LeftContainer = require("ui/widget/container/leftcontainer")
-local RenderText = require("ui/rendertext")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local TextWidget = require("ui/widget/textwidget")
@@ -59,16 +58,14 @@ function TrapWidget:init()
         }
     end
     if self.text then
-        local textw
+        local textw = TextWidget:new{
+            text = self.text,
+            face = self.face,
+        }
         -- Don't make our message reach full screen width, so
         -- it looks like popping from bottom left corner
-        local tsize = RenderText:sizeUtf8Text(0, Screen:getWidth(), self.face, self.text)
-        if tsize.x < Screen:getWidth() * 0.9 then
-            textw = TextWidget:new{
-                text = self.text,
-                face = self.face,
-            }
-        else -- if text too wide, use TextBoxWidget for multi lines display
+        if textw:getWidth() > Screen:getWidth() * 0.9 then
+            -- Text too wide: use TextBoxWidget for multi lines display
             textw = TextBoxWidget:new{
                 text = self.text,
                 face = self.face,

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -95,7 +95,7 @@ function CoverMenu:updateItems(select_number)
     self:updatePageInfo(select_number)
 
     if self.show_path then
-        self.path_text.text = self:truncatePath(self.path)
+        self.path_text:setText(self.path)
     end
     self.show_parent.dithered = self._has_cover_images
     UIManager:setDirty(self.show_parent, function()

--- a/plugins/goodreads.koplugin/doublekeyvaluepage.lua
+++ b/plugins/goodreads.koplugin/doublekeyvaluepage.lua
@@ -17,7 +17,6 @@ local LeftContainer = require("ui/widget/container/topcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local LuaSettings = require("luasettings")
 local OverlapGroup = require("ui/widget/overlapgroup")
-local RenderText = require("ui/rendertext")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
@@ -39,20 +38,12 @@ local DoubleKeyValueTitle = VerticalGroup:new{
 function DoubleKeyValueTitle:init()
     self.close_button = CloseButton:new{ window = self }
     local btn_width = self.close_button:getSize().w
-    local title_txt_width = RenderText:sizeUtf8Text(
-                                0, self.width, self.tface, self.title).x
-    local show_title_txt
-    if self.width < (title_txt_width + btn_width) then
-        show_title_txt = RenderText:truncateTextByWidth(
-                            self.title, self.tface, self.width - btn_width)
-    else
-        show_title_txt = self.title
-    end
     -- title and close button
     table.insert(self, OverlapGroup:new{
         dimen = { w = self.width },
         TextWidget:new{
-            text = show_title_txt,
+            text = self.title,
+            max_width = self.width - btn_width,
             face = self.tface,
         },
         self.close_button,
@@ -114,7 +105,6 @@ local DoubleKeyValueItem = InputContainer:new{
 
 function DoubleKeyValueItem:init()
     self.dimen = Geom:new{align = "left", w = self.width, h = self.height}
-    local padding = Screen:scaleBySize(20)
     if self.callback and Device:isTouchDevice() then
         self.ges_events.Tap = {
             GestureRange:new{
@@ -123,18 +113,8 @@ function DoubleKeyValueItem:init()
             }
         }
     end
-    local key_w = RenderText:sizeUtf8Text(0, self.width, self.cface_down, self.key).x
-    local value_w = RenderText:sizeUtf8Text(0, self.width, self.cface_up, self.value).x
-    if key_w > self.width - 2*padding then
-        self.show_key = RenderText:truncateTextByWidth(self.key, self.cface_down, self.width - 2*padding)
-    else
-        self.show_key = self.key
-    end
-    if value_w > self.width - 2*padding then
-        self.show_value = RenderText:truncateTextByWidth(self.value, self.cface_up, self.width - 2*padding)
-    else
-        self.show_value = self.value
-    end
+    local padding = Screen:scaleBySize(20)
+    local max_width = self.width - 2*padding
     local h = self.dimen.h / 2
     local w = self.dimen.w
     self[1] = FrameContainer:new{
@@ -147,7 +127,8 @@ function DoubleKeyValueItem:init()
                 padding = 0,
                 dimen = Geom:new{ h = h, w = w },
                 TextWidget:new{
-                    text = self.show_value,
+                    text = self.value,
+                    max_width = max_width,
                     face = self.cface_up,
                 }
             },
@@ -155,7 +136,8 @@ function DoubleKeyValueItem:init()
                 padding = 0,
                 dimen = Geom:new{ h = h, w = w },
                 TextWidget:new{
-                    text = self.show_key,
+                    text = self.key,
+                    max_width = max_width,
                     face = self.cface_down,
                 }
             }


### PR DESCRIPTION
Lots of code was doing some renderText calls to get the size of some text string, and truncate it to some width if needed, with or without an added ellipsis, before instantiating a TextWidget with that tweaked text string.

This PR fixes/adds some properties and methods to TextWidget so all that can be done by it. It makes the caller codes simpler, as they don't need to use RenderText directly.
(Additionally, if we ever go at using Harfbuzz for text rendering, we'll just have to update or replace textwidget.lua without the need to update any higher level code.)

RenderText: removed the space added by truncateTextByWidth after the ellipsis, as it doesn't feel needed, and break right alignment of the ellipsis with other texts.
KeyValuePage: fix some subtle size and alignment issues.
NumberPickerWidget: fix font size (provided font size was not used)

Menu.lua: I did not touch the part of the code that #5496 affects, so these 2 PRs should be mergeable in any order. If needed, I'll update what can be from #5496 to follow the spirit of this PR.
Pinging @robert00s for info, for your future widgets :)