### PR TITLE
Gesture "Turn Wi-Fi off": a better indication 

### DIFF
--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -1471,12 +1471,18 @@ function ReaderGesture:gestureAction(action, ges)
     elseif action == "wifi_off" then
         local NetworkMgr = require("ui/network/manager")
         -- can't hurt
-        NetworkMgr:turnOffWifi()
-
-        UIManager:show(InfoMessage:new{
-            text = _("Wi-Fi off."),
-            timeout = 1,
-        })
+        if not NetworkMgr:isOnline() then
+            UIManager:show(InfoMessage:new{
+                text = _("Wi-Fi is already off."),
+                timeout = 1,
+            })
+        else
+            NetworkMgr:turnOffWifi()
+            UIManager:show(InfoMessage:new{
+                text = _("Turning Wi-Fi off."),
+                timeout = 1,
+            })
+        end
     elseif action == "wifi_on" then
         local NetworkMgr = require("ui/network/manager")
 


### PR DESCRIPTION
Hi guys!

I suggest a better indication if Wi-Fi was already turned off when using "Turn Wi-Fi off" gesture directly (not "Toggle Wi-Fi").
For example, I set up gesture top bar to the left as "Turn Wi-Fi off", gesture top bar to the right as "Turn Wi-Fi on". Now:
1) If I use the first gesture if Wi-Fi is already off, it will says "Wi-Fi is already off"
2) If use the first gesture if Wi-Fi was on, it will say "Turning Wi-Fi on".
Gesture "Turning on" already has such detection, so I just completed the "Turning off" case.

One caveat though is that we will probably need to add another translation string for that..
Please let me know if this works.

Thank you!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5959)
<!-- Reviewable:end -->
