### PR TITLE
Add additional media types to OPDS Browser

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -59,6 +59,7 @@ local OPDSBrowser = Menu:extend{
         ["application/x-cbr"] = "CBR",
         ["application/vnd.comicbook-rar"] = "CBR",
         ["application/x-rar-compressed"] = "CBR",
+        ["application/vnd.rar"] = "CBR",
         ["application/djvu"] = "DJVU",
     },
 

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -54,7 +54,11 @@ local OPDSBrowser = Menu:extend{
         ["application/x-mobipocket-ebook"] = "MOBI",
         ["application/x-mobi8-ebook"] = "AZW3",
         ["application/x-cbz"] = "CBZ",
+        ["application/vnd.comicbook+zip"] = "CBZ",
+        ["application/zip"] = "CBZ",
         ["application/x-cbr"] = "CBR",
+        ["application/vnd.comicbook-rar"] = "CBR",
+        ["application/x-rar-compressed"] = "CBR",
         ["application/djvu"] = "DJVU",
     },
 


### PR DESCRIPTION
The media types for CBZ and CBR (added in #5940) are deprecated, and replaced by `vnd.comicbook+zip` and `vnd.comicbook+rar`. In addition, many OPDS servers will use the actual media type of the file, ie `application/zip` and `application/x-rar-compressed`.

See here about the new `vnd` types:
- https://www.iana.org/assignments/media-types/application/vnd.comicbook+zip
- https://www.iana.org/assignments/media-types/application/vnd.comicbook-rar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6443)
<!-- Reviewable:end -->
