### PR TITLE
Fix a deadlock with empty settings

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -43,8 +43,6 @@ sdl2 lua@5.1 luarocks gettext pkg-config wget md5sha1sum
 echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> "$HOME"/.bash_profile
 ```
 
-If you run into a gettext error while building glib, try `brew link --force gettext` to override the built-in macOS BSD gettext with GNU gettext.
-
 *Note:* With current XCode versions, you *will* need to set a minimum deployment version higher than `10.04`. Otherwise, you'll hit various linking errors related to missing unwinding libraries/symbols.
 On Mojave, `10.09` has been known to behave with XCode 10, And `10.14` with XCode 11. When in doubt, go with your current macOS version.
 ```
@@ -76,6 +74,8 @@ To run KOReader on your development machine:
 ```
 ./kodev run
 ```
+
+*Note:* On non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds are probably not behaving properly.
 
 
 You can specify the size and DPI of the emulator's screen using

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -75,7 +75,7 @@ To run KOReader on your development machine:
 ./kodev run
 ```
 
-*Note:* On non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds are probably not behaving properly.
+*Note:* On Mac and possibly other non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds may not behave properly.
 
 
 You can specify the size and DPI of the emulator's screen using

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -75,7 +75,7 @@ To run KOReader on your development machine:
 ./kodev run
 ```
 
-*Note:* On non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds are probably not behaving properly. Might also need to send a ^C if the very first startup hangs.
+*Note:* On non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds are probably not behaving properly.
 
 
 You can specify the size and DPI of the emulator's screen using

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -1,6 +1,6 @@
 # Setting up a build environment for KOReader
 
-These instructions are intended to build the emulator in Linux and MacOS. Windows users are suggested to develop in a [Linux VM](https://www.howtogeek.com/howto/11287/how-to-run-ubuntu-in-windows-7-with-vmware-player/) or using the [Windows Subsystem for Linux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux).
+These instructions are intended to build the emulator in Linux and macOS. Windows users are suggested to develop in a [Linux VM](https://www.howtogeek.com/howto/11287/how-to-run-ubuntu-in-windows-7-with-vmware-player/) or using the [Windows Subsystem for Linux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux).
 
 If you only want to work with Lua frontend stuff, you can grab the AppImage and
 run it with `--appimage-extract`.
@@ -63,7 +63,7 @@ Building the emulator
 
 ## Building and running the emulator
 
-To build an emulator on your Linux or MacOS machine:
+To build an emulator on your Linux or macOS machine:
 
 ```
 ./kodev build
@@ -75,7 +75,7 @@ To run KOReader on your development machine:
 ./kodev run
 ```
 
-*Note:* On Mac and possibly other non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds may not behave properly.
+*Note:* On macOS and possibly other non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds may not behave properly.
 
 
 You can specify the size and DPI of the emulator's screen using

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -75,7 +75,7 @@ To run KOReader on your development machine:
 ./kodev run
 ```
 
-*Note:* On non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds are probably not behaving properly.
+*Note:* On non-Linux hosts, you might want to pass `--no-build` to prevent re-running the buildsystem, as incremental builds are probably not behaving properly. Might also need to send a ^C if the very first startup hangs.
 
 
 You can specify the size and DPI of the emulator's screen using

--- a/plugins/docsettingtweak.koplugin/main.lua
+++ b/plugins/docsettingtweak.koplugin/main.lua
@@ -98,7 +98,13 @@ function DocSettingTweak:onDocSettingsLoad(doc_settings, document)
                 doc_settings.data = util.tableDeepCopy(directory_defaults:readSetting(directory))
                 break
             else
-                directory = FFIUtil.dirname(directory)
+                next_directory = FFIUtil.dirname(directory)
+                if directory == next_directory then
+                    -- Can't go further back, abort.
+                    break
+                else
+                    directory = next_directory
+                end
             end
         end
     end

--- a/plugins/docsettingtweak.koplugin/main.lua
+++ b/plugins/docsettingtweak.koplugin/main.lua
@@ -98,12 +98,11 @@ function DocSettingTweak:onDocSettingsLoad(doc_settings, document)
                 doc_settings.data = util.tableDeepCopy(directory_defaults:readSetting(directory))
                 break
             else
-                next_directory = FFIUtil.dirname(directory)
-                if directory == next_directory then
-                    -- Can't go further back, abort.
+                if directory == "/" or directory == "." then
+                    -- have reached the filesystem root, abort
                     break
                 else
-                    directory = next_directory
+                    directory = FFIUtil.dirname(directory)
                 end
             end
         end


### PR DESCRIPTION
Might be emulator only. Can be easily replicated by deleting `settings.reader.lua*`, `settings/*` & `help/*` (recursively).

Opening the newly generated quickstart guide will deadlock in docsettingtweak:main:97 by busy-looping forever, because `directory == next_directory == base` (`== .`).