### PR TITLE
Remove a dodgy scheduleIn

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -786,7 +786,7 @@ function ReaderRolling:onUpdatePos()
         return true
     end
     -- Calling this now ensures the re-rendering is done by crengine
-    -- so the delayed updatePos() has good info and can reposition
+    -- so updatePos() has good info and can reposition
     -- the previous xpointer accurately:
     self.ui.document:getCurrentPos()
     -- Otherwise, _readMetadata() would do that, but the positionning
@@ -794,7 +794,7 @@ function ReaderRolling:onUpdatePos()
     -- previously because of some bad setDirty() in ConfigDialog widgets
     -- that were triggering a full repaint of crengine (so, the needed
     -- rerendering) before updatePos() is called.
-    UIManager:scheduleIn(0.1, function () self:updatePos() end)
+    self:updatePos()
 end
 
 function ReaderRolling:updatePos()


### PR DESCRIPTION
It was causing a double-refresh on orientation change via ConfigDialog

I could only reproduce it on Kindle, for some strange reason (slower?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6241)
<!-- Reviewable:end -->
