### PR TITLE
bump crengine: text typography by language

### DIFF
--- a/spec/unit/readerlink_spec.lua
+++ b/spec/unit/readerlink_spec.lua
@@ -17,9 +17,9 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
-        readerui.rolling:onGotoPage(4)
-        readerui.link:onTap(nil, {pos = {x = 320, y = 120}})
-        assert.is.same(36, readerui.rolling.current_page)
+        readerui.rolling:onGotoPage(5)
+        readerui.link:onTap(nil, {pos = {x = 320, y = 190}})
+        assert.is.same(37, readerui.rolling.current_page)
     end)
 
     it("should jump to links in pdf page mode", function()
@@ -56,11 +56,11 @@ describe("ReaderLink module", function()
         local readerui = ReaderUI:new{
             document = DocumentRegistry:openDocument(sample_epub),
         }
-        readerui.rolling:onGotoPage(4)
-        readerui.link:onTap(nil, {pos = {x = 320, y = 120}})
-        assert.is.same(36, readerui.rolling.current_page)
+        readerui.rolling:onGotoPage(5)
+        readerui.link:onTap(nil, {pos = {x = 320, y = 190}})
+        assert.is.same(37, readerui.rolling.current_page)
         readerui.link:onGoBackLink()
-        assert.is.same(4, readerui.rolling.current_page)
+        assert.is.same(5, readerui.rolling.current_page)
     end)
 
     it("should be able to go back after link jump in pdf page mode", function()


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/337 :
- Fix a few clang-tidy warnings
- Add support for <img src="data:image/png;base64,...> - Closes #5529.
- XML parsing: add more HTML5 named entities, optimize search
- Text: fix standalone BR not making an empty line
- Fix BR with "display: block" not making an empty line
- Fix hyphens from soft-hyphens not part of highlighted segments
- Use libunibreak for line breaking
- Adds TextLangMan for text typography by language
- Force BR to always be display:inline https://github.com/koreader/crengine/pull/338

Tweak ReaderHyphenation to work with the new TextLangMan (even if it will be replaced soon by ReaderTypography).
(Removed uneeded onUpdateToc() which were useless as they were done before the new rendering - another one was done elsewhere after the re-rendering)

This is just a bump to get a build with the new crengine code, which should still work with our current single global hyphenation language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6069)
<!-- Reviewable:end -->
