### PR TITLE
TextBoxWidget: handle tabs and tabstops

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -97,7 +97,8 @@ local TextBoxWidget = InputContainer:new{
                                  -- used as a weak hint about direction)
     alignment_strict = false, -- true to force the alignemnt set by the alignment= attribute.
                               -- When false, specified alignment is inverted when para direction is RTL
-    tabstop_nb_space_width = 8, -- width of tabstops, as a factor of the width of a space
+    tabstop_nb_space_width = 8, -- unscaled_size_check: ignore
+                                -- width of tabstops, as a factor of the width of a space
                                 -- (set to 0 to disable any tab handling and display a tofu glyph)
     _xtext = nil, -- for internal use
     _alt_color_for_rtl = nil, -- (for debugging) draw LTR glyphs in black, RTL glyphs in gray


### PR DESCRIPTION
Don't display a tofu glyph when meeting a tab (none of our fonts have a glyph for it).
New parameter: TextBoxWidget.tabstop_nb_space_width, that defaults to 8, to ensure tabstops in the usual left aligmnent.
Needs a bump for base/xtext.cpp https://github.com/koreader/koreader-base/pull/1049.
Closes #5837,

Defaulted to 8 spaces, because our spaces are really small and 4 was really tiny.
Also, only for TextBoxWidget - makes no real sense in TextWidget that hopefully only gets our own text or filenames.

I initially thought: why bother? as all our input is mostly tab-free (most dictionaries, Wikipedia, Google translate results, our own Lua code), except, as seen, some dict - and possibly some text files edited with TextEditor.
So, well, let's have a go: if it's not handled correctly, or the trick with text justification is really ugly, it won't affect much of our usual UI. And it's not that intrusive into the usual code, so, let's have it.

<kbd>![image](https://user-images.githubusercontent.com/24273478/74610422-7b0dd300-50f3-11ea-85ad-a7b5dbb2e091.png)</kbd>

When text is justified, space extension is done only on spaces after the last tab on the line (which is a bit ugly, but well... haven't check how other text editors do it):
<kbd>![image](https://user-images.githubusercontent.com/24273478/74610473-d0e27b00-50f3-11ea-837c-8be0904a32e8.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/74610441-9b3d9200-50f3-11ea-85e4-dc7bf169e2ab.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5870)
<!-- Reviewable:end -->
