### PR TITLE
Footer: fix items possibly missing

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -343,6 +343,7 @@ function ReaderFooter:init()
     self.mode_index = {}
     self.mode_nb = 0
 
+    local handled_modes = {}
     if self.settings.order then
         -- Start filling self.mode_index from what's been ordered by the user and saved
         for i=0, #self.settings.order do
@@ -351,7 +352,7 @@ function ReaderFooter:init()
             if MODE[name] then -- this mode still exists
                 self.mode_index[self.mode_nb] = name
                 self.mode_nb = self.mode_nb + 1
-                MODE[name] = nil -- remove those previously known, ordered and handled
+                handled_modes[name] = true
             end
         end
         -- go on completing it with remaining new modes in MODE
@@ -361,8 +362,10 @@ function ReaderFooter:init()
     local orig_indexes = {}
     local orig_indexes_to_name = {}
     for name, orig_index in pairs(MODE) do
-        table.insert(orig_indexes, orig_index)
-        orig_indexes_to_name[orig_index] = name
+        if not handled_modes[name] then
+            table.insert(orig_indexes, orig_index)
+            orig_indexes_to_name[orig_index] = name
+        end
     end
     table.sort(orig_indexes)
     for i = 1, #orig_indexes do


### PR DESCRIPTION
Iterating a k/v table as an array would have us stopped on the first disabled MODE (frontlight, battery... on some devices). Details at https://github.com/koreader/koreader/issues/6210#issuecomment-636132193. Closes #6210.
Rework that initial setup, and make it correctly handle added or removed MODEs when using the ordered items saved in the user settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6212)
<!-- Reviewable:end -->
