### PR TITLE
[UX] Add left to close to ConfigDialog for hasFewKeys

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -824,7 +824,8 @@ function ConfigDialog:init()
     end
     if Device:hasKeys() then
         -- set up keyboard events
-        self.key_events.Close = { {"Back"}, doc = "close config menu" }
+        local close_keys = Device:hasFewKeys() and { "Back", "Left" } or "Back"
+        self.key_events.Close = { { close_keys }, doc = "close config menu" }
     end
     if Device:hasDPad() then
         self.key_events.Select = { {"Press"}, doc = "select current menu item" }


### PR DESCRIPTION
Follow-up to <https://github.com/koreader/koreader/pull/6195>.

Part of <https://github.com/koreader/koreader/issues/4029>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6318)
<!-- Reviewable:end -->
