### PR TITLE
fix current book on statistics enable

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -205,6 +205,8 @@ function ReaderStatistics:initData()
     self.total_read_pages, self.total_read_time = self:getPageTimeTotalStats(self.id_curr_book)
     if self.total_read_pages > 0 then
         self.avg_time = self.total_read_time / self.total_read_pages
+    else
+        self.avg_time = 0
     end
 end
 


### PR DESCRIPTION
when enabling statistics while reading a new book.
if you then click on `current book` koreader crashes as `avg_time` is nill

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/5971)
<!-- Reviewable:end -->
