### PR TITLE
Don't bypass fbdepth when starting KOReader @ 8bpp

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -154,6 +154,7 @@ ORIG_FB_BPP="$(./fbdepth -g)"
 echo "Original fb bitdepth is set @ ${ORIG_FB_BPP}bpp" >>crash.log 2>&1
 # Sanity check...
 case "${ORIG_FB_BPP}" in
+    8)  ;;
     16) ;;
     32) ;;
     *)

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -154,7 +154,7 @@ ORIG_FB_BPP="$(./fbdepth -g)"
 echo "Original fb bitdepth is set @ ${ORIG_FB_BPP}bpp" >>crash.log 2>&1
 # Sanity check...
 case "${ORIG_FB_BPP}" in
-    8)  ;;
+    8) ;;
     16) ;;
     32) ;;
     *)

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -85,6 +85,7 @@ echo "Original fb settings: bitdepth = ${ORIG_FB_BPP}, rotation = ${ORIG_FB_ROTA
 
 # Sanity check...
 case "${ORIG_FB_BPP}" in
+    8)  ;;
     16) ;;
     32) ;;
     *)

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -85,7 +85,7 @@ echo "Original fb settings: bitdepth = ${ORIG_FB_BPP}, rotation = ${ORIG_FB_ROTA
 
 # Sanity check...
 case "${ORIG_FB_BPP}" in
-    8)  ;;
+    8) ;;
     16) ;;
     32) ;;
     *)


### PR DESCRIPTION
Not quite sure how this happened on @Frenzie's device, but in any case, skipping fbdepth in this case was nonsensical ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5841)
<!-- Reviewable:end -->
