### PR TITLE
Fake battery status in readerfooter_spec to succeed on devices with batteries

### DIFF
--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -5,7 +5,7 @@ local SDLPowerD = BasePowerD:new{}
 
 function SDLPowerD:getCapacityHW()
     local _, _, _, percent = SDL.getPowerInfo()
-    -- never return negative values, since tests rely on battery being 0%
+    -- -1 looks a bit odd compared to 0
     if percent == -1 then return 0 end
     return percent
 end

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -6,7 +6,11 @@ describe("Readerfooter module", function()
     setup(function()
         require("commonrequire")
         package.unloadAll()
-        require("document/canvascontext"):init(require("device"))
+        local Device = require("device")
+        -- Override powerd for running tests on devices with batteries.
+        Device.powerd.isChargingHW = function() return false end
+        Device.powerd.getCapacityHW = function() return 0 end
+        require("document/canvascontext"):init(Device)
         DocumentRegistry = require("document/documentregistry")
         DocSettings = require("docsettings")
         ReaderUI = require("apps/reader/readerui")


### PR DESCRIPTION
Cf. <https://github.com/koreader/koreader/pull/6370#issuecomment-662382487>.

@pazos No spies/stubs necessary here. ^_^

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6417)
<!-- Reviewable:end -->
