### PR TITLE
[fix] Empty directory path and crash on TextWidget

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -32,7 +32,7 @@ function filemanagerutil.abbreviate(path)
         end
         local len = home_dir:len()
         local start = path:sub(1, len)
-        if start == home_dir then
+        if start == home_dir and path:sub(len+1, len+1) == "/" then
             return path:sub(len+2)
         end
     end

--- a/frontend/apps/reader/skimtowidget.lua
+++ b/frontend/apps/reader/skimtowidget.lua
@@ -185,7 +185,7 @@ function SkimToWidget:init()
         end,
     }
     self.current_page_text = Button:new{
-        text = self.curr_page,
+        text = tostring(self.curr_page),
         bordersize = 0,
         margin = self.button_margin,
         radius = 0,

--- a/frontend/apps/reader/skimtowidget.lua
+++ b/frontend/apps/reader/skimtowidget.lua
@@ -365,7 +365,7 @@ function SkimToWidget:update()
         self.curr_page = self.page_count
     end
     self.progress_bar.percentage = self.curr_page / self.page_count
-    self.current_page_text:setText(self.curr_page, self.current_page_text.width)
+    self.current_page_text:setText(tostring(self.curr_page), self.current_page_text.width)
 end
 
 function SkimToWidget:addOriginToLocationStack(add_current)

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -137,7 +137,7 @@ end
 
 function BookStatusWidget:getStatDays()
     if stats_book.days then
-        return stats_book.days
+        return tostring(stats_book.days)
     else
         return _("N/A")
     end

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -40,6 +40,8 @@ local dayOfWeekTranslation = {
 }
 
 function ReaderProgress:init()
+    self.current_pages = tostring(self.current_pages)
+    self.today_pages = tostring(self.today_pages)
     self.small_font_face = Font:getFace("smallffont")
     self.medium_font_face = Font:getFace("ffont")
     self.large_font_face = Font:getFace("largeffont")
@@ -456,7 +458,7 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = total_pages,
+                text = tostring(total_pages),
                 face = self.medium_font_face,
             },
         },
@@ -470,7 +472,7 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = math.floor(total_pages / 7),
+                text = tostring(math.floor(total_pages / 7)),
                 face = self.medium_font_face,
             }
         },


### PR DESCRIPTION
PR fix prevent empty path in filemanager.

![obraz](https://user-images.githubusercontent.com/22982594/69050267-f29f6980-0a01-11ea-8b10-ded0a0d2bf5b.png)

Step to reproduce:
1. Create two folders:
+ /home/koreader/test
+ /home/koreader/test1
2. Set folder `/home/koreader/test` as home folder in KO
3. Set option `Shorten home directory` (Other settings -> Shorten home directory)
4. Go to folder in fm to `/home/koreader/test1`