### PR TITLE
A couple of minor remarkable port fixes

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -87,8 +87,6 @@ function Remarkable:outofScreenSaver()
     if self.screen_saver_mode == true then
         local Screensaver = require("ui/screensaver")
         Screensaver:close()
-        local UIManager = require("ui/uimanager")
-        UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
     end
     self.powerd:afterResume()
     self.screen_saver_mode = false

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -132,7 +132,7 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         ko_do_fbdepth
     fi
 
-    ./reader.lua "$HOME" >>crash.log 2>&1
+    ./reader.lua "/home/root/" >>crash.log 2>&1
     RETURN_VALUE=$?
 
     # Did we crash?

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -118,6 +118,12 @@ if [ -e crash.log ]; then
     mv -f crash.log.new crash.log
 fi
 
+if [ "$#" -eq 0 ]; then
+    args="/home/root"
+else
+    args="$*"
+fi
+
 CRASH_COUNT=0
 CRASH_TS=0
 CRASH_PREV_TS=0
@@ -132,7 +138,7 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         ko_do_fbdepth
     fi
 
-    ./reader.lua "/home/root/" >>crash.log 2>&1
+    ./reader.lua "${args}" >>crash.log 2>&1
     RETURN_VALUE=$?
 
     # Did we crash?

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -132,7 +132,7 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         ko_do_fbdepth
     fi
 
-    ./reader.lua >>crash.log 2>&1
+    ./reader.lua "$HOME" >>crash.log 2>&1
     RETURN_VALUE=$?
 
     # Did we crash?


### PR DESCRIPTION
First change just removes some unnecessary code as pointed out by @NiLuJe in the original remarkable support pull request.

Second change is quite important but I don't quite understand the reasoning for the code in `reader.lua` which requires it. If you look at the if statement in `reader.lua` starting at line 239, you can see that if no argument is passed, *and* no `lastfile` setting is set then koreader will just exit with the usage help output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5834)
<!-- Reviewable:end -->
