### PR TITLE
[fix] Use orderedPairs in touch menu item table

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -8,6 +8,7 @@ local BottomContainer = require("ui/widget/container/bottomcontainer")
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
+local FFIUtil = require("ffi/util")
 local FocusManager = require("ui/widget/focusmanager")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -1326,7 +1327,7 @@ end
 
 function Menu.itemTableFromTouchMenu(t)
     local item_t = {}
-    for k,v in pairs(t) do
+    for k, v in FFIUtil.orderedPairs(t) do
         local item = { text = k }
         if v.callback then
             item.callback = v.callback

--- a/spec/unit/widget_menu_spec.lua
+++ b/spec/unit/widget_menu_spec.lua
@@ -20,7 +20,11 @@ describe("Menu widget", function()
             },
         })
         --- @fixme: Currently broken because pairs (c.f., https://github.com/koreader/koreader/pull/6371#issuecomment-657251302)
-        assert.are.same(re, {
+        assert.are.same({
+            {
+                text = 'exit',
+                callback = cb2,
+            },
             {
                 text = 'navi',
                 sub_item_table = {
@@ -29,10 +33,6 @@ describe("Menu widget", function()
                     { text = 'bar', callback = cb2 },
                 }
             },
-            {
-                text = 'exit',
-                callback = cb2,
-            }
-        })
+        }, re)
     end)
 end)


### PR DESCRIPTION
Cf. <https://github.com/koreader/koreader/pull/6403> and <https://github.com/koreader/koreader/pull/6371>.

I'm not completely sure if this would be correct/expected behavior, hence why I put it in a separate PR. See https://github.com/koreader/koreader/commit/394c847e2b276e07b9a639d53d29b59ac6eb4609 for some context. On the flip side, I don't see much in the way of alternatives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6404)
<!-- Reviewable:end -->
