### PR TITLE
[fix] Support proper local links

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -524,7 +524,7 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
     end
 
     -- Check if it is a link to a local file
-    local linked_filename = link_url:gsub("^file:", "") -- remove local file protocol if any
+    local linked_filename = link_url:gsub("^file:/?/?", "") -- remove local file protocol if any
     local anchor
     if linked_filename:find("?") then -- remove any query string (including any following anchor)
         linked_filename, anchor = linked_filename:match("^(.-)(%?.*)$")

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -524,7 +524,7 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
     end
 
     -- Check if it is a link to a local file
-    local linked_filename = link_url:gsub("^file:/?/?", "") -- remove local file protocol if any
+    local linked_filename = link_url:gsub("^file:(//)?", "") -- remove local file protocol if any
     local anchor
     if linked_filename:find("?") then -- remove any query string (including any following anchor)
         linked_filename, anchor = linked_filename:match("^(.-)(%?.*)$")


### PR DESCRIPTION
Only borked ones were supported. The new behavior mimics Firefox.

The following incorrect varieties will be treated the same as the correct `file:///tmp/test.txt`.
* file:/tmp/test.txt
* file://tmp/test.txt

Fixes <https://github.com/koreader/koreader/issues/5941>.

See <https://github.com/koreader/koreader/issues/5941#issuecomment-598633973> for discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5945)
<!-- Reviewable:end -->
