### PR TITLE
Add “searchable” capabilities to OPDS catalogs

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -115,14 +115,14 @@ end
 function OPDSBrowser:addServerFromInput(fields)
     logger.info("input catalog", fields)
     local servers = G_reader_settings:readSetting("opds_servers") or {}
-    local new_item = {
+    local new_server = {
         title = fields[1],
         url = (fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2]),
         searchable =  (fields[2]:match("%%s") and true or false),
         username = fields[3],
         password = fields[4],
     }
-    table.insert(servers, new_item)
+    table.insert(servers, new_server)
     G_reader_settings:saveSetting("opds_servers", servers)
     self:init()
 end

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -123,7 +123,6 @@ function OPDSBrowser:addServerFromInput(fields)
       password = fields[4],
     }
     table.insert(servers, new_item)
-    logge.info("new catalog fields", new_item)
     G_reader_settings:saveSetting("opds_servers", servers)
     self:init()
 end
@@ -661,19 +660,19 @@ function OPDSBrowser:showDownloads(item)
     UIManager:show(self.download_dialog)
 end
 
-function OPDSBrowser:browse(url, username, password)
-  logger.info("launch url", url)
+function OPDSBrowser:browse(browse_url, username, password)
+  logger.info("launch url", browse_url)
   table.insert(self.paths, {
-                 url = url,
+                 url = browse_url,
                  username = username,
                  password = password,
   })
-  if not self:updateCatalog(url, username, password) then
+  if not self:updateCatalog(browse_url, username, password) then
     table.remove(self.paths)
   end
 end
 
-function OPDSBrowser:browseSearchable(url, username, password)
+function OPDSBrowser:browseSearchable(browse_url, username, password)
     self.search_server_dialog = InputDialog:new{
         title = _("Search OPDS catalog"),
         input = "",
@@ -694,8 +693,8 @@ function OPDSBrowser:browseSearchable(url, username, password)
                     is_enter_default = true,
                     callback = function()
                                 UIManager:close(self.search_server_dialog)
-                                local search,   = self.search_server_dialog:getInputText():gsub(" ", "+")
-                                local searched_url,   = url:gsub("%%s", search)
+                                local search, _ = self.search_server_dialog:getInputText():gsub(" ", "+")
+                                local searched_url, _ = browse_url:gsub("%%s", search)
                                 logger.info ("Searched url becomes", searched_url)
                                 self:browse(searched_url, username, password)
                     end,
@@ -703,7 +702,7 @@ function OPDSBrowser:browseSearchable(url, username, password)
             }
         },
     }
-    logger.info ("display broswse search for url", url)
+    logger.info ("display broswse search for url", browse_url)
     UIManager:show(self.search_server_dialog)
     self.search_server_dialog:onShowKeyboard()
 end

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -692,10 +692,10 @@ function OPDSBrowser:browseSearchable(browse_url, username, password)
                     text = _("Search"),
                     is_enter_default = true,
                     callback = function()
-                                UIManager:close(self.search_server_dialog)
-                                local search = self.search_server_dialog:getInputText():gsub(" ", "+")
-                                local searched_url = browse_url:gsub("%%s", search)
-                                self:browse(searched_url, username, password)
+                        UIManager:close(self.search_server_dialog)
+                        local search = self.search_server_dialog:getInputText():gsub(" ", "+")
+                        local searched_url = browse_url:gsub("%%s", search)
+                        self:browse(searched_url, username, password)
                     end,
                 },
             }

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -7,6 +7,7 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local InfoMessage = require("ui/widget/infomessage")
 local Menu = require("ui/widget/menu")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
+local InputDialog = require("ui/widget/inputdialog")
 local NetworkMgr = require("ui/network/manager")
 local OPDSParser = require("ui/opdsparser")
 local Screen = require("device").screen
@@ -69,6 +70,11 @@ function OPDSBrowser:init()
             url = "http://m.gutenberg.org/ebooks.opds/?format=opds",
           },
           {
+            title = "Project Gutenberg [Searchable]",
+            url = "https://m.gutenberg.org/ebooks/search.mobile/?format=opds&query=%s",
+            searchable = true,
+          },
+          {
              title = "Feedbooks",
              url = "http://www.feedbooks.com/publicdomain/catalog.atom",
           },
@@ -92,6 +98,11 @@ function OPDSBrowser:init()
              title = "Gallica (French)",
              url = "https://gallica.bnf.fr/opds",
           },
+          {
+             title = "Gallica [Fr] [Searchable]",
+             url = "https://gallica.bnf.fr/services/engine/search/opds?operation=searchRetrieve&query=(gallica all \"%s\")",
+             searchable = true,
+          }
         }
         G_reader_settings:saveSetting("opds_servers", servers)
     elseif servers[4] and servers[4].title == "Internet Archive" and servers[4].url == "http://bookserver.archive.org/catalog/"  then
@@ -104,12 +115,15 @@ end
 function OPDSBrowser:addServerFromInput(fields)
     logger.info("input catalog", fields)
     local servers = G_reader_settings:readSetting("opds_servers") or {}
-    table.insert(servers, {
-        title = fields[1],
-        url = (fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2]),
-        username = fields[3],
-        password = fields[4],
-    })
+    local new_item = {
+      title = fields[1],
+      url = (fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2]),
+      searchable =  (fields[2]:match("%%s") and true or false),
+      username = fields[3],
+      password = fields[4],
+    }
+    table.insert(servers, new_item)
+    logge.info("new catalog fields", new_item)
     G_reader_settings:saveSetting("opds_servers", servers)
     self:init()
 end
@@ -243,6 +257,7 @@ function OPDSBrowser:genItemTableFromRoot()
             password = server.password,
             deletable = true,
             editable = true,
+            searchable = server.searchable,
         })
     end
     local calibre_opds = G_reader_settings:readSetting("calibre_opds") or {}
@@ -263,6 +278,7 @@ function OPDSBrowser:genItemTableFromRoot()
             password = calibre_opds.password,
             editable = true,
             deletable = false,
+            searchable = false,
         })
     end
     table.insert(item_table, {
@@ -282,7 +298,7 @@ function OPDSBrowser:fetchFeed(item_url, username, password, method)
     request['url'] = item_url
     request['method'] = method and method or "GET"
     request['sink'] = ltn12.sink.table(sink)
-    request['headers'] = { Authorization = "Basic " .. mime.b64(auth), ["Host"] = hostname, }
+    request['headers'] = username and { Authorization = "Basic " .. mime.b64(auth), ["Host"] = hostname, } or  { ["Host"] = hostname, }
     logger.info("request", request)
     http.TIMEOUT, https.TIMEOUT = 10, 10
     local httpRequest = parsed.scheme == 'http' and http.request or https.request
@@ -645,7 +661,55 @@ function OPDSBrowser:showDownloads(item)
     UIManager:show(self.download_dialog)
 end
 
+function OPDSBrowser:browse(url, username, password)
+  logger.info("launch url", url)
+  table.insert(self.paths, {
+                 url = url,
+                 username = username,
+                 password = password,
+  })
+  if not self:updateCatalog(url, username, password) then
+    table.remove(self.paths)
+  end
+end
+
+function OPDSBrowser:browseSearchable(url, username, password)
+    self.search_server_dialog = InputDialog:new{
+        title = _("Search OPDS catalog"),
+        input = "",
+        hint = _("Search string"),
+        input_hint = _("author:dumas alexandre"),
+        input_type = "string",
+        description = _("%s in url will be replaced by your input"),
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    callback = function()
+                        UIManager:close(self.search_server_dialog)
+                    end,
+                },
+                {
+                    text = _("Search"),
+                    is_enter_default = true,
+                    callback = function()
+                                UIManager:close(self.search_server_dialog)
+                                local search,   = self.search_server_dialog:getInputText():gsub(" ", "+")
+                                local searched_url,   = url:gsub("%%s", search)
+                                logger.info ("Searched url becomes", searched_url)
+                                self:browse(searched_url, username, password)
+                    end,
+                },
+            }
+        },
+    }
+    logger.info ("display broswse search for url", url)
+    UIManager:show(self.search_server_dialog)
+    self.search_server_dialog:onShowKeyboard()
+end
+
 function OPDSBrowser:onMenuSelect(item)
+    logger.info("selected catalog item", item)
     -- add catalog
     if item.callback then
         item.callback()
@@ -655,13 +719,10 @@ function OPDSBrowser:onMenuSelect(item)
         self:showDownloads(item)
     -- navigation
     else
-        table.insert(self.paths, {
-            url = item.url,
-            username = item.username,
-            password = item.password,
-        })
-        if not self:updateCatalog(item.url, item.username, item.password) then
-            table.remove(self.paths)
+        if item.searchable then
+            self:browseSearchable(item.url, item.username, item.password)
+        else
+            self:browse(item.url, item.username, item.password)
         end
     end
     return true
@@ -674,6 +735,7 @@ function OPDSBrowser:editServerFromInput(item, fields)
         if server.title == item.text or server.url == item.url then
             server.title = fields[1]
             server.url = (fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2])
+            server.searchable =  (fields[2]:match("%%s") and true or false)
             server.username = fields[3]
             server.password = fields[4]
         end

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -661,15 +661,15 @@ function OPDSBrowser:showDownloads(item)
 end
 
 function OPDSBrowser:browse(browse_url, username, password)
-  logger.info("launch url", browse_url)
-  table.insert(self.paths, {
-                 url = browse_url,
-                 username = username,
-                 password = password,
-  })
-  if not self:updateCatalog(browse_url, username, password) then
-    table.remove(self.paths)
-  end
+    logger.dbg("Browse opds url", browse_url)
+    table.insert(self.paths, {
+                     url = browse_url,
+                     username = username,
+                     password = password,
+    })
+    if not self:updateCatalog(browse_url, username, password) then
+        table.remove(self.paths)
+    end
 end
 
 function OPDSBrowser:browseSearchable(browse_url, username, password)
@@ -693,8 +693,8 @@ function OPDSBrowser:browseSearchable(browse_url, username, password)
                     is_enter_default = true,
                     callback = function()
                                 UIManager:close(self.search_server_dialog)
-                                local search, _ = self.search_server_dialog:getInputText():gsub(" ", "+")
-                                local searched_url, _ = browse_url:gsub("%%s", search)
+                                local search = self.search_server_dialog:getInputText():gsub(" ", "+")
+                                local searched_url = browse_url:gsub("%%s", search)
                                 logger.info ("Searched url becomes", searched_url)
                                 self:browse(searched_url, username, password)
                     end,
@@ -702,13 +702,11 @@ function OPDSBrowser:browseSearchable(browse_url, username, password)
             }
         },
     }
-    logger.info ("display broswse search for url", browse_url)
     UIManager:show(self.search_server_dialog)
     self.search_server_dialog:onShowKeyboard()
 end
 
 function OPDSBrowser:onMenuSelect(item)
-    logger.info("selected catalog item", item)
     -- add catalog
     if item.callback then
         item.callback()

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -116,11 +116,11 @@ function OPDSBrowser:addServerFromInput(fields)
     logger.info("input catalog", fields)
     local servers = G_reader_settings:readSetting("opds_servers") or {}
     local new_item = {
-      title = fields[1],
-      url = (fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2]),
-      searchable =  (fields[2]:match("%%s") and true or false),
-      username = fields[3],
-      password = fields[4],
+        title = fields[1],
+        url = (fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2]),
+        searchable =  (fields[2]:match("%%s") and true or false),
+        username = fields[3],
+        password = fields[4],
     }
     table.insert(servers, new_item)
     G_reader_settings:saveSetting("opds_servers", servers)
@@ -663,9 +663,9 @@ end
 function OPDSBrowser:browse(browse_url, username, password)
     logger.dbg("Browse opds url", browse_url)
     table.insert(self.paths, {
-                     url = browse_url,
-                     username = username,
-                     password = password,
+        url = browse_url,
+        username = username,
+        password = password,
     })
     if not self:updateCatalog(browse_url, username, password) then
         table.remove(self.paths)
@@ -695,7 +695,6 @@ function OPDSBrowser:browseSearchable(browse_url, username, password)
                                 UIManager:close(self.search_server_dialog)
                                 local search = self.search_server_dialog:getInputText():gsub(" ", "+")
                                 local searched_url = browse_url:gsub("%%s", search)
-                                logger.info ("Searched url becomes", searched_url)
                                 self:browse(searched_url, username, password)
                     end,
                 },


### PR DESCRIPTION
OPDS catalogs may have search query capabilities. It is very usefull to find a
book in huge catalog, even when they are organized as directories. This commit
provides the possibility to add a %s mark in an OPS catalog URL, that would
trigger a search box when browsing the OPDS in koreader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5823)
<!-- Reviewable:end -->
