### PR TITLE
Reader: strict ordering of tap & hold gestures

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -484,15 +484,17 @@ function ReaderFooter:setupTouchZones()
                 "tap_backward",
                 "readerconfigmenu_tap",
             },
+            -- (Low priority: tap on existing highlights
+            -- or links have priority)
         },
         {
             id = "readerfooter_hold",
             ges = "hold",
             screen_zone = footer_screen_zone,
             handler = function() return self:onHoldFooter() end,
-            overrides = {
-                "readerhighlight_hold",
-            },
+            -- (Low priority: word lookup and text selection
+            -- have priority - SkimTo widget can be more easily
+            -- brought up via some other gestures)
         },
     })
 end

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -1005,6 +1005,10 @@ function ReaderGesture:setupGesture(ges, action)
             "readerfooter_tap",
         }
         overrides_hold_corner = {
+            -- As hold corners are "ignored" by default, and we have
+            -- a "Ignore hold on corners" menu item and gesture, let
+            -- them have priority over word lookup and text selection.
+            "readerhighlight_hold",
             "readerfooter_hold",
         }
         overrides_vertical_edge = {

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -38,10 +38,18 @@ function ReaderHighlight:setupTouchZones()
                 ratio_x = 0, ratio_y = 0, ratio_w = 1, ratio_h = 1,
             },
             overrides = {
+                -- Tap on existing highlights have priority over
+                -- everything but tap on links (as links can be
+                -- part of some highlighted text)
                 "tap_forward",
                 "tap_backward",
                 "readermenu_tap",
                 "readerconfigmenu_tap",
+                "readerfooter_tap",
+                "tap_top_left_corner",
+                "tap_top_right_corner",
+                "tap_left_bottom_corner",
+                "tap_right_bottom_corner",
             },
             handler = function(ges) return self:onTap(nil, ges) end
         },
@@ -50,6 +58,9 @@ function ReaderHighlight:setupTouchZones()
             ges = "hold",
             screen_zone = {
                 ratio_x = 0, ratio_y = 0, ratio_w = 1, ratio_h = 1,
+            },
+            overrides = {
+                "readerfooter_hold",
             },
             handler = function(ges) return self:onHold(nil, ges) end
         },
@@ -521,14 +532,14 @@ end
 
 function ReaderHighlight:onHold(arg, ges)
     -- disable hold gesture if highlighting is disabled
-    if self.view.highlight.disabled then return true end
+    if self.view.highlight.disabled then return false end
     self:clear() -- clear previous highlight (delayed clear may not have done it yet)
     self.hold_ges_pos = ges.pos -- remember hold original gesture position
     self.hold_pos = self.view:screenToPageTransform(ges.pos)
     logger.dbg("hold position in page", self.hold_pos)
     if not self.hold_pos then
         logger.dbg("not inside page area")
-        return true
+        return false
     end
 
     -- check if we were holding on an image
@@ -576,8 +587,9 @@ function ReaderHighlight:onHold(arg, ges)
             -- is handled in onHoldPan()
             self.selected_text_start_xpointer = word.pos0
         end
+        return true
     end
-    return true
+    return false
 end
 
 function ReaderHighlight:onHoldPan(_, ges)

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -34,8 +34,18 @@ function ReaderLink:init()
                     ratio_w = 1, ratio_h = 1,
                 },
                 overrides = {
+                    -- Tap on links have priority over everything (it can
+                    -- be disabled with "Tap to follow links" menu item)
                     "tap_forward",
                     "tap_backward",
+                    "readermenu_tap",
+                    "readerconfigmenu_tap",
+                    "readerhighlight_tap",
+                    "readerfooter_tap",
+                    "tap_top_left_corner",
+                    "tap_top_right_corner",
+                    "tap_left_bottom_corner",
+                    "tap_right_bottom_corner",
                 },
                 handler = function(ges) return self:onTap(_, ges) end,
             },

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -414,6 +414,11 @@ function ReaderUI:init()
         v()
     end
     self.postReaderCallback = nil
+
+    -- print("Ordered registered gestures:")
+    -- for _, tzone in ipairs(self._ordered_touch_zones) do
+    --     print("  "..tzone.def.id)
+    -- end
 end
 
 function ReaderUI:getLastDirFile()

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -152,15 +152,19 @@ function InputContainer:registerTouchZones(zones)
             },
         }
         self.touch_zone_dg:addNode(zone.id)
+        -- print("added "..zone.id)
         if zone.overrides then
             for _, override_zone_id in ipairs(zone.overrides) do
+                -- print("  override "..override_zone_id)
                 self.touch_zone_dg:addNodeDep(override_zone_id, zone.id)
             end
         end
     end
+    -- print("ordering:")
     self._ordered_touch_zones = {}
     for _, zone_id in ipairs(self.touch_zone_dg:serialize()) do
         table.insert(self._ordered_touch_zones, self._zones[zone_id])
+        -- print("  "..zone_id)
     end
 end
 


### PR DESCRIPTION
The lack of proper "overrides" could make their order/precedence/priority non-deterministic.
Issued described at https://github.com/koreader/koreader/pull/4878#issuecomment-577371343 - but this PR does not exactly set them as I proposed there :)

I had quite a hard time following the flow, having it not working at all with circular override, having to decide where to break it :) and hopefully, making it consistent.
So, not describing right now what's the ordering/priorities: I put in some comments, please have a look and see if the way you read it and understand it make sense :)

(I let in some `print()` because it's not the first time I had to use that - and so probably not the last time :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5789)
<!-- Reviewable:end -->
