### PR TITLE
Warn if color rendering is enabled on a grayscale device.

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -198,7 +198,8 @@ if Device:canToggleGSensor() then
     common_settings.screen_toggle_gsensor = require("ui/elements/screen_toggle_gsensor")
 end
 
-if Screen.isColorScreen() then
+-- NOTE: Allow disabling color if it's mistakenly enabled on a Grayscale screen (after a settings import?)
+if Screen:isColorEnabled() or Screen:isColorScreen() then
     common_settings.color_rendering = require("ui/elements/screen_color_menu_table")
 end
 

--- a/frontend/ui/elements/screen_color_menu_table.lua
+++ b/frontend/ui/elements/screen_color_menu_table.lua
@@ -4,9 +4,10 @@ local UIManager = require("ui/uimanager")
 local CanvasContext = require("document/canvascontext")
 local _ = require("gettext")
 
+-- NOTE: Again, make sure this is enabled if for some reason color is enabled on a Grayscale screen...
 return {
     text = _("Color rendering"),
-    enabled_func = Screen.isColorScreen,
+    enabled = Screen:isColorEnabled() or Screen:isColorScreen(),
     checked_func = Screen.isColorEnabled,
     callback = function()
         local new_val = not Screen.isColorEnabled()

--- a/reader.lua
+++ b/reader.lua
@@ -182,6 +182,16 @@ if Device:hasColorScreen() and not G_reader_settings:has("color_rendering") then
     })
 end
 
+-- Conversely, if color is enabled on a Grayscale screen (e.g., after importing settings from a color device), warn that it'll break stuff and adversely affect performance.
+if G_reader_settings:isTrue("color_rendering") and not Device:hasColorScreen() then
+    -- Don't disable it straight-away, might be useful for developers?
+    --G_reader_settings:delSetting("color_rendering")
+    local InfoMessage = require("ui/widget/infomessage")
+    UIManager:show(InfoMessage:new{
+        text = _("Color rendering is mistakenly enabled on your grayscale device.\nThis will subtly break some features, and adversely affect performance, please disable color rendering in the screen sub-menu."),
+    })
+end
+
 -- Helpers
 local lfs = require("libs/libkoreader-lfs")
 local function retryLastFile()

--- a/reader.lua
+++ b/reader.lua
@@ -185,7 +185,7 @@ end
 -- Conversely, if color is enabled on a Grayscale screen (e.g., after importing settings from a color device), warn that it'll break stuff and adversely affect performance.
 if G_reader_settings:isTrue("color_rendering") and not Device:hasColorScreen() then
     local ConfirmBox = require("ui/widget/confirmbox")
-    UIManager:show(InfoMessage:new{
+    UIManager:show(ConfirmBox:new{
         text = _("Color rendering is mistakenly enabled on your grayscale device.\nThis will subtly break some features, and adversely affect performance."),
         cancel_text = _("Ignore"),
         cancel_callback = function()

--- a/reader.lua
+++ b/reader.lua
@@ -194,6 +194,8 @@ if G_reader_settings:isTrue("color_rendering") and not Device:hasColorScreen() t
         ok_text = _("Disable"),
         ok_callback = function()
                 G_reader_settings:delSetting("color_rendering")
+                CanvasContext:setColorRenderingEnabled(false)
+                UIManager:broadcastEvent(Event:new("ColorRenderingUpdate"))
         end,
     })
 end

--- a/reader.lua
+++ b/reader.lua
@@ -188,7 +188,7 @@ if G_reader_settings:isTrue("color_rendering") and not Device:hasColorScreen() t
     --G_reader_settings:delSetting("color_rendering")
     local InfoMessage = require("ui/widget/infomessage")
     UIManager:show(InfoMessage:new{
-        text = _("Color rendering is mistakenly enabled on your grayscale device.\nThis will subtly break some features, and adversely affect performance, please disable color rendering in the screen sub-menu."),
+        text = _("Color rendering is mistakenly enabled on your grayscale device.\nThis will subtly break some features, and adversely affect performance.\nPlease disable color rendering in the screen sub-menu."),
     })
 end
 

--- a/reader.lua
+++ b/reader.lua
@@ -184,11 +184,17 @@ end
 
 -- Conversely, if color is enabled on a Grayscale screen (e.g., after importing settings from a color device), warn that it'll break stuff and adversely affect performance.
 if G_reader_settings:isTrue("color_rendering") and not Device:hasColorScreen() then
-    -- Don't disable it straight-away, might be useful for developers?
-    --G_reader_settings:delSetting("color_rendering")
-    local InfoMessage = require("ui/widget/infomessage")
+    local ConfirmBox = require("ui/widget/confirmbox")
     UIManager:show(InfoMessage:new{
-        text = _("Color rendering is mistakenly enabled on your grayscale device.\nThis will subtly break some features, and adversely affect performance.\nPlease disable color rendering in the screen sub-menu."),
+        text = _("Color rendering is mistakenly enabled on your grayscale device.\nThis will subtly break some features, and adversely affect performance."),
+        cancel_text = _("Ignore"),
+        cancel_callback = function()
+                return
+        end,
+        ok_text = _("Disable"),
+        ok_callback = function()
+                G_reader_settings:delSetting("color_rendering")
+        end,
     })
 end
 

--- a/reader.lua
+++ b/reader.lua
@@ -193,6 +193,7 @@ if G_reader_settings:isTrue("color_rendering") and not Device:hasColorScreen() t
         end,
         ok_text = _("Disable"),
         ok_callback = function()
+                local Event = require("ui/event")
                 G_reader_settings:delSetting("color_rendering")
                 CanvasContext:setColorRenderingEnabled(false)
                 UIManager:broadcastEvent(Event:new("ColorRenderingUpdate"))


### PR DESCRIPTION
Can happen if a user imports settings from a color device (see today's discussion with @ptrm on gitter ;)).

Also, make sure the "Color rendering" checkbox is actually available in these instances ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5871)
<!-- Reviewable:end -->
