### PR TITLE
cre: add toggable crengine call cache

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -440,6 +440,27 @@ function FileManagerMenu:setUpdateItemTable()
             }
         }
     })
+    table.insert(self.menu_items.developer_options.sub_item_table, {
+        text_func = function()
+            if G_reader_settings:isTrue("use_cre_call_cache")
+                    and G_reader_settings:isTrue("use_cre_call_cache_log_stats") then
+                return _("Enable CRE call cache (with stats)")
+            end
+            return _("Enable CRE call cache")
+        end,
+        checked_func = function()
+            return G_reader_settings:isTrue("use_cre_call_cache")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("use_cre_call_cache")
+            -- No need to show "This will take effect on next CRE book opening."
+            -- as this menu is only accessible from file browser
+        end,
+        hold_callback = function(touchmenu_instance)
+            G_reader_settings:flipNilOrFalse("use_cre_call_cache_log_stats")
+            touchmenu_instance:updateItems()
+        end,
+    })
 
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -88,6 +88,10 @@ function OPDSBrowser:init()
              title = "textos.info (Spanish)",
              url = "https://www.textos.info/catalogo.atom",
           },
+          {
+             title = "Gallica (French)",
+             url = "https://gallica.bnf.fr/opds",
+          },
         }
         G_reader_settings:saveSetting("opds_servers", servers)
     elseif servers[4] and servers[4].title == "Internet Archive" and servers[4].url == "http://bookserver.archive.org/catalog/"  then
@@ -455,7 +459,17 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url, username, passwo
         local author = "Unknown Author"
         if type(entry.author) == "table" and entry.author.name then
             author = entry.author.name
-            item.text = title .. "\n" .. author
+            if type(author) == "table" then
+                if #author > 0 then
+                    author = table.concat(author, ", ")
+                else
+                    -- we may get an empty table on https://gallica.bnf.fr/opds
+                    author = nil
+                end
+            end
+            if author then
+                item.text = title .. "\n" .. author
+            end
         end
         item.title = title
         item.author = author


### PR DESCRIPTION
Optimise usage of some of CreDocument methods by caching their results, either globally, or per page/pos for those whose result may depend on current page number or y-pos.
This helps a lot on cre books with a lot of highlights. More info in https://github.com/koreader/koreader/issues/5766#issuecomment-574410890.

Currently off by default, can be enabled via File browser > Developer options. Please do so to help testing it. We'll see how it does before enabling it by default.

Also adds OPDS for https://gallica.bnf.fr (not super interesting, but I was testing it, found some possible bug in their output, and added some "fix" to workaround it, so, might as well add it to the list to justify the fix :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5773)
<!-- Reviewable:end -->
