### PR TITLE
Style tweaks: adds "Book specific tweak" menu item

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -189,7 +189,7 @@ end
 function TweakInfoWidget:onTap(arg, ges)
     if ges.pos:intersectWith(self.css_frame.dimen) and Device:hasClipboard() then
         -- Tap inside CSS text copies it into clipboard (so it
-        -- can be pasted into the book specific tweak editor)
+        -- can be pasted into the book-specific tweak editor)
         -- (Add \n on both sides for easier pasting)
         Device.input.setClipboardText("\n"..self.css_text.."\n")
         UIManager:show(Notification:new{
@@ -543,14 +543,14 @@ You can enable individual tweaks on this book with a tap, or view more details a
     addTweakMenuItem(self.tweaks_table, user_tweaks_table, 6)
                                             -- limit to 6 user tweaks per page
 
-    -- Book specific editable tweak
+    -- Book-specific editable tweak
     self.tweaks_table[#self.tweaks_table].separator = true
     local book_tweak_item = {
         text_func = function()
             if self.book_style_tweak then
-                return _("Book specific tweak (hold to edit)")
+                return _("Book-specific tweak (hold to edit)")
             else
-                return _("Book specific tweak")
+                return _("Book-specific tweak")
             end
         end,
         enabled_func = function() return self.enabled end,
@@ -644,7 +644,7 @@ function ReaderStyleTweak:editBookTweak(touchmenu_instance)
     -- same time: having it similar will make that unnoticed.
     local NOT_MODIFIED_MSG = _("Book tweak not modified.")
     editor = InputDialog:new{
-        title =  _("Edit book specific style tweak"),
+        title =  _("Edit book-specific style tweak"),
         input = self.book_style_tweak or "",
         input_hint = BOOK_TWEAK_INPUT_HINT,
         input_face = Font:getFace("infont", 16), -- same as in TweakInfoWidget

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -152,6 +152,7 @@ local InputDialog = InputContainer:new{
                       -- - on success: as the notification text instead of the default one
                       -- - on failure: in an InfoMessage
     close_callback = nil, -- Called when closing (if discarded or saved, after save_callback if saved)
+    edited_callback = nil,  -- Called on each text modification
 
     -- For use by TextEditor plugin:
     view_pos_callback = nil, -- Called with no arg to get initial top_line_num/charpos,
@@ -466,8 +467,11 @@ function InputDialog:getInputValue()
     end
 end
 
-function InputDialog:setInputText(text)
+function InputDialog:setInputText(text, edited_state)
     self._input_widget:setText(text)
+    if edited_state ~= nil and self._buttons_edit_callback then
+        self._buttons_edit_callback(edited_state)
+    end
 end
 
 function InputDialog:isTextEditable()
@@ -579,6 +583,9 @@ function InputDialog:_addSaveCloseButtons()
             button("save"):enable()
             if button("reset") then button("reset"):enable() end
             self:refreshButtons()
+        end
+        if self.edited_callback then
+            self.edited_callback()
         end
     end
     if self.reset_callback then

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -908,6 +908,47 @@ function util.htmlEscape(text)
     })
 end
 
+--- Prettify a CSS stylesheet
+-- Not perfect, but enough to make some ugly CSS readable.
+-- By default, each selector and each property is put on its own line.
+-- With condensed=true, condense each full declaration on a single line.
+--
+--- @string CSS string
+--- @boolean condensed[opt=false] true to condense each declaration on a line
+--- @treturn string the CSS prettified
+function util.prettifyCSS(css_text, condensed)
+    if not condensed then
+        -- Get rid of \t so we can use it as a replacement/hiding char
+        css_text = css_text:gsub("\t", " ")
+        -- Wrap and indent declarations
+        css_text = css_text:gsub("%s*{%s*", " {\n    ")
+        css_text = css_text:gsub(";%s*}%s*", ";\n}\n")
+        css_text = css_text:gsub(";%s*([^}])", ";\n    %1")
+        css_text = css_text:gsub("%s*}%s*", "\n}\n")
+        -- Cleanup declarations
+        css_text = css_text:gsub("{[^}]*}", function(s)
+            s = s:gsub("%s*:%s*", ": ")
+            -- Temporarily hide/replace ',' in declaration so they
+            -- are not matched and made multi-lines by followup gsub
+            s = s:gsub("%s*,%s*", "\t")
+            return s
+        end)
+        -- Have each selector (separated by ',') on a new line
+        css_text = css_text:gsub("%s*,%s*", " ,\n")
+        -- Restore hidden ',' in declarations
+        css_text = css_text:gsub("\t", ", ")
+    else
+        -- Go thru previous method to have something standard to work on
+        css_text = util.prettifyCSS(css_text)
+        -- And condense that
+        css_text = css_text:gsub(" {\n    ", " { ")
+        css_text = css_text:gsub(";\n    ", "; ")
+        css_text = css_text:gsub("\n}", " }")
+        css_text = css_text:gsub(" ,\n", ", ")
+    end
+    return css_text
+end
+
 --- Escape list for shell usage
 --- @table args the list of arguments to escape
 --- @treturn string the escaped and concatenated arguments


### PR DESCRIPTION
Allows editing a CSS snippet to be applied to this book only, without the need to create and edit a User style tweak.
Allows copying any other tweak CSS by just taping on it (and pasting into this with Hold).
Limit User style tweaks nb of items per menu page to 6 (like we try to do for other tweaks menus).

(Dunno if there's a better wording than "Book specific tweak" to make that clearer... "Book own tweak" ?)

<kbd>![image](https://user-images.githubusercontent.com/24273478/83997185-1e624c80-a95e-11ea-82e4-c5ff8feb672a.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/83997216-2e7a2c00-a95e-11ea-9dcd-6695e282d346.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/83997235-3a65ee00-a95e-11ea-8deb-13013922d975.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/83997272-4e115480-a95e-11ea-8c10-6c6d3af84a49.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6244)
<!-- Reviewable:end -->
