### PR TITLE
Keyboard: avoid additional key stroke on hold release

### DIFF
--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -58,7 +58,10 @@ function VirtualKey:init()
         self.skiptap = true
     elseif self.label == "Backspace" then
         self.callback = function () self.keyboard:delChar() end
-        self.hold_callback = function () self.keyboard:delToStartOfLine() end
+        self.hold_callback = function ()
+            self.ignore_key_release = true -- don't have delChar called on release
+            self.keyboard:delToStartOfLine()
+        end
         --self.skiphold = true
     elseif self.label =="←" then
         self.callback = function() self.keyboard:leftChar() end
@@ -241,21 +244,31 @@ function VirtualKey:onSwipeKey(arg, ges)
 end
 
 function VirtualKey:onHoldReleaseKey()
+    if self.ignore_key_release then
+        self.ignore_key_release = nil
+        return true
+    end
     Device:performHapticFeedback("LONG_PRESS")
     if self.keyboard.ignore_first_hold_release then
         self.keyboard.ignore_first_hold_release = false
         return true
     end
     self:onTapSelect()
+    return true
 end
 
 function VirtualKey:onPanReleaseKey()
+    if self.ignore_key_release then
+        self.ignore_key_release = nil
+        return true
+    end
     Device:performHapticFeedback("LONG_PRESS")
     if self.keyboard.ignore_first_hold_release then
         self.keyboard.ignore_first_hold_release = false
         return true
     end
     self:onTapSelect()
+    return true
 end
 
 function VirtualKey:invert(invert, hold)
@@ -377,6 +390,7 @@ function VirtualKeyPopup:init()
                 virtual_key.onHoldReleaseKey = function()
                     virtual_key:onTapSelect(true)
                     UIManager:close(self)
+                    return true
                 end
                 virtual_key.onPanReleaseKey = virtual_key.onHoldReleaseKey
 


### PR DESCRIPTION
Added some forgotten `return true` on hold release event handlers: the event would otherwise trigger
a tap (as we generate a tap normally only at release time) and cause duplicate key strokes.
Details in https://github.com/koreader/koreader/issues/5555#issuecomment-550423347. Closes #5555.

(I included your suggested fix for the keyboard popup, as it's more related to my other fixes. You might want to remove it from #5569).