### PR TITLE
desktop: disable battery on touch menu and reader footer

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -51,7 +51,7 @@ function ReaderFont:init()
     end
     -- build face_table for menu
     self.face_table = {}
-    if Device:isAndroid() or Device:isDesktop() then
+    if Device:isAndroid() or Device:isDesktop() or Device:isEmulator() then
         table.insert(self.face_table, require("ui/elements/font_settings"):getMenuTable())
     end
     local face_list = cre.getFontFaces()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -336,6 +336,9 @@ function ReaderFooter:init()
     if not Device:hasFrontlight() then
         MODE.frontlight = nil
     end
+    if Device:isDesktop() then
+        MODE.battery = nil
+    end
     for k, v in pairs(MODE) do
         mode_tbl[v] = k
     end

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -74,7 +74,6 @@ local Emulator = Device:new{
     hasFrontlight = yes,
     hasWifiToggle = yes,
     hasWifiManager = yes,
-    isDesktop = yes,
 }
 
 local Linux = Device:new{

--- a/frontend/document/canvascontext.lua
+++ b/frontend/document/canvascontext.lua
@@ -38,6 +38,7 @@ function CanvasContext:init(device)
     self.screen = device.screen
     self.isAndroid = device.isAndroid
     self.isDesktop = device.isDesktop
+    self.isEmulator = device.isEmulator
     self.isKindle = device.isKindle
     self.should_restrict_JIT = device.should_restrict_JIT
     self:setColorRenderingEnabled(device.screen.isColorEnabled())

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -84,7 +84,7 @@ local function isInFontsBlacklist(f)
 end
 
 local function getExternalFontDir()
-    if CanvasContext.isAndroid() or CanvasContext.isDesktop() then
+    if CanvasContext.isAndroid() or CanvasContext.isDesktop() or CanvasContext.isEmulator() then
         return require("frontend/ui/elements/font_settings"):getPath()
     else
         return os.getenv("EXT_FONT_DIR")

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -26,7 +26,7 @@ end
 -- user font path, should be rw. On linux/mac it goes under $HOME.
 -- on Android it goes in the primary storage (internal/sd)
 local function getUserDir()
-    if Device:isDesktop() then
+    if Device:isDesktop() or Device:isEmulator() then
         local home = os.getenv("HOME")
         if home then return home..DESKTOP_USER_FONT_DIR end
     elseif Device:isAndroid() then
@@ -37,7 +37,7 @@ end
 
 -- system (ttf) fonts are available on linux and android but not on mac
 local function getSystemDir()
-    if Device:isDesktop() then
+    if Device:isDesktop() or Device:isEmulator() then
         if util.pathExists(LINUX_SYSTEM_FONT_DIR) then
             return LINUX_SYSTEM_FONT_DIR
         else return nil end
@@ -91,7 +91,7 @@ function FontSettings:getMenuTable()
         end,
     }}
 
-    if Device:isDesktop() then table.insert(t, 2, {
+    if Device:isDesktop() or Device:isEmulator() then table.insert(t, 2, {
             text = _("Open fonts folder"),
             keep_menu_open = true,
             callback = openFontDir,

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -660,7 +660,9 @@ function TouchMenu:updateItems()
             batt_symbol = ""
         end
     end
-    time_info_txt = BD.wrap(time_info_txt) .. " " .. BD.wrap("⌁") .. BD.wrap(batt_symbol) ..  BD.wrap(batt_lvl .. "%")
+    if not Device:isDesktop() then
+        time_info_txt = BD.wrap(time_info_txt) .. " " .. BD.wrap("⌁") .. BD.wrap(batt_symbol) ..  BD.wrap(batt_lvl .. "%")
+    end
     self.time_info:setText(time_info_txt)
 
     -- recalculate dimen based on new layout


### PR DESCRIPTION
The emulator will still show the battery.

## Emulator

![emulator](https://user-images.githubusercontent.com/975883/79048377-018af080-7c1d-11ea-8283-e31851377fcc.png)

## Desktop

![desktop](https://user-images.githubusercontent.com/975883/79048381-09e32b80-7c1d-11ea-97cb-3b32b112aa5f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6040)
<!-- Reviewable:end -->
