### PR TITLE
bump crengine: various fixes and FB2 tweaks

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -338,8 +338,8 @@ ruby { display: inline !important; }
                 id = "lineheight_all_normal_strut_confined";
                 title = _("Enforce steady line heights"),
                 description = _("Prevent inline content like sub- and superscript from changing their paragraph line height."),
-                priority = -5, -- so other -cr-hint can override (this one has effect only on inline content)
-                css = [[* { -cr-hint: strut-confined; }]],
+                -- strut-confined is among the few cr-hints that are inherited
+                css = [[body { -cr-hint: strut-confined; }]],
                 separator = true,
             },
             {
@@ -650,13 +650,17 @@ This is just an example, that will need to be adapted into a user style tweak.]]
                     title = _("In-page FB2 footnotes"),
                     description = _([[
 Show FB2 footnote text at the bottom of pages that contain links to them.]]),
+                    -- Restrict this to FB2 documents, even if we won't probably
+                    -- match in any other kind of document
                     css = [[
 body[name="notes"] section {
-    -cr-hint: footnote-inpage;
-    margin: 0 !important;
+    -cr-only-if: fb2-document;
+        -cr-hint: footnote-inpage;
+        margin: 0 !important;
 }
 body[name="notes"] > section {
-    font-size: 0.75rem;
+    -cr-only-if: fb2-document;
+        font-size: 0.75rem;
 }
                     ]],
                 },
@@ -667,11 +671,13 @@ body[name="notes"] > section {
 Show FB2 endnote text at the bottom of pages that contain links to them.]]),
                     css = [[
 body[name="comments"] section {
-    -cr-hint: footnote-inpage;
-    margin: 0 !important;
+    -cr-only-if: fb2-document;
+        -cr-hint: footnote-inpage;
+        margin: 0 !important;
 }
 body[name="comments"] > section {
-    font-size: 0.85rem;
+    -cr-only-if: fb2-document;
+        font-size: 0.85rem;
 }
                     ]],
                     separator = true,
@@ -685,7 +691,8 @@ FB2 footnotes and endnotes get a smaller font size when displayed in-page. This 
 body[name="notes"] > section,
 body[name="comments"] > section
 {
-    font-size: 1rem !important;
+    -cr-only-if: fb2-document;
+        font-size: 1rem !important;
 }
                     ]],
                 },
@@ -697,6 +704,7 @@ body[name="comments"] > section
                 description = _([[
 Show EPUB footnote text at the bottom of pages that contain links to them.
 This only works with footnotes that have specific attributes set by the publisher.]]),
+                -- Restrict this to EPUB documents, as FB2 can have <a type="note">
                 css = [[
 *[type~="note"],
 *[type~="footnote"],
@@ -705,8 +713,9 @@ This only works with footnotes that have specific attributes set by the publishe
 *[role~="doc-footnote"],
 *[role~="doc-rearnote"]
 {
-    -cr-hint: footnote-inpage;
-    margin: 0 !important;
+    -cr-only-if: epub-document;
+        -cr-hint: footnote-inpage;
+        margin: 0 !important;
 }
                 ]],
             },
@@ -716,6 +725,8 @@ This only works with footnotes that have specific attributes set by the publishe
                 description = _([[
 Show EPUB footnote text at the bottom of pages that contain links to them.
 This only works with footnotes that have specific attributes set by the publisher.]]),
+                -- Restrict this to EPUB documents, as FB2 can have <a type="note">
+                -- and we don't want to have them smaller
                 css = [[
 *[type~="note"],
 *[type~="footnote"],
@@ -724,9 +735,10 @@ This only works with footnotes that have specific attributes set by the publishe
 *[role~="doc-footnote"],
 *[role~="doc-rearnote"]
 {
-    -cr-hint: footnote-inpage;
-    margin: 0 !important;
-    font-size: 0.8rem !important;
+    -cr-only-if: epub-document;
+        -cr-hint: footnote-inpage;
+        margin: 0 !important;
+        font-size: 0.8rem !important;
 }
                 ]],
                 separator = true,

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -90,6 +90,11 @@ body > li { list-style-type: none; }
 /* Remove any (possibly multiple) backlinks in Wikipedia EPUBs footnotes */
 .noprint { display: none; }
 
+/* Style some FB2 tags not known to MuPDF */
+emphasis { font-style: italic; }
+strikethrough { text-decoration: line-through; }
+underline { text-decoration: underline; }
+
 /* Attempt to display FB2 footnotes as expected (as crengine does, putting
  * the footnote number on the same line as the first paragraph via its
  * support of "display: run-in" and a possibly added autoBoxing element) */


### PR DESCRIPTION
Includes:
- New German hyphenation patterns https://github.com/koreader/crengine/pull/356
- CSS: adds `text-align-last: -cr-right-if-not-first` private keywords https://github.com/koreader/crengine/pull/357
- CSS: adds `-cr-only-if: fb2-document`
- fb2.css: fix verses, minor cleanup
- FB2 footnotes: fix spacing between number and text
- ldomTextCollector: guess block boundaries better
- Text: fix read/write outside array bounds
- Text: fix read outside array bounds https://github.com/koreader/crengine/pull/358
- Fix crash when more than 64 nested elements - Closes #6391 
- Fix possible crash on book with embedded fonts load - Closes #6394 
- (Upstream) lvstsheet: avoid compilation warnings https://github.com/koreader/crengine/pull/359
- Strut confining: don't when there is no strut
- CSS: switch `-cr-hint` from enum to bitmap

`Style tweaks: limit EPUB/FB2 footnotes to these formats`
Avoid conflicts having "In-page EPUB footnotes (smaller)" affects FB2 documents that use `<a type=note>12</a>` which would then get smaller if both tweaks are enabled (which they are, by default). See https://github.com/koreader/koreader/issues/6344#issuecomment-658273890
Footnote popups: add styles for some non-HTML FB2 tags, so MuPDF can render them as expected. See https://github.com/koreader/koreader/issues/6344#issuecomment-657007634 (I just styled the obvious, may be more styling is needed, dunno.)

This PR fixes most issues with FB2 noticed from https://github.com/koreader/koreader/issues/6344#issuecomment-655936850 and later comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6405)
<!-- Reviewable:end -->
