### PR TITLE
allow default FM rotation on init when `Keep FM rotation` is disabled

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -72,7 +72,7 @@ end
 
 function FileManager:setRotationMode(init)
     local locked = G_reader_settings:readSetting("lock_rotation")
-    local rotation_mode = G_reader_settings:readSetting("fm_rotation_mode") or 0
+    local rotation_mode = G_reader_settings:readSetting("fm_rotation_mode") or Screen.ORIENTATION_PORTRAIT
     if locked or init then
         self:onSetRotationMode(rotation_mode)
     end
@@ -1033,10 +1033,10 @@ function FileManager:getStartWithMenuTable()
     }
 end
 
-function FileManager:showFiles(path, focused_file, init)
+function FileManager:showFiles(path, focused_file)
     path = path or G_reader_settings:readSetting("lastdir") or filemanagerutil.getDefaultDir()
     G_reader_settings:saveSetting("lastdir", path)
-    self:setRotationMode(init)
+    self:setRotationMode()
     local file_manager = FileManager:new{
         dimen = Screen:getSize(),
         covers_fullscreen = true, -- hint for UIManager:_repaint()

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -70,10 +70,10 @@ function FileManager:onSetRotationMode(rotation)
     return true
 end
 
-function FileManager:setRotationMode()
+function FileManager:setRotationMode(init)
     local locked = G_reader_settings:readSetting("lock_rotation")
     local rotation_mode = G_reader_settings:readSetting("fm_rotation_mode") or 0
-    if locked then
+    if locked or init then
         self:onSetRotationMode(rotation_mode)
     end
 end
@@ -1033,10 +1033,10 @@ function FileManager:getStartWithMenuTable()
     }
 end
 
-function FileManager:showFiles(path, focused_file)
+function FileManager:showFiles(path, focused_file, init)
     path = path or G_reader_settings:readSetting("lastdir") or filemanagerutil.getDefaultDir()
     G_reader_settings:saveSetting("lastdir", path)
-    self:setRotationMode()
+    self:setRotationMode(init)
     local file_manager = FileManager:new{
         dimen = Screen:getSize(),
         covers_fullscreen = true, -- hint for UIManager:_repaint()

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -70,6 +70,8 @@ function FileManager:onSetRotationMode(rotation)
     return true
 end
 
+-- init should be set to True when starting the FM for the first time
+-- (not coming from the reader). This allows the default to be properly set.
 function FileManager:setRotationMode(init)
     local locked = G_reader_settings:readSetting("lock_rotation")
     local rotation_mode = G_reader_settings:readSetting("fm_rotation_mode") or Screen.ORIENTATION_PORTRAIT

--- a/reader.lua
+++ b/reader.lua
@@ -277,7 +277,8 @@ if ARGV[argidx] and ARGV[argidx] ~= "" then
         local home_dir =
             G_reader_settings:readSetting("home_dir") or ARGV[argidx]
         UIManager:nextTick(function()
-            FileManager:showFiles(home_dir, "", true)
+            FileManager:setRotationMode(true)
+            FileManager:showFiles(home_dir)
         end)
         -- always open history on top of filemanager so closing history
         -- doesn't result in exit

--- a/reader.lua
+++ b/reader.lua
@@ -277,7 +277,7 @@ if ARGV[argidx] and ARGV[argidx] ~= "" then
         local home_dir =
             G_reader_settings:readSetting("home_dir") or ARGV[argidx]
         UIManager:nextTick(function()
-            FileManager:showFiles(home_dir)
+            FileManager:showFiles(home_dir, "", true)
         end)
         -- always open history on top of filemanager so closing history
         -- doesn't result in exit


### PR DESCRIPTION
fixes issue discovered in #6347

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6348)
<!-- Reviewable:end -->
