### PR TITLE
Add Set Frontlight/Set Frontlight Warmth to dispatcher

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -114,19 +114,18 @@ if Device:hasFrontlight() then
 
         if new_intensity == nil then return true end
         -- when new_intensity <=0, toggle light off
+	self:onSetFlIntensity(new_intensity)
+        self:onShowIntensity()
+        return true
+    end
+
+    function DeviceListener:onSetFlIntensity(new_intensity)
+        local powerd = Device:getPowerDevice()
         if new_intensity <= 0 then
             powerd:turnOffFrontlight()
         else
             powerd:setIntensity(new_intensity)
         end
-        self:onShowIntensity()
-        return true
-    end
-
-    -- Used by dispatcher only (all the conditions such as min/max frontlight value should be handled by dispatcher already)
-    function DeviceListener:onSetFlIntensity(new_intensity)
-        local powerd = Device:getPowerDevice()
-        powerd:setIntensity(new_intensity)
         return true
     end
 
@@ -209,20 +208,20 @@ if Device:hasFrontlight() then
             direction = 1
         end
         local warmth = powerd.fl_warmth + direction * delta_int
+	self:onSetFlWarmth(warmth)
+        self:onShowWarmth()
+        return true
+    end
+
+    -- Used by dispatcher only (all the conditions such as min/max frontlight warmth should be handled by dispatcher already)
+    function DeviceListener:onSetFlWarmth(warmth)
+        local powerd = Device:getPowerDevice()
         if warmth > 100 then
             warmth = 100
         elseif warmth < 0 then
             warmth = 0
         end
         powerd:setWarmth(warmth)
-        self:onShowWarmth()
-        return true
-    end
-
-    -- Used by dispatcher only (all the conditions such as min/max frontlight warmth should be handled by dispatcher already)
-    function DeviceListener:onSetFlWarmth(new_warmth)
-        local powerd = Device:getPowerDevice()
-        powerd:setWarmth(new_warmth)
         return true
     end
 

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -123,6 +123,13 @@ if Device:hasFrontlight() then
         return true
     end
 
+    -- Used by dispatcher only(all the conditions such as min/max frontlight value should be handled by dispatcher already)
+    function DeviceListener:onSetFlIntensity(new_intensity)
+        local powerd = Device:getPowerDevice()
+        powerd:setIntensity(new_intensity)
+        return true
+    end
+
     function DeviceListener:onIncreaseFlIntensity(ges)
         self:onChangeFlIntensity(ges, 1)
         return true
@@ -209,6 +216,13 @@ if Device:hasFrontlight() then
         end
         powerd:setWarmth(warmth)
         self:onShowWarmth()
+        return true
+    end
+
+    -- Used by dispatcher only(all the conditions such as min/max frontlight warmth should be handled by dispatcher already)
+    function DeviceListener:onSetFlWarmth(new_warmth)
+        local powerd = Device:getPowerDevice()
+        powerd:setWarmth(new_warmth)
         return true
     end
 

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -123,7 +123,7 @@ if Device:hasFrontlight() then
         return true
     end
 
-    -- Used by dispatcher only(all the conditions such as min/max frontlight value should be handled by dispatcher already)
+    -- Used by dispatcher only (all the conditions such as min/max frontlight value should be handled by dispatcher already)
     function DeviceListener:onSetFlIntensity(new_intensity)
         local powerd = Device:getPowerDevice()
         powerd:setIntensity(new_intensity)
@@ -219,7 +219,7 @@ if Device:hasFrontlight() then
         return true
     end
 
-    -- Used by dispatcher only(all the conditions such as min/max frontlight warmth should be handled by dispatcher already)
+    -- Used by dispatcher only (all the conditions such as min/max frontlight warmth should be handled by dispatcher already)
     function DeviceListener:onSetFlWarmth(new_warmth)
         local powerd = Device:getPowerDevice()
         powerd:setWarmth(new_warmth)

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -114,7 +114,7 @@ if Device:hasFrontlight() then
 
         if new_intensity == nil then return true end
         -- when new_intensity <=0, toggle light off
-	self:onSetFlIntensity(new_intensity)
+        self:onSetFlIntensity(new_intensity)
         self:onShowIntensity()
         return true
     end
@@ -208,7 +208,7 @@ if Device:hasFrontlight() then
             direction = 1
         end
         local warmth = powerd.fl_warmth + direction * delta_int
-	self:onSetFlWarmth(warmth)
+        self:onSetFlWarmth(warmth)
         self:onShowWarmth()
         return true
     end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -213,7 +213,6 @@ if Device:hasFrontlight() then
         return true
     end
 
-    -- Used by dispatcher only (all the conditions such as min/max frontlight warmth should be handled by dispatcher already)
     function DeviceListener:onSetFlWarmth(warmth)
         local powerd = Device:getPowerDevice()
         if warmth > 100 then

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -33,8 +33,10 @@ local settingsList = {
     -- Device settings
     show_frontlight_dialog = { category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), device=true, condition=Device:hasFrontlight(),},
     toggle_frontlight = { category="none", event="ToggleFrontlight", title=_("Toggle frontlight"), device=true, condition=Device:hasFrontlight(),},
+    set_frontlight = { category="incrementalnumber", event="SetFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Set frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
     increase_frontlight = { category="incrementalnumber", event="IncreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Increase frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
     decrease_frontlight = { category="incrementalnumber", event="DecreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Decrease frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
+    set_frontlight_warmth = { category="incrementalnumber", event="SetFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Set frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     increase_frontlight_warmth = { category="incrementalnumber", event="IncreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Increase frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     decrease_frontlight_warmth = { category="incrementalnumber", event="DecreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Decrease frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     toggle_gsensor = { category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:canToggleGSensor(),},
@@ -164,6 +166,7 @@ local dispatcher_menu_order = {
     "show_config_menu",
     "show_frontlight_dialog",
     "toggle_frontlight",
+    "set_frontlight",
     "increase_frontlight",
     "decrease_frontlight",
     "increase_frontlight_warmth",

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -33,10 +33,10 @@ local settingsList = {
     -- Device settings
     show_frontlight_dialog = { category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), device=true, condition=Device:hasFrontlight(),},
     toggle_frontlight = { category="none", event="ToggleFrontlight", title=_("Toggle frontlight"), device=true, condition=Device:hasFrontlight(),},
-    set_frontlight = { category="incrementalnumber", event="SetFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Set frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
+    set_frontlight = { category="absolutenumber", event="SetFlIntensity", min=0, max=Device:getPowerDevice().fl_max, title=_("Set frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
     increase_frontlight = { category="incrementalnumber", event="IncreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Increase frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
     decrease_frontlight = { category="incrementalnumber", event="DecreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Decrease frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
-    set_frontlight_warmth = { category="incrementalnumber", event="SetFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Set frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
+    set_frontlight_warmth = { category="absolutenumber", event="SetFlWarmth", min=0, max=100, title=_("Set frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     increase_frontlight_warmth = { category="incrementalnumber", event="IncreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Increase frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     decrease_frontlight_warmth = { category="incrementalnumber", event="DecreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Decrease frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     toggle_gsensor = { category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:canToggleGSensor(),},

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -169,6 +169,7 @@ local dispatcher_menu_order = {
     "set_frontlight",
     "increase_frontlight",
     "decrease_frontlight",
+    "set_frontlight_warmth",
     "increase_frontlight_warmth",
     "decrease_frontlight_warmth",
 


### PR DESCRIPTION
Currently dispatcher has ability to change frontlight/warmth by a given number, this PR aims to allow user to change FL intensity/warmth to a new value. This is pretty useful, as it allows users to make profiles for day reading/night reading. I\m not sure if I should check all the conditions in events, since dispatcher already handles that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6440)
<!-- Reviewable:end -->
