### PR TITLE
Fonts, Style tweaks: smaller menus to see more of the book

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -309,6 +309,9 @@ function ReaderFont:makeDefault(face, touchmenu_instance)
 end
 
 function ReaderFont:addToMainMenu(menu_items)
+    -- Have TouchMenu show half of the usual nb of items, so we
+    -- have more room to see how the text looks with that font
+    self.face_table.max_per_page = 5
     -- insert table to main reader menu
     menu_items.change_font = {
         text = self.font_menu_title,

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -34,6 +34,7 @@ local CssTweaks = {
                 title = _("Ignore vertical margins"),
                 priority = 2,
                 css = [[* { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+                separator = true,
             },
             {
                 id = "padding_horizontal_all_0";
@@ -50,78 +51,81 @@ local CssTweaks = {
             separator = true,
         },
         {
-            id = "titles_page-break-before_avoid ";
-            title = _("Avoid blank page on chapter start"),
-            priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
-            css = [[h1, h2, h3 { page-break-before: auto !important; }]],
+            title = _("Page breaks and blank pages"),
+            {
+                id = "titles_page-break-before_avoid ";
+                title = _("Avoid blank page on chapter start"),
+                priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
+                css = [[h1, h2, h3 { page-break-before: auto !important; }]],
 
-        },
-        {
-            id = "docfragment_page-break-before_avoid ";
-            title = _("Avoid blank page on chapter end"),
-            priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
-            css = [[DocFragment { page-break-before: auto !important; }]],
-        },
-        {
-            id = "publisher_page-breaks_avoid ";
-            title = _("Avoid publisher page breaks"),
-            description = _("Disable all publisher page breaks, keeping only KOReader's epub.css ones.\nWhen combined with the two previous tweaks, all page-breaks are disabled."),
-            css = [[
+            },
+            {
+                id = "docfragment_page-break-before_avoid ";
+                title = _("Avoid blank page on chapter end"),
+                priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
+                css = [[DocFragment { page-break-before: auto !important; }]],
+            },
+            {
+                id = "publisher_page-breaks_avoid ";
+                title = _("Avoid publisher page breaks"),
+                description = _("Disable all publisher page breaks, keeping only KOReader's epub.css ones.\nWhen combined with the two previous tweaks, all page-breaks are disabled."),
+                css = [[
 * { page-break-before: auto !important; page-break-after: auto !important; }
 /* put back epub.css page-breaks */
 DocFragment { page-break-before: always !important; }
 h1 { -cr-only-if: -epub-document; page-break-before: always !important; }
 h2, h3 { -cr-only-if: legacy -epub-document; page-break-before: always !important; }
 h1, h2, h3, h4, h5, h6 { page-break-after: avoid !important; }
-            ]],
-            separator = true,
-        },
-        {
-            title = _("New page on headings"),
-            {
-                id = "h1_page-break-before_always";
-                title = _("New page on <H1>"),
-                css = [[h1 { page-break-before: always !important; }]],
+                ]],
+                separator = true,
             },
             {
-                id = "h2_page-break-before_always";
-                title = _("New page on <H2>"),
-                css = [[
+                title = _("New page on headings"),
+                {
+                    id = "h1_page-break-before_always";
+                    title = _("New page on <H1>"),
+                    css = [[h1 { page-break-before: always !important; }]],
+                },
+                {
+                    id = "h2_page-break-before_always";
+                    title = _("New page on <H2>"),
+                    css = [[
 h2 { page-break-before: always !important; }
 h1 + h2 { page-break-before: avoid !important; }
-                ]],
-            },
-            {
-                id = "h3_page-break-before_always";
-                title = _("New page on <H3>"),
-                css = [[
+                    ]],
+                },
+                {
+                    id = "h3_page-break-before_always";
+                    title = _("New page on <H3>"),
+                    css = [[
 h3 { page-break-before: always !important; }
 h1 + h3, h2 + h3 { page-break-before: avoid !important; }
-                ]],
-            },
-            {
-                id = "h4_page-break-before_always";
-                title = _("New page on <H4>"),
-                css = [[
+                    ]],
+                },
+                {
+                    id = "h4_page-break-before_always";
+                    title = _("New page on <H4>"),
+                    css = [[
 h4 { page-break-before: always !important; }
 h1 + h4, h2 + h4, h3 + h4 { page-break-before: avoid !important; }
-                ]],
-            },
-            {
-                id = "h5_page-break-before_always";
-                title = _("New page on <H5>"),
-                css = [[
+                    ]],
+                },
+                {
+                    id = "h5_page-break-before_always";
+                    title = _("New page on <H5>"),
+                    css = [[
 h5 { page-break-before: always !important; }
 h1 + h5, h2 + h5, h3 + h5, h4 + h5 { page-break-before: avoid !important; }
-                ]],
-            },
-            {
-                id = "h6_page-break-before_always";
-                title = _("New page on <H6>"),
-                css = [[
+                    ]],
+                },
+                {
+                    id = "h6_page-break-before_always";
+                    title = _("New page on <H6>"),
+                    css = [[
 h6 { page-break-before: always !important; }
 h1 + h6, h2 + h6, h3 + h6, h4 + h6, h5 + h6 { page-break-before: avoid !important; }
-                ]],
+                    ]],
+                },
             },
         },
     },
@@ -204,6 +208,7 @@ You may also want to enable, in the top menu → Gear → Navigation →, Invert
                 title = _("Document direction LTR"),
                 css = [[body { direction: ltr !important; }]],
             },
+            separator = true,
         },
         {
             title = _("Widows and orphans"),
@@ -279,43 +284,47 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
             separator = true,
         },
         {
-            id = "sub_sup_smaller";
-            title = _("Smaller sub- and superscript"),
-            description = _("Prevent sub- and superscript from affecting line-height."),
-            priority = 5, -- so we can override "font_size_all_inherit"
-            -- https://friendsofepub.github.io/eBookTricks/
-            -- https://github.com/koreader/koreader/issues/3923#issuecomment-386510294
-            css = [[
+            title = _("Fonts and line heights"),
+            {
+                id = "font_family_all_inherit";
+                title = _("Ignore publisher font families"),
+                description = _("Disable font-family specified in embedded styles."),
+                -- we have to use this trick, font-family handling by crengine is a bit complex
+                css = [[* { font-family: "NoSuchFont" !important; }]],
+            },
+            {
+                id = "font_size_all_inherit";
+                title = _("Ignore publisher font sizes"),
+                description = _("Disable font-size specified in embedded styles."),
+                css = [[* { font-size: inherit !important; }]],
+                separator = true,
+            },
+            {
+                id = "lineheight_all_inherit";
+                title = _("Ignore publisher line heights"),
+                description = _("Disable line-height specified in embedded styles, and may allow KOReader's line spacing settings to work on books where they would not."),
+                css = [[* { line-height: inherit !important; }]],
+            },
+            {
+                id = "lineheight_all_normal_strut_confined";
+                title = _("Enforce steady line heights"),
+                description = _("Prevent inline content like sub- and superscript from changing their paragraph line height."),
+                priority = -5, -- so other -cr-hint can override (this one has effect only on inline content)
+                css = [[* { -cr-hint: strut-confined; }]],
+                separator = true,
+            },
+            {
+                id = "sub_sup_smaller";
+                title = _("Smaller sub- and superscript"),
+                description = _("Prevent sub- and superscript from affecting line-height."),
+                priority = 5, -- so we can override "font_size_all_inherit"
+                -- https://friendsofepub.github.io/eBookTricks/
+                -- https://github.com/koreader/koreader/issues/3923#issuecomment-386510294
+                css = [[
 sup { font-size: 50% !important; vertical-align: super !important; }
 sub { font-size: 50% !important; vertical-align: sub !important; }
-            ]],
-        },
-        {
-            id = "lineheight_all_inherit";
-            title = _("Ignore publisher line heights"),
-            description = _("Disable line-height specified in embedded styles, and may allow KOReader's line spacing settings to work on books where they would not."),
-            css = [[* { line-height: inherit !important; }]],
-        },
-        {
-            id = "lineheight_all_normal_strut_confined";
-            title = _("Enforce steady line heights"),
-            description = _("Prevent inline content like sub- and superscript from changing their paragraph line height."),
-            priority = -5, -- so other -cr-hint can override (this one has effect only on inline content)
-            css = [[* { -cr-hint: strut-confined; }]],
-            separator = true,
-        },
-        {
-            id = "font_size_all_inherit";
-            title = _("Ignore publisher font sizes"),
-            description = _("Disable font-size specified in embedded styles."),
-            css = [[* { font-size: inherit !important; }]],
-        },
-        {
-            id = "font_family_all_inherit";
-            title = _("Ignore publisher font families"),
-            description = _("Disable font-family specified in embedded styles."),
-            -- we have to use this trick, font-family handling by crengine is a bit complex
-            css = [[* { font-family: "NoSuchFont" !important; }]],
+                ]],
+            },
         },
     },
     {
@@ -338,38 +347,83 @@ p {
             separator = true,
         },
         {
-            id = "paragraph_no_indent";
-            title = _("No indentation on first paragraph line"),
-            description = _("Do not indent the first line of paragraphs."),
-            css = [[p { text-indent: 0 !important; }]],
-        },
-        {
-            id = "paragraph_indent";
-            title = _("Indentation on first paragraph line"),
-            description = _("Indentation on the first line of a paragraph is the default, but it may be overridden by publisher styles. This will force KOReader's defaults on common elements."),
-            css = [[
+            title = _("Paragraph first-line indentation"),
+            {
+                id = "paragraph_no_indent";
+                title = _("No indentation on first paragraph line"),
+                description = _("Do not indent the first line of paragraphs."),
+                css = [[p { text-indent: 0 !important; }]],
+                separator = true,
+            },
+            {
+                id = "paragraph_indent";
+                title = _("Indentation on first paragraph line"),
+                description = _("Indentation on the first line of a paragraph is the default, but it may be overridden by publisher styles. This will force KOReader's defaults on common elements."),
+                css = [[
 p { text-indent: 1.2em !important; }
 body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
-            ]],
-            separator = true,
+                ]],
+            },
+            {
+                id = "paragraph_first_no_indent";
+                title = _("No indentation on first paragraph"),
+                description = _("Do not indent the first line of the first paragraph of its container. This might be needed to correctly display drop caps, while still having indentation on following paragraphs."),
+                priority = 2, -- so it can override 'paragraph_indent'
+                css = [[p:first-child { text-indent: 0 !important; }]],
+            },
+            {
+                id = "paragraph_following_no_indent";
+                title = _("No indentation on following paragraphs"),
+                description = _("Do not indent the first line of following paragraphs, but leave the first paragraph of its container untouched."),
+                priority = 2, -- so it can override 'paragraph_indent'
+                css = [[p + p { text-indent: 0 !important; }]],
+            },
         },
         {
-            id = "paragraph_whitespace";
             title = _("Spacing between paragraphs"),
-            description = _("Add a line of whitespace between paragraphs."),
-            css = [[p + p { margin-top: 1em !important; }]],
+            {
+                id = "paragraph_whitespace";
+                title = _("Spacing between paragraphs"),
+                description = _("Add a line of whitespace between paragraphs."),
+                priority = 5, -- Override "Ignore margins and paddings" below
+                css = [[p + p { margin-top: 1em !important; }]],
+            },
+            {
+                id = "paragraph_whitespace_half";
+                title = _("Spacing between paragraphs (half)"),
+                description = _("Add half a line of whitespace between paragraphs."),
+                priority = 5,
+                css = [[p + p { margin-top: .5em !important; }]],
+            },
+            {
+                id = "paragraph_no_whitespace";
+                title = _("No spacing between paragraphs"),
+                description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
+                priority = 5,
+                css = [[p, li { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+                separator = true,
+            },
+            {
+                id = "paragraph_no_vertical_padding";
+                title = _("Ignore vertical paragraph padding"),
+                priority = 3, -- Override "Pages > Ignore margin and padding"
+                css = [[p, li { padding-top: 0 !important; padding-bottom: 0 !important; }]],
+            },
         },
         {
-            id = "paragraph_whitespace_half";
-            title = _("Spacing between paragraphs (half)"),
-            description = _("Add half a line of whitespace between paragraphs."),
-            css = [[p + p { margin-top: .5em !important; }]],
-        },
-        {
-            id = "paragraph_no_whitespace";
-            title = _("No spacing between paragraphs"),
-            description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
-            css = [[p, li { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+            title = _("Horizontal paragraph margins"),
+            {
+                id = "paragraph_no_horizontal_margin";
+                title = _("Ignore horizontal paragraph margins"),
+                priority = 3, -- Override "Pages > Ignore margin and padding"
+                css = [[p, li { margin-left: 0 !important; margin-right: 0 !important; }]],
+            },
+            {
+                id = "paragraph_no_horizontal_padding";
+                title = _("Ignore horizontal paragraph padding"),
+                priority = 3,
+                css = [[p, li { padding-left: 0 !important; padding-right: 0 !important; }]],
+            },
         },
     },
     {
@@ -391,6 +445,7 @@ body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
             title = _("Center small tables"),
             description = _("Horizontally center tables that do not use the full page width."),
             css = [[table { margin-left: auto !important; margin-right: auto !important; }]],
+            priority = 3, -- Override "Pages > Ignore margin and padding"
             separator = true,
         },
         {
@@ -438,6 +493,18 @@ table, tcaption, tr, th, td { border: black solid 1px; border-collapse: collapse
             id = "a_not_bold";
             title = _("Links never bold"),
             css = [[a { font-weight: normal !important; }]],
+            separator = true,
+        },
+        {
+            id = "a_underline";
+            title = _("Links always underlined"),
+            css = [[a[href] { text-decoration: underline !important; }]],
+            -- Have it apply only on real links with a href=, not on anchors
+        },
+        {
+            id = "a_not_underline";
+            title = _("Links never underlined"),
+            css = [[a { text-decoration: none !important; }]],
         },
     },
     {

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -64,13 +64,14 @@ body {
     line-height: 1.3;
     text-align: justify;
 }
+/* We keep left and right margin the same so it also displays as expected in RTL */
 h1, h2, h3, h4, h5, h6 { margin: 0; } /* MuPDF: margin: XXem 0 , vary with level */
-blockquote { margin: 0 3em }    /* MuPDF: margin: 1em 40px */
+blockquote { margin: 0 1em; }   /* MuPDF: margin: 1em 40px */
 p   { margin: 0; }              /* MuPDF: margin: 1em 0 */
-ol  { margin: 0.5em 0; }        /* MuPDF: margin: 1em 0; padding: 0 0 0 30pt */
-ul  { margin: 0.5em 0; }        /* MuPDF: margin: 1em 0; padding: 0 0 0 30pt */
-dl  { margin: 0.5em; }          /* MuPDF: margin: 1em 0 */
-dd  { margin-left: 1.3em; }     /* MuPDF: margin: 0 0 0 40px */
+ol  { margin: 0; }              /* MuPDF: margin: 1em 0; padding: 0 0 0 30pt */
+ul  { margin: 0; }              /* MuPDF: margin: 1em 0; padding: 0 0 0 30pt */
+dl  { margin: 0; }              /* MuPDF: margin: 1em 0 */
+dd  { margin: 0 1em; }          /* MuPDF: margin: 0 0 0 40px */
 pre { margin: 0.5em 0; }        /* MuPDF: margin: 1em 0 */
 a   { color: black; }           /* MuPDF: color: #06C; */
 /* MuPDF has no support for text-decoration, so we can't underline links,

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -379,7 +379,7 @@ local TouchMenu = FocusManager:new{
     width = nil,
     height = nil,
     page = 1,
-    max_per_page = 10,
+    max_per_page_default = 10,
     -- for UIManager:setDirty
     show_parent = nil,
     cur_tab = -1,
@@ -560,8 +560,9 @@ function TouchMenu:_recalculatePageLayout()
 
     local item_list_content_height = content_height - footer_height
     self.perpage = math.floor(item_list_content_height / self.item_height)
-    if self.perpage > self.max_per_page then
-        self.perpage = self.max_per_page
+    local max_per_page = self.item_table.max_per_page or self.max_per_page_default
+    if self.perpage > max_per_page then
+        self.perpage = max_per_page
     end
 
     self.page_num = math.ceil(#self.item_table / self.perpage)


### PR DESCRIPTION
Show only 5 fonts by menu page to get more room below to see how the text looks with the selected font. Not sure everybody will like that (needs to extend your thumb more to browse menu pages), but the net effect is that you see the font and don't need to close the menu as previously to appreciate how it looks, and go back re-opening that menu to test another font.

<kbd>![fontmenu](https://user-images.githubusercontent.com/24273478/74511846-31609500-4f07-11ea-94b4-2b515a91adf4.png)</kbd>

Re-organize style tweaks into more submenus to also get more room below.
Add a few styletweaks: "No indentation on first/following paragraphs" https://github.com/koreader/koreader/pull/4358#issuecomment-585591943, "Paragraphs margins and paddings", and Links underlining.
Popup footnotes: some CSS fixes https://github.com/koreader/koreader/issues/5859#issuecomment-585664640

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5863)
<!-- Reviewable:end -->
