### PR TITLE
Add Moldavian diacritics to ru_keyboard

### DIFF
--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -43,28 +43,26 @@ return {
         north = "Ä",
         northeast = "Á",
         northwest = "À",
-        east = "Â", -- A with circumflex (French, Romanian)
+        east = "Â",
         west = "Ã",
         south = "Ą",
-        southeast = "Ă", -- A with breve (Romanian)
+        southeast = "Æ",
         southwest = "Å",
         "Ā",
         "Ǎ",
-        "Æ",
     },
     _a_ = {
         "a",
         north = "ä",
         northeast = "á",
         northwest = "à",
-        east = "â", -- a with circumflex (French, Romanian)
+        east = "â",
         west = "ã",
         south = "ą",
-        southeast = "ă", -- a with breve (Romanian)
+        southeast = "æ",
         southwest = "å",
         "ā",
         "ǎ",
-        "æ",
     },
     _B_ = {
         "B",
@@ -177,10 +175,9 @@ return {
         north = "Í",
         northeast = "Í",
         northwest = "Ì",
-        east = "Î", -- I with circumflex (French, Romanian)
+        east = "Î",
         west = "Ĩ",
         south = "Į",
-        southeast = "Ĭ", -- I with breve (old Romanian)
         "Ī",
         "ɪ", -- small capital letter i, near-close front unrounded vowel IPA
     },
@@ -189,10 +186,9 @@ return {
         north = "ï",
         northeast = "í",
         northwest = "ì",
-        east = "î", -- i with circumflex (French, Romanian)
+        east = "î",
         west = "ĩ",
         south = "į",
-        southeast = "ĭ", -- i with breve (old Romanian)
         "ī",
         "ɪ", -- small capital letter i, near-close front unrounded vowel IPA
     },
@@ -364,11 +360,11 @@ return {
         "S",
         north = "ẞ", -- uppercase eszett
         northeast = "Ś",
-        northwest = "Ș", -- S with comma below (Romanian)
+        northwest = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
         east = "Ŝ",
         west = "Š",
         south = "Ş",
-        southeast = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
+        southeast = "$",
         southwest = "Ṣ",
         "ſ", -- long s
         "Σ", -- uppercase sigma
@@ -377,11 +373,11 @@ return {
         "s",
         north = "ß", -- lowercase eszett
         northeast = "ś",
-        northwest = "ș", -- s with comma below (Romanian)
+        northwest = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
         east = "ŝ",
         west = "š",
         south = "ş",
-        southeast = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
+        southeast = "$",
         southwest = "ṣ",
         "ſ", -- long s
         "σ", -- lowercase sigma
@@ -391,7 +387,7 @@ return {
         "T",
         north = "θ",
         northeast = "Þ",
-        northwest = "Ț", -- T with comma below (Romanian)
+        northwest = "Ț",
         east = "Ʈ",
         west = "Ť",
         south = "Ţ",
@@ -404,7 +400,7 @@ return {
         "t",
         north = "θ",
         northeast = "þ",
-        northwest = "ț", -- t with comma below (Romanian)
+        northwest = "ț",
         east = "Ʈ",
         west = "ť",
         south = "ţ",
@@ -422,7 +418,6 @@ return {
         west = "Ũ",
         south = "Ų",
         southwest = "Ů",
-        southeast = "Ŭ", -- U with breve (old Romanian)
         "Ū",
         "ʌ", -- turned v, open-mid back unrounded vowel IPA
     },
@@ -435,7 +430,6 @@ return {
         west = "ũ",
         south = "ų",
         southwest = "ů",
-        southeast = "ŭ", -- u with breve (old Romanian)
         "ū",
         "ʌ", -- turned v, open-mid back unrounded vowel IPA
     },

--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -43,28 +43,28 @@ return {
         north = "Ä",
         northeast = "Á",
         northwest = "À",
-        east = "Â", -- A with circumflex (Romanian)
-        west = "Ă", -- A with breve (Romanian)
+        east = "Â", -- A with circumflex (Romanian, French)
+        west = "Ã",
         south = "Ą",
-        southeast = "Æ",
+        southeast = "Ă", -- A with breve (Romanian)
         southwest = "Å",
         "Ā",
         "Ǎ",
-        "Ã",
+        "Æ",
     },
     _a_ = {
         "a",
         north = "ä",
         northeast = "á",
         northwest = "à",
-        east = "â", -- a with circumflex (Romanian)
-        west = "ă", -- a with breve (Romanian)
+        east = "â", -- a with circumflex (Romanian, French)
+        west = "ã",
         south = "ą",
-        southeast = "æ",
+        southeast = "ă", -- a with breve (Romanian)
         southwest = "å",
         "ā",
         "ǎ",
-        "ã",
+        "æ",
     },
     _B_ = {
         "B",
@@ -177,7 +177,7 @@ return {
         north = "Í",
         northeast = "Í",
         northwest = "Ì",
-        east = "Î", -- I with circumflex (Romanian)
+        east = "Î", -- I with circumflex (Romanian, French)
         west = "Ĩ",
         south = "Į",
         southeast = "Ĭ", -- I with breve (old Romanian)
@@ -189,7 +189,7 @@ return {
         north = "ï",
         northeast = "í",
         northwest = "ì",
-        east = "î", -- i with circumflex (Romanian)
+        east = "î", -- i with circumflex (Romanian, French)
         west = "ĩ",
         south = "į",
         southeast = "ĭ", -- i with breve (old Romanian)

--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -43,7 +43,7 @@ return {
         north = "Ä",
         northeast = "Á",
         northwest = "À",
-        east = "Â", -- A with circumflex (Romanian, French)
+        east = "Â", -- A with circumflex (French, Romanian)
         west = "Ã",
         south = "Ą",
         southeast = "Ă", -- A with breve (Romanian)
@@ -57,7 +57,7 @@ return {
         north = "ä",
         northeast = "á",
         northwest = "à",
-        east = "â", -- a with circumflex (Romanian, French)
+        east = "â", -- a with circumflex (French, Romanian)
         west = "ã",
         south = "ą",
         southeast = "ă", -- a with breve (Romanian)
@@ -177,7 +177,7 @@ return {
         north = "Í",
         northeast = "Í",
         northwest = "Ì",
-        east = "Î", -- I with circumflex (Romanian, French)
+        east = "Î", -- I with circumflex (French, Romanian)
         west = "Ĩ",
         south = "Į",
         southeast = "Ĭ", -- I with breve (old Romanian)
@@ -189,7 +189,7 @@ return {
         north = "ï",
         northeast = "í",
         northwest = "ì",
-        east = "î", -- i with circumflex (Romanian, French)
+        east = "î", -- i with circumflex (French, Romanian)
         west = "ĩ",
         south = "į",
         southeast = "ĭ", -- i with breve (old Romanian)

--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -43,26 +43,28 @@ return {
         north = "Ä",
         northeast = "Á",
         northwest = "À",
-        east = "Â",
-        west = "Ã",
+        east = "Â", -- A with circumflex (Romanian)
+        west = "Ă", -- A with breve (Romanian)
         south = "Ą",
         southeast = "Æ",
         southwest = "Å",
         "Ā",
         "Ǎ",
+        "Ã",
     },
     _a_ = {
         "a",
         north = "ä",
         northeast = "á",
         northwest = "à",
-        east = "â",
-        west = "ã",
+        east = "â", -- a with circumflex (Romanian)
+        west = "ă", -- a with breve (Romanian)
         south = "ą",
         southeast = "æ",
         southwest = "å",
         "ā",
         "ǎ",
+        "ã",
     },
     _B_ = {
         "B",
@@ -175,9 +177,10 @@ return {
         north = "Í",
         northeast = "Í",
         northwest = "Ì",
-        east = "Î",
+        east = "Î", -- I with circumflex (Romanian)
         west = "Ĩ",
         south = "Į",
+        southeast = "Ĭ", -- I with breve (old Romanian)
         "Ī",
         "ɪ", -- small capital letter i, near-close front unrounded vowel IPA
     },
@@ -186,9 +189,10 @@ return {
         north = "ï",
         northeast = "í",
         northwest = "ì",
-        east = "î",
+        east = "î", -- i with circumflex (Romanian)
         west = "ĩ",
         south = "į",
+        southeast = "ĭ", -- i with breve (old Romanian)
         "ī",
         "ɪ", -- small capital letter i, near-close front unrounded vowel IPA
     },
@@ -360,11 +364,11 @@ return {
         "S",
         north = "ẞ", -- uppercase eszett
         northeast = "Ś",
-        northwest = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
+        northwest = "Ș", -- S with comma below (Romanian)
         east = "Ŝ",
         west = "Š",
         south = "Ş",
-        southeast = "$",
+        southeast = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
         southwest = "Ṣ",
         "ſ", -- long s
         "Σ", -- uppercase sigma
@@ -373,11 +377,11 @@ return {
         "s",
         north = "ß", -- lowercase eszett
         northeast = "ś",
-        northwest = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
+        northwest = "ș", -- s with comma below (Romanian)
         east = "ŝ",
         west = "š",
         south = "ş",
-        southeast = "$",
+        southeast = "ʃ", -- esh, voiceless palato-alveolar fricative IPA
         southwest = "ṣ",
         "ſ", -- long s
         "σ", -- lowercase sigma
@@ -387,7 +391,7 @@ return {
         "T",
         north = "θ",
         northeast = "Þ",
-        northwest = "Ț",
+        northwest = "Ț", -- T with comma below (Romanian)
         east = "Ʈ",
         west = "Ť",
         south = "Ţ",
@@ -400,7 +404,7 @@ return {
         "t",
         north = "θ",
         northeast = "þ",
-        northwest = "ț",
+        northwest = "ț", -- t with comma below (Romanian)
         east = "Ʈ",
         west = "ť",
         south = "ţ",
@@ -418,6 +422,7 @@ return {
         west = "Ũ",
         south = "Ų",
         southwest = "Ů",
+        southeast = "Ŭ", -- U with breve (old Romanian)
         "Ū",
         "ʌ", -- turned v, open-mid back unrounded vowel IPA
     },
@@ -430,6 +435,7 @@ return {
         west = "ũ",
         south = "ų",
         southwest = "ů",
+        southeast = "ŭ", -- u with breve (old Romanian)
         "ū",
         "ʌ", -- turned v, open-mid back unrounded vowel IPA
     },

--- a/frontend/ui/data/keyboardlayouts/keypopup/ru_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/ru_popup.lua
@@ -1,0 +1,10 @@
+return {
+    _Je_ = {
+        "Ж",
+        north = "Ӂ", -- Ж with breve (Moldavian)
+    },
+    _je_ = {
+        "ж",
+        north = "ӂ", -- ж with breve (Moldavian)
+    },
+}

--- a/frontend/ui/data/keyboardlayouts/ru_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ru_keyboard.lua
@@ -1,8 +1,11 @@
 local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
+local ru_popup = require("ui/data/keyboardlayouts/keypopup/ru_popup")
 local com = en_popup.com -- comma (,)
 local prd = en_popup.prd -- period (.)
 local _at = en_popup._at
 local _eq = en_popup._eq -- equals sign (=)
+local _Je_ = ru_popup._Je_
+local _je_ = ru_popup._je_
 
 return {
     min_layer = 1,
@@ -34,7 +37,7 @@ return {
             { "П",    "п",    ":",    ";",    "Ү",    "ү",    "Č",    "č", },
             { "Р",    "р",    '"',    "'",    "Ұ",    "ұ",    "Đ",    "đ", },
             { "О",    "о",    "{",    "[",    "Қ",    "қ",    "Š",    "š", },
-            { "Л",    "л",    "}",    "]",    "Ж",    "ж",    "Ž",    "ž", },
+            { "Л",    "л",    "}",    "]",   _Je_,   _je_,    "Ž",    "ž", },
             { "Д",    "д",    "_",    "-",    "Э",    "э",    "Ő",    "ő", },
         },
         -- third row


### PR DESCRIPTION
This commit contains the following changes:
~~- Added Șș diacritics - I added those instead of $ symbol which was already duplicate on the main en layout popup.~~
~~- Added Ĭĭ, Ŭŭ, Ăă (on the en layout popup)~~
~~- Added comments for all Romanian characters with diacritics - also rearranges some of them for consistency.~~
- Added Ӂӂ on the Russian layout popup for Moldavian.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5652)
<!-- Reviewable:end -->
