### PR TITLE
Don't store document-specific rotation when sticky rotation is enabled

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -827,7 +827,11 @@ end
 
 function ReaderView:onSaveSettings()
     self.ui.doc_settings:saveSetting("render_mode", self.render_mode)
-    self.ui.doc_settings:saveSetting("rotation_mode", Screen:getRotationMode())
+    -- Don't etch the current rotation in stone when sticky rotation is enabled
+    local locked = G_reader_settings:isTrue("lock_rotation")
+    if not locked then
+        self.ui.doc_settings:saveSetting("rotation_mode", Screen:getRotationMode())
+    end
     self.ui.doc_settings:saveSetting("gamma", self.state.gamma)
     self.ui.doc_settings:saveSetting("highlight", self.highlight.saved)
     self.ui.doc_settings:saveSetting("page_overlap_style", self.page_overlap_style)


### PR DESCRIPTION
It doesn't do so for the FM, so the inconsistency is confusing.
Plus, if you're actively using sticky rotation, saved rotations are
ignored anyway.

Re #6420

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6423)
<!-- Reviewable:end -->
