### PR TITLE
Android fixes

### DIFF
--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -61,10 +61,10 @@ function FontSettings:getAndroidPath()
     local user_path = android.getExternalStoragePath()
     if user_path == "Unknown" then
         -- unable to identify external storage. Use defaults
-        return system_path..";".."/sdcard/koreader/fonts"
+        return system_path..";".."/sdcard/fonts;/sdcard/koreader/fonts"
     else
         -- use the external storage identified by the app
-        return system_path..";"..user_path.."/koreader/fonts"
+        return system_path..";"..user_path.."/fonts;"..user_path.."/koreader/fonts"
     end
 end
 

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -24,8 +24,6 @@ function SystemStat:init()
         self.storage_filter = "' /mnt/us$'"
     elseif Device:isSDL() then
         self.storage_filter = "/dev/sd"
-    elseif Device:isAndroid() then
-        self.storage_filter = Device.external_storage()
     end
 end
 


### PR DESCRIPTION
Fixes #5631 
Fixes #5621 

Fonts can be placed in the following directories (under the primary storage partition): `fonts/` and `koreader/fonts`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5643)
<!-- Reviewable:end -->
