### PR TITLE
More compact dictionary download window

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -832,8 +832,8 @@ end
 
 function ReaderDictionary:showDownload(downloadable_dicts)
     local kv_pairs = {}
-    table.insert(kv_pairs, {_("Tap dictionary name to download"), ""})
-    table.insert(kv_pairs, "----------------------------")
+    -- table.insert(kv_pairs, {_("Tap dictionary name to download"), ""})
+    -- table.insert(kv_pairs, "----------------------------")
     for dummy, dict in ipairs(downloadable_dicts) do
         table.insert(kv_pairs, {dict.name, "",
             callback = function()
@@ -855,7 +855,8 @@ function ReaderDictionary:showDownload(downloadable_dicts)
         table.insert(kv_pairs, "----------------------------")
     end
     self.download_window = KeyValuePage:new{
-        title = _("Download dictionaries"),
+        -- title = _("Download dictionaries"),
+        title = _("Tap dictionary name to download"),
         kv_pairs = kv_pairs,
     }
     UIManager:show(self.download_window)

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -832,8 +832,6 @@ end
 
 function ReaderDictionary:showDownload(downloadable_dicts)
     local kv_pairs = {}
-    -- table.insert(kv_pairs, {_("Tap dictionary name to download"), ""})
-    -- table.insert(kv_pairs, "----------------------------")
     for dummy, dict in ipairs(downloadable_dicts) do
         table.insert(kv_pairs, {dict.name, "",
             callback = function()
@@ -855,7 +853,6 @@ function ReaderDictionary:showDownload(downloadable_dicts)
         table.insert(kv_pairs, "----------------------------")
     end
     self.download_window = KeyValuePage:new{
-        -- title = _("Download dictionaries"),
         title = _("Tap dictionary name to download"),
         kv_pairs = kv_pairs,
     }


### PR DESCRIPTION
#5955 
So I just combined the first two titles on the first page. This saves space and allows three complete dictionary entries to fit one page. This works on Kindle PW3, I don't know about other screens.
Please have a look:
![Reader_2020-Mar-15_020536](https://user-images.githubusercontent.com/6279855/76697158-e0f56800-6669-11ea-9a9c-cbf08924ab9e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5960)
<!-- Reviewable:end -->
