### PR TITLE
FileManager: tell plugins to save settings on close

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -664,6 +664,7 @@ end
 
 function FileManager:onClose()
     logger.dbg("close filemanager")
+    self:handleEvent(Event:new("SaveSettings"))
     G_reader_settings:flush()
     UIManager:close(self)
     if self.onExit then

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -972,9 +972,11 @@ function ReaderDictionary:onReadSettings(config)
 end
 
 function ReaderDictionary:onSaveSettings()
-    logger.dbg("save default dictionary", self.default_dictionary)
-    self.ui.doc_settings:saveSetting("default_dictionary", self.default_dictionary)
-    self.ui.doc_settings:saveSetting("disable_fuzzy_search", self.disable_fuzzy_search)
+    if self.ui.doc_settings then
+        logger.dbg("save default dictionary", self.default_dictionary)
+        self.ui.doc_settings:saveSetting("default_dictionary", self.default_dictionary)
+        self.ui.doc_settings:saveSetting("disable_fuzzy_search", self.disable_fuzzy_search)
+    end
 end
 
 function ReaderDictionary:toggleFuzzyDefault()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1808,6 +1808,9 @@ function ReaderStatistics:deleteBooksByTotalDuration(max_total_duration_mn)
                     max_total_duration_mn), max_total_duration_mn),
         ok_text = _("Remove"),
         ok_callback = function()
+            -- Allow following SQL statements to work even when doc less by
+            -- using -1 as the book id, as real book ids are positive.
+            local id_curr_book = self.id_curr_book or -1
             local conn = SQ3.open(db_location)
             local sql_stmt = [[
                     DELETE from page_stat
@@ -1816,13 +1819,13 @@ function ReaderStatistics:deleteBooksByTotalDuration(max_total_duration_mn)
                     )
                 ]]
             local stmt = conn:prepare(sql_stmt)
-            stmt:reset():bind(self.id_curr_book, max_total_duration_sec):step()
+            stmt:reset():bind(id_curr_book, max_total_duration_sec):step()
             sql_stmt = [[
                     DELETE from book
                     WHERE  id != ? and (total_read_time is NULL or total_read_time < ?)
                 ]]
             stmt = conn:prepare(sql_stmt)
-            stmt:reset():bind(self.id_curr_book, max_total_duration_sec):step()
+            stmt:reset():bind(id_curr_book, max_total_duration_sec):step()
             stmt:close()
             -- Get nb of deleted books
             sql_stmt = [[


### PR DESCRIPTION
So that Statistics settings modified while in FileManager are saved.
Also allows resetting statistics when in FileManager (where there is no current book id to exclude).
Issue reported at https://github.com/koreader/koreader/pull/5867#issuecomment-586911339.

I decided to have FM do a `self:handleEvent(Event:new("SaveSettings"))` - as that seems logical to have - even if currently, the only imported stuff in FM that has it is the Statistics plugin - and ReaderDictionnary that I had to fix to not fail when no document.
So, a bit risky, but we'll see if side effects.
The alternative would have been to just have StatisticsManager call its own saveSettings() on each UI setting widget action (which is what it did before with the old single setting) - which would have been less risky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5872)
<!-- Reviewable:end -->
