### PR TITLE
android: make system fonts toggable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,6 @@ androidupdate: all
 	# assets are compressed manually and stored inside the APK.
 	cd $(INSTALL_DIR)/koreader && zip -r9 \
 		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).zip * \
-		--exclude=*fonts/droid* \
 		--exclude=*resources/fonts* \
 		--exclude=*resources/icons/src* \
 		--exclude=*share/man* \

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -50,7 +50,7 @@ function ReaderFont:init()
     end
     -- build face_table for menu
     self.face_table = {}
-    if Device:isDesktop() then
+    if Device:isAndroid() or Device:isDesktop() then
         table.insert(self.face_table, require("ui/elements/font_settings"):getMenuTable())
     end
     local face_list = cre.getFontFaces()

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -64,9 +64,7 @@ local function isInFontsBlacklist(f)
 end
 
 local function getExternalFontDir()
-    if CanvasContext.isAndroid() then
-        return require("frontend/ui/elements/font_settings"):getAndroidPath()
-    elseif CanvasContext.isDesktop() then
+    if CanvasContext.isAndroid() or CanvasContext.isDesktop() then
         return require("frontend/ui/elements/font_settings"):getPath()
     else
         return os.getenv("EXT_FONT_DIR")

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -5,21 +5,44 @@ local _ = require("gettext")
 
 --[[ Font settings for desktop linux, mac and android ]]--
 
-local function getUserDir()
-    local home = os.getenv("HOME")
-    if home then
-        return home.."/.local/share/fonts"
+local ANDROID_SYSTEM_FONT_DIR = "/system/fonts"
+local LINUX_SYSTEM_FONT_DIR = "/usr/share/fonts"
+local DESKTOP_USER_FONT_DIR = "/.local/share/fonts"
+
+-- get primary storage on Android
+local function getAndroidPrimaryStorage()
+    local A, android = pcall(require, "android")
+    if not A then return end
+    local path = android.getExternalStoragePath()
+    if path ~= "Unknown" then
+        -- use the external storage identified by the app
+        return path
+    else
+        -- unable to identify external storage. Use defaults
+        return "/sdcard"
     end
 end
 
--- System fonts are common in linux
+-- user font path, should be rw. On linux/mac it goes under $HOME.
+-- on Android it goes in the primary storage (internal/sd)
+local function getUserDir()
+    if Device:isDesktop() then
+        local home = os.getenv("HOME")
+        if home then return home..DESKTOP_USER_FONT_DIR end
+    elseif Device:isAndroid() then
+        local p = getAndroidPrimaryStorage()
+        return p.."/koreader/fonts;"..p.."/fonts"
+    end
+end
+
+-- system (ttf) fonts are available on linux and android but not on mac
 local function getSystemDir()
-    local path = "/usr/share/fonts"
-    if util.pathExists(path) then
-        return path
-    else
-        -- mac doesn't use ttf fonts
-        return nil
+    if Device:isDesktop() then
+        if util.pathExists(LINUX_SYSTEM_FONT_DIR) then
+            return LINUX_SYSTEM_FONT_DIR
+        else return nil end
+    elseif Device:isAndroid() then
+        return ANDROID_SYSTEM_FONT_DIR
     end
 end
 
@@ -54,43 +77,31 @@ function FontSettings:getPath()
     return getUserDir()
 end
 
-function FontSettings:getAndroidPath()
-    local A, android = pcall(require, "android")
-    if not A then return end
-    local system_path = "/system/fonts"
-    local user_path = android.getExternalStoragePath()
-    if user_path == "Unknown" then
-        -- unable to identify external storage. Use defaults
-        return system_path..";".."/sdcard/fonts;/sdcard/koreader/fonts"
-    else
-        -- use the external storage identified by the app
-        return system_path..";"..user_path.."/fonts;"..user_path.."/koreader/fonts"
-    end
-end
-
 function FontSettings:getMenuTable()
+    local t = {{
+        text = _("Enable system fonts"),
+        checked_func = usesSystemFonts,
+        callback = function()
+            G_reader_settings:saveSetting("system_fonts", not usesSystemFonts())
+            local UIManager = require("ui/uimanager")
+            local InfoMessage = require("ui/widget/infomessage")
+            UIManager:show(InfoMessage:new{
+                text = _("This will take effect on next restart.")
+            })
+        end,
+    }}
+
+    if Device:isDesktop() then table.insert(t, 2, {
+            text = _("Open fonts folder"),
+            keep_menu_open = true,
+            callback = openFontDir,
+        })
+    end
+
     return {
         text = _("Font settings"),
         separator = true,
-        sub_item_table = {
-            {
-                text = _("Enable system fonts"),
-                checked_func = usesSystemFonts,
-                callback = function()
-                    G_reader_settings:saveSetting("system_fonts", not usesSystemFonts())
-                    local UIManager = require("ui/uimanager")
-                    local InfoMessage = require("ui/widget/infomessage")
-                    UIManager:show(InfoMessage:new{
-                        text = _("This will take effect on next restart.")
-                    })
-                end,
-            },
-            {
-                text = _("Open fonts folder"),
-                keep_menu_open = true,
-                callback = openFontDir,
-            },
-        }
+        sub_item_table = t
     }
 end
 

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -2,8 +2,6 @@
 Font module.
 ]]
 
-local is_android = pcall(require, "android")
-
 local FontList = require("fontlist")
 local Freetype = require("ffi/freetype")
 local Screen = require("device").screen
@@ -88,10 +86,6 @@ local Font = {
     -- face table
     faces = {},
 }
-
-if is_android then
-    table.insert(Font.fallbacks, 3, "DroidSansFallback.ttf") -- for some ancient pre-4.4 Androids
-end
 
 -- Synthetized bold strength can be tuned:
 -- local bold_strength_factor = 1   -- really too bold


### PR DESCRIPTION
like on desktop linux, but without the menu entry to open fonts dir.

Wip: works fine on fresh installation (without the koreader folder or with the folder without further modifications) but crashes on my main device, which is actually is/was heavily modified.

I'll update the crash logs when I have a bit of time.

**Edit:** the main reason for this PR is to avoid *15* pages of noto fonts on my huawei tablet. Others will find this useful too, specially on generic, modern, phones/tablets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5670)
<!-- Reviewable:end -->
