### PR TITLE
Various fixes (reader.lua, ConfirmBox, In-page footnotes style tweaks)

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -604,7 +604,9 @@ ol.references > li > .mw-cite-backlink { display: none; }
 Show footnotes with classic class names at the bottom of pages.
 This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
                 css = [[
-.footnote, .note, .note1, .ntb, .ntb-txt, .ntb-txt-j
+.footnote, .footnotes, .fn,
+.note, .note1, .note2, .note3,
+.ntb, .ntb-txt, .ntb-txt-j
 {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
@@ -618,7 +620,9 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
 Show footnotes with classic classname at the bottom of pages.
 This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
                 css = [[
-.footnote, .note, .note1, .ntb, .ntb-txt, .ntb-txt-j
+.footnote, .footnotes, .fn,
+.note, .note1, .note2, .note3,
+.ntb, .ntb-txt, .ntb-txt-j
 {
     -cr-hint: footnote-inpage;
     margin: 0 !important;

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -168,9 +168,9 @@ end
 function ConfirmBox:onTapClose(arg, ges)
     if ges.pos:notIntersectWith(self[1][1].dimen) then
         self:onClose()
-        return true
     end
-    return false
+    -- Don't let it propagate to underlying widgets
+    return true
 end
 
 function ConfirmBox:onSelect()

--- a/reader.lua
+++ b/reader.lua
@@ -136,10 +136,6 @@ if Device:hasEinkScreen() then
         Device.screen:toggleSWDithering()
     end
 end
--- Touch screen
-if Device:needsTouchScreenProbe() then
-    Device:touchScreenProbe()
-end
 
 -- Handle global settings migration
 local SettingsMigration = require("ui/data/settings_migration")
@@ -148,6 +144,13 @@ SettingsMigration:migrateSettings(G_reader_settings)
 -- Document renderers canvas
 local CanvasContext = require("document/canvascontext")
 CanvasContext:init(Device)
+
+-- Touch screen (this may display some widget, on first install on Kobo Touch,
+-- so have it done after CanvasContext:init() but before Bidi.setup() to not
+-- have mirroring mess x/y probing).
+if Device:needsTouchScreenProbe() then
+    Device:touchScreenProbe()
+end
 
 -- UI mirroring for RTL languages, and text shaping configuration
 local Bidi = require("ui/bidi")


### PR DESCRIPTION
- reader.lua: re-order touchScreenProbe() after CanvasContext. Should close #5717.
- ConfirmBox: prevent lower widgets from responding to tap: could happen when toggling Render Mode in the bottom menu, when we get the "Styles have changed in such a way... do you want to reload the document": taping on that text instead of the buttons would activate some other buttons in the bottom config menu hidden by that ConfirmBox :)
- Style tweaks: In-page footnotes: add some classic classnames: just adds `note2` and `note3`. Closes #5707.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5727)
<!-- Reviewable:end -->
