### PR TITLE
UI mirroring for RTL languages (Arabic, Farsi, Hebrew...)

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
@@ -457,9 +458,10 @@ function FileManager:onShowPlusMenu()
 end
 
 function FileManager:onSwipeFM(ges)
-    if ges.direction == "west" then
+    local direction = BD.flipDirectionIfMirroredUILayout(ges.direction)
+    if direction == "west" then
         self.file_chooser:onNextPage()
-    elseif ges.direction == "east" then
+    elseif direction == "east" then
         self.file_chooser:onPrevPage()
     end
     return true

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -109,6 +109,7 @@ function FileManager:init()
     self.path_text = TextWidget:new{
         face = Font:getFace("xx_smallinfofont"),
         text = filemanagerutil.abbreviate(self.root_path),
+        para_direction_rtl = false, -- force LTR
         max_width = Screen:getWidth() - 2*Size.padding.small,
         truncate_left = true,
     }

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -399,6 +399,37 @@ function FileManagerMenu:setUpdateItemTable()
             })
         end,
     })
+    table.insert(self.menu_items.developer_options.sub_item_table, {
+        text = "UI layout mirroring and text direction",
+        sub_item_table = {
+            {
+                text = _("Reverse UI layout mirroring"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("dev_reverse_ui_layout_mirroring")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrFalse("dev_reverse_ui_layout_mirroring")
+                    local InfoMessage = require("ui/widget/infomessage")
+                    UIManager:show(InfoMessage:new{
+                        text = _("This will take effect on next restart."),
+                    })
+                end
+            },
+            {
+                text = _("Reverse UI text direction"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("dev_reverse_ui_text_direction")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrFalse("dev_reverse_ui_text_direction")
+                    local InfoMessage = require("ui/widget/infomessage")
+                    UIManager:show(InfoMessage:new{
+                        text = _("This will take effect on next restart."),
+                    })
+                end
+            }
+        }
+    })
 
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local CloudStorage = require("apps/cloudstorage/cloudstorage")
 local ConfirmBox = require("ui/widget/confirmbox")
@@ -611,10 +612,10 @@ function FileManagerMenu:_getTabIndexFromLocation(ges)
         return last_tab_index
     -- if the start position is far right
     elseif ges.pos.x > 2 * Screen:getWidth() / 3 then
-        return #self.tab_item_table
+        return BD.mirroredUILayout() and 1 or #self.tab_item_table
     -- if the start position is far left
     elseif ges.pos.x < Screen:getWidth() / 3 then
-        return 1
+        return BD.mirroredUILayout() and #self.tab_item_table or 1
     -- if center return the last index
     else
         return last_tab_index

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
@@ -231,7 +232,7 @@ function ReaderBookmark:onShowBookmark()
                     w = Screen:getWidth(),
                     h = Screen:getHeight(),
                 },
-                direction = "east"
+                direction = BD.flipDirectionIfMirroredUILayout("east")
             }
         }
     }

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Device = require("device")
 local Geom = require("ui/geometry")
 local ImageWidget = require("ui/widget/imagewidget")
@@ -33,6 +34,7 @@ function ReaderDogear:setupDogear(new_dogear_size)
             dimen = Geom:new{w = Screen:getWidth(), h = self.dogear_size},
             ImageWidget:new{
                 file = "resources/icons/dogear.png",
+                rotation_angle = BD.mirroredUILayout() and 90 or 0,
                 width = self.dogear_size,
                 height = self.dogear_size,
             }

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -225,6 +226,44 @@ function ReaderGesture:init()
     }
     local gm = G_reader_settings:readSetting(self.ges_mode)
     if gm == nil then G_reader_settings:saveSetting(self.ges_mode, {}) end
+
+    -- Some of these defaults need to be reversed in RTL mirrored UI,
+    -- and as we set them in the saved gestures, we need to reset them
+    -- to the defaults in case of UI language's direction change.
+    local mirrored_if_rtl = {
+        tap_top_left_corner = "tap_top_right_corner",
+        tap_right_bottom_corner = "tap_left_bottom_corner",
+    }
+    local is_rtl = BD.mirroredUILayout()
+    if is_rtl then
+        for k, v in pairs(mirrored_if_rtl) do
+            self.default_gesture[k], self.default_gesture[v] = self.default_gesture[v], self.default_gesture[k]
+        end
+    end
+    -- We remember the last UI direction gestures were made on. If it changes,
+    -- reset the mirrored_if_rtl ones to the default for the new direction.
+    local ges_dir_setting = self.ges_mode.."ui_lang_direction_rtl"
+    local prev_lang_dir_rtl = G_reader_settings:isTrue(ges_dir_setting)
+    if (is_rtl and not prev_lang_dir_rtl) or (not is_rtl and prev_lang_dir_rtl) then
+        local reset = false
+        for k, v in pairs(mirrored_if_rtl) do
+            -- We only replace them if they are still the other direction's default.
+            -- If not, the user has changed them: let him deal with setting new ones if needed.
+            if gm[k] == self.default_gesture[v] then
+                gm[k] = self.default_gesture[k]
+                reset = true
+            end
+            if gm[v] == self.default_gesture[k] then
+                gm[v] = self.default_gesture[v]
+                reset = true
+            end
+        end
+        if reset then
+            logger.info("UI language direction changed: resetting some gestures to direction default")
+        end
+        G_reader_settings:flipNilOrFalse(ges_dir_setting)
+    end
+
     self.ui.menu:registerToMainMenu(self)
     self:initGesture()
 end
@@ -1577,8 +1616,12 @@ function ReaderGesture:onToggleReadingOrder()
     local document_module = self.ui.document.info.has_pages and self.ui.paging or self.ui.rolling
     document_module.inverse_reading_order = not document_module.inverse_reading_order
     document_module:setupTouchZones()
+    local is_rtl = BD.mirroredUILayout()
+    if document_module.inverse_reading_order then
+        is_rtl = not is_rtl
+    end
     UIManager:show(Notification:new{
-        text = document_module.inverse_reading_order and _("RTL page turning.") or _("LTR page turning."),
+        text = is_rtl and _("RTL page turning.") or _("LTR page turning."),
         timeout = 2.5,
     })
     return true

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local Device = require("device")
 local Event = require("ui/event")
@@ -350,9 +351,19 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
     }
 
     if not self.ui.document.info.has_pages then
+        local start_prev = "◁⇱"
+        local start_next = "⇱▷"
+        local end_prev = "◁⇲"
+        local end_next = "⇲▷"
+        if BD.mirroredUILayout() then
+            -- Sadly, there's only north west & south east arrow to corner,
+            -- north east and south west do not exist in Unicode.
+            start_prev, start_next = BD.ltr(start_next), BD.ltr(start_prev)
+            end_prev, end_next = BD.ltr(end_next), BD.ltr(end_prev)
+        end
         table.insert(buttons, {
             {
-                text = "◁⇱",
+                text = start_prev,
                 callback = function()
                     self:updateHighlight(page, index, 0, -1, false)
                 end,
@@ -362,7 +373,7 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
                 end
             },
             {
-                text = "⇱▷",
+                text = start_next,
                 callback = function()
                     self:updateHighlight(page, index, 0, 1, false)
                 end,
@@ -372,7 +383,7 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
                 end
             },
             {
-                text = "◁⇲",
+                text = end_prev,
                 callback = function()
                     self:updateHighlight(page, index, 1, -1, false)
                 end,
@@ -381,7 +392,7 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
                 end
             },
             {
-                text = "⇲▷",
+                text = end_next,
                 callback = function()
                     self:updateHighlight(page, index, 1, 1, false)
                 end,
@@ -577,6 +588,14 @@ function ReaderHighlight:onHoldPan(_, ges)
                                   and self.holdpan_pos.x < 1/8*Screen:getWidth()
         local is_in_bottom_right_corner = self.holdpan_pos.y > 7/8*Screen:getHeight()
                                       and self.holdpan_pos.x > 7/8*Screen:getWidth()
+        if BD.mirroredUILayout() then
+            -- Note: this might not be really usable, as crengine native selection
+            -- is not adapted to RTL text
+            is_in_top_left_corner = self.holdpan_pos.y < 1/8*Screen:getHeight()
+                                      and self.holdpan_pos.x > 7/8*Screen:getWidth()
+            is_in_bottom_right_corner = self.holdpan_pos.y > 7/8*Screen:getHeight()
+                                          and self.holdpan_pos.x < 1/8*Screen:getWidth()
+        end
         if is_in_top_left_corner or is_in_bottom_right_corner then
             if self.was_in_some_corner then
                 -- Do nothing, wait for the user to move his finger out of that corner

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -781,6 +781,8 @@ function ReaderHighlight:viewSelectionHTML(debug_view)
                                 text = css_text or _("Failed getting CSS content"),
                                 text_face = Font:getFace("smallinfont"),
                                 justified = false,
+                                para_direction_rtl = false,
+                                auto_para_direction = false,
                                 buttons_table = {
                                     {{
                                         text = _("Prettify"),
@@ -792,6 +794,8 @@ function ReaderHighlight:viewSelectionHTML(debug_view)
                                                 text = prettifyCss(css_text),
                                                 text_face = Font:getFace("smallinfont"),
                                                 justified = false,
+                                                para_direction_rtl = false,
+                                                auto_para_direction = false,
                                             })
                                         end,
                                     }},
@@ -838,6 +842,8 @@ function ReaderHighlight:viewSelectionHTML(debug_view)
                 text = html,
                 text_face = Font:getFace("smallinfont"),
                 justified = false,
+                para_direction_rtl = false,
+                auto_para_direction = false,
                 buttons_table = buttons_table,
             }
             UIManager:show(textviewer)

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -2,6 +2,7 @@
 ReaderLink is an abstraction for document-specific link interfaces.
 ]]
 
+local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
@@ -689,7 +690,8 @@ function ReaderLink:onGoBackLink(show_notification_if_empty)
 end
 
 function ReaderLink:onSwipe(arg, ges)
-    if ges.direction == "east" then
+    local direction = BD.flipDirectionIfMirroredUILayout(ges.direction)
+    if direction == "east" then
         if isSwipeToGoBackEnabled() then
             if #self.location_stack > 0 then
                 -- Remember if location stack is going to be empty, so we
@@ -709,7 +711,7 @@ function ReaderLink:onSwipe(arg, ges)
                 return true
             end
         end
-    elseif ges.direction == "west" then
+    elseif direction == "west" then
         local ret = false
         if isSwipeToFollowNearestLinkEnabled() then
             ret = self:onGoToPageLink(ges, isSwipeIgnoreExternalLinksEnabled(), isFootnoteLinkInPopupEnabled())

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1062,12 +1062,13 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
     -- then just ignore the whole stylesheet, including our own declarations
     -- we add at start)
     --
-    -- flags = 0x0000 to get the simplest/purest HTML without CSS
+    -- flags = 0x0001 to get the simplest/purest HTML without CSS, and dir=
+    -- and lang= attributes grabbed from parent nodes
     local html
     if extStartXP and extEndXP then
-        html = self.ui.document:getHTMLFromXPointers(extStartXP, extEndXP, 0x0000)
+        html = self.ui.document:getHTMLFromXPointers(extStartXP, extEndXP, 0x0001)
     else
-        html = self.ui.document:getHTMLFromXPointer(target_xpointer, 0x0000, true)
+        html = self.ui.document:getHTMLFromXPointer(target_xpointer, 0x0001, true)
         -- from_final_parent = true to get a possibly more complete footnote
     end
     if not html then

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
@@ -373,10 +374,10 @@ function ReaderMenu:_getTabIndexFromLocation(ges)
         return self.last_tab_index
     -- if the start position is far right
     elseif ges.pos.x > 2 * Screen:getWidth() / 3 then
-        return #self.tab_item_table
+        return BD.mirroredUILayout() and 1 or #self.tab_item_table
     -- if the start position is far left
     elseif ges.pos.x < Screen:getWidth() / 3 then
-        return 1
+        return BD.mirroredUILayout() and #self.tab_item_table or 1
     -- if center return the last index
     else
         return self.last_tab_index

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
@@ -28,6 +29,11 @@ function ReaderSearch:addToMainMenu(menu_items)
 end
 
 function ReaderSearch:onShowFulltextSearchInput()
+    local backward_text = "◁"
+    local forward_text = "▷"
+    if BD.mirroredUILayout() then
+        backward_text, forward_text = forward_text, backward_text
+    end
     self:onInput{
         title = _("Enter text to search for"),
         type = "text",
@@ -40,14 +46,14 @@ function ReaderSearch:onShowFulltextSearchInput()
                     end,
                 },
                 {
-                    text = "◁",
+                    text = backward_text,
                     callback = function()
                         self:onShowSearchDialog(self.input_dialog:getInputText(), 1)
                         self:closeInputDialog()
                     end,
                 },
                 {
-                    text = "▷",
+                    text = forward_text,
                     is_enter_default = true,
                     callback = function()
                         self:onShowSearchDialog(self.input_dialog:getInputText(), 0)
@@ -138,24 +144,33 @@ function ReaderSearch:onShowSearchDialog(text, direction)
             end
         end
     end
+    local from_start_text = "▕◁"
+    local backward_text = "◁"
+    local forward_text = "▷"
+    local from_end_text = "▷▏"
+    if BD.mirroredUILayout() then
+        backward_text, forward_text = forward_text, backward_text
+        -- Keep the LTR order of |< and >|:
+        from_start_text, from_end_text = BD.ltr(from_end_text), BD.ltr(from_start_text)
+    end
     self.search_dialog = ButtonDialog:new{
         -- alpha = 0.7,
         buttons = {
             {
                 {
-                    text = "▕◁",
+                    text = from_start_text,
                     callback = do_search(self.searchFromStart, text),
                 },
                 {
-                    text = "◁",
+                    text = backward_text,
                     callback = do_search(self.searchNext, text, 1),
                 },
                 {
-                    text = "▷",
+                    text = forward_text,
                     callback = do_search(self.searchNext, text, 0),
                 },
                 {
-                    text = "▷▏",
+                    text = from_end_text,
                     callback = do_search(self.searchFromEnd, text),
                 },
             }

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -97,6 +97,7 @@ function TweakInfoWidget:init()
             text = css,
             face = Font:getFace("infont", 16),
             width = self.width - 2*Size.padding.large,
+            para_direction_rtl = false, -- LTR
         }
     })
     if self.is_global_default then

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
@@ -285,6 +286,7 @@ function ReaderToc:onShowToc()
     -- update collapsible state
     self.expand_button = Button:new{
         icon = "resources/icons/appbar.control.expand.png",
+        icon_rotation_angle = BD.mirroredUILayout() and 180 or 0,
         width = Screen:scaleBySize(30),
         bordersize = 0,
         show_parent = self,
@@ -338,7 +340,7 @@ function ReaderToc:onShowToc()
                     w = Screen:getWidth(),
                     h = Screen:getHeight(),
                 },
-                direction = "west"
+                direction = BD.flipDirectionIfMirroredUILayout("west")
             }
         }
     }
@@ -352,7 +354,15 @@ function ReaderToc:onShowToc()
     function toc_menu:onMenuSelect(item, pos)
         -- if toc item has expand/collapse state and tap select on the left side
         -- the state switch action is triggered, otherwise goto the linked page
-        if item.state and pos and pos.x < 0.3 then
+        local do_toggle_state = false
+        if item.state and pos and pos.x then
+            if BD.mirroredUILayout() then
+                do_toggle_state = pos.x > 0.7
+            else
+                do_toggle_state = pos.x < 0.3
+            end
+        end
+        if do_toggle_state then
             item.state.callback()
         else
             toc_menu:close_callback()

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -488,6 +488,7 @@ function ReaderWikipedia:lookupWikipedia(word, box, get_fullpage, forced_lang)
                 definition = definition,
                 is_fullpage = get_fullpage,
                 lang = lang,
+                rtl_lang = Wikipedia:isWikipediaLanguageRTL(lang),
                 images = page.images,
             }
             table.insert(results, result)

--- a/frontend/apps/reader/skimtowidget.lua
+++ b/frontend/apps/reader/skimtowidget.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
@@ -91,7 +92,7 @@ function SkimToWidget:init()
             text = dialog_title,
             face = self.title_face,
             bold = true,
-            width = self.screen_width * 0.95,
+            max_width = self.screen_width * 0.95,
         },
     }
 
@@ -198,8 +199,16 @@ function SkimToWidget:init()
         end,
     }
 
+    local chapter_next_text = "▷│"
+    local chapter_prev_text = "│◁"
+    local bookmark_next_text = "☆▷"
+    local bookmark_prev_text = "◁☆"
+    if BD.mirroredUILayout() then
+        chapter_next_text, chapter_prev_text = chapter_prev_text, chapter_next_text
+        bookmark_next_text, bookmark_prev_text = bookmark_prev_text, bookmark_next_text
+    end
     local button_chapter_next = Button:new{
-        text = '▷│',
+        text = chapter_next_text,
         bordersize = self.button_bordersize,
         margin = self.button_margin,
         radius = 0,
@@ -218,7 +227,7 @@ function SkimToWidget:init()
     }
 
     local button_chapter_prev = Button:new{
-        text = "│◁",
+        text = chapter_prev_text,
         bordersize = self.button_bordersize,
         margin = self.button_margin,
         radius = 0,
@@ -237,7 +246,7 @@ function SkimToWidget:init()
     }
 
     local button_bookmark_next = Button:new{
-        text = "☆▷",
+        text = bookmark_next_text,
         bordersize = self.button_bordersize,
         margin = self.button_margin,
         radius = 0,
@@ -265,7 +274,7 @@ function SkimToWidget:init()
     }
 
     local button_bookmark_prev = Button:new{
-        text = "◁☆",
+        text = bookmark_prev_text,
         bordersize = self.button_bordersize,
         margin = self.button_margin,
         radius = 0,
@@ -420,9 +429,10 @@ end
 
 function SkimToWidget:onTapProgress(arg, ges_ev)
     if ges_ev.pos:intersectWith(self.progress_bar.dimen) then
-        local width = self.progress_bar.dimen.w
-        local pos = ges_ev.pos.x - self.progress_bar.dimen.x
-        local perc = pos / width
+        local perc = self.progress_bar:getPercentageFromPosition(ges_ev.pos)
+        if not perc then
+            return true
+        end
         local page = Math.round(perc * self.page_count)
         self:addOriginToLocationStack()
         self.ui:handleEvent(Event:new("GotoPage", page ))

--- a/frontend/ui/bidi.lua
+++ b/frontend/ui/bidi.lua
@@ -1,0 +1,189 @@
+--[[--
+Bidirectional text and UI mirroring setup and helpers.
+
+There are 2 concepts we attempt to handle:
+- Text direction: Left-To-Right (LTR) or Right-To-Left (RTL)
+- UI elements mirroring: not-mirrored, or mirrored
+
+These 2 concepts are somehow orthogonal to each other in
+their implementation, even if in the real world there are
+only 2 valid combinations:
+- LTR and not-mirrored: for western languages, CJK, Indic...
+- RTL and mirrored: for Arabic, Hebrew, Farsi and a few others.
+
+Text direction is handled by the libkoreader-xtext.so C module,
+and the TextWidget and TextBoxWidget widgets that handle text
+aligment. We just need here to set the default global paragraph
+direction (that widgets can override if needed).
+
+UI mirroring is to be handled by our widget themselves, with the
+help of a few functions defined here.
+
+Fortunately, low level widgets like LeftContainer, RightContainer,
+FrameContainer, HorizontalGroup, OverlapGroup... will do most of
+the work.
+But some care must be taken in other widgets and apps when:
+- some arrow symbols are used (for next, previous, first, last...):
+  they might need to be swapped, or some alternative symbols or
+  images can be used.
+- some geometry arithmetic is done (e.g. detecting if a tap is on the
+  right part of screen, to go forward), which need to be adapted/reversed.
+- handling left or right swipe, whose action might need to be reversed
+- some TextBoxWidget/InputText might need to be forced to be LTR (when
+  showing HTML or CSS code, or entering URLs, path...)
+
+Some overview at:
+https://material.io/design/usability/bidirectionality.html
+]]
+
+local Language = require("ui/language")
+local _ = require("gettext")
+
+local Bidi = {
+    _mirrored_ui_layout = false,
+    _rtl_ui_text = false,
+}
+
+-- Setup UI mirroring and RTL text for UI language
+function Bidi.setup(lang)
+    local is_rtl = Language:isLanguageRTL(lang)
+    -- Mirror UI if language is RTL
+    Bidi._mirrored_ui_layout = is_rtl
+    -- Unless requested not to (or requested mirroring with LTR language)
+    if G_reader_settings:isTrue("dev_reverse_ui_layout_mirroring") then
+        Bidi._mirrored_ui_layout = not Bidi._mirrored_ui_layout
+    end
+    -- Xtext default language and direction
+    if G_reader_settings:nilOrTrue("use_xtext") then
+        local xtext = require("libs/libkoreader-xtext")
+
+        -- Text direction should normally not follow ui mirroring
+        -- lang override (so that Arabic is still right aligned
+        -- when one wants the UI layout LTR). But allow it to
+        -- be independantly reversed (for testing UI mirroring
+        -- with english text right aligned).
+        if G_reader_settings:isTrue("dev_reverse_ui_text_direction") then
+            is_rtl = not is_rtl
+        end
+        Bidi._rtl_ui_text = is_rtl
+        xtext.setDefaultParaDirection(is_rtl)
+
+        -- Text language: this helps picking localized glyphs from the
+        -- font (eg. ideographs shaped differently for Japanese vs
+        -- Simplified Chinese vs Traditional Chinese).
+        -- Allow overriding xtext language rules from main UI language
+        -- (eg. English UI, with French line breaking rules)
+        local alt_lang = G_reader_settings:readSetting("xtext_alt_lang") or lang
+        if alt_lang then
+            xtext.setDefaultLang(alt_lang)
+        end
+    end
+    -- Optimise Bidi.default and Bidi.wrap by aliasing them to the right wrappers
+    if Bidi._rtl_ui_text then
+        Bidi.default = Bidi.rtl
+        Bidi.wrap = Bidi.rtl
+    else
+        Bidi.default = Bidi.ltr
+        Bidi.wrap = Bidi.noop
+    end
+end
+
+
+-- Use this function in widgets to check if UI elements mirroring
+-- is to be done
+function Bidi.mirroredUILayout()
+    return Bidi._mirrored_ui_layout
+end
+
+-- This function might only be useful in some rare cases (RTL text
+-- is handled directly by TextWidget and TextBoxWidget)
+function Bidi.rtlUIText()
+    return Bidi._rtl_ui_text
+end
+
+-- Small helper to mirror gesture directions
+local mirrored_directions = {
+    east = "west",
+    west = "east",
+    northeast = "northwest",
+    northwest = "northeast",
+    southeast = "southwest",
+    southwest = "southeast",
+}
+
+function Bidi.flipDirectionIfMirroredUILayout(direction)
+    if Bidi._mirrored_ui_layout then
+        return mirrored_directions[direction] or direction
+    end
+    return direction
+end
+
+function Bidi.flipIfMirroredUILayout(bool)
+    if Bidi._mirrored_ui_layout then
+        return not bool
+    end
+    return bool
+end
+
+-- Wrap provided text with bidirectionality control characters, see:
+--   http://unicode.org/reports/tr9/#Markup_And_Formatting
+--   https://www.w3.org/International/questions/qa-bidi-unicode-controls.en
+--   https://www.w3.org/International/articles/inline-bidi-markup/
+-- This works only when use_xtext=true: these characters are used
+-- by FriBidi for correct char visual ordering, and later stripped
+-- by Harfbuzz.
+-- When use_xtext=false, these characters are considered as normal
+-- characters, and would be printed. Fortunately, most fonts know them
+-- and provide an invisible glyph of zero-width - except FreeSans and
+-- FreeSerif which provide a real glyph (a square with "LRI" inside)
+-- which would be an issue and would need stripping. But as these
+-- Free fonts are only used as fallback fonts, and the invisible glyphs
+-- will have been found in the previous fonts, we don't need to.
+local LRI = "\xE2\x81\xA6"     -- U+2066 LRI / LEFT-TO-RIGHT ISOLATE
+local RLI = "\xE2\x81\xA7"     -- U+2067 RLI / RIGHT-TO-LEFT ISOLATE
+local FSI = "\xE2\x81\xA8"     -- U+2068 FSI / FIRST STRONG ISOLATE
+local PDI = "\xE2\x81\xA9"     -- U+2069 PDI / POP DIRECTIONAL ISOLATE
+
+function Bidi.ltr(text)
+    return string.format("%s%s%s", LRI, text, PDI)
+end
+
+function Bidi.rtl(text) -- should hardly be needed
+    return string.format("%s%s%s", RLI, text, PDI)
+end
+
+function Bidi.auto(text) -- from first strong character
+    return string.format("%s%s%s", FSI, text, PDI)
+end
+
+function Bidi.default(text) -- default direction
+    return Bidi._rtl_ui_text and Bidi.rtl(text) or Bidi.ltr(text)
+end
+
+function Bidi.noop(text) -- no wrap
+    return text
+end
+
+-- Helper for concatenated string bits of numbers an symbols (like
+-- our reader footer) to keep them ordered in RTL UI (to not have
+-- a letter B for battery make the whole string considered LTR).
+-- Note: it will be replaced and aliased to Bidi.noop or Bidi.rtl
+-- by Bibi.setup() as an optimisation
+function Bidi.wrap(text)
+    return Bidi._rtl_ui_text and Bidi.rtl(text) or text
+end
+
+-- See at having GetText_mt.__call() wrap untranslated strings in Bidi.ltr()
+-- so they are fully displayed LTR.
+
+-- Use these specific wrappers when the wrapped content type is known
+-- (so we can easily switch to use rtl() if RTL readers prefer filenames
+-- shown as real RTL).
+-- Note: when the filename or path are standalone in a TextWidget, it's
+-- better to use "para_direction_rtl = false" without any wrapping.
+Bidi.filename = Bidi.ltr
+Bidi.directory = Bidi.ltr
+Bidi.path = Bidi.ltr
+Bidi.url = Bidi.ltr
+
+return Bidi

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Device = require("device")
 local S = require("ui/data/strings")
 local optionsutil = require("ui/data/optionsutil")
@@ -314,5 +315,17 @@ This can also be used to remove some gray background or to convert a grayscale o
         }
     },
 }
+
+if BD.mirroredUILayout() then
+    -- The justification items {AUTO, LEFT, CENTER, RIGHT, JUSTIFY} will
+    -- be mirrored - but that's not enough: we need to swap LEFT and RIGHT,
+    -- so they appear in a more expected and balanced order to RTL users:
+    -- {JUSTIFY, LEFT, CENTER, RIGHT, AUTO}
+    local j = KoptOptions[3].options[6]
+    assert(j.name == "justification")
+    j.item_icons[2], j.item_icons[4] = j.item_icons[4], j.item_icons[2]
+    j.values[2], j.values[4] = j.values[4], j.values[2]
+    j.labels[2], j.labels[4] = j.labels[4], j.labels[2]
+end
 
 return KoptOptions

--- a/frontend/ui/language.lua
+++ b/frontend/ui/language.lua
@@ -1,7 +1,5 @@
 -- high level wrapper module for gettext
 
-local InfoMessage = require("ui/widget/infomessage")
-local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 
 local Language = {
@@ -47,13 +45,46 @@ local Language = {
         zh_TW = "中文（台灣)",
         ["zh_TW.Big5"] = "中文（台灣）（Big5）",
     },
+    -- Languages that are written RTL, and should have the UI mirrored.
+    -- Should match lang tags defined in harfbuzz/src/hb-ot-tag-table.hh.
+    -- https://meta.wikimedia.org/wiki/Template:List_of_language_names_ordered_by_code
+    -- Not included are those absent or commented out in hb-ot-tag-table.hh.
+    languages_rtl = {
+        ar  = true, -- Arabic
+        arz = true, -- Egyptian Arabic
+        ckb = true, -- Sorani (Central Kurdish)
+        dv  = true, -- Divehi
+        fa  = true, -- Persian
+        he  = true, -- Hebrew
+        ks  = true, -- Kashmiri
+        ku  = true, -- Kurdish
+        ps  = true, -- Pashto
+        sd  = true, -- Sindhi
+        ug  = true, -- Uyghur
+        ur  = true, -- Urdu
+        yi  = true, -- Yiddish
+    }
 }
 
 function Language:getLanguageName(lang_locale)
     return self.language_names[lang_locale] or lang_locale
 end
 
+function Language:isLanguageRTL(lang_locale)
+    if not lang_locale then
+        return false
+    end
+    local lang = lang_locale
+    local sep = lang:find("_")
+    if sep then
+        lang = lang:sub(1, sep-1)
+    end
+    return self.languages_rtl[lang] or false
+end
+
 function Language:changeLanguage(lang_locale)
+    local InfoMessage = require("ui/widget/infomessage")
+    local UIManager = require("ui/uimanager")
     _.changeLang(lang_locale)
     G_reader_settings:saveSetting("language", lang_locale)
     UIManager:show(InfoMessage:new{

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -33,6 +33,7 @@ local Button = InputContainer:new{
     text = nil, -- mandatory
     text_func = nil,
     icon = nil,
+    icon_rotation_angle = 0,
     preselect = false,
     callback = nil,
     enabled = true,
@@ -74,6 +75,7 @@ function Button:init()
     else
         self.label_widget = ImageWidget:new{
             file = self.icon,
+            rotation_angle = self.icon_rotation_angle,
             dim = not self.enabled,
             scale_for_dpi = true,
         }

--- a/frontend/ui/widget/checkmark.lua
+++ b/frontend/ui/widget/checkmark.lua
@@ -14,6 +14,7 @@ Example:
 
 ]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Font = require("ui/font")
 local InputContainer = require("ui/widget/container/inputcontainer")
@@ -27,30 +28,40 @@ local CheckMark = InputContainer:new{
     face = Font:getFace("smallinfofont"),
     width = 0,
     height = 0,
+    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function CheckMark:init()
+    -- Adjust these checkmarks if mirroring UI (para_direction_rtl should
+    -- follow BD.mirroredUILayout(), and not the set or reverted text
+    -- direction, for proper rendering on the right).
+    local para_direction_rtl = self._mirroredUI
     local checked_widget = TextWidget:new{
         text = " ✓", -- preceded by thin space for better alignment
         face = self.face,
+        para_direction_rtl = para_direction_rtl,
     }
     local unchecked_widget = TextWidget:new{
         text = "▢ ",
         face = self.face,
+        para_direction_rtl = para_direction_rtl,
     }
     local disabled_checked_widget = TextWidget:new{
         text = " ✓", -- preceded by thin space for better alignment
         face = self.face,
         fgcolor = Blitbuffer.COLOR_DARK_GRAY,
+        para_direction_rtl = para_direction_rtl,
     }
     local disabled_unchecked_widget = TextWidget:new{
         text = "▢ ",
         face = self.face,
         fgcolor = Blitbuffer.COLOR_DARK_GRAY,
+        para_direction_rtl = para_direction_rtl,
     }
     local empty_widget = TextWidget:new{
         text = "",
         face = self.face,
+        para_direction_rtl = para_direction_rtl,
     }
     local widget
     if self.checkable then

--- a/frontend/ui/widget/closebutton.lua
+++ b/frontend/ui/widget/closebutton.lua
@@ -34,11 +34,11 @@ function CloseButton:init()
         face = Font:getFace("cfont", 30),
     }
 
+    -- The text box height is greater than its width, and we want this × to be
+    -- diagonally aligned with the top right corner (assuming padding_right=0,
+    -- or padding_right = padding_top so the diagonal aligment is preserved).
     local text_size = text_widget:getSize()
-    -- The text box height is greater than its width, and we want this × to
-    -- be diagonally aligned with our top right border
     local text_width_pad = (text_size.h - text_size.w) / 2
-    -- We also add the provided padding_right
 
     self[1] = FrameContainer:new{
         bordersize = 0,

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -18,6 +18,7 @@ Example:
 
 --]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Geom = require("ui/geometry")
 local Size = require("ui/size")
@@ -38,6 +39,8 @@ local FrameContainer = WidgetContainer:new{
     width = nil,
     height = nil,
     invert = false,
+    allow_mirroring = true,
+    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function FrameContainer:getSize()
@@ -46,6 +49,9 @@ function FrameContainer:getSize()
     self._padding_right = self.padding_right or self.padding
     self._padding_bottom = self.padding_bottom or self.padding
     self._padding_left = self.padding_left or self.padding
+    if self._mirroredUI and self.allow_mirroring then
+        self._padding_left, self._padding_right = self._padding_right, self._padding_left
+    end
     return Geom:new{
         w = content_size.w + ( self.margin + self.bordersize ) * 2 + self._padding_left + self._padding_right,
         h = content_size.h + ( self.margin + self.bordersize ) * 2 + self._padding_top + self._padding_bottom
@@ -61,6 +67,11 @@ function FrameContainer:paintTo(bb, x, y)
     }
     local container_width = self.width or my_size.w
     local container_height = self.height or my_size.h
+
+    local shift_x = 0
+    if self._mirroredUI and self.allow_mirroring then
+        shift_x = container_width - my_size.w
+    end
 
     --- @todo get rid of margin here?  13.03 2013 (houqp)
     if self.background then
@@ -83,7 +94,7 @@ function FrameContainer:paintTo(bb, x, y)
     end
     if self[1] then
         self[1]:paintTo(bb,
-            x + self.margin + self.bordersize + self._padding_left,
+            x + self.margin + self.bordersize + self._padding_left + shift_x,
             y + self.margin + self.bordersize + self._padding_top)
     end
     if self.invert then

--- a/frontend/ui/widget/container/leftcontainer.lua
+++ b/frontend/ui/widget/container/leftcontainer.lua
@@ -2,9 +2,13 @@
 LeftContainer aligns its content (1 widget) at the left of its own dimensions
 --]]
 
+local BD = require("ui/bidi")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
-local LeftContainer = WidgetContainer:new()
+local LeftContainer = WidgetContainer:new{
+    allow_mirroring = true,
+    _mirroredUI = BD.mirroredUILayout(),
+}
 
 function LeftContainer:paintTo(bb, x, y)
     local contentSize = self[1]:getSize()
@@ -13,6 +17,9 @@ function LeftContainer:paintTo(bb, x, y)
         -- throw error? paint to scrap buffer and blit partially?
         -- for now, we ignore this
     -- end
+    if self._mirroredUI and self.allow_mirroring then
+        x = x + (self.dimen.w - contentSize.w) -- as in RightContainer
+    end
     self[1]:paintTo(bb, x , y + math.floor((self.dimen.h - contentSize.h)/2))
 end
 

--- a/frontend/ui/widget/container/rightcontainer.lua
+++ b/frontend/ui/widget/container/rightcontainer.lua
@@ -2,9 +2,13 @@
 RightContainer aligns its content (1 widget) at the right of its own dimensions
 --]]
 
+local BD = require("ui/bidi")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
-local RightContainer = WidgetContainer:new()
+local RightContainer = WidgetContainer:new{
+    allow_mirroring = true,
+    _mirroredUI = BD.mirroredUILayout(),
+}
 
 function RightContainer:paintTo(bb, x, y)
     local contentSize = self[1]:getSize()
@@ -13,8 +17,12 @@ function RightContainer:paintTo(bb, x, y)
         -- throw error? paint to scrap buffer and blit partially?
         -- for now, we ignore this
     -- end
+    if not self._mirroredUI or not self.allow_mirroring then
+        x = x + (self.dimen.w - contentSize.w)
+    -- else: keep x, as in LeftContainer
+    end
     self[1]:paintTo(bb,
-        x + (self.dimen.w - contentSize.w),
+        x,
         y + math.floor((self.dimen.h - contentSize.h)/2))
 end
 

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -312,6 +312,9 @@ function DictQuickLookup:update()
             dialog = self,
             -- allow for disabling justification
             justified = G_reader_settings:nilOrTrue("dict_justify"),
+            lang = self.lang and self.lang:lower(), -- only available on wikipedia results
+            para_direction_rtl = self.rtl_lang,     -- only available on wikipedia results
+            auto_para_direction = not self.is_wiki, -- only for dict results (we don't know their lang)
             image_alt_face = self.image_alt_face,
             images = self.images,
         }
@@ -659,6 +662,7 @@ function DictQuickLookup:changeDictionary(index)
     self.is_html = self.results[index].is_html
     self.css = self.results[index].css
     self.lang = self.results[index].lang
+    self.rtl_lang = self.results[index].rtl_lang
     self.images = self.results[index].images
     if self.images and #self.images > 0 then
         -- We'll be giving some images to textboxwidget that will

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -237,22 +237,24 @@ function DictQuickLookup:update()
     end
     -- dictionary title
     local close_button = CloseButton:new{ window = self, padding_top = self.title_margin, }
+    local btn_width = close_button:getSize().w + Size.padding.default * 2
     local dict_title_text = TextWidget:new{
         text = self.dictionary,
         face = self.title_face,
         bold = true,
-        width = self.width,
+        max_width = self.width - btn_width,
     }
     -- Some different UI tweaks for dict or wiki
     local lookup_word_font_size, lookup_word_padding, lookup_word_margin
+    local dict_title_widget
     if self.is_wiki then
         -- visual hint : dictionary title left adjusted, Wikipedia title centered
-        dict_title_text = CenterContainer:new{
+        dict_title_widget = CenterContainer:new{
                 dimen = Geom:new{
                     w = self.width,
                     h = dict_title_text:getSize().h,
                 },
-                dict_title_text
+                dict_title_text,
         }
         -- Wikipedia has longer titles, so use a smaller font
         lookup_word_font_size = 18
@@ -262,6 +264,7 @@ function DictQuickLookup:update()
         -- by DictQuickLookup:resyncWikiLanguages()
         self.wiki_languages_copy = self.wiki_languages and {unpack(self.wiki_languages)} or nil
     else
+        dict_title_widget = dict_title_text
         -- Usual font size for dictionary
         lookup_word_font_size = 22
         lookup_word_padding = self.word_padding
@@ -271,7 +274,7 @@ function DictQuickLookup:update()
         padding = self.title_padding,
         margin = self.title_margin,
         bordersize = 0,
-        dict_title_text
+        dict_title_widget,
     }
     -- lookup word
     local lookup_word = Button:new{
@@ -507,7 +510,7 @@ function DictQuickLookup:update()
         close_button,
     }
     -- Fix dict title max width now that we know the final width
-    dict_title_text.width = self.dict_bar.dimen.w - close_button:getSize().w
+    dict_title_text:setMaxWidth(self.dict_bar.dimen.w - close_button:getSize().w)
 
     self.dict_frame = FrameContainer:new{
         radius = Size.radius.window,

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Device = require("device")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
@@ -121,7 +122,7 @@ end
 function FileChooser:genItemTableFromPath(path)
     local dirs = {}
     local files = {}
-    local up_folder_arrow = "⬆ ../"
+    local up_folder_arrow = BD.mirroredUILayout() and BD.ltr("../ ⬆") or "⬆ ../"
 
     self.list(path, dirs, files)
 
@@ -213,15 +214,18 @@ function FileChooser:genItemTableFromPath(path)
         local num_items = #sub_dirs + #dir_files
         local istr = ffiUtil.template(N_("1 item", "%1 items", num_items), num_items)
         local text
+        local bidi_wrap_func
         if dir.name == ".." then
             text = up_folder_arrow
         elseif dir.name == "." then -- possible with show_current_dir_for_hold
             text = _("Long-press to select current directory")
         else
             text = dir.name.."/"
+            bidi_wrap_func = BD.directory
         end
         table.insert(item_table, {
             text = text,
+            bidi_wrap_func = bidi_wrap_func,
             mandatory = istr,
             path = subdir_path,
             is_go_up = dir.name == ".."
@@ -239,6 +243,7 @@ function FileChooser:genItemTableFromPath(path)
         local sstr = getFriendlySize(file_size)
         local file_item = {
             text = file.name,
+            bidi_wrap_func = BD.filename,
             mandatory = sstr,
             path = full_path
         }
@@ -437,7 +442,7 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
                 if self.set_provider_dialog._check_file_button.checked then
                     UIManager:show(ConfirmBox:new{
                         text = T(_("Always open '%2' with %1?"),
-                                   provider.provider_name, filename_pure),
+                                   provider.provider_name, BD.filename(filename_pure)),
                         ok_text = _("Always"),
                         ok_callback = function()
                             DocumentRegistry:setProvider(file, provider, false)
@@ -485,7 +490,7 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
     end
 
     self.set_provider_dialog = OpenWithDialog:new{
-        title = T(_("Open %1 with:"), filename_pure),
+        title = T(_("Open %1 with:"), BD.filename(filename_pure)),
         radio_buttons = radio_buttons,
         buttons = buttons,
     }

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -651,9 +651,10 @@ function FrontLightWidget:onTapProgress(arg, ges_ev)
         -- Unschedule any pending updates.
         UIManager:unschedule(self.update)
 
-        local width = self.fl_group.dimen.w
-        local pos = ges_ev.pos.x - self.fl_group.dimen.x
-        local perc = pos / width
+        local perc = self.fl_group:getPercentageFromPosition(ges_ev.pos)
+        if not perc then
+            return true
+        end
         local num = Math.round(perc * self.fl_max)
 
         -- Always set the frontlight intensity.

--- a/frontend/ui/widget/horizontalgroup.lua
+++ b/frontend/ui/widget/horizontalgroup.lua
@@ -2,10 +2,14 @@
 A layout widget that puts objects besides each other.
 --]]
 
+local BD = require("ui/bidi")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local util = require("util")
 
 local HorizontalGroup = WidgetContainer:new{
     align = "center",
+    allow_mirroring = true,
+    _mirroredUI = BD.mirroredUILayout(),
     _size = nil,
 }
 
@@ -13,6 +17,9 @@ function HorizontalGroup:getSize()
     if not self._size then
         self._size = { w = 0, h = 0 }
         self._offsets = { }
+        if self._mirroredUI and self.allow_mirroring then
+            util.arrayReverse(self)
+        end
         for i, widget in ipairs(self) do
             local w_size = widget:getSize()
             self._offsets[i] = {
@@ -24,6 +31,9 @@ function HorizontalGroup:getSize()
                 self._size.h = w_size.h
             end
         end
+        if self._mirroredUI and self.allow_mirroring then
+            util.arrayReverse(self)
+        end
     end
     return self._size
 end
@@ -31,6 +41,9 @@ end
 function HorizontalGroup:paintTo(bb, x, y)
     local size = self:getSize()
 
+    if self._mirroredUI and self.allow_mirroring then
+        util.arrayReverse(self)
+    end
     for i, widget in ipairs(self) do
         if self.align == "center" then
             widget:paintTo(bb,
@@ -44,6 +57,9 @@ function HorizontalGroup:paintTo(bb, x, y)
             io.stderr:write("[!] invalid alignment for HorizontalGroup: ",
                             self.align)
         end
+    end
+    if self._mirroredUI and self.allow_mirroring then
+        util.arrayReverse(self)
     end
 end
 

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -2,6 +2,7 @@
 ImageViewer displays an image with some simple manipulation options.
 ]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
@@ -459,11 +460,19 @@ function ImageViewer:onTap(_, ges)
     end
     if self._images_list then
         -- If it's a list of image (e.g. animated gifs), tap left/right 1/3 of screen to navigate
+        local show_prev_image, show_next_image
         if ges.pos.x < Screen:getWidth()/3 then
+            show_prev_image = not BD.mirroredUILayout()
+            show_next_image = BD.mirroredUILayout()
+        elseif ges.pos.x > Screen:getWidth()*2/3 then
+            show_prev_image = BD.mirroredUILayout()
+            show_next_image = not BD.mirroredUILayout()
+        end
+        if show_prev_image then
             if self._images_list_cur > 1 then
                 self:switchToImageNum(self._images_list_cur - 1)
             end
-        elseif ges.pos.x > Screen:getWidth()*2/3 then
+        elseif show_next_image then
             if self._images_list_cur < self._images_list_nb then
                 self:switchToImageNum(self._images_list_cur + 1)
             end

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -181,6 +181,14 @@ local InputDialog = InputContainer:new{
     button_padding = Size.padding.default,
     border_size = Size.border.window,
 
+    -- See TextBoxWidget for details about these options
+    alignment = "left",
+    justified = false,
+    lang = nil,
+    para_direction_rtl = nil,
+    auto_para_direction = false,
+    alignment_strict = false,
+
     -- for internal use
     _text_modified = false, -- previous known modified status
     _top_line_num = nil,
@@ -307,6 +315,9 @@ function InputDialog:init()
             width = self.text_width,
             padding = self.input_padding,
             margin = self.input_margin,
+            lang = self.lang, -- these might influence height
+            para_direction_rtl = self.para_direction_rtl,
+            auto_para_direction = self.auto_para_direction,
         }
         local text_height = input_widget:getTextHeight()
         local line_height = input_widget:getLineHeight()
@@ -351,6 +362,12 @@ function InputDialog:init()
         text = self.input,
         hint = self.input_hint,
         face = self.input_face,
+        alignment = self.alignment,
+        justified = self.justified,
+        lang = self.lang,
+        para_direction_rtl = self.para_direction_rtl,
+        auto_para_direction = self.auto_para_direction,
+        alignment_strict = self.alignment_strict,
         width = self.text_width,
         height = self.text_height or nil,
         padding = self.input_padding,

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -42,6 +42,14 @@ local InputText = InputContainer:new{
     margin = Size.margin.default,
     bordersize = Size.border.inputtext,
 
+    -- See TextBoxWidget for details about these options
+    alignment = "left",
+    justified = false,
+    lang = nil,
+    para_direction_rtl = nil,
+    auto_para_direction = false,
+    alignment_strict = false,
+
     -- for internal use
     text_widget = nil, -- Text Widget for cursor movement, possibly a ScrollTextWidget
     charlist = nil, -- table of individual chars from input string
@@ -308,6 +316,9 @@ function InputText:initTextBox(text, char_added)
             charlist = show_charlist,
             face = self.face,
             width = text_width,
+            lang = self.lang, -- these might influence height
+            para_direction_rtl = self.para_direction_rtl,
+            auto_para_direction = self.auto_para_direction,
         }
         self.height = text_widget:getTextHeight()
         self.scroll = true
@@ -322,6 +333,12 @@ function InputText:initTextBox(text, char_added)
             editable = self.focused,
             face = self.face,
             fgcolor = fgcolor,
+            alignment = self.alignment,
+            justified = self.justified,
+            lang = self.lang,
+            para_direction_rtl = self.para_direction_rtl,
+            auto_para_direction = self.auto_para_direction,
+            alignment_strict = self.alignment_strict,
             width = self.width,
             height = self.height,
             dialog = self.parent,
@@ -337,6 +354,12 @@ function InputText:initTextBox(text, char_added)
             editable = self.focused,
             face = self.face,
             fgcolor = fgcolor,
+            alignment = self.alignment,
+            justified = self.justified,
+            lang = self.lang,
+            para_direction_rtl = self.para_direction_rtl,
+            auto_para_direction = self.auto_para_direction,
+            alignment_strict = self.alignment_strict,
             width = self.width,
             height = self.height,
             dialog = self.parent,

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -19,6 +19,7 @@ Example:
 
 ]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local BottomContainer = require("ui/widget/container/bottomcontainer")
 local Button = require("ui/widget/button")
@@ -333,6 +334,7 @@ function KeyValuePage:init()
     end
 
     -- return button
+    --- @todo: alternative icon if BD.mirroredUILayout()
     self.page_return_arrow = Button:new{
         icon = "resources/icons/appbar.arrow.left.up.png",
         callback = function() self:onReturn() end,
@@ -340,26 +342,34 @@ function KeyValuePage:init()
         show_parent = self,
     }
     -- group for page info
+    local chevron_left = "resources/icons/appbar.chevron.left.png"
+    local chevron_right = "resources/icons/appbar.chevron.right.png"
+    local chevron_first = "resources/icons/appbar.chevron.first.png"
+    local chevron_last = "resources/icons/appbar.chevron.last.png"
+    if BD.mirroredUILayout() then
+        chevron_left, chevron_right = chevron_right, chevron_left
+        chevron_first, chevron_last = chevron_last, chevron_first
+    end
     self.page_info_left_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.left.png",
+        icon = chevron_left,
         callback = function() self:prevPage() end,
         bordersize = 0,
         show_parent = self,
     }
     self.page_info_right_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.right.png",
+        icon = chevron_right,
         callback = function() self:nextPage() end,
         bordersize = 0,
         show_parent = self,
     }
     self.page_info_first_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.first.png",
+        icon = chevron_first,
         callback = function() self:goToPage(1) end,
         bordersize = 0,
         show_parent = self,
     }
     self.page_info_last_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.last.png",
+        icon = chevron_last,
         callback = function() self:goToPage(self.pages) end,
         bordersize = 0,
         show_parent = self,
@@ -446,6 +456,7 @@ function KeyValuePage:init()
 
     local content = OverlapGroup:new{
         dimen = self.dimen:copy(),
+        allow_mirroring = false,
         VerticalGroup:new{
             align = "left",
             self.title_bar,
@@ -557,16 +568,17 @@ function KeyValuePage:onPrevPage()
 end
 
 function KeyValuePage:onSwipe(arg, ges_ev)
-    if ges_ev.direction == "west" then
+    local direction = BD.flipDirectionIfMirroredUILayout(ges_ev.direction)
+    if direction == "west" then
         self:nextPage()
         return true
-    elseif ges_ev.direction == "east" then
+    elseif direction == "east" then
         self:prevPage()
         return true
-    elseif ges_ev.direction == "south" then
+    elseif direction == "south" then
         -- Allow easier closing with swipe down
         self:onClose()
-    elseif ges_ev.direction == "north" then
+    elseif direction == "north" then
         -- no use for now
         do end -- luacheck: ignore 541
     else -- diagonal swipe

--- a/frontend/ui/widget/listview.lua
+++ b/frontend/ui/widget/listview.lua
@@ -36,6 +36,7 @@ Note that ListView is created mainly to be used as a building block for other
 widgets like @{ui.widget.networksetting|NetworkSetting}, so they can share the same pagination code.
 ]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -113,10 +114,11 @@ function ListView:prevPage()
 end
 
 function ListView:onSwipe(arg, ges_ev)
-    if ges_ev.direction == "west" then
+    local direction = BD.flipDirectionIfMirroredUILayout(ges_ev.direction)
+    if direction == "west" then
         self:nextPage()
         return true
-    elseif ges_ev.direction == "east" then
+    elseif direction == "east" then
         self:prevPage()
         return true
     end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -611,6 +611,7 @@ function Menu:init()
         self.path_text = TextWidget:new{
             face = Font:getFace("xx_smallinfofont"),
             text = self.path,
+            para_direction_rtl = false, -- force LTR
             max_width = self.dimen.w - 2*Size.padding.small,
             truncate_left = true,
         }

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -2,6 +2,7 @@
 Widget that displays a shortcut icon for menu item.
 --]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local BottomContainer = require("ui/widget/container/bottomcontainer")
 local Button = require("ui/widget/button")
@@ -33,7 +34,6 @@ local util = require("ffi/util")
 local _ = require("gettext")
 local Input = Device.input
 local Screen = Device.screen
-local getMenuText = require("util").getMenuText
 
 local ItemShortCutIcon = WidgetContainer:new{
     dimen = Geom:new{ w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
@@ -92,21 +92,30 @@ local MenuCloseButton = InputContainer:new{
 }
 
 function MenuCloseButton:init()
-    self[1] = TextWidget:new{
+    local text_widget = TextWidget:new{
         text = "×",
         face = Font:getFace("cfont", 30), -- this font size align nicely with title
     }
-
-    local text_size = self[1]:getSize()
-    -- The text box height is greater than its width, and we want this × to
-    -- be diagonally aligned with our top right border
+    -- The text box height is greater than its width, and we want this × to be
+    -- diagonally aligned with the top right corner (assuming padding_right=0,
+    -- or padding_right = padding_top so the diagonal aligment is preserved).
+    local text_size = text_widget:getSize()
     local text_width_pad = (text_size.h - text_size.w) / 2
-    -- We also add the provided padding_right
+
+    self[1] = FrameContainer:new{
+        bordersize = 0,
+        padding = 0,
+        padding_top = self.padding_top,
+        padding_bottom = self.padding_bottom,
+        padding_left = self.padding_left,
+        padding_right = self.padding_right + text_width_pad,
+        text_widget,
+    }
+
     self.dimen = Geom:new{
         w = text_size.w + text_width_pad + self.padding_right,
         h = text_size.h,
     }
-
     self.ges_events.Close = {
         GestureRange:new{
             ges = "tap",
@@ -401,6 +410,7 @@ function MenuItem:init()
         table.insert(hgroup, HorizontalSpan:new{ width = Size.span.horizontal_default })
     end
     table.insert(hgroup, self._underline_container)
+    table.insert(hgroup, HorizontalSpan:new{ width = Size.padding.fullscreen })
 
     self[1] = FrameContainer:new{
         bordersize = 0,
@@ -641,26 +651,34 @@ function Menu:init()
     -- group for items
     self.item_group = VerticalGroup:new{}
     -- group for page info
+    local chevron_left = "resources/icons/appbar.chevron.left.png"
+    local chevron_right = "resources/icons/appbar.chevron.right.png"
+    local chevron_first = "resources/icons/appbar.chevron.first.png"
+    local chevron_last = "resources/icons/appbar.chevron.last.png"
+    if BD.mirroredUILayout() then
+        chevron_left, chevron_right = chevron_right, chevron_left
+        chevron_first, chevron_last = chevron_last, chevron_first
+    end
     self.page_info_left_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.left.png",
+        icon = chevron_left,
         callback = function() self:onPrevPage() end,
         bordersize = 0,
         show_parent = self.show_parent,
     }
     self.page_info_right_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.right.png",
+        icon = chevron_right,
         callback = function() self:onNextPage() end,
         bordersize = 0,
         show_parent = self.show_parent,
     }
     self.page_info_first_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.first.png",
+        icon = chevron_first,
         callback = function() self:onFirstPage() end,
         bordersize = 0,
         show_parent = self.show_parent,
     }
     self.page_info_last_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.last.png",
+        icon = chevron_last,
         callback = function() self:onLastPage() end,
         bordersize = 0,
         show_parent = self.show_parent,
@@ -807,6 +825,10 @@ function Menu:init()
         }
     end
     local content = OverlapGroup:new{
+        -- This unique allow_mirroring=false looks like it's enough
+        -- to have this complex Menu, and all widgets based on it,
+        -- be mirrored correctly with RTL languages
+        allow_mirroring = false,
         dimen = self.dimen:copy(),
         self.content_group,
         page_return,
@@ -979,7 +1001,7 @@ function Menu:updateItems(select_number)
                 show_parent = self.show_parent,
                 state = self.item_table[i].state,
                 state_size = self.state_size or {},
-                text = getMenuText(self.item_table[i]),
+                text = Menu.getMenuText(self.item_table[i]),
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 dim = self.item_table[i].dim,
@@ -1237,11 +1259,12 @@ function Menu:onTapCloseAllMenus(arg, ges_ev)
 end
 
 function Menu:onSwipe(arg, ges_ev)
-    if ges_ev.direction == "west" then
+    local direction = BD.flipDirectionIfMirroredUILayout(ges_ev.direction)
+    if direction == "west" then
         self:onNextPage()
-    elseif ges_ev.direction == "east" then
+    elseif direction == "east" then
         self:onPrevPage()
-    elseif ges_ev.direction == "south" then
+    elseif direction == "south" then
         if self.has_close_button and not self.no_title then
             -- If there is a close button displayed (so, this Menu can be
             -- closed), allow easier closing with swipe up/down
@@ -1249,13 +1272,49 @@ function Menu:onSwipe(arg, ges_ev)
         end
         -- If there is no close button, it's a top level Menu and swipe
         -- up/down may hide/show top menu
-    elseif ges_ev.direction == "north" then
+    elseif direction == "north" then
         -- no use for now
         do end -- luacheck: ignore 541
     else -- diagonal swipe
         -- trigger full refresh
         UIManager:setDirty(nil, "full")
     end
+end
+
+--- Adds > to touch menu items with a submenu
+local arrow_left  = "◂" -- U+25C2 BLACK LEFT-POINTING SMALL TRIANGLE
+local arrow_right = "▸" -- U+25B8 BLACK RIGHT-POINTING SMALL TRIANGLE
+local sub_item_format
+-- Adjust arrow direction and position for menu with sub items
+-- according to possible user choices
+if BD.mirroredUILayout() then
+    if BD.rtlUIText() then -- normal case with RTL language
+        sub_item_format = "%s " .. BD.rtl(arrow_left)
+    else -- user reverted text direction, so LTR
+        sub_item_format = BD.ltr(arrow_left) .. " %s"
+    end
+else
+    if BD.rtlUIText() then -- user reverted text direction, so RTL
+        sub_item_format = BD.rtl(arrow_right) .. " %s"
+    else -- normal case with LTR language
+        sub_item_format = "%s " .. BD.ltr(arrow_right)
+    end
+end
+
+function Menu.getMenuText(item)
+    local text
+    if item.text_func then
+        text = item.text_func()
+    else
+        text = item.text
+    end
+    if item.bidi_wrap_func then
+        text = item.bidi_wrap_func(text)
+    end
+    if item.sub_item_table ~= nil or item.sub_item_table_func then
+        text = string.format(sub_item_format, text)
+    end
+    return text
 end
 
 function Menu.itemTableFromTouchMenu(t)

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -17,8 +17,6 @@ local Screen = Device.screen
 local input_field, input_description
 
 local MultiInputDialog = InputDialog:extend{
-    field = {},
-    field_hint = {},
     fields = {},
     description_padding = Size.padding.default,
     description_margin = Size.margin.small,
@@ -50,6 +48,13 @@ function MultiInputDialog:init()
             parent = self,
             padding = field.padding or nil,
             margin = field.margin or nil,
+            -- Allow these to be specified per field if needed
+            alignment = field.alignment or self.alignment,
+            justified = field.justified or self.justified,
+            lang = field.lang or self.lang,
+            para_direction_rtl = field.para_direction_rtl or self.para_direction_rtl,
+            auto_para_direction = field.auto_para_direction or self.auto_para_direction,
+            alignment_strict = field.alignment_strict or self.alignment_strict,
         }
         if Device:hasDPad() then
             -- little hack to piggyback on the layout of the button_table to handle the new InputText

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -2,6 +2,7 @@
 HTML widget with vertical scroll bar.
 --]]
 
+local BD = require("ui/bidi")
 local Device = require("device")
 local HtmlBoxWidget = require("ui/widget/htmlboxwidget")
 local Geom = require("ui/geometry")
@@ -143,7 +144,7 @@ function ScrollHtmlWidget:onScrollText(arg, ges)
 end
 
 function ScrollHtmlWidget:onTapScrollText(arg, ges)
-    if ges.pos.x < Screen:getWidth()/2 then
+    if BD.flipIfMirroredUILayout(ges.pos.x < Screen:getWidth()/2) then
         if self.htmlbox_widget.page_number > 1 then
             self:scrollText(-1)
             return true

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -2,6 +2,7 @@
 Text widget with vertical scroll bar.
 --]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Device = require("device")
 local Geom = require("ui/geometry")
@@ -161,6 +162,9 @@ function ScrollTextWidget:moveCursorToCharPos(charpos)
 end
 
 function ScrollTextWidget:moveCursorToXY(x, y, no_overflow)
+    if BD.mirroredUILayout() then -- the scroll bar is on the left
+        x = x - self.scroll_bar_width - self.text_scroll_span
+    end
     self.text_widget:moveCursorToXY(x, y, no_overflow)
     self:updateScrollBar()
 end
@@ -238,7 +242,7 @@ function ScrollTextWidget:onTapScrollText(arg, ges)
         return false
     end
     -- same tests as done in TextBoxWidget:scrollUp/Down
-    if ges.pos.x < Screen:getWidth()/2 then
+    if BD.flipIfMirroredUILayout(ges.pos.x < Screen:getWidth()/2) then
         if self.text_widget.virtual_line_num > 1 then
             self:scrollText(-1)
             return true

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -22,7 +22,6 @@ local ScrollTextWidget = InputContainer:new{
     charpos = nil,
     top_line_num = nil,
     editable = false,
-    justified = false,
     scroll_callback = nil, -- called with (low, high) when view is scrolled
     scroll_by_pan = false, -- allow scrolling by lines with Pan
     face = nil,
@@ -33,6 +32,13 @@ local ScrollTextWidget = InputContainer:new{
     text_scroll_span = Screen:scaleBySize(12),
     dialog = nil,
     images = nil,
+    -- See TextBoxWidget for details about these options
+    alignment = "left",
+    justified = false,
+    lang = nil,
+    para_direction_rtl = nil,
+    auto_para_direction = false,
+    alignment_strict = false,
 }
 
 function ScrollTextWidget:init()
@@ -43,13 +49,18 @@ function ScrollTextWidget:init()
         top_line_num = self.top_line_num,
         dialog = self.dialog,
         editable = self.editable,
-        justified = self.justified,
         face = self.face,
         image_alt_face = self.image_alt_face,
         fgcolor = self.fgcolor,
         width = self.width - self.scroll_bar_width - self.text_scroll_span,
         height = self.height,
         images = self.images,
+        alignment = self.alignment,
+        justified = self.justified,
+        lang = self.lang,
+        para_direction_rtl = self.para_direction_rtl,
+        auto_para_direction = self.auto_para_direction,
+        alignment_strict = self.alignment_strict,
     }
     local visible_line_count = self.text_widget:getVisLineCount()
     local total_line_count = self.text_widget:getAllLineCount()

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local BottomContainer = require("ui/widget/container/bottomcontainer")
 local Button = require("ui/widget/button")
@@ -452,14 +453,15 @@ function SortWidget:onPrevPage()
 end
 
 function SortWidget:onSwipe(arg, ges_ev)
-    if ges_ev.direction == "west" then
+    local direction = BD.flipDirectionIfMirroredUILayout(ges_ev.direction)
+    if direction == "west" then
         self:onNextPage()
-    elseif ges_ev.direction == "east" then
+    elseif direction == "east" then
         self:onPrevPage()
-    elseif ges_ev.direction == "south" then
+    elseif direction == "south" then
         -- Allow easier closing with swipe down
         self:onClose()
-    elseif ges_ev.direction == "north" then
+    elseif direction == "north" then
         -- no use for now
         do end -- luacheck: ignore 541
     else -- diagonal swipe

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -37,7 +37,18 @@ local TextViewer = InputContainer:new{
     width = nil,
     height = nil,
     buttons_table = nil,
+    -- See TextBoxWidget for details about these options
+    -- We default to justified and auto_para_direction to adapt
+    -- to any kind of text we are given (book descriptions,
+    -- bookmarks' text, translation results...).
+    -- When used to display more technical text (HTML, CSS,
+    -- application logs...), it's best to reset them to false.
+    alignment = "left",
     justified = true,
+    lang = nil,
+    para_direction_rtl = nil,
+    auto_para_direction = true,
+    alignment_strict = false,
 
     title_face = Font:getFace("x_smalltfont"),
     text_face = Font:getFace("x_smallinfofont"),
@@ -157,7 +168,12 @@ function TextViewer:init()
         width = self.width - 2*self.text_padding - 2*self.text_margin,
         height = textw_height - 2*self.text_padding -2*self.text_margin,
         dialog = self,
+        alignment = self.alignment,
         justified = self.justified,
+        lang = self.lang,
+        para_direction_rtl = self.para_direction_rtl,
+        auto_para_direction = self.auto_para_direction,
+        alignment_strict = self.alignment_strict,
     }
     self.textw = FrameContainer:new{
         padding = self.text_padding,

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -8,6 +8,7 @@ Displays some text in a scrollable view.
     }
     UIManager:show(textviewer)
 ]]
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
@@ -256,10 +257,11 @@ end
 
 function TextViewer:onSwipe(arg, ges)
     if ges.pos:intersectWith(self.textw.dimen) then
-        if ges.direction == "west" then
+        local direction = BD.flipDirectionIfMirroredUILayout(ges.direction)
+        if direction == "west" then
             self.scroll_text_w:scrollText(1)
             return true
-        elseif ges.direction == "east" then
+        elseif direction == "east" then
             self.scroll_text_w:scrollText(-1)
             return true
         else

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -5,6 +5,7 @@ Displays a button that toggles between states. Used in bottom configuration pane
     local ToggleSwitch = require("ui/widget/toggleswitch")
 ]]
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
@@ -173,6 +174,9 @@ end
 
 function ToggleSwitch:calculatePosition(gev)
     local x = (gev.pos.x - self.dimen.x) / self.dimen.w * self.n_pos
+    if BD.mirroredUILayout() then
+        x = self.n_pos - x
+    end
     local y = (gev.pos.y - self.dimen.y) / self.dimen.h * self.row_count
     return math.max(1, math.ceil(x)) + math.min(self.row_count-1, math.floor(y)) * self.n_pos
 end

--- a/frontend/ui/widget/verticalgroup.lua
+++ b/frontend/ui/widget/verticalgroup.lua
@@ -2,12 +2,15 @@
 A layout widget that puts objects under each other.
 --]]
 
+local BD = require("ui/bidi")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local VerticalGroup = WidgetContainer:new{
     align = "center",
+    allow_mirroring = true,
+    _mirroredUI = BD.mirroredUILayout(),
     _size = nil,
-    _offsets = {}
+    _offsets = {},
 }
 
 function VerticalGroup:getSize()
@@ -31,15 +34,23 @@ end
 
 function VerticalGroup:paintTo(bb, x, y)
     local size = self:getSize()
+    local align = self.align
+    if self._mirroredUI and self.allow_mirroring then
+        if align == "left" then
+            align = "right"
+        elseif align == "right" then
+            align = "left"
+        end
+    end
 
     for i, widget in ipairs(self) do
-        if self.align == "center" then
+        if align == "center" then
             widget:paintTo(bb,
                 x + math.floor((size.w - self._offsets[i].x) / 2),
                 y + self._offsets[i].y)
-        elseif self.align == "left" then
+        elseif align == "left" then
             widget:paintTo(bb, x, y + self._offsets[i].y)
-        elseif self.align == "right" then
+        elseif align == "right" then
             widget:paintTo(bb,
                 x + size.w - self._offsets[i].x,
                 y + self._offsets[i].y)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -163,6 +163,7 @@ function VirtualKey:init()
         background = Blitbuffer.COLOR_WHITE,
         radius = 0,
         padding = 0,
+        allow_mirroring = false,
         CenterContainer:new{
             dimen = Geom:new{
                 w = self.width - 2*self.bordersize,
@@ -465,11 +466,11 @@ function VirtualKeyPopup:init()
     }
     local v_key_padding = VerticalSpan:new{width = parent_key.keyboard.key_padding}
 
-    local vertical_group = VerticalGroup:new{}
-    local horizontal_group_extra = HorizontalGroup:new{}
-    local horizontal_group_top = HorizontalGroup:new{}
-    local horizontal_group_middle = HorizontalGroup:new{}
-    local horizontal_group_bottom = HorizontalGroup:new{}
+    local vertical_group = VerticalGroup:new{ allow_mirroring = false }
+    local horizontal_group_extra = HorizontalGroup:new{ allow_mirroring = false }
+    local horizontal_group_top = HorizontalGroup:new{ allow_mirroring = false }
+    local horizontal_group_middle = HorizontalGroup:new{ allow_mirroring = false }
+    local horizontal_group_bottom = HorizontalGroup:new{ allow_mirroring = false }
 
     local function horizontalRow(chars, group)
         local layout_horizontal = {}
@@ -565,6 +566,7 @@ function VirtualKeyPopup:init()
         background = Blitbuffer.COLOR_WHITE,
         radius = 0,
         padding = parent_key.keyboard.padding,
+        allow_mirroring = false,
         CenterContainer:new{
             dimen = Geom:new{
                 w = parent_key.width*num_columns + 2*Size.border.default + (num_columns)*parent_key.keyboard.key_padding,
@@ -778,9 +780,9 @@ function VirtualKeyboard:addKeys()
     local base_key_height = math.floor((self.height - (#self.KEYS + 1)*self.key_padding - 2*self.padding)/#self.KEYS)
     local h_key_padding = HorizontalSpan:new{width = self.key_padding}
     local v_key_padding = VerticalSpan:new{width = self.key_padding}
-    local vertical_group = VerticalGroup:new{}
+    local vertical_group = VerticalGroup:new{ allow_mirroring = false }
     for i = 1, #self.KEYS do
-        local horizontal_group = HorizontalGroup:new{}
+        local horizontal_group = HorizontalGroup:new{ allow_mirroring = false }
         local layout_horizontal = {}
         for j = 1, #self.KEYS[i] do
             local key
@@ -828,6 +830,7 @@ function VirtualKeyboard:addKeys()
         background = Blitbuffer.COLOR_WHITE,
         radius = 0,
         padding = self.padding,
+        allow_mirroring = false,
         CenterContainer:new{
             dimen = Geom:new{
                 w = self.width - 2*Size.border.default - 2*self.padding,

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -681,6 +681,13 @@ local rtl_wiki_code = {
     ks  = "Kashmiri",
 }
 
+function Wikipedia:isWikipediaLanguageRTL(lang)
+    if lang and rtl_wiki_code[lang:lower()] then
+        return true
+    end
+    return false
+end
+
 -- Create an epub file (with possibly images)
 function Wikipedia:createEpub(epub_path, page, lang, with_images)
     -- Use Trapper to display progress and ask questions through the UI.
@@ -1298,7 +1305,7 @@ table {
     local see_online_version = T(_("See %1 for up-to-date content"), online_version_htmllink)
     -- Set dir= attribute on the HTML tag for RTL languages
     local html_dir = ""
-    if rtl_wiki_code[lang:lower()] then
+    if self:isWikipediaLanguageRTL(lang) then
         html_dir = ' dir="rtl"'
     end
     epub:add("OEBPS/content.html", string.format([[

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -280,6 +280,17 @@ function util.arrayAppend(t1, t2)
     end
 end
 
+-- Reverse array elements in-place in table t
+---- @param t Lua table
+function util.arrayReverse(t)
+    local i, j = 1, #t
+    while i < j do
+        t[i], t[j] = t[j], t[i]
+        i = i + 1
+        j = j - 1
+    end
+end
+
 -- Merge t2 into t1, overwriting existing elements if they already exist
 -- Probably not safe with nested tables (c.f., https://stackoverflow.com/q/1283388)
 ---- @param t1 Lua table

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -694,20 +694,6 @@ function util.getFormattedSize(size)
     return s
 end
 
---- Adds > to touch menu items with a submenu
-function util.getMenuText(item)
-    local text
-    if item.text_func then
-        text = item.text_func()
-    else
-        text = item.text
-    end
-    if item.sub_item_table ~= nil or item.sub_item_table_func then
-        text = text .. " ▸"
-    end
-    return text
-end
-
 --[[--
 Replaces invalid UTF-8 characters with a replacement string.
 

--- a/plugins/docsettingtweak.koplugin/main.lua
+++ b/plugins/docsettingtweak.koplugin/main.lua
@@ -51,6 +51,7 @@ function DocSettingTweak:editDirectoryDefaults()
         title = T(_("Directory Defaults: %1"),directory_defaults_path),
         input = defaults,
         input_type = "string",
+        para_direction_rtl = false, -- force LTR
         fullscreen = true,
         condensed = true,
         allow_newline = true,

--- a/plugins/goodreads.koplugin/doublekeyvaluepage.lua
+++ b/plugins/goodreads.koplugin/doublekeyvaluepage.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local BottomContainer = require("ui/widget/container/bottomcontainer")
 local Button = require("ui/widget/button")
@@ -239,15 +240,20 @@ function DoubleKeyValuePage:init()
         text_font_bold = false,
     }
     -- group for page info
+    local chevron_left = "resources/icons/appbar.chevron.left.png"
+    local chevron_right = "resources/icons/appbar.chevron.right.png"
+    if BD.mirroredUILayout() then
+        chevron_left, chevron_right = chevron_right, chevron_left
+    end
     self.page_info_left_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.left.png",
+        icon = chevron_left,
         callback = function() self:prevPage() end,
         bordersize = 0,
         show_parent = self,
     }
     self.page_info_right_chev = Button:new{
-        icon = "resources/icons/appbar.chevron.right.png",
-        callback = function() self:_nextPage() end,
+        icon = chevron_right,
+        callback = function() self:nextPage() end,
         bordersize = 0,
         show_parent = self,
     }
@@ -413,16 +419,17 @@ function DoubleKeyValuePage:onPrevPage()
 end
 
 function DoubleKeyValuePage:onSwipe(arg, ges_ev)
-    if ges_ev.direction == "west" then
+    local direction = BD.flipDirectionIfMirroredUILayout(ges_ev.direction)
+    if direction == "west" then
         self:_nextPage()
         return true
-    elseif ges_ev.direction == "east" then
+    elseif direction == "east" then
         self:prevPage()
         return true
-    elseif ges_ev.direction == "south" then
+    elseif direction == "south" then
         -- Allow easier closing with swipe down
         self:onClose()
-    elseif ges_ev.direction == "north" then
+    elseif direction == "north" then
         -- no use for now
         do end -- luacheck: ignore 541
     else -- diagonal swipe

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -411,6 +411,7 @@ function NewsDownloader:changeFeedConfig()
         title = T(_("Config: %1"),feed_config_path),
         input = config,
         input_type = "string",
+        para_direction_rtl = false, -- force LTR
         fullscreen = true,
         condensed = true,
         allow_newline = true,

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -23,6 +23,7 @@ function Terminal:start()
     self.input = InputDialog:new{
         title =  _("Enter a command and press \"Execute\""),
         input = self.command,
+        para_direction_rtl = false, -- force LTR
         text_height = Screen:getHeight() * 0.4,
         input_type = "string",
         buttons = {{{

--- a/reader.lua
+++ b/reader.lua
@@ -30,6 +30,8 @@ io.stdout:flush()
 G_reader_settings = require("luasettings"):open(
     DataStorage:getDataDir().."/settings.reader.lua")
 local lang_locale = G_reader_settings:readSetting("language")
+-- Allow quick switching to Arabic for testing RTL/UI mirroring
+if os.getenv("KO_RTL") then lang_locale = "ar_AA" end
 local _ = require("gettext")
 if lang_locale then
     _.changeLang(lang_locale)
@@ -146,6 +148,13 @@ SettingsMigration:migrateSettings(G_reader_settings)
 -- Document renderers canvas
 local CanvasContext = require("document/canvascontext")
 CanvasContext:init(Device)
+
+-- UI mirroring for RTL languages, and text shaping configuration
+local Bidi = require("ui/bidi")
+Bidi.setup(lang_locale)
+-- Avoid loading UIManager and widgets before here, as they may
+-- cache Bidi mirroring settings. Check that with:
+-- for name, _ in pairs(package.loaded) do print(name) end
 
 -- User fonts override
 local fontmap = G_reader_settings:readSetting("fontmap")


### PR DESCRIPTION
Follow up to #5598 (_TextWidget/TextBoxWidget: enhanced text shaping_) that plugs the UI language and its text direction as defaults into the XText C module, which should be all that's needed to have RTL text right aligned and drawn correctly. (Should also close #2936 _No support for font variants in UI based on language_).

Also adds UI mirroring support in many widgets and apps (many files modified, but it's usually just a few lines in each of them).
Should finally close #5359 when the full arabic translation is in to have a nice mirrored UI in arabic (pinging @WaseemAlkurdi :)

@Frenzie @NiLuJe @robert00s 
The 2nd commit defines some helpers in the bidi.lua module, that are used by stuff in the 3rd commit.
Can you have a quick look at the function names defined in the 2nd commit, if they are obvious/concise/short enough, and if the way they are used in the 3rd commit looks natural and non-obtrusive enough? And if it's worthwhile introducing all this little noise to get a RTL UI none of us will ever use :)

I may split the 3rd commit in multiple smallers ones (low-level widgets, symbols mirroring, gesture mirroring, geometry arithmetic mirroring, textboxwidget parameters forwarding...), but it will be easier to do that while all is still flat :)
So some quick OK or comments on the BD API are appreciated :)

This mirrors all the UI elements I met that felt they needed mirroring.
The simple stuff in the low level widgets (*Container, HorizontalGroup, OverlapGroup, FrameContainer) was enough to make 90% of the stuff mirrored naturally - and we can just continue developping in LTR - and things should work in RTL. There are just some special cases with symbols, swipe directions, and some direct geometry arithmetic or direct painting, that need additional care.

What's left to do is some additional `BD.wrap()`, `BD.filename()`, `BD.path()` where needed, where they are give as parameters to some `T(L())`, but that's probably for another PR to not make this one even larger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5667)
<!-- Reviewable:end -->
