### PR TITLE
Make xpointers migration ConfirmBox non-dismissable

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1276,6 +1276,10 @@ Note that %1 (out of %2) xpaths from your bookmarks and highlights have been nor
 
     UIManager:show(ConfirmBox:new{
         text = text,
+        -- Given the layout of the buttons (Cancel|OK, and a big other button below
+        -- with "Not now"), we don't want cancel_callback to be called when dismissing
+        -- this ConfirmBox by taping outside. So, make it non dismissable.
+        dismissable = false,
         other_buttons = {{
             {
                 -- this is the real cancel/do nothing


### PR DESCRIPTION
Because dismissing it by tapping outside would have "not for this book" selected, which is the least welcome action...
Details at https://github.com/koreader/koreader/pull/5897#issuecomment-596209498.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5931)
<!-- Reviewable:end -->
