### PR TITLE
[wip] Remove article from Wallabag server right after download

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -83,7 +83,7 @@ function Wallabag:init()
     if self.wb_settings.data.wallabag.articles_per_sync ~= nil then
         self.articles_per_sync = self.wb_settings.data.wallabag.articles_per_sync
     end
-    self.is_remove_downloaded_from_remote = self.wb_settings.data.wallabag.is_remove_downloaded_from_remote or false
+    self.remove_downloaded_from_remote = self.wb_settings.data.wallabag.remove_downloaded_from_remote or false
     self.remove_finished_from_history = self.wb_settings.data.wallabag.remove_finished_from_history or false
 
     -- workaround for dateparser only available if newsdownloader is active
@@ -244,9 +244,11 @@ function Wallabag:addToMainMenu(menu_items)
                     },
                     {
                         text = _("Remove downloaded from remote"),
-                        checked_func = function() return self.is_remove_downloaded_from_remote end,
+                        checked_func = function() 
+                            return self.remove_downloaded_from_remote 
+                        end,
                         callback = function()
-                            self.is_remove_downloaded_from_remote = not self.is_remove_downloaded_from_remote
+                            self.remove_downloaded_from_remote = not self.remove_downloaded_from_remote
                             self:saveSettings()
                         end,
                     },
@@ -612,7 +614,7 @@ function Wallabag:synchronize()
                 end
             end
 
-            if self.is_remove_downloaded_from_remote then
+            if self.remove_downloaded_from_remote then
                 -- remove from remote right after download
                 for k,_ in pairs(remote_article_ids) do
                     self:callAPI("DELETE", "/api/entries/" .. k .. ".json", nil, "", "")
@@ -998,7 +1000,7 @@ function Wallabag:saveSettings()
         is_auto_delete        = self.is_auto_delete,
         is_sync_remote_delete = self.is_sync_remote_delete,
         articles_per_sync     = self.articles_per_sync,
-        is_remove_downloaded_from_remote = self.is_remove_downloaded_from_remote,
+        remove_downloaded_from_remote = self.remove_downloaded_from_remote,
         remove_finished_from_history = self.remove_finished_from_history,
     }
     self.wb_settings:saveSetting("wallabag", tempsettings)

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -611,11 +611,10 @@ function Wallabag:synchronize()
                     failed_count = failed_count + 1
                 end
             end
-            deleted_count = 0
 
             if self.is_remove_downloaded_from_remote then
                 -- remove from remote right after download
-                for k,_ in pairs(tab) do
+                for k,_ in pairs(remote_article_ids) do
                     self:callAPI("DELETE", "/api/entries/" .. k .. ".json", nil, "", "")
                     deleted_count = deleted_count + 1
                 end

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -244,8 +244,8 @@ function Wallabag:addToMainMenu(menu_items)
                     },
                     {
                         text = _("Remove downloaded from remote"),
-                        checked_func = function() 
-                            return self.remove_downloaded_from_remote 
+                        checked_func = function()
+                            return self.remove_downloaded_from_remote
                         end,
                         callback = function()
                             self.remove_downloaded_from_remote = not self.remove_downloaded_from_remote


### PR DESCRIPTION
Before I found bug #6119 I did code such change:
To remove just downloaded files from wallabag server, right after download. 

Please check if it might be useful and someone might want to see such feature in Koreader plugin.

Due to the bug #6119 it was not tested because I need to first reoganize my files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6121)
<!-- Reviewable:end -->
