### PR TITLE
Kill the RMSDK, too.

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -110,7 +110,7 @@ if [ "${VIA_NICKEL}" = "true" ]; then
     sync
     # And we can now stop the full Kobo software stack
     # NOTE: We don't need to kill KFMon, it's smart enough not to allow running anything else while we're up
-    killall -TERM nickel hindenburg sickel fickel fmon 2>/dev/null
+    killall -TERM nickel hindenburg sickel fickel adobehost fmon 2>/dev/null
 fi
 
 # fallback for old fmon, KFMon and advboot users (-> if no args were passed to the script, start the FM)


### PR DESCRIPTION
It's a big pile 'o RAM we could use.
Plus, it might be causing bad interactions with DRM on Nickel restart if we keep it around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6179)
<!-- Reviewable:end -->
