### PR TITLE
Settings: use fsync() for more robust setting files saving

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -43,12 +43,19 @@ local symbol_prefix = {
     letters = {
         time = nil,
         pages_left = "=>",
+        -- @translators This is the footer letter prefix for battery % remaining.
         battery = C_("FooterLetterPrefix", "B:"),
+        -- @translators This is the footer letter prefix for percentage read.
         percentage = C_("FooterLetterPrefix", "R:"),
+        -- @translators This is the footer letter prefix for book time to read.
         book_time_to_read = C_("FooterLetterPrefix", "TB:"),
+        -- @translators This is the footer letter prefix for chapter time to read.
         chapter_time_to_read = C_("FooterLetterPrefix", "TC:"),
+        -- @translators This is the footer letter prefix for frontlight level.
         frontlight = C_("FooterLetterPrefix", "L:"),
+        -- @translators This is the footer letter prefix for memory usage.
         mem_usage = C_("FooterLetterPrefix", "M:"),
+        -- @translators This is the footer letter prefix for wifi status.
         wifi_status = C_("FooterLetterPrefix", "W:"),
     },
     icons = {

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -928,11 +928,10 @@ function ReaderView:onReaderReady()
             end
         else
             self.autoSaveSettings = function()
+                self.auto_save_paging_count = self.auto_save_paging_count + 1
                 if self.auto_save_paging_count == DAUTO_SAVE_PAGING_COUNT then
                     self.ui:saveSettings()
                     self.auto_save_paging_count = 0
-                else
-                    self.auto_save_paging_count = self.auto_save_paging_count + 1
                 end
             end
         end

--- a/frontend/luadata.lua
+++ b/frontend/luadata.lua
@@ -51,21 +51,27 @@ function LuaData:open(file_path, o) -- luacheck: ignore 312
         end
     end
 
-    local ok = pcall(dofile, new.file)
-
-    if ok then
-        logger.dbg("data is read from ", new.file)
-    else
-        logger.dbg(new.file, " is invalid, remove.")
-        os.remove(new.file)
+    local ok = false
+    if lfs.attributes(new.file, "mode") == "file" then
+        ok = pcall(dofile, new.file)
+        if ok then
+            logger.dbg("data is read from ", new.file)
+        else
+            logger.dbg(new.file, " is invalid, remove.")
+            os.remove(new.file)
+        end
+    end
+    if not ok then
         for i=1, self.max_backups, 1 do
             local backup_file = new.file..".old."..i
-            if pcall(dofile, backup_file) then
-                logger.dbg("data is read from ", backup_file)
-                break
-            else
-                logger.dbg(backup_file, " is invalid, remove.")
-                os.remove(backup_file)
+            if lfs.attributes(backup_file, "mode") == "file" then
+                if pcall(dofile, backup_file) then
+                    logger.dbg("data is read from ", backup_file)
+                    break
+                else
+                    logger.dbg(backup_file, " is invalid, remove.")
+                    os.remove(backup_file)
+                end
             end
         end
     end

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -1,10 +1,11 @@
 local DataStorage = require("datastorage")
 local DocSettings = require("docsettings")
 local dump = require("dump")
+local ffiutil = require("ffi/util")
 local getFriendlySize = require("util").getFriendlySize
-local joinPath = require("ffi/util").joinPath
+local joinPath = ffiutil.joinPath
 local lfs = require("libs/libkoreader-lfs")
-local realpath = require("ffi/util").realpath
+local realpath = ffiutil.realpath
 
 local history_file = joinPath(DataStorage:getDataDir(), "history.lua")
 
@@ -91,6 +92,7 @@ function ReadHistory:_flush()
     end
     local f = io.open(history_file, "w")
     f:write("return " .. dump(content) .. "\n")
+    ffiutil.fsyncOpenedFile(f) -- force flush to the storage device
     f:close()
 end
 

--- a/spec/unit/docsettings_spec.lua
+++ b/spec/unit/docsettings_spec.lua
@@ -100,6 +100,12 @@ describe("docsettings module", function()
         d:flush()
         -- metadata.pdf.lua should be generated.
         assert.Equals("file", lfs.attributes(d.sidecar_file, "mode"))
+        d:flush()
+        -- metadata.pdf.lua.old should not yet be generated.
+        assert.are.not_equal("file", lfs.attributes(d.sidecar_file .. ".old", "mode"))
+        -- make metadata.pdf.lua older to bypass 60s age needed for .old rotation
+        local minutes_ago = os.time() - 120
+        lfs.touch(d.sidecar_file, minutes_ago)
         d:close()
         -- metadata.pdf.lua and metadata.pdf.lua.old should be generated.
         assert.Equals("file", lfs.attributes(d.sidecar_file, "mode"))
@@ -152,6 +158,9 @@ describe("docsettings module", function()
             d:flush()
             -- metadata.pdf.lua should be generated.
             assert.Equals("file", lfs.attributes(d.sidecar_file, "mode"))
+            -- make metadata.pdf.lua older to bypass 60s age needed for .old rotation
+            local minutes_ago = os.time() - 120
+            lfs.touch(d.sidecar_file, minutes_ago)
             d:close()
             -- metadata.pdf.lua and metadata.pdf.lua.old should be generated.
             assert.Equals("file", lfs.attributes(d.sidecar_file, "mode"))
@@ -182,6 +191,9 @@ describe("docsettings module", function()
             d:flush()
             -- metadata.pdf.lua should be generated.
             assert.Equals("file", lfs.attributes(d.sidecar_file, "mode"))
+            -- make metadata.pdf.lua older to bypass 60s age needed for .old rotation
+            local minutes_ago = os.time() - 120
+            lfs.touch(d.sidecar_file, minutes_ago)
             d:close()
             -- metadata.pdf.lua and metadata.pdf.lua.old should be generated.
             assert.Equals("file", lfs.attributes(d.sidecar_file, "mode"))


### PR DESCRIPTION
Bump base for util.fsyncOpenedFile() and util.fsyncDirectory() https://github.com/koreader/koreader-base/pull/1021

Use these to force flush to storage device when saving luasetting, docsetting, and history.lua.
Also dont rotate them to .old until they are at least 60 seconds old.
Discussion in #3625.

(Unrelated, but I also updated Luadata so it does not output stuff when there is no file - I used to see a few lines as I got not custom multiswiple.lua defined.)

Also bump crengine: open (as text) small or empty files https://github.com/koreader/crengine/pull/322

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5678)
<!-- Reviewable:end -->
