### PR TITLE
Enable Highlight action on single word selection

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -963,7 +963,7 @@ function ReaderHighlight:onTranslateText(text)
 end
 
 function ReaderHighlight:onHoldRelease()
-    if G_reader_settings:isTrue("highlight_action_on_single_word") then
+    if G_reader_settings:isTrue("highlight_action_on_single_word") and self.selected_word then
         -- Force a 0-distance pan to have a self.selected_text with this word,
         -- which will enable the highlight menu or action instead of dict lookup
         self:onHoldPan(nil, {pos=self.hold_ges_pos})
@@ -992,6 +992,9 @@ function ReaderHighlight:onHoldRelease()
         elseif default_highlight_action == "wikipedia" then
             self:lookupWikipedia()
             self:onClose()
+        elseif default_highlight_action == "dictionary" then
+            self:onHighlightDictLookup()
+            self:onClose()
         elseif default_highlight_action == "search" then
             self:onHighlightSearch()
             -- No self:onClose() to not remove the selected text
@@ -1008,7 +1011,8 @@ function ReaderHighlight:onCycleHighlightAction()
     local next_actions = {
         highlight = "translate",
         translate = "wikipedia",
-        wikipedia = "search",
+        wikipedia = "dictionary",
+        dictionary = "search",
         search = nil,
     }
     local current_action = G_reader_settings:readSetting("default_highlight_action")

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -593,6 +593,15 @@ common_settings.document = {
                     end,
                 },
                 {
+                    text = _("Dictionary"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "dictionary"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "dictionary")
+                    end,
+                },
+                {
                     text = _("Fulltext search"),
                     checked_func = function()
                         return G_reader_settings:readSetting("default_highlight_action") == "search"

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -547,6 +547,16 @@ common_settings.document = {
             text = _("Highlight action"),
             sub_item_table = {
                 {
+                    text = _("Enable on single word selection"),
+                    checked_func = function()
+                        return G_reader_settings:isTrue("highlight_action_on_single_word")
+                    end,
+                    callback = function()
+                        G_reader_settings:flipNilOrFalse("highlight_action_on_single_word", nil)
+                    end,
+                    separator = true,
+                },
+                {
                     text = _("Ask with popup dialog"),
                     checked_func = function()
                         return G_reader_settings:nilOrFalse("default_highlight_action")
@@ -580,6 +590,15 @@ common_settings.document = {
                     end,
                     callback = function()
                         G_reader_settings:saveSetting("default_highlight_action", "wikipedia")
+                    end,
+                },
+                {
+                    text = _("Fulltext search"),
+                    checked_func = function()
+                        return G_reader_settings:readSetting("default_highlight_action") == "search"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("default_highlight_action", "search")
                     end,
                 },
             }


### PR DESCRIPTION
Also add "Fulltext search" as an option for highlight action.
See https://github.com/koreader/koreader/issues/6111#issuecomment-623088751. Closes #6111.

@protist, in this [highlight_search_singleword.zip](https://github.com/koreader/koreader/files/4571118/highlight_search_singleword.zip) are the 2 modified files, if you want to confirm this works for you.

<kbd>![image](https://user-images.githubusercontent.com/24273478/80921250-84631f00-8d75-11ea-86fb-8d4dc0f1a6dc.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6114)
<!-- Reviewable:end -->
