### PR TITLE
desktop/emulator changes

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -328,6 +328,10 @@ function Device:setDateTime(year, month, day, hour, min, sec) end
 -- Device specific method if any setting needs being saved
 function Device:saveSettings() end
 
+-- Simulates suspend/resume
+function Device:simulateSuspend() end
+function Device:simulateResume() end
+
 --[[--
 Device specific method for performing haptic feedback.
 


### PR DESCRIPTION
SimulateSuspend/SimulateResume are implemented for emulator and no-op for other sdl platforms.
viewport/portrait/touchless toggles via environment can be useful on other sdl platforms as well.
Fixed calling commands on OSX
~~Don't set a window icon on OSX, the bundle icon will be shown on the dock.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6383)
<!-- Reviewable:end -->
