### PR TITLE
Prevent crash on local calibre OPDS server

### DIFF
--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -84,7 +84,7 @@ function OPDSParser:parse(text)
         return s:gsub( "%p", {["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;" } )
     end )
     local xlex = luxl.new(text, #text)
-    return self:createFlatXTable(xlex)
+    return assert(self:createFlatXTable(xlex))
 end
 
 return OPDSParser

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -298,6 +298,9 @@ function OPDSBrowser:fetchFeed(item_url, username, password, method)
         if xml ~= "" then
             return xml
         end
+    elseif method == "HEAD" then
+        -- Don't show error messages when we check headers only.
+        return
     elseif code == 301 then
         UIManager:show(InfoMessage:new{
             text = T(_("The catalog has been permanently moved. Please update catalog URL to '%1'."), headers['Location']),
@@ -401,6 +404,11 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url, username, passwo
     end
 
     if not feed.entry then
+        if #hrefs == 0 then
+            UIManager:show(InfoMessage:new{
+                text = _("Catalog not found."),
+            })
+        end
         return item_table
     end
 


### PR DESCRIPTION
Close: #5476 
- Prevent segmentation fault when we enter incorrect address of calibre opds server (eg http://192.168.1.1:8080/ instead of proper http://192.168.1.1:8080/opds
- prevent unnecessary infos in Gutenberg OPDS like 
<img src=https://user-images.githubusercontent.com/22982594/68319041-f7892280-00bd-11ea-989e-abc23092240d.png width=60%>
 