### PR TITLE
Synchronize local folder with dropbox

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -422,7 +422,7 @@ function CloudStorage:synchronizeCloud(item)
         else
             Trapper:reset() -- close any last widget not cleaned if error
             UIManager:show(InfoMessage:new{
-                text = _("No files to download from dropbox.\nCheck your configuration and connection."),
+                text = _("No files to download from Dropbox.\nPlease check your configuration and connection."),
                 timeout = 3,
             })
         end

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -464,14 +464,14 @@ function CloudStorage:downloadListFiles(item)
     end
 
     local response, go_on
-    local procceded_file = 0
+    local proccessed_files = 0
     local success_files = 0
     local unsuccess_files = 0
     for _, file in ipairs(remote_files) do
         if file.download then
-            procceded_file = procceded_file + 1
+            proccessed_files = proccessed_files + 1
             print(file.url)
-            local text = string.format("Downloading file (%d/%d):\n%s", procceded_file, files_to_download, file.text)
+            local text = string.format("Downloading file (%d/%d):\n%s", proccessed_files, files_to_download, file.text)
             go_on = UI:info(text)
             if not go_on then
                 break

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -412,7 +412,7 @@ function CloudStorage:synchronizeCloud(item)
             elseif downloaded_files > 0 and failed_files == 0 then
                 text = T(_("Successfuly downloaded %1 files from Dropbox to local storage."), downloaded_files)
             else
-                text = T(_("Successfuly downloaded %1 files from dropbox to local disk.\nFailed downloaded %2 files."),
+                text = T(_("Successfuly downloaded %1 files from Dropbox to local storage.\nFailed downloaded %2 files."),
                     downloaded_files, failed_files)
             end
             UIManager:show(InfoMessage:new{

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -410,7 +410,7 @@ function CloudStorage:synchronizeCloud(item)
             if downloaded_files == 0 and failed_files == 0 then
                 text = _("No files to download from dropbox.")
             elseif downloaded_files > 0 and failed_files == 0 then
-                text = T(_("Successfuly downloaded %1 files from dropbox to local disk."), downloaded_files)
+                text = T(_("Successfuly downloaded %1 files from Dropbox to local storage."), downloaded_files)
             else
                 text = T(_("Successfuly downloaded %1 files from dropbox to local disk.\nFailed downloaded %2 files."),
                     downloaded_files, failed_files)

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -10,8 +10,12 @@ local _ = require("gettext")
 
 local DropBox = {}
 
-function DropBox:run(url, password)
-    return DropBoxApi:listFolder(url, password)
+function DropBox:run(url, password, choose_folder_mode)
+    return DropBoxApi:listFolder(url, password, choose_folder_mode)
+end
+
+function DropBox:showFiles(url, password)
+    return DropBoxApi:showFiles(url, password)
 end
 
 function DropBox:downloadFile(item, password, path, close)
@@ -36,6 +40,15 @@ function DropBox:downloadFile(item, password, path, close)
             text = T(_("Could not save file to:\n%1"), path),
             timeout = 3,
         })
+    end
+end
+
+function DropBox:downloadFileNoUI(url, password, path)
+    local code_response = DropBoxApi:downloadFile(url, password, path)
+    if code_response == 200 then
+        return true
+    else
+        return false
     end
 end
 

--- a/frontend/ui/cloudmgr.lua
+++ b/frontend/ui/cloudmgr.lua
@@ -1,0 +1,29 @@
+local CloudStorage = require("apps/cloudstorage/cloudstorage")
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+
+local CloudMgr = {
+    onConfirm = function() end,
+}
+
+function CloudMgr:new(from_o)
+    local o = from_o or {}
+    setmetatable(o, self)
+    self.__index = self
+    return o
+end
+
+--- Displays a PathChooser for cloud drive for picking a (source) directory.
+-- @treturn string path chosen by the user
+function CloudMgr:chooseDir()
+    local cloud_storage = CloudStorage:new{
+        title = _("Long-press to select directory"),
+        item = self.item,
+        onConfirm = function(dir_path)
+            self.onConfirm(dir_path)
+        end,
+    }
+    UIManager:show(cloud_storage)
+end
+
+return CloudMgr


### PR DESCRIPTION
Option to synchronize files in local koreader folder with folder on Dropbox. All files that aren't on the local disk will be downloaded. Files with different sizes will also be downloaded and overwritten.
The download process can be paused or stopped at any time (similar to downloading images in Wikipedia).

Synchronize and settings are available after long press in dropbox account in Cloud storage. 
Limitations: Only one folder (without subfolders) can be synchronize with one folder on local storage.

<img src=https://user-images.githubusercontent.com/22982594/68765048-2b170000-061c-11ea-9520-8f93b4ffb896.png width=60%>

<img src=https://user-images.githubusercontent.com/22982594/68765054-310ce100-061c-11ea-930d-f0e5c77b7714.png width=60%>

<img src=https://user-images.githubusercontent.com/22982594/68765068-38cc8580-061c-11ea-9616-185403c67937.png width=60%>

<img src=https://user-images.githubusercontent.com/22982594/68765080-408c2a00-061c-11ea-836b-50152ac214c6.png width=60%>


Close: #4971