### PR TITLE
bump crengine: various table and other fixes

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -1030,6 +1030,20 @@ body > div:dir(rtl) > div.thumb { /* invert if RTL */
         clear: left;
         margin:  0 0.5em 0.2em 0 !important;
 }
+/* Allow original mix of left/right floats in web mode */
+body > div > div.thumb.tleft {
+    -cr-only-if: float-floatboxes allow-style-w-h-absolute-units;
+        float: left !important;
+        clear: left;
+        margin:  0 0.5em 0.2em 0 !important;
+}
+body > div > div.thumb.tright {
+    -cr-only-if: float-floatboxes allow-style-w-h-absolute-units;
+        float: right !important;
+        clear: right;
+        margin:  0 0 0.2em 0.5em !important;
+}
+
 body > div > div.thumb img {
     /* Make float's inner images 100% of their container's width when not in "web" mode */
     -cr-only-if: float-floatboxes -allow-style-w-h-absolute-units;


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/327 :
- (Upstream) Fix potential segfault
- lvtextfm: avoid spurious spaces when hyphenating (bis)
- View HTML: cosmetic fixes for floats and inline blocks
- Text: avoid clipping of overflowing inline-block content
- Fix images with "display: inline-block" not shown
- elementFromPoint(): skip moved-down block floats
- Rend methods init: fix inconsistency when floats disabled
- getRectEx(): don't crash in case of rend method bug
- getRenderedWidths(): slightly better estimate table width
- Tables cells: handle vertical-align: baseline
- Page splitting: add missing 'discard at start' handling
- Page splitting: split single column tables by lines instead of row
- Hardcoded elements list: add `<legend>`
- Drawing: fix some y/y+h vs page top/bottom comparisons
- Drawing: disable HidePartialGlyphs in scroll mode

Also, some small change to Wikipedia EPUBs to allow this in "web" mode ((just to look more like the original article on Wikipedia "web"...)
<kbd>![image](https://user-images.githubusercontent.com/24273478/74170151-c116f280-4c2c-11ea-996e-553feb7c8e65.png)</kbd>

while we'll get in 'book' mode as previously (which I think I prefer reading with):
<kbd>![image](https://user-images.githubusercontent.com/24273478/74170073-9dec4300-4c2c-11ea-9e8a-33aa2fc2bbe9.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5840)
<!-- Reviewable:end -->
