### PR TITLE
[UX] Implement hasFewKeys prototype

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -59,10 +59,16 @@ function ReaderMenu:init()
     if Device:hasKeys() then
         if Device:isTouchDevice() then
             self.key_events.TapShowMenu = { { "Menu" }, doc = "show menu", }
+            if Device:hasFewKeys() then
+                self.key_events.TapShowMenu = { { { "Menu", "Right" } }, doc = "show menu", }
+            end
         else
             -- map menu key to only top menu because bottom menu is only
             -- designed for touch devices
             self.key_events.ShowReaderMenu = { { "Menu" }, doc = "show menu", }
+            if Device:hasFewKeys() then
+                self.key_events.ShowReaderMenu = { { { "Menu", "Right" } }, doc = "show menu", }
+            end
         end
     end
     self.activation_menu = G_reader_settings:readSetting("activate_menu")

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -52,6 +52,10 @@ function ReaderPaging:init()
             { { "RPgBack", "LPgBack", "Left" } }, doc = "go to previous page",
             event = "GotoViewRel", args = -1,
         }
+        if Device:hasFewKeys() then
+            table.remove(self.key_events.GotoNextPage[1][1], 3) -- right
+            table.remove(self.key_events.GotoPrevPage[1][1], 3) -- left
+        end
         self.key_events.GotoNextPos = {
             { {"Down" } }, doc = "go to next position",
             event = "GotoPosRel", args = 1,

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -20,8 +20,9 @@ local ButtonDialog = InputContainer:new{
 
 function ButtonDialog:init()
     if Device:hasKeys() then
+        local close_keys = Device:hasFewKeys() and { "Back", "Left" } or "Back"
         self.key_events = {
-            Close = { {"Back"}, doc = "close button dialog" }
+            Close = { { close_keys }, doc = "close button dialog" }
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -34,8 +34,9 @@ local ButtonDialogTitle = InputContainer:new{
 function ButtonDialogTitle:init()
     if self.dismissable then
         if Device:hasKeys() then
+            local close_keys = Device:hasFewKeys() and { "Back", "Left" } or "Back"
             self.key_events = {
-                Close = { { "Back" }, doc = "close button dialog" }
+                Close = { { close_keys }, doc = "close button dialog" }
             }
         end
         if Device:isTouchDevice() then

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -43,6 +43,9 @@ function FocusManager:init()
             FocusLeft =  { {"Left"},  doc = "move focus left",  event = "FocusMove", args = {-1, 0} },
             FocusRight = { {"Right"}, doc = "move focus right", event = "FocusMove", args = {1,  0} },
         }
+        if Device:hasFewKeys() then
+            self.key_events.FocusLeft = nil
+        end
     end
 end
 

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -892,6 +892,9 @@ function Menu:init()
     if Device:hasKeys() then
         -- set up keyboard events
         self.key_events.Close = { {"Back"}, doc = "close menu" }
+        if Device:hasFewKeys() then
+            self.key_events.Close = { {"Left"}, doc = "close menu" }
+        end
         self.key_events.NextPage = {
             {Input.group.PgFwd}, doc = "goto next page of the menu"
         }

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -420,6 +420,9 @@ function TouchMenu:init()
     }
 
     self.key_events.Back = { {"Back"}, doc = "back to upper menu or close touchmenu" }
+    if Device:hasFewKeys() then
+        self.key_events.Back = { {"Left"}, doc = "back to upper menu or close touchmenu" }
+    end
     self.key_events.NextPage = { {Input.group.PgFwd}, doc = "next page" }
     self.key_events.PrevPage = { {Input.group.PgBack}, doc = "previous page" }
     self.key_events.Press = { {"Press"}, doc = "chose selected item" }


### PR DESCRIPTION
This is a quick exploration into how the new Device:hasFewKeys() method could work to make things more usable on very limited devices.

In the reader, the right is repurposed to open the menu. Left in turn closes it.

The same principle is applied to ButtonDialog. This means you can select anything in principle, but once you go right you can't go back.

References <https://github.com/koreader/koreader/issues/4029>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6195)
<!-- Reviewable:end -->
