### PR TITLE
bump crengine: handle block elements inside inline element

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -621,19 +621,52 @@ This is just an example, that will need to be adapted into a user style tweak.]]
         {
             title = _("In-page footnotes"),
             {
-                id = "footnote-inpage_fb2";
                 title = _("In-page FB2 footnotes"),
-                description = _([[
+                {
+                    id = "footnote-inpage_fb2";
+                    title = _("In-page FB2 footnotes"),
+                    description = _([[
 Show FB2 footnote text at the bottom of pages that contain links to them.]]),
-                -- (fb2.css already set font-size to 70% - so no need for a "smaller" variant)
-                css = [[
-body[name="notes"] section,
-body[name="comments"] section
-{
+                    -- Avoid 75% of 75% in case of nested <section>
+                    css = [[
+body[name="notes"] section {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
 }
-                ]],
+body[name="notes"] > section {
+    font-size: 75%;
+}
+                    ]],
+                },
+                {
+                    id = "footnote-inpage_fb2_comments";
+                    title = _("In-page FB2 endnotes"),
+                    description = _([[
+Show FB2 endnote text at the bottom of pages that contain links to them.]]),
+                    css = [[
+body[name="comments"] section {
+    -cr-hint: footnote-inpage;
+    margin: 0 !important;
+}
+body[name="comments"] > section {
+    font-size: 85%;
+}
+                    ]],
+                    separator = true,
+                },
+                {
+                    id = "fb2_footnotes_regular_font_size";
+                    title = _("Keep regular font size"),
+                    description = _([[
+FB2 footnotes and endnotes get a smaller font size when displayed in-page. This allows them to be shown with the normal font size.]]),
+                    css = [[
+body[name="notes"] > section,
+body[name="comments"] > section
+{
+    font-size: 100% !important;
+}
+                    ]],
+                },
                 separator = true,
             },
             {

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -104,6 +104,10 @@ body > section > autoBoxing + p,
 body > section > p + p {
     display: block;
 }
+body > section > autoBoxing > title,
+body > section > title {
+    font-weight: bold;
+}
 ]]
 
 -- Add this if needed for debugging:


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/330
- FB2 footnotes: disable hardcoded handling as in-page 2
- CSS: also support gray colors spelled "grey"
- Text: move past floats when wide image or inlineBox does not fit
- Fix list item marker clipping check
- Ensure nodeDisplayStyleHash change when boxing prevented by cache
- Text: adds LFormattedText.is_reusable
- Handle block elements inside inline element
- Fix getBookmark() on multi-pages embedded block
- (Upstream) Support raw picture in RTF
- (Upstream) Fixed integer overflow in cache size calculations
- Add libCURL's CA bundle to the ignore list https://github.com/koreader/crengine/pull/332
- FB2 footnotes: fix setBoxingWishedButPreventedByCache() https://github.com/koreader/crengine/pull/333
- fb2.css: handle body[name="comments"] as footnotes

Also: Update base/thirdparty/turbo to v2.1.3 https://github.com/koreader/koreader-base/pull/1064

Also includes some FB2 footnotes tweaks, discussion around https://github.com/koreader/crengine/pull/329#issuecomment-599046771.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5962)
<!-- Reviewable:end -->
