### PR TITLE
bump crengine: various fixes, tweaks and cleanups

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -258,6 +258,11 @@ function ReaderRolling:onCloseDocument()
         end
     end
     logger.dbg("cre cache used:", cache_file_path or "none")
+    -- Unknown elements and attributes, uncomment if needed for debugging:
+    -- local elements, attributes, namespaces = self.ui.document:getUnknownEntities()
+    -- if elements ~= "" then logger.info("cre unknown elements: ", elements) end
+    -- if attributes ~= "" then logger.info("cre unknown attributes: ", attributes) end
+    -- if namespaces ~= "" then logger.info("cre unknown namespaces: ", namespaces) end
 end
 
 function ReaderRolling:onCheckDomStyleCoherence()

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -205,6 +205,14 @@ function CreDocument:setupDefaultView()
         self._document:setIntProperty("crengine.page.header.font.size",
             G_reader_settings:readSetting("cre_header_status_font_size"))
     end
+
+    -- One can set these to change from white background
+    if G_reader_settings:readSetting("cre_background_color") then
+        self:setBackgroundColor(G_reader_settings:readSetting("cre_background_color"))
+    end
+    if G_reader_settings:readSetting("cre_background_image") then
+        self:setBackgroundImage(G_reader_settings:readSetting("cre_background_image"))
+    end
 end
 
 function CreDocument:loadDocument(full_document)
@@ -893,6 +901,11 @@ function CreDocument:setStatusLineProp(prop)
     self._document:setStringProperty("window.status.line", prop)
 end
 
+function CreDocument:setBackgroundColor(bgcolor) -- use nil to set to white
+    logger.dbg("CreDocument: set background color", bgcolor)
+    self._document:setBackgroundColor(bgcolor)
+end
+
 function CreDocument:setBackgroundImage(img_path) -- use nil to unset
     logger.dbg("CreDocument: set background image", img_path)
     self._document:setBackgroundImage(img_path)
@@ -939,6 +952,10 @@ end
 
 function CreDocument:getStatistics()
     return self._document:getStatistics()
+end
+
+function CreDocument:getUnknownEntities()
+    return self._document:getUnknownEntities()
 end
 
 function CreDocument:canHaveAlternativeToc()


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/344 :
- Don't reset invisible BR to display: inline https://github.com/koreader/koreader/issues/6152#issuecomment-629241554
- ldomTextCollector: handle inline-block/table as inline
- Avoid re-rendering on font hinting mode change
- List markers: fix positionning when floats involved
- GIF decoding: avoid uneeded abort on LZW table overflow
- Adds getUnknownEntities(), can help with debugging
- Don't check stylesheet hashes when loading from cache
- Hardcoded elements and attributes list: cleanup
- Full rendering: 2 small optimisations
- Strut confinning: deal with images earlier
- lvtextfm: some cleanup and reordering

Also includes:
- cre.cpp : fix getPageFromXPointer() and getPosFromXPointer() to not fail on invisible nodes and work on the next visible node (so links whose target is `display:none` can work). https://github.com/koreader/koreader-base/pull/1104. Closes #6175.
- Explicitly disable WOFF2 support in FT  https://github.com/koreader/koreader-base/pull/1102

Add support for 2 settings one can set manually in reader.settings.reader.lua:
```lua
["cre_background_color"] = "0xccffcc",
["cre_background_image"] = "/path/to/bg_paper.jpg",
```
(not enough to allow closing #3871 :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6188)
<!-- Reviewable:end -->
