### PR TITLE
fix arabic keyboard to conform to #5639

### DIFF
--- a/frontend/ui/data/keyboardlayouts/ar_AA_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ar_AA_keyboard.lua
@@ -97,9 +97,9 @@ return {
             {  arabic_comma,             waw,          "#",    "↑", },
             { ".",                       zay,          "@",    "↓", },
             { "؟",                       thaa,         "!",    _at, },
-            { label = "Backspace",
-              icon = "resources/icons/appbar.clear.reflect.horizontal.png",
-              width = 1.5
+            { label = "",
+              width = 1.5,
+              bold = false
             },
         },
         -- fourth row
@@ -116,9 +116,8 @@ return {
             { prd,    prd,          "”",    "→", },
             { label = "حركات", diacritics, diacritics,    diacritics,  diacritics,
               width = 1.5},
-            { label = "Enter",
+            { label = "⮠",
               "\n",       "\n",   "\n",   "\n",
-              icon = "resources/icons/appbar.arrow.enter.png",
               width = 1.5,
             },
         },


### PR DESCRIPTION
Fixes #5792

change Del/Backspace & Enter from icons to glyphs

this was done for all other keyboards between when #5569 was opened and merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5793)
<!-- Reviewable:end -->
