### PR TITLE
Text widgets, crengine: fix wrong vertical positionning

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -793,7 +793,7 @@ function TextBoxWidget:_renderText(start_row_idx, end_row_idx)
                         end
                         self._bb:colorblitFrom(glyph.bb,
                                     xglyph.x0 + glyph.l + xglyph.x_offset,
-                                    y - glyph.t + xglyph.y_offset,
+                                    y - glyph.t - xglyph.y_offset,
                                     0, 0, glyph.bb:getWidth(), glyph.bb:getHeight(), color)
                     end
                 end

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -348,7 +348,7 @@ function TextWidget:paintTo(bb, x, y)
         bb:colorblitFrom(
             glyph.bb,
             x + pen_x + glyph.l + xglyph.x_offset,
-            y + baseline - glyph.t + xglyph.y_offset,
+            y + baseline - glyph.t - xglyph.y_offset,
             0, 0,
             glyph.bb:getWidth(), glyph.bb:getHeight(),
             self.fgcolor)


### PR DESCRIPTION
bump crengine: fix wrong usage of Harfbuzz y_offset https://github.com/koreader/crengine/pull/340
Same in TextWidget and TextBoxWidget.

Noticable with nastaliq arabic fonts, see https://github.com/koreader/koreader/pull/6090#issuecomment-619418198 :

<kbd>![image](https://user-images.githubusercontent.com/24273478/80290807-45671500-8748-11ea-8009-bd5ed5fd2364.png)</kbd> => <kbd>![image](https://user-images.githubusercontent.com/24273478/80290812-52840400-8748-11ea-8494-118698664fca.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6093)
<!-- Reviewable:end -->
