### PR TITLE
fix openLink on linux

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -56,7 +56,7 @@ local Device = Generic:new{
     openLink = function(self, link)
         local enabled, tool = getLinkOpener()
         if not enabled or not tool or not link or type(link) ~= "string" then return end
-        return os.execute(tool.." '"..link.."'") == 0
+        return os.execute('LD_LIBRARY_PATH="" '..tool.." '"..link.."'") == 0
     end,
 }
 


### PR DESCRIPTION
fix an issue caused by our LD_LIBRARY_PATH on some linux distros. The issue does look like:

```
/usr/bin/google-chrome-stable: symbol lookup error: /lib/x86_64-linux-gnu/libpango-1.0.so.0: undefined symbol: hb_glib_script_to_script
/usr/bin/x-www-browser: symbol lookup error: /lib/x86_64-linux-gnu/libpango-1.0.so.0: undefined symbol: hb_glib_script_to_script
XPCOMGlueLoad error for file /usr/lib/firefox/libmozgtk.so:
/lib/x86_64-linux-gnu/libpango-1.0.so.0: undefined symbol: hb_glib_script_to_script
Couldn't load XPCOM.
/usr/bin/xdg-open: 869: iceweasel: not found
/usr/bin/xdg-open: 869: seamonkey: not found
/usr/bin/xdg-open: 869: mozilla: not found
/usr/bin/xdg-open: 869: epiphany: not found
/usr/bin/xdg-open: 869: konqueror: not found
/usr/bin/xdg-open: 869: chromium: not found
/usr/bin/xdg-open: 869: chromium-browser: not found
/usr/bin/google-chrome: symbol lookup error: /lib/x86_64-linux-gnu/libpango-1.0.so.0: undefined symbol: hb_glib_script_to_script
/usr/bin/xdg-open: 869: www-browser: not found
/usr/bin/xdg-open: 869: links2: not found
/usr/bin/xdg-open: 869: elinks: not found
/usr/bin/xdg-open: 869: links: not found
/usr/bin/xdg-open: 869: lynx: not found
/usr/bin/xdg-open: 869: w3m: not found
xdg-open: no method available for opening 'https://en.wikipedia.org/wiki/Fellow_of_the_London_Zoological_Society'
```

and affects anything run via xdg-open, including urls and directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6161)
<!-- Reviewable:end -->
