### PR TITLE
bump crengine: add support for <ruby> elements

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -594,7 +594,8 @@ p.someTitleClassName { text-indent: 0; }
 DIV.advertisement { display: none !important; }
 
 .footnoteContainerClassName {
-    font-size: 80%;
+    font-size: 0.8rem !important;
+    text-align: justify !important;
     margin: 0 !important;
     -cr-hint: footnote-inpage;
 }

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -650,14 +650,13 @@ This is just an example, that will need to be adapted into a user style tweak.]]
                     title = _("In-page FB2 footnotes"),
                     description = _([[
 Show FB2 footnote text at the bottom of pages that contain links to them.]]),
-                    -- Avoid 75% of 75% in case of nested <section>
                     css = [[
 body[name="notes"] section {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
 }
 body[name="notes"] > section {
-    font-size: 75%;
+    font-size: 0.75rem;
 }
                     ]],
                 },
@@ -672,7 +671,7 @@ body[name="comments"] section {
     margin: 0 !important;
 }
 body[name="comments"] > section {
-    font-size: 85%;
+    font-size: 0.85rem;
 }
                     ]],
                     separator = true,
@@ -686,7 +685,7 @@ FB2 footnotes and endnotes get a smaller font size when displayed in-page. This 
 body[name="notes"] > section,
 body[name="comments"] > section
 {
-    font-size: 100% !important;
+    font-size: 1rem !important;
 }
                     ]],
                 },
@@ -727,7 +726,7 @@ This only works with footnotes that have specific attributes set by the publishe
 {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
-    font-size: 80% !important;
+    font-size: 0.8rem !important;
 }
                 ]],
                 separator = true,
@@ -754,7 +753,7 @@ ol.references > li > .mw-cite-backlink { display: none; }
 ol.references > li {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
-    font-size: 80% !important;
+    font-size: 0.8rem !important;
 }
 /* hide backlinks */
 ol.references > li > .noprint { display: none; }
@@ -794,7 +793,7 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
 {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
-    font-size: 80% !important;
+    font-size: 0.8rem !important;
 }
                 ]],
             },

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -281,7 +281,7 @@ DocFragment {
             },
         },
         {
-            title = _("Hyphenation and ligatures"),
+            title = _("Hyphenation, ligatures, ruby"),
             {
                 id = "hyphenate_all_auto";
                 title = _("Allow hyphenation on all text"),
@@ -299,6 +299,15 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
                 -- from being applied
                 css = [[
 * { font-variant: no-common-ligatures; }
+                ]],
+                separator = true,
+            },
+            {
+                id = "ruby_inline";
+                title = _("Render <ruby> content inline"),
+                description = _("Disable handling of <ruby> tags and render them inline."),
+                css = [[
+ruby { display: inline !important; }
                 ]],
             },
             separator = true,


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/347 :
- Fix some non-recursive subtree walkers
- Text: skip formatting optimisations when inlineBoxes
- CSS parsing: parse selectors starting with [attrib]
- Use T="" for internal elements attributes
- CSS: re-order css_d_* (display) enum for easier checking
- Rendering methods: remove erm_table_cell
- Rendering methods: remove erm_table_caption
- Rendering methods: remove erm_list_item
- getRenderedWidths(): better estimate table width
- styleToTextFmtFlags(): adds is_block parameter
- Adds support for "display: ruby" and `<ruby>` elements
- Fix prev/next-VisibleWord-Start/End() with CJK text

Also:
- bump HarfBuzz to 2.6.8 https://github.com/koreader/koreader-base/pull/1122
- bump evernote-lua-sdk https://github.com/koreader/koreader-base/pull/1121

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6305)
<!-- Reviewable:end -->
