### PR TITLE
Fix a few logic holes in dithering mode selection

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -357,7 +357,7 @@ function FileManagerMenu:setUpdateItemTable()
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_no_hw_dither")
-                Device.screen:toggleHWDithering()
+                Device.screen:toggleHWDithering(not G_reader_settings:isTrue("dev_no_hw_dither"))
                 -- Make sure SW dithering gets disabled when we enable HW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
                     Device.screen:toggleSWDithering(false)
@@ -377,7 +377,7 @@ function FileManagerMenu:setUpdateItemTable()
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_no_sw_dither")
-                Device.screen:toggleSWDithering()
+                Device.screen:toggleSWDithering(not G_reader_settings:isTrue("dev_no_sw_dither"))
                 -- Make sure HW dithering gets disabled when we enable SW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
                     Device.screen:toggleHWDithering(false)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -356,8 +356,8 @@ function FileManagerMenu:setUpdateItemTable()
                 return not Device.screen.hw_dithering
             end,
             callback = function()
-                G_reader_settings:flipNilOrFalse("dev_no_hw_dither")
-                Device.screen:toggleHWDithering(not G_reader_settings:isTrue("dev_no_hw_dither"))
+                Device.screen:toggleHWDithering()
+                G_reader_settings:saveSetting("dev_no_hw_dither", not Device.screen.hw_dithering)
                 -- Make sure SW dithering gets disabled when we enable HW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
                     G_reader_settings:saveSetting("dev_no_sw_dither", true)
@@ -377,8 +377,8 @@ function FileManagerMenu:setUpdateItemTable()
                 return not Device.screen.sw_dithering
             end,
             callback = function()
-                G_reader_settings:flipNilOrFalse("dev_no_sw_dither")
-                Device.screen:toggleSWDithering(not G_reader_settings:isTrue("dev_no_sw_dither"))
+                Device.screen:toggleSWDithering()
+                G_reader_settings:saveSetting("dev_no_sw_dither", not Device.screen.sw_dithering)
                 -- Make sure HW dithering gets disabled when we enable SW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
                     G_reader_settings:saveSetting("dev_no_hw_dither", true)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -360,6 +360,7 @@ function FileManagerMenu:setUpdateItemTable()
                 Device.screen:toggleHWDithering(not G_reader_settings:isTrue("dev_no_hw_dither"))
                 -- Make sure SW dithering gets disabled when we enable HW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
+                    G_reader_settings:saveSetting("dev_no_sw_dither", true)
                     Device.screen:toggleSWDithering(false)
                 end
                 UIManager:setDirty("all", "full")
@@ -380,6 +381,7 @@ function FileManagerMenu:setUpdateItemTable()
                 Device.screen:toggleSWDithering(not G_reader_settings:isTrue("dev_no_sw_dither"))
                 -- Make sure HW dithering gets disabled when we enable SW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
+                    G_reader_settings:saveSetting("dev_no_hw_dither", true)
                     Device.screen:toggleHWDithering(false)
                 end
                 UIManager:setDirty("all", "full")

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -360,7 +360,7 @@ function FileManagerMenu:setUpdateItemTable()
                 Device.screen:toggleHWDithering()
                 -- Make sure SW dithering gets disabled when we enable HW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
-                    Device.screen:toggleSWDithering()
+                    Device.screen:toggleSWDithering(false)
                 end
                 UIManager:setDirty("all", "full")
             end,
@@ -380,7 +380,7 @@ function FileManagerMenu:setUpdateItemTable()
                 Device.screen:toggleSWDithering()
                 -- Make sure HW dithering gets disabled when we enable SW dithering
                 if Device.screen.hw_dithering and Device.screen.sw_dithering then
-                    Device.screen:toggleHWDithering()
+                    Device.screen:toggleHWDithering(false)
                 end
                 UIManager:setDirty("all", "full")
             end,

--- a/reader.lua
+++ b/reader.lua
@@ -129,13 +129,16 @@ end
 -- Dithering
 if Device:hasEinkScreen() then
     Device.screen:setupDithering()
-    -- FIXME: If device can HW dither (i.e., after setupDithering, hw_dithering is true, but sw_dithering is false),
-    --        but HW dither is explicitly disabled, and SW dither enabled, don't disable SW dither (i.e., re-enable sw_dithering)!
     if Device.screen.hw_dithering and G_reader_settings:isTrue("dev_no_hw_dither") then
         Device.screen:toggleHWDithering(false)
     end
     if Device.screen.sw_dithering and G_reader_settings:isTrue("dev_no_sw_dither") then
         Device.screen:toggleSWDithering(false)
+    end
+    -- NOTE: If device can HW dither (i.e., after setupDithering(), hw_dithering is true, but sw_dithering is false),
+    --       but HW dither is explicitly disabled, and SW dither enabled, don't leave SW dither disabled (i.e., re-enable sw_dithering)!
+    if Device:canHWDither() and G_reader_settings:isTrue("dev_no_hw_dither") and G_reader_settings:nilOrFalse("dev_no_sw_dither") then
+        Device.screen:toggleSWDithering(true)
     end
 end
 

--- a/reader.lua
+++ b/reader.lua
@@ -129,11 +129,13 @@ end
 -- Dithering
 if Device:hasEinkScreen() then
     Device.screen:setupDithering()
+    -- FIXME: If device can HW dither (i.e., after setupDithering, hw_dithering is true, but sw_dithering is false),
+    --        but HW dither is explicitly disabled, and SW dither enabled, don't disable SW dither (i.e., re-enable sw_dithering)!
     if Device.screen.hw_dithering and G_reader_settings:isTrue("dev_no_hw_dither") then
-        Device.screen:toggleHWDithering()
+        Device.screen:toggleHWDithering(false)
     end
     if Device.screen.sw_dithering and G_reader_settings:isTrue("dev_no_sw_dither") then
-        Device.screen:toggleSWDithering()
+        Device.screen:toggleSWDithering(false)
     end
 end
 


### PR DESCRIPTION
* Allow switching to SW dithering on a HW-capable device without that being lost on boot (and, worse, left in an undithered state).
* Make sure the automagic toggles between HW/SW in the Dev menu are properly saved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6419)
<!-- Reviewable:end -->
