### PR TITLE
bump crengine: support inline-block, better text selection

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -783,17 +783,19 @@ function ReaderHighlight:viewSelectionHTML(debug_view)
     end
     if self.selected_text and self.selected_text.pos0 and self.selected_text.pos1 then
         -- For available flags, see the "#define WRITENODEEX_*" in crengine/src/lvtinydom.cpp
-        local html_flags = 0x3030 -- valid and classic displayed HTML, with only block nodes indented
+        -- Start with valid and classic displayed HTML (with only block nodes indented),
+        -- including styles found in <HEAD>, and linked CSS files content.
+        local html_flags = 0x6030
         if not debug_view then
             debug_view = 0
         end
         if debug_view == 1 then
             -- Each node on a line, with markers and numbers of skipped chars and siblings shown,
             -- with possibly invalid HTML (text nodes not escaped)
-            html_flags = 0x3353
+            html_flags = 0x635A
         elseif debug_view == 2 then
             -- Additionally see rendering methods and unicode codepoint of each char
-            html_flags = 0x3757
+            html_flags = 0x675E
         end
         local html, css_files = self.ui.document:getHTMLFromXPointers(self.selected_text.pos0,
                                     self.selected_text.pos1, html_flags, true)

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1064,13 +1064,15 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
     -- then just ignore the whole stylesheet, including our own declarations
     -- we add at start)
     --
-    -- flags = 0x0001 to get the simplest/purest HTML without CSS, and dir=
-    -- and lang= attributes grabbed from parent nodes
+    -- flags = 0x1001 to get the simplest/purest HTML without CSS, with added
+    -- soft-hyphens where hyphenation is allowed (done by crengine according
+    -- to user's hyphenation settings), and dir= and lang= attributes grabbed
+    -- from parent nodes
     local html
     if extStartXP and extEndXP then
-        html = self.ui.document:getHTMLFromXPointers(extStartXP, extEndXP, 0x0001)
+        html = self.ui.document:getHTMLFromXPointers(extStartXP, extEndXP, 0x1001)
     else
-        html = self.ui.document:getHTMLFromXPointer(target_xpointer, 0x0001, true)
+        html = self.ui.document:getHTMLFromXPointer(target_xpointer, 0x1001, true)
         -- from_final_parent = true to get a possibly more complete footnote
     end
     if not html then

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -342,11 +342,13 @@ end
 -- FLOAT_FLOATBOXES                   0x00040000               x   x
 -- DO_NOT_CLEAR_OWN_FLOATS            0x00100000               x   x
 -- ALLOW_EXACT_FLOATS_FOOTPRINTS      0x00200000               x   x
+--
+-- BOX_INLINE_BLOCKS                  0x01000000          x    x   x
 
 local BLOCK_RENDERING_FLAGS = {
     0x00000000, -- legacy block rendering
-    0x00030031, -- flat mode (with prepared floatBoxes, so inlined, to avoid display hash mismatch)
-    0x00375131, -- book mode (floating floatBoxes, limited widths support)
+    0x01030031, -- flat mode (with prepared floatBoxes, so inlined, to avoid display hash mismatch)
+    0x01375131, -- book mode (floating floatBoxes, limited widths support)
     0x7FFFFFFF, -- web mode, all features/flags
 }
 


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/325 :
- lvtinydom.cpp: fix Use-after-free
- lvtextfm: fix/cleanup lastnonspace code bits
- lvtextfm: fix vertical-align: top & bottom
- renderBlockElementEnhanced: minor fixes related to floats
- renderBlockElementEnhanced: compute baseline of block
- Add support for display: inline-block/inline-table
- Better selection highlighting by using getSegmentRects(). Closes #5735
- getHtml(): add flag to get text soft-hyphenated

cre.cpp: toggable text selection highlighting method, default to the new one using segments. https://github.com/koreader/koreader-base/pull/1030

Update various cre flags to use the new features (and to conform with some flags re-ordering):
- support display: inline-block in flat, book and web render modes. Screenshots in https://github.com/koreader/crengine/pull/325.
- get HTML with soft-hyphens for footnote popups, as MuPDF supports them and will use them when rendering the footnote. Closes #5699.
<kbd>![image](https://user-images.githubusercontent.com/24273478/72224389-7301c700-357a-11ea-80b7-c6a37afba370.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5763)
<!-- Reviewable:end -->
