### PR TITLE
android: OTA fallback using the browser

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -261,11 +261,18 @@ function OTAManager:fetchAndProcessUpdate()
                 ok_callback = function()
                     local isAndroid, android = pcall(require, "android")
                     if isAndroid then
-                        -- download the package if not present.
-                        if android.download(link, ota_package) then
-                            android.notification(T(_("The file %1 already exists."), BD.filename(ota_package)))
+                        -- try to download the package
+                        local ok = android.download(link, ota_package)
+                        if ok == 1 then
+                            android.notification(T(_("The file %1 already exists."), ota_package))
+                        elseif ok == 0 then
+                            android.notification(T(_("Downloading %1"), ota_package))
                         else
-                            android.notification(T(_("Downloading %1"), BD.filename(ota_package)))
+                            UIManager:show(ConfirmBox:new{
+                                text = _("Your device seems to be unable to download packages.\nRetry using the browser?"),
+                                ok_text = _("Retry"),
+                                ok_callback = function() Device:openLink(link) end,
+                            })
                         end
                     elseif Device:isSDL() then
                         Device:openLink(link)


### PR DESCRIPTION
Requires https://github.com/koreader/android-luajit-launcher/pull/215
Fixes #5731 

If the device is borked and fails to download using DownloadManager show a confirmBox to retry using the browser.

See how it works/looks (simulated because I don't have any borked device)

![test (2)](https://user-images.githubusercontent.com/975883/71752502-96908780-2e7f-11ea-8e3a-20ca1de274f3.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5738)
<!-- Reviewable:end -->
