### PR TITLE
Stop using the "calibre catalog" wording

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -477,7 +477,7 @@ function FileManagerMenu:setUpdateItemTable()
 
     -- search tab
     self.menu_items.find_book_in_calibre_catalog = {
-        text = _("Find a book in calibre catalog"),
+        text = _("Find a book via calibre metadata"),
         callback = function()
             Search:getCalibre()
             Search:ShowSearch()

--- a/frontend/apps/filemanager/filemanagersearch.lua
+++ b/frontend/apps/filemanager/filemanagersearch.lua
@@ -190,7 +190,7 @@ function Search:ShowSearch()
                         end,
                     },
                     {
-                        -- @translators Search for books in calibre catalog.
+                        -- @translators Search for books in calibre Library, via on-device metadata (as setup by Calibre's 'Send To Device').
                         text = _("Find books"),
                         enabled = true,
                         callback = function()

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -37,7 +37,7 @@ local CatalogCache = Cache:new{
 
 local OPDSBrowser = Menu:extend{
     opds_servers = {},
-    calibre_name = _("Local calibre catalog"),
+    calibre_name = _("Local calibre library"),
 
     catalog_type = "application/atom%+xml",
     search_type = "application/opensearchdescription%+xml",


### PR DESCRIPTION
It's extremely confusing, as it has nothing to do with calibre catalogs,
which are actual things the user can generate manually.

What it's using instead is actually a metadata cache in a flatfile db
that's always present, as long as "Send To Device" was used to upload
the content to the device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5813)
<!-- Reviewable:end -->
