### PR TITLE
emulator: add fake network manager

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -329,6 +329,29 @@ function Device:simulateResume()
     })
 end
 
+-- fake network manager for the emulator
+function Emulator:initNetworkManager(NetworkMgr)
+    local connectionChangedEvent = function()
+        local UIManager = require("ui/uimanager")
+        if G_reader_settings:nilOrTrue("emulator_fake_wifi_connected") then
+            UIManager:broadcastEvent(Event:new("NetworkConnected")
+        else
+            UIManager:broadcastEvent(Event:new("NetworkDisconnected")
+        end
+    end
+    function NetworkMgr:turnOffWifi(complete_callback)
+        G_reader_settings:flipNilOrTrue("emulator_fake_wifi_connected")
+        UIManager:scheduleIn(2, connectionChangedEvent)
+    end
+    function NetworkMgr:turnOnWifi(complete_callback)
+        G_reader_settings:flipNilOrTrue("emulator_fake_wifi_connected")
+        UIManager:scheduleIn(2, connectionChangedEvent)
+    end
+    function NetworkMgr:isWifiOn()
+        return G_reader_settings:nilOrTrue("emulator_fake_wifi_connected")
+    end
+end
+
 -------------- device probe ------------
 if os.getenv("APPIMAGE") then
     return AppImage

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -331,12 +331,12 @@ end
 
 -- fake network manager for the emulator
 function Emulator:initNetworkManager(NetworkMgr)
+    local UIManager = require("ui/uimanager")
     local connectionChangedEvent = function()
-        local UIManager = require("ui/uimanager")
         if G_reader_settings:nilOrTrue("emulator_fake_wifi_connected") then
-            UIManager:broadcastEvent(Event:new("NetworkConnected")
+            UIManager:broadcastEvent(Event:new("NetworkConnected"))
         else
-            UIManager:broadcastEvent(Event:new("NetworkDisconnected")
+            UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         end
     end
     function NetworkMgr:turnOffWifi(complete_callback)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -120,7 +120,7 @@ function NetworkMgr:beforeWifiAction(callback)
  end
 
 function NetworkMgr:isConnected()
-    if Device:isAndroid() or Device:isCervantes() or Device:isPocketBook() then
+    if Device:isAndroid() or Device:isCervantes() or Device:isPocketBook() or Device:isEmulator() then
         return self:isWifiOn()
     else
         -- Pull the default gateway first, so we don't even try to ping anything if there isn't one...
@@ -189,7 +189,7 @@ end
 function NetworkMgr:getWifiToggleMenuTable()
     return {
         text = _("Wi-Fi connection"),
-        enabled_func = function() return Device:hasWifiToggle() and not Device:isEmulator() end,
+        enabled_func = function() return Device:hasWifiToggle() end,
         checked_func = function() return NetworkMgr:isWifiOn() end,
         callback = function(touchmenu_instance)
             local wifi_status = NetworkMgr:isWifiOn() and NetworkMgr:isConnected()


### PR DESCRIPTION
Useful to test things that rely on network state changes, like #6299 

Probably useful to fix #6080

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6314)
<!-- Reviewable:end -->
