### PR TITLE
Show or hide hidden folders in folder shortcut chooser

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -67,6 +67,7 @@ function FileManagerShortcuts:addNewFolder()
         select_directory = true,
         select_file = false,
         path = self.fm_bookmark.curr_path,
+        show_hidden = self.ui.file_chooser.show_hidden,
         onConfirm = function(path)
             local add_folder_input
             local friendly_name = util.basename(path) or _("my folder")


### PR DESCRIPTION
Close: #5759 
Chooser in folder shortcut should show or hide hidden dirs based on current settings in FM (`show hidden files`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5785)
<!-- Reviewable:end -->
