### PR TITLE
[Plugin] Fix move to archive plugin names

### DIFF
--- a/plugins/movetoarchive.koplugin/_meta.lua
+++ b/plugins/movetoarchive.koplugin/_meta.lua
@@ -1,6 +1,6 @@
 local _ = require("gettext")
 return {
-    name = "move_to_archive",
+    name = "movetoarchive",
     fullname = _("Move to archive"),
     description = _([[Moves/copies current book to archive folder]]),
 }

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -14,7 +14,7 @@ local BaseUtil = require("ffi/util")
 local _ = require("gettext")
 
 local MoveToArchive = WidgetContainer:new{
-    name = "move2archive",
+    name = "movetoarchive",
 }
 
 function MoveToArchive:init()


### PR DESCRIPTION
Mismatches in these names prevent this plugin from being disabled'able. https://github.com/koreader/koreader/pull/6101#issuecomment-623131390

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6113)
<!-- Reviewable:end -->
