### PR TITLE
Tests: make sure files are deleted

### DIFF
--- a/spec/unit/document_registry_spec.lua
+++ b/spec/unit/document_registry_spec.lua
@@ -33,7 +33,6 @@ describe("document registry module", function()
 
         local docsettings = DocSettings:open(path)
         docsettings:purge()
-        docsettings:flush()
     end)
     it("should set global setting for rendering engine", function()
         local path = "../../foo.fb2"
@@ -58,7 +57,6 @@ describe("document registry module", function()
         assert.is_equal("mupdf", provider.provider)
 
         docsettings:purge()
-        docsettings:flush()
     end)
     it("should return global setting for rendering engine", function()
         local path = "../../foofoo.fb2"


### PR DESCRIPTION
calling `docsettings:flush()` was causing the sidecar file to be recreated leaving garbage folders in the KOreader folder after running the tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6323)
<!-- Reviewable:end -->
