### PR TITLE
migrate user directories after update

### DIFF
--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -16,37 +16,51 @@ end
 -- path to primary external storage partition
 local path = android.getExternalStoragePath()
 
--- run user shell scripts
-local function runUserScripts(dir)
+-- run user shell scripts or recursive migration of user data
+local function runUserScripts(dir, migration, parent)
     for entry in lfs.dir(dir) do
         if entry ~= "." and entry ~= ".." then
             local fullpath = dir .. "/" .. entry
             local mode = lfs.attributes(fullpath).mode
-            if mode == "file" and fullpath:match(".sh$") then
+            if mode == "file" and migration then
+                if entry ~= "migrate" and not fullpath:match(".sh$") then
+                    local destdir = parent and android.dir .. "/" .. parent or android.dir
+                    -- we cannot create new directories on asset storage.
+                    -- trying to do that crashes the VM with error=13, Permission Denied
+                    android.execute("cp", fullpath, destdir .."/".. entry)
+                end
+            elseif mode == "file" and fullpath:match(".sh$") then
                 android.execute("sh", fullpath, path .. "/koreader", android.dir)
             elseif mode == "directory" then
-                runUserScripts(fullpath) -- recurse into next directory
+                runUserScripts(fullpath, migration, parent and parent .. "/" .. entry or entry) -- recurse into next directory
             end
         end
     end
 end
 
--- scripts executed once after an update of koreader
+-- run scripts once after an update of koreader,
+-- it can also trigger a recursive migration of user data
 local run_once_scripts = path .. "/koreader/scripts.afterupdate"
 if lfs.attributes(run_once_scripts, "mode") == "directory" then
     local afterupdate_marker = android.dir .. "/afterupdate.marker"
     if lfs.attributes(afterupdate_marker, "mode") ~= nil then
-         runUserScripts(run_once_scripts)
+         if lfs.attributes(run_once_scripts .. "/migrate", "mode") ~= nil then
+             android.LOGI("after-update: running migration")
+             runUserScripts(run_once_scripts, true)
+         else
+             android.LOGI("after-update: running shell scripts")
+             runUserScripts(run_once_scripts)
+         end
          android.execute("rm", afterupdate_marker)
-     end
+    end
 end
 
--- scripts executed every start of koreader
+-- scripts executed every start of koreader, no migration here
 local run_always_scripts = path .. "/koreader/scripts.always"
 if lfs.attributes(run_always_scripts, "mode") == "directory" then
     runUserScripts(run_always_scripts)
 end
- 
+
 -- run koreader patch before koreader startup
 pcall(dofile, path.."/koreader/patch.lua")
 


### PR DESCRIPTION
I've played a bit with #6275, to make the iterator available for non-power users too.

this PR automate user data migration (which happens once per update). If the folder `koreader/scripts.afterupdate` contains a file `migrate` then files will be copied to internal dir preserving their relative path. Thus user data **needs** to have the same hierarchy as internal directories.

Shell scripts will be find and run if the folder `koreader/scripts.afterupdate` exists and has no `migrate file`.

In the case of `koreader/scripts.always` there's no migration available, just shell scripts.

Digging a bit seems not possible to create new directories on app internal storage (it just crashes on the emulator since API25). So very fancy extensions are not supported, but it is ok to override files and create new files if dir already exists.

Tested with:

```find scripts.afterupdate/                                            
scripts.afterupdate/
scripts.afterupdate/data
scripts.afterupdate/data/hyph
scripts.afterupdate/data/hyph/Roman.pattern
scripts.afterupdate/data/example.css
scripts.afterupdate/migrate
```

Results:

```
06-20 16:16:33.590  3584  3597 I KOReader: after-update: running migration
06-20 16:16:33.596  3584  3597 I KOReader: command cp /storage/emulated/0/koreader/scripts.afterupdate/data/hyph/Roman.pattern /data/user/0/org.koreader.launcher/files/data/hyph/Roman.pattern returned 0
06-20 16:16:33.600  3584  3597 I KOReader: command cp /storage/emulated/0/koreader/scripts.afterupdate/data/example.css /data/user/0/org.koreader.launcher/files/data/example.css returned 0
06-20 16:16:33.604  3584  3597 I KOReader: command rm /data/user/0/org.koreader.launcher/files/afterupdate.marker returned 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6287)
<!-- Reviewable:end -->
