### PR TITLE
Debian - fix some lintian errors

### DIFF
--- a/platform/debian/changelog
+++ b/platform/debian/changelog
@@ -1,0 +1,11 @@
+koreader (0.1) unstable; urgency=low
+
+  * Fixes most lintian errors and warnings
+
+ -- Martín Fdez <paziusss@gmail.com>  Thu, 14 May 2020 00:00:00 +0100
+
+koreader (0.0.1) experimental; urgency=low
+
+  * Initial release as Debian package (Closes: https://github.com/koreader/koreader/issues/3108)
+
+ -- Martín Fdez <paziusss@gmail.com>  Tue, 03 Jan 2019 00:00:00 +0100

--- a/platform/debian/copyright
+++ b/platform/debian/copyright
@@ -1,0 +1,142 @@
+Files: *
+Copyright: Copyright (C) 2012 - 2020 KOReader developers
+License: AGPL-3
+  The full text of the AGPL-3 license is distributed with the software as in
+  /usr/share/doc/koreader/COPYING on Debian systems.
+
+Files: base
+Copyright: Various
+License: Various
+  Have a look at https://github.com/koreader/koreader-base/tree/master/thirdparty
+  for a exhaustive list of third party software distributed with this program.
+
+Files: resources/fonts/nerdfonts
+Copyright: Copyright (C) 2014 Ryan L McIntyre
+License: MIT
+
+Files: resources/fonts/noto
+Copyright: Copyright (C) 2018 The Noto Project Authors
+License: SIL OFL
+
+Files: resources/fonts/urw
+Copyright: Copyright (C) 2019 URW Type Foundry GmbH
+License: AGPL-3
+  As a special exception, permission is granted to include these font
+  programs in a Postscript or PDF file that consists of a document that
+  contains text to be displayed or printed using this font, regardless
+  of the conditions or license applying to the document itself.
+
+  The full text of the AGPL-3 license is distributed with the software as in
+  /usr/share/doc/koreader/COPYING on Debian systems.
+
+
+MIT License (for all the MIT licensed code indicated above)
+-----------------------------------------------------------
+Copyright (c) <YEAR>, <OWNER>
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+SIL Open Font License (for all the SIL licensed code indicated above)
+---------------------------------------------------------------------
+Copyright (c) <YEAR>, <OWNER>
+All rights reserved.
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/platform/debian/do_debian_package.sh
+++ b/platform/debian/do_debian_package.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Script to generate debian packages for KOReader
+# shellcheck disable=SC2164
 
 if [ -z "${1}" ]; then
     echo "${0}: can't find KOReader build, please specify a path"
@@ -21,6 +22,13 @@ uname_to_debian() {
     fi
 }
 
+link_font() {
+    font_name="$(basename $1)"
+    system_name="${2}/${font_name}"
+    rm -rf "$1"
+    ln -s "$system_name" "$i"
+}
+
 if [ -z "${2}" ]; then
     ARCH="$(uname_to_debian)"
 else
@@ -34,23 +42,84 @@ command_exists() {
 # Run only if dpkg-deb exists
 COMMAND="dpkg-deb"
 if command_exists "${COMMAND}"; then
+    BASE_DIR="${INSTALL_DIR}/debian/usr"
+
+    # populate debian control file
     mkdir -p "${INSTALL_DIR}/debian/DEBIAN"
     {
         echo "Section: graphics"
         echo "Priority: optional"
-        echo "Depends: libsdl2-2.0-0"
+        echo "Depends: libsdl2-2.0-0, fonts-noto-hinted, fonts-freefont-ttf, fonts-droid-fallback, libc6 (>= 2.2.3)"
         echo "Architecture: ${ARCH}"
         echo "Version: ${VERSION}"
         echo "Installed-Size: $(du -ks "${INSTALL_DIR}/debian/usr/" | cut -f 1)"
-
-        echo "Package: KOReader"
-        echo "Maintainer: KOReader team"
+        echo "Package: koreader"
+        echo "Maintainer: Martín Fdez <paziusss@gmail.com>"
         echo "Homepage: https://koreader.rocks"
-        echo "Description: An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
-        echo " KOReader is a document viewer application, originally created for Kindle e-ink readers."
-        echo " It currently runs on Kindle, Kobo, PocketBook, Ubuntu Touch, Android and Linux devices"
+        echo "Description: Ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
+        echo " KOReader is a document viewer for E Ink devices."
+        echo " Supported fileformats include EPUB, PDF, DjVu, XPS, CBT,"
+        echo " CBZ, FB2, PDB, TXT, HTML, RTF, CHM, DOC, MOBI and ZIP files."
+        echo " It’s available for Kindle, Kobo, PocketBook, Android and desktop Linux."
 
     } >"${INSTALL_DIR}/debian/DEBIAN/control"
+
+    # remove leftovers
+    find "${BASE_DIR}" -type f -name ".gitignore" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}" -type f -name "discovery2spore" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}" -type f -name "wadl2spore" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}" -type d -name "test" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}" -type f -name "*.txt" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}" -type f -name "LICENSE" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}" -type f -name "NOTICE" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}" -type f -name "README.md" -print0 | xargs -0 rm -rf
+    find "${BASE_DIR}/lib" -type f -name "COPYING" -print0 | xargs -0 rm -rf
+
+    # fix permissions
+    find "${BASE_DIR}" -type d -print0 | xargs -0 chmod 755
+    find "${BASE_DIR}" -executable -type f -print0 | xargs -0 chmod 755
+    find "${BASE_DIR}" -type f -name "*.crt" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "*.html" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "*.lua" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "*manifest" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "*.pattern" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "*.png" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "*.po*" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "*.so*" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "git-rev" -print0 | xargs -0 chmod 644
+    find "${BASE_DIR}" -type f -name "reader.lua" -print0 | xargs -0 chmod 755
+
+    # use absolute path to luajit in reader.lua
+    sed -i 's/.\/luajit/\/usr\/lib\/koreader\/luajit/' "${BASE_DIR}/lib/koreader/reader.lua"
+
+    # use debian packaged fonts instead of our embedded ones to save a couple of MB.
+    # Note: avoid linking against fonts-noto-cjk-extra, cause it weights ~200MB.
+
+    (cd "${BASE_DIR}/lib/koreader/fonts/noto" &&
+        for i in $(find . -type f -name "*.ttf"); do
+            link_font "$i" "../../../../share/fonts/truetype/noto"
+        done
+    )
+
+    (cd "${BASE_DIR}/lib/koreader/fonts/freefont" &&
+        for i in $(find . -type f -name "*.ttf"); do
+            link_font "$i" "../../../../share/fonts/truetype/freefont"
+        done
+    )
+
+    # DroidSansMono has a restrictive license. Replace it with DroidSansFallback
+    (cd "${BASE_DIR}/lib/koreader/fonts/droid" &&
+        rm -rf DroidSansMono.ttf
+        ln -s "../../../../share/fonts-droid-fallback/truetype/DroidSansFallback.ttf"
+        mv DroidSansFallback.ttf DroidSansMono.ttf
+    )
+
+    # try to remove rpath
+    if command_exists chrpath; then
+        find "${BASE_DIR}/lib/koreader/libs" -type f -name "*.so*" -print0 | xargs -0 chrpath -d
+    else
+        echo "chrpath tool not found. Skipping RPATH deletion"
+    fi
 
     (cd "${INSTALL_DIR}/.." &&
         fakeroot dpkg-deb -b "${INSTALL_DIR}/debian" "koreader-${VERSION}-${ARCH}.deb")

--- a/platform/debian/do_debian_package.sh
+++ b/platform/debian/do_debian_package.sh
@@ -100,8 +100,7 @@ if command_exists "${COMMAND}"; then
 
     # DroidSansMono has a restrictive license. Replace it with DroidSansFallback
     (
-        cd "${BASE_DIR}/lib/koreader/fonts/droid" &&
-            rm -rf DroidSansMono.ttf
+        cd "${BASE_DIR}/lib/koreader/fonts/droid" && rm -rf DroidSansMono.ttf &&
             ln -s ../../../../share/fonts-droid-fallback/truetype/DroidSansFallback.ttf DroidSansMono.ttf
     )
 

--- a/platform/debian/do_debian_package.sh
+++ b/platform/debian/do_debian_package.sh
@@ -22,11 +22,12 @@ uname_to_debian() {
     fi
 }
 
-link_font() {
-    font_name="$(basename $1)"
-    system_name="${2}/${font_name}"
-    rm -rf "$1"
-    ln -s "$system_name" "$i"
+link_fonts() {
+    syspath="../../../../share/fonts/truetype/$(basename "${1}")"
+    for FILE in *.ttf; do
+        rm -rf "${FILE}"
+        ln -s "${syspath}/${FILE}" "${FILE}"
+    done
 }
 
 if [ -z "${2}" ]; then
@@ -94,24 +95,14 @@ if command_exists "${COMMAND}"; then
 
     # use debian packaged fonts instead of our embedded ones to save a couple of MB.
     # Note: avoid linking against fonts-noto-cjk-extra, cause it weights ~200MB.
-
-    (cd "${BASE_DIR}/lib/koreader/fonts/noto" &&
-        for i in $(find . -type f -name "*.ttf"); do
-            link_font "$i" "../../../../share/fonts/truetype/noto"
-        done
-    )
-
-    (cd "${BASE_DIR}/lib/koreader/fonts/freefont" &&
-        for i in $(find . -type f -name "*.ttf"); do
-            link_font "$i" "../../../../share/fonts/truetype/freefont"
-        done
-    )
+    (cd "${BASE_DIR}/lib/koreader/fonts/noto" && link_fonts "$(pwd)")
+    (cd "${BASE_DIR}/lib/koreader/fonts/freefont" && link_fonts "$(pwd)")
 
     # DroidSansMono has a restrictive license. Replace it with DroidSansFallback
-    (cd "${BASE_DIR}/lib/koreader/fonts/droid" &&
-        rm -rf DroidSansMono.ttf
-        ln -s "../../../../share/fonts-droid-fallback/truetype/DroidSansFallback.ttf"
-        mv DroidSansFallback.ttf DroidSansMono.ttf
+    (
+        cd "${BASE_DIR}/lib/koreader/fonts/droid" &&
+            rm -rf DroidSansMono.ttf
+            ln -s ../../../../share/fonts-droid-fallback/truetype/DroidSansFallback.ttf DroidSansMono.ttf
     )
 
     # try to remove rpath

--- a/platform/debian/koreader.1
+++ b/platform/debian/koreader.1
@@ -1,0 +1,41 @@
+.TH KOReader 1 "May 4, 2020"
+.SH NAME
+koreader \- document viewer
+
+.SH SYNOPSIS
+.B koreader
+.RI [-dvp]
+.RI [file]
+
+.SH DESCRIPTION
+.B KOReader
+is a document viewer primarily aimed at e-ink readers. This manual page documents briefly its desktop usage.
+
+.SH OPTIONS
+
+Call
+.B KOReader
+followed by a file to open it directly. Supported document formats include PDF, DjVu, XPS, CBZ, FB2, PDB, TXT, HTML, RTF, CHM, EPUB, DOC, MOBI, and ZIP
+.B files.
+
+If no file is passed
+.B KOReader
+will start using user settings among a file manager (default), a history and the last document opened.
+
+A list of
+.BI flags
+and their descriptions:
+
+.PP
+.B -d	start in debug mode
+.PP
+.B -v	debug in verbose mode
+.PP
+.B -p	enable Lua code profiling
+
+.SH SETTINGS
+User settings are stored in ~/.config/koreader.
+
+.SH SEE ALSO
+Online documentation: https://github.com/koreader/koreader/wiki
+.PP


### PR DESCRIPTION
Follow-up to https://github.com/koreader/koreader/pull/4434#issuecomment-451219568

Fixed some errors and warnings. ~~I didn't care of warnings (there are soooo many)~~.
The mail address is a dummy address, feel free to suggest a change :p 

~~I didn't fix the `no-copyright-file` and `debian-changelog-file-missing` as I don't know how to fix them on non source debian packages.~~

The rest of errors left are:

`binary-or-shlib-defines-rpath` -> fixable during build
~~`unstripped-binary-or-object`-> fixable during build. I don't know why these are yet unstripped.~~
`embedded-library` -> not easily fixable without dismiss our own versions of libpng, libturbojpeg, libfreetype...

The whole list of remaining issues can be obtained running `lintian --no-tag-display-limit` against a debian package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6099)
<!-- Reviewable:end -->
