### PR TITLE
[fix] Don't waste time on dir/file attributes in subdirs

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -56,12 +56,14 @@ function FileChooser:init()
         end
         return true
     end
-    self.list = function(path, dirs, files)
+    self.list = function(path, dirs, files, count_only)
         -- lfs.dir directory without permission will give error
         local ok, iter, dir_obj = pcall(lfs.dir, path)
         if ok then
             for f in iter, dir_obj do
-                if self.show_hidden or not string.match(f, "^%.[^.]") then
+                if count_only then
+                    table.insert(dirs, true)
+                elseif self.show_hidden or not string.match(f, "^%.[^.]") then
                     local filename = path.."/"..f
                     local attributes = lfs.attributes(filename)
                     if attributes ~= nil then
@@ -211,7 +213,7 @@ function FileChooser:genItemTableFromPath(path)
         local sub_dirs = {}
         local dir_files = {}
         local subdir_path = self.path.."/"..dir.name
-        self.list(subdir_path, sub_dirs, dir_files)
+        self.list(subdir_path, sub_dirs, dir_files, true)
         local num_items = #sub_dirs + #dir_files
         local istr = ffiUtil.template(N_("1 item", "%1 items", num_items), num_items)
         local text

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -61,7 +61,8 @@ function FileChooser:init()
         local ok, iter, dir_obj = pcall(lfs.dir, path)
         if ok then
             for f in iter, dir_obj do
-                if count_only then
+                if count_only
+                   and (self.show_hidden or (not string.match(f, "^%.[^.]") and not util.stringStartsWith(f, "._"))) then
                     table.insert(dirs, true)
                 elseif self.show_hidden or not string.match(f, "^%.[^.]") then
                     local filename = path.."/"..f

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -61,9 +61,10 @@ function FileChooser:init()
         local ok, iter, dir_obj = pcall(lfs.dir, path)
         if ok then
             for f in iter, dir_obj do
-                if count_only
-                   and (self.show_hidden or (not string.match(f, "^%.[^.]") and not util.stringStartsWith(f, "._"))) then
-                    table.insert(dirs, true)
+                if count_only then
+                    if self.show_hidden or not util.stringStartsWith(f, ".") then
+                        table.insert(dirs, true)
+                    end
                 elseif self.show_hidden or not string.match(f, "^%.[^.]") then
                     local filename = path.."/"..f
                     local attributes = lfs.attributes(filename)


### PR DESCRIPTION
An awful lot of effort was wasted getting attributes just for getting a count of the number of files/directories in subdirectories. Getting the count is pretty fast. Getting all the attributes is not, and in this context we don't even use the attributes.

See <https://www.mobileread.com/forums/showthread.php?t=327085> and <https://gitter.im/koreader/koreader?at=5e3ac3b9e8a838355918ba13> for discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5819)
<!-- Reviewable:end -->
