### PR TITLE
Style tweaks: enable EPUB/FB2 in-page footnotes by default

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -312,7 +312,9 @@ end
 function ReaderStyleTweak:onReadSettings(config)
     self.enabled = not (config:readSetting("style_tweaks_enabled") == false)
     self.doc_tweaks = config:readSetting("style_tweaks") or {}
-    self.global_tweaks = G_reader_settings:readSetting("style_tweaks") or {}
+    -- Default globally enabled style tweaks (for new installations)
+    -- are defined in css_tweaks.lua
+    self.global_tweaks = G_reader_settings:readSetting("style_tweaks") or CssTweaks.DEFAULT_GLOBAL_STYLE_TWEAKS
     self:updateCssText()
 end
 
@@ -323,7 +325,7 @@ function ReaderStyleTweak:onSaveSettings()
         self.ui.doc_settings:saveSetting("style_tweaks_enabled", false)
     end
     self.ui.doc_settings:saveSetting("style_tweaks", util.tableSize(self.doc_tweaks) > 0 and self.doc_tweaks or nil)
-    G_reader_settings:saveSetting("style_tweaks", util.tableSize(self.global_tweaks) > 0 and self.global_tweaks or nil)
+    G_reader_settings:saveSetting("style_tweaks", self.global_tweaks)
 end
 
 function ReaderStyleTweak:init()

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -12,7 +12,14 @@ They may have the following optional attributes:
 local _ = require("gettext")
 local C_ = _.pgettext
 
+-- Default globally enabled style tweaks, for new installations
+local DEFAULT_GLOBAL_STYLE_TWEAKS = {}
+-- Display in-page per-specs footnotes for EPUB and FB2:
+DEFAULT_GLOBAL_STYLE_TWEAKS["footnote-inpage_epub_smaller"] = true
+DEFAULT_GLOBAL_STYLE_TWEAKS["footnote-inpage_fb2"] = true
+
 local CssTweaks = {
+    DEFAULT_GLOBAL_STYLE_TWEAKS = DEFAULT_GLOBAL_STYLE_TWEAKS,
     {
         title = C_("Style tweaks category", "Pages"),
         {


### PR DESCRIPTION
Set these 2 tweaks as default global tweaks for new users (and existing users that have not set any global defaults).
One can disable them by long-press on each of them.
Only per-specs EPUB and FB2 footnotes (other in-page footnotes tweaks may trigger on non-footnote content on some books, so let enabling them be a user decision).
Discussed at https://github.com/koreader/koreader/issues/5015#issuecomment-592609337

So, (mostly) everybody will get:

<kbd>![image](https://user-images.githubusercontent.com/24273478/75568621-e93b8980-5a53-11ea-8c21-5a430f24b244.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/75568590-da54d700-5a53-11ea-9f2d-2f293f77ab2b.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5908)
<!-- Reviewable:end -->
