### PR TITLE
[fix] Prevent xtext crash by not freeing TextWidget prematurely

### DIFF
--- a/frontend/ui/widget/radiobutton.lua
+++ b/frontend/ui/widget/radiobutton.lua
@@ -81,9 +81,6 @@ function RadioButton:init()
 end
 
 function RadioButton:update()
-    if self[1] then
-        self[1]:free()
-    end
     self.frame = FrameContainer:new{
         margin = self.margin,
         bordersize = self.bordersize,


### PR DESCRIPTION
Fixes <https://github.com/koreader/koreader/issues/5614>.