### PR TITLE
Fix missing glyphs Ï and Ö in EN keyboard popup

### DIFF
--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -172,7 +172,7 @@ return {
     },
     _I_ = {
         "I",
-        north = "Í",
+        north = "Ï",
         northeast = "Í",
         northwest = "Ì",
         east = "Î",
@@ -282,7 +282,7 @@ return {
     },
     _O_ = {
         "O",
-        north = "Ó",
+        north = "Ö",
         northeast = "Ó",
         northwest = "Ò",
         east = "Ô",


### PR DESCRIPTION
Fixes #6221.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6254)
<!-- Reviewable:end -->
