### PR TITLE
Remove uneeded doc_settings:close()

### DIFF
--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -69,7 +69,6 @@ function PdfDocument:convertKoptToReflowableFontSize(font_size)
     if DocSettings:hasSidecarFile(self.file) then
         local doc_settings = DocSettings:open(self.file)
         size = doc_settings:readSetting("kopt_font_size")
-        doc_settings:close()
     end
     if size then
         return size * default_font_size

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -176,7 +176,6 @@ function Screensaver:excluded()
     if DocSettings:hasSidecarFile(lastfile) then
         local doc_settings = DocSettings:open(lastfile)
         exclude_ss = doc_settings:readSetting("exclude_screensaver")
-        doc_settings:close()
     end
     return exclude_ss or false
 end
@@ -260,7 +259,6 @@ function Screensaver:show(event, fallback_message)
         if DocSettings:hasSidecarFile(lastfile) then
             local doc_settings = DocSettings:open(lastfile)
             exclude = doc_settings:readSetting("exclude_screensaver")
-            doc_settings:close()
         end
         if exclude ~= true then
             if lfs.attributes(lastfile, "mode") == "file" then
@@ -306,7 +304,6 @@ function Screensaver:show(event, fallback_message)
                 screensaver_type = "message"
             end
             doc:close()
-            doc_settings:close()
         else
             screensaver_type = "message"
         end


### PR DESCRIPTION
When just reading settings, no need to close and write the file to disk - as it's just a table that disappear when out of scope, and no ressource attached.