### PR TITLE
EvernoteOAuth set logger

### DIFF
--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -7,9 +7,9 @@ local DataStorage = require("datastorage")
 local DocSettings = require("docsettings")
 local UIManager = require("ui/uimanager")
 local Screen = require("device").screen
+local logger = require("logger")
 local util = require("ffi/util")
 local Device = require("device")
-local logger = require("logger")
 local JoplinClient = require("JoplinClient")
 local T = require("ffi/util").template
 local _ = require("gettext")
@@ -607,7 +607,7 @@ function EvernoteExporter:exportClippings(clippings)
                 NetworkMgr:promptWifiOn()
                 return
             elseif not ok and err then
-                logger.dbg("Error occurs when exporting book:", title, err)
+                logger.dbg("Error while exporting book", title, err)
                 error_count = error_count + 1
                 error_title = title
             elseif ok then

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -1,3 +1,4 @@
+local logger = require('logger')
 local BD = require("ui/bidi")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LoginDialog = require("ui/widget/logindialog")
@@ -405,6 +406,7 @@ function EvernoteExporter:doLogin(username, password)
         domain = self.evernote_domain,
         username = username,
         password = password,
+        logger = logger.dbg
     }
     self.evernote_username = username
     local ok, token = pcall(oauth.getToken, oauth)

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -405,7 +405,7 @@ function EvernoteExporter:doLogin(username, password)
         domain = self.evernote_domain,
         username = username,
         password = password,
-        logger = logger.dbg
+        logger = logger.dbg,
     }
     self.evernote_username = username
     local ok, token = pcall(oauth.getToken, oauth)

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -1,4 +1,3 @@
-local logger = require('logger')
 local BD = require("ui/bidi")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LoginDialog = require("ui/widget/logindialog")
@@ -406,7 +405,7 @@ function EvernoteExporter:doLogin(username, password)
         domain = self.evernote_domain,
         username = username,
         password = password,
-        logger = logger.dbg
+        logger = DEBUG
     }
     self.evernote_username = username
     local ok, token = pcall(oauth.getToken, oauth)

--- a/plugins/evernote.koplugin/main.lua
+++ b/plugins/evernote.koplugin/main.lua
@@ -9,7 +9,7 @@ local UIManager = require("ui/uimanager")
 local Screen = require("device").screen
 local util = require("ffi/util")
 local Device = require("device")
-local DEBUG = require("dbg")
+local logger = require("logger")
 local JoplinClient = require("JoplinClient")
 local T = require("ffi/util").template
 local _ = require("gettext")
@@ -405,7 +405,7 @@ function EvernoteExporter:doLogin(username, password)
         domain = self.evernote_domain,
         username = username,
         password = password,
-        logger = DEBUG
+        logger = logger.dbg
     }
     self.evernote_username = username
     local ok, token = pcall(oauth.getToken, oauth)
@@ -487,7 +487,7 @@ function EvernoteExporter:updateHistoryClippings(clippings, new_clippings)
                     or clippings[title][chapter_index][note_index].time ~= note.time
                     or clippings[title][chapter_index][note_index].text ~= note.text
                     or clippings[title][chapter_index][note_index].note ~= note.note then
-                    DEBUG("found new notes in history", booknotes.title)
+                    logger.dbg("found new notes in history", booknotes.title)
                     clippings[title] = booknotes
                 end
             end
@@ -501,7 +501,7 @@ function EvernoteExporter:updateMyClippings(clippings, new_clippings)
     -- since appending is the only way to modify notes in My Clippings
     for title, booknotes in pairs(new_clippings) do
         if clippings[title] == nil or #clippings[title] < #booknotes then
-            DEBUG("found new notes in MyClipping", booknotes.title)
+            logger.dbg("found new notes in MyClipping", booknotes.title)
             clippings[title] = booknotes
         end
     end
@@ -540,7 +540,7 @@ function EvernoteExporter:exportAllNotes()
             clippings[title] = nil
         end
     end
-    --DEBUG("clippings", clippings)
+    --logger.dbg("clippings", clippings)
     self:exportClippings(clippings)
     self.config:saveSetting("clippings", clippings)
     self.config:flush()
@@ -607,11 +607,11 @@ function EvernoteExporter:exportClippings(clippings)
                 NetworkMgr:promptWifiOn()
                 return
             elseif not ok and err then
-                DEBUG("Error occurs when exporting book:", title, err)
+                logger.dbg("Error occurs when exporting book:", title, err)
                 error_count = error_count + 1
                 error_title = title
             elseif ok then
-                DEBUG("Exported notes in book:", title)
+                logger.dbg("Exported notes in book:", title)
                 export_count = export_count + 1
                 export_title = title
                 booknotes.exported[exported_stamp] = true
@@ -649,7 +649,7 @@ function EvernoteExporter:exportBooknotesToEvernote(client, title, booknotes)
         booknotes = booknotes,
         notemarks = self.notemarks,
     })
-    --DEBUG("content", content)
+    --logger.dbg("content", content)
     local note_guid = client:findNoteByTitle(title, self.notebook_guid)
     local resources = {}
     for _, chapter in ipairs(booknotes) do
@@ -675,7 +675,7 @@ function EvernoteExporter:exportBooknotesToHTML(title, booknotes)
         booknotes = booknotes,
         notemarks = self.notemarks,
     })
-    --DEBUG("content", content)
+    --logger.dbg("content", content)
     local html = io.open(self.clipping_dir .. "/" .. title .. ".html", "w")
     if html then
         html:write(content)


### PR DESCRIPTION
This sets default EvernoteOAuth logger introduced in https://github.com/koreader/evernote-sdk-lua/pull/4 to `DEBUG`, instead of default `print`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6308)
<!-- Reviewable:end -->
