### PR TITLE
History: fix possible issues when saving and loading

### DIFF
--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -84,11 +84,11 @@ end
 function ReadHistory:_flush()
     assert(self ~= nil)
     local content = {}
-    for k, v in pairs(self.hist) do
-        content[k] = {
+    for _, v in ipairs(self.hist) do
+        table.insert(content, {
             time = v.time,
             file = v.file
-        }
+        })
     end
     local f = io.open(history_file, "w")
     f:write("return " .. dump(content) .. "\n")
@@ -108,7 +108,8 @@ function ReadHistory:_read()
     self.last_read_time = history_file_modification_time
     local ok, data = pcall(dofile, history_file)
     if ok and data then
-        for k, v in pairs(data) do
+        self.hist = {}
+        for _, v in ipairs(data) do
             table.insert(self.hist, buildEntry(v.time, v.file))
         end
     end

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -979,7 +979,7 @@ a {
     display:inline;
     text-decoration: underline;
     color: black;
-    font-weight: normal;
+    font-weight: inherit;
 }
 /* No underline for links without their href that we removed */
 a.newwikinonexistent {


### PR DESCRIPTION
Internal `self.hist` being an array, iterating it with `pairs` could have some strange effects. Best to use `ipairs`. See https://github.com/koreader/koreader/issues/6201#issuecomment-635291450 . Closes #6201

Also includes: Wikipedia EPUBs: keep links in bold text bold

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6209)
<!-- Reviewable:end -->
