### PR TITLE
Wikipedia lookup results: fix page turning when image loading

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -421,7 +421,7 @@ local function image_load_bb_func(image, highres)
         -- We use an invisible widget that will resend the dismiss event,
         -- so that image loading in TextBoxWdiget is unobtrusive and
         -- interruptible
-        trap_widget = false
+        trap_widget = nil
         source = image.source
     else
         -- We need to let the user know image loading is happening,


### PR DESCRIPTION
Tapping to turn pages while some image is loading was interrupting the image loading, but not turning the page, since #5173 where using `trap_widget=false` is to be used to not resend the event (while `=nil` does resend it).