### PR TITLE
Correct Frontlight status on suspend when screensaver mode is 'Leave …

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -232,7 +232,8 @@ function Device:onPowerEvent(ev)
         -- Mostly always suspend in Portrait/Inverted Portrait mode...
         -- ... except when we just show an InfoMessage or when the screensaver
         -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290)
-        if (G_reader_settings:readSetting("screensaver_type") ~= "message" and G_reader_settings:readSetting("screensaver_type") ~= "disable") then
+        if G_reader_settings:readSetting("screensaver_type") ~= "message" and
+           G_reader_settings:readSetting("screensaver_type") ~= "disable" then
             self.orig_rotation_mode = self.screen:getRotationMode()
             -- Leave Portrait & Inverted Portrait alone, that works just fine.
             if bit.band(self.orig_rotation_mode, 1) == 1 then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -231,7 +231,7 @@ function Device:onPowerEvent(ev)
         logger.dbg("Suspending...")
         -- Mostly always suspend in Portrait/Inverted Portrait mode...
         -- ... except when we just show an InfoMessage, it plays badly with Landscape mode (c.f., #4098)
-        if G_reader_settings:readSetting("screensaver_type") ~= "message" then
+        if (G_reader_settings:readSetting("screensaver_type") ~= "message" and G_reader_settings:readSetting("screensaver_type") ~= "disable") then
             self.orig_rotation_mode = self.screen:getRotationMode()
             -- Leave Portrait & Inverted Portrait alone, that works just fine.
             if bit.band(self.orig_rotation_mode, 1) == 1 then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -230,7 +230,8 @@ function Device:onPowerEvent(ev)
         local UIManager = require("ui/uimanager")
         logger.dbg("Suspending...")
         -- Mostly always suspend in Portrait/Inverted Portrait mode...
-        -- ... except when we just show an InfoMessage, it plays badly with Landscape mode (c.f., #4098)
+        -- ... except when we just show an InfoMessage or when the screensaver
+        -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290)
         if (G_reader_settings:readSetting("screensaver_type") ~= "message" and G_reader_settings:readSetting("screensaver_type") ~= "disable") then
             self.orig_rotation_mode = self.screen:getRotationMode()
             -- Leave Portrait & Inverted Portrait alone, that works just fine.

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -232,8 +232,8 @@ function Device:onPowerEvent(ev)
         -- Mostly always suspend in Portrait/Inverted Portrait mode...
         -- ... except when we just show an InfoMessage or when the screensaver
         -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290)
-        if G_reader_settings:readSetting("screensaver_type") ~= "message" and
-           G_reader_settings:readSetting("screensaver_type") ~= "disable" then
+        local screensaver_type = G_reader_settings:readSetting("screensaver_type")
+        if screensaver_type ~= "message" and screensaver_type ~= "disable" then
             self.orig_rotation_mode = self.screen:getRotationMode()
             -- Leave Portrait & Inverted Portrait alone, that works just fine.
             if bit.band(self.orig_rotation_mode, 1) == 1 then
@@ -246,9 +246,8 @@ function Device:onPowerEvent(ev)
             -- On eInk, if we're using a screensaver mode that shows an image,
             -- flash the screen to white first, to eliminate ghosting.
             if self:hasEinkScreen() and
-               G_reader_settings:readSetting("screensaver_type") == "cover" or
-               G_reader_settings:readSetting("screensaver_type") == "random_image" or
-               G_reader_settings:readSetting("screensaver_type") == "image_file" then
+               screensaver_type == "cover" or screensaver_type == "random_image" or
+               screensaver_type == "image_file" then
                 if not G_reader_settings:isTrue("screensaver_no_background") then
                     self.screen:clear()
                 end


### PR DESCRIPTION
Address #5920 to correct Frontlight status on suspend when screensaver mode is 'Leave screen as it is' in landscape mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5928)
<!-- Reviewable:end -->
