### PR TITLE
Allow automatically marking the book as read on end of doc

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -54,6 +54,12 @@ function ReaderStatus:onEndOfBook()
     if G_reader_settings:readSetting("collate") == "access" then
         collate = false
     end
+
+    -- Should we start by marking the book as read?
+    if G_reader_settings:isTrue("end_document_auto_mark") then
+        self:onMarkBook(true)
+    end
+
     if settings == "pop-up" or settings == nil then
         local buttons = {
             {

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -466,6 +466,16 @@ common_settings.document = {
             text = _("End of document action"),
             sub_item_table = {
                 {
+                    text = _("Always mark as read"),
+                    checked_func = function()
+                        return G_reader_settings:isTrue("end_document_auto_mark")
+                    end,
+                    callback = function()
+                        G_reader_settings:flipNilOrFalse("end_document_auto_mark", nil)
+                    end,
+                    separator = true,
+                },
+                {
                     text = _("Ask with pop-up dialog"),
                     checked_func = function()
                         local setting = G_reader_settings:readSetting("end_document_action")

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -471,7 +471,7 @@ common_settings.document = {
                         return G_reader_settings:isTrue("end_document_auto_mark")
                     end,
                     callback = function()
-                        G_reader_settings:flipNilOrFalse("end_document_auto_mark", nil)
+                        G_reader_settings:flipNilOrFalse("end_document_auto_mark")
                     end,
                     separator = true,
                 },
@@ -572,7 +572,7 @@ common_settings.document = {
                         return G_reader_settings:isTrue("highlight_action_on_single_word")
                     end,
                     callback = function()
-                        G_reader_settings:flipNilOrFalse("highlight_action_on_single_word", nil)
+                        G_reader_settings:flipNilOrFalse("highlight_action_on_single_word")
                     end,
                     separator = true,
                 },


### PR DESCRIPTION
Keep showing the "mark as" option/button, though, because that one is a
toggle, it doesn't enforce the "read" status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6256)
<!-- Reviewable:end -->
