### PR TITLE
avoid writting to read-only pdfs

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1175,7 +1175,7 @@ function ReaderHighlight:exportToDocument(page, item)
         self.warned_once = true
         UIManager:show(InfoMessage:new{
             text = _([[
-The highlights you'll be making on this document will be saved in the setting file but won't be written in the document itself, as the file is in a read-only location.
+Highlights in this document will be saved in the settings file, but they won't be written in the document itself because the file is in a read-only location.
 
 If you wish your highlights to be saved in the document, just move it first to a writable directory.]]),
             timeout = 5,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1167,8 +1167,19 @@ end
 --]]
 
 function ReaderHighlight:exportToDocument(page, item)
+    local setting = G_reader_settings:readSetting("save_document")
+    if setting == "disable" then return end
     logger.dbg("export highlight to document", item)
-    self.ui.document:saveHighlight(page, item)
+    local can_write = self.ui.document:saveHighlight(page, item)
+    if can_write == false and not self.warned_once then
+        self.warned_once = true
+        UIManager:show(InfoMessage:new{
+            text = _([[The highlights you'll be making on this document will be saved in the setting file but won't be written in the document itself, as the file is in a read-only location.
+
+If you wish your highlights to be saved in the document just move it first to a writable directory]]),
+            timeout = 5,
+        })
+    end
 end
 
 function ReaderHighlight:addNote()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1174,9 +1174,10 @@ function ReaderHighlight:exportToDocument(page, item)
     if can_write == false and not self.warned_once then
         self.warned_once = true
         UIManager:show(InfoMessage:new{
-            text = _([[The highlights you'll be making on this document will be saved in the setting file but won't be written in the document itself, as the file is in a read-only location.
+            text = _([[
+The highlights you'll be making on this document will be saved in the setting file but won't be written in the document itself, as the file is in a read-only location.
 
-If you wish your highlights to be saved in the document just move it first to a writable directory]]),
+If you wish your highlights to be saved in the document, just move it first to a writable directory.]]),
             timeout = 5,
         })
     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1177,7 +1177,7 @@ function ReaderHighlight:exportToDocument(page, item)
             text = _([[
 Highlights in this document will be saved in the settings file, but they won't be written in the document itself because the file is in a read-only location.
 
-If you wish your highlights to be saved in the document, just move it first to a writable directory.]]),
+If you wish your highlights to be saved in the document, just move it to a writable directory first.]]),
             timeout = 5,
         })
     end

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -175,6 +175,14 @@ function PdfDocument:saveHighlight(pageno, item)
     local suffix = util.getFileNameSuffix(self.file)
     if string.lower(suffix) ~= "pdf" then return end
 
+    if self.is_writable == nil then
+        local handle = io.open(self.file, 'r+b')
+        self.is_writable = handle ~= nil
+        if handle then handle:close() end
+    end
+    if self.is_writable == false then
+        return false
+    end
     self.is_edited = true
     -- will also need mupdf_h.lua to be evaluated once
     -- but this is guaranteed at this point


### PR DESCRIPTION
Fixes #5881

Poor atempt to fix issues with read-only pdfs, when auto or manual save settings is triggered. I don't like it because it adds UI stuff to a document. Probably there are better ways of doing this without messing with InfoMessages in pdfdocument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5889)
<!-- Reviewable:end -->
