### PR TITLE
set FULL_REFRESH_COUNT to a sane value if no pref is set and toggleNi…

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -697,7 +697,7 @@ end
 
 --- Gets full refresh rate for e-ink screen.
 function UIManager:getRefreshRate()
-    return G_reader_settings:readSetting("full_refresh_count"), G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count")
+    return G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT, G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT
 end
 
 function UIManager:ToggleNightMode(night_mode)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -702,9 +702,9 @@ end
 
 function UIManager:ToggleNightMode(night_mode)
     if night_mode then
-        self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count")
+        self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT
     else
-        self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("full_refresh_count")
+        self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT
     end
 end
 


### PR DESCRIPTION
…ghtMode

regression from #6386

Closes: #6398

bad mistake on my part. I didn't test the case if the user has not changed `Full refresh rate` setting (not even to the default one).

this would crash when toggling night mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6400)
<!-- Reviewable:end -->
