### PR TITLE
android: unbreak KO on scoped storage devices

### DIFF
--- a/datastorage.lua
+++ b/datastorage.lua
@@ -11,7 +11,7 @@ function DataStorage:getDataDir()
     if data_dir then return data_dir end
 
     if isAndroid then
-        data_dir = android.externalStorage() .. "/koreader"
+        data_dir = android.getExternalStoragePath() .. "/koreader"
     elseif os.getenv("UBUNTU_APPLICATION_ISOLATION") then
         local app_id = os.getenv("APP_ID")
         local package_name = app_id:match("^(.-)_")

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -20,7 +20,11 @@ local function getCodename()
     local api = android.app.activity.sdkVersion
     local codename = ""
 
-    if api > 27 then
+    if api > 29 then
+        codename = "R"
+    elseif api == 29 then
+        codename = "Q"
+    elseif api == 28 then
         codename = "Pie"
     elseif api == 27 or api == 26 then
         codename = "Oreo"


### PR DESCRIPTION
Requires https://github.com/koreader/android-luajit-launcher/pull/201

Tested against the Android 10 - emulator

Build with targetApi 28: normal storage, RW path retrieved: `/storage/emulated/0`
Build with targetApi 29: scoped storage, RW path retrieved: `/storage/emulated/0/Android/data/org.koreader.launcher/files`
 
This isn't intended as a long term solution but as a workaround. Lets see what other reading software do to avoid scoped storage limitations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5680)
<!-- Reviewable:end -->
