### PR TITLE
Unbreak OTA on Kindle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ kindleupdate: all
 	# note that the targz file extension is intended to keep ISP from caching
 	# the file, see koreader#1644.
 	cd $(INSTALL_DIR) && \
-		tar -I"gzip --rsyncable" -cah --no-recursion -f ../$(KINDLE_PACKAGE_OTA) \
+		tar --hard-dereference -I"gzip --rsyncable" -cah --no-recursion -f ../$(KINDLE_PACKAGE_OTA) \
 		-T koreader/ota/package.index
 
 KOBO_PACKAGE:=koreader-kobo$(KODEDUG_SUFFIX)-$(VERSION).zip
@@ -233,7 +233,7 @@ koboupdate: all
 		koreader/ota/package.index koreader.png README_kobo.txt
 	# make gzip koboupdate for zsync OTA update
 	cd $(INSTALL_DIR) && \
-		tar -I"gzip --rsyncable" -cah --no-recursion -f ../$(KOBO_PACKAGE_OTA) \
+		tar --hard-dereference -I"gzip --rsyncable" -cah --no-recursion -f ../$(KOBO_PACKAGE_OTA) \
 		-T koreader/ota/package.index
 
 PB_PACKAGE:=koreader-pocketbook$(KODEDUG_SUFFIX)-$(VERSION).zip
@@ -272,7 +272,7 @@ pbupdate: all
 		applications/koreader/ota/package.index system
 	# make gzip pbupdate for zsync OTA update
 	cd $(INSTALL_DIR)/applications && \
-		tar -I"gzip --rsyncable" -cah --no-recursion -f ../../$(PB_PACKAGE_OTA) \
+		tar --hard-dereference -I"gzip --rsyncable" -cah --no-recursion -f ../../$(PB_PACKAGE_OTA) \
 		-T koreader/ota/package.index
 
 utupdate: all
@@ -410,7 +410,7 @@ sony-prstuxupdate: all
 	        koreader/ota/package.index
 	# make gzip sonyprstux update for zsync OTA update
 	cd $(INSTALL_DIR) && \
-	        tar -I"gzip --rsyncable" -cah --no-recursion -f ../$(SONY_PRSTUX_PACKAGE_OTA) \
+	        tar --hard-dereference -I"gzip --rsyncable" -cah --no-recursion -f ../$(SONY_PRSTUX_PACKAGE_OTA) \
 	        -T koreader/ota/package.index
 
 CERVANTES_PACKAGE:=koreader-cervantes$(KODEDUG_SUFFIX)-$(VERSION).zip
@@ -439,7 +439,7 @@ cervantesupdate: all
 	koreader/ota/package.index
 	# make gzip cervantes update for zsync OTA update
 	cd $(INSTALL_DIR) && \
-	tar -I"gzip --rsyncable" -cah --no-recursion -f ../$(CERVANTES_PACKAGE_OTA) \
+	tar --hard-dereference -I"gzip --rsyncable" -cah --no-recursion -f ../$(CERVANTES_PACKAGE_OTA) \
 	-T koreader/ota/package.index
 
 update:

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -367,7 +367,7 @@ if [ "${PASSCODE_DISABLED}" = "yes" ]; then
     touch "/var/local/system/userpasswdenabled"
 fi
 
-# Wipe the clone on exit
+# Wipe the clones on exit
 rm -f /var/tmp/koreader.sh /var/tmp/fbink
 
 exit ${RETURN_VALUE}

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
+
+# NOTE: Stupid workaround to make sure the script we end up running is a *copy*,
+# living in a magical land that doesn't suffer from gross filesystem deficiencies.
+# Otherwise, the vfat+fuse mess means an OTA update will break the script on exit,
+# and potentially leave the user in a broken state, with the WM still paused...
+if [ "$(dirname ${0})" != "/var/tmp" ]; then
+    cp -pf "${0}" /var/tmp/koreader.sh
+    chmod 777 /var/tmp/koreader.sh
+    exec /var/tmp/koreader.sh
+fi
+
 export LC_ALL="en_US.UTF-8"
 
 PROC_KEYPAD="/proc/keypad"

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -363,4 +363,7 @@ if [ "${PASSCODE_DISABLED}" = "yes" ]; then
     touch "/var/local/system/userpasswdenabled"
 fi
 
+# Wipe the clone on exit
+rm -f /var/tmp/koreader.sh
+
 exit ${RETURN_VALUE}

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -7,7 +7,7 @@
 if [ "$(dirname ${0})" != "/var/tmp" ]; then
     cp -pf "${0}" /var/tmp/koreader.sh
     chmod 777 /var/tmp/koreader.sh
-    exec /var/tmp/koreader.sh
+    exec /var/tmp/koreader.sh "$@"
 fi
 
 export LC_ALL="en_US.UTF-8"

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -4,7 +4,7 @@
 # living in a magical land that doesn't suffer from gross filesystem deficiencies.
 # Otherwise, the vfat+fuse mess means an OTA update will break the script on exit,
 # and potentially leave the user in a broken state, with the WM still paused...
-if [ "$(dirname ${0})" != "/var/tmp" ]; then
+if [ "$(dirname "${0}")" != "/var/tmp" ]; then
     cp -pf "${0}" /var/tmp/koreader.sh
     chmod 777 /var/tmp/koreader.sh
     exec /var/tmp/koreader.sh "$@"

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -20,6 +20,10 @@ PROC_FIVEWAY="/proc/fiveway"
 # KOReader's working directory
 export KOREADER_DIR="/mnt/us/koreader"
 
+# NOTE: Same vfat+fuse shenanigans needed for FBink, before we source libko...
+cp -pf ${KOREADER_DIR}/fbink /var/tmp/fbink
+chmod 777 /var/tmp/fbink
+
 # Load our helper functions...
 if [ -f "${KOREADER_DIR}/libkohelper.sh" ]; then
     # shellcheck source=/dev/null
@@ -364,6 +368,6 @@ if [ "${PASSCODE_DISABLED}" = "yes" ]; then
 fi
 
 # Wipe the clone on exit
-rm -f /var/tmp/koreader.sh
+rm -f /var/tmp/koreader.sh /var/tmp/fbink
 
 exit ${RETURN_VALUE}

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -20,8 +20,8 @@ PROC_FIVEWAY="/proc/fiveway"
 # KOReader's working directory
 export KOREADER_DIR="/mnt/us/koreader"
 
-# NOTE: Same vfat+fuse shenanigans needed for FBink, before we source libko...
-cp -pf ${KOREADER_DIR}/fbink /var/tmp/fbink
+# NOTE: Same vfat+fuse shenanigans needed for FBInk, before we source libko...
+cp -pf "${KOREADER_DIR}/fbink" /var/tmp/fbink
 chmod 777 /var/tmp/fbink
 
 # Load our helper functions...

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -18,7 +18,7 @@ fi
 ## Check if we have an FBInk binary available somewhere...
 # Default to something that won't horribly blow up...
 # NOTE: Put our own at the end of the list, because if it gets picked up during an OTA upgrade,
-#       we get an EBUSY when tar tries to overwrite it, because vfat + fuse -_-".
+#       we get an EBUSY when tar tries to overwrite it, because vfat+fuse -_-".
 FBINK_BIN="true"
 for my_dir in libkh/bin linkss/bin linkfonts/bin usbnet/bin koreader; do
     my_fbink="/mnt/us/${my_dir}/fbink"

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -17,11 +17,9 @@ fi
 # Adapted from libkh[5]
 ## Check if we have an FBInk binary available somewhere...
 # Default to something that won't horribly blow up...
-# NOTE: Put our own at the end of the list, because if it gets picked up during an OTA upgrade,
-#       we get an EBUSY when tar tries to overwrite it, because vfat+fuse -_-".
 FBINK_BIN="true"
-for my_dir in libkh/bin linkss/bin linkfonts/bin usbnet/bin koreader; do
-    my_fbink="/mnt/us/${my_dir}/fbink"
+for my_dir in /var/tmp /mnt/us/koreader /mnt/us/libkh/bin /mnt/us/linkss/bin /mnt/us/linkfonts/bin /mnt/us/usbnet/bin; do
+    my_fbink="${my_dir}/fbink"
     if [ -x "${my_fbink}" ]; then
         FBINK_BIN="${my_fbink}"
         # Got it!

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -17,8 +17,10 @@ fi
 # Adapted from libkh[5]
 ## Check if we have an FBInk binary available somewhere...
 # Default to something that won't horribly blow up...
+# NOTE: Put our own at the end of the list, because if it gets picked up during an OTA upgrade,
+#       we get an EBUSY when tar tries to overwrite it, because vfat  fuse -_-".
 FBINK_BIN="true"
-for my_dir in koreader libkh/bin linkss/bin linkfonts/bin usbnet/bin; do
+for my_dir in libkh/bin linkss/bin linkfonts/bin usbnet/bin koreader; do
     my_fbink="/mnt/us/${my_dir}/fbink"
     if [ -x "${my_fbink}" ]; then
         FBINK_BIN="${my_fbink}"

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -18,7 +18,7 @@ fi
 ## Check if we have an FBInk binary available somewhere...
 # Default to something that won't horribly blow up...
 # NOTE: Put our own at the end of the list, because if it gets picked up during an OTA upgrade,
-#       we get an EBUSY when tar tries to overwrite it, because vfat  fuse -_-".
+#       we get an EBUSY when tar tries to overwrite it, because vfat + fuse -_-".
 FBINK_BIN="true"
 for my_dir in libkh/bin linkss/bin linkfonts/bin usbnet/bin koreader; do
     my_fbink="/mnt/us/${my_dir}/fbink"


### PR DESCRIPTION
Regression since #5715 (because I forgot to test with tarballs, and links be weird).

Also, pile on yet another stupid Kindle workaround to make sure an OTA update won't break the launcher script itself because of truncation, which would break the exit sequence, leaving the user with an apparently hung device, simply because the WM was never unpaused...

Yay Kindle. -_-"

Fix #5721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5758)
<!-- Reviewable:end -->
