### PR TITLE
ConfigDialog: allow larger toggle title text

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -80,7 +80,7 @@ function CreDocument:engineInit()
         -- we need to initialize the CRE font list
         local fonts = FontList:getFontList()
         for _k, _v in ipairs(fonts) do
-            if not _v:find("/urw/") then
+            if not _v:find("/urw/") and not _v:find("/nerdfonts/symbols.ttf") then
                 local ok, err = pcall(cre.registerFont, _v)
                 if not ok then
                     logger.err("failed to register crengine font:", err)

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -265,7 +265,10 @@ function ConfigOption:init()
             if self.options[c].name_text then
                 -- the horizontal padding on the left will be ensured by the RightContainer
                 local name_widget_width = math.floor(name_align * Screen:getWidth())
-                local name_text_max_width = name_widget_width - default_option_hpadding - 2*padding_small
+                -- We don't remove default_option_hpadding from name_text_max_width
+                -- to give more to text and avoid truncation: as it is right aligned,
+                -- the text can grow on the left, padding_small is enough.
+                local name_text_max_width = name_widget_width - 2*padding_small
                 local text = self.options[c].name_text
                 local face = Font:getFace(name_font_face, name_font_size)
                 local option_name_container = RightContainer:new{


### PR DESCRIPTION
-  ConfigDialog: allow larger toggle title text : avoid a few truncated text, as some fit when allowed
to bite a bit on the (large) left padding.
Allows `Embedded fonts`, `Sync T/B Margins`, and `Render Mode` (truncated since we added the finetuning button) to no more be truncated.

- cre fonts list: ignore nerdfonts/symbol.ttf : it's rejected anyway by crengine, this just avoids
an error from being logged.
