### PR TITLE
[UX] Simple symbol keyboard layer paging

### DIFF
--- a/frontend/ui/data/keyboardlayouts/en_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/en_keyboard.lua
@@ -59,7 +59,7 @@ local _z_ = en_popup._z_
 return {
     min_layer = 1,
     max_layer = 8,
-    shiftmode_keys = {[""] = true},
+    shiftmode_keys = {[""] = true, ["1/2"] = true, ["2/2"] = true,},
     symbolmode_keys = {["Sym"] = true, ["ABC"] = true},
     utf8mode_keys = {["🌐"] = true},
     umlautmode_keys = {["Äéß"] = true},
@@ -91,7 +91,7 @@ return {
         },
         -- third row
         {  --  1       2       3       4       5       6       7       8
-            { label = "",
+            { "",   "",   "2/2",  "1/2",   "",   "",   "",    "",
               width = 1.5
             },
             { _Z_,    _z_,    "&",    "7",    "Á",    "á",    "Ű",    "ű", },


### PR DESCRIPTION
Here's a quick concept for consideration. Use 1/2 and 2/2 instead of Shift.

![Screenshot_2019-11-30_16-01-28](https://user-images.githubusercontent.com/202757/69902209-0f855680-138b-11ea-87a5-b526fbc19f7f.png)
![Screenshot_2019-11-30_16-01-35](https://user-images.githubusercontent.com/202757/69902211-0f855680-138b-11ea-9922-237550a382a8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5659)
<!-- Reviewable:end -->
