### PR TITLE
Keyboard: better isolation of FR/ES/TR from EN base

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -429,6 +429,9 @@ function ReaderUI:init()
 end
 
 function ReaderUI:setLastDirForFileBrowser(dir)
+    if dir and #dir > 1 and dir:sub(-1) == "/" then
+        dir = dir:sub(1, -2)
+    end
     self.last_dir_for_file_browser = dir
 end
 

--- a/frontend/ui/data/keyboardlayouts/es_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/es_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout
-local es_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
+-- Start with the english keyboard layout (deep copy, to not alter it)
+local es_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
 
 local keys = es_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/fr_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/fr_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout
-local fr_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
+-- Start with the english keyboard layout (deep copy, to not alter it)
+local fr_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
 
 -- Swap the four AZWQ keys (only in the lowercase and
 -- uppercase letters layouts) to change it from QWERTY to AZERTY
@@ -14,14 +14,30 @@ table.insert(keys[2],
            --  1       2       3       4       5       6       7       8
             { "M",    "m",    "§",    "+",    "Œ",    "œ",    "Ő",    "ő", }
 )
--- And swap the english M on the 3rd row to ','
-keys[3][8][1] = ","
-keys[3][8][2] = ","
--- And swap the english ',' on the 4th row (an extended key
--- including a popup) to ';'
-local en_com = keys[4][5][1]
-en_com[1] = ";"
-en_com.north = "," -- and swap the ';' there to ','
+-- But replace the alpha "M" and "m" with the original key+popup from english M/m
+keys[2][10][1] = keys[3][8][1]
+keys[2][10][2] = keys[3][8][2]
+
+-- We have one more key than en_keyboard: replace that original M key
+-- to show another char on alpha layouts: let's use ";", and a popup
+-- helpful for CSS style tweaks editing.
+local _semicolon = {
+    ";",
+    -- north = "!",
+    north = { label = "!…", key = "!important;" },
+    northeast = "}",
+    northwest = "{",
+    west = "-",
+    east = ":",
+    south = "*",
+    southwest = "0",
+    southeast = ">",
+    "[",
+    '+',
+    "]",
+}
+keys[3][8][1] = _semicolon
+keys[3][8][2] = _semicolon
 
 -- Swap ê and ë (and the like) in the keyboard popups, so the
 -- common french accentuated chars are all on the upper row.

--- a/frontend/ui/data/keyboardlayouts/tr_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/tr_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout
-local tr_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
+-- Start with the english keyboard layout (deep copy, to not alter it)
+local tr_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
 
 local keys = tr_keyboard.keys
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -132,6 +132,9 @@ function VirtualKey:init()
             local key_function = self.key_chars[ges.direction.."_func"]
 
             if not key_function and key_string then
+                if type(key_string) == "table" and key_string.key then
+                    key_string = key_string.key
+                end
                 self.keyboard:addChar(key_string)
             elseif key_function then
                 key_function()


### PR DESCRIPTION
`ReaderUI:setLastDirForFileBrowser(): remove trailing /`
Closes #6243 (untested though)

`Keyboard: better isolation of FR/ES/TR from EN base`
Fix some issue really noticable only with the FR keyboard, noticed at the bottom of https://github.com/koreader/koreader/pull/6244#issuecomment-640395594 :
`dofile()` wasn't enough to copy en_keyboard, as the references to key popups would still be shared, and hacks to them (as done by the FR keyboard) would be active on the EN keyboard.

Also, for the FR Keyboard:
- bring <kbd>M</kbd> key popup too when moving it to 2nd row.
- keep original <kbd>,</kbd> and <kbd>.</kbd> as on EN keyboard (as this is more useful and intuitive, even if not really AZERTY, but we didn't really have the 4 AZERTY bottom puncts in a row <kbd>,</kbd><kbd>;</kbd><kbd>:</kbd><kbd>!</kbd> so...)
- add <kbd>;</kbd> instead of <kbd>,</kbd> as the added key, and let it have some key popup too, with keys helpful when CSS editing.

I gave myself (and FR keyboard users) a treat, that other keyboards don't have (yet?):
<kbd>![image](https://user-images.githubusercontent.com/24273478/84074936-b0586c80-a9d3-11ea-9a73-4ac4d3e68754.png)</kbd> => <kbd>![image](https://user-images.githubusercontent.com/24273478/84075014-bf3f1f00-a9d3-11ea-9169-2e0e24e81231.png)</kbd> for furious style tweaking !

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6246)
<!-- Reviewable:end -->
