### PR TITLE
More robust way to detect our own path on Kobo

### DIFF
--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -2,7 +2,7 @@
 export LC_ALL="en_US.UTF-8"
 
 # working directory of koreader
-KOREADER_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
+KOREADER_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
 
 # we're always starting from our working directory
 cd "${KOREADER_DIR}" || exit

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -2,7 +2,7 @@
 export LC_ALL="en_US.UTF-8"
 
 # working directory of koreader
-KOREADER_DIR="${0%/*}"
+KOREADER_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 
 # we're always starting from our working directory
 cd "${KOREADER_DIR}" || exit

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 export LC_ALL="en_US.UTF-8"
 
-# working directory of koreader
+# Compute our working directory in an extremely defensive manner
 KOREADER_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
 
-# we're always starting from our working directory
-cd "${KOREADER_DIR}" || exit
+# We rely on starting from our working directory, and it needs to be set, sane and absolute.
+cd "${KOREADER_DIR:-/dev/null}" || exit
 
 # Attempt to switch to a sensible CPUFreq governor when that's not already the case...
 IFS= read -r current_cpufreq_gov <"/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"


### PR DESCRIPTION
Should take care of all the weird and interesting ways people manage to
find to break it...

NOTE: "$(dirname $(realpath "${0}"))" works, too, but I'm not sure if
really old devices ship with the realpath applet...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6283)
<!-- Reviewable:end -->
