### PR TITLE
TextBoxWidget: fix crash when empty last line and alignment center/right

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -311,6 +311,7 @@ function TextBoxWidget:_splitToLines()
                     offset = size+1,
                     end_offset = nil,
                     width = 0,
+                    targeted_width = targeted_width,
                 }
             end
             ln = ln + 1


### PR DESCRIPTION
When `text = "Stuff\n"` and `alignment="center"` or `="right"`, TextBoxWidget would crash with:
```
./luajit: frontend/ui/widget/textboxwidget.lua:494: attempt to perform arithmetic on field 'targeted_width' (a nil value)
stack traceback:
        frontend/ui/widget/textboxwidget.lua:494: in function '_shapeLine'
        frontend/ui/widget/textboxwidget.lua:676: in function '_renderText'
        frontend/ui/widget/textboxwidget.lua:166: in function 'init'
        frontend/ui/widget/widget.lua:48: in function 'new'
        frontend/ui/widget/buttondialogtitle.lua:65: in function 'init'
        frontend/ui/widget/widget.lua:48: in function 'new'
        frontend/apps/reader/modules/readerlink.lua:668: in function 'onGoToExternalLink'
```
(I had added aligmnent="center" in my own patch, I guess we don't have any occurence of these circonstances in our current code. And I must have not followed any Wikipedia link for weeks :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5691)
<!-- Reviewable:end -->
