### PR TITLE
fix util.secondsToHClock when hmsFormat is true

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -156,7 +156,11 @@ function util.secondsToHClock(seconds, withoutSeconds, hmsFormat)
         if withoutSeconds then
             if hours == "0" then
                 mins = string.format("%.f", round(seconds / 60))
-                return mins .. "'"
+                if hmsFormat then
+                    return T(_("%1m"), mins)
+                else
+                    return mins .. "'"
+                end
             end
             -- @translators This is the 'h' for hour, like in 1h30. This is a duration.
             return T(_("%1h%2"), hours, mins)

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -430,6 +430,22 @@ describe("util module", function()
             assert.is_equal("10h01",
                             util.secondsToHClock(36060, true))
         end)
+        it("should round seconds to minutes in 0h00m format", function()
+            assert.is_equal("1m",
+                util.secondsToHClock(89, true, true))
+            assert.is_equal("2m",
+                util.secondsToHClock(90, true, true))
+            assert.is_equal("2m",
+                util.secondsToHClock(110, true, true))
+            assert.is_equal("1h00",
+                util.secondsToHClock(3600, true, true))
+            assert.is_equal("1h00",
+                util.secondsToHClock(3599, true, true))
+            assert.is_equal("59m",
+                util.secondsToHClock(3569, true, true))
+            assert.is_equal("10h01",
+                util.secondsToHClock(36060, true, true))
+        end)
         it("should convert seconds to 0h00'00'' format", function()
             assert.is_equal("0''",
                             util.secondsToHClock(0))


### PR DESCRIPTION
`util.secondsToHClock(xx, true, true)` should show _xx_**m** instead _xx_**'** when xx<3600.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5640)
<!-- Reviewable:end -->
