### PR TITLE
[fix, plugin] Evernote exporter only writes one documents clippings when txt export used, rest is ignored

### DIFF
--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -485,14 +485,16 @@ Parses highlights and calls exporter functions.
 Entry point for exporting highlights. User interface calls this function.
 Parses current document and documents from history, passes them to exportClippings().
 Highlight: Highlighted text or image in document, stored in "highlights" table in
-documents sidecar file. Parser uses this table.
-Bookmarks: Text in bookmark explorer, user can edit this fields. If user didn't
-edit highlight or "renamed" bookmark this is not created. Stored in "bookmarks" table
-in documents sidecar file. Parser looks to this file for edited notes.
+documents sidecar file. Parser uses this table. If highlight._._.text field is empty parser uses
+highlight._._.pboxes field to get an image instead.
+Bookmarks: Data in bookmark explorer. Stored in "bookmarks" table of documents sidecar file. Every
+field in bookmarks._ has "text" and "notes" fields When user edits a highlight or "renames" bookmark,
+text field is created or updated. Parser looks to bookmarks._.text field for edited notes. bookmarks._.notes isn't used for exporting operations.
+https://github.com/koreader/koreader/blob/605f6026bbf37856ee54741b8a0697337ca50039/plugins/evernote.koplugin/clip.lua#L229
 Clippings: Parsed form of highlights, stored in clipboard/evernote.sdr/metadata.sdr.lua
-for all documents. Used only for exporting bookmarks. Internal functions does not use
-this table.
-Booknotes: Every table in clippings table. Clippings = {"title" = booknotes}
+for all documents. Used only for exporting bookmarks. Internal highlight or bookmark functions
+does not usew this table.
+Booknotes: Every table in clippings table. clippings = {"title" = booknotes}
 --]]
 function EvernoteExporter:exportAllNotes()
     -- Flush highlights of current document.

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -488,11 +488,11 @@ Highlight: Highlighted text or image in document, stored in "highlights" table i
 documents sidecar file. Parser uses this table.
 Bookmarks: Text in bookmark explorer, user can edit this fields. If user didn't
 edit highlight or "renamed" bookmark this is not created. Stored in "bookmarks" table
-in documents sidecar file. Parser looks to this file for edited parts.
+in documents sidecar file. Parser looks to this file for edited notes.
 Clippings: Parsed form of highlights, stored in clipboard/evernote.sdr/metadata.sdr.lua
-for all documents.Used only for exporting bookmarks. Internal functions does not use
+for all documents. Used only for exporting bookmarks. Internal functions does not use
 this table.
-Booknotes: Every table in clippings table. Clippings = {"key" = booknotes}
+Booknotes: Every table in clippings table. Clippings = {"title" = booknotes}
 --]]
 function EvernoteExporter:exportAllNotes()
     -- Flush highlights of current document.

--- a/spec/unit/evernote_plugin_main_spec.lua
+++ b/spec/unit/evernote_plugin_main_spec.lua
@@ -86,7 +86,7 @@ describe("Evernote plugin module", function()
         readerui.evernote:exportBooknotesToTXT("Title1", sample_clippings.Title1)
         assert.spy(io.open).was.called()
         assert.spy(file_mock.write).was.called_with(match.is_ref(file_mock), "Some important stuff 1")
-       _G.io = old_io
+        _G.io = old_io
 
     end)
 

--- a/spec/unit/evernote_plugin_main_spec.lua
+++ b/spec/unit/evernote_plugin_main_spec.lua
@@ -1,8 +1,11 @@
 describe("Evernote plugin module", function()
-    local readerui
+    local readerui, match
+    local sample_clippings, sample_epub
+    local DocumentRegistry
     setup(function()
         require("commonrequire")
-        ReaderUI = require("apps/reader/readerui")
+        match = require("luassert.match")
+        local ReaderUI = require("apps/reader/readerui")
         DocumentRegistry = require("document/documentregistry")
         sample_epub = "spec/front/unit/data/juliet.epub"
         readerui = ReaderUI:new{

--- a/spec/unit/evernote_plugin_main_spec.lua
+++ b/spec/unit/evernote_plugin_main_spec.lua
@@ -1,0 +1,99 @@
+describe("Evernote plugin module", function()
+    local readerui
+    setup(function()
+        require("commonrequire")
+        ReaderUI = require("apps/reader/readerui")
+        DocumentRegistry = require("document/documentregistry")
+        sample_epub = "spec/front/unit/data/juliet.epub"
+        readerui = ReaderUI:new{
+                document = DocumentRegistry:openDocument(sample_epub),
+            }
+
+        sample_clippings = {
+            ["Title1"] = {
+                [1] = {
+                    [1] = {
+                        ["page"] = 6,
+                        ["time"] = 1578946897,
+                        ["sort"] = "highlight",
+                        ["text"] = "Some important stuff 1"
+                    }
+                },
+                [2] = {
+                    [1] = {
+                        ["page"] = 13,
+                        ["time"] = 1578946903,
+                        ["sort"] = "highlight",
+                        ["text"] = "Some important stuff 2"
+                    }
+                },
+                ["file"] = "path/to/title1",
+                ["exported"] = {
+                    ["txt"] = true,
+                    ["html"] = true,
+                },
+                ["title"] = "Title1"
+            },
+            ["Title2"] = {
+                [1] = {
+                    [1] = {
+                        ["page"] = 233,
+                        ["time"] = 1578946918,
+                        ["sort"] = "highlight",
+                        ["text"] = "Some important stuff 3"
+                    }
+                },
+                [2] = {
+                    [1] = {
+                        ["page"] = 237,
+                        ["time"] = 1578947501,
+                        ["sort"] = "highlight",
+                        ["text"] = "",
+                        ["image"] = {
+                            ["hash"] = "cb7b40a63afc89f0aa452f2b655877e6",
+                            ["png"] = "Binary Encoding of image"
+                        },
+                    }
+                },
+                ["file"] = "path/to/title2",
+                ["exported"] = {
+                },
+                ["title"] = "Title2"
+            },
+    }
+
+    end)
+
+    it("should write clippings to txt file", function ()
+        local file_mock = mock( {
+            write = function() return end,
+            close = function() return end
+        })
+        local old_io = _G.io
+        _G.io = mock({
+           open = function(file, mode)
+            if file == readerui.evernote.text_clipping_file then
+                return file_mock
+            else
+                return old_io.open(file, mode)
+            end
+        end
+        })
+
+        readerui.evernote:exportBooknotesToTXT("Title1", sample_clippings.Title1)
+        assert.spy(io.open).was.called()
+        assert.spy(file_mock.write).was.called_with(match.is_ref(file_mock), "Some important stuff 1")
+       _G.io = old_io
+
+    end)
+
+    it("should not export booknotes with exported_stamp", function()
+        readerui.evernote.html_export = true
+        stub(readerui.evernote, "exportBooknotesToHTML")
+        readerui.evernote:exportClippings(sample_clippings)
+        assert.stub(readerui.evernote.exportBooknotesToHTML).was_called_with(match.is_truthy(), "Title2", match.is_truthy())
+        assert.stub(readerui.evernote.exportBooknotesToHTML).was_not_called_with(match.is_truthy(), "Title1", match.is_truthy())
+    end)
+
+
+end)


### PR DESCRIPTION
When using txt export with multiple books koreader produces an output like this: [bugged_exports.txt](https://github.com/koreader/koreader/files/4073633/bugged_exports.txt) Only first entry has clippings. fixes https://github.com/koreader/koreader/issues/3690

On every `booknotes` `:exportToTXT()` compares `booknotes.time` with file modification time. After first run this modification time is updated to current time, then comparison returns false. 
I think idea behind it was a .txt file for every book without using flag like `exported_stamp`. Or an artifact from here: https://github.com/koreader/koreader/blob/b111ccc2b803fc78425d9791fcc8bb7a9a704e6e/frontend/apps/reader/modules/readerhighlight.lua#L1134-L1136

Solution
I think best solution here is rewriting .txt file everytime. To append on existing file we must locate previous entry from book, find end of it and delete it; overly complicated process for little reason. In other export schemes flag method works because every book has its own output file.

In my plan, we delete KOReaderClippings.txt file at every export, and append to it book by book overriding `exported_stamp`.

Also I wrote a small explanation at `:exportAllNotes()` about how this highlight thing works and a unit test if I got it right.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5774)
<!-- Reviewable:end -->
