### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# See <https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners>.
+
+/docs/ @Frenzie @NiLuJe
+
+/frontend/device/cervantes/    @pazos
+/frontend/device/kobo/         @Frenzie @NiLuJe @pazos @poire-z
+
+kodev @Frenzie
+Makefile @Frenzie


### PR DESCRIPTION
A bit of an experiment with GitHub functionality.

Teams can be added like `@koreader/kobo-dev` but that doesn't seem too much use to us right now.