### PR TITLE
Don't rotate BookStatus & ReadingProgress in screensavers.

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -235,9 +235,12 @@ function Device:onPowerEvent(ev)
         logger.dbg("Suspending...")
         -- Mostly always suspend in Portrait/Inverted Portrait mode...
         -- ... except when we just show an InfoMessage or when the screensaver
-        -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290)
+        -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290).
+        -- We also exclude full-screen widgets that work fine in Landscape mode,
+        -- like ReadingProgress and BookStatus (c.f., #5724)
         local screensaver_type = G_reader_settings:readSetting("screensaver_type")
-        if screensaver_type ~= "message" and screensaver_type ~= "disable" then
+        if screensaver_type ~= "message" and screensaver_type ~= "disable" and
+           screensaver_type ~= "readingprogress" and screensaver_type ~= "bookstatus" then
             self.orig_rotation_mode = self.screen:getRotationMode()
             -- Leave Portrait & Inverted Portrait alone, that works just fine.
             if bit.band(self.orig_rotation_mode, 1) == 1 then

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -174,7 +174,7 @@ function Kindle:intoScreenSaver()
             -- like ReadingProgress and BookStatus (c.f., #5724)
             local screensaver_type = G_reader_settings:readSetting("screensaver_type")
             if screensaver_type ~= "message" and screensaver_type ~= "disable" and
-            screensaver_type ~= "readingprogress" and screensaver_type ~= "bookstatus" then
+               screensaver_type ~= "readingprogress" and screensaver_type ~= "bookstatus" then
                 self.orig_rotation_mode = self.screen:getRotationMode()
                 -- Leave Portrait & Inverted Portrait alone, that works just fine.
                 if bit.band(self.orig_rotation_mode, 1) == 1 then
@@ -187,8 +187,8 @@ function Kindle:intoScreenSaver()
                 -- On eInk, if we're using a screensaver mode that shows an image,
                 -- flash the screen to white first, to eliminate ghosting.
                 if self:hasEinkScreen() and
-                screensaver_type == "cover" or screensaver_type == "random_image" or
-                screensaver_type == "image_file" then
+                   screensaver_type == "cover" or screensaver_type == "random_image" or
+                   screensaver_type == "image_file" then
                     if not G_reader_settings:isTrue("screensaver_no_background") then
                         self.screen:clear()
                     end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -169,9 +169,12 @@ function Kindle:intoScreenSaver()
             -- NOTE: Pilefered from Device:onPowerEvent @ frontend/device/generic/device.lua
             -- Mostly always suspend in Portrait/Inverted Portrait mode...
             -- ... except when we just show an InfoMessage or when the screensaver
-            -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290)
+            -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290).
+            -- We also exclude full-screen widgets that work fine in Landscape mode,
+            -- like ReadingProgress and BookStatus (c.f., #5724)
             local screensaver_type = G_reader_settings:readSetting("screensaver_type")
-            if screensaver_type ~= "message" and screensaver_type ~= "disable" then
+            if screensaver_type ~= "message" and screensaver_type ~= "disable" and
+            screensaver_type ~= "readingprogress" and screensaver_type ~= "bookstatus" then
                 self.orig_rotation_mode = self.screen:getRotationMode()
                 -- Leave Portrait & Inverted Portrait alone, that works just fine.
                 if bit.band(self.orig_rotation_mode, 1) == 1 then


### PR DESCRIPTION
They're full-screen, and they work fine in Landscape.

re: #5724

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6286)
<!-- Reviewable:end -->
