### PR TITLE
Bookmarks prev/next via gestures: add location to stack

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -647,12 +647,18 @@ function ReaderBookmark:onGotoNextBookmark(pn_or_xp)
     return true
 end
 
-function ReaderBookmark:onGotoNextBookmarkFromPage()
+function ReaderBookmark:onGotoNextBookmarkFromPage(add_current_location_to_stack)
+    if add_current_location_to_stack ~= false then -- nil or true
+        self.ui.link:addCurrentLocationToStack()
+    end
     self:gotoBookmark(self:getNextBookmarkedPageFromPage(self.ui:getCurrentPage()))
     return true
 end
 
-function ReaderBookmark:onGotoPreviousBookmarkFromPage()
+function ReaderBookmark:onGotoPreviousBookmarkFromPage(add_current_location_to_stack)
+    if add_current_location_to_stack ~= false then -- nil or true
+        self.ui.link:addCurrentLocationToStack()
+    end
     self:gotoBookmark(self:getPreviousBookmarkedPageFromPage(self.ui:getCurrentPage()))
     return true
 end

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -79,7 +79,7 @@ function ReaderToc:onPosUpdate(pos, pageno)
 end
 
 function ReaderToc:fillToc()
-    if self.toc and #self.toc > 0 then return end
+    if self.toc then return end
     if self.ui.document:canHaveAlternativeToc() then
         if self.ui.doc_settings:readSetting("alternative_toc") then
             -- (if the document has a cache, the previously built alternative

--- a/frontend/apps/reader/skimtowidget.lua
+++ b/frontend/apps/reader/skimtowidget.lua
@@ -412,7 +412,8 @@ end
 function SkimToWidget:goToByEvent(event_name)
     if event_name then
         self:addOriginToLocationStack()
-        self.ui:handleEvent(Event:new(event_name))
+        self.ui:handleEvent(Event:new(event_name, false))
+            -- add_current_location_to_stack=false, as we handled it here
         self.curr_page = self.ui:getCurrentPage()
         self:update()
     end


### PR DESCRIPTION
Was correctly done when jumping bookmarks via the Bookmarks menu and the SkimTo widget, but not from gestures. Details in https://github.com/koreader/koreader/pull/6259#issuecomment-642677750.  Supersede #6259.
Also prevent fillToc() on each page turn when book has no TOC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6306)
<!-- Reviewable:end -->
