### PR TITLE
bump crengine, fribidi, xtext - some CoverBrowser Mosaic tweaks

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -304,6 +304,10 @@ function TextBoxWidget:_splitToLines()
             -- - Between a line end_offset= and the next line offset=, there may be only
             --   a single indice not included: the \n or the space that allowed the break.
             self.vertical_string_list[ln] = line
+            if line.no_allowed_break_met then
+                -- let the fact a long word was splitted be known
+                self.has_split_inside_word = true
+            end
             if line.hard_newline_at_eot and not line.next_start_offset then
                 -- Add an empty line to reprensent the \n at end of text
                 -- and allow positionning cursor after it

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -648,6 +648,9 @@ function ListMenuItem:update()
             local text_widget
             local fontsize_no_bookinfo = _fontSize(18)
             repeat
+                if text_widget then
+                    text_widget:free()
+                end
                 text_widget = TextBoxWidget:new{
                     text = self.text .. hint,
                     face = Font:getFace("cfont", fontsize_no_bookinfo),


### PR DESCRIPTION
- bump crengine: (Upstream) DocX: fix paragraphs with single hyperlink https://github.com/koreader/crengine/pull/323
- bump fribidi to 1.0.8 (for nested isolates fix, https://github.com/koreader/koreader/issues/5359#issuecomment-565001148)
- xtext.makeLine(): return `no_allowed_break_met=true` when that happens, so we know the line breaks inside a word. https://github.com/koreader/koreader-base/pull/1022 https://github.com/koreader/koreader/pull/5598#issuecomment-565836669

Also CoverBrowser: Mosaic: better words wrap in text covers
- Update words wrapping tweaks for use_xtext: add zero-width spaces around dots and underscores to allow more wraps.
- Fix overlap of directory name and nbitems for long directory names.

Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70929990-816cc980-2034-11ea-9ac9-4457ff61c29b.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/70930031-95b0c680-2034-11ea-9962-ba5b21b7a388.png)</kbd>

After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70930091-b4af5880-2034-11ea-8333-1baf08b90270.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/70930121-c09b1a80-2034-11ea-8d34-f4350f2c28ea.png)</kbd>


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5693)
<!-- Reviewable:end -->
