### PR TITLE
Fix ConfigDialog's ButtonProgress Fine tune updating presets

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -997,12 +997,17 @@ function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, 
             if direction == "-" then
                 value = self.configurable[name] or values[1]
                 if type(value) == "table" then
+                    -- Don't update directly this table: it might be a reference
+                    -- to one of the original preset values tables
+                    local updated = {}
                     for i=1, #value do
-                        value[i] = value[i] - 1
-                        if value[i] < 0 then
-                            value[i] = 0
+                        v = value[i] - 1
+                        if v < 0 then
+                            v = 0
                         end
+                        table.insert(updated, v)
                     end
+                    value = updated
                 else
                     value = value - 1
                     if value < 0 then
@@ -1012,9 +1017,11 @@ function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, 
             else
                 value = self.configurable[name] or values[#values]
                 if type(value) == "table" then
+                    local updated = {}
                     for i=1, #value do
-                        value[i] = value[i] + 1
+                        table.insert(updated, value[i] + 1)
                     end
+                    value = updated
                 else
                     value = value + 1
                 end

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1001,7 +1001,7 @@ function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, 
                     -- to one of the original preset values tables
                     local updated = {}
                     for i=1, #value do
-                        v = value[i] - 1
+                        local v = value[i] - 1
                         if v < 0 then
                             v = 0
                         end


### PR DESCRIPTION
Witnessed with "L/R Margins": tapping on a button sets the value to the preset table by reference.
Tapping the -/+ fine tuning buttons would update these tables in-place, in effect modifying the presets. This avoids that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6433)
<!-- Reviewable:end -->
