### PR TITLE
[plugin, UX] Wallabag: aid with setting up missing information

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -13,6 +13,7 @@ local InputDialog = require("ui/widget/inputdialog")
 local JSON = require("json")
 local LuaSettings = require("frontend/luasettings")
 local Math = require("optmath")
+local MultiConfirmBox = require("ui/widget/multiconfirmbox")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local NetworkMgr = require("ui/network/manager")
 local ReadHistory = require("readhistory")
@@ -292,9 +293,27 @@ function Wallabag:getBearerToken()
         return s == nil or s == ""
     end
 
-    if isempty(self.server_url) or isempty(self.username) or isempty(self.password)  or isempty(self.client_id) or isempty(self.client_secret) or isempty(self.directory) then
-        UIManager:show(InfoMessage:new{
-            text = _("Please configure the server and local settings.")
+    local server_empty = isempty(self.server_url) or isempty(self.username) or isempty(self.password) or isempty(self.client_id) or isempty(self.client_secret)
+    local directory_empty = isempty(self.directory)
+    if server_empty or directory_empty then
+        UIManager:show(MultiConfirmBox:new{
+            text = _("Please configure the server and local settings."),
+            choice1_text_func = function()
+                if server_empty then
+                    return _("Server (★)")
+                else
+                    return _("Server")
+                end
+            end,
+            choice1_callback = function() self:editServerSettings() end,
+            choice2_text_func = function()
+                if directory_empty then
+                    return _("Folder (★)")
+                else
+                    return _("Folder")
+                end
+            end,
+            choice2_callback = function() self:setDownloadDirectory() end,
         })
         return false
     end

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -297,7 +297,7 @@ function Wallabag:getBearerToken()
     local directory_empty = isempty(self.directory)
     if server_empty or directory_empty then
         UIManager:show(MultiConfirmBox:new{
-            text = _("Please configure the server and local settings."),
+            text = _("Please configure the server settings and set a download folder."),
             choice1_text_func = function()
                 if server_empty then
                     return _("Server (★)")


### PR DESCRIPTION
The MultiConfirmBox indicates which settings are still missing and offers you a quick way to get to them.

Cf. <https://github.com/koreader/koreader/issues/6129>.

![Screenshot_20200612_190042](https://user-images.githubusercontent.com/202757/84528097-590e1100-acdf-11ea-94e5-5bb0df5efe05.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6262)
<!-- Reviewable:end -->
