### PR TITLE
bump crengine: normalized xpointers fix, FB2 footnotes tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1000,13 +1000,15 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
         -- if not trusted, checks marked (*) don't apply
         flags = flags + 0x0002
     end
+    -- Checks for private CSS properties "-cr-hint: footnote/noteref/..." are
+    -- always done (they can be applied to specific elements or classe names
+    -- with Styles tweaks.)
 
     -- Trust role= and epub:type= attribute values if defined, for source(*) and target
-    -- (If needed, we could add a check for a private CSS property "-cr-hint: footnote"
-    -- or "-cr-hint: noteref", so one can define it to specific classes with Styles
-    -- tweaks.)
     flags = flags + 0x0004
-    -- flags = flags + 0x0008 -- Unused yet
+
+    -- Accept classic FB2 footnotes: body[name="notes" or "comments"] > section
+    flags = flags + 0x0008
 
     -- TARGET STATUS AND SOURCE RELATION
     -- Target must have an anchor #id (ie: must not be a simple link to a html file)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -586,6 +586,18 @@ function CreDocument:setFontFace(new_font_face)
         --          for font-family: monospace
         -- +256001: prefer our font to any existing font-family font
         self._document:setAsPreferredFontWithBias(new_font_face, 1)
+        -- +1 +128x5 +256x5: we want our main font, even if it has no italic
+        -- nor bold variant (eg FreeSerif), to win over all other fonts that
+        -- have an italic or bold variant:
+        --   italic_match = 5 * (256 for real italic, or 128 for fake italic
+        --   weight_match = 5 * (256 - weight_diff * 256 / 800)
+        -- so give our font a bias enough to win over real italic or bold fonts
+        -- (all others params (size, family, name), used for computing the match
+        -- score, have a factor of 100 or 1000 vs the 5 used for italic & weight,
+        -- so it shouldn't hurt much).
+        -- Note that this is mostly necessary when forcing a not found name,
+        -- as we do in the Ignore font-family style tweak.
+        self._document:setAsPreferredFontWithBias(new_font_face, 1 + 128*5 + 256*5)
     end
 end
 

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -614,6 +614,22 @@ This is just an example, that will need to be adapted into a user style tweak.]]
         {
             title = _("In-page footnotes"),
             {
+                id = "footnote-inpage_fb2";
+                title = _("In-page FB2 footnotes"),
+                description = _([[
+Show FB2 footnote text at the bottom of pages that contain links to them.]]),
+                -- (fb2.css already set font-size to 70% - so no need for a "smaller" variant)
+                css = [[
+body[name="notes"] section,
+body[name="comments"] section
+{
+    -cr-hint: footnote-inpage;
+    margin: 0 !important;
+}
+                ]],
+                separator = true,
+            },
+            {
                 id = "footnote-inpage_epub";
                 title = _("In-page EPUB footnotes"),
                 description = _([[

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -89,6 +89,21 @@ body > li { list-style-type: none; }
 
 /* Remove any (possibly multiple) backlinks in Wikipedia EPUBs footnotes */
 .noprint { display: none; }
+
+/* Attempt to display FB2 footnotes as expected (as crengine does, putting
+ * the footnote number on the same line as the first paragraph via its
+ * support of "display: run-in" and a possibly added autoBoxing element) */
+body > section > autoBoxing > *,
+body > section > autoBoxing > title > *,
+body > section > title,
+body > section > title > p,
+body > section > p {
+    display: inline;
+}
+body > section > autoBoxing + p,
+body > section > p + p {
+    display: block;
+}
 ]]
 
 -- Add this if needed for debugging:


### PR DESCRIPTION
Will need a base bump for https://github.com/koreader/koreader-base/pull/1055.

Includes https://github.com/koreader/crengine/pull/329 :
- toStringV2(): fix when target node is a boxing node
- CSS font-family parsing: set usual default of sans-serif
- FB2 footnotes: fix spurious newline ("display: run-in")
- FB2 footnotes: disable hardcoded handling as in-page

cre.cpp: accepts classic FB2 footnotes in footnote popup detection

Make FB2 footnotes behaviour consistent with what we have for footnotes in EPUB:
- FB2 footnotes are no more rendered in-page by default
- In-page rendering can be enabled by the added Style tweak
- FB2 footnotes can also show in footnote popup (with some added not-so-nice CSS so MuPDF can render them as crengine)

`cre: setFontFace(): increase bias given to the main font`
An attempt at solving this:
<kbd>![image](https://user-images.githubusercontent.com/24273478/75391182-e15fd600-58e9-11ea-860a-f5b094193903.png)</kbd>
when selecting FreeSerif as the default font, and using "Ignore publisher font-family": any of our other fonts could be used for the italic text (actually, the first of our font that has an italic variant).
So we can get the nicer:
<kbd>![image](https://user-images.githubusercontent.com/24273478/75391263-05231c00-58ea-11ea-87e7-f56167f9a3f8.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5904)
<!-- Reviewable:end -->
