### PR TITLE
loading bar thicker

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1030,9 +1030,9 @@ function ReaderRolling:showEngineProgress(percent)
         -- Widget size and position: best to anchor it at top left,
         -- so it does not override the footer or a bookmark dogear
         local x = 0
-        local y = 0
+        local y = 3
         local w = Screen:getWidth() / 3
-        local h = Screen:scaleBySize(15)
+        local h = Screen:scaleBySize(7)
         if self.engine_progress_widget then
             self.engine_progress_widget:setPercentage(percent)
         else

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1032,7 +1032,7 @@ function ReaderRolling:showEngineProgress(percent)
         local x = 0
         local y = 0
         local w = Screen:getWidth() / 3
-        local h = Screen:scaleBySize(5)
+        local h = Screen:scaleBySize(15)
         if self.engine_progress_widget then
             self.engine_progress_widget:setPercentage(percent)
         else

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -6,6 +6,7 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local MultiConfirmBox = require("ui/widget/multiconfirmbox")
 local ProgressWidget = require("ui/widget/progresswidget")
 local ReaderPanning = require("apps/reader/modules/readerpanning")
+local Size = require("ui/size")
 local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
 local bit = require("bit")
@@ -1032,7 +1033,7 @@ function ReaderRolling:showEngineProgress(percent)
         local x = 0
         local y = 3
         local w = Screen:getWidth() / 3
-        local h = Screen:scaleBySize(7)
+        local h = Size.line.progress
         if self.engine_progress_widget then
             self.engine_progress_widget:setPercentage(percent)
         else

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1031,7 +1031,7 @@ function ReaderRolling:showEngineProgress(percent)
         -- Widget size and position: best to anchor it at top left,
         -- so it does not override the footer or a bookmark dogear
         local x = 0
-        local y = 3
+        local y = Size.margin.small
         local w = Screen:getWidth() / 3
         local h = Size.line.progress
         if self.engine_progress_widget then

--- a/frontend/ui/size.lua
+++ b/frontend/ui/size.lua
@@ -62,6 +62,7 @@ local Size = {
         thin = Screen:scaleBySize(0.5),
         medium = Screen:scaleBySize(1),
         thick = Screen:scaleBySize(1.5),
+        progress = Screen:scaleBySize(7),
     },
     item = {
         height_default = Screen:scaleBySize(30),


### PR DESCRIPTION
the current thickness for the loading bar when opening a document is to thin to really see on my KT4,
i don't have screenshots as they only trigger once koreader finishes loading.

i would like to make it a little thicker, it still does not fully cover the top menu bar.

let me know if this is the wrong place to change the number, and if it has negative effects on other devices. (my emulator loads books too fast to get the bar)