### PR TITLE
bump crengine: support for pseudo elements ::before/after

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1581,26 +1581,14 @@ function ReaderFooter:setTocMarkers(reset)
     end
     if self.settings.toc_markers then
         self.progress_bar.tick_width = Screen:scaleBySize(self.settings.toc_markers_width)
-        if self.progress_bar.ticks ~= nil then return end
-        local ticks_candidates = {}
+        if self.progress_bar.ticks ~= nil then -- already computed
+            return
+        end
+        self.progress_bar.ticks = {}
         if self.ui.toc then
-            local max_level = self.ui.toc:getMaxDepth()
-            for i = 0, -max_level, -1 do
-                local ticks = self.ui.toc:getTocTicks(i)
-                table.insert(ticks_candidates, ticks)
-            end
-            -- find the finest toc ticks by sorting out the largest one
-            table.sort(ticks_candidates, function(a, b) return #a > #b end)
+            self.progress_bar.ticks = self.ui.toc:getTocTicksForFooter()
         end
-
-        if #ticks_candidates > 0 then
-            self.progress_bar.ticks = ticks_candidates[1]
-            self.progress_bar.last = self.pages or self.view.document:getPageCount()
-        else
-            -- we still set ticks here so self.progress_bar.ticks will not be
-            -- initialized again if ticks_candidates is empty
-            self.progress_bar.ticks = {}
-        end
+        self.progress_bar.last = self.pages or self.view.document:getPageCount()
     else
         self.progress_bar.ticks = nil
     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -828,21 +828,21 @@ function ReaderHighlight:viewSelectionHTML(debug_view)
     if self.selected_text and self.selected_text.pos0 and self.selected_text.pos1 then
         -- For available flags, see the "#define WRITENODEEX_*" in crengine/src/lvtinydom.cpp
         -- Start with valid and classic displayed HTML (with only block nodes indented),
-        -- including styles found in <HEAD>, and linked CSS files content.
-        local html_flags = 0x6030
+        -- including styles found in <HEAD>, linked CSS files content, and misc info.
+        local html_flags = 0x6830
         if not debug_view then
             debug_view = 0
         end
         if debug_view == 1 then
             -- Each node on a line, with markers and numbers of skipped chars and siblings shown,
             -- with possibly invalid HTML (text nodes not escaped)
-            html_flags = 0x635A
+            html_flags = 0x6B5A
         elseif debug_view == 2 then
             -- Additionally see rendering methods of each node
-            html_flags = 0x675A
+            html_flags = 0x6F5A
         elseif debug_view == 3 then
             -- Or additionally see unicode codepoint of each char
-            html_flags = 0x635E
+            html_flags = 0x6B5E
         end
         local html, css_files = self.ui.document:getHTMLFromXPointers(self.selected_text.pos0,
                                     self.selected_text.pos1, html_flags, true)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -814,6 +814,7 @@ function ReaderRolling:updatePos()
         self.ui:handleEvent(Event:new("UpdateToc"))
         self.view.footer:updateFooter()
     end
+    self:updateTopStatusBarMarkers()
     UIManager:setDirty(self.view.dialog, "partial")
     -- Allow for the new rendering to be shown before possibly showing
     -- the "Styles have changes..." ConfirmBox so the user can decide
@@ -1003,6 +1004,15 @@ function ReaderRolling:onSetStatusLine(status_line, on_read_settings)
         self.view.footer:setVisible(status_line == 1)
     end
     self.ui:handleEvent(Event:new("UpdatePos"))
+end
+
+function ReaderRolling:updateTopStatusBarMarkers()
+    if not self.cre_top_bar_enabled then
+        return
+    end
+    local pages = self.ui.document:getPageCount()
+    local ticks = self.ui.toc:getTocTicksForFooter()
+    self.ui.document:setHeaderProgressMarks(pages, ticks)
 end
 
 function ReaderRolling:updateBatteryState()

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -285,6 +285,21 @@ function ReaderToc:getTocTicks(level)
     return ticks
 end
 
+function ReaderToc:getTocTicksForFooter()
+    local ticks_candidates = {}
+    local max_level = self:getMaxDepth()
+    for i = 0, -max_level, -1 do
+        local ticks = self:getTocTicks(i)
+        table.insert(ticks_candidates, ticks)
+    end
+    if #ticks_candidates > 0 then
+        -- Find the finest toc ticks by sorting out the largest one
+        table.sort(ticks_candidates, function(a, b) return #a > #b end)
+        return ticks_candidates[1]
+    end
+    return {}
+end
+
 function ReaderToc:getNextChapter(cur_pageno, level)
     local ticks = self:getTocTicks(level)
     local next_chapter = nil

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -767,6 +767,10 @@ function CreDocument:setViewDimen(dimen)
     self._document:setViewDimen(dimen.w, dimen.h)
 end
 
+function CreDocument:setHeaderProgressMarks(pages, ticks)
+    self._document:setHeaderProgressMarks(pages, ticks)
+end
+
 function CreDocument:setHeaderFont(new_font)
     if new_font then
         logger.dbg("CreDocument: set header font", new_font)

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -281,13 +281,26 @@ DocFragment {
             },
         },
         {
-            id = "hyphenate_all_auto";
-            title = _("Allow hyphenation on all text"),
-            description = _("Allow hyphenation on all text (except headings), in case the publisher has disabled it."),
-            css = [[
+            title = _("Hyphenation and ligatures"),
+            {
+                id = "hyphenate_all_auto";
+                title = _("Allow hyphenation on all text"),
+                description = _("Allow hyphenation on all text (except headings), in case the publisher has disabled it."),
+                css = [[
 * { hyphens: auto !important; }
 h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
-            ]],
+                ]],
+            },
+            {
+                id = "ligature_all_no_common_ligature";
+                title = _("Disable common ligatures"),
+                description = _("Disable common ligatures, which are enabled by default in 'best' kerning mode."),
+                -- We don't use !important, as this would stop other font-variant properties
+                -- from being applied
+                css = [[
+* { font-variant: no-common-ligatures; }
+                ]],
+            },
             separator = true,
         },
         {
@@ -454,6 +467,7 @@ body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
             title = _("Full-width tables"),
             description = _("Make table expand to the full width of the page. (Tables with small content now use only the width needed to display that content. This restores the previous behavior.)"),
             css = [[table { width: 100% !important; }]],
+            priority = 2, -- Override next one
         },
         {
             id = "table_td_width_auto";
@@ -788,6 +802,15 @@ This tweak toggles this behavior, and may show the <epub:case> content as plain 
             css = [[
 switch > case    { display: inline; }
 switch > default { display: none; }
+            ]],
+        },
+        {
+            id = "no_pseudo_element_before_after";
+            title = _("Disable before/after pseudo elements"),
+            description = _([[Disable generated text from ::before and ::after pseudo elements, usually used to add cosmetic text around some content.]]),
+            css = [[
+*::before { display: none !important; }
+*::after  { display: none !important; }
             ]],
         },
         {


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/345 :
- GIF decoding: avoid crash on some images - Closes #6215 
- Top progress bar: avoid re-computing when not needed - Closes #6191 
- Top progress bar: allow external filling of marks
- CSS/Text: properly inherit and handle text-align-last
- getRenderedWidths(): fix handling of text-indent
- Reorder some flags to make the sets clearer
- CSS: support more white-space named values
- Text: fix standalone BR not making an empty line (rework)
- CSS: support for pseudo elements ::before & ::after
- CSS: content: open-quote support via TextLangMan
- CSS/Text selection: adds a few "-cr-hint:" tweaks - (Can help with https://github.com/koreader/koreader/issues/6223#issuecomment-638834510 )

Also:
- cre.cpp: adds setHeaderProgressMarks() https://github.com/koreader/koreader-base/pull/1112
- Update to SQLite 3.32.2 https://github.com/koreader/koreader-base/pull/1111

Added 2 style tweaks to disable pseudo elements ::before/after and common ligatures.

CRE: use same marks in top and bottom progress bars
Feed to crengine the same ticks (build from the TOC entries) that we use in the bottom status bar. (crengine otherwise builds a tick for each DocFragment, which most often is really different than what's seen in the bottom bar.)
Closes https://github.com/koreader/crengine/issues/335. See https://github.com/koreader/koreader/issues/5848#issuecomment-584766009

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6236)
<!-- Reviewable:end -->
