### PR TITLE
[UX] Reduce ButtonTable vertical separator height

### DIFF
--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -73,7 +73,7 @@ function ButtonTable:init()
                 background = Blitbuffer.COLOR_DARK_GRAY,
                 dimen = Geom:new{
                     w = self.sep_width,
-                    h = button_dim.h,
+                    h = button_dim.h/3*2,
                 }
             }
             buttons_layout_line[j] = button


### PR DESCRIPTION
In preparation for 2019.11 this commit improves the visual style
without completely overhauling it yet.

Cf. https://github.com/koreader/koreader/pull/5554#issuecomment-548931725

## Before/After

<img src=https://user-images.githubusercontent.com/202757/68546196-53acb900-03d4-11ea-81bf-1acb3274728a.png>
<img src=https://user-images.githubusercontent.com/202757/68546205-73dc7800-03d4-11ea-9ace-e19c74744f99.png>

