### PR TITLE
add natural light for Tolino Epos 2 

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -358,7 +358,7 @@ function Device:canExecuteScript(file)
 end
 
 local AndroidNaturalLight = Device:new{
-    model = "android_with_natural_lights",
+    model = "Android_with_natural_lights",
     hasNaturalLight = yes,
     frontlight_settings = {
         frontlight_white = "/sys/class/backlight/mxc_msp430_fl.0/brightness",
@@ -382,10 +382,10 @@ android.LOGI(string.format("Android %s - %s (API %d, product %s) - flavor: %s",
 
 local product = android.prop.product
 
--- todo: check if color frontlight_settings.frontlight_mixer is readable
-is_color_writeable = true
-
-if product == "ntx_6sl" and is_color_writeable then
+if product == "ntx_6sl" then
+    if lfs.touch(AndroidNaturalLight.frontlight_settings.frontlight_mixer) == nil then
+        AndroidNaturalLight.hasNaturalLight = no
+    end
     return AndroidNaturalLight
 else
     return Device

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -6,7 +6,7 @@ local _, android = pcall(require, "android")
 local AndroidPowerD = BasePowerD:new{
     fl_min = 0, fl_max = 100,
     fl_intensity = 10,
-    
+
     fl_warmth_min = 0, fl_warmth_max = 10,
     fl_warmth = nil,
     auto_warmth = false,
@@ -65,7 +65,6 @@ function AndroidPowerD:init()
         end
     end
 end
-
 
 function AndroidPowerD:setWarmth(warmth)
     if self.fl == nil then return end

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -1,9 +1,17 @@
 local BasePowerD = require("device/generic/powerd")
+local SysfsLight = require ("device/sysfs_light") -- for android eInk devices using natural light
+local PluginShare = require("pluginshare")
 local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
-    fl_min = 0, fl_max = 25,
+    fl_min = 0, fl_max = 100,
     fl_intensity = 10,
+    
+    fl_warmth_min = 0, fl_warmth_max = 10,
+    fl_warmth = nil,
+    auto_warmth = false,
+    max_warmth_hour = 23,
+    fl_was_on = nil,
 }
 
 function AndroidPowerD:frontlightIntensityHW()
@@ -21,5 +29,104 @@ end
 function AndroidPowerD:isChargingHW()
     return android.isCharging()
 end
+
+function AndroidPowerD:init()
+    if self.device:hasFrontlight() then
+        -- If this device has natural light (currently only Android on Tolino Epos 2)
+        -- Use the SysFS interface, and ioctl otherwise.
+        -- NOTE: On the Forma, nickel still appears to prefer using ntx_io to handle the FL,
+        --       but it does use sysfs for the NL...
+        if self.device:hasNaturalLight() then
+            local nl_config = G_reader_settings:readSetting("natural_light_config")
+            if nl_config then
+                for key,val in pairs(nl_config) do
+                    self.device.frontlight_settings[key] = val
+                end
+            end
+            -- Does this device's NaturalLight use a custom scale?
+            self.fl_warmth_min = self.device.frontlight_settings.nl_min or self.fl_warmth_min
+            self.fl_warmth_max = self.device.frontlight_settings.nl_max or self.fl_warmth_max
+            -- If this device has a mixer, we can use the ioctl for brightness control, as it's much lower latency.
+            if self.device:hasNaturalLightMixer() then
+                local kobolight = require("ffi/kobolight")
+                local ok, light = pcall(kobolight.open)
+                if ok then
+                    self.device.frontlight_settings.frontlight_ioctl = light
+                end
+            end
+            self.fl = SysfsLight:new(self.device.frontlight_settings)
+            self.fl_warmth = 0
+        else
+            local kobolight = require("ffi/kobolight")
+            local ok, light = pcall(kobolight.open)
+            if ok then
+                self.fl = light
+            end
+        end
+    end
+end
+
+
+function AndroidPowerD:setWarmth(warmth)
+    if self.fl == nil then return end
+    if not warmth and self.auto_warmth then
+        self:calculateAutoWarmth()
+    end
+    self.fl_warmth = warmth or self.fl_warmth
+    -- Don't turn the light back on on legacy NaturalLight devices just for the sake of setting the warmth!
+    -- That's because we can only set warmth independently of brightness on devices with a mixer.
+    -- On older ones, calling setWarmth *will* actually set the brightness, too!
+    if self.device:hasNaturalLightMixer() or self:isFrontlightOnHW() then
+        self.fl:setWarmth(self.fl_warmth)
+    end
+end
+
+-- Sets fl_warmth according to current hour and max_warmth_hour
+-- and starts background job if necessary.
+function AndroidPowerD:calculateAutoWarmth()
+    local current_time = os.date("%H") + os.date("%M")/60
+    local max_hour = self.max_warmth_hour
+    local diff_time = max_hour - current_time
+    if diff_time < 0 then
+        diff_time = diff_time + 24
+    end
+    if diff_time < 12 then
+        -- We are before bedtime. Use a slower progression over 5h.
+        self.fl_warmth = math.max(20 * (5 - diff_time), 0)
+    elseif diff_time > 22 then
+        -- Keep warmth at maximum for two hours after bedtime.
+        self.fl_warmth = 100
+    else
+        -- Between 2-4h after bedtime, return to zero.
+        self.fl_warmth = math.max(100 - 50 * (22 - diff_time), 0)
+    end
+    self.fl_warmth = math.floor(self.fl_warmth + 0.5)
+    -- Make sure sysfs_light actually picks that new value up without an explicit setWarmth call...
+    -- This avoids having to bypass the ramp-up on resume w/ an explicit setWarmth call on devices where brightness & warmth
+    -- are linked (i.e., when there's no mixer) ;).
+    -- NOTE: A potentially saner solution would be to ditch the internal sysfs_light current_* values,
+    --       and just pass it a pointer to this powerd instance, so it has access to fl_warmth & hw_intensity.
+    --       It seems harmless enough for warmth, but brightness might be a little trickier because of the insanity
+    --       that is hw_intensity handling because we can't actually *read* the frontlight status...
+    --       (Technically, we could, on Mk. 7 devices, but we don't,
+    --       because this is already messy enough without piling on special cases.)
+    if self.fl then
+        self.fl.current_warmth = self.fl_warmth
+    end
+    -- Enable background job for setting Warmth, if not already done.
+    if not self.autowarmth_job_running then
+        table.insert(PluginShare.backgroundJobs, {
+                         when = 180,
+                         repeated = true,
+                         executable = function()
+                             if self.auto_warmth then
+                                 self:setWarmth()
+                             end
+                         end,
+        })
+        self.autowarmth_job_running = true
+    end
+end
+
 
 return AndroidPowerD

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -65,7 +65,7 @@ function FrontLightWidget:init()
         self.nl_min = self.powerd.fl_warmth_min
         self.nl_max = self.powerd.fl_warmth_max
         -- NOTE: fl_warmth is always [0...100] even when internal scale is [0...10]
-        self.nl_scale = (100 / self.nl_max)
+        self.nl_scale = (self.powerd.fl_max / self.nl_max)
     end
 
     -- button width to fit screen size


### PR DESCRIPTION
This is a first attempt to add natural light settings to the Tolino Epos 2. 
Currently the device is runnung on Android 4.4.2.
The device uses `/sys/class/backlight/tlc5947_bl/color` for the warmth, similar as on Kobo Forma.

There are some things to do, help is needed:

1. `/sys/class/backlight` is not writeable. But if the permissions are set with `chmod 666 /sys/class/backlight/tlc5947_bl/color` , the  warmth and the brightness of the backlight can be set.
~I do not know how to grant that permission within the app. Can anyone help with this?~
I decided to detect, if the color file is writeable. If not, the user gets an information about this. It he wants to get instructions to make the file writeable, a message window is shown.
Since every Tolino Epos2 has to be rooted to run koreader, this additional steps should be doable for advanced users.
 
~2. Safety check if `/sys/class/backlight/tlc5947_bl/color` is writeable, is not implemented yet. (easy)~ done

~3. Do a better check if the device is really a Tolino Epos 2, not just check `android.prop.product` (easy)~ not necessary

4. The brightness and warmth values have to be in the range 0-100, otherwise the slider of the warmth is broken. I don't know why.

5. The automatic warmth setting is duplicated from Kobo -> should be combined later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6332)
<!-- Reviewable:end -->
