### PR TITLE
Fix gesture migration when user never had custom multiswipes

### DIFF
--- a/plugins/gestures.koplugin/migration.lua
+++ b/plugins/gestures.koplugin/migration.lua
@@ -186,9 +186,11 @@ function Migration:migrateGestures(caller)
         G_reader_settings:delSetting(ges_mode)
     end
     --custom multiswipes
-    for k, v in pairs(custom_multiswipes_table) do
-        local multiswipe = "multiswipe_" .. caller:safeMultiswipeName(v)
-        caller.settings_data.data.custom_multiswipes[multiswipe] = true
+    if custom_multiswipes_table then
+        for k, v in pairs(custom_multiswipes_table) do
+            local multiswipe = "multiswipe_" .. caller:safeMultiswipeName(v)
+            caller.settings_data.data.custom_multiswipes[multiswipe] = true
+        end
     end
     caller.settings_data:flush()
     G_reader_settings:saveSetting("gestures_migrated", true)


### PR DESCRIPTION
issue found by @poire-z https://github.com/koreader/koreader/pull/6441#issuecomment-666466047

when a user never set any custom multiswipes there is no file `multiswipes.lua` leading to `custom_multiswipes_table` being nil and pairs fails.

since it happens after the rest of the migration, the migration is successful and when the user reloads gestures (via restart or switching FR/reader) it works fine.

@poire-z 
To confirm this is what you issue was you should have a line in you crash.log from when you migrated:
```lua
ERROR Failed to initialize gestures plugin:  plugins/gestures.koplugin/migration.lua:189: bad argument #1 to 'pairs' (table expected, got nil)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6467)
<!-- Reviewable:end -->
