### PR TITLE
android: import from Storage Access Framework

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -552,6 +552,20 @@ function FileManager:tapPlus()
         }
     }
 
+    if Device:canImportFiles() then
+        table.insert(buttons, 3, {
+            {
+                text = _("Import files here"),
+                enabled = Device.isValidPath(self.file_chooser.path),
+                callback = function()
+                    local current_dir = self.file_chooser.path
+                    UIManager:close(self.file_dialog)
+                    Device.importFile(current_dir)
+                end,
+            },
+        })
+    end
+
     self.file_dialog = ButtonDialogTitle:new{
         title = filemanagerutil.abbreviate(self.file_chooser.path),
         title_align = "center",

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -45,6 +45,7 @@ local Device = {
     canUseCBB = yes, -- The C BB maintains a 1:1 feature parity with the Lua BB, except that is has NO support for BB4, and limited support for BBRGB24
     hasColorScreen = no,
     hasBGRFrameBuffer = no,
+    canImportFiles = no,
     canToggleGSensor = no,
     canToggleMassStorage = no,
     canUseWAL = yes, -- requires mmap'ed I/O on the target FS


### PR DESCRIPTION
Add an option to the filemanager "plus" menu to import files in current path using Android storage access framework.

The new menu entry will be displayed on Android 4.4+. Once the user select one or more files in the dialog these files will be imported on the specified folder.

Only supported mimetypes can be imported.

On folders *outside* the file sandbox the "import files here" entry will be disabled.

![saf (1)](https://user-images.githubusercontent.com/975883/71309613-4559b000-240a-11ea-869d-9b4221fe7f7e.gif)

**Edit**: updated description and sample

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5686)
<!-- Reviewable:end -->
