### PR TITLE
Statistics: fix md5 leaking between newly opened books

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1962,7 +1962,7 @@ function ReaderStatistics:saveSettings()
 end
 
 function ReaderStatistics:onReadSettings(config)
-    self.data = config.data.stats
+    self.data = config.data.stats or {}
 end
 
 function ReaderStatistics:onReaderReady()


### PR DESCRIPTION
Which could cause a same book appearing multiple times as different entries in statistics.
More details in https://github.com/koreader/koreader-base/pull/1077#issuecomment-613353913

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6052)
<!-- Reviewable:end -->
