### PR TITLE
Keyboard layout change and Coverbrowser Mosaic tweaks

### DIFF
--- a/frontend/ui/data/keyboardlayouts/ko_KR_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ko_KR_keyboard.lua
@@ -26,9 +26,21 @@ local wrapInputBox = function(inputbox)
     if inputbox._wrapped == nil then
         inputbox._wrapped = true
 
-        -- helper function
+        -- helper functions
+        local copied_names = {}
+        local function restore_func_references(obj)
+            for __, name in ipairs(copied_names) do
+                local orig_name = "_" .. name
+                if obj[orig_name] then
+                    obj[name] = obj[orig_name]
+                    obj[orig_name] = nil
+                end
+            end
+        end
+
         local function copy_func_reference(obj, name)
             obj["_" .. name] = obj[name]
+            table.insert(copied_names, name)
         end
 
         -- override original implementations with helper object
@@ -82,6 +94,11 @@ local wrapInputBox = function(inputbox)
         wrap_touch_event_func_with_hghelper_reset(inputbox, "onTapTextBox")
         wrap_touch_event_func_with_hghelper_reset(inputbox, "onHoldTextBox")
         wrap_touch_event_func_with_hghelper_reset(inputbox, "onSwipeTextBox")
+
+        return function() -- return unwrap function
+            restore_func_references(inputbox)
+            inputbox._wrapped = nil
+        end
     end
 end
 

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -406,6 +406,13 @@ function InputText:onCloseKeyboard()
     UIManager:close(self.keyboard)
 end
 
+function InputText:onCloseWidget()
+    if self.keyboard then
+        self.keyboard:free()
+    end
+    self:free()
+end
+
 function InputText:getTextHeight()
     return self.text_widget:getTextHeight()
 end

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -662,6 +662,10 @@ local VirtualKeyboard = FocusManager:new{
 }
 
 function VirtualKeyboard:init()
+    if self.uwrap_func then
+        self.uwrap_func()
+        self.uwrap_func = nil
+    end
     local lang = self:getKeyboardLayout()
     local keyboard_layout = self.lang_to_keyboard_layout[lang] or self.lang_to_keyboard_layout["en"]
     local keyboard = require("ui/data/keyboardlayouts/" .. keyboard_layout)
@@ -681,7 +685,7 @@ function VirtualKeyboard:init()
         self.key_events.Close = { {"Back"}, doc = "close keyboard" }
     end
     if keyboard.wrapInputBox then
-        keyboard.wrapInputBox(self.inputbox)
+        self.uwrap_func = keyboard.wrapInputBox(self.inputbox) or self.uwrap_func
     end
 end
 

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -602,6 +602,7 @@ function CoverBrowser:setupFileManagerDisplayMode(display_mode)
         FileChooser._do_cover_images = nil
         FileChooser._do_filename_only = nil
         FileChooser._do_hint_opened = nil
+        FileChooser._do_center_partial_rows = nil
         self:refreshFileManagerInstance(true)
         return
     end
@@ -620,6 +621,8 @@ function CoverBrowser:setupFileManagerDisplayMode(display_mode)
         -- Set MosaicMenu behaviour:
         FileChooser._do_cover_images = display_mode ~= "mosaic_text"
         FileChooser._do_hint_opened = true -- dogear at bottom
+        -- Don't have "../" centered in empty directories
+        FileChooser._do_center_partial_rows = false
         -- One could override default 3x3 grid here (put that as settings ?)
         -- FileChooser.nb_cols_portrait = 4
         -- FileChooser.nb_rows_portrait = 4
@@ -637,6 +640,7 @@ function CoverBrowser:setupFileManagerDisplayMode(display_mode)
         FileChooser._do_filename_only = display_mode == "list_image_filename"
         FileChooser._do_hint_opened = true -- dogear at bottom
     end
+
 
     -- Replace this FileManager method with the one from CoverMenu
     -- (but first, make the original method saved here as local available
@@ -684,7 +688,7 @@ local function _FileManagerHistory_updateItemTable(self)
             hist_menu._updateItemsBuildUI = MosaicMenu._updateItemsBuildUI
             -- Set MosaicMenu behaviour:
             hist_menu._do_cover_images = display_mode ~= "mosaic_text"
-            -- no need for do_hint_opened with History
+            hist_menu._do_center_partial_rows = true -- nicer looking when few elements
 
         elseif display_mode == "list_image_meta" or display_mode == "list_only_meta" or
                                  display_mode == "list_image_filename" then -- list modes
@@ -695,7 +699,6 @@ local function _FileManagerHistory_updateItemTable(self)
             -- Set ListMenu behaviour:
             hist_menu._do_cover_images = display_mode ~= "list_only_meta"
             hist_menu._do_filename_only = display_mode == "list_image_filename"
-            -- no need for do_hint_opened with History
 
         end
         hist_menu._do_hint_opened = BookInfoManager:getSetting("history_hint_opened")
@@ -763,6 +766,7 @@ local function _FileManagerCollections_updateItemTable(self)
             coll_menu._updateItemsBuildUI = MosaicMenu._updateItemsBuildUI
             -- Set MosaicMenu behaviour:
             coll_menu._do_cover_images = display_mode ~= "mosaic_text"
+            coll_menu._do_center_partial_rows = true -- nicer looking when few elements
 
         elseif display_mode == "list_image_meta" or display_mode == "list_only_meta" or
             display_mode == "list_image_filename" then -- list modes

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -751,9 +751,10 @@ function MosaicMenu:_updateItemsBuildUI()
             table.insert(self.item_group, VerticalSpan:new{ width = self.item_margin })
             cur_row = HorizontalGroup:new{}
             -- Have items on the possibly non-fully filled last row aligned to the left
-            table.insert(self.item_group, LeftContainer:new{
+            local container = self._do_center_partial_rows and CenterContainer or LeftContainer
+            table.insert(self.item_group, container:new{
                 dimen = Geom:new{
-                    w = self.dimen.w - 2*self.item_margin,
+                    w = self.dimen.w,
                     h = self.item_height
                 },
                 cur_row


### PR DESCRIPTION
Avoid some of the issues noticed in #5632:
- Korean keyboard: unwrap InputText on layout change:
The korean keyboard wraps InputText and overrides some of its methods to process input in some specific way (details in #5053). When switching to another keyboard layout, the original methods need to be restored.

- Keyboard: properly handle keyboard layout height change
The japanese keyboard being taller than the others, when switching to/from it from/to another layout:
Re-init InputDialog for proper sizing and positionning
Refresh the whole screen, to remove any trace of a previous taller keyboard
Also add calls to :free() here and there to free keyboard keys' TextWidgets' XText C objects without waiting for GC.
(The `width = icon_height * 100` change is just because I was seeing some huge values in the log like a refresh on x=-1500..., and I figured it would just be cleaner to not see such huge values - possibly some small bug in ImageWidget. No issue noticed - and with #5639 it shouldn't be visited anymore).

Also included:
- CoverBrowser: Mosaic: only left-align for File browser
Left align partially filled rows for File browser/chooser, but have them centered for History and Favorites for a prettier look when only a few items are displayed. Followup to #5638.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5642)
<!-- Reviewable:end -->
