### PR TITLE
[RTL UI] Bidi-wrap filenames, paths, urls, metadata

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
@@ -343,7 +344,7 @@ end
 
 function CloudStorage:onMenuHold(item)
     if item.type == "folder_long_press" then
-        local title = T(_("Select this directory?\n\n%1"), item.url)
+        local title = T(_("Select this directory?\n\n%1"), BD.dirpath(item.url))
         local onConfirm = self.onConfirm
         local button_dialog
         button_dialog = ButtonDialogTitle:new{
@@ -524,7 +525,7 @@ function CloudStorage:synchronizeSettings(item)
     local dropbox_sync_folder = item.sync_source_folder or "not set"
     local local_sync_folder = item.sync_dest_folder or "not set"
     syn_dialog = ButtonDialogTitle:new {
-        title = T(_("Dropbox folder:\n%1\nLocal folder:\n%2"), dropbox_sync_folder, local_sync_folder),
+        title = T(_("Dropbox folder:\n%1\nLocal folder:\n%2"), BD.dirpath(dropbox_sync_folder), BD.dirpath(local_sync_folder)),
         title_align = "center",
         buttons = {
             {

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DocumentRegistry = require("document/documentregistry")
 local DropBoxApi = require("apps/cloudstorage/dropboxapi")
@@ -26,12 +27,12 @@ function DropBox:downloadFile(item, password, path, close)
         local __, filename = util.splitFilePathName(path)
         if G_reader_settings:isTrue("show_unsupported") and not DocumentRegistry:hasProvider(filename) then
             UIManager:show(InfoMessage:new{
-                text = T(_("File saved to:\n%1"), path),
+                text = T(_("File saved to:\n%1"), BD.filename(path)),
             })
         else
             UIManager:show(ConfirmBox:new{
                 text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
-                    path),
+                    BD.filepath(path)),
                 ok_callback = function()
                     close()
                     ReaderUI:showReader(path)
@@ -40,7 +41,7 @@ function DropBox:downloadFile(item, password, path, close)
         end
     else
         UIManager:show(InfoMessage:new{
-            text = T(_("Could not save file to:\n%1"), path),
+            text = T(_("Could not save file to:\n%1"), BD.filepath(path)),
             timeout = 3,
         })
     end

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DocumentRegistry = require("document/documentregistry")
 local FtpApi = require("apps/cloudstorage/ftpapi")
@@ -30,12 +31,12 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
         local __, filename = util.splitFilePathName(path)
         if G_reader_settings:isTrue("show_unsupported") and not DocumentRegistry:hasProvider(filename) then
             UIManager:show(InfoMessage:new{
-                text = T(_("File saved to:\n%1"), path),
+                text = T(_("File saved to:\n%1"), BD.filepath(path)),
             })
         else
             UIManager:show(ConfirmBox:new{
                 text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
-                    path),
+                    BD.filepath(path)),
                 ok_callback = function()
                     close()
                     ReaderUI:showReader(path)
@@ -44,7 +45,7 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
         end
     else
         UIManager:show(InfoMessage:new{
-            text = T(_("Could not save file to:\n%1"), path),
+            text = T(_("Could not save file to:\n%1"), BD.filepath(path)),
             timeout = 3,
         })
     end

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DocumentRegistry = require("document/documentregistry")
 local InfoMessage = require("ui/widget/infomessage")
@@ -22,12 +23,12 @@ function WebDav:downloadFile(item, address, username, password, local_path, clos
         local __, filename = util.splitFilePathName(local_path)
         if G_reader_settings:isTrue("show_unsupported") and not DocumentRegistry:hasProvider(filename) then
             UIManager:show(InfoMessage:new{
-                text = T(_("File saved to:\n%1"), local_path),
+                text = T(_("File saved to:\n%1"), BD.filepath(local_path)),
             })
         else
             UIManager:show(ConfirmBox:new{
                 text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
-                    local_path),
+                    BD.filepath(local_path)),
                 ok_callback = function()
                     close()
                     ReaderUI:showReader(local_path)
@@ -36,7 +37,7 @@ function WebDav:downloadFile(item, address, username, password, local_path, clos
         end
     else
         UIManager:show(InfoMessage:new{
-            text = T(_("Could not save file to:\n%1"), local_path),
+            text = T(_("Could not save file to:\n%1"), BD.filepath(local_path)),
             timeout = 3,
         })
     end

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local DocSettings = require("docsettings")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
@@ -53,7 +54,7 @@ function FileManagerHistory:onMenuHold(item)
                 callback = function()
                     local ConfirmBox = require("ui/widget/confirmbox")
                     UIManager:show(ConfirmBox:new{
-                        text = util.template(_("Purge .sdr to reset settings for this document?\n\n%1"), item.text),
+                        text = util.template(_("Purge .sdr to reset settings for this document?\n\n%1"), BD.filename(item.text)),
                         ok_text = _("Purge"),
                         ok_callback = function()
                             filemanagerutil.purgeSettings(item.file)
@@ -80,7 +81,7 @@ function FileManagerHistory:onMenuHold(item)
                 callback = function()
                     local ConfirmBox = require("ui/widget/confirmbox")
                     UIManager:show(ConfirmBox:new{
-                        text = _("Are you sure that you want to delete this file?\n") .. item.file .. ("\n") .. _("If you delete a file, it is permanently lost."),
+                        text = _("Are you sure that you want to delete this file?\n") .. BD.filepath(item.file) .. ("\n") .. _("If you delete a file, it is permanently lost."),
                         ok_text = _("Delete"),
                         ok_callback = function()
                             local FileManager = require("apps/filemanager/filemanager")
@@ -116,7 +117,7 @@ function FileManagerHistory:onMenuHold(item)
         },
     }
     self.histfile_dialog = ButtonDialogTitle:new{
-        title = item.text:match("([^/]+)$"),
+        title = BD.filename(item.text:match("([^/]+)$")),
         title_align = "center",
         buttons = buttons,
     }

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -469,7 +469,7 @@ function FileManagerMenu:setUpdateItemTable()
             end
             local last_file = G_reader_settings:readSetting("lastfile")
             local path, file_name = util.splitFilePathName(last_file); -- luacheck: no unused
-            return T(_("Last: %1"), file_name)
+            return T(_("Last: %1"), BD.filename(file_name))
         end,
         enabled_func = function()
             return G_reader_settings:readSetting("lastfile") ~= nil
@@ -480,7 +480,7 @@ function FileManagerMenu:setUpdateItemTable()
         hold_callback = function()
             local last_file = G_reader_settings:readSetting("lastfile")
             UIManager:show(ConfirmBox:new{
-                text = T(_("Would you like to open the last document: %1?"), last_file),
+                text = T(_("Would you like to open the last document: %1?"), BD.filepath(last_file)),
                 ok_text = _("OK"),
                 ok_callback = function()
                     self:openLastDoc()

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
@@ -73,7 +74,7 @@ function FileManagerShortcuts:addNewFolder()
                 title = self.title,
                 input = friendly_name,
                 input_type = "text",
-                description = T(_("Title for selected folder:\n%1"), path),
+                description = T(_("Title for selected folder:\n%1"), BD.dirpath(path)),
                 buttons = {
                     {
                         {
@@ -162,7 +163,7 @@ function FileManagerShortcuts:editFolderShortcut(item)
         title = _("Edit friendly name"),
         input = item.friendly_name,
         input_type = "text",
-        description = T(_("Rename title for selected folder:\n%1"), item.folder),
+        description = T(_("Rename title for selected folder:\n%1"), BD.dirpath(item.folder)),
         buttons = {
             {
                 {

--- a/frontend/apps/opdscatalog/opdscatalog.lua
+++ b/frontend/apps/opdscatalog/opdscatalog.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -26,7 +27,7 @@ function OPDSCatalog:init()
         file_downloaded_callback = function(downloaded_file)
             UIManager:show(ConfirmBox:new{
                 text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
-                    downloaded_file),
+                    BD.filepath(downloaded_file)),
                 ok_text = _("Read now"),
                 cancel_text = _("Read later"),
                 ok_callback = function()

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -233,7 +234,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
                         text = T(_([[
 If you'd like to change the order in which dictionaries are queried (and their results displayed), you can:
 - move all dictionary directories out of %1.
-- move them back there, one by one, in the order you want them to be used.]]), self.data_dir)
+- move them back there, one by one, in the order you want them to be used.]]), BD.dirpath(self.data_dir))
                     })
                 end,
             },
@@ -928,7 +929,7 @@ function ReaderDictionary:downloadDictionary(dict, download_location, continue)
         logger.dbg("file downloaded to", download_location)
     else
         UIManager:show(InfoMessage:new{
-            text = _("Could not save file to:\n") .. download_location,
+            text = _("Could not save file to:\n") .. BD.filepath(download_location),
             --timeout = 3,
         })
         return false

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
@@ -397,7 +398,7 @@ a { color: black; }
     f:write("</body></html>\n")
     f:close()
     UIManager:show(ConfirmBox:new{
-        text = T(_("Document created as:\n%1\n\nWould you like to read it now?"), fonts_test_path),
+        text = T(_("Document created as:\n%1\n\nWould you like to read it now?"), BD.filepath(fonts_test_path)),
         ok_callback = function()
             UIManager:scheduleIn(1.0, function()
                 self.ui:switchDocument(fonts_test_path)

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -1490,7 +1490,7 @@ function ReaderGesture:gestureAction(action, ges)
             local current_network = NetworkMgr:getCurrentNetwork()
             -- this method is only available for some implementations
             if current_network and current_network.ssid then
-                info_text = T(_("Already connected to network %1."), current_network.ssid)
+                info_text = T(_("Already connected to network %1."), BD.wrap(current_network.ssid))
             else
                 info_text = _("Already connected.")
             end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -791,7 +791,7 @@ function ReaderHighlight:viewSelectionHTML(debug_view)
             if css_files then
                 for i=1, #css_files do
                     local button = {
-                        text = T(_("View %1"), css_files[i]),
+                        text = T(_("View %1"), BD.filepath(css_files[i])),
                         callback = function()
                             local css_text = self.ui.document:getDocumentFileContent(css_files[i])
                             local cssviewer

--- a/frontend/apps/reader/modules/readerhyphenation.lua
+++ b/frontend/apps/reader/modules/readerhyphenation.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Device = require("device")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
@@ -25,13 +26,16 @@ function ReaderHyphenation:init()
 
     table.insert(self.hyph_table, {
         text_func = function()
-            local limits_text = _("language defaults")
-            if G_reader_settings:readSetting("hyph_left_hyphen_min")
-                or G_reader_settings:readSetting("hyph_right_hyphen_min") then
-                limits_text = T("%1 - %2", G_reader_settings:readSetting("hyph_left_hyphen_min"),
+            -- Note: with our callback, we either get hyph_left_hyphen_min and
+            -- hyph_right_hyphen_min both nil, or both defined.
+            if G_reader_settings:readSetting("hyph_left_hyphen_min") or
+                        G_reader_settings:readSetting("hyph_right_hyphen_min") then
+                -- @translators to RTL language translators: %1/left is the min length of the start of a hyphenated word, %2/right is the min length of the end of a hyphenated word (note that there is yet no support for hyphenation with RTL languages, so this will mostly apply to LTR documents)
+                return T(_("Left/right minimal sizes: %1 - %2"),
+                    G_reader_settings:readSetting("hyph_left_hyphen_min"),
                     G_reader_settings:readSetting("hyph_right_hyphen_min"))
             end
-            return T(_("Left/right minimal sizes: %1"), limits_text)
+            return _("Left/right minimal sizes: language defaults")
         end,
         callback = function()
             local DoubleSpinWidget = require("/ui/widget/doublespinwidget")
@@ -120,7 +124,7 @@ These settings will apply to all books with any hyphenation dictionary.
                     self.hyph_alg = v.filename
                     self.ui.doc_settings:saveSetting("hyph_alg", self.hyph_alg)
                     UIManager:show(InfoMessage:new{
-                        text = T(_("Changed hyphenation to %1."), v.name),
+                        text = T(_("Changed hyphenation to %1."), BD.wrap(v.name)),
                     })
                     self.ui.document:setHyphDictionary(v.filename)
                     -- Apply hyphenation sides limits
@@ -137,7 +141,7 @@ These settings will apply to all books with any hyphenation dictionary.
                         -- one is set, no fallback will ever be used - if a fallback one
                         -- is set, no default is wanted; so when we set one below, we
                         -- remove the other).
-                        text = T( _("Would you like %1 to be used as the default (★) or fallback (�) hyphenation language?\n\nDefault will always take precedence while fallback will only be used if the language of the book can't be automatically determined."), v.name),
+                        text = T( _("Would you like %1 to be used as the default (★) or fallback (�) hyphenation language?\n\nDefault will always take precedence while fallback will only be used if the language of the book can't be automatically determined."), BD.wrap(v.name)),
                         choice1_text = _("Default"),
                         choice1_callback = function()
                             G_reader_settings:saveSetting("hyph_alg_default", v.filename)

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -534,7 +534,7 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
                 display_filename = display_filename .. anchor
             end
             UIManager:show(ConfirmBox:new{
-                text = T(_("Would you like to read this local document?\n\n%1\n"), display_filename),
+                text = T(_("Would you like to read this local document?\n\n%1\n"), BD.filepath(display_filename)),
                 ok_callback = function()
                     UIManager:scheduleIn(0.1, function()
                         self.ui:switchDocument(linked_filename)
@@ -543,7 +543,7 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
             })
         else
             UIManager:show(InfoMessage:new{
-                text = T(_("Link to unsupported local file:\n%1"), link_url),
+                text = T(_("Link to unsupported local file:\n%1"), BD.url(link_url)),
             })
         end
         return true
@@ -551,7 +551,7 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
 
     -- Not supported
     UIManager:show(InfoMessage:new{
-        text = T(_("Invalid or external link:\n%1"), link_url),
+        text = T(_("Invalid or external link:\n%1"), BD.url(link_url)),
         -- no timeout to allow user to type that link in his web browser
     })
     -- don't propagate, user will notice and tap elsewhere if he wants to change page
@@ -658,7 +658,7 @@ function ReaderLink:onGoToExternalLink(link_url)
             -- No external link handler
             return false
         end
-        text = T(_("External link:\n\n%1"), link_url)
+        text = T(_("External link:\n\n%1"), BD.url(link_url))
     end
 
     -- Add all alternative handlers buttons

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -228,7 +228,7 @@ function ReaderMenu:setUpdateItemTable()
                 return _("Open previous document")
             end
             local path, file_name = util.splitFilePathName(previous_file) -- luacheck: no unused
-            return T(_("Previous: %1"), file_name)
+            return T(_("Previous: %1"), BD.filename(file_name))
         end,
         enabled_func = function()
             return self:getPreviousFile() ~= nil
@@ -239,7 +239,7 @@ function ReaderMenu:setUpdateItemTable()
         hold_callback = function()
             local previous_file = self:getPreviousFile()
             UIManager:show(ConfirmBox:new{
-                text = T(_("Would you like to open the previous document: %1?"), previous_file),
+                text = T(_("Would you like to open the previous document: %1?"), BD.filepath(previous_file)),
                 ok_text = _("OK"),
                 ok_callback = function()
                     self.ui:switchDocument(previous_file)

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local Device = require("device")
@@ -181,7 +182,7 @@ function ReaderStatus:deleteFile(file, text_end_book)
         message_end_book = "You've reached the end of the document.\n"
     end
     UIManager:show(ConfirmBox:new{
-        text = T(_("%1Are you sure that you want to delete this file?\n%2\nIf you delete a file, it is permanently lost."), message_end_book, file),
+        text = T(_("%1Are you sure that you want to delete this file?\n%2\nIf you delete a file, it is permanently lost."), message_end_book, BD.filepath(file)),
         ok_text = _("Delete"),
         ok_callback = function()
             local FileManager = require("apps/filemanager/filemanager")

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
@@ -498,7 +499,7 @@ You can enable individual tweaks on this book with a tap, or view more details a
             table.insert(item_table, {
                 title = title,
                 id = file, -- keep ".css" in id, to distinguish between koreader/user tweaks
-                description = T(_("User style tweak at %1"), filepath),
+                description = T(_("User style tweak at %1"), BD.filepath(filepath)),
                 priority = 10, -- give user tweaks a higher priority
                 css_path = filepath,
             })

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
@@ -252,7 +253,7 @@ function ReaderTypeset:genStyleSheetMenu()
         text_func = function()
             local text = _("Obsolete")
             if obsoleted_css[self.css] then
-                text = T(_("Obsolete (%1)"), obsoleted_css[self.css])
+                text = T(_("Obsolete (%1)"), BD.filename(obsoleted_css[self.css]))
             end
             if obsoleted_css[G_reader_settings:readSetting("copt_css")] then
                 text = text .. "   ★"
@@ -450,7 +451,7 @@ end
 
 function ReaderTypeset:makeDefaultStyleSheet(css, text, touchmenu_instance)
     UIManager:show(ConfirmBox:new{
-        text = T( _("Set default style to %1?"), text),
+        text = T( _("Set default style to %1?"), BD.filename(text)),
         ok_callback = function()
             G_reader_settings:saveSetting("copt_css", css)
             if touchmenu_instance then touchmenu_instance:updateItems() end

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
@@ -175,7 +176,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                         if not default_dir then default_dir = require("apps/filemanager/filemanagerutil").getDefaultDir() end
                         local dialog
                         dialog = ButtonDialogTitle:new{
-                            title = T(_("Current Wikipedia 'Save as EPUB' directory:\n\n%1\n"), default_dir),
+                            title = T(_("Current Wikipedia 'Save as EPUB' directory:\n\n%1\n"), BD.dirpath(default_dir)),
                             buttons = {
                                 {
                                     {
@@ -220,7 +221,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                                             onConfirm = function(path)
                                                 G_reader_settings:saveSetting("wikipedia_save_dir", path)
                                                 UIManager:show(InfoMessage:new{
-                                                    text = T(_("Wikipedia 'Save as EPUB' directory set to:\n%1"), path),
+                                                    text = T(_("Wikipedia 'Save as EPUB' directory set to:\n%1"), BD.dirpath(path)),
                                                 })
                                             end
                                         }
@@ -257,7 +258,7 @@ Where do you want them saved?]])
                                     end
                                     G_reader_settings:saveSetting("wikipedia_save_dir", wikipedia_dir)
                                     UIManager:show(InfoMessage:new{
-                                        text = T(_("Wikipedia 'Save as EPUB' directory set to:\n%1"), wikipedia_dir),
+                                        text = T(_("Wikipedia 'Save as EPUB' directory set to:\n%1"), BD.dirpath(wikipedia_dir)),
                                     })
                                 end,
                                 cancel_text = _("Select directory"),

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -4,6 +4,7 @@ ReaderUI is an abstraction for a reader interface.
 It works using data gathered from a document interface.
 ]]--
 
+local BD = require("ui/bidi")
 local Cache = require("cache")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
@@ -448,14 +449,14 @@ function ReaderUI:showReader(file, provider)
 
     if lfs.attributes(file, "mode") ~= "file" then
         UIManager:show(InfoMessage:new{
-             text = T(_("File '%1' does not exist."), file)
+             text = T(_("File '%1' does not exist."), BD.filepath(file))
         })
         return
     end
 
     if not DocumentRegistry:hasProvider(file) and provider == nil then
         UIManager:show(InfoMessage:new{
-            text = T(_("File '%1' is not supported."), file)
+            text = T(_("File '%1' is not supported."), BD.filepath(file))
         })
         self:showFileManager(file)
         return
@@ -471,7 +472,7 @@ function ReaderUI:showReader(file, provider)
             (provider.provider == "mupdf" and type(bookmarks[1].page) == "string")) then
                 UIManager:show(ConfirmBox:new{
                     text = T(_("The document '%1' with bookmarks or highlights was previously opened with a different engine. To prevent issues, bookmarks need to be deleted before continuing."),
-                        file),
+                        BD.filepath(file)),
                     ok_text = _("Delete"),
                     ok_callback = function()
                         doc_settings:delSetting("bookmarks")
@@ -488,7 +489,7 @@ end
 
 function ReaderUI:showReaderCoroutine(file, provider)
     UIManager:show(InfoMessage:new{
-        text = T(_("Opening file '%1'."), file),
+        text = T(_("Opening file '%1'."), BD.filepath(file)),
         timeout = 0.0,
     })
     -- doShowReader might block for a long time, so force repaint here

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -142,9 +142,10 @@ function Device:init()
                     -- we cannot blit to a window here since we have no focus yet.
                     local UIManager = require("ui/uimanager")
                     local InfoMessage = require("ui/widget/infomessage")
+                    local BD = require("ui/bidi")
                     UIManager:scheduleIn(0.1, function()
                         UIManager:show(InfoMessage:new{
-                            text = T(_("Opening file '%1'."), new_file),
+                            text = T(_("Opening file '%1'."), BD.filepath(new_file)),
                             timeout = 0.0,
                         })
                     end)
@@ -255,7 +256,8 @@ function Device:retrieveNetworkInfo()
     if ip == "0" or gw == "0" then
         return _("Not connected")
     else
-        return T(_("Connected to %1\n IP address: %2\n gateway: %3"), ssid, ip, gw)
+        local BD = require("ui/bidi")
+        return T(_("Connected to %1\n IP address: %2\n gateway: %3"), BD.wrap(ssid), BD.ltr(ip), BD.ltr(gw))
     end
 end
 

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -334,7 +334,7 @@ if BD.mirroredUILayout() then
     -- be mirrored - but that's not enough: we need to swap LEFT and RIGHT,
     -- so they appear in a more expected and balanced order to RTL users:
     -- {JUSTIFY, LEFT, CENTER, RIGHT, AUTO}
-    local j = KoptOptions[3].options[6]
+    local j = KoptOptions[3].options[7]
     assert(j.name == "justification")
     j.item_icons[2], j.item_icons[4] = j.item_icons[4], j.item_icons[2]
     j.values[2], j.values[4] = j.values[4], j.values[2]

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local InfoMessage = require("ui/widget/infomessage")
@@ -44,7 +45,7 @@ common_info.about = {
     keep_menu_open = true,
     callback = function()
         UIManager:show(InfoMessage:new{
-            text = T(_("KOReader %1\n\nA document viewer for E Ink devices.\n\nLicensed under Affero GPL v3. All dependencies are free software.\n\nhttp://koreader.rocks/"), version),
+            text = T(_("KOReader %1\n\nA document viewer for E Ink devices.\n\nLicensed under Affero GPL v3. All dependencies are free software.\n\nhttp://koreader.rocks/"), BD.ltr(version)),
             icon_file = "resources/ko-icon.png",
             alpha = true,
         })

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -225,7 +226,7 @@ function NetworkMgr:getProxyMenuTable()
     end
     return {
         text_func = function()
-            return T(_("HTTP proxy %1"), (proxy_enabled() and proxy() or ""))
+            return T(_("HTTP proxy %1"), (proxy_enabled() and BD.url(proxy()) or ""))
         end,
         checked_func = function() return proxy_enabled() end,
         callback = function()
@@ -388,7 +389,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback)
                            complete_callback()
                        end
                        UIManager:show(InfoMessage:new{
-                           text = T(_("Connected to network %1"), network.ssid),
+                           text = T(_("Connected to network %1"), BD.wrap(network.ssid)),
                            timeout = 3,
                        })
                        return

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -2,6 +2,7 @@
 Checks for updates on the specified nightly build server.
 ]]
 
+local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -243,13 +244,13 @@ function OTAManager:fetchAndProcessUpdate()
         })
     elseif ota_version then
         local update_message = T(_("Do you want to update?\nInstalled version: %1\nAvailable version: %2"),
-                                 local_version,
-                                 ota_version)
+                                 BD.ltr(local_version),
+                                 BD.ltr(ota_version))
         local update_ok_text = _("Update")
         if ota_version < local_version then
             update_message =  T(_("The currently installed version is newer than the available version.\nWould you still like to continue and downgrade?\nInstalled version: %1\nAvailable version: %2"),
-                                local_version,
-                                ota_version)
+                                BD.ltr(local_version),
+                                BD.ltr(ota_version))
             update_ok_text = _("Downgrade")
         end
 
@@ -262,9 +263,9 @@ function OTAManager:fetchAndProcessUpdate()
                     if isAndroid then
                         -- download the package if not present.
                         if android.download(link, ota_package) then
-                            android.notification(T(_("The file %1 already exists."), ota_package))
+                            android.notification(T(_("The file %1 already exists."), BD.filename(ota_package)))
                         else
-                            android.notification(T(_("Downloading %1"), ota_package))
+                            android.notification(T(_("Downloading %1"), BD.filename(ota_package)))
                         end
                     elseif Device:isSDL() then
                         Device:openLink(link)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
@@ -66,7 +67,7 @@ function Screensaver:chooseFolder()
                         logger.dbg("set screensaver directory to", path)
                         G_reader_settings:saveSetting("screensaver_dir", path)
                         UIManager:show(InfoMessage:new{
-                            text = T(_("Screensaver directory set to:\n%1"), path),
+                            text = T(_("Screensaver directory set to:\n%1"), BD.dirpath(path)),
                             timeout = 3,
                         })
                     end,
@@ -87,7 +88,7 @@ function Screensaver:chooseFolder()
         screensaver_dir = DataStorage:getDataDir() .. "/screenshots/"
     end
     self.choose_dialog = ButtonDialogTitle:new{
-        title = T(_("Current screensaver image directory:\n%1"), screensaver_dir),
+        title = T(_("Current screensaver image directory:\n%1"), BD.dirpath(screensaver_dir)),
         buttons = buttons
     }
     UIManager:show(self.choose_dialog)
@@ -120,13 +121,13 @@ function Screensaver:chooseFile(document_cover)
                         if document_cover then
                             G_reader_settings:saveSetting("screensaver_document_cover", file_path)
                             UIManager:show(InfoMessage:new{
-                                text = T(_("Screensaver document cover set to:\n%1"), file_path),
+                                text = T(_("Screensaver document cover set to:\n%1"), BD.filepath(file_path)),
                                 timeout = 3,
                             })
                         else
                             G_reader_settings:saveSetting("screensaver_image", file_path)
                             UIManager:show(InfoMessage:new{
-                                text = T(_("Screensaver image set to:\n%1"), file_path),
+                                text = T(_("Screensaver image set to:\n%1"), BD.filepath(file_path)),
                                 timeout = 3,
                             })
                         end
@@ -149,8 +150,8 @@ function Screensaver:chooseFile(document_cover)
     if screensaver_image == nil then
         screensaver_image = DataStorage:getDataDir() .. "/resources/koreader.png"
     end
-    local title = document_cover and T(_("Current screensaver document cover:\n%1"), screensaver_document_cover)
-        or T(_("Current screensaver image:\n%1"), screensaver_image)
+    local title = document_cover and T(_("Current screensaver document cover:\n%1"), BD.filepath(screensaver_document_cover))
+        or T(_("Current screensaver image:\n%1"), BD.filepath(screensaver_image))
     self.choose_dialog = ButtonDialogTitle:new{
         title = title,
         buttons = buttons

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -365,14 +365,14 @@ function DictQuickLookup:update()
                         end
                         local epub_path = dir .. "/" .. filename
                         UIManager:show(ConfirmBox:new{
-                            text = T(_("Save as %1?"), filename),
+                            text = T(_("Save as %1?"), BD.filename(filename)),
                             ok_callback = function()
                                 UIManager:scheduleIn(0.1, function()
                                     local Wikipedia = require("ui/wikipedia")
                                     Wikipedia:createEpubWithUI(epub_path, self.lookupword, lang, function(success)
                                         if success then
                                             UIManager:show(ConfirmBox:new{
-                                                text = T(_("Article saved to:\n%1\n\nWould you like to read the downloaded article now?"), epub_path),
+                                                text = T(_("Article saved to:\n%1\n\nWould you like to read the downloaded article now?"), BD.filepath(epub_path)),
                                                 ok_callback = function()
                                                     -- close all dict/wiki windows, without scheduleIn(highlight.clear())
                                                     self:onHoldClose(true)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -627,8 +627,7 @@ function Menu:init()
     if self.show_path then
         self.path_text = TextWidget:new{
             face = Font:getFace("xx_smallinfofont"),
-            text = self.path,
-            para_direction_rtl = false, -- force LTR
+            text = BD.directory(self.path),
             max_width = self.dimen.w - 2*Size.padding.small,
             truncate_left = true,
         }
@@ -1035,7 +1034,7 @@ function Menu:updateItems(select_number)
 
     self:updatePageInfo(select_number)
     if self.show_path then
-        self.path_text:setText(self.path)
+        self.path_text:setText(BD.directory(self.path))
     end
 
     UIManager:setDirty(self.show_parent, function()

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -30,6 +30,7 @@ Example:
 
 ]]
 
+local BD = require("ui/bidi")
 local bit = require("bit")
 local Blitbuffer = require("ffi/blitbuffer")
 local CenterContainer = require("ui/widget/container/centercontainer")
@@ -469,7 +470,7 @@ function NetworkSetting:init()
                 UIManager:close(self, 'ui', self.dimen)
             end
             UIManager:show(InfoMessage:new{
-                text = T(_("Connected to network %1"), connected_item.info.ssid),
+                text = T(_("Connected to network %1"), BD.wrap(connected_item.info.ssid)),
                 timeout = 3,
             })
             if self.connect_callback then

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local Cache = require("cache")
@@ -303,7 +304,7 @@ function OPDSBrowser:fetchFeed(item_url, username, password, method)
         return
     elseif code == 301 then
         UIManager:show(InfoMessage:new{
-            text = T(_("The catalog has been permanently moved. Please update catalog URL to '%1'."), headers['Location']),
+            text = T(_("The catalog has been permanently moved. Please update catalog URL to '%1'."), BD.url(headers['Location'])),
         })
     elseif code == 401 then
         UIManager:show(InfoMessage:new{
@@ -355,7 +356,7 @@ function OPDSBrowser:getCatalog(item_url, username, password)
     elseif not ok and catalog then
         logger.info("cannot get catalog info from", item_url, catalog)
         UIManager:show(InfoMessage:new{
-            text = T(_("Cannot get catalog info from %1"), (item_url or "")),
+            text = T(_("Cannot get catalog info from %1"), (BD.url(item_url) or "")),
         })
         return
     end
@@ -545,7 +546,7 @@ function OPDSBrowser:downloadFile(item, format, remote_url)
                 end
             else
                 UIManager:show(InfoMessage:new {
-                    text = _("Could not save file to:\n") .. local_path,
+                    text = _("Could not save file to:\n") .. BD.filepath(local_path),
                     timeout = 3,
                 })
             end
@@ -559,7 +560,7 @@ function OPDSBrowser:downloadFile(item, format, remote_url)
 
     if lfs.attributes(local_path, "mode") == "file" then
         UIManager:show(ConfirmBox:new {
-            text = T(_("The file %1 already exists. Do you want to overwrite it?"), local_path),
+            text = T(_("The file %1 already exists. Do you want to overwrite it?"), BD.filepath(local_path)),
             ok_text = _("Overwrite"),
             ok_callback = function()
                 download()
@@ -572,7 +573,7 @@ end
 
 function OPDSBrowser:createNewDownloadDialog(path, buttons)
     self.download_dialog = ButtonDialogTitle:new{
-        title = T(_("Download directory:\n%1\n\nDownload file type:"), path),
+        title = T(_("Download directory:\n%1\n\nDownload file type:"), BD.dirpath(path)),
         buttons = buttons
     }
 end

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local FileChooser = require("ui/widget/filechooser")
 local Font = require("ui/font")
@@ -104,14 +105,14 @@ function PathChooser:onMenuHold(item)
             local filesize = util.getFormattedSize(attr.size)
             local lastmod = os.date("%Y-%m-%d %H:%M", attr.modification)
             title = T(_("Select this file?\n\n%1\n\nFile size: %2 bytes\nLast modified: %3"),
-                        path, filesize, lastmod)
+                        BD.filepath(path), filesize, lastmod)
         else
-            title = T(_("Select this file?\n\n%1"), path)
+            title = T(_("Select this file?\n\n%1"), BD.filepath(path))
         end
     elseif attr.mode == "directory" then
-        title = T(_("Select this directory?\n\n%1"), path)
+        title = T(_("Select this directory?\n\n%1"), BD.dirpath(path))
     else -- just in case we get something else
-        title = T(_("Select this path?\n\n%1"), path)
+        title = T(_("Select this path?\n\n%1"), BD.path(path))
     end
     local onConfirm = self.onConfirm
     self.button_dialog = ButtonDialogTitle:new{

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
@@ -42,7 +43,7 @@ function Screenshoter:onScreenshot(filename)
     local screenshot_name = filename or os.date(self.screenshot_fn_fmt)
     Screen:shot(screenshot_name)
     local widget = ConfirmBox:new{
-        text = T( _("Saved screenshot to %1.\nWould you like to set it as screensaver?"), screenshot_name),
+        text = T( _("Saved screenshot to %1.\nWould you like to set it as screensaver?"), BD.filepath(screenshot_name)),
         ok_text = _("Yes"),
         ok_callback = function()
             G_reader_settings:saveSetting("screensaver_type", "image_file")
@@ -67,7 +68,7 @@ function Screenshoter:chooseFolder()
                     onConfirm = function(path)
                         G_reader_settings:saveSetting("screenshot_dir", path .. "/")
                         UIManager:show(InfoMessage:new{
-                            text = T(_("Screenshot directory set to:\n%1"), path),
+                            text = T(_("Screenshot directory set to:\n%1"), BD.dirpath(path)),
                             timeout = 3,
                         })
                     end,
@@ -85,7 +86,7 @@ function Screenshoter:chooseFolder()
     })
     local screenshot_dir = G_reader_settings:readSetting("screenshot_dir") or DataStorage:getDataDir() .. "/screenshots/"
     self.choose_dialog = ButtonDialogTitle:new{
-        title = T(_("Current screenshot directory:\n%1"), screenshot_dir),
+        title = T(_("Current screenshot directory:\n%1"), BD.dirpath(screenshot_dir)),
         buttons = buttons
     }
     UIManager:show(self.choose_dialog)

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -182,8 +182,16 @@ function SortWidget:init()
     self.item_height = Size.item.height_big
 
     -- group for footer
+    local footer_left_text = "◀"
+    local footer_right_text = "▶"
+    local footer_first_up_text = "◀◀"
+    local footer_last_down_text = "▶▶"
+    if BD.mirroredUILayout() then
+        footer_left_text, footer_right_text = footer_right_text, footer_left_text
+        footer_first_up_text, footer_last_down_text = footer_last_down_text, footer_first_up_text
+    end
     self.footer_left = Button:new{
-        text = "◀",
+        text = footer_left_text,
         width = self.width_widget * 13 / 100,
         callback = function() self:prevPage() end,
         text_font_size = 28,
@@ -192,7 +200,7 @@ function SortWidget:init()
         radius = 0,
     }
     self.footer_right = Button:new{
-        text = "▶",
+        text = footer_right_text,
         width = self.width_widget * 13 / 100,
         callback = function() self:nextPage() end,
         text_font_size = 28,
@@ -201,7 +209,7 @@ function SortWidget:init()
         radius = 0,
     }
     self.footer_first_up = Button:new{
-        text = "◀◀",
+        text = footer_first_up_text,
         width = self.width_widget * 13 / 100,
         callback = function()
             if self.marked > 0 then
@@ -216,7 +224,7 @@ function SortWidget:init()
         radius = 0,
     }
     self.footer_last_down = Button:new{
-        text = "▶▶",
+        text = footer_last_down_text,
         width = self.width_widget * 13 / 100,
         callback = function()
             if self.marked > 0 then
@@ -415,13 +423,18 @@ function SortWidget:_populateItems()
         )
     end
 
-    self.footer_page:setText(T(_("%1/%2"), self.show_page, self.pages), self.width_widget * 22 / 100)
+    self.footer_page:setText(T(_("%1 / %2"), self.show_page, self.pages), self.width_widget * 22 / 100)
+    local footer_first_up_text = "◀◀"
+    local footer_last_down_text = "▶▶"
+    if BD.mirroredUILayout() then
+        footer_first_up_text, footer_last_down_text = footer_last_down_text, footer_first_up_text
+    end
     if self.marked > 0 then
         self.footer_first_up:setText("▲", self.width_widget * 13 / 100)
         self.footer_last_down:setText("▼", self.width_widget * 13 / 100)
     else
-        self.footer_first_up:setText("◀◀", self.width_widget * 13 / 100)
-        self.footer_last_down:setText("▶▶", self.width_widget * 13 / 100)
+        self.footer_first_up:setText(footer_first_up_text, self.width_widget * 13 / 100)
+        self.footer_last_down:setText(footer_last_down_text, self.width_widget * 13 / 100)
     end
     self.footer_left:enableDisable(self.show_page > 1)
     self.footer_right:enableDisable(self.show_page < self.pages)

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -665,7 +665,8 @@ function TextBoxWidget:_renderText(start_row_idx, end_row_idx)
                 -- Requested to add an ellipsis on this line
                 local ellipsis_width = RenderText:getEllipsisWidth(self.face)
                     -- no bold: xtext does synthetized bold with normal metrics
-                if line.width + ellipsis_width > line.targeted_width then
+                line.width = line.width + ellipsis_width
+                if line.width > line.targeted_width then
                     -- The ellipsis would overflow: we need to re-makeLine()
                     -- this line with a smaller targeted_width
                     line = self._xtext:makeLine(line.offset, line.targeted_width - ellipsis_width)

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -954,14 +954,15 @@ end
 function util.unpackArchive(archive, extract_to)
     dbg.dassert(type(archive) == "string")
 
+    local BD = require("ui/bidi")
     local ok
     if archive:match("%.tar%.bz2$") or archive:match("%.tar%.gz$") or archive:match("%.tar%.lz$") or archive:match("%.tgz$") then
         ok = os.execute(("./tar xf %q -C %q"):format(archive, extract_to))
     else
-        return false, T(_("Couldn't extract archive:\n\n%1\n\nUnrecognized filename extension."), archive)
+        return false, T(_("Couldn't extract archive:\n\n%1\n\nUnrecognized filename extension."), BD.filepath(archive))
     end
     if not ok then
-        return false, T(_("Extracting archive failed:\n\n%1", archive))
+        return false, T(_("Extracting archive failed:\n\n%1", BD.filepath(archive)))
     end
     return true
 end

--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local DataStorage = require("datastorage")
 local Device =  require("device")
 local InfoMessage = require("ui/widget/infomessage")  -- luacheck:ignore
@@ -178,7 +179,7 @@ function SSH:addToMainMenu(menu_items)
                 callback = function()
                     local info = InfoMessage:new{
                         timeout = 60,
-                        text = T(_("Put your public SSH keys in %1"), path.."/settings/SSH/authorized_keys"),
+                        text = T(_("Put your public SSH keys in %1"), BD.filepath(path.."/settings/SSH/authorized_keys")),
                     }
                     UIManager:show(info)
                 end,

--- a/plugins/calibrecompanion.koplugin/main.lua
+++ b/plugins/calibrecompanion.koplugin/main.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
@@ -127,7 +128,7 @@ function CalibreCompanion:addToMainMenu(menu_items)
                         address = G_reader_settings:readSetting("calibre_wireless_url")
                         address = string.format("%s:%s", address["address"], address["port"])
                     end
-                    return T(_("Server address (%1)"), address)
+                    return T(_("Server address (%1)"), BD.ltr(address))
                 end,
                 sub_item_table = {
                     {
@@ -214,7 +215,7 @@ function CalibreCompanion:initCalibreMQ(host, port)
                 self:onReceiveJSON(data)
                 if not self.connect_message then
                     UIManager:show(InfoMessage:new{
-                        text = T(_("Connected to calibre server at %1:%2"), host, port),
+                        text = T(_("Connected to calibre server at %1"), BD.ltr(T("%1:%2", host, port))),
                     })
                     self.connect_message = true
                     if self.failed_connect_callback then
@@ -467,7 +468,7 @@ function CalibreCompanion:sendBook(arg)
             outfile:close()
             logger.info("complete writing file", filename)
             UIManager:show(InfoMessage:new{
-                text = _("Received file:") .. filename,
+                text = _("Received file:") .. BD.filepath(filename),
                 timeout = 1,
             })
             -- switch to JSON data receiving mode

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -844,7 +845,7 @@ Do you want to prune the cache of removed books?]]
 
         local orig_moved_offset = info.movable:getMovedOffset()
         info:free()
-        info.text = T(_("Indexing %1 / %2…\n\n%3"), i, nb_files, filename)
+        info.text = T(_("Indexing %1 / %2…\n\n%3"), i, nb_files, BD.filename(filename))
         info:init()
         local text_widget = table.remove(info.movable[1][1], 3)
         local text_widget_size = text_widget:getSize()

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local DocumentRegistry = require("document/documentregistry")
 local DocSettings = require("docsettings")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
@@ -95,7 +96,7 @@ function CoverMenu:updateItems(select_number)
     self:updatePageInfo(select_number)
 
     if self.show_path then
-        self.path_text:setText(self.path)
+        self.path_text:setText(BD.directory(self.path))
     end
     self.show_parent.dithered = self._has_cover_images
     UIManager:setDirty(self.show_parent, function()

--- a/plugins/docsettingtweak.koplugin/main.lua
+++ b/plugins/docsettingtweak.koplugin/main.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local DataStorage = require("datastorage")
 local FFIUtil = require("ffi/util")
 local InputDialog = require("ui/widget/inputdialog")
@@ -48,7 +49,7 @@ function DocSettingTweak:editDirectoryDefaults()
     directory_defaults_file:close()
     local config_editor
     config_editor = InputDialog:new{
-        title = T(_("Directory Defaults: %1"),directory_defaults_path),
+        title = T(_("Directory Defaults: %1"), BD.filepath(directory_defaults_path)),
         input = defaults,
         input_type = "string",
         para_direction_rtl = false, -- force LTR

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LoginDialog = require("ui/widget/logindialog")
 local InfoMessage = require("ui/widget/infomessage")
@@ -242,7 +243,7 @@ For Windows: netsh interface portproxy add listeningaddress:0.0.0.0 listeningpor
 For Linux: $socat tcp-listen:41185,reuseaddr,fork tcp:localhost:41184
 
 For more information, please visit https://github.com/koreader/koreader/wiki/Evernote-export.]])
-                            ,DataStorage:getDataDir())
+                            , BD.dirpath(DataStorage:getDataDir()))
                             })
                         end
                     }
@@ -595,7 +596,7 @@ function EvernoteExporter:exportClippings(clippings)
         end
     end
     if (self.html_export or self.txt_export) and export_count > 0 then
-        msg = msg .. T(_("\nNotes can be found in %1/."), realpath(self.clipping_dir))
+        msg = msg .. T(_("\nNotes can be found in %1/."), BD.dirpath(realpath(self.clipping_dir)))
     end
     UIManager:show(InfoMessage:new{ text = msg })
 end

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local DataStorage = require("datastorage")
 --local DownloadBackend = require("internaldownloadbackend")
 --local DownloadBackend = require("luahttpdownloadbackend")
@@ -125,7 +126,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 callback = function()
                     UIManager:show(InfoMessage:new{
                         text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
-                                 news_download_dir_path)
+                                 BD.dirpath(news_download_dir_path))
                     })
                 end,
             },
@@ -183,7 +184,7 @@ function NewsDownloader:loadConfigAndProcessFeeds()
         local download_full_article = feed.download_full_article == nil or feed.download_full_article
         local include_images = feed.include_images
         if url and limit then
-            local feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, url)
+            local feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
             UI:info(feed_message)
             NewsDownloader:processFeedSource(url, tonumber(limit), unsupported_feeds_urls, download_full_article, include_images, feed_message)
         else
@@ -198,7 +199,7 @@ function NewsDownloader:loadConfigAndProcessFeeds()
         for k,url in pairs(unsupported_feeds_urls) do
             unsupported_urls = unsupported_urls .. url
             if k ~= #unsupported_feeds_urls then
-                unsupported_urls = unsupported_urls .. ", "
+                unsupported_urls = BD.url(unsupported_urls) .. ", "
             end
         end
         UI:info(T(_("Downloading news finished. Could not process some feeds. Unsupported format in: %1"), unsupported_urls))
@@ -408,7 +409,7 @@ function NewsDownloader:changeFeedConfig()
     feed_config_file:close()
     local config_editor
     config_editor = InputDialog:new{
-        title = T(_("Config: %1"),feed_config_path),
+        title = T(_("Config: %1"), BD.filepath(feed_config_path)),
         input = config,
         input_type = "string",
         para_direction_rtl = false, -- force LTR

--- a/plugins/send2ebook.koplugin/main.lua
+++ b/plugins/send2ebook.koplugin/main.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local DataStorage = require("datastorage")
 local DocSettings = require("frontend/docsettings")
 local ReadHistory = require("readhistory")
@@ -103,7 +104,7 @@ function Send2Ebook:addToMainMenu(menu_items)
                 keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{
-                        text = T(_('Send2Ebook lets you send articles found on PC/Android phone to your Ebook reader (using ftp server).\n\nMore details: https://github.com/mwoz123/send2ebook\n\nDownloads to local folder: %1'), download_dir_path)
+                        text = T(_('Send2Ebook lets you send articles found on PC/Android phone to your Ebook reader (using ftp server).\n\nMore details: https://github.com/mwoz123/send2ebook\n\nDownloads to local folder: %1'), BD.dirpath(download_dir_path))
                     })
                 end,
             },
@@ -143,7 +144,7 @@ function Send2Ebook:process()
     local ftp_files_table = FtpApi:listFolder(connection_url .. ftp_config.folder, ftp_config.folder) --args looks strange but otherwise resonse with invalid paths
 
     if not ftp_files_table then
-      info = InfoMessage:new{ text = T(_("Could not get file list for server: %1, user: %2, folder: %3"), ftp_config.address, ftp_config.username, ftp_config.folder) }
+      info = InfoMessage:new{ text = T(_("Could not get file list for server: %1, user: %2, folder: %3"), BD.ltr(ftp_config.address), ftp_config.username, BD.dirpath(ftp_config.folder)) }
     else
       local total_entries = table.getn(ftp_files_table)
       logger.dbg("Send2Ebook: total_entries ", total_entries)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
@@ -235,7 +236,7 @@ Cannot open database in %1.
 The database may have been moved or deleted.
 Do you want to create an empty database?
 ]]),
-                        db_location),
+                        BD.filepath(db_location)),
                 cancel_text = _("Close"),
                 cancel_callback = function()
                     return

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -171,7 +171,7 @@ Enable this if you are mostly editing code, HTML, CSS…]]),
         local file_path = self.history[i]
         local directory, filename = util.splitFilePathName(file_path) -- luacheck: no unused
         table.insert(sub_item_table, {
-            text = T("%1. %2", i, filename),
+            text = T("%1. %2", i, BD.filename(filename)),
             keep_menu_open = true,
             callback = function(touchmenu_instance)
                 self:setupWhenDoneFunc(touchmenu_instance)
@@ -186,10 +186,10 @@ Enable this if you are mostly editing code, HTML, CSS…]]),
                     local filesize = util.getFormattedSize(attr.size)
                     local lastmod = os.date("%Y-%m-%d %H:%M", attr.modification)
                     text = T(_("File path:\n%1\n\nFile size: %2 bytes\nLast modified: %3\n\nRemove this file from text editor history?"),
-                                file_path, filesize, lastmod)
+                                BD.filepath(file_path), filesize, lastmod)
                 else
                     text = T(_("File path:\n%1\n\nThis file does not exist anymore.\n\nRemove it from text editor history?"),
-                                file_path)
+                                BD.filepath(file_path))
                 end
                 UIManager:show(ConfirmBox:new{
                     text = text,
@@ -332,7 +332,7 @@ function TextEditor:checkEditFile(file_path, from_history, possibly_new_file)
     local attr = lfs.attributes(file_path)
     if not possibly_new_file and not attr then
         UIManager:show(ConfirmBox:new{
-            text = T(_("This file does not exist anymore:\n\n%1\n\nDo you want to create it and start editing it?"), file_path),
+            text = T(_("This file does not exist anymore:\n\n%1\n\nDo you want to create it and start editing it?"), BD.filepath(file_path)),
             ok_text = _("Yes"),
             cancel_text = _("No"),
             ok_callback = function()
@@ -350,7 +350,7 @@ function TextEditor:checkEditFile(file_path, from_history, possibly_new_file)
     if attr then -- File exists
         if attr.mode ~= "file" then
             UIManager:show(InfoMessage:new{
-                text = T(_("This file is not a regular file:\n\n%1"), file_path)
+                text = T(_("This file is not a regular file:\n\n%1"), BD.filepath(file_path))
             })
             return
         end
@@ -368,7 +368,7 @@ function TextEditor:checkEditFile(file_path, from_history, possibly_new_file)
         if not from_history and attr.size > self.min_file_size_warn then
             UIManager:show(ConfirmBox:new{
                 text = T(_("This file is %2:\n\n%1\n\nAre you sure you want to open it?\n\nOpening big files may take some time."),
-                    file_path, util.getFriendlySize(attr.size)),
+                    BD.filepath(file_path), util.getFriendlySize(attr.size)),
                 ok_text = _("Yes"),
                 cancel_text = _("No"),
                 ok_callback = function()
@@ -389,7 +389,7 @@ function TextEditor:checkEditFile(file_path, from_history, possibly_new_file)
             self:editFile(file_path)
         else
             UIManager:show(InfoMessage:new{
-                text = T(_("This file can not be created:\n\n%1\n\nReason: %2"), file_path, err)
+                text = T(_("This file can not be created:\n\n%1\n\nReason: %2"), BD.filepath(file_path), err)
             })
             return
         end
@@ -526,7 +526,7 @@ Lua syntax check failed:
 KOReader may crash if this is saved.
 Do you really want to save to this file?
 
-%2]]), parse_error, file_path),  _("Do not save"), _("Save anyway"))
+%2]]), parse_error, BD.filepath(file_path)),  _("Do not save"), _("Save anyway"))
                 -- we'll get the safer "Do not save" on tap outside
                 if save_anyway then
                     local ok, err = self:saveFileContent(file_path, content)
@@ -543,7 +543,7 @@ Do you really want to save to this file?
 Text content is empty.
 Do you want to keep this file as empty, or do you prefer to delete it?
 
-%1]]), file_path), _("Keep empty file"), _("Delete file"))
+%1]]), BD.filepath(file_path)), _("Keep empty file"), _("Delete file"))
                 -- we'll get the safer "Keep empty file" on tap outside
                 if delete_file then
                     local ok, err = self:deleteFile(file_path)

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -2,6 +2,7 @@
 @module koplugin.wallabag
 ]]
 
+local BD = require("ui/bidi")
 local DataStorage = require("datastorage")
 local DocSettings = require("docsettings")
 local Event = require("ui/event")
@@ -163,7 +164,7 @@ function Wallabag:addToMainMenu(menu_items)
                             else
                                 path = filemanagerutil.abbreviate(self.directory)
                             end
-                            return T(_("Set download directory (%1)"), path)
+                            return T(_("Set download directory (%1)"), BD.dirpath(path))
                         end,
                         keep_menu_open = true,
                         callback = function(touchmenu_instance)
@@ -261,7 +262,7 @@ The 'Synchronize remotely deleted files' option will remove local files that no 
 
 More details: https://wallabag.org
 
-Downloads to directory: %1]]), filemanagerutil.abbreviate(self.directory))
+Downloads to directory: %1]]), BD.dirpath(filemanagerutil.abbreviate(self.directory)))
                     })
                 end,
             },
@@ -824,7 +825,7 @@ Enter the details of your Wallabag server and account.
 Client ID and client secret are long strings so you might prefer to save the empty settings and edit the config file directly in your installation directory:
 %1/wallabag.lua
 
-Restart KOReader after editing the config file.]]), DataStorage:getSettingsDir())
+Restart KOReader after editing the config file.]]), BD.dirpath(DataStorage:getSettingsDir()))
 
     self.settings_dialog = MultiInputDialog:new {
         title = _("Wallabag settings"),
@@ -994,11 +995,11 @@ function Wallabag:onAddWallabagArticle(article_url)
     local wallabag_result = self:addArticle(article_url)
     if wallabag_result then
         UIManager:show(InfoMessage:new{
-            text = T(_("Article added to Wallabag:\n%1"), article_url),
+            text = T(_("Article added to Wallabag:\n%1"), BD.url(article_url)),
         })
     else
         UIManager:show(InfoMessage:new{
-            text = T(_("Error adding link to Wallabag:\n%1"), article_url),
+            text = T(_("Error adding link to Wallabag:\n%1"), BD.url(article_url)),
         })
     end
 


### PR DESCRIPTION
Follow up to #5667 and #5694. Discussion in https://github.com/koreader/koreader/issues/5359#issuecomment-566959691.

This also helps displaying correctly RTL and bidi filenames and directories in a LTR UI.
Not tested, may have typo and parens errors :)
The Bidi._path and co at the bottom of bidi.lua and the aliasing will need some tuning.

I hardcoded Bidi.ltr() for IP adresses and IP:port combo. Dunno if they need some other kind of wrapping, or if `192.0.0.1:433` could really be displayed `443:1.0.0.192` in RTL :)

Also fix UI mirroring of SortWidget that I forgot in #5667.
Closes #1426.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5696)
<!-- Reviewable:end -->
