### PR TITLE
bump crengine: fix possible crash, some TextBoxWidget tweaks

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -230,6 +230,9 @@ end
 -- the text widget to have the new text splittted into possibly different
 -- lines than before
 function InputText:initTextBox(text, char_added)
+    if self.text_widget then
+        self.text_widget:free()
+    end
     self.text = text
     local fgcolor
     local show_charlist

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -225,7 +225,8 @@ function ListMenuItem:update()
             text = self.mandatory,
             face = Font:getFace("infont", math.min(max_fontsize_fileinfo, _fontSize(15))),
         }
-        local wleft_width = dimen.w - wright:getSize().w
+        local pad_width = Screen:scaleBySize(10) -- on the left, in between, and on the right
+        local wleft_width = dimen.w - wright:getWidth() - 3*pad_width
         local wleft = TextBoxWidget:new{
             text = self.text,
             face = Font:getFace("cfont", _fontSize(20)),
@@ -238,7 +239,7 @@ function ListMenuItem:update()
             LeftContainer:new{
                 dimen = dimen,
                 HorizontalGroup:new{
-                    HorizontalSpan:new{ width = Screen:scaleBySize(10) },
+                    HorizontalSpan:new{ width = pad_width },
                     wleft,
                 }
             },
@@ -246,7 +247,7 @@ function ListMenuItem:update()
                 dimen = dimen,
                 HorizontalGroup:new{
                     wright,
-                    HorizontalSpan:new{ width = Screen:scaleBySize(10) },
+                    HorizontalSpan:new{ width = pad_width },
                 },
             },
         }


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/321:
- CSS: remove invalid and unused item in selector enum
- Fix possible crash with backward search

Also:
- xtext.cpp: adds `XText.getParaDirection()` to help with cursor positionning in empty lines in RTL/bidi https://github.com/koreader/koreader-base/pull/1019 
- xtext: fix occasionally wrong measured width https://github.com/koreader/koreader-base/pull/1020

Also includes some TextBoxWidget tweaks:
- have the XText object freed early when no more needed.
- slightly better cursor positionning in RTL text (not really visible for now, will need proper UI RTL language support in a followup PR - but this change needs the xtext.cpp base bump, which is unrelated to RTL UI mirrorring)

And a CoverBrowser list view mode fix for:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70213872-a90d8900-173a-11ea-9c1e-1a566ce2ea30.png)</kbd>

Bidi cursor positionning is quite nightmarish :)
Just dumping some URLs for future revisits:
https://ux.stackexchange.com/questions/36774/designing-bidi-text-editing
https://docs.microsoft.com/en-us/windows/win32/intl/displaying-the-caret-in-bidirectional-strings
https://www.chromium.org/developers/rtl-in-webkit
https://wiki.mozilla.org/User:Uri/Bidi_editing
https://opensource.com/life/16/3/twisted-road-right-left-language-support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5666)
<!-- Reviewable:end -->
