### PR TITLE
Screensaver: avoid crash / CoverBrowser Mosaic: fix alignment

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -261,7 +261,7 @@ function Screensaver:show(event, fallback_message)
             exclude = doc_settings:readSetting("exclude_screensaver")
         end
         if exclude ~= true then
-            if lfs.attributes(lastfile, "mode") == "file" then
+            if lastfile and lfs.attributes(lastfile, "mode") == "file" then
                 local doc = DocumentRegistry:openDocument(lastfile)
                 if doc.loadDocument then -- CreDocument
                     doc:loadDocument(false) -- load only metadata
@@ -287,7 +287,7 @@ function Screensaver:show(event, fallback_message)
         end
     end
     if screensaver_type == "bookstatus" then
-        if lfs.attributes(lastfile, "mode") == "file" then
+        if lastfile and lfs.attributes(lastfile, "mode") == "file" then
             local doc = DocumentRegistry:openDocument(lastfile)
             local doc_settings = DocSettings:open(lastfile)
             local instance = require("apps/reader/readerui"):_getRunningInstance()
@@ -410,9 +410,9 @@ function Screensaver:expandSpecial(message, fallback)
     local ret = message
 
     local lastfile = G_reader_settings:readSetting("lastfile")
-    local doc = DocumentRegistry:openDocument(lastfile)
     local instance = require("apps/reader/readerui"):_getRunningInstance()
-    if instance ~= nil then
+    if lastfile and lfs.attributes(lastfile, "mode") == "file" and instance ~= nil then
+        local doc = DocumentRegistry:openDocument(lastfile)
         local currentpage = instance.view.state.page
         ret = string.gsub(ret, "%%c", currentpage)
 
@@ -424,10 +424,10 @@ function Screensaver:expandSpecial(message, fallback)
 
         local props = doc:getProps()
         ret = string.gsub(ret, "%%T", props.title)
+        doc:close()
     else
         ret = fallback
     end
-    doc:close()
 
     return ret
 end

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -12,6 +12,7 @@ local HorizontalSpan = require("ui/widget/horizontalspan")
 local ImageWidget = require("ui/widget/imagewidget")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local LeftContainer = require("ui/widget/container/leftcontainer")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
@@ -749,7 +750,14 @@ function MosaicMenu:_updateItemsBuildUI()
         if idx % self.nb_cols == 1 then -- new row
             table.insert(self.item_group, VerticalSpan:new{ width = self.item_margin })
             cur_row = HorizontalGroup:new{}
-            table.insert(self.item_group, cur_row)
+            -- Have items on the possibly non-fully filled last row aligned to the left
+            table.insert(self.item_group, LeftContainer:new{
+                dimen = Geom:new{
+                    w = self.dimen.w - 2*self.item_margin,
+                    h = self.item_height
+                },
+                cur_row
+            })
             table.insert(cur_row, HorizontalSpan:new({ width = self.item_margin }))
         end
 


### PR DESCRIPTION
Small fixes:
- Screensaver: avoid crash when no lastfile. Closes #5633. 
- CoverBrowser: Mosaic: fix alignment on non-fully filled rows. Closes #5634.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5638)
<!-- Reviewable:end -->
