### PR TITLE
ButtonTable: taller buttons for easier tap

### DIFF
--- a/frontend/ui/size.lua
+++ b/frontend/ui/size.lua
@@ -50,6 +50,7 @@ local Size = {
         small = Screen:scaleBySize(2),
         large = Screen:scaleBySize(10),
         button = Screen:scaleBySize(2),
+        buttontable = Screen:scaleBySize(4),
         fullscreen = Screen:scaleBySize(15),
     },
     radius = {

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -41,6 +41,8 @@ local Button = InputContainer:new{
     background = Blitbuffer.COLOR_WHITE,
     radius = Size.radius.button,
     padding = Size.padding.button,
+    padding_h = nil,
+    padding_v = nil,
     width = nil,
     max_width = nil,
     text_font_face = "cfont",
@@ -54,10 +56,17 @@ function Button:init()
         self.text = self.text_func()
     end
 
+    if not self.padding_h then
+        self.padding_h = self.padding
+    end
+    if not self.padding_v then
+        self.padding_v = self.padding
+    end
+
     if self.text then
         self.label_widget = TextWidget:new{
             text = self.text,
-            max_width = self.max_width and self.max_width - 2*self.padding - 2*self.margin - 2*self.bordersize or nil,
+            max_width = self.max_width and self.max_width - 2*self.padding_h - 2*self.margin - 2*self.bordersize or nil,
             fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
             bold = self.text_font_bold,
             face = Font:getFace(self.text_font_face, self.text_font_size)
@@ -79,7 +88,10 @@ function Button:init()
         bordersize = self.bordersize,
         background = self.background,
         radius = self.radius,
-        padding = self.padding,
+        padding_top = self.padding_v,
+        padding_bottom = self.padding_v,
+        padding_left = self.padding_h,
+        padding_right = self.padding_h,
         CenterContainer:new{
             dimen = Geom:new{
                 w = self.width,

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -59,7 +59,8 @@ function ButtonTable:init()
                 max_width = (self.width - sizer_space)/column_cnt - 2*self.sep_width - 2*self.padding,
                 bordersize = 0,
                 margin = 0,
-                padding = 0,
+                padding = Size.padding.buttontable, -- a bit taller than standalone buttons, for easier tap
+                padding_h = 0, -- allow text to take more of the horizontal space
                 text_font_face = self.button_font_face,
                 text_font_size = self.button_font_size,
                 show_parent = self.show_parent,


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/5449#issuecomment-548363585. I went with `Screen:scaleBySize(4),`, which is between the 2nd (2) and the 3rd (5) options among the screenshots there.
Went with 4 so I have no regret not aiming high - we'll decrease it to 3 (or 2 if really needed) if people find that too big.
Closes #5449.
