### PR TITLE
[fix, Android] Crash on startup when no homedir is set

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -11,7 +11,7 @@ local filemanagerutil = {}
 
 function filemanagerutil.getDefaultDir()
     if Device:isAndroid() then
-        return Device.external_storage
+        return Device.external_storage()
     elseif Device:isCervantes() then
         return "/mnt/public"
     elseif Device:isKindle() then


### PR DESCRIPTION
By calling the function instead of returning it. Fixes #5547.