### PR TITLE
[android]: share text with other apps

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -498,6 +498,17 @@ function ReaderHighlight:onShowHighlightMenu()
             },
         })
     end
+    if Device:canShareText() then
+            table.insert(highlight_buttons, {
+            {
+                text = _("Share text"),
+                callback = function()
+                    Device.doShareText(self.selected_text.text)
+                end,
+            },
+        })
+    end
+
     self.highlight_dialog = ButtonDialog:new{
         buttons = highlight_buttons,
         tap_close_callback = function() self:handleEvent(Event:new("Tap")) end,

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -86,6 +86,8 @@ local Device = Generic:new{
     canImportFiles = function() return android.app.activity.sdkVersion >= 19 end,
     importFile = function(path) android.importFile(path) end,
     isValidPath = function(path) return android.isPathInsideSandbox(path) end,
+    canShareText = yes,
+    doShareText = function(text) android.sendText(text) end,
 
     canExternalDictLookup = yes,
     getExternalDictLookupList = getExternalDicts,

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -46,6 +46,7 @@ local Device = {
     hasColorScreen = no,
     hasBGRFrameBuffer = no,
     canImportFiles = no,
+    canShareText = no,
     canToggleGSensor = no,
     canToggleMassStorage = no,
     canUseWAL = yes, -- requires mmap'ed I/O on the target FS


### PR DESCRIPTION
I'm an user of [Markor](https://github.com/gsantner/markor), an awesome markdown/text tool for android.

It has a Quicknote feature which is greeeat. Works with ACTION_SEND, so it is compatible with a lot of applications, including all web browsers. When a user shares text with markor and press "quicknote" he/she will return to the previous activity and the note will be stored in Quicknote.md.

See how it works with a browser:

![test1](https://user-images.githubusercontent.com/975883/71772709-d9ba2b80-2f4f-11ea-94a7-d6b45604dfe7.gif)

It is extremely useful to do initial researching about a topic, at least for me. So I did the same with KO
![test2 (1)](https://user-images.githubusercontent.com/975883/71772726-4df4cf00-2f50-11ea-9d78-688db1aa2cab.gif)

It works exactly the same, but in my case I setup markor as my preferred app to send text from KO, so no application picker is shown.

This is kind of a one-user feature, but the share text can be repurposed for other uses: twitter?, whatsapp? I don't know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5745)
<!-- Reviewable:end -->
