### PR TITLE
Allow user to set higher hold pan rate

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -30,7 +30,10 @@ function ReaderHighlight:setupTouchZones()
     self.onGesture = nil
 
     if not Device:isTouchDevice() then return end
-
+    local hold_pan_rate = G_reader_settings:readSetting("hold_pan_rate")
+    if not hold_pan_rate then
+        hold_pan_rate = Screen.low_pan_rate and 5.0 or 30.0
+    end
     self.ui:registerTouchZones({
         {
             id = "readerhighlight_tap",
@@ -76,7 +79,7 @@ function ReaderHighlight:setupTouchZones()
         {
             id = "readerhighlight_hold_pan",
             ges = "hold_pan",
-            rate = 2.0,
+            rate = hold_pan_rate,
             screen_zone = {
                 ratio_x = 0, ratio_y = 0, ratio_w = 1, ratio_h = 1,
             },
@@ -1295,6 +1298,10 @@ function ReaderHighlight:onReadSettings(config)
         disable_highlight = G_reader_settings:readSetting("highlight_disabled") or false
     end
     self.view.highlight.disabled = disable_highlight
+end
+
+function ReaderHighlight:onUpdateHoldPanRate()
+    self:setupTouchZones()
 end
 
 function ReaderHighlight:onSaveSettings()

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -429,6 +429,36 @@ function Gestures:addIntervals(menu_items)
         text = _("Gesture intervals"),
         sub_item_table = {
             {
+                text = _("Text selection rate"),
+                callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local current_value = G_reader_settings:readSetting("hold_pan_rate")
+                    if not current_value then
+                        current_value = Screen.low_pan_rate and 5.0 or 30.0
+                    end
+                    local items = SpinWidget:new{
+                        text = T(_([[
+Used when highlighting text. Higher values mean faster screen updates, but also use more CPU.
+Default value: %1]]), current_value),
+                        width = math.floor(Screen:getWidth() * 0.6),
+                        value = current_value,
+                        value_min = 1.0,
+                        value_max = 60.0,
+                        value_step = 1,
+                        value_hold_step = 15,
+                        ok_text = _("Set rate"),
+                        title_text = _("Hold pan rate"),
+                        default_value = Screen.low_pan_rate and 5.0 or 30.0,
+                        callback = function(spin)
+                            G_reader_settings:saveSetting("hold_pan_rate", spin.value)
+                            UIManager:broadcastEvent(Event:new("UpdateHoldPanRate"))
+                        end
+                    }
+                    UIManager:show(items)
+                end,
+                separator = true,
+            },
+            {
                 text = _("Double tap interval"),
                 callback = function()
                     local SpinWidget = require("ui/widget/spinwidget")
@@ -531,35 +561,6 @@ Default value: %1]]), GestureDetector.PAN_DELAYED_INTERVAL/1000),
                         callback = function(spin)
                             G_reader_settings:saveSetting("ges_pan_delayed_interval", spin.value*1000)
                             GestureDetector:setNewInterval("ges_pan_delayed_interval", spin.value*1000)
-                        end
-                    }
-                    UIManager:show(items)
-                end,
-            },
-            {
-                text = _("Hold pan rate"),
-                callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local current_value = G_reader_settings:readSetting("pan_rate")
-                    if not current_value then
-                        current_value = Screen.low_pan_rate and 5.0 or 30.0
-                    end
-                    local items = SpinWidget:new{
-                        text = T(_([[
-Used when highlighting text. Higher values mean faster screen updates, but also use more CPU.
-Default value: %1]]), current_value),
-                        width = math.floor(Screen:getWidth() * 0.6),
-                        value = current_value,
-                        value_min = 1.0,
-                        value_max = 60.0,
-                        value_step = 1,
-                        value_hold_step = 5,
-                        ok_text = _("Set rate"),
-                        title_text = _("Hold pan rate"),
-                        default_value = Screen.low_pan_rate and 5.0 or 30.0,
-                        callback = function(spin)
-                            G_reader_settings:saveSetting("hold_pan_rate", spin.value)
-                            UIManager:broadcastEvent(Event:new("UpdateHoldPanRate"))
                         end
                     }
                     UIManager:show(items)

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -438,7 +438,10 @@ function Gestures:addIntervals(menu_items)
                     end
                     local items = SpinWidget:new{
                         text = T(_([[
-Used when highlighting text. Higher values mean faster screen updates, but also use more CPU.
+Used when selecting the text.
+The rate is the number of times per second screen will be refreshed,
+while selecting the text (for translating/highlighting/wikipedia search).
+Higher values mean faster screen updates, but also use more CPU.
 Default value: %1]]), current_value),
                         width = math.floor(Screen:getWidth() * 0.6),
                         value = current_value,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -441,7 +441,7 @@ function Gestures:addIntervals(menu_items)
 Used when selecting text.
 The rate is how often screen will be refreshed per second while selecting text.
 Higher values mean faster screen updates, but also use more CPU.
-Default value: %1]]), current_value),
+Default value: %1]]), Screen.low_pan_rate and 5.0 or 30.0),
                         width = math.floor(Screen:getWidth() * 0.6),
                         value = current_value,
                         value_min = 1.0,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -546,7 +546,7 @@ Default value: %1]]), GestureDetector.PAN_DELAYED_INTERVAL/1000),
                     end
                     local items = SpinWidget:new{
                         text = T(_([[
-Used when highlighting text, higher value means faster refresh, but uses more CPU.
+Used when highlighting text. Higher values mean faster screen updates, but also use more CPU.
 Default value: %1]]), current_value),
                         width = math.floor(Screen:getWidth() * 0.6),
                         value = current_value,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -3,6 +3,7 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
 local Dispatcher = require("dispatcher")
+local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
@@ -530,6 +531,36 @@ Default value: %1]]), GestureDetector.PAN_DELAYED_INTERVAL/1000),
                         callback = function(spin)
                             G_reader_settings:saveSetting("ges_pan_delayed_interval", spin.value*1000)
                             GestureDetector:setNewInterval("ges_pan_delayed_interval", spin.value*1000)
+                        end
+                    }
+                    UIManager:show(items)
+                end,
+            },
+            {
+                text = _("Hold pan rate"),
+                callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local current_value = G_reader_settings:readSetting("pan_rate")
+                    if not current_value then
+                        current_value = Screen.has_low_pan_rate and 2.0 or 30.0
+                    end
+                    local items = SpinWidget:new{
+                        text = T(_([[
+Used when highlighting text, higher value means faster refresh, but uses more CPU.
+5.0 should be good for most e-ink ereaders.
+Default value: %1]]), current_value),
+                        width = math.floor(Screen:getWidth() * 0.6),
+                        value = current_value,
+                        value_min = 1.0,
+                        value_max = 60.0,
+                        value_step = 1,
+                        value_hold_step = 5,
+                        ok_text = _("Set rate"),
+                        title_text = _("Hold pan rate"),
+                        default_value = Screen.has_low_pan_rate and 5.0 or 30.0,
+                        callback = function(spin)
+                            G_reader_settings:saveSetting("hold_pan_rate", spin.value)
+                            UIManager:broadcastEvent(Event:new("UpdateHoldPanRate"))
                         end
                     }
                     UIManager:show(items)

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -438,9 +438,8 @@ function Gestures:addIntervals(menu_items)
                     end
                     local items = SpinWidget:new{
                         text = T(_([[
-Used when selecting the text.
-The rate is the number of times per second screen will be refreshed,
-while selecting the text (for translating/highlighting/wikipedia search).
+Used when selecting text.
+The rate is how often screen will be refreshed per second while selecting text.
 Higher values mean faster screen updates, but also use more CPU.
 Default value: %1]]), current_value),
                         width = math.floor(Screen:getWidth() * 0.6),

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -542,12 +542,11 @@ Default value: %1]]), GestureDetector.PAN_DELAYED_INTERVAL/1000),
                     local SpinWidget = require("ui/widget/spinwidget")
                     local current_value = G_reader_settings:readSetting("pan_rate")
                     if not current_value then
-                        current_value = Screen.has_low_pan_rate and 2.0 or 30.0
+                        current_value = Screen.low_pan_rate and 5.0 or 30.0
                     end
                     local items = SpinWidget:new{
                         text = T(_([[
 Used when highlighting text, higher value means faster refresh, but uses more CPU.
-5.0 should be good for most e-ink ereaders.
 Default value: %1]]), current_value),
                         width = math.floor(Screen:getWidth() * 0.6),
                         value = current_value,
@@ -557,7 +556,7 @@ Default value: %1]]), current_value),
                         value_hold_step = 5,
                         ok_text = _("Set rate"),
                         title_text = _("Hold pan rate"),
-                        default_value = Screen.has_low_pan_rate and 5.0 or 30.0,
+                        default_value = Screen.low_pan_rate and 5.0 or 30.0,
                         callback = function(spin)
                             G_reader_settings:saveSetting("hold_pan_rate", spin.value)
                             UIManager:broadcastEvent(Event:new("UpdateHoldPanRate"))


### PR DESCRIPTION
This PR adds new menu entry called `Hold pan rate` to `Taps and Gestures -> Gesture intervals`. This allows users to increase speed at which highlighting is refreshed, instead of the default 2 refreshes per second. Discussed partially in #6381.
closes #6381
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6449)
<!-- Reviewable:end -->
