### PR TITLE
Ensure feature-parity in ScreenSaver handling on Kindle

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -161,10 +161,10 @@ function Kindle:usbPlugIn()
 end
 
 function Kindle:intoScreenSaver()
-    local Screensaver = require("ui/screensaver")
-    if self:supportsScreensaver() then
-        -- NOTE: Meaning this is not a SO device ;)
-        if self.screen_saver_mode == false then
+    if self.screen_saver_mode == false then
+        if self:supportsScreensaver() then
+            -- NOTE: Meaning this is not a SO device ;)
+            local Screensaver = require("ui/screensaver")
             -- NOTE: Pilefered from Device:onPowerEvent @ frontend/device/generic/device.lua
             -- Mostly always suspend in Portrait/Inverted Portrait mode...
             -- ... except when we just show an InfoMessage or when the screensaver
@@ -195,10 +195,8 @@ function Kindle:intoScreenSaver()
                 self.orig_rotation_mode = nil
             end
             Screensaver:show()
-        end
-    else
-        -- Let the native system handle screensavers on SO devices...
-        if self.screen_saver_mode == false then
+        else
+            -- Let the native system handle screensavers on SO devices...
             if os.getenv("AWESOME_STOPPED") == "yes" then
                 os.execute("killall -cont awesome")
             end
@@ -210,8 +208,8 @@ end
 
 function Kindle:outofScreenSaver()
     if self.screen_saver_mode == true then
-        local Screensaver = require("ui/screensaver")
         if self:supportsScreensaver() then
+            local Screensaver = require("ui/screensaver")
             -- Restore to previous rotation mode, if need be.
             if self.orig_rotation_mode then
                 self.screen:setRotationMode(self.orig_rotation_mode)

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -217,16 +217,19 @@ function Kindle:outofScreenSaver()
                 self.screen:setRotationMode(self.orig_rotation_mode)
             end
             Screensaver:close()
+            -- And redraw everything in case the framework managed to screw us over...
+            local UIManager = require("ui/uimanager")
+            UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
         else
             -- Stop awesome again if need be...
             if os.getenv("AWESOME_STOPPED") == "yes" then
                 os.execute("killall -stop awesome")
             end
+            local UIManager = require("ui/uimanager")
+            -- NOTE: We redraw after a slightly longer delay to take care of the potentially dynamic ad screen...
+            --       This is obviously brittle as all hell. Tested on a slow-ass PW1.
+            UIManager:scheduleIn(1.5, function() UIManager:setDirty("all", "full") end)
         end
-        local UIManager = require("ui/uimanager")
-        -- NOTE: If we *really* wanted to avoid the framework seeping through, we could use tickAfterNext instead,
-        --       at the cost of an extra flashing update...
-        UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
     end
     self.powerd:afterResume()
     self.screen_saver_mode = false


### PR DESCRIPTION
We were missing the fancy extra white flash and landscape handling that
most every other eInk device gets ;).

(On non-SO devices, of course).

Fix #5724

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6240)
<!-- Reviewable:end -->
