### PR TITLE
[plugin] Wallabag: Make remove from history consistent with deletion

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -144,6 +144,7 @@ function Wallabag:addToMainMenu(menu_items)
                 callback_func = function()
                     return nil
                 end,
+                separator = true,
                 sub_item_table = {
                     {
                         text = _("Configure Wallabag server"),
@@ -173,6 +174,7 @@ function Wallabag:addToMainMenu(menu_items)
                         callback = function(touchmenu_instance)
                             self:setDownloadDirectory(touchmenu_instance)
                         end,
+                        separator = true,
                     },
                     {
                         text_func = function()
@@ -200,46 +202,55 @@ function Wallabag:addToMainMenu(menu_items)
                         callback = function(touchmenu_instance)
                             self:setIgnoreTags(touchmenu_instance)
                         end,
+                        separator = true,
                     },
                     {
-                        text = _("Remotely delete finished articles"),
-                        checked_func = function() return self.is_delete_finished end,
-                        callback = function()
-                            self.is_delete_finished = not self.is_delete_finished
-                            self:saveSettings()
-                        end,
-                    },
-                    {
-                        text = _("Remotely delete 100% read articles"),
-                        checked_func = function() return self.is_delete_read end,
-                        callback = function()
-                            self.is_delete_read = not self.is_delete_read
-                            self:saveSettings()
-                        end,
-                    },
-                    {
-                        text = _("Mark as read instead of deleting"),
-                        checked_func = function() return self.is_archiving_deleted end,
-                        callback = function()
-                            self.is_archiving_deleted = not self.is_archiving_deleted
-                            self:saveSettings()
-                        end,
-                    },
-                    {
-                        text = _("Process deletions when downloading"),
-                        checked_func = function() return self.is_auto_delete end,
-                        callback = function()
-                            self.is_auto_delete = not self.is_auto_delete
-                            self:saveSettings()
-                        end,
-                    },
-                    {
-                        text = _("Synchronize remotely deleted files"),
-                        checked_func = function() return self.is_sync_remote_delete end,
-                        callback = function()
-                            self.is_sync_remote_delete = not self.is_sync_remote_delete
-                            self:saveSettings()
-                        end,
+                        text = _("Article deletion"),
+                        separator = true,
+                        sub_item_table = {
+                            {
+                                text = _("Remotely delete finished articles"),
+                                checked_func = function() return self.is_delete_finished end,
+                                callback = function()
+                                    self.is_delete_finished = not self.is_delete_finished
+                                    self:saveSettings()
+                                end,
+                            },
+                            {
+                                text = _("Remotely delete 100% read articles"),
+                                checked_func = function() return self.is_delete_read end,
+                                callback = function()
+                                    self.is_delete_read = not self.is_delete_read
+                                    self:saveSettings()
+                                end,
+                                separator = true,
+                            },
+                            {
+                                text = _("Mark as read instead of deleting"),
+                                checked_func = function() return self.is_archiving_deleted end,
+                                callback = function()
+                                    self.is_archiving_deleted = not self.is_archiving_deleted
+                                    self:saveSettings()
+                                end,
+                                separator = true,
+                            },
+                            {
+                                text = _("Process deletions when downloading"),
+                                checked_func = function() return self.is_auto_delete end,
+                                callback = function()
+                                    self.is_auto_delete = not self.is_auto_delete
+                                    self:saveSettings()
+                                end,
+                            },
+                            {
+                                text = _("Synchronize remotely deleted files"),
+                                checked_func = function() return self.is_sync_remote_delete end,
+                                callback = function()
+                                    self.is_sync_remote_delete = not self.is_sync_remote_delete
+                                    self:saveSettings()
+                                end,
+                            },
+                        },
                     },
                     {
                         text = _("Remove finished articles from history"),
@@ -251,6 +262,18 @@ function Wallabag:addToMainMenu(menu_items)
                             self.remove_finished_from_history = not self.remove_finished_from_history
                             self:saveSettings()
                         end,
+                    },
+                    {
+                        text = _("Remove 100% read articles from history"),
+                        keep_menu_open = true,
+                        checked_func = function()
+                            return self.remove_read_from_history or false
+                        end,
+                        callback = function()
+                            self.remove_read_from_history = not self.remove_read_from_history
+                            self:saveSettings()
+                        end,
+                        separator = true,
                     },
                     {
                         text = _("Help"),
@@ -1007,6 +1030,7 @@ function Wallabag:saveSettings()
         is_sync_remote_delete = self.is_sync_remote_delete,
         articles_per_sync     = self.articles_per_sync,
         remove_finished_from_history = self.remove_finished_from_history,
+        remove_read_from_history = self.remove_read_from_history,
         download_queue        = self.download_queue,
     }
     self.wb_settings:saveSetting("wallabag", tempsettings)
@@ -1079,9 +1103,19 @@ function Wallabag:addToDownloadQueue(article_url)
 end
 
 function Wallabag:onCloseDocument()
-    if self.remove_finished_from_history then
+    if self.remove_finished_from_history or self.remove_read_from_history then
         local document_full_path = self.ui.document.file
-        if document_full_path and self.directory and self:getLastPercent() == 1 and self.directory == string.sub(document_full_path, 1, string.len(self.directory)) then
+        local is_finished
+        if self.ui.status.settings.data.summary and self.ui.status.settings.data.summary.status then
+            local status = self.ui.status.settings.data.summary.status
+            is_finished = (status == "complete" or status == "abandoned")
+        end
+        local is_read = self:getLastPercent() == 1
+
+        if document_full_path
+           and self.directory
+           and ( (self.remove_finished_from_history and is_finished) or (self.remove_read_from_history and is_read) )
+           and self.directory == string.sub(document_full_path, 1, string.len(self.directory)) then
             ReadHistory:removeItemByPath(document_full_path)
             self.ui:setLastDirForFileBrowser(self.directory)
         end


### PR DESCRIPTION
Finished is a specific status distinct from 100% read.

Also reorganize the menus slightly.

Closes <#6316>.

### Before
<img src=https://user-images.githubusercontent.com/202757/85921143-3c92dc80-b87a-11ea-949a-f45853dab666.png width=30%><img src=https://user-images.githubusercontent.com/202757/85921144-3d2b7300-b87a-11ea-8130-eb03215f9729.png width=30%><img src=https://user-images.githubusercontent.com/202757/85921145-3dc40980-b87a-11ea-91a0-929f29eecb09.png width=30%>


### After
<img src=https://user-images.githubusercontent.com/202757/85921109-f0e03300-b879-11ea-9a9c-6dc8237754b0.png width=30%><img src=https://user-images.githubusercontent.com/202757/85921110-f178c980-b879-11ea-8469-bcd80ce8453c.png width=30%><img src=https://user-images.githubusercontent.com/202757/85921111-f2116000-b879-11ea-9930-d376871e0fcf.png width=30%>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6320)
<!-- Reviewable:end -->
