### PR TITLE
Add the possibility to execute a shell script on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ endif
 ifdef ANDROID
 	cd $(INSTALL_DIR)/koreader && \
 		ln -sf ../../$(ANDROID_DIR)/*.lua .
+	@echo "[*] Install scripts"
+	$(RCP) -pL scripts $(INSTALL_DIR)/koreader/
 endif
 ifdef WIN32
 	@echo "[*] Install runtime libraries for win32..."
@@ -105,7 +107,7 @@ endif
 	@# purge deleted plugins
 	for d in $$(ls $(INSTALL_DIR)/koreader/plugins); do \
 		test -d plugins/$$d || rm -rf $(INSTALL_DIR)/koreader/plugins/$$d ; done
-	@echo "[*] Installresources"
+	@echo "[*] Install resources"
 	$(RCP) -pL resources/fonts/. $(INSTALL_DIR)/koreader/fonts/.
 	install -d $(INSTALL_DIR)/koreader/{screenshots,data/{dict,tessdata},fonts/host,ota}
 ifeq ($(IS_RELEASE),1)

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -15,6 +15,10 @@ end
 -- path to primary external storage partition
 local path = android.getExternalStoragePath()
 
+-- startup scripts before patch.lua
+android.execute("chmod", "755", "./scripts/startup-script.sh") -- make script rwx for all
+android.execute("sh", "./scripts/startup-script.sh", path.."/koreader" );
+
 -- run koreader patch before koreader startup
 pcall(dofile, path.."/koreader/patch.lua")
 

--- a/scripts/startup-script.sh
+++ b/scripts/startup-script.sh
@@ -21,7 +21,7 @@ CUT="busybox cut"
 REV="busybox rev"
 
 # system dir of koreader
-SYYTEM_DIR=$PWD
+SYSTEM_DIR=$PWD
 
 # ./scripts.done does not exist after apk update
 if [ ! -f ./scripts.done ]; then

--- a/scripts/startup-script.sh
+++ b/scripts/startup-script.sh
@@ -15,7 +15,6 @@
 ## (also on the first one).
 
 
-
 # $1 is the koreader user directory
 
 CUT="busybox cut"
@@ -23,44 +22,44 @@ REV="busybox rev"
 WD=$(pwd)
 
 # system dir of koreader
-SYSTEM_DIR=$(echo $WD | $REV | $CUT -d'/' -f1- | $REV)
+SYSTEM_DIR=$(echo "$WD" | $REV | $CUT -d'/' -f1- | $REV)
 
 
 # ./scripts.done does not exist after apk update
 if [ ! -f "./scripts.done" ]; then
   # if scripts.once does not exist, create and populate it
-  if [ ! -d $1/scripts.once ]; then
-    mkdir $1/scripts.once
-    echo "#place *.sh scripts here, which should be executed after an update of koreader" > $1/scripts.once/README
-    echo "#you could overwrite hyphenation patterns with your own ones" >> $1/scripts.once/README
+  if [ ! -d "$1"/scripts.once ]; then
+    mkdir "$1"/scripts.once
+    echo "#place *.sh scripts here, which should be executed after an update of koreader" > "$1"/scripts.once/README
+    echo "#you could overwrite hyphenation patterns with your own ones" >> "$1"/scripts.once/README
 
-   cp $SYSTEM_DIR/scripts/*once.sh $1/scripts.once/ 
+   cp "$SYSTEM_DIR"/scripts/*once.sh "$1"/scripts.once/ 
   fi
 
   # if scripts.update does not exist, create and populate it
-  if [ ! -d $1/scripts.update ]; then
-    mkdir $1/scripts.update
-    echo "#place *.sh scripts here, which should be executed everytime koreader starts" > $1/scripts.update/README
-    echo "#you could update the hyphenation patterns with new ones" >> $1/scripts.update/README
+  if [ ! -d "$1"/scripts.update ]; then
+    mkdir "$1"/scripts.update
+    echo "#place *.sh scripts here, which should be executed everytime koreader starts" > "$1"/scripts.update/README
+    echo "#you could update the hyphenation patterns with new ones" >> "$1"/scripts.update/README
   
-  cp $SYSTEM_DIR/scripts/*update.sh $1/scripts.update/
+  cp "$SYSTEM_DIR"/scripts/*update.sh "$1"/scripts.update/
   fi
 
   # execute all scripts in scripts.once	
-  for script in $(ls $1/scripts.once/*.sh); do
+  for script in $(ls "$1"/scripts.once/*.sh); do
     echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
-    sh $script $1 $SYSTEM_DIR
+    sh "$script" "$1" "$SYSTEM_DIR"
   done
   echo "scripts once done" >> ./scripts.done
 else
   rm ./scripts.done
 fi
 
-if [ -d $1/scripts.update ]; then
+if [ -d "$1"/scripts.update ]; then
   # execute all scripts in scripts.update	
-  for script in $(ls $1/scripts.update/*.sh); do
+  for script in $(ls "$1"/scripts.update/*.sh); do
     echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
-    sh $script $1 $SYSTEM_DIR
+    sh "$script" "$1" "$SYSTEM_DIR"
   done
 fi
 

--- a/scripts/startup-script.sh
+++ b/scripts/startup-script.sh
@@ -19,11 +19,9 @@
 
 CUT="busybox cut"
 REV="busybox rev"
-WD=$(pwd)
 
 # system dir of koreader
-SYSTEM_DIR=$(echo "$WD" | $REV | $CUT -d'/' -f1- | $REV)
-SYYTEM_DIR=$(pwd)
+SYYTEM_DIR=$PWD
 
 # ./scripts.done does not exist after apk update
 if [ ! -f ./scripts.done ]; then

--- a/scripts/startup-script.sh
+++ b/scripts/startup-script.sh
@@ -8,10 +8,10 @@
 ## If they do not exist the get populated with an example to update 
 ## hyphen patterns from /sdcard/koreader/hyph/*.pattern
 
-## The scripts in /sdcard/koreader/scripts.once are only executed on the first
+## The scripts in /sdcard/koreader/scripts.afterupdate are only executed on the first
 ## start after an update of the apk
 
-## The scripts in /sdcard/koreader/scripts.update are executed on every start
+## The scripts in /sdcard/koreader/scripts.always are executed on every start
 ## (also on the first one).
 
 
@@ -25,38 +25,38 @@ SYSTEM_DIR=$PWD
 
 # ./scripts.done does not exist after apk update
 if [ ! -f ./scripts.done ]; then
-  # if scripts.once does not exist, create and populate it
-  if [ ! -d "$1"/scripts.once ]; then
-    mkdir "$1"/scripts.once
-    echo "#place *.sh scripts here, which should be executed after an update of koreader" > "$1"/scripts.once/README
-    echo "#you could overwrite hyphenation patterns with your own ones" >> "$1"/scripts.once/README
+  # if scripts.afterupdate does not exist, create and populate it
+  if [ ! -d "$1"/scripts.afterupdate ]; then
+    mkdir "$1"/scripts.afterupdate
+    echo "#place *.sh scripts here, which should be executed after an update of koreader" > "$1"/scripts.afterupdate/README
+    echo "#you could overwrite hyphenation patterns with your own ones" >> "$1"/scripts.afterupdate/README
 
-   cp "$SYSTEM_DIR"/scripts/*once.sh "$1"/scripts.once/ 
+   cp "$SYSTEM_DIR"/scripts/*afterupdate.sh "$1"/scripts.afterupdate/ 
   fi
 
-  # if scripts.update does not exist, create and populate it
-  if [ ! -d "$1"/scripts.update ]; then
-    mkdir "$1"/scripts.update
-    echo "#place *.sh scripts here, which should be executed everytime koreader starts" > "$1"/scripts.update/README
-    echo "#you could update the hyphenation patterns with new ones" >> "$1"/scripts.update/README
+  # if scripts.always does not exist, create and populate it
+  if [ ! -d "$1"/scripts.always ]; then
+    mkdir "$1"/scripts.always
+    echo "#place *.sh scripts here, which should be executed everytime koreader starts" > "$1"/scripts.always/README
+    echo "#you could update the hyphenation patterns with new ones" >> "$1"/scripts.always/README
   
-  cp "$SYSTEM_DIR"/scripts/*update.sh "$1"/scripts.update/
+  cp "$SYSTEM_DIR"/scripts/*update.sh "$1"/scripts.always/
   fi
 
-  # execute all scripts in scripts.once	
-  for script in $(ls "$1"/scripts.once/*.sh); do
+  # execute all scripts in scripts.afterupdate	
+  for script in $(ls "$1"/scripts.afterupdate/*.sh); do
     [[ -e "$script" ]] || break
     echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
     sh "$script" "$1" "$SYSTEM_DIR"
   done
-  echo "scripts once done" >> ./scripts.done
+  echo "scripts afterupdate done" >> ./scripts.done
 else
   rm ./scripts.done
 fi
 
-if [ -d "$1"/scripts.update ]; then
-  # execute all scripts in scripts.update	
-  for script in $(ls "$1"/scripts.update/*.sh); do
+if [ -d "$1"/scripts.always ]; then
+  # execute all scripts in scripts.always	
+  for script in $(ls "$1"/scripts.always/*.sh); do
     [[ -e "$script" ]] || break
     echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
     sh "$script" "$1" "$SYSTEM_DIR"

--- a/scripts/startup-script.sh
+++ b/scripts/startup-script.sh
@@ -45,6 +45,7 @@ if [ ! -f ./scripts.done ]; then
 
   # execute all scripts in scripts.once	
   for script in $(ls "$1"/scripts.once/*.sh); do
+    [[ -e "$script" ]] || break
     echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
     sh "$script" "$1" "$SYSTEM_DIR"
   done
@@ -56,6 +57,7 @@ fi
 if [ -d "$1"/scripts.update ]; then
   # execute all scripts in scripts.update	
   for script in $(ls "$1"/scripts.update/*.sh); do
+    [[ -e "$script" ]] || break
     echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
     sh "$script" "$1" "$SYSTEM_DIR"
   done

--- a/scripts/startup-script.sh
+++ b/scripts/startup-script.sh
@@ -23,10 +23,10 @@ WD=$(pwd)
 
 # system dir of koreader
 SYSTEM_DIR=$(echo "$WD" | $REV | $CUT -d'/' -f1- | $REV)
-
+SYYTEM_DIR=$(pwd)
 
 # ./scripts.done does not exist after apk update
-if [ ! -f "./scripts.done" ]; then
+if [ ! -f ./scripts.done ]; then
   # if scripts.once does not exist, create and populate it
   if [ ! -d "$1"/scripts.once ]; then
     mkdir "$1"/scripts.once

--- a/scripts/startup-script.sh
+++ b/scripts/startup-script.sh
@@ -1,0 +1,67 @@
+#!/system/bin/sh
+
+## This script is executed every time koreader starts.
+## The log is written to scripts.done. This file is important!
+## If the log does not exist, it is the first start after an update of the apk.
+
+## On the first start of koreader, two directories on the SDCard are checked.
+## If they do not exist the get populated with an example to update 
+## hyphen patterns from /sdcard/koreader/hyph/*.pattern
+
+## The scripts in /sdcard/koreader/scripts.once are only executed on the first
+## start after an update of the apk
+
+## The scripts in /sdcard/koreader/scripts.update are executed on every start
+## (also on the first one).
+
+
+
+# $1 is the koreader user directory
+
+CUT="busybox cut"
+REV="busybox rev"
+WD=$(pwd)
+
+# system dir of koreader
+SYSTEM_DIR=$(echo $WD | $REV | $CUT -d'/' -f1- | $REV)
+
+
+# ./scripts.done does not exist after apk update
+if [ ! -f "./scripts.done" ]; then
+  # if scripts.once does not exist, create and populate it
+  if [ ! -d $1/scripts.once ]; then
+    mkdir $1/scripts.once
+    echo "#place *.sh scripts here, which should be executed after an update of koreader" > $1/scripts.once/README
+    echo "#you could overwrite hyphenation patterns with your own ones" >> $1/scripts.once/README
+
+   cp $SYSTEM_DIR/scripts/*once.sh $1/scripts.once/ 
+  fi
+
+  # if scripts.update does not exist, create and populate it
+  if [ ! -d $1/scripts.update ]; then
+    mkdir $1/scripts.update
+    echo "#place *.sh scripts here, which should be executed everytime koreader starts" > $1/scripts.update/README
+    echo "#you could update the hyphenation patterns with new ones" >> $1/scripts.update/README
+  
+  cp $SYSTEM_DIR/scripts/*update.sh $1/scripts.update/
+  fi
+
+  # execute all scripts in scripts.once	
+  for script in $(ls $1/scripts.once/*.sh); do
+    echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
+    sh $script $1 $SYSTEM_DIR
+  done
+  echo "scripts once done" >> ./scripts.done
+else
+  rm ./scripts.done
+fi
+
+if [ -d $1/scripts.update ]; then
+  # execute all scripts in scripts.update	
+  for script in $(ls $1/scripts.update/*.sh); do
+    echo "execute: sh $script $1 $SYSTEM_DIR" >> ./scripts.done
+    sh $script $1 $SYSTEM_DIR
+  done
+fi
+
+echo "scripts update done" >> ./scripts.done

--- a/scripts/update-patterns.once.sh
+++ b/scripts/update-patterns.once.sh
@@ -1,0 +1,14 @@
+#!/system/bin/sh
+
+# $1 is the koreader user directory
+# $2 is the koreader system directory
+
+SYSTEM_DIR=$2
+
+# copy pattern files from user to system directory
+if  [ -d $1/hyph ]; then
+	for i in $(ls $1/hyph/*.pattern); do
+		cp $i $SYSTEM_DIR/data/hyph/
+	done
+fi
+

--- a/scripts/update-patterns.once.sh
+++ b/scripts/update-patterns.once.sh
@@ -8,6 +8,7 @@ SYSTEM_DIR=$2
 # copy pattern files from user to system directory
 if  [ -d "$1"/hyph ]; then
 	for i in $(ls "$1"/hyph/*.pattern); do
+		[[ -e "$i" ]] || break
 		cp "$i" "$SYSTEM_DIR"/data/hyph/
 	done
 fi

--- a/scripts/update-patterns.once.sh
+++ b/scripts/update-patterns.once.sh
@@ -6,9 +6,9 @@
 SYSTEM_DIR=$2
 
 # copy pattern files from user to system directory
-if  [ -d $1/hyph ]; then
-	for i in $(ls $1/hyph/*.pattern); do
-		cp $i $SYSTEM_DIR/data/hyph/
+if  [ -d "$1"/hyph ]; then
+	for i in $(ls "$1"/hyph/*.pattern); do
+		cp "$i" "$SYSTEM_DIR"/data/hyph/
 	done
 fi
 

--- a/scripts/update-patterns.update.sh
+++ b/scripts/update-patterns.update.sh
@@ -9,8 +9,8 @@ HYPH_DIR=$2/data/hyph/
 if [ -d "$1"/hyph ]; then
 	cd "$1"/hyph/ || exit
 	for i in $(ls *.pattern); do
-		[ "$i" -nt "$HYPH_DIR"/"$i" ] && cp "$i" "$HYPH_DIR"/
 		[ ! -f "$i" ] && cp "$i" "$HYPHT_DIR"
+		[ "$i" -nt "$HYPH_DIR"/"$i" ] && cp "$i" "$HYPH_DIR"/
 	done
 fi
 

--- a/scripts/update-patterns.update.sh
+++ b/scripts/update-patterns.update.sh
@@ -1,0 +1,16 @@
+#!/system/bin/sh
+
+# $1 is the koreader user directory
+# $2 is the koreader system directory
+
+HYPH_DIR=$2/data/hyph/
+
+#copy newer patterns fomr user to system directory
+if [ -d $1/hyph ]; then
+	cd $1/hyph/
+	for i in $(ls *.pattern); do
+		[ $i -nt $HYPH_DIR/$i ] && cp $i $HYPH_DIR/
+		[ ! -f $i ] && cp $i $HYPHT_DIR
+	done
+fi
+

--- a/scripts/update-patterns.update.sh
+++ b/scripts/update-patterns.update.sh
@@ -6,11 +6,11 @@
 HYPH_DIR=$2/data/hyph/
 
 #copy newer patterns fomr user to system directory
-if [ -d $1/hyph ]; then
-	cd $1/hyph/
+if [ -d "$1"/hyph ]; then
+	cd "$1"/hyph/ || exit
 	for i in $(ls *.pattern); do
-		[ $i -nt $HYPH_DIR/$i ] && cp $i $HYPH_DIR/
-		[ ! -f $i ] && cp $i $HYPHT_DIR
+		[ "$i" -nt "$HYPH_DIR"/"$i" ] && cp "$i" "$HYPH_DIR"/
+		[ ! -f "$i" ] && cp "$i" "$HYPHT_DIR"
 	done
 fi
 


### PR DESCRIPTION
    Add the possibility to execute the shell script
    apk_install_directory/files/scripts/startup-script.sh at startup of koreader.
    
    The startup-scripts.sh checks, if it is the first startup of koreader after an installation.
    If so, two the two directorys sdcard/koreader/scripts.[once,update]
    are created and populated with working example scripts,  but only if
    the directories did not exist.
    
    On the first startup all scripts in the sdcard/koreader/scripts.once
    (koreader user-directory) are executed.
    
    On every startup all scripts in sdcard/koreader/scripts.update are executed.
    
    The scripts do have full to access the installation directory and the
    user directory of koreader.
    ........
    
    The example scripts allow to update the hyphenation patterns from user supplied
    patterns in /sdcard/hyph/*.pattern on a new installation of koreader, or if
    the user patterns are newer than the installed ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6253)
<!-- Reviewable:end -->
