### PR TITLE
Startup Scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ ifdef ANDROID
 	cd $(INSTALL_DIR)/koreader && \
 		ln -sf ../../$(ANDROID_DIR)/*.lua .
 	@echo "[*] Install afterupdate marker"
-	$(RCP) afterupdate.marker $(INSTALL_DIR)/koreader/
+	@echo "# If this file is here, there are no afterupdate scripts in /sdcard/koreader/scripts/afterupdate." > $(INSTALL_DIR)/koreader/afterupdate.marker
 endif
 ifdef WIN32
 	@echo "[*] Install runtime libraries for win32..."

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ endif
 ifdef ANDROID
 	cd $(INSTALL_DIR)/koreader && \
 		ln -sf ../../$(ANDROID_DIR)/*.lua .
+	@echo "[*] Install afterupdate marker"
+	$(RCP) afterupdate.marker $(INSTALL_DIR)/koreader/
 endif
 ifdef WIN32
 	@echo "[*] Install runtime libraries for win32..."
@@ -105,7 +107,7 @@ endif
 	@# purge deleted plugins
 	for d in $$(ls $(INSTALL_DIR)/koreader/plugins); do \
 		test -d plugins/$$d || rm -rf $(INSTALL_DIR)/koreader/plugins/$$d ; done
-	@echo "[*] Installresources"
+	@echo "[*] Install resources"
 	$(RCP) -pL resources/fonts/. $(INSTALL_DIR)/koreader/fonts/.
 	install -d $(INSTALL_DIR)/koreader/{screenshots,data/{dict,tessdata},fonts/host,ota}
 ifeq ($(IS_RELEASE),1)

--- a/afterupdate.marker
+++ b/afterupdate.marker
@@ -1,0 +1,1 @@
+# If this file is here, the afterupdate scripts did not run.

--- a/afterupdate.marker
+++ b/afterupdate.marker
@@ -1,1 +1,0 @@
-# If this file is here, there are no afterupdate scripts in /sdcard/koreader/scripts/afterupdate.

--- a/afterupdate.marker
+++ b/afterupdate.marker
@@ -1,1 +1,1 @@
-# If this file is here, there are no afterupdate scripts in /sdcard/koreader/scripts/afterupdate .
+# If this file is here, there are no afterupdate scripts in /sdcard/koreader/scripts/afterupdate.

--- a/afterupdate.marker
+++ b/afterupdate.marker
@@ -1,1 +1,1 @@
-# If this file is here, the afterupdate scripts did not run.
+# If this file is here, there are no afterupdate scripts in /sdcard/koreader/scripts/afterupdate .

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -26,18 +26,15 @@ local run_always_scripts = user_dir .. "/scripts.always"
 local shell_scripts = {}
 
 local function getUserScripts(path)
-    local ret = lfs.attributes(path)
-    if ret.mode == "directory" then
-        for entry in lfs.dir(path) do
-            if entry ~= "." and entry ~= ".." then
-                local fullpath = path .. "/" .. entry
-                if lfs.attributes(fullpath).mode ~= "directory" then
-                    if fullpath:match(".sh$") then  -- only include files ending in ".sh"
-                        table.insert(shell_scripts, fullpath)
-                    end
-                else
-                    getUserScripts(fullpath) -- recurse into next directory
+    for entry in lfs.dir(path) do
+        if entry ~= "." and entry ~= ".." then
+            local fullpath = path .. "/" .. entry
+            if lfs.attributes(fullpath).mode ~= "directory" then
+                if fullpath:match(".sh$") then  -- only include files ending in ".sh"
+                    table.insert(shell_scripts, fullpath)
                 end
+            else
+                getUserScripts(fullpath) -- recurse into next directory
             end
         end
     end
@@ -55,15 +52,13 @@ local function runUserScripts(scripts)
 end
 
 -- scripts executed once after an update of koreader
-android.LOGI("checking and running scripts on update, if necessary.")
 if lfs.attributes(run_once_scripts, "mode") == "directory" then
     if lfs.attributes(afterupdate_marker, "mode") == "file" then
         shell_scripts = {} -- clear table
         getUserScripts(run_once_scripts)
         runUserScripts(shell_scripts)
         android.LOGI(string.format("Executed %d afterupdate scripts from %s", #shell_scripts, run_once_scripts))
-        android.execute("/system/bin/rm", afterupdate_marker)
-        android.LOGI("Afterupdate marker " .. afterupdate_marker .." removed") 
+        android.execute("rm", afterupdate_marker)
     end
 end
 
@@ -82,8 +77,8 @@ pcall(dofile, path.."/koreader/patch.lua")
 -- Set proper permission for binaries.
 --- @todo Take care of this on extraction instead.
 -- Cf. <https://github.com/koreader/koreader/issues/5347#issuecomment-529476693>.
-android.execute("/system/bin/chmod", "755", "./sdcv")
-android.execute("/system/bin/chmod", "755", "./tar")
+android.execute("chmod", "755", "./sdcv")
+android.execute("chmod", "755", "./tar")
 
 -- set TESSDATA_PREFIX env var
 C.setenv("TESSDATA_PREFIX", path.."/koreader/data", 1)

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -39,13 +39,13 @@ if lfs.attributes(run_once_scripts, "mode") == "directory" then
          runUserScripts(run_once_scripts)
          android.execute("rm", afterupdate_marker)
      end
- end
+end
 
 -- scripts executed every start of koreader
 local run_always_scripts = path .. "/koreader/scripts.always"
 if lfs.attributes(run_always_scripts, "mode") == "directory" then
     runUserScripts(run_always_scripts)
- end
+end
  
 -- run koreader patch before koreader startup
 pcall(dofile, path.."/koreader/patch.lua")


### PR DESCRIPTION
Add the possibility to run *.sh scripts:

After an update of koreader all *.sh scripts in /sdcard/koreader/scripts.afterupdate are executed.

On every start of koreader run all *.sh scripts in /sdcard/koreader/scripts.always


This is a further development of the proposal of the pull request: #6253

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6275)
<!-- Reviewable:end -->
