### PR TITLE
Implement numeric collator in file manager

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -944,7 +944,7 @@ function FileManager:getSortingMenuTable()
     local fm = self
     local collates = {
         strcoll = {_("filename"), _("Sort by filename")},
-        numeric = {_("numeric"), _("Sort by filename(detect numbers)")},
+        numeric = {_("numeric"), _("Sort by filename (natural sorting)")},
         strcoll_mixed = {_("name mixed"), _("Sort by name – mixed files and folders")},
         access = {_("date read"), _("Sort by last read date")},
         change = {_("date added"), _("Sort by date added")},

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -944,6 +944,7 @@ function FileManager:getSortingMenuTable()
     local fm = self
     local collates = {
         strcoll = {_("filename"), _("Sort by filename")},
+        numeric = {_("numeric"), _("Sort by filename(detect numbers)")},
         strcoll_mixed = {_("name mixed"), _("Sort by name – mixed files and folders")},
         access = {_("date read"), _("Sort by last read date")},
         change = {_("date added"), _("Sort by date added")},
@@ -985,6 +986,7 @@ function FileManager:getSortingMenuTable()
             set_collate_table("modification"),
             set_collate_table("size"),
             set_collate_table("type"),
+            set_collate_table("numeric"),
             {
                 text_func =  get_collate_percent,
                 checked_func = function()

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -201,7 +201,7 @@ function FileChooser:genItemTableFromPath(path)
         end
         sorting = function(a, b)
             return tostring(a.name):gsub("%.?%d+", addLeadingZeroes)..("%3d"):format(#b.name)
-         < tostring(b.name):gsub("%.?%d+",addLeadingZeroes)..("%3d"):format(#a.name)
+                    < tostring(b.name):gsub("%.?%d+",addLeadingZeroes)..("%3d"):format(#a.name)
         end
     else
         sorting = function(a, b)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -193,6 +193,16 @@ function FileChooser:genItemTableFromPath(path)
 
             return a.percent_finished < b.percent_finished
         end
+    elseif self.collate == "numeric" then
+        -- adapted from: http://notebook.kulchenko.com/algorithms/alphanumeric-natural-sorting-for-humans-in-lua
+        local function addLeadingZeroes(d)
+            local dec, n = string.match(d, "(%.?)0*(.+)")
+            return #dec > 0 and ("%.12f"):format(d) or ("%s%03d%s"):format(dec, #n, n)
+        end
+        sorting = function(a, b)
+            return tostring(a.name):gsub("%.?%d+", addLeadingZeroes)..("%3d"):format(#b.name)
+         < tostring(b.name):gsub("%.?%d+",addLeadingZeroes)..("%3d"):format(#a.name)
+        end
     else
         sorting = function(a, b)
             return a.name < b.name


### PR DESCRIPTION
Allows users to detect numbers in text when sorting filenames. We get:
```
AAA 1
AAA 2
AAA 10
```
instead of 
```
AAA 1
AAA 10
AAA 2
```
Most of the code was adapted from http://notebook.kulchenko.com/algorithms/alphanumeric-natural-sorting-for-humans-in-lua.
closes #6374

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6378)
<!-- Reviewable:end -->
