### PR TITLE
end of document: add go to beginning

### DIFF
--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -119,4 +119,17 @@ function ReaderGoto:gotoPage()
     end
 end
 
+function ReaderGoto:gotoBeginning()
+    self.ui.link:addCurrentLocationToStack()
+    self.ui:handleEvent(Event:new("GotoPage", 1))
+end
+
+function ReaderGoto:gotoEnd()
+    local endpage = self.document:getPageCount()
+    if endpage then
+        self.ui.link:addCurrentLocationToStack()
+        self.ui:handleEvent(Event:new("GotoPage", number))
+    end
+end
+
 return ReaderGoto

--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -119,17 +119,19 @@ function ReaderGoto:gotoPage()
     end
 end
 
-function ReaderGoto:gotoBeginning()
+function ReaderGoto:onGoToBeginning()
     self.ui.link:addCurrentLocationToStack()
     self.ui:handleEvent(Event:new("GotoPage", 1))
+    return true
 end
 
-function ReaderGoto:gotoEnd()
+function ReaderGoto:onGoToEnd()
     local endpage = self.document:getPageCount()
     if endpage then
         self.ui.link:addCurrentLocationToStack()
         self.ui:handleEvent(Event:new("GotoPage", endpage))
     end
+    return true
 end
 
 return ReaderGoto

--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -128,7 +128,7 @@ function ReaderGoto:gotoEnd()
     local endpage = self.document:getPageCount()
     if endpage then
         self.ui.link:addCurrentLocationToStack()
-        self.ui:handleEvent(Event:new("GotoPage", number))
+        self.ui:handleEvent(Event:new("GotoPage", endpage))
     end
 end
 

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -80,9 +80,9 @@ function ReaderStatus:onEndOfBook()
             },
             {
                 {
-                    text = _("Delete file"),
+                    text = _("Go to beginning"),
                     callback = function()
-                        self:deleteFile(self.document.file, false)
+                        self.ui.gotopage:gotoBeginning()
                         UIManager:close(choose_action)
                     end,
                 },
@@ -97,8 +97,9 @@ function ReaderStatus:onEndOfBook()
             },
             {
                 {
-                    text = _("Cancel"),
+                    text = _("Delete file"),
                     callback = function()
+                        self:deleteFile(self.document.file, false)
                         UIManager:close(choose_action)
                     end,
                 },
@@ -106,6 +107,14 @@ function ReaderStatus:onEndOfBook()
                     text = _("File browser"),
                     callback = function()
                         self:openFileBrowser()
+                        UIManager:close(choose_action)
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Cancel"),
+                    callback = function()
                         UIManager:close(choose_action)
                     end,
                 },
@@ -134,6 +143,8 @@ function ReaderStatus:onEndOfBook()
                 text = _("Could not open next file. Sort by last read date does not support this feature."),
             })
         end
+    elseif settings == "goto_beginning" then
+        self.ui.gotopage:gotoBeginning()
     elseif settings == "file_browser" then
         self:openFileBrowser()
     elseif settings == "mark_read" then

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -2,6 +2,7 @@ local BD = require("ui/bidi")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local Device = require("device")
+local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
@@ -82,7 +83,7 @@ function ReaderStatus:onEndOfBook()
                 {
                     text = _("Go to beginning"),
                     callback = function()
-                        self.ui.gotopage:gotoBeginning()
+                        self.ui:handleEvent(Event:new("GoToBeginning"))
                         UIManager:close(choose_action)
                     end,
                 },
@@ -144,7 +145,7 @@ function ReaderStatus:onEndOfBook()
             })
         end
     elseif settings == "goto_beginning" then
-        self.ui.gotopage:gotoBeginning()
+        self.ui:handleEvent(Event:new("GoToBeginning"))
     elseif settings == "file_browser" then
         self:openFileBrowser()
     elseif settings == "mark_read" then

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -505,6 +505,15 @@ common_settings.document = {
                     end,
                 },
                 {
+                    text = _("Go to beginning"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("end_document_action") == "goto_beginning"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("end_document_action", "goto_beginning")
+                    end,
+                },
+                {
                     text = _("Return to file browser"),
                     checked_func = function()
                         return G_reader_settings:readSetting("end_document_action") == "file_browser"


### PR DESCRIPTION
Allow `go to beginning` in end actions.
I Use this quite often
![Reader_2020-Feb-04_151700](https://user-images.githubusercontent.com/38916402/73783728-2fa60d00-4762-11ea-9184-c3ce161be74c.png)
If anyone has any opinions where in the menu it belongs i am all ears, i put it at the end by default.

I would like to add `go to beginning` and `go to end` to the goto UI,
but i am not sure if to put it in the `goto` or `skim` menu.
please advise, as i am sure everyone has their own preferred UI look :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5814)
<!-- Reviewable:end -->
