### PR TITLE
[fix] Ignore sha2.lua in doc generation

### DIFF
--- a/doc/config.ld
+++ b/doc/config.ld
@@ -22,4 +22,5 @@ file = {
     '../frontend',
     '../base/ffi',
     '../platform/android/luajit-launcher/assets',
+    exclude = {'../base/ffi/sha2.lua'},
 }


### PR DESCRIPTION
Otherwise it'll choke on the comments in that file.

See <https://github.com/koreader/koreader/pull/6195#issuecomment-638801075>.

Accidentally introduced in <https://github.com/koreader/koreader-base/pull/1105>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6229)
<!-- Reviewable:end -->
