### PR TITLE
TextBoxWidget: fix crash on hold after end of text

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1744,6 +1744,15 @@ function TextBoxWidget:onHoldReleaseText(callback, ges)
         if sel_start_idx > sel_end_idx then -- re-order if needed
             sel_start_idx, sel_end_idx = sel_end_idx, sel_start_idx
         end
+        -- We get cursor positions, which can be after last char,
+        -- and that we need to correct. But if both positions are
+        -- after last char, the full selection is out of text.
+        if sel_start_idx > #self._xtext then -- Both are after last char
+            return true
+        end
+        if sel_end_idx > #self._xtext then -- Only end is after last char
+            sel_end_idx = #self._xtext
+        end
         -- Delegate word boundaries search to xtext.cpp, which can
         -- use libunibreak's wordbreak features.
         -- (50 is the nb of chars backward and ahead of selection indices


### PR DESCRIPTION
Fix crash (witnessed when swiping quickly to change dict/wiki results and a swipe registers as hold and does text selection):
```
./luajit: frontend/ui/widget/textboxwidget.lua:1751: bad argument #1 to 'getSelectedWords' (index out of range)
stack traceback:
    [C]: in function 'getSelectedWords'
    frontend/ui/widget/textboxwidget.lua:1751: in function 'handleEvent'
    frontend/ui/widget/container/widgetcontainer.lua:88: in function 'propagateEvent'
    frontend/ui/widget/container/widgetcontainer.lua:106: in function 'handleEvent'
    frontend/ui/widget/container/widgetcontainer.lua:88: in function 'propagateEvent'
    frontend/ui/widget/container/widgetcontainer.lua:106: in function 'handleEvent'
    frontend/ui/widget/container/widgetcontainer.lua:88: in function 'propagateEvent'
    frontend/ui/widget/container/widgetcontainer.lua:106: in function 'handleEvent'
    frontend/ui/widget/container/widgetcontainer.lua:88: in function 'propagateEvent'
    frontend/ui/widget/container/widgetcontainer.lua:106: in function 'handleEvent'
    frontend/ui/widget/container/widgetcontainer.lua:88: in function 'propagateEvent'
    ...
    frontend/ui/widget/container/widgetcontainer.lua:88: in function 'propagateEvent'
    frontend/ui/widget/container/widgetcontainer.lua:106: in function 'handleEvent'
    frontend/ui/widget/container/inputcontainer.lua:259: in function 'handleEvent'
    frontend/ui/uimanager.lua:733: in function 'sendEvent'
    frontend/ui/uimanager.lua:202: in function '__default__'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5689)
<!-- Reviewable:end -->
