### PR TITLE
bump crengine, migrate books to normalized xpointers

### DIFF
--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -132,7 +132,7 @@ function DocSettings:open(docfile)
                                    return l[2] > r[2]
                                end
                            end)
-    local ok, stored
+    local ok, stored, filepath
     for _, k in pairs(candidates) do
         -- Ignore empty files
         if lfs.attributes(k[1], "size") > 0 then
@@ -140,6 +140,7 @@ function DocSettings:open(docfile)
             -- Ignore the empty table.
             if ok and next(stored) ~= nil then
                 logger.dbg("data is read from ", k[1])
+                filepath = k[1]
                 break
             end
         end
@@ -149,6 +150,7 @@ function DocSettings:open(docfile)
     if ok and stored then
         new.data = stored
         new.candidates = candidates
+        new.filepath = filepath
     else
         new.data = {}
     end
@@ -234,6 +236,10 @@ end
 
 function DocSettings:close()
     self:flush()
+end
+
+function DocSettings:getFilePath()
+    return self.filepath
 end
 
 --- Purges (removes) sidecar directory.

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -424,6 +424,20 @@ body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
                 priority = 3,
                 css = [[p, li { padding-left: 0 !important; padding-right: 0 !important; }]],
             },
+            separator = true,
+        },
+        {
+            title = _("List items"),
+            {
+                id = "ul_li_type_disc";
+                title = _("Force bullets with unordered lists"),
+                css = [[ul > li { list-style-type: disc !important; }]],
+            },
+            {
+                id = "ol_li_type_decimal";
+                title = _("Force decimal numbers with ordered lists"),
+                css = [[ol > li { list-style-type: decimal !important; }]],
+            },
         },
     },
     {


### PR DESCRIPTION
Will need a base bump for https://github.com/koreader/koreader-base/pull/1054:
Includes https://github.com/koreader/crengine/pull/328 :
- Fix shifted native selection/internal bookmarks in legacy mode
- Fix drawing of inline-block taller than page height
- (Upstream) createXPointer/toString: normalized xpointers
- toStringUsingNames(): rename to toStringV2()
- DOM_VERSION_WITH_NORMALIZED_XPOINTERS 20200223
- CSS/List items: skip boxing elements when walking
- CSS: parse pseudoclass nth_child(3n+2)
- toStringV2(): output [1] when first but not single
- Tables: complete incomplete tables
- Store gDOMVersionRequested in cache file header
- Cache: increase Rects cache size

cre.cpp: adds `getDomVersionWithNormalizedXPointers()` and `getNormalizedXPointer(xpv1)`

When opening a book previously opened with an older DOM version, a migration/upgrade to use the latest one, and migrate previous unnormalized XPointers to normalized ones is proposed (previous metadata.lua is backup'ed as `metadata.epub.lua.old_dom20180528`).
Currently with those kind of ConfirmBoxes:

![image](https://user-images.githubusercontent.com/24273478/75162404-ce000f80-571d-11ea-8d02-5335f87b98f4.png)

![image](https://user-images.githubusercontent.com/24273478/75162604-14ee0500-571e-11ea-8237-e5fb3142d280.png)

![image](https://user-images.githubusercontent.com/24273478/75162538-03a4f880-571e-11ea-9a98-96edc1b19faf.png)
(I'm not a big highlighter, and I think I've seen that 3rd one only on test html files that I often edited to add test cases, so easily inducing shifts in the DOM and breaking past highlights.)

I don't know if we should really show these messages, or just do the migration in the 1) and 2) cases, which could just look like 2 consecutive openings of the same document.
I guess we should show the 3rd, even if I'm not sure the user will be able to get these lost ones back.
May be let them for a few weeks in the nightlies, so testers can see and tell, and we'll then decide if it's worthwhile showing them? Should I still let these message translatable then?

The style tweaks about list items (added to the Paragraphs> section ) might help getting back bullets when the publisher uses features that we don't support, like:
```css
ul.tiret, ul.lettremin, ul.lettremaj {
    list-style-type: none;
}
ul.tiret > li:before {
    content: '-\00a0';
    float: left;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5897)
<!-- Reviewable:end -->
