### PR TITLE
[chore] FileChooser: use "traditional" for loop for ~20% better performance

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -242,7 +242,8 @@ function FileChooser:genItemTableFromPath(path)
     -- otherwise, show new files in bold
     local show_file_in_bold = G_reader_settings:readSetting("show_file_in_bold")
 
-    for _, file in ipairs(files) do
+    for i = 1, #files do
+        local file = files[i]
         local full_path = self.path.."/"..file.name
         local file_size = lfs.attributes(full_path, "size") or 0
         local sstr = getFriendlySize(file_size)


### PR DESCRIPTION
Apparently there's less overhead this way.

See https://github.com/koreader/koreader/pull/5819 for context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5827)
<!-- Reviewable:end -->
