### PR TITLE
[fix] kodev: Allow nightly build to succeed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,8 +504,7 @@ pot:
 	$(MAKE) -C l10n push
 
 po:
-	$(MAKE) -i -C l10n bootstrap
-	$(MAKE) -C l10n pull
+	git submodule update --remote l10n
 
 
 static-check:

--- a/kodev
+++ b/kodev
@@ -388,6 +388,7 @@ ${SUPPORTED_RELEASE_TARGETS}"
         shift 1
     done
 
+    check_submodules
     if [ "${ignore_translation}" -eq 0 ]; then
         if command -v tx>/dev/null; then
             make po || {


### PR DESCRIPTION
Translations live in a submodule since <https://github.com/koreader/koreader/pull/5506>,
and without initialized submodules `kodev release` will therefore fail.

The specifics need a fair bit more attention once Weblate has been set up, but this should
suffice for the nightly/stable build to succeed.