### PR TITLE
Make Inverted Portrait a first-class citizen

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -55,7 +55,6 @@ local function restoreScreenMode()
     --         See also ReaderView:onSetScreenMode in apps/reader/modules/readerview.lua for a similar logic,
     --         if we ever need to add Landscape to the mix.
     --         c.f., https://github.com/koreader/koreader/issues/5772#issuecomment-577242365
-    print("FM:restoreScreenMode from", Screen:getScreenMode(), "to", screen_mode, "rota:", Screen:getRotationMode())
     if Screen:getScreenMode() ~= screen_mode then
         Screen:setScreenMode(screen_mode)
     end

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -49,10 +49,12 @@ local T = require("ffi/util").template
 local function restoreScreenMode()
     --- @todo: Not Yet Implemented. Layout is currently broken in Landscape.
     local screen_mode = G_reader_settings:readSetting("fm_screen_mode") or "portrait"
-    --- @note: Basically, if we were in Inverted Portrait, don't mess with it, as the FM supports it.
-    --       See setScreenMode in base/ffi/framebuffer.lua for the gory details.
-    --       See also ReaderView:onSetScreenMode in apps/reader/modules/readerview.lua for a similar logic.
-    --       c.f., https://github.com/koreader/koreader/issues/5772#issuecomment-577242365
+    --- @note: Basically, if we were already in Portrait/Inverted Portrait, don't mess with it,
+    --         as the FM supports it.
+    --         See setScreenMode in base's ffi/framebuffer.lua for the gory details.
+    --         See also ReaderView:onSetScreenMode in apps/reader/modules/readerview.lua for a similar logic,
+    --         if we ever need to add Landscape to the mix.
+    --         c.f., https://github.com/koreader/koreader/issues/5772#issuecomment-577242365
     print("FM:restoreScreenMode from", Screen:getScreenMode(), "to", screen_mode, "rota:", Screen:getRotationMode())
     if Screen:getScreenMode() ~= screen_mode then
         Screen:setScreenMode(screen_mode)

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -47,8 +47,14 @@ local Screen = Device.screen
 local T = require("ffi/util").template
 
 local function restoreScreenMode()
+    --- @todo: Not Yet Implemented. Layout is currently broken in Landscape.
     local screen_mode = G_reader_settings:readSetting("fm_screen_mode")
+    --- @note: Basically, if we were in Inverted <Orientation>, switch to Inverted Portrat, as the FM supports it.
+    --       See setScreenMode in base/ffi/framebuffer.lua for the gory details.
+    --       See also ReaderView:onSetScreenMode in apps/reader/modules/readerview.lua for a similar logic.
     if Screen:getScreenMode() ~= screen_mode then
+        --- @note: By virtue of the NYI above, this branch is always taken (as screen_mode will always be nil).
+	--         Logic might need to be reworked if/when the FM supports Landscape layouts.
         Screen:setScreenMode(screen_mode or "portrait")
     end
 end

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -53,6 +53,7 @@ local function restoreScreenMode()
     --       See setScreenMode in base/ffi/framebuffer.lua for the gory details.
     --       See also ReaderView:onSetScreenMode in apps/reader/modules/readerview.lua for a similar logic.
     --       c.f., https://github.com/koreader/koreader/issues/5772#issuecomment-577242365
+    print("FM:restoreScreenMode from", Screen:getScreenMode(), "to", screen_mode, "rota:", Screen:getRotationMode())
     if Screen:getScreenMode() ~= screen_mode then
         Screen:setScreenMode(screen_mode)
     end

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -48,14 +48,13 @@ local T = require("ffi/util").template
 
 local function restoreScreenMode()
     --- @todo: Not Yet Implemented. Layout is currently broken in Landscape.
-    local screen_mode = G_reader_settings:readSetting("fm_screen_mode")
-    --- @note: Basically, if we were in Inverted <Orientation>, switch to Inverted Portrat, as the FM supports it.
+    local screen_mode = G_reader_settings:readSetting("fm_screen_mode") or "portrait"
+    --- @note: Basically, if we were in Inverted Portrait, don't mess with it, as the FM supports it.
     --       See setScreenMode in base/ffi/framebuffer.lua for the gory details.
     --       See also ReaderView:onSetScreenMode in apps/reader/modules/readerview.lua for a similar logic.
+    --       c.f., https://github.com/koreader/koreader/issues/5772#issuecomment-577242365
     if Screen:getScreenMode() ~= screen_mode then
-        --- @note: By virtue of the NYI above, this branch is always taken (as screen_mode will always be nil).
-	--         Logic might need to be reworked if/when the FM supports Landscape layouts.
-        Screen:setScreenMode(screen_mode or "portrait")
+        Screen:setScreenMode(screen_mode)
     end
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -854,6 +854,7 @@ end
 function ReaderRolling:onChangeScreenMode(mode, rotation)
     -- Flag it as interactive so we can properly swap to Inverted orientations
     -- (we usurp the second argument, which usually means rotation)
+    print("ReaderRolling:onChangeScreenMode", mode, rotation)
     self.ui:handleEvent(Event:new("SetScreenMode", mode, rotation or true))
     -- (This had the above ReaderRolling:onSetDimensions() called to resize
     -- document dimensions and keep up with current position)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -854,7 +854,6 @@ end
 function ReaderRolling:onChangeScreenMode(mode, rotation)
     -- Flag it as interactive so we can properly swap to Inverted orientations
     -- (we usurp the second argument, which usually means rotation)
-    print("ReaderRolling:onChangeScreenMode", mode, rotation)
     self.ui:handleEvent(Event:new("SetScreenMode", mode, rotation or true))
     -- (This had the above ReaderRolling:onSetDimensions() called to resize
     -- document dimensions and keep up with current position)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -674,6 +674,7 @@ end
 --       This is also used as a sink for gsensor input events, because we can only send a single event per input,
 --       and we need to cover both CRe & KOpt...
 function ReaderView:onSwapScreenMode(new_mode, rotation)
+    print("ReaderView:onSwapScreenMode", new_mode, rotation)
     -- Don't do anything if an explicit rotation was requested, but it hasn't actually changed,
     -- because we may be sending this event *right before* a ChangeScreenMode in CRe (gyro)
     if rotation ~= nil and rotation ~= true and rotation == Screen:getRotationMode() then
@@ -686,6 +687,7 @@ function ReaderView:onSwapScreenMode(new_mode, rotation)
 end
 
 function ReaderView:onSetScreenMode(new_mode, rotation, noskip)
+    print("ReaderView:onSetScreenMode", new_mode, rotation, noskip)
     -- Don't do anything if an explicit rotation was requested, but it hasn't actually changed,
     -- because we may be sending this event *right after* a ChangeScreenMode in CRe (gsensor)
     -- We only want to let the onReadSettings one go through, otherwise the testsuite blows up...
@@ -693,7 +695,7 @@ function ReaderView:onSetScreenMode(new_mode, rotation, noskip)
         return true
     end
     if new_mode == "landscape" or new_mode == "portrait" then
-        self.screen_mode = new_mode
+        --self.screen_mode = new_mode
         -- NOTE: Hacky hack! If rotation is "true", that's actually an "interactive" flag for setScreenMode
         --- @fixme That's because we can't store nils in a table, which is what Event:new attempts to do ;).
         --        c.f., <https://stackoverflow.com/q/7183998/> & <http://lua-users.org/wiki/VarargTheSecondClassCitizen>
@@ -710,7 +712,8 @@ function ReaderView:onSetScreenMode(new_mode, rotation, noskip)
         self.ui:onScreenResize(new_screen_size)
         self.ui:handleEvent(Event:new("InitScrollPageStates"))
     end
-    self.cur_rotation_mode = Screen:getRotationMode()
+    --self.cur_rotation_mode = Screen:getRotationMode()
+    --print("Updated self.cur_rotation_mode to", self.cur_rotation_mode)
     return true
 end
 
@@ -758,7 +761,7 @@ function ReaderView:onReadSettings(config)
         screen_mode = config:readSetting("screen_mode") or G_reader_settings:readSetting("copt_screen_mode") or "portrait"
     end
     if screen_mode then
-        Screen:setScreenMode(screen_mode)
+        --Screen:setScreenMode(screen_mode)
         self:onSetScreenMode(screen_mode, config:readSetting("rotation_mode"), true)
     end
     self.state.gamma = config:readSetting("gamma") or 1.0
@@ -846,8 +849,8 @@ end
 
 function ReaderView:onSaveSettings()
     self.ui.doc_settings:saveSetting("render_mode", self.render_mode)
-    self.ui.doc_settings:saveSetting("screen_mode", self.screen_mode)
-    self.ui.doc_settings:saveSetting("rotation_mode", self.cur_rotation_mode)
+    self.ui.doc_settings:saveSetting("screen_mode", Screen:getScreenMode())
+    self.ui.doc_settings:saveSetting("rotation_mode", Screen:getRotationMode())
     self.ui.doc_settings:saveSetting("gamma", self.state.gamma)
     self.ui.doc_settings:saveSetting("highlight", self.highlight.saved)
     self.ui.doc_settings:saveSetting("page_overlap_style", self.page_overlap_style)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -674,7 +674,6 @@ end
 --       This is also used as a sink for gsensor input events, because we can only send a single event per input,
 --       and we need to cover both CRe & KOpt...
 function ReaderView:onSwapScreenMode(new_mode, rotation)
-    print("ReaderView:onSwapScreenMode", new_mode, rotation)
     -- Don't do anything if an explicit rotation was requested, but it hasn't actually changed,
     -- because we may be sending this event *right before* a ChangeScreenMode in CRe (gyro)
     if rotation ~= nil and rotation ~= true and rotation == Screen:getRotationMode() then
@@ -687,7 +686,6 @@ function ReaderView:onSwapScreenMode(new_mode, rotation)
 end
 
 function ReaderView:onSetScreenMode(new_mode, rotation, noskip)
-    print("ReaderView:onSetScreenMode", new_mode, rotation, noskip)
     -- Don't do anything if an explicit rotation was requested, but it hasn't actually changed,
     -- because we may be sending this event *right after* a ChangeScreenMode in CRe (gsensor)
     -- We only want to let the onReadSettings one go through, otherwise the testsuite blows up...
@@ -695,7 +693,6 @@ function ReaderView:onSetScreenMode(new_mode, rotation, noskip)
         return true
     end
     if new_mode == "landscape" or new_mode == "portrait" then
-        --self.screen_mode = new_mode
         -- NOTE: Hacky hack! If rotation is "true", that's actually an "interactive" flag for setScreenMode
         --- @fixme That's because we can't store nils in a table, which is what Event:new attempts to do ;).
         --        c.f., <https://stackoverflow.com/q/7183998/> & <http://lua-users.org/wiki/VarargTheSecondClassCitizen>
@@ -712,8 +709,6 @@ function ReaderView:onSetScreenMode(new_mode, rotation, noskip)
         self.ui:onScreenResize(new_screen_size)
         self.ui:handleEvent(Event:new("InitScrollPageStates"))
     end
-    --self.cur_rotation_mode = Screen:getRotationMode()
-    --print("Updated self.cur_rotation_mode to", self.cur_rotation_mode)
     return true
 end
 
@@ -761,7 +756,6 @@ function ReaderView:onReadSettings(config)
         screen_mode = config:readSetting("screen_mode") or G_reader_settings:readSetting("copt_screen_mode") or "portrait"
     end
     if screen_mode then
-        --Screen:setScreenMode(screen_mode)
         self:onSetScreenMode(screen_mode, config:readSetting("rotation_mode"), true)
     end
     self.state.gamma = config:readSetting("gamma") or 1.0

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -205,7 +205,7 @@ function Device:onPowerEvent(ev)
                     network_manager:scheduleConnectivityCheck()
                 end
                 self:resume()
-                -- restore to previous rotation mode, if need be.
+                -- Restore to previous rotation mode, if need be.
                 if self.orig_rotation_mode then
                     self.screen:setRotationMode(self.orig_rotation_mode)
                 end
@@ -228,11 +228,17 @@ function Device:onPowerEvent(ev)
         self.powerd:beforeSuspend()
         local UIManager = require("ui/uimanager")
         logger.dbg("Suspending...")
-        -- Mostly always suspend in portrait mode...
-        -- ... except when we just show an InfoMessage, it plays badly with landscape mode (c.f., #4098)
+        -- Mostly always suspend in Portrait/Inverted Portrait mode...
+        -- ... except when we just show an InfoMessage, it plays badly with Landscape mode (c.f., #4098)
         if G_reader_settings:readSetting("screensaver_type") ~= "message" then
             self.orig_rotation_mode = self.screen:getRotationMode()
-            self.screen:setRotationMode(0)
+            -- Leave Portrait & Inverted Portrait alone, that works just fine.
+            if bit.band(self.orig_rotation_mode, 1) == 1 then
+                -- i.e., only switch to Portrait if we're currently in *any* Landscape orientation (odd number)
+                self.screen:setRotationMode(0)
+            else
+                self.orig_rotation_mode = nil
+            end
 
             -- On eInk, if we're using a screensaver mode that shows an image,
             -- flash the screen to white first, to eliminate ghosting.


### PR DESCRIPTION
Mainly by ensuring we actually *always* remember it properly in a book sidecar, and that we support it in ScreenSaver mode, as well as in the FM.

This basically makes the whole "lefty" workflow consistent, without any spurious rotations back to Portrait.

Landscape is another kettle of fish, because the FM doesn't support it (and neither do image ScreenSaver modes).

Fix #5772

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5783)
<!-- Reviewable:end -->
