### PR TITLE
UI font rendering: use available bold fonts for bold

### DIFF
--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -7,7 +7,35 @@ local Freetype = require("ffi/freetype")
 local Screen = require("device").screen
 local logger = require("logger")
 
+-- Known regular (and italic) fonts with an available bold font file
+local _bold_font_variant = {}
+_bold_font_variant["NotoSans-Regular.ttf"] = "NotoSans-Bold.ttf"
+_bold_font_variant["NotoSans-Italic.ttf"] = "NotoSans-BoldItalic.ttf"
+_bold_font_variant["NotoSansArabicUI-Regular.ttf"] = "NotoSansArabicUI-Bold.ttf"
+_bold_font_variant["NotoSerif-Regular.ttf"] = "NotoSerif-Bold.ttf"
+_bold_font_variant["NotoSerif-Italic.ttf"] = "NotoSerif-BoldItalic.ttf"
+
+-- Build the reverse mapping, so we can know a font is bold
+local _regular_font_variant = {}
+for regular, bold in pairs(_bold_font_variant) do
+    _regular_font_variant[bold] = regular
+end
+
 local Font = {
+    -- Make these available in the Font object, so other code
+    -- can complete them if needed.
+    bold_font_variant = _bold_font_variant,
+    regular_font_variant = _regular_font_variant,
+
+    -- Allow globally not promoting fonts to their bold variants
+    -- (and use thiner and narrower synthetized bold instead).
+    use_bold_font_for_bold = G_reader_settings:nilOrTrue("use_bold_font_for_bold"),
+
+    -- Widgets can provide "bold = Font.FORCE_SYNTHETIZED_BOLD" instead
+    -- of "bold = true" to explicitely request synthetized bold, which,
+    -- with XText, makes a bold string the same width as itself non-bold.
+    FORCE_SYNTHETIZED_BOLD = "FORCE_SYNTHETIZED_BOLD",
+
     fontmap = {
         -- default font for menu contents
         cfont = "NotoSans-Regular.ttf",
@@ -74,6 +102,8 @@ local Font = {
         x_smallinfofont = 20,
         xx_smallinfofont = 18,
     },
+    -- This fallback fonts list should only contain
+    -- regular weight (non bold) font files.
     fallbacks = {
         [1] = "NotoSans-Regular.ttf",
         [2] = "NotoSansCJKsc-Regular.otf",
@@ -87,39 +117,89 @@ local Font = {
     faces = {},
 }
 
+-- Helper functions with explicite names around
+-- bold/regular_font_variant tables
+function Font:hasBoldVariant(name)
+    return self.bold_font_variant[name] and true or false
+end
+
+function Font:getBoldVariantName(name)
+    return self.bold_font_variant[name]
+end
+
+function Font:isRealBoldFont(name)
+    return self.regular_font_variant[name] and true or false
+end
+
+function Font:getRegularVariantName(name)
+    return self.regular_font_variant[name] or name
+end
+
 -- Synthetized bold strength can be tuned:
 -- local bold_strength_factor = 1   -- really too bold
 -- local bold_strength_factor = 1/2 -- bold enough
 local bold_strength_factor = 3/8 -- as crengine, lighter
 
+-- Add some properties to a face object as needed
+local _completeFaceProperties = function(face_obj)
+    if not face_obj.embolden_half_strength then
+        -- Cache this value in case we use bold, to avoid recomputation
+        face_obj.embolden_half_strength = face_obj.ftface:getEmboldenHalfStrength(bold_strength_factor)
+    end
+end
+
 -- Callback to be used by libkoreader-xtext.so to get Freetype
 -- instantiated fallback fonts when needed for shaping text
+-- (Beware: any error in this code won't be noticed when this
+-- is called from the C module...)
 local _getFallbackFont = function(face_obj, num)
     if not num or num == 0 then -- return the main font
-        if not face_obj.embolden_half_strength then
-            -- cache this value in case we use bold, to avoid recomputation
-            face_obj.embolden_half_strength = face_obj.ftface:getEmboldenHalfStrength(bold_strength_factor)
-        end
+        _completeFaceProperties(face_obj)
         return face_obj
     end
     if not face_obj.fallbacks then
         face_obj.fallbacks = {}
     end
-    if face_obj.fallbacks[num] ~= nil then
+    if face_obj.fallbacks[num] ~= nil then -- (false means: no more fallback font)
         return face_obj.fallbacks[num]
     end
     local next_num = #face_obj.fallbacks + 1
     local cur_num = 0
+    local realname = face_obj.realname
+    if face_obj.is_real_bold then
+        -- Get the regular name, to skip it from Font.fallbacks
+        realname = Font:getRegularVariantName(realname)
+    end
     for index, fontname in pairs(Font.fallbacks) do
-        if fontname ~= face_obj.realname then -- Skip base one if among fallbacks
+        if fontname ~= realname then -- Skip base one if among fallbacks
+            -- If main font is a real bold, or if it's not but we want bold,
+            -- get the bold variant of the fallback if one exists.
+            -- But if one exists, use the regular variant as an additional
+            -- fallback, drawn with synthetized bold (often, bold fonts
+            -- have less glyphs than their regular counterpart).
+            if face_obj.is_real_bold or face_obj.wants_bold == true then
+                                -- (not if wants_bold==Font.FORCE_SYNTHETIZED_BOLD)
+                local bold_variant_name = Font:getBoldVariantName(fontname)
+                if bold_variant_name then
+                    -- There is a bold variant of that fallback font, that we can use
+                    local fb_face = Font:getFace(bold_variant_name, face_obj.orig_size)
+                    if fb_face ~= nil then -- valid font
+                        cur_num = cur_num + 1
+                        if cur_num == next_num then
+                            _completeFaceProperties(fb_face)
+                            face_obj.fallbacks[next_num] = fb_face
+                            return fb_face
+                        end
+                        -- otherwise, go on with the regular variant
+                    end
+                end
+            end
             local fb_face = Font:getFace(fontname, face_obj.orig_size)
             if fb_face ~= nil then -- valid font
                 cur_num = cur_num + 1
                 if cur_num == next_num then
+                    _completeFaceProperties(fb_face)
                     face_obj.fallbacks[next_num] = fb_face
-                    if not fb_face.embolden_half_strength then
-                        fb_face.embolden_half_strength = fb_face.ftface:getEmboldenHalfStrength(bold_strength_factor)
-                    end
                     return fb_face
                 end
             end
@@ -143,14 +223,21 @@ function Font:getFace(font, size)
     local orig_size = size
     size = Screen:scaleBySize(size)
 
-    local hash = font..size
+    local realname = self.fontmap[font]
+    if not realname then
+        realname = font
+    end
+
+    -- Avoid emboldening already bold fonts
+    local is_real_bold = self:isRealBoldFont(realname)
+
+    -- Make a hash from the realname (many fonts in our fontmap use
+    -- the same font file: have them share their glyphs cache)
+    local hash = realname..size
+
     local face_obj = self.faces[hash]
     -- build face if not found
     if not face_obj then
-        local realname = self.fontmap[font]
-        if not realname then
-            realname = font
-        end
         local builtin_font_location = FontList.fontdir.."/"..realname
         local ok, face = pcall(Freetype.newFace, builtin_font_location, size)
 
@@ -187,6 +274,7 @@ function Font:getFace(font, size)
             orig_size = orig_size,
             ftface = face,
             hash = hash,
+            is_real_bold = is_real_bold,
         }
         self.faces[hash] = face_obj
 
@@ -212,6 +300,86 @@ function Font:getFace(font, size)
         --      "-dnom", "-rand", "-trak", "-vert", }
     end
     return face_obj
+end
+
+--- Returns an alternative face instance to be used for measuring
+-- and drawing (in most cases, the one provided untouched)
+--
+-- If 'bold' is true, or if 'face' is a real bold face, we may need to
+-- use an alternative instance of the font, with possibly the associated
+-- real bold font, and/or with tweaks so fallback fonts are rendered
+-- bold too, without affecting the regular 'face'.
+-- (This function should only be used by TextWidget and TextBoxWidget.
+-- Other widgets should not use it, and neither _getFallbackFont()
+-- which will do its own processing.)
+--
+-- @tparam ui.font.FontFaceObj provided face font face
+-- @bool bold whether bold is requested
+-- @treturn ui.font.FontFaceObj face face to use for drawing
+-- @treturn bool bold adjusted bold properties
+function Font:getAdjustedFace(face, bold)
+    if face.is_real_bold then
+        -- No adjustment needed: main real bold font will ensure
+        -- fallback fonts use their associated bold font or
+        -- get synthetized bold - whether bold is requested or not
+        -- (Set returned bold to true, to force synthetized bold
+        -- on fallback fonts with no associated real bold)
+        -- (Drop bold=FORCE_SYNTHETIZED_BOLD and use 'true' if
+        -- we were given a real bold font.)
+        return face, true
+    end
+    if not bold then
+        -- No adjustment needed: regular main font, and regular
+        -- fallback fonts untouched.
+        return face, false
+    end
+    -- We have bold requested, and a regular/non-bold font.
+    if not self.use_bold_font_for_bold then
+        -- If promotion to real bold is not wished, force synth bold
+        bold = Font.FORCE_SYNTHETIZED_BOLD
+    end
+    if bold ~= Font.FORCE_SYNTHETIZED_BOLD then
+        -- See if a bold font file exists for that regular font.
+        local bold_variant_name = self:getBoldVariantName(face.realname)
+        if bold_variant_name then
+            face = Font:getFace(bold_variant_name, face.orig_size)
+            -- It has is_real_bold=true: no adjustment needed
+            return face, true
+        end
+    end
+    -- Only the regular font is available, and bold requested:
+    -- we'll have synthetized bold - but _getFallbackFont() should
+    -- build a list of fallback fonts either synthetized, or possibly
+    -- using the bold variant of a regular fallback font.
+    -- We don't want to collide with the regular font face_obj.fallbacks
+    -- so let's make a shallow clone of this face_obj, and have it cached.
+    -- (Different hash if real bold accepted or not, as the fallback
+    -- fonts list may then be different.)
+    local hash = face.hash..(bold == Font.FORCE_SYNTHETIZED_BOLD and "synthbold" or "realbold")
+    local face_obj = self.faces[hash]
+    if face_obj then
+        return face_obj, bold
+    end
+    face_obj = {
+        orig_font = face.orig_font,
+        realname = face.realname,
+        size = face.size,
+        orig_size = face.orig_size,
+        -- We can keep the same FT object and the same hash in this face_obj
+        -- (which is only used to identify cached glyphs, that we don't need
+        -- to distinguish as "bold" is appended when synthetized as bold)
+        ftface = face.ftface,
+        hash = face.hash,
+        hb_features = face.hb_features,
+        is_real_bold = nil,
+        wants_bold = bold, -- true or Font.FORCE_SYNTHETIZED_BOLD, used
+                           -- to pick the appropritate fallback fonts
+    }
+    face_obj.getFallbackFont = function(num)
+        return _getFallbackFont(face_obj, num)
+    end
+    self.faces[hash] = face_obj
+    return face_obj, bold
 end
 
 return Font

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -84,6 +84,10 @@ end
 -- @bool[opt=false] bold whether the text should be measured as bold
 -- @treturn glyph
 function RenderText:getGlyph(face, charcode, bold)
+    local orig_bold = bold
+    if face.is_real_bold then
+        bold = false -- don't embolden glyphs already bold
+    end
     local hash = "glyph|"..face.hash.."|"..charcode.."|"..(bold and 1 or 0)
     local glyph = GlyphCache:check(hash)
     if glyph then
@@ -98,7 +102,7 @@ function RenderText:getGlyph(face, charcode, bold)
             if fb_face ~= nil then
             -- for some characters it cannot find in Fallbacks, it will crash here
                 if fb_face.ftface:checkGlyph(charcode) ~= 0 then
-                    rendered_glyph = fb_face.ftface:renderGlyph(charcode, bold)
+                    rendered_glyph = fb_face.ftface:renderGlyph(charcode, orig_bold)
                     break
                 end
             end
@@ -295,6 +299,9 @@ end
 -- @bool[opt=false] bold whether the glyph should be artificially boldened
 -- @treturn glyph
 function RenderText:getGlyphByIndex(face, glyphindex, bold)
+    if face.is_real_bold then
+        bold = false -- don't embolden glyphs already bold
+    end
     local hash = "xglyph|"..face.hash.."|"..glyphindex.."|"..(bold and 1 or 0)
     local glyph = GlyphCache:check(hash)
     if glyph then

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -38,7 +38,9 @@ local TextBoxWidget = InputContainer:new{
     alignment = "left", -- or "center", "right"
     dialog = nil, -- parent dialog that will be set dirty
     face = nil,
-    bold = nil,
+    bold = nil,   -- use bold=true to use a real bold font (or synthetized if not available),
+                  -- or bold=Font.FORCE_SYNTHETIZED_BOLD to force using synthetized bold,
+                  -- which, with XText, makes a bold string the same width as it non-bolded.
     line_height = 0.3, -- in em
     fgcolor = Blitbuffer.COLOR_BLACK,
     width = Screen:scaleBySize(400), -- in pixels
@@ -59,6 +61,7 @@ local TextBoxWidget = InputContainer:new{
     text_height = nil,    -- adjusted height to visible text (lines_per_page*line_height_px)
     cursor_line = nil, -- LineWidget to draw the vertical cursor.
     _bb = nil,
+    _face_adjusted = nil,
 
     -- We can provide a list of images: each image will be displayed on each
     -- scrolled page, in its top right corner (if more images than pages, remaining
@@ -99,6 +102,15 @@ local TextBoxWidget = InputContainer:new{
 }
 
 function TextBoxWidget:init()
+    if not self._face_adjusted then
+        self._face_adjusted = true -- only do that once
+        -- If self.bold, or if self.face is a real bold face, we may need to use
+        -- an alternative instance of self.face, with possibly the associated
+        -- real bold font, and/or with tweaks so fallback fonts are rendered bold
+        -- too, without affecting the regular self.face
+        self.face, self.bold = Font:getAdjustedFace(self.face, self.bold)
+    end
+
     self.line_height_px = Math.round( (1 + self.line_height) * self.face.size )
     self.cursor_line = LineWidget:new{
         dimen = Geom:new{

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -13,6 +13,7 @@ Example:
 --]]
 
 local Blitbuffer = require("ffi/blitbuffer")
+local Font = require("ui/font")
 local Geom = require("ui/geometry")
 local Math = require("optmath")
 local RenderText = require("ui/rendertext")
@@ -25,7 +26,9 @@ local util = require("util")
 local TextWidget = Widget:new{
     text = nil,
     face = nil,
-    bold = false, -- synthetized/fake bold (use a bold face for nicer bold)
+    bold = false, -- use bold=true to use a real bold font (or synthetized if not available),
+                  -- or bold=Font.FORCE_SYNTHETIZED_BOLD to force using synthetized bold,
+                  -- which, with XText, makes a bold string the same width as it non-bolded.
     fgcolor = Blitbuffer.COLOR_BLACK,
     padding = Size.padding.small, -- vertical padding (should it be function of face.size ?)
                                   -- (no horizontal padding is added)
@@ -35,6 +38,7 @@ local TextWidget = Widget:new{
 
     -- for internal use
     _updated = nil,
+    _face_adjusted = nil,
     _text_to_draw = nil,
     _length = 0,
     _height = 0,
@@ -57,6 +61,15 @@ function TextWidget:updateSize()
         return
     end
     self._updated = true
+
+    if not self._face_adjusted then
+        self._face_adjusted = true -- only do that once
+        -- If self.bold, or if self.face is a real bold face, we may need to use
+        -- an alternative instance of self.face, with possibly the associated
+        -- real bold font, and/or with tweaks so fallback fonts are rendered bold
+        -- too, without affecting the regular self.face
+        self.face, self.bold = Font:getAdjustedFace(self.face, self.bold)
+    end
 
     -- Compute height:
     -- Used to be:


### PR DESCRIPTION
Follow up to #5598 _"we might need to work on our bold font use and handling..."_

A few fixes and enhancement related to bold text:
- When using `bold=true` with a regular font, use its bold variant if one exists.
- When using a bold font without `bold=true`, promote `bold` to `true`, so fallback fonts are drawn bold too.
- Whether using a bold font, or using `bold=true`, ensure fallback fonts are drawn bold, with their available bold variant if one exists, or with synthetized bold.
- When using a bold variant of a fallback font, keep using the regular variant as another fallback (as bold fonts may contain less glyphs than their regular counterpart).
- Allow providing `bold=Font.FORCE_SYNTHETIZED_BOLD` to get fake bold even when a bold font exists (might be interesting to get text in bold the same width as the same text non-bold).
- Use the font realname in the key when caching glyphs, instead of our aliases (cfont, infont...) to avoid duplication and wasting memory.

Some of these issues are there since the switch to XText (#5598), but some where there before. I think CJK users may have seen our titles non-bold (I hope using synthetized bold with NotoSansCJK is ok and doesn't make the CJK glyphs too busy).

Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70380400-4a632d80-193b-11ea-9d9d-e02dd9752069.png)</kbd>

After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70380415-81394380-193b-11ea-8214-98add6d56882.png)</kbd>

Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70380407-6666cf00-193b-11ea-9227-ed3b7625c96b.png)</kbd>

After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70380422-a2019900-193b-11ea-8d9d-650ef3b5d668.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5675)
<!-- Reviewable:end -->
