### PR TITLE
Prevent overwriting text in footer

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -307,7 +307,7 @@ function ReaderFooter:init()
         self.settings.toc_markers_width = DMINIBAR_TOC_MARKER_WIDTH
     end
     if not self.settings.progress_bar_min_width then
-        self.settings.progress_bar_min_width = 20
+        self.settings.progress_bar_min_width = 20  -- unscaled_size_check: ignore
     end
     self.mode_list = {}
     for i = 0, #self.mode_index do

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1490,7 +1490,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
             self.footer_container.dimen.h = 0
             self.footer_text.height = 0
         end
-        self.footer_text.max_width = math.floor(self._saved_screen_width - 2 * self.settings.progress_margin_width)
+        self.footer_text:setMaxWidth(math.floor(self._saved_screen_width - 2 * self.settings.progress_margin_width))
         self.footer_text:setText(text)
         self.progress_bar.width = math.floor(self._saved_screen_width - 2 * self.settings.progress_margin_width)
         self.text_width = self.footer_text:getSize().w

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1497,6 +1497,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
     else
         if self.has_no_mode or not text or text == "" then
             self.text_width = 0
+            self.footer_text:setText(text)
         else
             local min_progress_bar_width = (100 - self.settings.progress_bar_min_width) / 100
             self.footer_text:setMaxWidth(math.floor(min_progress_bar_width * self._saved_screen_width - 2 * self.settings.progress_margin_width))

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -307,7 +307,7 @@ function ReaderFooter:init()
         self.settings.toc_markers_width = DMINIBAR_TOC_MARKER_WIDTH
     end
     if not self.settings.progress_bar_min_width_pct then
-        self.settings.progress_bar_min_width_pct = 20  -- unscaled_size_check: ignore
+        self.settings.progress_bar_min_width_pct = 20
     end
     self.mode_list = {}
     for i = 0, #self.mode_index do


### PR DESCRIPTION
This patch fix problem with overwriting text in footer in `Show all at once` mode and when we select many items to show. When text is to wide we truncate it and end with ellipsis(...).
Now we can also set minimal width of progress bar (from 20% to 50% of screen size) in all at once mode.

Before:
<img src=https://user-images.githubusercontent.com/22982594/72155326-2e77ff00-33b3-11ea-93b3-134475fdde16.png width=70%>


After: 

<img src=https://user-images.githubusercontent.com/22982594/72155337-35067680-33b3-11ea-8e52-bd3cd027c724.png width=70%>

<img src=https://user-images.githubusercontent.com/22982594/72155347-3a63c100-33b3-11ea-9e48-a8b052242cdf.png width=70%>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5757)
<!-- Reviewable:end -->
