### PR TITLE
[RTL UI] Bidi wrapping tweaks

### DIFF
--- a/frontend/ui/bidi.lua
+++ b/frontend/ui/bidi.lua
@@ -99,6 +99,20 @@ function Bidi.setup(lang)
         Bidi.path = Bidi.nowrap
         Bidi.url = Bidi.nowrap
     end
+    -- If RTL UI text, let's have untranslated strings (so english) still rendered LTR
+    if Bidi._rtl_ui_text then
+        _.wrapUntranslated = function(text)
+            -- We need to split by line and wrap each line as LTR (as the
+            -- paragraph direction will still be RTL).
+            local lines = {}
+            for s in text:gmatch("[^\r\n]+") do
+                table.insert(lines, Bidi.ltr(s))
+            end
+            return table.concat(lines, "\n")
+        end
+    else
+        _.wrapUntranslated = _.wrapUntranslated_nowrap
+    end
 end
 
 
@@ -185,9 +199,6 @@ end
 function Bidi.wrap(text)
     return Bidi._rtl_ui_text and Bidi.rtl(text) or text
 end
-
--- See at having GetText_mt.__call() wrap untranslated strings in Bidi.ltr()
--- so they are fully displayed LTR.
 
 -- Use these specific wrappers when the wrapped content type is known
 -- (so we can easily switch to use rtl() if RTL readers prefer filenames

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -135,6 +135,7 @@ Widget that displays an item for menu
 --]]
 local MenuItem = InputContainer:new{
     text = nil,
+    bidi_wrap_func = nil,
     show_parent = nil,
     detail = nil,
     font = "cfont",
@@ -256,6 +257,12 @@ function MenuItem:init()
     -- overflow and not be displayed, or show a tofu char when displayed by TextWidget:
     -- get rid of any \n (which could be found in highlighted text in bookmarks).
     local text = self.text:gsub("\n", " ")
+
+    -- Wrap text with provided bidi_wrap_func (only provided by FileChooser,
+    -- to correctly display filenames and directories)
+    if self.bidi_wrap_func then
+        text = self.bidi_wrap_func(text)
+    end
 
     if self.single_line then  -- items only in single line
         -- No font size change: text will be truncated if it overflows
@@ -1002,6 +1009,7 @@ function Menu:updateItems(select_number)
                 state = self.item_table[i].state,
                 state_size = self.state_size or {},
                 text = Menu.getMenuText(self.item_table[i]),
+                bidi_wrap_func = self.item_table[i].bidi_wrap_func,
                 mandatory = self.item_table[i].mandatory,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 dim = self.item_table[i].dim,
@@ -1307,9 +1315,6 @@ function Menu.getMenuText(item)
         text = item.text_func()
     else
         text = item.text
-    end
-    if item.bidi_wrap_func then
-        text = item.bidi_wrap_func(text)
     end
     if item.sub_item_table ~= nil or item.sub_item_table_func then
         text = string.format(sub_item_format, text)

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -663,24 +663,27 @@ end
 
 --- Gets human friendly size as string
 ---- @int size (bytes)
+---- @bool right_align (by padding with spaces on the left)
 ---- @treturn string
-function util.getFriendlySize(size)
+function util.getFriendlySize(size, right_align)
+    local frac_format = right_align and "%6.1f" or "%.1f"
+    local deci_format = right_align and "%6d" or "%d"
     size = tonumber(size)
     if not size or type(size) ~= "number" then return end
     if size > 1024*1024*1024 then
         -- @translators This is an abbreviation for the gigabyte, a unit of computer memory or data storage capacity.
-        return T(_("%1 GB"), string.format("%4.1f", size/1024/1024/1024))
+        return T(_("%1 GB"), string.format(frac_format, size/1024/1024/1024))
     end
     if size > 1024*1024 then
         -- @translators This is an abbreviation for the megabyte, a unit of computer memory or data storage capacity.
-        return T(_("%1 MB"), string.format("%4.1f", size/1024/1024))
+        return T(_("%1 MB"), string.format(frac_format, size/1024/1024))
     end
     if size > 1024 then
         -- @translators This is an abbreviation for the kilobyte, a unit of computer memory or data storage capacity.
-        return T(_("%1 KB"), string.format("%4.1f", size/1024))
+        return T(_("%1 KB"), string.format(frac_format, size/1024))
     else
         -- @translators This is an abbreviation for the byte, a unit of computer memory or data storage capacity.
-        return T(_("%1 B"), string.format("%d", size))
+        return T(_("%1 B"), string.format(deci_format, size))
     end
 end
 

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -334,21 +334,41 @@ describe("util module", function()
                 assert.is_equal("100.0 GB",
                                 util.getFriendlySize(100*1024*1024*1024))
             end)
-            it("to 1.0 GB with minimum field width alignment", function()
-                assert.is_equal(" 1.0 GB",
+            it("to 1.0 GB", function()
+                assert.is_equal("1.0 GB",
                                 util.getFriendlySize(1024*1024*1024+1))
             end)
-            it("to 1.0 MB with minimum field width alignment", function()
-                assert.is_equal(" 1.0 MB",
+            it("to 1.0 MB", function()
+                assert.is_equal("1.0 MB",
                                 util.getFriendlySize(1024*1024+1))
             end)
-            it("to 1.0 KB with minimum field width alignment", function()
-                assert.is_equal(" 1.0 KB",
+            it("to 1.0 KB", function()
+                assert.is_equal("1.0 KB",
                                 util.getFriendlySize(1024+1))
             end)
             it("to B", function()
-                assert.is_equal("100 B",
-                                util.getFriendlySize(100))
+                assert.is_equal("10 B",
+                                util.getFriendlySize(10))
+            end)
+            it("to 100.0 GB with minimum field width alignment", function()
+                assert.is_equal(" 100.0 GB",
+                                util.getFriendlySize(100*1024*1024*1024, true))
+            end)
+            it("to 1.0 GB with minimum field width alignment", function()
+                assert.is_equal("   1.0 GB",
+                                util.getFriendlySize(1024*1024*1024+1, true))
+            end)
+            it("to 1.0 MB with minimum field width alignment", function()
+                assert.is_equal("   1.0 MB",
+                                util.getFriendlySize(1024*1024+1, true))
+            end)
+            it("to 1.0 KB with minimum field width alignment", function()
+                assert.is_equal("   1.0 KB",
+                                util.getFriendlySize(1024+1, true))
+            end)
+            it("to B with minimum field width alignment", function()
+                assert.is_equal("    10 B",
+                                util.getFriendlySize(10, true))
             end)
         end)
         it("should return nil when input is nil or false", function()


### PR DESCRIPTION
Some followup tweaks to #5667:
- Alias everything to `Bidi.nowrap()` when in LTR UI, as using LTR isolates seems uneeded when already LTR. This might avoid unforeseen side effects for LTR languages (safer for the coming up release, but we might then notice general wrapping issues only in RTL UI, so less quickly :)
- Better wrapping of RTL filename by using auto direction and LTR-isolating only the suffix so it's always on a side. That's option C in https://github.com/koreader/koreader/issues/5359#issuecomment-564767926, used in the screenshot below.
- menu.lua: handle `bidi_wrap_func` outside `getMenuText()`, which may be used in other contexts. See https://github.com/koreader/koreader/pull/5693#issuecomment-566240993.
- GetText/Bidi: wrap untranslated strings in LTR. See https://github.com/koreader/koreader/pull/5667#issuecomment-564491264
- `util.getFriendlySize()`: remove leading space, which will fix:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70994210-01933d80-20ce-11ea-938a-4028fb9cdd64.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5694)
<!-- Reviewable:end -->
