### PR TITLE
New widget DoubleSpinWidget based on HyphenationLimits

### DIFF
--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -39,13 +39,20 @@ function ReaderHyphenation:init()
             local alg_left_hyphen_min = hyph_settings.left_hyphen_min
             local alg_right_hyphen_min = hyph_settings.right_hyphen_min
             local hyph_limits_widget = DoubleSpinWidget:new{
+                -- Min (2) and max (10) values are enforced by crengine
                 left_value = G_reader_settings:readSetting("hyph_left_hyphen_min") or alg_left_hyphen_min or 2,
+                left_min = 1,
+                left_max = 10,
                 right_value = G_reader_settings:readSetting("hyph_right_hyphen_min") or alg_right_hyphen_min or 2,
+                right_min = 1,
+                right_max = 10,
                 left_default = alg_left_hyphen_min or 2,
                 right_default = alg_right_hyphen_min or 2,
                 -- let room on the widget sides so we can see
                 -- the hyphenation changes happening
                 width = Screen:getWidth() * 0.6,
+                default_values = true,
+                default_text = _("Use language defaults"),
                 title_text = _("Hyphenation limits"),
                 info_text = _([[
 Set minimum length before hyphenation occurs.

--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -39,7 +39,7 @@ function ReaderHyphenation:init()
             local alg_left_hyphen_min = hyph_settings.left_hyphen_min
             local alg_right_hyphen_min = hyph_settings.right_hyphen_min
             local hyph_limits_widget = DoubleSpinWidget:new{
-                -- Min (2) and max (10) values are enforced by crengine
+                -- Min (1) and max (10) values are enforced by crengine
                 left_value = G_reader_settings:readSetting("hyph_left_hyphen_min") or alg_left_hyphen_min or 2,
                 left_min = 1,
                 left_max = 10,

--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -1,3 +1,4 @@
+local Device = require("device")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
@@ -9,6 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 local C_ = _.pgettext
 local T = require("ffi/util").template
+local Screen = Device.screen
 
 local ReaderHyphenation = InputContainer:new{
     hyph_menu_title = _("Hyphenation"),
@@ -32,15 +34,23 @@ function ReaderHyphenation:init()
             return T(_("Left/right minimal sizes: %1"), limits_text)
         end,
         callback = function()
-            local HyphenationLimitsWidget = require("ui/widget/hyphenationlimits")
+            local DoubleSpinWidget = require("/ui/widget/doublespinwidget")
             local hyph_settings = self.hyph_algs_settings[self.hyph_alg] or {}
             local alg_left_hyphen_min = hyph_settings.left_hyphen_min
             local alg_right_hyphen_min = hyph_settings.right_hyphen_min
-            local hyph_limits_widget = HyphenationLimitsWidget:new{
+            local hyph_limits_widget = DoubleSpinWidget:new{
                 left_value = G_reader_settings:readSetting("hyph_left_hyphen_min") or alg_left_hyphen_min or 2,
                 right_value = G_reader_settings:readSetting("hyph_right_hyphen_min") or alg_right_hyphen_min or 2,
                 left_default = alg_left_hyphen_min or 2,
                 right_default = alg_right_hyphen_min or 2,
+                -- let room on the widget sides so we can see
+                -- the hyphenation changes happening
+                width = Screen:getWidth() * 0.6,
+                title_text = _("Hyphenation limits"),
+                info_text = _([[
+Set minimum length before hyphenation occurs.
+These settings will apply to all books with any hyphenation dictionary.
+'Use language defaults' resets them.]]),
                 callback = function(left_hyphen_min, right_hyphen_min)
                     G_reader_settings:saveSetting("hyph_left_hyphen_min", left_hyphen_min)
                     G_reader_settings:saveSetting("hyph_right_hyphen_min", right_hyphen_min)

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -23,29 +23,30 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 local Screen = Device.screen
 
-local HyphenationLimitsWidget = InputContainer:new{
-    title_text = _("Hyphenation limits"),
+local DoubleSpinWidget = InputContainer:new{
+    title_text = "",
     title_face = Font:getFace("x_smalltfont"),
+    info_text = "",
     width = nil,
     height = nil,
-    -- Min (2) and max (10) values are enforced by crengine
     left_min = 1,
     left_max = 10,
     left_value = 2,
     left_default = nil,
+    left_text = _("Left"),
     right_min = 1,
     right_max = 10,
     right_value = 2,
     right_default = nil,
+    right_text = _("Right"),
+    button_default_text = _("Use language defaults"),
 }
 
-function HyphenationLimitsWidget:init()
+function DoubleSpinWidget:init()
     self.medium_font_face = Font:getFace("ffont")
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
-    -- let room on the widget sides so we can see
-    -- the hyphenation changes happening
-    self.width = self.screen_width * 0.6
+    self.width = self.width or self.screen_width * 0.8
     self.picker_width = self.screen_width * 0.25
     if Device:hasKeys() then
         self.key_events = {
@@ -63,12 +64,12 @@ function HyphenationLimitsWidget:init()
                     }
                 },
             },
-         }
+        }
     end
     self:update()
 end
 
-function HyphenationLimitsWidget:update()
+function DoubleSpinWidget:update()
     -- This picker_update_callback will be redefined later. It is needed
     -- so we can have our MovableContainer repainted on NumberPickerWidgets
     -- update It is needed if we have enabled transparency on MovableContainer,
@@ -92,33 +93,44 @@ function HyphenationLimitsWidget:update()
         wrap = false,
         update_callback = function() picker_update_callback() end,
     }
-    local hyph_group = HorizontalGroup:new{
+    local left_vertical_group = VerticalGroup:new{
         align = "center",
-        VerticalGroup:new{
-            align = "center",
-            VerticalSpan:new{ width = Size.span.vertical_large },
-            TextBoxWidget:new{
-                text = _("Left"),
-                alignment = "center",
-                face = self.title_face,
-                width = self.picker_width,
-            },
-            left_widget,
+        VerticalSpan:new{ width = Size.span.vertical_large },
+        TextWidget:new{
+            text = self.left_text,
+            face = self.title_face,
+            max_width = 0.95 * self.width / 2,
         },
-        VerticalGroup:new{
-            align = "center",
-            VerticalSpan:new{ width = Size.span.vertical_large },
-            TextBoxWidget:new{
-                text = _("Right"),
-                alignment = "center",
-                face = self.title_face,
-                width = self.picker_width,
-            },
-            right_widget,
-        },
+        left_widget,
     }
-
-    local hyph_title = FrameContainer:new{
+    local right_vertical_group = VerticalGroup:new{
+        align = "center",
+        VerticalSpan:new{ width = Size.span.vertical_large },
+        TextWidget:new{
+            text = self.right_text,
+            face = self.title_face,
+            max_width = 0.95 * self.width / 2,
+        },
+        right_widget,
+    }
+    local widget_group = HorizontalGroup:new{
+        align = "center",
+        CenterContainer:new{
+            dimen = Geom:new{
+                w = self.width / 2,
+                h = left_vertical_group:getSize().h,
+            },
+            left_vertical_group
+        },
+        CenterContainer:new{
+            dimen = Geom:new{
+                w = self.width / 2,
+                h = right_vertical_group:getSize().h,
+            },
+            right_vertical_group
+        }
+    }
+    local widget_title = FrameContainer:new{
         padding = Size.padding.default,
         margin = Size.margin.title,
         bordersize = 0,
@@ -129,36 +141,30 @@ function HyphenationLimitsWidget:update()
             width = self.width,
         },
     }
-    local hyph_line = LineWidget:new{
+    local widget_line = LineWidget:new{
         dimen = Geom:new{
             w = self.width,
             h = Size.line.thick,
         }
     }
-    local hyph_bar = OverlapGroup:new{
+    local widget_bar = OverlapGroup:new{
         dimen = {
             w = self.width,
-            h = hyph_title:getSize().h
+            h = widget_title:getSize().h
         },
-        hyph_title,
+        widget_title,
         CloseButton:new{ window = self, padding_top = Size.margin.title, },
     }
-
-    local hyph_into_text = _([[
-Set minimum length before hyphenation occurs.
-These settings will apply to all books with any hyphenation dictionary.
-'Use language defaults' resets them.]])
-    local hyph_info = FrameContainer:new{
+    local widget_info = FrameContainer:new{
         padding = Size.padding.default,
         margin = Size.margin.small,
         bordersize = 0,
         TextBoxWidget:new{
-            text = hyph_into_text,
+            text = self.info_text,
             face = Font:getFace("x_smallinfofont"),
             width = self.width * 0.9,
         }
     }
-
     local buttons = {
         {
             {
@@ -178,7 +184,7 @@ These settings will apply to all books with any hyphenation dictionary.
         },
         {
             {
-                text = _("Use language defaults"),
+                text = self.button_default_text,
                 callback = function()
                     left_widget.value = self.left_default
                     right_widget.value = self.right_default
@@ -197,23 +203,23 @@ These settings will apply to all books with any hyphenation dictionary.
         show_parent = self,
     }
 
-    self.hyph_frame = FrameContainer:new{
+    self.widget_frame = FrameContainer:new{
         radius = Size.radius.window,
         padding = 0,
         margin = 0,
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
             align = "left",
-            hyph_bar,
-            hyph_line,
-            hyph_info,
+            widget_bar,
+            widget_line,
+            widget_info,
             VerticalSpan:new{ width = Size.span.vertical_large },
             CenterContainer:new{
                 dimen = Geom:new{
                     w = self.width,
-                    h = hyph_group:getSize().h,
+                    h = widget_group:getSize().h,
                 },
-                hyph_group
+                widget_group
             },
             VerticalSpan:new{ width = Size.span.vertical_large },
             CenterContainer:new{
@@ -226,7 +232,7 @@ These settings will apply to all books with any hyphenation dictionary.
         }
     }
     self.movable = MovableContainer:new{
-        self.hyph_frame,
+        self.widget_frame,
     }
     self[1] = WidgetContainer:new{
         align = "center",
@@ -238,7 +244,7 @@ These settings will apply to all books with any hyphenation dictionary.
         self.movable,
     }
     UIManager:setDirty(self, function()
-        return "ui", self.hyph_frame.dimen
+        return "ui", self.widget_frame.dimen
     end)
     picker_update_callback = function()
         UIManager:setDirty("all", function()
@@ -249,35 +255,35 @@ These settings will apply to all books with any hyphenation dictionary.
     end
 end
 
-function HyphenationLimitsWidget:onCloseWidget()
+function DoubleSpinWidget:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "partial", self.hyph_frame.dimen
+        return "partial", self.widget_frame.dimen
     end)
     return true
 end
 
-function HyphenationLimitsWidget:onShow()
+function DoubleSpinWidget:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self.hyph_frame.dimen
+        return "ui", self.widget_frame.dimen
     end)
     return true
 end
 
-function HyphenationLimitsWidget:onAnyKeyPressed()
+function DoubleSpinWidget:onAnyKeyPressed()
     UIManager:close(self)
     return true
 end
 
-function HyphenationLimitsWidget:onTapClose(arg, ges_ev)
-    if ges_ev.pos:notIntersectWith(self.hyph_frame.dimen) then
+function DoubleSpinWidget:onTapClose(arg, ges_ev)
+    if ges_ev.pos:notIntersectWith(self.widget_frame.dimen) then
         self:onClose()
     end
     return true
 end
 
-function HyphenationLimitsWidget:onClose()
+function DoubleSpinWidget:onClose()
     UIManager:close(self)
     return true
 end
 
-return HyphenationLimitsWidget
+return DoubleSpinWidget

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -30,16 +30,18 @@ local DoubleSpinWidget = InputContainer:new{
     width = nil,
     height = nil,
     left_min = 1,
-    left_max = 10,
-    left_value = 2,
+    left_max = 20,
+    left_value = 1,
     left_default = nil,
     left_text = _("Left"),
     right_min = 1,
-    right_max = 10,
-    right_value = 2,
+    right_max = 20,
+    right_value = 1,
     right_default = nil,
     right_text = _("Right"),
-    button_default_text = _("Use language defaults"),
+    -- set this to see extra default button
+    default_values = nil,
+    default_text = _("Use defaults"),
 }
 
 function DoubleSpinWidget:init()
@@ -182,9 +184,11 @@ function DoubleSpinWidget:update()
                 end,
             },
         },
-        {
+    }
+    if self.default_values then
+        table.insert(buttons,{
             {
-                text = self.button_default_text,
+                text = self.default_text,
                 callback = function()
                     left_widget.value = self.left_default
                     right_widget.value = self.right_default
@@ -192,9 +196,9 @@ function DoubleSpinWidget:update()
                     right_widget:update()
                     self.callback(nil, nil)
                 end,
-            },
-        }
-    }
+            }
+        })
+    end
 
     local button_table = ButtonTable:new{
         width = self.width - 2*Size.padding.default,


### PR DESCRIPTION
More generic HyphenationLimits widget is now known as DoubleSpinWidget. TextBoxWidget was changed to TextWidget to prevent multiline in title above NumberPickerWidgets.

This is first step to create `more_option ⋮` for `Word Spacing` in ConfigDialog.
See: https://github.com/koreader/koreader/pull/5655#issue-346842175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5679)
<!-- Reviewable:end -->
