### PR TITLE
Statistics: some fixes, reorder book stats fields

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1160,6 +1160,7 @@ function ReaderStatistics:getBookStat(id_book)
 
     -- Due to some bug, some books opened around April 2020 might
     -- have notes and highlight NULL in the DB.
+    -- See: https://github.com/koreader/koreader/issues/6190#issuecomment-633693940
     -- (We made these last in the SQL so NULL/nil doesn't prevent
     -- fetching the other fields.)
     -- Show "?" when these values are not known (they will be

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1084,7 +1084,7 @@ function ReaderStatistics:getCurrentStat(id_book)
     local current_period, current_pages = self:getCurrentBookStats()
 
     local conn = SQ3.open(db_location)
-    local notes, highlights = conn:rowexec(string.format("SELECT notes, highlights  FROM book WHERE id = '%s';)", id_book))
+    local highlights, notes = conn:rowexec(string.format("SELECT highlights, notes  FROM book WHERE id = '%s';)", id_book)) -- luacheck: no unused
     local sql_stmt = [[
         SELECT count(*)
         FROM   (
@@ -1165,7 +1165,7 @@ function ReaderStatistics:getBookStat(id_book)
     -- Show "?" when these values are not known (they will be
     -- fixed next time this book is opened).
     highlights = highlights and tonumber(highlights) or "?"
-    notes = notes and tonumber(notes) or "?"
+    notes = notes and tonumber(notes) or "?" -- luacheck: no unused
 
     sql_stmt = [[
         SELECT count(*)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1679,6 +1679,7 @@ function ReaderStatistics:getTotalStats()
 
                 self.kv = KeyValuePage:new{
                     title = book_title,
+                    value_overflow_align = "right",
                     kv_pairs = self:getBookStat(id_book),
                     callback_return = function()
                         UIManager:show(kv)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1137,7 +1137,7 @@ function ReaderStatistics:getCurrentStat(id_book)
         -- estimation, from current page to end of book
         { _("Current page/Total pages"),  self.curr_page .. "/" .. self.data.pages },
         { _("Percentage completed"), formatstr:format(self.curr_page/self.data.pages * 100) },
-        { _("Time to read"), util.secondsToClock(time_to_read, false) },
+        { _("Estimated time to read"), util.secondsToClock(time_to_read, false) },
         { _("Estimated reading finished"),
             T(N_("%1 (1 day)", "%1 (%2 days)", estimate_days_to_read), estimate_end_of_read_date, estimate_days_to_read) },
 

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -172,7 +172,7 @@ function ReaderStatistics:init()
     ReaderGesture.getBookStats = function()
         if self:isDocless() or not self.is_enabled then return end
         local stats = KeyValuePage:new{
-            title = _("Statistics"),
+            title = _("Current statistics"),
             kv_pairs = self:getCurrentStat(self.id_curr_book),
         }
         return stats
@@ -835,7 +835,7 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                 keep_menu_open = true,
                 callback = function()
                     UIManager:show(KeyValuePage:new{
-                        title = _("Statistics"),
+                        title = _("Current statistics"),
                         kv_pairs = self:getCurrentStat(self.id_curr_book),
                     })
                 end,
@@ -895,6 +895,38 @@ function ReaderStatistics:statMenu()
                         title = total_msg,
                         value_align = "right",
                         kv_pairs = kv_pairs,
+                        callback_return = function()
+                            UIManager:show(kv)
+                            self.kv = kv
+                        end
+                    }
+                    UIManager:show(self.kv)
+                end,
+            },
+            { _("Books by week"),"",
+                callback = function()
+                    local kv = self.kv
+                    UIManager:close(self.kv)
+                    self.kv = KeyValuePage:new{
+                        title = _("Books by week"),
+                        value_overflow_align = "right",
+                        kv_pairs = self:getDatesFromAll(0, "weekly", true),
+                        callback_return = function()
+                            UIManager:show(kv)
+                            self.kv = kv
+                        end
+                    }
+                    UIManager:show(self.kv)
+                end,
+            },
+            { _("Books by month"),"",
+                callback = function()
+                    local kv = self.kv
+                    UIManager:close(self.kv)
+                    self.kv = KeyValuePage:new{
+                        title = _("Books by month"),
+                        value_overflow_align = "right",
+                        kv_pairs = self:getDatesFromAll(0, "monthly", true),
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
@@ -984,39 +1016,6 @@ function ReaderStatistics:statMenu()
                     UIManager:show(self.kv)
                 end,
             },
-            "----",
-            { _("Books by week"),"",
-                callback = function()
-                    local kv = self.kv
-                    UIManager:close(self.kv)
-                    self.kv = KeyValuePage:new{
-                        title = _("Books by week"),
-                        value_overflow_align = "right",
-                        kv_pairs = self:getDatesFromAll(0, "weekly", true),
-                        callback_return = function()
-                            UIManager:show(kv)
-                            self.kv = kv
-                        end
-                    }
-                    UIManager:show(self.kv)
-                end,
-            },
-            { _("Books by month"),"",
-                callback = function()
-                    local kv = self.kv
-                    UIManager:close(self.kv)
-                    self.kv = KeyValuePage:new{
-                        title = _("Books by month"),
-                        value_overflow_align = "right",
-                        kv_pairs = self:getDatesFromAll(0, "monthly", true),
-                        callback_return = function()
-                            UIManager:show(kv)
-                            self.kv = kv
-                        end
-                    }
-                    UIManager:show(self.kv)
-                end,
-            }
         }
     }
     UIManager:show(self.kv)
@@ -1095,13 +1094,15 @@ function ReaderStatistics:getCurrentStat(id_book)
                )
     ]]
     local total_days = conn:rowexec(string.format(sql_stmt, id_book))
+
     sql_stmt = [[
         SELECT sum(period),
-               count(DISTINCT page)
+               count(DISTINCT page),
+               min(start_time)
         FROM   page_stat
         WHERE  id_book = '%s'
     ]]
-    local total_time_book, total_read_pages = conn:rowexec(string.format(sql_stmt, id_book))
+    local total_time_book, total_read_pages, first_open = conn:rowexec(string.format(sql_stmt, id_book))
     conn:close()
 
     if total_time_book == nil then
@@ -1109,6 +1110,9 @@ function ReaderStatistics:getCurrentStat(id_book)
     end
     if total_read_pages == nil then
         total_read_pages = 0
+    end
+    if first_open == nil then
+        first_open = TimeVal:now().sec
     end
     self.data.pages = self.view.document:getPageCount()
     total_time_book = tonumber(total_time_book)
@@ -1129,6 +1133,7 @@ function ReaderStatistics:getCurrentStat(id_book)
         -- Current book statistics
         { _("Time spent reading this book"), util.secondsToClock(total_time_book, false) },
         -- per days
+        { _("Reading started"), os.date("%Y-%m-%d (%H:%M)", tonumber(first_open))},
         { _("Days reading this book"), tonumber(total_days) },
         { _("Average time per day"), util.secondsToClock(total_time_book/tonumber(total_days), false) },
         -- per page
@@ -1141,7 +1146,7 @@ function ReaderStatistics:getCurrentStat(id_book)
         { _("Estimated reading finished"),
             T(N_("%1 (1 day)", "%1 (%2 days)", estimate_days_to_read), estimate_end_of_read_date, estimate_days_to_read) },
 
-        { _("Total highlights"), tonumber(highlights) },
+        { _("Highlights"), tonumber(highlights) },
         -- { _("Total notes"), tonumber(notes) }, -- not accurate, don't show it
     }
 end
@@ -1181,18 +1186,13 @@ function ReaderStatistics:getBookStat(id_book)
 
     sql_stmt = [[
         SELECT sum(period),
-               count(DISTINCT page)
+               count(DISTINCT page),
+               min(start_time)
         FROM   page_stat
         WHERE  id_book = '%s'
     ]]
-    local total_time_book, total_read_pages = conn:rowexec(string.format(sql_stmt, id_book))
+    local total_time_book, total_read_pages, first_open = conn:rowexec(string.format(sql_stmt, id_book))
 
-    sql_stmt = [[
-        SELECT min(start_time)
-        FROM   page_stat
-        WHERE  id_book = '%s'
-    ]]
-    local first_open = conn:rowexec(string.format(sql_stmt, id_book))
     conn:close()
 
     if total_time_book == nil then
@@ -1200,6 +1200,9 @@ function ReaderStatistics:getBookStat(id_book)
     end
     if total_read_pages == nil then
         total_read_pages = 0
+    end
+    if first_open == nil then
+        first_open = TimeVal:now().sec
     end
     total_time_book = tonumber(total_time_book)
     total_read_pages = tonumber(total_read_pages)
@@ -1211,15 +1214,16 @@ function ReaderStatistics:getBookStat(id_book)
     return {
         { _("Title"), title},
         { _("Authors"), authors},
-        { _("First opened"), os.date("%Y-%m-%d (%H:%M)", tonumber(first_open))},
-        { _("Last opened"), os.date("%Y-%m-%d (%H:%M)", tonumber(last_open))},
+        { _("Reading started"), os.date("%Y-%m-%d (%H:%M)", tonumber(first_open))},
+        { _("Last read"), os.date("%Y-%m-%d (%H:%M)", tonumber(last_open))},
         { _("Days reading this book"), tonumber(total_days) },
         { _("Time spent reading this book"), util.secondsToClock(total_time_book, false) },
+        { _("Average time per day"), util.secondsToClock(total_time_book/tonumber(total_days), false) },
         { _("Average time per page"), util.secondsToClock(avg_time_per_page, false) },
         -- These 2 ones are about page actually read (not the current page and % into book)
         { _("Read pages/Total pages"), total_read_pages .. "/" .. pages },
         { _("Percentage read"), Math.round(total_read_pages / pages * 100) .. "%" },
-        { _("Total highlights"), highlights },
+        { _("Highlights"), highlights },
         -- { _("Total notes"), notes }, -- not accurate, don't show it
         "----",
         { _("Show days"), _("Tap to display"),
@@ -1227,7 +1231,7 @@ function ReaderStatistics:getBookStat(id_book)
                 local kv = self.kv
                 UIManager:close(self.kv)
                 self.kv = KeyValuePage:new{
-                    title = _("Read in days"),
+                    title = T(_("Days reading %1"), title),
                     value_overflow_align = "right",
                     kv_pairs = self:getDatesForBook(id_book),
                     callback_return = function()
@@ -1306,7 +1310,7 @@ function ReaderStatistics:callbackMonthly(begin, finish, date_text, book_mode)
     UIManager:close(kv)
     if book_mode then
         self.kv = KeyValuePage:new{
-            title = T(_("Books from: %1"), date_text),
+            title = T(_("Books read in %1"), date_text),
             value_align = "right",
             kv_pairs = self:getBooksFromPeriod(begin, finish),
             callback_return = function()
@@ -1333,7 +1337,7 @@ function ReaderStatistics:callbackWeekly(begin, finish, date_text, book_mode)
     UIManager:close(kv)
     if book_mode then
         self.kv = KeyValuePage:new{
-            title = T(_("Books from: %1"), date_text),
+            title = T(_("Books read in %1"), date_text),
             value_align = "right",
             kv_pairs = self:getBooksFromPeriod(begin, finish),
             callback_return = function()
@@ -1502,7 +1506,7 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
                 local kv = self.kv
                 UIManager:close(kv)
                 self.kv = KeyValuePage:new{
-                    title = T(_("Books in %1"), result_book[1][i]),
+                    title = T(_("Books read %1"), result_book[1][i]),
                     value_overflow_align = "right",
                     kv_pairs = self:getBooksFromPeriod(time_begin, time_begin + 86400),
                     callback_return = function()
@@ -1517,7 +1521,7 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
     return results
 end
 
-function ReaderStatistics:getBooksFromPeriod(period_begin, period_end)
+function ReaderStatistics:getBooksFromPeriod(period_begin, period_end, callback_shows_days)
     local results = {}
     local sql_stmt_res_book = [[
         SELECT  book_tbl.title AS title,
@@ -1542,15 +1546,27 @@ function ReaderStatistics:getBooksFromPeriod(period_begin, period_end)
             callback = function()
                 local kv = self.kv
                 UIManager:close(self.kv)
-                self.kv = KeyValuePage:new{
-                    title = _("Read in days"),
-                    value_overflow_align = "right",
-                    kv_pairs = self:getDatesForBook(tonumber(result_book[4][i])),
-                    callback_return = function()
-                        UIManager:show(kv)
-                        self.kv = kv
-                    end
-                }
+                if callback_shows_days then -- not used currently by any code
+                    self.kv = KeyValuePage:new{
+                        title = T(_("Days reading %1"), result_book[1][i]),
+                        kv_pairs = self:getDatesForBook(tonumber(result_book[4][i])),
+                        value_overflow_align = "right",
+                        callback_return = function()
+                            UIManager:show(kv)
+                            self.kv = kv
+                        end
+                    }
+                else
+                    self.kv = KeyValuePage:new{
+                        title = result_book[1][i],
+                        kv_pairs = self:getBookStat(tonumber(result_book[4][i])),
+                        value_overflow_align = "right",
+                        callback_return = function()
+                            UIManager:show(kv)
+                            self.kv = kv
+                        end
+                    }
+                end
                 UIManager:show(self.kv)
             end,
         })
@@ -1679,8 +1695,8 @@ function ReaderStatistics:getTotalStats()
 
                 self.kv = KeyValuePage:new{
                     title = book_title,
-                    value_overflow_align = "right",
                     kv_pairs = self:getBookStat(id_book),
+                    value_overflow_align = "right",
                     callback_return = function()
                         UIManager:show(kv)
                         self.kv = kv
@@ -1691,7 +1707,7 @@ function ReaderStatistics:getTotalStats()
         })
     end
     conn:close()
-    return T(_("Total hours read %1"), util.secondsToClock(total_books_time, false)), total_stats
+    return T(_("Total time spent reading: %1"), util.secondsToClock(total_books_time, false)), total_stats
 end
 
 function ReaderStatistics:genResetBookSubItemTable()


### PR DESCRIPTION
Fix wrong values for books opened (or first opened) from April 14th to May 20th: highlights and notes
possibly being NULL was preventing nb of pages and last_open from being fetched.
Details in https://github.com/koreader/koreader/issues/6190#issuecomment-633693940. Closes #6190.
Also fix paren issue noticed at https://github.com/koreader/koreader/issues/6181#issuecomment-633696209. Closes #6181.

Also re-order current book and all books stat items to some hopefully more sensible order.
That's quite subjective, so opinions welcome.

I let you look at the current order on your device.
Proposed new order (and some renames):
`Statistics > Current book`:
<kbd>![image](https://user-images.githubusercontent.com/24273478/82950996-b21f3a80-9fa6-11ea-9ad1-d5b4484fc68f.png)</kbd>

`Statistics > Time range > All books > that same book`:
<kbd>![image](https://user-images.githubusercontent.com/24273478/82944807-26081580-9f9c-11ea-9c31-ccb3f35caf90.png)</kbd>

(There are some fields in one that are not in the other, but could be - but that's not my purpose with this PR :) just trying to make the current info more readable.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6194)
<!-- Reviewable:end -->
