### PR TITLE
Fix name for GoldenDict Pro dictionary

### DIFF
--- a/frontend/device/android/dictionaries.lua
+++ b/frontend/device/android/dictionaries.lua
@@ -11,7 +11,7 @@ else
         { "ColorDict", "ColorDict", false, "com.socialnmobile.colordict", "colordict" },
         { "Fora", "Fora Dict", false, "com.ngc.fora", "search" },
         { "GoldenFree", "GoldenDict Free", false, "mobi.goldendict.android.free", "send" },
-        { "GoldenPro", "GoldenDict Pro", false, "mobi.goldendict.android.pro", "send" },
+        { "GoldenPro", "GoldenDict Pro", false, "mobi.goldendict.android", "send" },
         { "Kiwix", "Kiwix", false, "org.kiwix.kiwixmobile", "text" },
         { "Mdict", "Mdict", false, "cn.mdict", "send" },
         { "QuickDic", "QuickDic", false, "de.reimardoeffinger.quickdic", "quickdic" },


### PR DESCRIPTION
There is no `mobi.goldendict.android.pro` app:
https://play.google.com/store/apps/details?id=mobi.goldendict.android.pro

It's `mobi.goldendict.android`:
https://play.google.com/store/apps/details?id=mobi.goldendict.android

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6127)
<!-- Reviewable:end -->
