### PR TITLE
android: allow overrides on 3rd party dictionary list

### DIFF
--- a/frontend/device/android/dictionaries.lua
+++ b/frontend/device/android/dictionaries.lua
@@ -1,15 +1,19 @@
-return { --[[ supported android dictionary applications.
+local user_path = require("datastorage"):getDataDir() .. "/dictionaries.lua"
+local ok, dicts = pcall(dofile, user_path)
 
-Most of them should support Intent.ACTION_SEND, Intent.ACTION_SEARCH or
-Intent.ACTION_PROCESS_TEXT. Some applications implement their custom intents. ]]--
-
-    { "Aard2", "Aard2", false, "itkach.aard2", "aard2" },
-    { "Alpus", "Alpus", false, "com.ngcomputing.fora.android", "search" },
-    { "ColorDict", "ColorDict", false, "com.socialnmobile.colordict", "colordict" },
-    { "Fora", "Fora Dict", false, "com.ngc.fora", "search" },
-    { "GoldenFree", "GoldenDict Free", false, "mobi.goldendict.android.free", "send" },
-    { "GoldenPro", "GoldenDict Pro", false, "mobi.goldendict.android.pro", "send" },
-    { "Kiwix", "Kiwix", false, "org.kiwix.kiwixmobile", "text" },
-    { "Mdict", "Mdict", false, "cn.mdict", "send" },
-    { "QuickDic", "QuickDic", false, "de.reimardoeffinger.quickdic", "quickdic" },
-}
+if ok then
+    return dicts
+else
+    return {
+        -- tested dictionary applications
+        { "Aard2", "Aard2", false, "itkach.aard2", "aard2" },
+        { "Alpus", "Alpus", false, "com.ngcomputing.fora.android", "search" },
+        { "ColorDict", "ColorDict", false, "com.socialnmobile.colordict", "colordict" },
+        { "Fora", "Fora Dict", false, "com.ngc.fora", "search" },
+        { "GoldenFree", "GoldenDict Free", false, "mobi.goldendict.android.free", "send" },
+        { "GoldenPro", "GoldenDict Pro", false, "mobi.goldendict.android.pro", "send" },
+        { "Kiwix", "Kiwix", false, "org.kiwix.kiwixmobile", "text" },
+        { "Mdict", "Mdict", false, "cn.mdict", "send" },
+        { "QuickDic", "QuickDic", false, "de.reimardoeffinger.quickdic", "quickdic" },
+    }
+end


### PR DESCRIPTION
After a conversation with @Norbi24 in https://www.mobileread.com/forums/showthread.php?t=325088 I finally implemented [his original suggestion](https://www.mobileread.com/forums/showpost.php?p=3922401&postcount=4)

Requires https://github.com/koreader/android-luajit-launcher/pull/200 for being able to launch an action with no specific package

I tested it placing the file "dictionaries.lua" inside the koreader folder with

```lua
return {
    { "Generic", "App picker", true, nil, "send" },
    { "ColorDict", "ColorDict", false, "com.socialnmobile.colordict", "colordict" },
}
```
If no package is specified the item must be true to avoid checking if the package is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5664)
<!-- Reviewable:end -->
