### PR TITLE
desktop: add support for 3rd party dictionary apps

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -41,6 +41,34 @@ local function getLinkOpener()
     return enabled, tool
 end
 
+-- differenciate between urls and commands
+local function isUrl(s)
+    if type(s) == "string" and s:match("*?://") then
+        return true
+    end
+    return false
+end
+
+local EXTERNAL_DICTS_AVAILABILITY_CHECKED = false
+local EXTERNAL_DICTS = require("device/sdl/dictionaries")
+local external_dict_when_back_callback = nil
+
+local function getExternalDicts()
+    if not EXTERNAL_DICTS_AVAILABILITY_CHECKED then
+        EXTERNAL_DICTS_AVAILABILITY_CHECKED = true
+        for i, v in ipairs(EXTERNAL_DICTS) do
+            local tool = v[4]
+            if not tool then return end
+            if isUrl(tool) and getLinkOpener()
+            or os.execute("which "..tool) == 0 then
+                v[3] = true
+            end
+        end
+    end
+    return EXTERNAL_DICTS
+end
+
+
 local Device = Generic:new{
     model = "SDL",
     isSDL = yes,
@@ -56,7 +84,28 @@ local Device = Generic:new{
     openLink = function(self, link)
         local enabled, tool = getLinkOpener()
         if not enabled or not tool or not link or type(link) ~= "string" then return end
-        return os.execute('LD_LIBRARY_PATH="" '..tool.." '"..link.."'") == 0
+        return os.execute('env -u LD_LIBRARY_PATH '..tool.." '"..link.."'") == 0
+    end,
+    canExternalDictLookup = yes,
+    getExternalDictLookupList = getExternalDicts,
+    doExternalDictLookup = function(self, text, method, callback)
+        external_dict_when_back_callback = callback
+        local tool, ok = nil
+        for i, v in ipairs(getExternalDicts()) do
+            if v[1] == method then
+                tool = v[4]
+                break
+            end
+        end
+        if isUrl(tool) and getLinkOpener() then
+            ok = self:openLink(tool..text)
+        else
+            ok = os.execute('env -u LD_LIBRARY_PATH '..tool.." "..text.." &") == 0
+        end
+        if ok and external_dict_when_back_callback then
+            external_dict_when_back_callback()
+            external_dict_when_back_callback = nil
+        end
     end,
 }
 

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -41,7 +41,7 @@ local function getLinkOpener()
     return enabled, tool
 end
 
--- differenciate between urls and commands
+-- differentiate between urls and commands
 local function isUrl(s)
     if type(s) == "string" and s:match("*?://") then
         return true

--- a/frontend/device/sdl/dictionaries.lua
+++ b/frontend/device/sdl/dictionaries.lua
@@ -1,0 +1,20 @@
+local user_path = require("datastorage"):getDataDir() .. "/dictionaries.lua"
+local ok, dicts = pcall(dofile, user_path)
+
+local t = {}
+
+table.insert(t, 1, { "Goldendict", "Goldendict", false, "goldendict" })
+
+if jit.os == "OSX" then
+    table.insert(t, 1, { "Apple", "AppleDict", false, "dict://" })
+end
+
+if ok then
+    -- append user dictionaries to the bottom of the menu
+    for k, v in pairs(dicts) do
+        table.insert(t, #t + 1, v)
+    end
+end
+
+return t
+


### PR DESCRIPTION
Like #5108 but for desktop.

* Add support for goldendict in Linux and Mac
* Add support for apple dictionary on Mac.


![goldendict](https://user-images.githubusercontent.com/975883/82310193-59f3a180-99c4-11ea-88dd-78a119943866.png)


Users can also add other dictionaries, which will be appended in the list. Both commands and urls work.
```lua
return {
    { "MerriamWebster", "Merriam-Webster", false, "https://www.merriam-webster.com/dictionary/" },
    { "Wolfram", "WolframAlpha", false, "https://www.wolframalpha.com/input/?i=" },
    { "Qstardict", "QStardict", false, "qstardict" },
}

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6167)
<!-- Reviewable:end -->
