### PR TITLE
Print zsync2's output on screen

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -308,8 +308,8 @@ function OTAManager:fetchAndProcessUpdate()
                                         timeout = 3,
                                     })
                                     -- Clear the installed package, as well as the complete/incomplete update download
-                                    os.execute("rm -f" .. self.installed_package)
-                                    os.execute("rm -f" .. self.updated_package .. "*")
+                                    os.execute("rm -f " .. self.installed_package)
+                                    os.execute("rm -f " .. self.updated_package .. "*")
                                     -- As well as temporary files, in case zsync went kablooey too early...
                                     os.execute("rm -f ./rcksum-*")
                                     -- And then relaunch zsync in full download mode...
@@ -328,7 +328,7 @@ function OTAManager:fetchAndProcessUpdate()
                                             UIManager:show(ConfirmBox:new{
                                                 text = _("Error updating KOReader. Would you like to delete temporary files?"),
                                                 ok_callback = function()
-                                                    os.execute("rm -f" .. ota_dir .. "ko*")
+                                                    os.execute("rm -f " .. ota_dir .. "ko*")
                                                 end,
                                             })
                                         end
@@ -336,8 +336,8 @@ function OTAManager:fetchAndProcessUpdate()
                                 end,
                                 choice2_text = _("Abort"),
                                 choice2_callback = function()
-                                    os.execute("rm -f" .. ota_dir .. "ko*")
-                                    os.execute("rm -f" .. self.updated_package .. "*")
+                                    os.execute("rm -f " .. ota_dir .. "ko*")
+                                    os.execute("rm -f " .. self.updated_package .. "*")
                                     os.execute("rm -f ./rcksum-*")
                                 end,
                             })

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -308,8 +308,10 @@ function OTAManager:fetchAndProcessUpdate()
                                         timeout = 3,
                                     })
                                     -- Clear the installed package, as well as the complete/incomplete update download
-                                    os.execute("rm " .. self.installed_package)
-                                    os.execute("rm " .. self.updated_package .. "*")
+                                    os.execute("rm -f" .. self.installed_package)
+                                    os.execute("rm -f" .. self.updated_package .. "*")
+                                    -- As well as temporary files, in case zsync went kablooey too early...
+                                    os.execute("rm -f ./rcksum-*")
                                     -- And then relaunch zsync in full download mode...
                                     UIManager:scheduleIn(1, function()
                                         if OTAManager:zsync(true) == 0 then

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -328,7 +328,7 @@ function OTAManager:fetchAndProcessUpdate()
                                             UIManager:show(ConfirmBox:new{
                                                 text = _("Error updating KOReader. Would you like to delete temporary files?"),
                                                 ok_callback = function()
-                                                    os.execute("rm " .. ota_dir .. "ko*")
+                                                    os.execute("rm -f" .. ota_dir .. "ko*")
                                                 end,
                                             })
                                         end
@@ -336,7 +336,9 @@ function OTAManager:fetchAndProcessUpdate()
                                 end,
                                 choice2_text = _("Abort"),
                                 choice2_callback = function()
-                                    os.execute("rm " .. ota_dir .. "ko*")
+                                    os.execute("rm -f" .. ota_dir .. "ko*")
+                                    os.execute("rm -f" .. self.updated_package .. "*")
+                                    os.execute("rm -f ./rcksum-*")
                                 end,
                             })
                         end

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -36,7 +36,14 @@ else
     # We cannot use pipefail, extreme shell wizardry is required...
     # Pure magic courtesy of https://unix.stackexchange.com/a/70675
     # Much more compact than the stock answer from the Usenet shell FAQ: http://cfajohnson.com/shell/cus-faq-2.html#Q11
-    { { { { ./zsync2 "$@" 2>&1 3>&- 4>&-; echo $? >&3; } | ./fbink -q -z -pm -F scientifica >&4; } 3>&1; } | { read -r xs; exit "${xs}"; } } 4>&1
+    { { { {
+        ./zsync2 "$@" 2>&1 3>&- 4>&-
+        echo $? >&3
+    } | ./fbink -q -z -pm -F scientifica >&4; } 3>&1; } | {
+        read -r xs
+        exit "${xs}"
+    }; } 4>&1
+
     rc=$?
 fi
 

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -18,8 +18,7 @@ fi
 # Launch zsync2, and remember its exit code...
 # We'll be piping its output to FBInk in order to print it live, in a smaller font than usual...
 # NOTE: This depends on an undocumented FBInk hack (-z) in order to deal with the progress bars (and their CR) sanely.
-# NOTE: As usual, redirect FBInk's stderr to /dev/null because of the "missing codepoint" warnings ;).
-./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica 2>/dev/null
+./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica
 rc=$?
 
 # And return with zsync's exit code, not kill's ;).

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -3,12 +3,12 @@
 # We're going to need to remember failures from the *left* side of a pipeline...
 # shellcheck disable=SC2039
 if set -o pipefail 2>/dev/null; then
-    FAKE_PIPEFAIL="false"
+    WITH_PIPEFAIL="true"
 else
     # But because we can't have nice things, some devices (hi, Kindle) may use an extremely old busybox build,
     # one in which pipefail was not yet implemented,
     # (it appeared in busybox 1.16.0, and is contingent on bash compatibility being enabled in ash).
-    FAKE_PIPEFAIL="true"
+    WITH_PIPEFAIL="true"
 fi
 
 # Figure out whether that's a delta or a full download given the number of arguments passed...
@@ -28,12 +28,12 @@ fi
 # NOTE: This depends on an undocumented FBInk hack (-z) in order to deal with the progress bars (and their CR) sanely.
 rc=0
 
-if [ "${FAKE_PIPEFAIL}" = "false" ]; then
+if [ "${WITH_PIPEFAIL}" = "true" ]; then
     # We can use pipefail, let the shell do the heavy lifting for us...
     ./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica
     rc=$?
 else
-    # We cannot use pipefail, extreme shell wizardy is required...
+    # We cannot use pipefail, extreme shell wizardry is required...
     # Pure magic courtesy of https://unix.stackexchange.com/a/70675
     # Much more compact the the stock answer from the Usenet shell FAQ: http://cfajohnson.com/shell/cus-faq-2.html#Q11
     { { { { ./zsync2 "$@" 2>&1 3>&- 4>&-; echo $? >&3; } | ./fbink -q -z -pm -F scientifica >&4; } 3>&1; } | { read -r xs; exit "${xs}"; } } 4>&1

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -35,7 +35,7 @@ if [ "${WITH_PIPEFAIL}" = "true" ]; then
 else
     # We cannot use pipefail, extreme shell wizardry is required...
     # Pure magic courtesy of https://unix.stackexchange.com/a/70675
-    # Much more compact the the stock answer from the Usenet shell FAQ: http://cfajohnson.com/shell/cus-faq-2.html#Q11
+    # Much more compact than the stock answer from the Usenet shell FAQ: http://cfajohnson.com/shell/cus-faq-2.html#Q11
     { { { { ./zsync2 "$@" 2>&1 3>&- 4>&-; echo $? >&3; } | ./fbink -q -z -pm -F scientifica >&4; } 3>&1; } | { read -r xs; exit "${xs}"; } } 4>&1
     rc=$?
 fi

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -47,5 +47,5 @@ else
     rc=$?
 fi
 
-# And return with zsync's exit code, not kill's ;).
+# And return with zsync's exit code
 exit ${rc}

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# We're going to need to remember failures from the *left* side of a pipeline...
+set -o pipefail
+
 # Figure out whether that's a delta or a full download given the number of arguments passed...
 if [ $# -lt 7 ]; then
     ZSYNC_MESSAGE="Downloading update data"
@@ -7,43 +10,16 @@ else
     ZSYNC_MESSAGE="Computing zsync delta"
 fi
 
-# Small zsync wrapper so we can get a pretty spinner while it works...
-./fbink -q -y -7 -pmh "${ZSYNC_MESSAGE} !"
+# Small zsync wrapper so we can print its output while it works...
+./fbink -q -y -7 -pmh "${ZSYNC_MESSAGE} . . ."
 # Clear any potential leftover from the local OTA tarball creation.
 ./fbink -q -y -6 -pm ' '
 
-# Spin in the background while we work ;).
-(
-    # See https://stackoverflow.com/questions/2685435 for inspiration
-    # as well as https://www.npmjs.com/package/cli-spinners
-    # & https://github.com/swelljoe/spinner
-    # http://www.fileformat.info/info/unicode/block/block_elements/list.htm
-    ##
-    # Simple bars, they look better when a bit smoother, with a snappier interval (~250ms)
-    #SPINNER="� ▁ ▂ ▃ ▄ ▅ ▆ ▇ █ ▇ ▆ ▅ ▄ ▃ ▂ ▁"
-    #SPINNER="� ▏ ▎ ▍ ▌ ▋ ▊ ▉ █ ▉ ▊ ▋ ▌ ▍ ▎ ▏"
-    # Spinning blocks
-    SPINNER="▖ ▘ ▝ ▗"
-    #SPINNER="▜ ▟ ▙ ▛"
-    # Snaking blocks
-    #SPINNER="▌ ▀ ▐ ▄"
-    #SPINNER="▌ ▛ ▀ ▜ ▐ ▟ ▄ ▙"
-    while :; do
-        for spin in ${SPINNER}; do
-            usleep 500000 2>/dev/null || sleep 0.5
-            # NOTE: Throw stderr to the void because I'm cheating w/ U+FFFD for a blank character,
-            #       which FBInk replaces by a blank, but not before shouting at us on stderr ;).
-            ./fbink -q -y -7 -pmh "${ZSYNC_MESSAGE} ${spin}" 2>/dev/null
-        done
-    done
-) &
-
 # Launch zsync2, and remember its exit code...
-./zsync2 "$@"
+# We'll be piping its output to FBInk in order to print it live, in a smaller font than usual...
+# NOTE: This depends on an undocumented FBInk hack (-z) in order to deal with the progress bars (and their CR) sanely.
+./zsync2 "$@" | ./fbink -q -z -pm -F scientifica
 rc=$?
-
-# Kill the spinner subshell now that we're done
-kill -15 $!
 
 # And return with zsync's exit code, not kill's ;).
 exit ${rc}

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -1,7 +1,15 @@
 #!/bin/sh
 
 # We're going to need to remember failures from the *left* side of a pipeline...
-set -o pipefail
+set -o pipefail 2>/dev/null
+# But because we can't have nice things, some devices (hi, Kindle) may use an extremely old busybox build,
+# one in which pipefail was not yet implemented,
+# (it appeared in busybox 1.16.0, and is contingent on bash compatibility being enabled in ash).
+if [ $? -ne 0 ]; then
+    FAKE_PIPEFAIL="true"
+else
+    FAKE_PIPEFAIL="false"
+fi
 
 # Figure out whether that's a delta or a full download given the number of arguments passed...
 if [ $# -lt 7 ]; then
@@ -18,8 +26,19 @@ fi
 # Launch zsync2, and remember its exit code...
 # We'll be piping its output to FBInk in order to print it live, in a smaller font than usual...
 # NOTE: This depends on an undocumented FBInk hack (-z) in order to deal with the progress bars (and their CR) sanely.
-./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica
-rc=$?
+rc=0
+
+if [ "${FAKE_PIPEFAIL}" = "false" ]; then
+    # We can use pipefail, let the shell do the heavy lifting for us...
+    ./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica
+    rc=$?
+else
+    # We cannot use pipefail, extreme shell wizardy is required...
+    # Pure magic courtesy of https://unix.stackexchange.com/a/70675
+    # Much more compact the the stock answer from the Usenet shell FAQ: http://cfajohnson.com/shell/cus-faq-2.html#Q11
+    { { { { ./zsync2 "$@" 2>&1 3>&- 4>&-; echo $? >&3; } | ./fbink -q -z -pm -F scientifica >&4; } 3>&1; } | { read xs; exit $xs; } } 4>&1
+    rc=$?
+fi
 
 # And return with zsync's exit code, not kill's ;).
 exit ${rc}

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -18,7 +18,7 @@ fi
 # Launch zsync2, and remember its exit code...
 # We'll be piping its output to FBInk in order to print it live, in a smaller font than usual...
 # NOTE: This depends on an undocumented FBInk hack (-z) in order to deal with the progress bars (and their CR) sanely.
-./zsync2 "$@" | ./fbink -q -z -pm -F scientifica
+./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica
 rc=$?
 
 # And return with zsync's exit code, not kill's ;).

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -18,7 +18,8 @@ fi
 # Launch zsync2, and remember its exit code...
 # We'll be piping its output to FBInk in order to print it live, in a smaller font than usual...
 # NOTE: This depends on an undocumented FBInk hack (-z) in order to deal with the progress bars (and their CR) sanely.
-./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica
+# NOTE: As usual, redirect FBInk's stderr to /dev/null because of the "missing codepoint" warnings ;).
+./zsync2 "$@" 2>&1 | ./fbink -q -z -pm -F scientifica 2>/dev/null
 rc=$?
 
 # And return with zsync's exit code, not kill's ;).

--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -1,14 +1,14 @@
 #!/bin/sh
 
 # We're going to need to remember failures from the *left* side of a pipeline...
-set -o pipefail 2>/dev/null
-# But because we can't have nice things, some devices (hi, Kindle) may use an extremely old busybox build,
-# one in which pipefail was not yet implemented,
-# (it appeared in busybox 1.16.0, and is contingent on bash compatibility being enabled in ash).
-if [ $? -ne 0 ]; then
-    FAKE_PIPEFAIL="true"
-else
+# shellcheck disable=SC2039
+if set -o pipefail 2>/dev/null; then
     FAKE_PIPEFAIL="false"
+else
+    # But because we can't have nice things, some devices (hi, Kindle) may use an extremely old busybox build,
+    # one in which pipefail was not yet implemented,
+    # (it appeared in busybox 1.16.0, and is contingent on bash compatibility being enabled in ash).
+    FAKE_PIPEFAIL="true"
 fi
 
 # Figure out whether that's a delta or a full download given the number of arguments passed...
@@ -36,7 +36,7 @@ else
     # We cannot use pipefail, extreme shell wizardy is required...
     # Pure magic courtesy of https://unix.stackexchange.com/a/70675
     # Much more compact the the stock answer from the Usenet shell FAQ: http://cfajohnson.com/shell/cus-faq-2.html#Q11
-    { { { { ./zsync2 "$@" 2>&1 3>&- 4>&-; echo $? >&3; } | ./fbink -q -z -pm -F scientifica >&4; } 3>&1; } | { read xs; exit $xs; } } 4>&1
+    { { { { ./zsync2 "$@" 2>&1 3>&- 4>&-; echo $? >&3; } | ./fbink -q -z -pm -F scientifica >&4; } 3>&1; } | { read -r xs; exit "${xs}"; } } 4>&1
     rc=$?
 fi
 


### PR DESCRIPTION
Instead of the blind spinner we used to have.

This is a bit of a hack (on both sides), and it currently extends towards the middle of the screen, which means the tail end of it will probably get overwritten by the "Success/Failure" popup.

Can easily be tweaked later, I'd like to get it in as-is to try it for real first ;).

Requires https://github.com/koreader/koreader-base/pull/1038

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5824)
<!-- Reviewable:end -->
