### PR TITLE
Option to prevent tap on status bar

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -845,7 +845,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Lock tap status bar"),
+                text = _("Lock status bar"),
                 checked_func = function()
                     return self.settings.lock_tap
                 end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1785,10 +1785,7 @@ function ReaderFooter:onExitFlippingMode()
 end
 
 function ReaderFooter:onTapFooter(ges)
-    if self.settings.lock_tap then
-        return true
-    end
-    if self.has_no_mode then
+    if self.has_no_mode or self.settings.lock_tap then
         return
     end
     if self.view.flipping_visible then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -845,6 +845,15 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             {
+                text = _("Lock tap status bar"),
+                checked_func = function()
+                    return self.settings.lock_tap
+                end,
+                callback = function()
+                    self.settings.lock_tap = not self.settings.lock_tap
+                end,
+            },
+            {
                 text = _("Font"),
                 separator = true,
                 sub_item_table = {
@@ -1776,6 +1785,9 @@ function ReaderFooter:onExitFlippingMode()
 end
 
 function ReaderFooter:onTapFooter(ges)
+    if self.settings.lock_tap then
+        return true
+    end
     if self.has_no_mode then
         return
     end


### PR DESCRIPTION
See: #5969 

New option in Status bar -> Settings
`Lock tap status bar` (mayby better name?)

When we enable it - tap on status bar is disabled (locked)

<img src=https://user-images.githubusercontent.com/22982594/79981629-488ea680-84a5-11ea-81f1-d1ac62e2c264.png width=60%>

Close: #5969

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6083)
<!-- Reviewable:end -->
