### PR TITLE
Extend minimal progress bar width to 5%

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1335,7 +1335,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     local items = SpinWidget:new{
                         width = Screen:getWidth() * 0.6,
                         value = self.settings.progress_bar_min_width_pct,
-                        value_min = 20,
+                        value_min = 5,
                         value_step = 5,
                         value_hold_step = 20,
                         value_max = 50,


### PR DESCRIPTION
Close: #5778 
Minimal progress bar in footer can be now from 5% to 50%. Before 20%-50%.
Settings: `Status bar -> progress bar -> Minimal width`
Regression from #5757

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5788)
<!-- Reviewable:end -->
