### PR TITLE
PathChooser: fetch 'show_hidden' setting on each use

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -67,7 +67,6 @@ function FileManagerShortcuts:addNewFolder()
         select_directory = true,
         select_file = false,
         path = self.fm_bookmark.curr_path,
-        show_hidden = self.ui.file_chooser.show_hidden,
         onConfirm = function(path)
             local add_folder_input
             local friendly_name = util.basename(path) or _("my folder")

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -24,7 +24,6 @@ local PathChooser = FileChooser:extend{
     select_file = true,      -- allow selecting files
     show_files = true, -- show files, even if select_files=false
     -- (directories are always shown, to allow navigation)
-    show_hidden = G_reader_settings:readSetting("show_hidden"),
     detailed_file_info = false, -- show size and last mod time in Select message
 }
 
@@ -38,6 +37,7 @@ function PathChooser:init()
             self.title = _("Long-press to select")
         end
     end
+    self.show_hidden = G_reader_settings:readSetting("show_hidden")
     if not self.show_files then
         self.file_filter = function() return false end -- filter out regular files
     end


### PR DESCRIPTION
Rework #5785: `show_hidden` was fetched from G_reader_settings in new/extend(), so it kept the value it got on its first use/require. This just makes PathChooser pick it from G_reader_settings in PathChooser:init(), so on each instantiation - so we always get the current up to date value (https://github.com/koreader/koreader/issues/5919#issuecomment-595885460).
Closes #5919: fix crash when FileManagerShortcuts is called from outside File browser, e.g. from Reader via a gesture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5923)
<!-- Reviewable:end -->
