### PR TITLE
Add export to JSON option in Evernote plugin. Sort requires in Evernote plugin sources.

### DIFF
--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -16,6 +16,7 @@ local _ = require("gettext")
 local N_ = _.ngettext
 local slt2 = require('slt2')
 local MyClipping = require("clip")
+local json = require("json")
 local realpath = require("ffi/util").realpath
 
 local EvernoteExporter = InputContainer:new{
@@ -32,6 +33,7 @@ local EvernoteExporter = InputContainer:new{
 
 function EvernoteExporter:init()
     self.text_clipping_file = self.clipping_dir .. "/KOReaderClipping.txt"
+    self.json_clipping_file = self.clipping_dir .. "/KOReaderClipping.json"
     local settings = G_reader_settings:readSetting("evernote") or {}
     self.evernote_domain = settings.domain
     self.evernote_username = settings.username or ""
@@ -44,13 +46,18 @@ function EvernoteExporter:init()
     self.html_export = settings.html_export or false
     self.joplin_export = settings.joplin_export or false
     self.txt_export = settings.txt_export or false
-    --- @todo Is this if block necessarry? Nowhere in the code they are assigned both true.
+    self.json_export = settings.json_export or false
+    --- @todo Is this if block necessary? Nowhere in the code they are assigned both true.
     -- Do they check against external modifications to settings file?
 
     if self.html_export then
         self.txt_export = false
         self.joplin_export = false
+        self.json_export = false
     elseif self.txt_export then
+        self.joplin_export = false
+        self.json_export = false
+    elseif self.json_export then
         self.joplin_export = false
     end
 
@@ -73,6 +80,7 @@ function EvernoteExporter:readyToExport()
     return self.evernote_token ~= nil or
             self.html_export ~= false or
             self.txt_export ~= false or
+            self.json_export ~= false or
             self.joplin_export ~= false
 end
 
@@ -224,6 +232,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
                             if self.joplin_export then
                                 self.html_export = false
                                 self.txt_export = false
+                                self.json_export = false
                             end
                             self:saveSettings()
                         end
@@ -281,12 +290,26 @@ For more information, please visit https://github.com/koreader/koreader/wiki/Eve
                 end
             },
             {
+                text = _("Export to local JSON files"),
+                checked_func = function() return self.json_export end,
+                callback = function()
+                    self.json_export = not self.json_export
+                    if self.json_export then
+                        self.txt_export = false
+                        self.html_export = false
+                        self.joplin_export = false
+                    end
+                    self:saveSettings()
+                end
+            },
+            {
                 text = _("Export to local HTML files"),
                 checked_func = function() return self.html_export end,
                 callback = function()
                     self.html_export = not self.html_export
                     if self.html_export then
                         self.txt_export = false
+                        self.json_export = false
                         self.joplin_export = false
                     end
                     self:saveSettings()
@@ -299,6 +322,7 @@ For more information, please visit https://github.com/koreader/koreader/wiki/Eve
                     self.txt_export = not self.txt_export
                     if self.txt_export then
                         self.html_export = false
+                        self.json_export = false
                         self.joplin_export = false
                     end
                     self:saveSettings()
@@ -428,6 +452,7 @@ function EvernoteExporter:saveSettings()
         notebook = self.notebook_guid,
         html_export = self.html_export,
         txt_export = self.txt_export,
+        json_export = self.json_export,
         joplin_IP = self.joplin_IP,
         joplin_port = self.joplin_port,
         joplin_token = self.joplin_token,
@@ -493,7 +518,7 @@ text field is created or updated. Parser looks to bookmarks._.text field for edi
 https://github.com/koreader/koreader/blob/605f6026bbf37856ee54741b8a0697337ca50039/plugins/evernote.koplugin/clip.lua#L229
 Clippings: Parsed form of highlights, stored in clipboard/evernote.sdr/metadata.sdr.lua
 for all documents. Used only for exporting bookmarks. Internal highlight or bookmark functions
-does not usew this table.
+does not use this table.
 Booknotes: Every table in clippings table. clippings = {"title" = booknotes}
 --]]
 function EvernoteExporter:exportAllNotes()
@@ -521,7 +546,7 @@ function EvernoteExporter:exportClippings(clippings)
     local client = nil
     local exported_stamp
     local joplin_client
-    if not (self.html_export or self.txt_export or self.joplin_export) then
+    if not (self.html_export or self.txt_export or self.joplin_export or self.json_export) then
         client = require("EvernoteClient"):new{
             domain = self.evernote_domain,
             authToken = self.evernote_token,
@@ -529,6 +554,8 @@ function EvernoteExporter:exportClippings(clippings)
         exported_stamp = self.notebook_guid
     elseif self.html_export then
         exported_stamp= "html"
+    elseif self.json_export then
+        exported_stamp= "json"
     elseif self.txt_export then
         os.remove(self.text_clipping_file)
         exported_stamp = "txt"
@@ -558,12 +585,14 @@ function EvernoteExporter:exportClippings(clippings)
         -- check if booknotes are exported in this notebook
         -- so that booknotes will still be exported after switching user account
         --Don't respect exported_stamp on txt export since it isn't possible to delete(update) prior clippings.
-        if booknotes.exported[exported_stamp] ~= true or self.txt_export then
+        if booknotes.exported[exported_stamp] ~= true or self.txt_export or self.json_export then
             local ok, err
             if self.html_export then
                 ok, err = pcall(self.exportBooknotesToHTML, self, title, booknotes)
             elseif self.txt_export then
                 ok, err = pcall(self.exportBooknotesToTXT, self, title, booknotes)
+            elseif self.json_export then
+                ok, err = pcall(self.exportBooknotesToJSON, self, title, booknotes)
             elseif self.joplin_export then
                 ok, err = pcall(self.exportBooknotesToJoplin, self, joplin_client, title, booknotes)
             else
@@ -647,6 +676,15 @@ function EvernoteExporter:exportBooknotesToHTML(title, booknotes)
     if html then
         html:write(content)
         html:close()
+    end
+end
+
+function EvernoteExporter:exportBooknotesToJSON(title, booknotes)
+    local file = io.open(self.json_clipping_file, "a")
+    if file then
+        file:write(json.encode(booknotes))
+        file:write("\n")
+        file:close()
     end
 end
 


### PR DESCRIPTION
Tested in a Boox Max Carta.

The purpose (for me) of having JSON formatted clippings is that they are easy to parse, and then convert to org mode format, which is the format I am interested in.

I tried exporting html and converting to org with pandoc, but the result didn't please me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6067)
<!-- Reviewable:end -->
