### PR TITLE
android: call EPD test from within KOReader

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -389,7 +389,7 @@ function FileManagerMenu:setUpdateItemTable()
     end
     if Device:isAndroid() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
-            text = _("Start Eink Test"),
+            text = _("Start E-ink test"),
             callback = function()
                 Device:epdTest()
             end,

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -387,6 +387,15 @@ function FileManagerMenu:setUpdateItemTable()
             end,
         })
     end
+    if Device:isAndroid() then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            text = _("Start Eink Test"),
+            callback = function()
+                Device:epdTest()
+            end,
+        })
+    end
+
     table.insert(self.menu_items.developer_options.sub_item_table, {
         text = _("Disable enhanced UI text shaping (xtext)"),
         checked_func = function()

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -310,6 +310,10 @@ function Device:info()
     return common_text..eink_text..wakelocks_text
 end
 
+function Device:epdTest()
+    android.einkTest()
+end
+
 function Device:exit()
     android.LOGI(string.format("Stopping %s main activity", android.prop.name));
     android.lib.ANativeActivity_finish(android.app.activity)


### PR DESCRIPTION
Most users can call it from the developers menu:

![test (1)](https://user-images.githubusercontent.com/975883/71550272-846ca000-29cc-11ea-95ad-43092e0b562b.gif)

On some devices, where KOReader doesn't work at all, it can be called using adb with:

`adb shell am start -n org.koreader.launcher/.EPDTestActivity`

Fixes #5730 too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5737)
<!-- Reviewable:end -->
