### PR TITLE
Add some basic info on using ffi-cdecl

### DIFF
--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -25,6 +25,19 @@ Otherwise, when there'd be signficiant gain in doing so (i.e., when displaying m
 
 The actual framebuffer content is then refreshed (i.e., displayed) via device-specific ioctls, making the best effort in using device-specific capabilities, whether that be [optimized waveform modes](https://github.com/koreader/koreader-base/blob/a1fc4e43b7cce7a76b13224e145f9bada343d8ea/ffi/framebuffer_mxcfb.lua#L643-L655), hardware dithering or [hardware inversion](https://github.com/koreader/koreader-base/blob/a1fc4e43b7cce7a76b13224e145f9bada343d8ea/ffi/framebuffer_mxcfb.lua#L253-L256).
 
+The platform-specific Lua FFI modules for using the mxcfb driver are generated from the [kernel header files](https://github.com/koreader/koreader-base/ffi-cdecl/include) using [ffi-cdecl](https://github.com/koreader/ffi-cdecl). `ffi-cdecl` operates on [C files](https://github.com/koreader/koreader-base/ffi-cdecl/) which specify what to export.
+
+To use `ffi-cdecl` first you need to build the gcc plugin for the platform toolchain, e.g.:
+```
+cd ffi-cdecl
+make clean
+PATH=$HOME/x-tools/arm-remarkable-linux-gnueabihf/bin/:$PATH make CHOST=arm-remarkable-linux-gnueabihf CROSS_DIR=$HOME/x-tools/arm-remarkable-linux-gnueabihf/
+```
+Then you can (re)generate the [ffi lua files](https://github.com/koreader/koreader-base/ffi), e.g.
+```
+PATH=$HOME/x-tools/arm-remarkable-linux-gnueabihf/bin/:$PATH ./ffi-cdecl arm-remarkable-linux-gnueabihf-gcc ../koreader/base/ffi-cdecl/mxcfb_remarkable_decl.c ../koreader/base/ffi/mxcfb_remarkable_h.lua
+```
+
 ### Legacy einkfb eInk devices
 
 KOReader uses the Linux framebuffer to control eInk devices, so the output module for legacy einkfb devices is [`base/ffi/framebuffer_einkfb.lua`](https://github.com/koreader/koreader-base/blob/master/ffi/framebuffer_einkfb.lua).


### PR DESCRIPTION
I found this was a big stumbling block for me when porting to remarkable. I couldn't see any documentation on how these FFI Lua files were generated, so I added some where I expected to find in. Maybe there is some somewhere else which I missed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5808)
<!-- Reviewable:end -->
