### PR TITLE
[chore] Prevent useless POT updates

### DIFF
--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -13,10 +13,13 @@ if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ "${CIRCLE_BRANCH}" = 'master' ]; then
         make pot
         pushd l10n && {
             git checkout master
-            git -c user.name="KOReader build bot" -c user.email="non-reply@koreader.rocks" \
-                commit templates/koreader.pot -m "Updated translation source file"
-            git push --quiet "https://${TRANSLATIONS_GITHUB_TOKEN}@github.com/koreader/koreader-translations.git" master
-            echo -e "\\n${ANSI_GREEN}Translation update pushed."
+            # If only one line was added and removed, it was just the timestamp.
+            git diff --numstat | grep "1[[:space:]]1[[:space:]]templates/koreader.pot" && echo -e "\\n${ANSI_GREEN}No updated translations found." || {
+                git -c user.name="KOReader build bot" -c user.email="non-reply@koreader.rocks" \
+                    commit templates/koreader.pot -m "Updated translation source file"
+                git push --quiet "https://${TRANSLATIONS_GITHUB_TOKEN}@github.com/koreader/koreader-translations.git" master
+                echo -e "\\n${ANSI_GREEN}Translation update pushed."
+            }
         } && popd || exit
 
         echo -e "\\n${ANSI_GREEN}Checking out koreader/doc for update."


### PR DESCRIPTION
If only 1 line changed, it's just the timestamp. Otherwise every commit in the main repo will result in a useless one in koreader/koreader-translations, such as <https://github.com/koreader/koreader-translations/commit/eadc9f133a850361d2f532099aad248ac106f14c>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5734)
<!-- Reviewable:end -->
