### PR TITLE
SetNightMode event & Night Mode refresh rate

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -60,7 +60,7 @@ end
 
 function ReaderToc:onPageUpdate(pageno)
     self.pageno = pageno
-    if G_reader_settings:readSetting("full_refresh_count") == -1 then
+    if UIManager.FULL_REFRESH_COUNT == -1 then
         if self:isChapterEnd(pageno, 0) then
             self.chapter_refresh = true
         elseif self:isChapterBegin(pageno, 0) and self.chapter_refresh then

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -17,7 +17,15 @@ function DeviceListener:onToggleNightMode()
     local night_mode = G_reader_settings:isTrue("night_mode")
     Screen:toggleNightMode()
     UIManager:setDirty("all", "full")
+    UIManager:ToggleNightMode(not night_mode)
     G_reader_settings:saveSetting("night_mode", not night_mode)
+end
+
+function DeviceListener:onSetNightMode(night_mode_on)
+    local night_mode = G_reader_settings:isTrue("night_mode")
+    if (night_mode_on and not night_mode) or (not night_mode_on and night_mode) then
+        self:onToggleNightMode()
+    end
 end
 
 local function lightFrontlight()

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -51,7 +51,8 @@ local settingsList = {
     fulltext_search = { category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), device=true,},
     file_search = { category="none", event="ShowFileSearch", title=_("File search"), device=true,},
     full_refresh = { category="none", event="FullRefresh", title=_("Full screen refresh"), device=true,},
-    night_mode = { category="none", event="ToggleNightMode", title=_("Night mode"), device=true,},
+    night_mode = { category="none", event="ToggleNightMode", title=_("Toggle night mode"), device=true,},
+    set_night_mode = { category="string", event="SetNightMode", title=_("Set night mode"), device=true, args={true, false}, toggle={_("On"), _("Off")},},
     suspend = { category="none", event="SuspendEvent", title=_("Suspend"), device=true,},
     exit = { category="none", event="Exit", title=_("Exit KOReader"), device=true,},
     restart = { category="none", event="Restart", title=_("Restart KOReader"), device=true, condition=Device:canRestart(),},
@@ -152,6 +153,7 @@ local dispatcher_menu_order = {
 
     "full_refresh",
     "night_mode",
+    "set_night_mode",
     "suspend",
     "exit",
     "restart",

--- a/frontend/ui/elements/refresh_menu_table.lua
+++ b/frontend/ui/elements/refresh_menu_table.lua
@@ -13,23 +13,38 @@ local function custom(refresh_rate_num)
     else
         default_value = 99
     end
-    return G_reader_settings:readSetting(refresh_rate_num) or default_value
+    return (G_reader_settings:readSetting(refresh_rate_num) or default_value), (G_reader_settings:readSetting("night_" .. refresh_rate_num) or G_reader_settings:readSetting(refresh_rate_num) or default_value)
+end
+
+local function refreshChecked(savedday, savednight)
+    local day, night = UIManager:getRefreshRate()
+    return day == savedday and night == savednight
 end
 
 local function spinWidgetSetRefresh(touchmenu_instance, refresh_rate_num)
-    local SpinWidget = require("ui/widget/spinwidget")
-    local items = SpinWidget:new{
+    local left, right = custom(refresh_rate_num)
+    local DoubleSpinWidget = require("ui/widget/doublespinwidget")
+    local items = DoubleSpinWidget:new{
         width = math.floor(Screen:getWidth() * 0.6),
-        value = custom(refresh_rate_num),
-        value_min = 0,
-        value_max = 200,
-        value_step = 1,
-        value_hold_step = 10,
+        info_text = _("For every chapter set -1"),
+        left_value = left,
+        left_min = -1,
+        left_max = 200,
+        left_step = 1,
+        left_hold_step = 10,
+        left_text = _("Regular"),
+        right_value = right,
+        right_min = -1,
+        right_max = 200,
+        right_step = 1,
+        right_hold_step = 10,
+        right_text = _("Night"),
         ok_text = _("Set refresh"),
         title_text = _("Set custom refresh rate"),
-        callback = function(spin)
-            G_reader_settings:saveSetting(refresh_rate_num, spin.value)
-            UIManager:setRefreshRate(spin.value)
+        callback = function(left_value, right_value)
+            G_reader_settings:saveSetting(refresh_rate_num, left_value)
+            G_reader_settings:saveSetting("night_" .. refresh_rate_num, right_value)
+            UIManager:setRefreshRate(left_value, right_value)
             touchmenu_instance:updateItems()
         end
     }
@@ -43,24 +58,24 @@ return {
     sub_item_table = {
         {
             text = _("Never"),
-            checked_func = function() return UIManager:getRefreshRate() == 0 end,
-            callback = function() UIManager:setRefreshRate(0) end,
+            checked_func = function() return refreshChecked(0, 0) end,
+            callback = function() UIManager:setRefreshRate(0, 0) end,
         },
         {
             text = _("Every page"),
-            checked_func = function() return UIManager:getRefreshRate() == 1 end,
-            callback = function() UIManager:setRefreshRate(1) end,
+            checked_func = function() return refreshChecked(1, 1) end,
+            callback = function() UIManager:setRefreshRate(1, 1) end,
         },
         {
             text = _("Every 6 pages"),
-            checked_func = function() return UIManager:getRefreshRate() == 6 end,
-            callback = function() UIManager:setRefreshRate(6) end,
+            checked_func = function() return refreshChecked(6, 6) end,
+            callback = function() UIManager:setRefreshRate(6, 6) end,
         },
         {
             text_func = function()
-                return T(_("Custom 1: %1 pages"), custom("refresh_rate_1"))
+                return T(_("Custom 1: %1:%2 pages"), custom("refresh_rate_1"))
             end,
-            checked_func = function() return UIManager:getRefreshRate() == custom("refresh_rate_1") end,
+            checked_func = function() return refreshChecked(custom("refresh_rate_1")) end,
             callback = function() UIManager:setRefreshRate(custom("refresh_rate_1")) end,
             hold_callback = function(touchmenu_instance)
                 spinWidgetSetRefresh(touchmenu_instance, "refresh_rate_1")
@@ -68,9 +83,9 @@ return {
         },
         {
             text_func = function()
-                return T(_("Custom 2: %1 pages"), custom("refresh_rate_2"))
+                return T(_("Custom 2: %1:%2 pages"), custom("refresh_rate_2"))
             end,
-            checked_func = function() return UIManager:getRefreshRate() == custom("refresh_rate_2") end,
+            checked_func = function() return refreshChecked(custom("refresh_rate_2")) end,
             callback = function() UIManager:setRefreshRate(custom("refresh_rate_2")) end,
             hold_callback = function(touchmenu_instance)
                 spinWidgetSetRefresh(touchmenu_instance, "refresh_rate_2")
@@ -78,9 +93,9 @@ return {
         },
         {
             text_func = function()
-                return T(_("Custom 3: %1 pages"), custom("refresh_rate_3"))
+                return T(_("Custom 3: %1:%2 pages"), custom("refresh_rate_3"))
             end,
-            checked_func = function() return UIManager:getRefreshRate() == custom("refresh_rate_3") end,
+            checked_func = function() return refreshChecked(custom("refresh_rate_3")) end,
             callback = function() UIManager:setRefreshRate(custom("refresh_rate_3")) end,
             hold_callback = function(touchmenu_instance)
                 spinWidgetSetRefresh(touchmenu_instance, "refresh_rate_3")
@@ -88,8 +103,8 @@ return {
         },
         {
             text = _("Every chapter"),
-            checked_func = function() return UIManager:getRefreshRate() == -1 end,
-            callback = function() UIManager:setRefreshRate(-1) end,
+            checked_func = function() return refreshChecked(-1, -1) end,
+            callback = function() UIManager:setRefreshRate(-1, -1) end,
         },
     }
 }

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -19,7 +19,7 @@ local DEFAULT_FULL_REFRESH_COUNT = 6
 local UIManager = {
     -- trigger a full refresh when counter reaches FULL_REFRESH_COUNT
     FULL_REFRESH_COUNT =
-        G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT,
+        G_reader_settings:isTrue("night_mode") and G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT,
     refresh_count = 0,
 
     -- How long to wait between ZMQ wakeups: 50ms.
@@ -688,15 +688,24 @@ end
 --- Sets full refresh rate for e-ink screen.
 --
 -- Also makes the refresh rate persistent in global reader settings.
-function UIManager:setRefreshRate(rate)
+function UIManager:setRefreshRate(rate, night_rate)
     logger.dbg("set screen full refresh rate", rate)
-    self.FULL_REFRESH_COUNT = rate
+    self.FULL_REFRESH_COUNT =  G_reader_settings:isTrue("night_mode") and night_rate or rate
     G_reader_settings:saveSetting("full_refresh_count", rate)
+    G_reader_settings:saveSetting("night_full_refresh_count", night_rate)
 end
 
 --- Gets full refresh rate for e-ink screen.
-function UIManager:getRefreshRate(rate)
-    return self.FULL_REFRESH_COUNT
+function UIManager:getRefreshRate()
+    return G_reader_settings:readSetting("full_refresh_count"), G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count")
+end
+
+function UIManager:ToggleNightMode(night_mode)
+    if night_mode then
+        self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count")
+    else
+        self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("full_refresh_count")
+    end
 end
 
 --- Get top widget.


### PR DESCRIPTION
idea from #5079

allows setting night mode directly not only toggling it.

If the user has not set a separate refresh rate for night mode
the default one will be used, as was the previous behavior

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6386)
<!-- Reviewable:end -->
