### PR TITLE
Gestures: add action "Statistics calendar view"

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -680,14 +680,7 @@ end
 
 function FileManager:goHome()
     local home_dir = G_reader_settings:readSetting("home_dir")
-    if home_dir then
-        -- Jump to the first page if we're already home
-        if self.file_chooser.path and home_dir == self.file_chooser.path then
-            self.file_chooser:onGotoPage(1)
-        else
-            self.file_chooser:changeToPath(home_dir)
-        end
-    else
+    if not home_dir or lfs.attributes(home_dir, "mode") ~= "directory"  then
         -- Try some sane defaults, depending on platform
         if Device:isKindle() then
             home_dir = "/mnt/us"
@@ -700,16 +693,16 @@ function FileManager:goHome()
         elseif Device:isAndroid() then
             home_dir = Device.external_storage()
         end
-
-        if home_dir then
-            if self.file_chooser.path and home_dir == self.file_chooser.path then
-                self.file_chooser:onGotoPage(1)
-            else
-                self.file_chooser:changeToPath(home_dir)
-            end
+    end
+    if home_dir then
+        -- Jump to the first page if we're already home
+        if self.file_chooser.path and home_dir == self.file_chooser.path then
+            self.file_chooser:onGotoPage(1)
         else
-            self:setHome()
+            self.file_chooser:changeToPath(home_dir)
         end
+    else
+        self:setHome()
     end
     return true
 end

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -47,6 +47,7 @@ local action_strings = {
     book_info = _("Book information"),
     book_description = _("Book description"),
     book_cover = _("Book cover"),
+    stats_calendar_view = _("Statistics calendar view"),
 
     history = _("History"),
     open_previous_document = _("Open previous document"),
@@ -719,7 +720,7 @@ function ReaderGesture:buildMenu(ges, default)
         {"show_plus_menu", self.is_docless},
         {"folder_shortcuts", true, true},
 
-        { "toc", not self.is_docless},
+        {"toc", not self.is_docless},
         {"bookmarks", not self.is_docless},
         {"reading_progress", ReaderGesture.getReaderProgress ~= nil},
         {"book_statistics", not self.is_docless},
@@ -733,6 +734,7 @@ function ReaderGesture:buildMenu(ges, default)
         {"open_previous_document", true, true},
         {"favorites", true},
         {"filemanager", not self.is_docless, true},
+        {"stats_calendar_view", true, true},
 
         {"dictionary_lookup", true},
         {"wikipedia_lookup", true, true},
@@ -1265,6 +1267,8 @@ function ReaderGesture:gestureAction(action, ges)
         UIManager:show(ReaderGesture.getReaderProgress())
     elseif action == "book_statistics" and ReaderGesture.getBookStats then
         UIManager:show(ReaderGesture.getBookStats())
+    elseif action == "stats_calendar_view" and ReaderGesture.getCalendarView then
+        UIManager:show(ReaderGesture.getCalendarView())
     elseif action == "toc" then
         self.ui:handleEvent(Event:new("ShowToc"))
     elseif action == "night_mode" then

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -176,6 +176,10 @@ function ReaderStatistics:init()
         }
         return stats
     end
+
+    ReaderGesture.getCalendarView = function()
+        return self:getCalendarView()
+    end
 end
 
 function ReaderStatistics:initData()
@@ -866,17 +870,7 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                 text = _("Calendar view"),
                 keep_menu_open = true,
                 callback = function()
-                    local CalendarView = require("calendarview")
-                    UIManager:show(CalendarView:new{
-                        reader_statistics = self,
-                        monthTranslation = monthTranslation,
-                        shortDayOfWeekTranslation = shortDayOfWeekTranslation,
-                        longDayOfWeekTranslation = longDayOfWeekTranslation,
-                        start_day_of_week = self.calendar_start_day_of_week,
-                        nb_book_spans = self.calendar_nb_book_spans,
-                        show_hourly_histogram = self.calendar_show_histogram,
-                        browse_future_months = self.calendar_browse_future_months,
-                    })
+                    UIManager:show(self:getCalendarView())
                 end,
             },
         },
@@ -1975,6 +1969,21 @@ function ReaderStatistics:onReaderReady()
     -- we have correct page count now, do the actual initialization work
     self:initData()
     self.view.footer:updateFooter()
+end
+
+function ReaderStatistics:getCalendarView()
+    self:insertDB(self.id_curr_book)
+    local CalendarView = require("calendarview")
+    return CalendarView:new{
+        reader_statistics = self,
+        monthTranslation = monthTranslation,
+        shortDayOfWeekTranslation = shortDayOfWeekTranslation,
+        longDayOfWeekTranslation = longDayOfWeekTranslation,
+        start_day_of_week = self.calendar_start_day_of_week,
+        nb_book_spans = self.calendar_nb_book_spans,
+        show_hourly_histogram = self.calendar_show_histogram,
+        browse_future_months = self.calendar_browse_future_months,
+    }
 end
 
 -- Used by calendarview.lua CalendarView


### PR DESCRIPTION
Add a gesture action to show Statistics calendar view - because I realised I was hitting that menu too often :)
Also flush statistics to DB when showing it, so we see the last minutes/hours reading in the hourly histogram.

Also: File browser: sane fallback when home_dir invalid or missing - see https://github.com/koreader/koreader/issues/6026#issuecomment-610856059

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6035)
<!-- Reviewable:end -->
