### PR TITLE
Render metadata text with book language

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -210,10 +210,18 @@ function BookInfo:show(file, book_props)
     end
     table.insert(kv_pairs, { _("Cover image:"), _("Tap to display"), callback=viewCoverImage })
 
+    -- Get a chance to have title, authors... rendered with alternate
+    -- glyphs for the book language (e.g. japanese book in chinese UI)
+    local values_lang = nil
+    if book_props.language and book_props.language ~= "" then
+        values_lang = book_props.language
+    end
+
     local widget = KeyValuePage:new{
         title = _("Book information"),
         value_overflow_align = "right",
         kv_pairs = kv_pairs,
+        values_lang = values_lang,
     }
     UIManager:show(widget)
 end

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -397,6 +397,12 @@ function ReaderBookmark:removeHighlight(item)
         self.ui:handleEvent(Event:new("Unhighlight", item))
     else
         self:removeBookmark(item)
+        -- Update dogear in case we removed a bookmark for current page
+        if self.ui.document.info.has_pages then
+            self:setDogearVisibility(self.view.state.page)
+        else
+            self:setDogearVisibility(self.ui.document:getXPointer())
+        end
     end
 end
 

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -293,12 +293,20 @@ function BookStatusWidget:genBookInfoGroup()
 
     local height = img_height
     local width = screen_width - split_span_width - img_width
+
+    -- Get a chance to have title and authors rendered with alternate
+    -- glyphs for the book language
+    local lang = nil
+    if self.props.language and self.props.language ~= "" then
+        lang = self.props.language
+    end
     -- title
     local book_meta_info_group = VerticalGroup:new{
         align = "center",
         VerticalSpan:new{ width = height * 0.2 },
         TextBoxWidget:new{
             text = self.props.title,
+            lang = lang,
             width = width,
             face = self.medium_font_face,
             alignment = "center",
@@ -308,6 +316,7 @@ function BookStatusWidget:genBookInfoGroup()
     -- author
     local text_author = TextBoxWidget:new{
         text = self.props.authors,
+        lang = lang,
         face = self.small_font_face,
         width = width,
         alignment = "center",

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -81,6 +81,11 @@ a   { color: black; }           /* MuPDF: color: #06C; */
  * Wikipedia EPUBs, each footnote is a LI */
 body > li { list-style-type: none; }
 
+/* MuPDF always aligns the last line to the left when text-align: justify,
+ * which is wrong with RTL. So cancel justification on RTL elements: they
+ * will be correctly aligned to the right */
+*[dir=rtl] { text-align: initial; }
+
 /* Remove any (possibly multiple) backlinks in Wikipedia EPUBs footnotes */
 .noprint { display: none; }
 ]]

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -116,6 +116,7 @@ end
 local KeyValueItem = InputContainer:new{
     key = nil,
     value = nil,
+    value_lang = nil,
     cface = Font:getFace("smallinfofont"),
     tface = Font:getFace("smallinfofontbold"),
     width = nil,
@@ -162,6 +163,7 @@ function KeyValueItem:init()
         text = tvalue,
         max_width = available_width,
         face = self.cface,
+        lang = self.value_lang,
     }
     local key_w_rendered = key_widget:getWidth()
     local value_w_rendered = value_widget:getWidth()
@@ -288,6 +290,7 @@ function KeyValueItem:onHold()
     local textviewer = TextViewer:new{
         title = self.key,
         text = self.value,
+        lang = self.value_lang,
         width = self.textviewer_width,
         height = self.textviewer_height,
     }
@@ -300,6 +303,7 @@ local KeyValuePage = InputContainer:new{
     title = "",
     width = nil,
     height = nil,
+    values_lang = nil,
     -- index for the first item to show
     show_page = 1,
     use_top_page_count = false,
@@ -514,6 +518,7 @@ function KeyValuePage:_populateItems()
                     width = self.item_width,
                     key = entry[1],
                     value = entry[2],
+                    value_lang = self.values_lang,
                     callback = entry.callback,
                     callback_back = entry.callback_back,
                     textviewer_width = self.textviewer_width,

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -556,8 +556,11 @@ function ListMenuItem:update()
                 end
                 -- BookInfoManager:extractBookInfo() made sure
                 -- to save as nil (NULL) metadata that were an empty string
+                -- We provide the book language to get a chance to render title
+                -- and authors with alternate glyphs for that language.
                 wtitle = TextBoxWidget:new{
                     text = title,
+                    lang = bookinfo.language,
                     face = Font:getFace(fontname_title, fontsize_title),
                     width = wmain_width,
                     alignment = "left",
@@ -568,6 +571,7 @@ function ListMenuItem:update()
                 if authors then
                     wauthors = TextBoxWidget:new{
                         text = authors,
+                        lang = bookinfo.language,
                         face = Font:getFace(fontname_authors, fontsize_authors),
                         width = wmain_width,
                         alignment = "left",

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -108,6 +108,7 @@ local FakeCover = FrameContainer:new{
     filename_add = nil,
     title_add = nil,
     authors_add = nil,
+    book_lang = nil,
     -- these font sizes will be scaleBySize'd by Font:getFace()
     authors_font_max = 20,
     authors_font_min = 6,
@@ -225,6 +226,7 @@ function FakeCover:init()
         if authors then
             authors_wg = TextBoxWidget:new{
                 text = authors,
+                lang = self.book_lang,
                 face = Font:getFace("cfont", math.max(self.authors_font_max - sizedec, self.authors_font_min)),
                 width = text_width,
                 alignment = "center",
@@ -234,6 +236,7 @@ function FakeCover:init()
         if title then
             title_wg = TextBoxWidget:new{
                 text = title,
+                lang = self.book_lang,
                 face = Font:getFace("cfont", math.max(self.title_font_max - sizedec, self.title_font_min)),
                 width = text_width,
                 alignment = "center",
@@ -243,6 +246,7 @@ function FakeCover:init()
         if filename then
             filename_wg = TextBoxWidget:new{
                 text = filename,
+                lang = self.book_lang, -- might as well use it for filename
                 face = Font:getFace("cfont", math.max(self.filename_font_max - sizedec, self.filename_font_min)),
                 width = text_width,
                 alignment = "center",
@@ -625,6 +629,7 @@ function MosaicMenuItem:update()
                         authors = not bookinfo.ignore_meta and bookinfo.authors,
                         title_add = not bookinfo.ignore_meta and title_add,
                         authors_add = not bookinfo.ignore_meta and authors_add,
+                        book_lang = not bookinfo.ignore_meta and bookinfo.language,
                         file_deleted = self.file_deleted,
                     }
                 }


### PR DESCRIPTION
Gives the book language to Text*Widget (and XText) when drawing title, authors and other metadata text (mentionned at https://github.com/koreader/koreader/pull/5696#issuecomment-570739039).
Might be needed to properly display a Japanese book title when the UI language is Chinese when the glyphs are different.
The following 2 books have the same UTF8 text in their metadata title and authors, but a different language - our CJK font would default to the chinese glyphs (but it does contain the japanese glyphs, and Harfbuzz will use them when we tell it to):
<kbd>![image](https://user-images.githubusercontent.com/24273478/73005438-42871c00-3e09-11ea-95a4-3acb1cc87291.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/73005533-664a6200-3e09-11ea-9825-2f2f1f718000.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/73005600-82e69a00-3e09-11ea-8881-f8ae4dc7a5fc.png)</kbd>

Also:
- [Fix] Update dogear when back from bookmarks list - Issue described at https://github.com/koreader/koreader/issues/5777#issuecomment-575703642.
- Footnote popups: drop justification if RTL content
MuPDF (even latest version, looking at the code) does not handle "text-align: justify" correctly on
RTL text: the last line is left-aligned, but it should be right-aligned. Not using justify makes it correctly right align the whole text.
We still need to tweak our MuPDF patch to have it use FreeSerif instead of FreeSans to be able to display arabic or hebrew in our footnote popups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5786)
<!-- Reviewable:end -->
