### PR TITLE
fix, confusing info/error message when exporting bookmarks

### DIFF
--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -575,25 +575,21 @@ function EvernoteExporter:exportClippings(clippings)
     local msg = "Nothing was exported."
     local all_count = export_count + error_count
     if export_count > 0 and error_count == 0 then
-        if all_count == 1 then
-            msg = T(
-                N_("Exported notes from the book:\n%1",
-                   "Exported notes from the book:\n%1\nand %2 others.",
-                   all_count-1),
-                export_title,
-                all_count-1
-            )
-        end
+        msg = T(
+            N_("Exported notes from the book:\n%1",
+                "Exported notes from the book:\n%1\nand %2 others.",
+                all_count-1),
+            export_title,
+            all_count-1
+        )
     elseif error_count > 0 then
-        if all_count == 1 then
-            msg = T(
-                N_("An error occurred while trying to export notes from the book:\n%1",
-                   "Multiple errors occurred while trying to export notes from the book:\n%1\nand %2 others.",
-                   error_count-1),
-                error_title,
-                error_count-1
-            )
-        end
+        msg = T(
+            N_("An error occurred while trying to export notes from the book:\n%1",
+                "Multiple errors occurred while trying to export notes from the book:\n%1\nand %2 others.",
+                error_count-1),
+            error_title,
+            error_count-1
+        )
     end
     if (self.html_export or self.txt_export) and export_count > 0 then
         msg = msg .. T(_("\nNotes can be found in %1/."), BD.dirpath(realpath(self.clipping_dir)))

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -578,7 +578,7 @@ function EvernoteExporter:exportClippings(clippings)
         msg = T(
             N_("Exported notes from the book:\n%1",
                "Exported notes from the book:\n%1\nand %2 others.",
-                all_count-1),
+               all_count-1),
             export_title,
             all_count-1
         )
@@ -586,7 +586,7 @@ function EvernoteExporter:exportClippings(clippings)
         msg = T(
             N_("An error occurred while trying to export notes from the book:\n%1",
                "Multiple errors occurred while trying to export notes from the book:\n%1\nand %2 others.",
-                error_count-1),
+               error_count-1),
             error_title,
             error_count-1
         )

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -577,7 +577,7 @@ function EvernoteExporter:exportClippings(clippings)
     if export_count > 0 and error_count == 0 then
         msg = T(
             N_("Exported notes from the book:\n%1",
-                "Exported notes from the book:\n%1\nand %2 others.",
+               "Exported notes from the book:\n%1\nand %2 others.",
                 all_count-1),
             export_title,
             all_count-1
@@ -585,7 +585,7 @@ function EvernoteExporter:exportClippings(clippings)
     elseif error_count > 0 then
         msg = T(
             N_("An error occurred while trying to export notes from the book:\n%1",
-                "Multiple errors occurred while trying to export notes from the book:\n%1\nand %2 others.",
+               "Multiple errors occurred while trying to export notes from the book:\n%1\nand %2 others.",
                 error_count-1),
             error_title,
             error_count-1


### PR DESCRIPTION
When multiple bookmarks exported Koreader shows following message/error:
![nothingwasexportedbug](https://user-images.githubusercontent.com/24368325/72319565-8c0c9400-36b0-11ea-94e2-f28594c5fde0.png)

This PR removes `all_count == 1` check (holds `false` with multiple books). 

I guess it was added to decide which message to display but string template already does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5765)
<!-- Reviewable:end -->
