### PR TITLE
Allow toggling use of additional fallback fonts

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -362,14 +362,14 @@ These fonts will be used in this order:
 
 %1
 
-You can set a prefered fallback font with a long-press on a font name, and it will be used before these.
+You can set a preferred fallback font with a long-press on a font name, and it will be used before these.
 If that font happens to be part of this list already, it will be used first.]]),
             table.concat(self.ui.document.fallback_fonts, "\n")),
         separator = true,
     })
 
     table.insert(settings_table, {
-        text = _("Generate font test HTML document"),
+        text = _("Generate font test document"),
         callback = function()
             UIManager:show(ConfirmBox:new{
                 text = _("Would you like to generate an HTML document showing some sample text rendered with each available font?");

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -82,8 +82,28 @@ function ReaderFont:init()
         })
         face_list[k] = {text = v}
     end
+    self.face_table[#self.face_table].separator = true
+    table.insert(self.face_table, {
+        text = _("Complementary standard fallback fonts"),
+        checked_func = function()
+            return G_reader_settings:nilOrTrue("complementary_fallback_fonts")
+        end,
+        callback = function()
+        G_reader_settings:flipNilOrTrue("complementary_fallback_fonts")
+            self.ui.document:setupFallbackFontFaces()
+            self.ui:handleEvent(Event:new("UpdatePos"))
+        end,
+        help_text = T(_([[
+Enable additional fallback fonts, for the most complete scripts and languages coverage.
+Complementary fonts, used in this order:
+
+%1
+
+The fallback font set with a long-press on a font name will be used before these.
+Note that the first font of the whole fallback fonts set is still used when this option is disabled.]]),
+            table.concat(self.ui.document.fallback_fonts, "\n")),
+    })
     if self:hasFontsTestSample() then
-        self.face_table[#self.face_table].separator = true
         table.insert(self.face_table, {
             text = _("Generate fonts test HTML document"),
             callback = function()

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -362,7 +362,7 @@ These fonts will be used in this order:
 
 %1
 
-You can set a prefered fallback font set with a long-press on a font name, and it will be used before these.
+You can set a prefered fallback font with a long-press on a font name, and it will be used before these.
 If that font happens to be part of this list already, it will be used first.]]),
             table.concat(self.ui.document.fallback_fonts, "\n")),
         separator = true,
@@ -397,7 +397,7 @@ function ReaderFont:buildFontsTestDocument()
         f:close()
     end
     if not html_sample then
-        local f = io.open(FONT_TEST_DEFAULT_SAMPLE_PATH, "r")
+        f = io.open(FONT_TEST_DEFAULT_SAMPLE_PATH, "r")
         if not f then return nil end
         html_sample = f:read("*all")
         f:close()

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -639,7 +639,7 @@ function CreDocument:setupFallbackFontFaces()
             seen_fonts[font_name] = true
         end
     end
-    if G_reader_settings:isFalse("complementary_fallback_fonts") then
+    if G_reader_settings:isFalse("additional_fallback_fonts") then
         -- Keep the first fallback font (user set or first from self.fallback_fonts),
         -- as crengine won't reset its current set when provided with an empty string
         for i=#fallbacks, 2, -1 do

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -639,6 +639,13 @@ function CreDocument:setupFallbackFontFaces()
             seen_fonts[font_name] = true
         end
     end
+    if G_reader_settings:isFalse("complementary_fallback_fonts") then
+        -- Keep the first fallback font (user set or first from self.fallback_fonts),
+        -- as crengine won't reset its current set when provided with an empty string
+        for i=#fallbacks, 2, -1 do
+            table.remove(fallbacks, i)
+        end
+    end
     -- We use '|' as the delimiter (which is less likely to be found in font
     -- names than ',' or ';', without the need to have to use quotes.
     local s_fallbacks = table.concat(fallbacks, "|")

--- a/frontend/ui/elements/font-test-sample-default.html
+++ b/frontend/ui/elements/font-test-sample-default.html
@@ -1,0 +1,63 @@
+<p><b>Leonardo di ser Piero da Vinci</b> (Italian: [leoˈnardo di
+ˌsɛr ˈpjɛːro da (v)ˈvintʃi]; 14/15 April 1452 – 2
+May 1519), known as Leonardo da Vinci, was an Italian polymath of the
+Renaissance whose areas of interest included «invention, drawing,
+painting, sculpture, architecture, science, music, mathematics,
+engineering, literature, anatomy, geology, astronomy, botany,
+paleontology, and cartography». He has been variously called the
+father of palaeontology, ichnology, and architecture, and is widely
+considered one of the greatest painters of all time (despite perhaps
+only 15 of his paintings having survived).</p>
+
+<p>Leonardo is renowned primarily as a painter. The <i>Mona Lisa</i>
+is the most famous of his works <a href="#footnote34"><sup>34</sup></a>
+and the most popular portrait ever made. <i>The Last Supper</i>
+is the most reproduced religious painting of all
+time<a href="#footnote35"><sup>35</sup></a> and his
+Vitruvian Man drawing is regarded as a cultural icon as
+well<a href="#footnote36"><sup>36</sup></a>. Salvator Mundi was
+sold for a world record $450.3 million at a Christie's auction
+in New York, 15 November 2017, the <a href="nolink">highest price</a>
+ever paid for a work of art. <i>Leonardo's paintings and preparatory
+drawings—together with his notebooks, which contain sketches,
+scientific diagrams, and his thoughts on the nature of
+painting—compose a contribution to later generations of artists
+rivalled only by that of his contemporary Michelangelo.</i></p>
+<p>&nbsp;</p>
+
+<div>Above is some random text to appreciate lines height, and how
+much height or pages the same text occupy with each font &mdash;
+with bits in bold and italic, numbers and footnote links.</div>
+<div>&nbsp;</div>
+
+<div>These are some numbers ans possibly ambiguous letters and symbols:<br/>
+427, 809, 1635, 1IlLi, oO0, _-=+*#$~,;:!()[]{} "'«»</div>
+<div>&nbsp;</div>
+
+<div>Next are some bits to appreciate this font's OpenType features:<br/>
+This might show some ligatures: afflicting filling.<br/>
+<span style="font-variant: small-caps ">This line might be in Small Caps</span>.<br/>
+Lining numbers <span style="font-variant: lining-nums">123456</span> vs
+<span style="font-variant: oldstyle-nums">123456</span> oldstyle numbers.
+</div>
+<div>&nbsp;</div>
+
+<div>Finally, some words in various scripts to see how the baseline
+and height of this font and those of the fallback fonts compare: 
+a few classic greek words are νους, intelligence, ειδος, form,
+and λογος, which have nothing to do with the following text
+in simplified chinese <span lang="zh-CN">关门吃及刃</span>,
+and the same text in traditional chinese <span lang="zh-Hant">关门吃及刃</span>
+or in japanese <span lang="ja">关门吃及刃</span>.
+Nothing in common either with these RTL and BiDi bits
+in hebrew סֶּלַע ססס
+and in arabic الرحيم (123 456) الْحَمْدُ and وال
+(بااتي: abcd) من.
+This should be enough to appreciate this font.</div>
+<div>&nbsp;</div>
+
+<div>This is some sample content. You can have this document generated
+with some text of yours in your prefered language(s) by creating and
+adding it to a file named:<br/>
+<code>koreader/settings/font-test-sample.html</code>
+</div>

--- a/frontend/ui/elements/font-test-sample-default.html
+++ b/frontend/ui/elements/font-test-sample-default.html
@@ -51,8 +51,7 @@ and the same text in traditional chinese <span lang="zh-Hant">关门吃及刃</s
 or in japanese <span lang="ja">关门吃及刃</span>.
 Nothing in common either with these RTL and BiDi bits
 in hebrew סֶּלַע ססס
-and in arabic الرحيم (123 456) الْحَمْدُ and وال
-(بااتي: abcd) من.
+and in arabic الرحيم (123 456) الْحَمْدُ and وال (بااتي: abcd) من.
 This should be enough to appreciate this font.</div>
 <div>&nbsp;</div>
 

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -77,7 +77,7 @@ function FontSettings:getPath()
     return getUserDir()
 end
 
-function FontSettings:getMenuTable()
+function FontSettings:getSystemFontMenuItems()
     local t = {{
         text = _("Enable system fonts"),
         checked_func = usesSystemFonts,
@@ -98,11 +98,7 @@ function FontSettings:getMenuTable()
         })
     end
 
-    return {
-        text = _("Font settings"),
-        separator = true,
-        sub_item_table = t
-    }
+    return t
 end
 
 return FontSettings


### PR DESCRIPTION
Allow toggling the use of multiple fallback fonts (#6090).
Might be handly when testing new fonts or choosing the first fallback font - when you really want to see what a font supports.

I've put it at the bottom of the font menu (if will be alone, the last one is optionnal):
<kbd>![image](https://user-images.githubusercontent.com/24273478/80306994-c1a03d80-87c6-11ea-8176-915580c11384.png)</kbd>

Dunno if it's better if it was at start (with the Font settings that is not shown on most devices - or inside it, which would made this menu shown on all devices, so with a single item on most devices):
<kbd>![image](https://user-images.githubusercontent.com/24273478/80307050-10e66e00-87c7-11ea-8932-c1c511a5401e.png)</kbd>

InfoMessage shown on long-press (for rewording suggestions):

<kbd>![image](https://user-images.githubusercontent.com/24273478/80307065-2fe50000-87c7-11ea-8e73-b36d0a92eae6.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6095)
<!-- Reviewable:end -->
