### PR TITLE
Ensure we flush everything to disk after an update.

### DIFF
--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -34,6 +34,8 @@ ko_update_check() {
         fi
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
         unset BLOCKS CPOINTS
+        # Ensure everything is flushed to disk before we restart. This *will* stall for a while on slow storage!
+        sync
     fi
 }
 

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -134,6 +134,8 @@ ko_update_check() {
         fi
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
         unset BLOCKS CPOINTS
+        # Ensure everything is flushed to disk before we restart. This *will* stall for a while on slow storage!
+        sync
     fi
 }
 # NOTE: Keep doing an initial update check, in addition to one during the restart loop, so we can pickup potential updates of this very script...

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -49,6 +49,8 @@ ko_update_check() {
         fi
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
         unset BLOCKS CPOINTS
+        # Ensure everything is flushed to disk before we restart. This *will* stall for a while on slow storage!
+        sync
     fi
 }
 # NOTE: Keep doing an initial update check, in addition to one during the restart loop, so we can pickup potential updates of this very script...


### PR DESCRIPTION
Will stall for longer, but with a visible message (vs. less stalling on
a white screen during the startup and a laggy FM for a while).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5685)
<!-- Reviewable:end -->
