### PR TITLE
Statistics: fix number of highlights

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -639,4 +639,22 @@ function ReaderBookmark:hasBookmarks()
     return self.bookmarks and #self.bookmarks > 0
 end
 
+function ReaderBookmark:getNumberOfHighlightsAndNotes()
+    local highlights = 0
+    local notes = 0
+    for i = 1, #self.bookmarks do
+        if self.bookmarks[i].highlighted then
+            highlights = highlights + 1
+            -- No real way currently to know which highlights
+            -- have been edited and became "notes". Editing them
+            -- adds this 'text' field, but just showing bookmarks
+            -- do that as well...
+            if self.bookmarks[i].text then
+                notes = notes + 1
+            end
+        end
+    end
+    return highlights, notes
+end
+
 return ReaderBookmark

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -203,6 +203,9 @@ function ReaderStatistics:initData()
     if not self.data.md5 then
         self.data.md5 = self:partialMd5(self.document.file)
     end
+    -- Update these numbers to what's actually stored in the settings
+    -- (not that "notes" is invalid and does not represent edited highlights)
+    self.data.highlights, self.data.notes = self.ui.bookmark:getNumberOfHighlightsAndNotes()
     self.curr_total_time = 0
     self.curr_total_pages = 0
     self.id_curr_book = self:getIdBookDB()


### PR DESCRIPTION
Fixes issue noticed at https://github.com/koreader/koreader/pull/6052#issuecomment-629610275: no error log message anymore, and the number of highlights will be updated (and corrected if previously wrong because leaked from another book) to the number of highlights in the settings on each book opening. 
Note that the number of "Notes" shown does not mean much.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6173)
<!-- Reviewable:end -->
