### PR TITLE
wip: android - share files

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -311,6 +311,20 @@ function FileManager:init()
                     end,
                 }
             })
+
+            if Device:canShareFile() then
+                local title = _("Share")
+                table.insert(buttons, {
+                    {
+                        text = title,
+                        callback = function()
+                            UIManager:close(self.file_dialog)
+                            Device.doShareFile(file, title)
+                        end,
+                    }
+                })
+            end
+
             table.insert(buttons, {
                 {
                     text_func = function()

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -87,8 +87,9 @@ local Device = Generic:new{
     importFile = function(path) android.importFile(path) end,
     isValidPath = function(path) return android.isPathInsideSandbox(path) end,
     canShareText = yes,
+    canShareFile = yes,
     doShareText = function(text) android.sendText(text) end,
-
+    doShareFile = function(path, title) android.sendFile(path, title) end,
     canExternalDictLookup = yes,
     getExternalDictLookupList = getExternalDicts,
     doExternalDictLookup = function (self, text, method, callback)

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -47,6 +47,7 @@ local Device = {
     hasBGRFrameBuffer = no,
     canImportFiles = no,
     canShareText = no,
+    canShareFile = no,
     canToggleGSensor = no,
     canToggleMassStorage = no,
     canUseWAL = yes, -- requires mmap'ed I/O on the target FS


### PR DESCRIPTION
bluetooth, mail and social apps are the main targets, but should work with any app that's able to handle SEND intents for a given mimetype.

Requires https://github.com/koreader/android-luajit-launcher/pull/218

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5762)
<!-- Reviewable:end -->
