### PR TITLE
add more media types to OPDS browser

### DIFF
--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -53,6 +53,7 @@ local OPDSBrowser = Menu:extend{
         ["text/plain"] = "TXT",
         ["application/x-mobipocket-ebook"] = "MOBI",
         ["application/x-mobi8-ebook"] = "AZW3",
+        ["application/vnd.amazon.mobi8-ebook"] = "AZW3",
         ["application/x-cbz"] = "CBZ",
         ["application/vnd.comicbook+zip"] = "CBZ",
         ["application/zip"] = "CBZ",
@@ -61,6 +62,8 @@ local OPDSBrowser = Menu:extend{
         ["application/x-rar-compressed"] = "CBR",
         ["application/vnd.rar"] = "CBR",
         ["application/djvu"] = "DJVU",
+        ["image/x-djvu"] = "DJVU",
+        ["image/vnd.djvu"] = "DJVU",
     },
 
     width = Screen:getWidth(),


### PR DESCRIPTION
following #6443 i thought i would check the other types

application/x-mobi8-ebook is replaced by application/vnd.amazon.mobi8-ebook (see https://www.iana.org/assignments/media-types/application/vnd.amazon.mobi8-ebook)
application/djvu doesn't seem to be an official one. image/x-djvu was the previous one, and is replaced by image/vnd.djvu (https://www.iana.org/assignments/media-types/image/vnd.djvu)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6450)
<!-- Reviewable:end -->
