### PR TITLE
[plugin] Add menu separators to Evernote menu

### DIFF
--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -136,6 +136,7 @@ function EvernoteExporter:addToMainMenu(menu_items)
             {
                 text = _("Joplin") ,
                 checked_func = function() return self.joplin_export end,
+                separator = true,
                 sub_item_table ={
                     {
                         text = _("Set Joplin IP and Port"),
@@ -287,7 +288,8 @@ For more information, please visit https://github.com/koreader/koreader/wiki/Eve
                         text = _("Exporting may take several minutes…"),
                         timeout = 1,
                     })
-                end
+                end,
+                separator = true,
             },
             {
                 text = _("Export to local JSON files"),
@@ -326,7 +328,8 @@ For more information, please visit https://github.com/koreader/koreader/wiki/Eve
                         self.joplin_export = false
                     end
                     self:saveSettings()
-                end
+                end,
+                separator = true,
             },
             {
                 text = _("Purge history records"),


### PR DESCRIPTION
This makes the menu structure slightly clearer.
See <https://github.com/koreader/koreader/issues/2778#issuecomment-647324742>.

### Before/After
<img src=https://user-images.githubusercontent.com/202757/85257466-36f65a80-b466-11ea-89a3-7a8c2946e249.png width=45%> <img src=https://user-images.githubusercontent.com/202757/85257469-378ef100-b466-11ea-9750-e22da12604bc.png width=45%>

Pinging @Galunid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6294)
<!-- Reviewable:end -->
