### PR TITLE
Option to change page gap in continuous mode

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -774,7 +774,7 @@ function ReaderView:onReadSettings(config)
     self.highlight.saved = config:readSetting("highlight") or {}
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
     self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height") or
-    G_reader_settings:readSetting("kopt_page_gap_height") or 8)
+        G_reader_settings:readSetting("kopt_page_gap_height") or 8)
 end
 
 function ReaderView:onPageUpdate(new_page_no)
@@ -838,6 +838,9 @@ function ReaderView:onSetViewMode(new_mode)
     return true
 end
 
+--Refresh after changing a variable done by koptoptions.lua since all of them
+--requires full screen refresh. If this handler used for changing page gap from
+--another source (eg. coptions.lua) triggering a redraw is needed.
 function ReaderView:onPageGapUpdate(page_gap)
     self.page_gap.height = page_gap
     return true

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -773,7 +773,7 @@ function ReaderView:onReadSettings(config)
     self.page_scroll = page_scroll == 1 and true or false
     self.highlight.saved = config:readSetting("highlight") or {}
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
-    self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height") or 
+    self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height") or
     G_reader_settings("kopt_page_gap_height") or 8)
 end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -51,10 +51,6 @@ local ReaderView = OverlapGroup:extend{
     scroll_mode = "vertical",
     -- properties of the gap drawn between each page in scroll mode:
     page_gap = {
-        -- width in pixels (when scrolling horizontally)
-        width = Screen:scaleBySize(G_reader_settings:readSetting("page_gap_width") or 8),
-        -- height in pixels (when scrolling vertically)
-        height = Screen:scaleBySize(G_reader_settings:readSetting("page_gap_height") or 8),
         -- color (0 = white, 8 = gray, 15 = black)
         color = Blitbuffer.gray((G_reader_settings:readSetting("page_gap_color") or 8)/15),
     },
@@ -782,8 +778,7 @@ function ReaderView:onReadSettings(config)
     self.page_scroll = page_scroll == 1 and true or false
     self.highlight.saved = config:readSetting("highlight") or {}
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
-    self.page_gap.height = config:readSetting("kopt_page_gap") or 8
-    self.page_gap_width = config:readSetting("kopt_page_gap") or 8
+    self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height") or 8)
 end
 
 function ReaderView:onPageUpdate(new_page_no)
@@ -849,7 +844,6 @@ end
 
 function ReaderView:onPageGapUpdate(page_gap)
     self.page_gap.height = page_gap
-    self.page_gap.width = page_gap
     return true
 end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -48,7 +48,6 @@ local ReaderView = OverlapGroup:extend{
     page_scroll = nil,
     page_bgcolor = Blitbuffer.gray(DBACKGROUND_COLOR/15),
     page_states = {},
-    scroll_mode = "vertical",
     -- properties of the gap drawn between each page in scroll mode:
     page_gap = {
         -- color (0 = white, 8 = gray, 15 = black)
@@ -385,11 +384,7 @@ function ReaderView:getScrollPageRect(page, rect_p)
 end
 
 function ReaderView:drawPageGap(bb, x, y)
-    if self.scroll_mode == "vertical" then
-        bb:paintRect(x, y, self.dimen.w, self.page_gap.height, self.page_gap.color)
-    elseif self.scroll_mode == "horizontal" then
-        bb:paintRect(x, y, self.page_gap.width, self.dimen.h, self.page_gap.color)
-    end
+    bb:paintRect(x, y, self.dimen.w, self.page_gap.height, self.page_gap.color)
 end
 
 function ReaderView:drawSinglePage(bb, x, y)
@@ -778,7 +773,8 @@ function ReaderView:onReadSettings(config)
     self.page_scroll = page_scroll == 1 and true or false
     self.highlight.saved = config:readSetting("highlight") or {}
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
-    self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height") or 8)
+    self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height") or 
+    G_reader_settings("kopt_page_gap_height") or 8)
 end
 
 function ReaderView:onPageUpdate(new_page_no)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -774,7 +774,7 @@ function ReaderView:onReadSettings(config)
     self.highlight.saved = config:readSetting("highlight") or {}
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
     self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height") or
-    G_reader_settings("kopt_page_gap_height") or 8)
+    G_reader_settings:readSetting("kopt_page_gap_height") or 8)
 end
 
 function ReaderView:onPageUpdate(new_page_no)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -782,6 +782,8 @@ function ReaderView:onReadSettings(config)
     self.page_scroll = page_scroll == 1 and true or false
     self.highlight.saved = config:readSetting("highlight") or {}
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
+    self.page_gap.height = config:readSetting("kopt_page_gap") or 8
+    self.page_gap_width = config:readSetting("kopt_page_gap") or 8
 end
 
 function ReaderView:onPageUpdate(new_page_no)
@@ -842,6 +844,12 @@ function ReaderView:onSetViewMode(new_mode)
         self.ui.document:setViewMode(new_mode)
         self.ui:handleEvent(Event:new("ChangeViewMode"))
     end
+    return true
+end
+
+function ReaderView:onPageGapUpdate(page_gap)
+    self.page_gap.height = page_gap
+    self.page_gap.width = page_gap
     return true
 end
 

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -84,6 +84,15 @@ local KoptOptions = {
                 name_text_hold_callback = optionsutil.showValues,
             },
             {
+                name = "page_gap",
+                name_text = S.PAGE_GAP,
+                toggle = {S.NONE, S.SMALL, S.MEDIUM, S.LARGE},
+                values = {0, 8, 16, 32},
+                default_value = 8,
+                args = {0, 8, 16, 32},
+                event = "PageGapUpdate"
+            },
+            {
                 name = "max_columns",
                 name_text = S.COLUMNS,
                 item_icons = {

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -84,7 +84,7 @@ local KoptOptions = {
                 name_text_hold_callback = optionsutil.showValues,
             },
             {
-                name = "page_gap",
+                name = "page_gap_height",
                 name_text = S.PAGE_GAP,
                 toggle = {S.NONE, S.SMALL, S.MEDIUM, S.LARGE},
                 values = {0, 8, 16, 32},

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -90,7 +90,11 @@ local KoptOptions = {
                 values = {0, 8, 16, 32},
                 default_value = 8,
                 args = {0, 8, 16, 32},
-                event = "PageGapUpdate"
+                event = "PageGapUpdate",
+                enabled_func = function (configurable)
+                    return optionsutil.enableIfEquals(configurable, "page_scroll", 1)
+                end,
+                name_text_hold_callback = optionsutil.showValues,
             },
             {
                 name = "max_columns",

--- a/frontend/ui/data/strings.lua
+++ b/frontend/ui/data/strings.lua
@@ -46,6 +46,7 @@ S.HW_DITHERING = _("Dithering")
 S.INVERSE_READING_ORDER = _("Inverse Order")
 S.IMAGE_SCALING = _("Image Scaling")
 S.NIGHTMODE_IMAGES = _("Invert Images")
+S.PAGE_GAP = _("Page Gap")
 
 S.ON = _("on")
 S.OFF = _("off")


### PR DESCRIPTION
for request see https://github.com/koreader/koreader/issues/5656

Adds an option to select page gap in continuous mode. Option only shows up on documents that have numbered pages (.pdf, .cbz) because i think there is not much use to this option when reading arbitrarily paged documents. If seen necessary same logic can be duplicated for .epub files.

koptoptions.lua handles user selection and saving that selection
ReaderView:readSettings() handles reading previously selected option when opening book
ReaderVİew:onPageGapUpdate() renders changes when selection made

Page gap is same in both landscape and portrait modes, I think adding different settings for both is little unnecessary. 
The options for gap is 0, 8, 16 and 32, default one before was 8.

commit log
> 
> page_gap setting on opening a book
> if it does not exist defaults to 8
> -adds page_gap selector to koptoptions.lua,
> user can select 0, 8, 16, 32 via footer settings
> -adds :onPageGapUpdate event handler to ReaderView


![page-1](https://user-images.githubusercontent.com/24368325/71388462-84a21f80-2609-11ea-8191-e839718ced98.png)
![page-gap2](https://user-images.githubusercontent.com/24368325/71388468-8b309700-2609-11ea-9c3f-4ae1807065f9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5705)
<!-- Reviewable:end -->
