### PR TITLE
Make dictionary margin depend on font size

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -191,14 +191,18 @@ function DictQuickLookup:getHtmlDictionaryCss()
             ]]..css_justify..[[
         }
 
-        blockquote {
-            margin-left: 1em;
-            margin-right: .5em;
-        }
-
-        dd {
-            margin-left: 1em;
-            margin-right: 0;
+        /* MuPDF doesn't currently scale CSS pixels, so we have to use a font-size based measurement.
+         * Unfortunately MuPDF doesn't properly support `rem` either, which it bases on a hard-coded
+         * value of `16px`, so we have to go with `em` (or `%`).
+         *
+         * These `em`-based margins can vary slightly, but it's the best available compromise.
+         *
+         * We also keep left and right margin the same so it also displays as expected in RTL.
+         * Because MuPDF doesn't currently support `margin-start`, this results in a slightly
+         * unconventional but hopefully barely noticeable right margin for <dd>.
+         */
+        blockquote, dd {
+            margin: 0 1em;
         }
     ]]
 

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -189,18 +189,19 @@ function DictQuickLookup:getHtmlDictionaryCss()
             margin: 0;
             line-height: 1.3;
             ]]..css_justify..[[
-        }
-
-        /* MuPDF doesn't currently scale CSS pixels, so we have to use a font-size based measurement.
-         * Unfortunately MuPDF doesn't properly support `rem` either, which it bases on a hard-coded
-         * value of `16px`, so we have to go with `em` (or `%`).
-         *
-         * These `em`-based margins can vary slightly, but it's the best available compromise.
-         *
-         * We also keep left and right margin the same so it also displays as expected in RTL.
-         * Because MuPDF doesn't currently support `margin-start`, this results in a slightly
-         * unconventional but hopefully barely noticeable right margin for <dd>.
-         */
+        }]]
+        ..
+        -- MuPDF doesn't currently scale CSS pixels, so we have to use a font-size based measurement.
+        -- Unfortunately MuPDF doesn't properly support `rem` either, which it bases on a hard-coded
+        -- value of `16px`, so we have to go with `em` (or `%`).
+        --
+        -- These `em`-based margins can vary slightly, but it's the best available compromise.
+        --
+        -- We also keep left and right margin the same so it also displays as expected in RTL.
+        -- Because MuPDF doesn't currently support `margin-start`, this results in a slightly
+        -- unconventional but hopefully barely noticeable right margin for <dd>.
+        --
+        [[
         blockquote, dd {
             margin: 0 1em;
         }

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -189,23 +189,21 @@ function DictQuickLookup:getHtmlDictionaryCss()
             margin: 0;
             line-height: 1.3;
             ]]..css_justify..[[
-        }]]
-        ..
-        -- MuPDF doesn't currently scale CSS pixels, so we have to use a font-size based measurement.
-        -- Unfortunately MuPDF doesn't properly support `rem` either, which it bases on a hard-coded
-        -- value of `16px`, so we have to go with `em` (or `%`).
-        --
-        -- These `em`-based margins can vary slightly, but it's the best available compromise.
-        --
-        -- We also keep left and right margin the same so it also displays as expected in RTL.
-        -- Because MuPDF doesn't currently support `margin-start`, this results in a slightly
-        -- unconventional but hopefully barely noticeable right margin for <dd>.
-        --
-        [[
+        }
+
         blockquote, dd {
             margin: 0 1em;
         }
     ]]
+    -- MuPDF doesn't currently scale CSS pixels, so we have to use a font-size based measurement.
+    -- Unfortunately MuPDF doesn't properly support `rem` either, which it bases on a hard-coded
+    -- value of `16px`, so we have to go with `em` (or `%`).
+    --
+    -- These `em`-based margins can vary slightly, but it's the best available compromise.
+    --
+    -- We also keep left and right margin the same so it'll display as expected in RTL.
+    -- Because MuPDF doesn't currently support `margin-start`, this results in a slightly
+    -- unconventional but hopefully barely noticeable right margin for <dd>.
 
     if self.css then
         return css .. self.css

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -190,6 +190,16 @@ function DictQuickLookup:getHtmlDictionaryCss()
             line-height: 1.3;
             ]]..css_justify..[[
         }
+
+        blockquote {
+            margin-left: 1em;
+            margin-right: .5em;
+        }
+
+        dd {
+            margin-left: 1em;
+            margin-right: 0;
+        }
     ]]
 
     if self.css then


### PR DESCRIPTION
The default left margin on blockquote and dd is `40px`. There are two potential problems with this:

1. 40px is a lot on a small font and perhaps rather little on a large font. Conversely, *if* blockquote font size were variable you'd get strange differences in indentation. `rem` should be a better choice.
2. <del>We don't interact with MuPDF quite as I believe we should (cf., the way I implemented this stuff with layoutDocument for opening EPUB/FB2 with MuPDF). While effectively the same problem, the distinction is that point (1) is real but nevertheless largely academic, while this point constitutes a very real problem both on DPIs over ~300 and under ~200.</del><ins>Actually there may be some MuPDF issue involved.</ins>

For problem (2) this may be a bit of a quick & lazy fix, but problem (1) exists regardless.

PS If we assume 1em = 16px then 40px is actually 2.5em, not 1em. This reduction in indentation is mainly intended for the benefit of smaller E Ink devices.

Closes <https://github.com/koreader/koreader/issues/5859>.

### Before/after small DPI (160)
<img src=https://user-images.githubusercontent.com/202757/74526477-c07ba600-4f23-11ea-98dc-c3ec07c756b7.png width=45%> <img src=https://user-images.githubusercontent.com/202757/74526479-c1143c80-4f23-11ea-8554-fe1d385c63f8.png width=45%>

### Before/after medium DPI (300)
<img src=https://user-images.githubusercontent.com/202757/74526494-cb363b00-4f23-11ea-9ca1-a3e453e6ff28.png width=45%> <img src=https://user-images.githubusercontent.com/202757/74526656-1ea88900-4f24-11ea-8918-696b374f7d87.png width=45%>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5865)
<!-- Reviewable:end -->
