### PR TITLE
Dispatcher Gestures Profiles: only flush settings when changed

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -338,7 +338,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                         else
                             location[settings][k] = true
                         end
-                        caller._updated = true
+                        caller.updated = true
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                    end,
                    separator = settingsList[k].separator,
@@ -367,7 +367,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                                     location[settings] = {}
                                 end
                                 location[settings][k] = spin.value
-                                caller._updated = true
+                                caller.updated = true
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -378,7 +378,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
-                            caller._updated = true
+                            caller.updated = true
                         end
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,
@@ -410,7 +410,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                                     location[settings] = {}
                                 end
                                 location[settings][k] = spin.value
-                                caller._updated = true
+                                caller.updated = true
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -421,7 +421,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
-                            caller._updated = true
+                            caller.updated = true
                         end
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
@@ -444,7 +444,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                                 location[settings] = {}
                             end
                             location[settings][k] = settingsList[k].args[i]
-                            caller._updated = true
+                            caller.updated = true
                         end,
                     })
                 end
@@ -460,7 +460,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
-                            caller._updated = true
+                            caller.updated = true
                         end
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
@@ -476,7 +476,7 @@ end
 --[[--
 Add a submenu to edit which items are dispatched
 arguments are:
-    1) the caller so dispatcher can set the _updated flag
+    1) the caller so dispatcher can set the updated flag
     2) the table representing the submenu (can be empty)
     3) the object (table) in which the settings table is found
     4) the name of the settings table
@@ -493,7 +493,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         end,
         callback = function(touchmenu_instance)
             location[settings] = {}
-            caller._updated = true
+            caller.updated = true
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })
@@ -522,7 +522,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
                     for k, _ in pairs(location[settings]) do
                         if settingsList[k][section[1]] == true then
                             location[settings][k] = nil
-                            caller._updated = true
+                            caller.updated = true
                         end
                     end
                     if touchmenu_instance then touchmenu_instance:updateItems() end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -318,7 +318,7 @@ function Dispatcher:getNameFromItem(item, location, settings)
     return T(settingsList[item].title, amount)
 end
 
-function Dispatcher:addItem(menu, location, settings, section)
+function Dispatcher:addItem(caller, menu, location, settings, section)
     for _, k in ipairs(dispatcher_menu_order) do
         if settingsList[k][section] == true and
             (settingsList[k].condition == nil or settingsList[k].condition)
@@ -338,7 +338,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                         else
                             location[settings][k] = true
                         end
-                        location._updated = true
+                        caller._updated = true
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                    end,
                    separator = settingsList[k].separator,
@@ -367,7 +367,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                                     location[settings] = {}
                                 end
                                 location[settings][k] = spin.value
-                                location._updated = true
+                                caller._updated = true
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -378,7 +378,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
-                            location._updated = true
+                            caller._updated = true
                         end
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,
@@ -410,7 +410,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                                     location[settings] = {}
                                 end
                                 location[settings][k] = spin.value
-                                location._updated = true
+                                caller._updated = true
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -421,7 +421,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
-                            location._updated = true
+                            caller._updated = true
                         end
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
@@ -444,7 +444,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                                 location[settings] = {}
                             end
                             location[settings][k] = settingsList[k].args[i]
-                            location._updated = true
+                            caller._updated = true
                         end,
                     })
                 end
@@ -460,7 +460,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
-                            location._updated = true
+                            caller._updated = true
                         end
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
@@ -476,13 +476,14 @@ end
 --[[--
 Add a submenu to edit which items are dispatched
 arguments are:
-    1) the table representing the submenu (can be empty)
-    2) the object (table) in which the settings table is found
-    3) the name of the settings table
+    1) the caller so dispatcher can set the _updated flag
+    2) the table representing the submenu (can be empty)
+    3) the object (table) in which the settings table is found
+    4) the name of the settings table
 example usage:
-    Dispatcher.addSubMenu(sub_items, self.data, "profile1")
+    Dispatcher.addSubMenu(self, sub_items, self.data, "profile1")
 --]]--
-function Dispatcher:addSubMenu(menu, location, settings)
+function Dispatcher:addSubMenu(caller, menu, location, settings)
     if not Dispatcher.initialized then Dispatcher:init() end
     table.insert(menu, {
         text = _("Nothing"),
@@ -492,7 +493,7 @@ function Dispatcher:addSubMenu(menu, location, settings)
         end,
         callback = function(touchmenu_instance)
             location[settings] = {}
-            location._updated = true
+            caller._updated = true
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })
@@ -504,8 +505,7 @@ function Dispatcher:addSubMenu(menu, location, settings)
     }
     for _, section in ipairs(section_list) do
         local submenu = {}
-        -- pass caller's context
-        Dispatcher:addItem(submenu, location, settings, section[1])
+        Dispatcher:addItem(caller, submenu, location, settings, section[1])
         table.insert(menu, {
             text = section[2],
             checked_func = function()
@@ -522,7 +522,7 @@ function Dispatcher:addSubMenu(menu, location, settings)
                     for k, _ in pairs(location[settings]) do
                         if settingsList[k][section[1]] == true then
                             location[settings][k] = nil
-                            location._updated = true
+                            caller._updated = true
                         end
                     end
                     if touchmenu_instance then touchmenu_instance:updateItems() end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -338,6 +338,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                         else
                             location[settings][k] = true
                         end
+                        location._updated = true
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                    end,
                    separator = settingsList[k].separator,
@@ -366,6 +367,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                                     location[settings] = {}
                                 end
                                 location[settings][k] = spin.value
+                                location._updated = true
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -376,6 +378,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
+                            location._updated = true
                         end
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,
@@ -407,6 +410,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                                     location[settings] = {}
                                 end
                                 location[settings][k] = spin.value
+                                location._updated = true
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -417,6 +421,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
+                            location._updated = true
                         end
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
@@ -439,6 +444,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                                 location[settings] = {}
                             end
                             location[settings][k] = settingsList[k].args[i]
+                            location._updated = true
                         end,
                     })
                 end
@@ -454,6 +460,7 @@ function Dispatcher:addItem(menu, location, settings, section)
                     hold_callback = function(touchmenu_instance)
                         if location[settings] ~= nil and location[settings][k] ~= nil then
                             location[settings][k] = nil
+                            location._updated = true
                         end
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
@@ -485,6 +492,7 @@ function Dispatcher:addSubMenu(menu, location, settings)
         end,
         callback = function(touchmenu_instance)
             location[settings] = {}
+            location._updated = true
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })
@@ -514,6 +522,7 @@ function Dispatcher:addSubMenu(menu, location, settings)
                     for k, _ in pairs(location[settings]) do
                         if settingsList[k][section[1]] == true then
                             location[settings][k] = nil
+                            location._updated = true
                         end
                     end
                     if touchmenu_instance then touchmenu_instance:updateItems() end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -27,7 +27,7 @@ local Gestures = InputContainer:new{
     gestures = nil,
     defaults = nil,
     custom_multiswipes = nil,
-    _updated = false,
+    updated = false,
 }
 local gestures_path = FFIUtil.joinPath(DataStorage:getSettingsDir(), "gestures.lua")
 
@@ -167,7 +167,7 @@ function Gestures:init()
             end
         end
         if reset then
-            self._updated = true
+            self.updated = true
             logger.info("UI language direction changed: resetting some gestures to direction default")
         end
         G_reader_settings:flipNilOrFalse(ges_dir_setting)
@@ -208,7 +208,7 @@ function Gestures:genMenu(ges)
             end,
             callback = function()
                 self.gestures[ges] = util.tableDeepCopy(self.defaults[ges])
-                self._updated = true
+                self.updated = true
             end,
         })
     end
@@ -221,7 +221,7 @@ function Gestures:genMenu(ges)
         end,
         callback = function()
             self.gestures[ges] = nil
-            self._updated = true
+            self.updated = true
         end,
     })
     Dispatcher:addSubMenu(self, sub_items, self.gestures, ges)
@@ -346,7 +346,7 @@ function Gestures:multiswipeRecorder(touchmenu_instance)
                         end
 
                         self.custom_multiswipes[recorded_multiswipe] = true
-                        self._updated = true
+                        self.updated = true
                         --touchmenu_instance.item_table = self:genMultiswipeMenu()
                         -- We need to update touchmenu_instance.item_table in-place for the upper
                         -- menu to have it updated too
@@ -408,7 +408,7 @@ function Gestures:genCustomMultiswipeSubmenu()
                     -- remove any settings for the muliswipe
                     self.settings_data.data["gesture_fm"][item] = nil
                     self.settings_data.data["gesture_reader"][item] = nil
-                    self._updated = true
+                    self.updated = true
 
                     --touchmenu_instance.item_table = self:genMultiswipeMenu()
                     -- We need to update touchmenu_instance.item_table in-place for the upper
@@ -1034,9 +1034,9 @@ function Gestures:onIgnoreHoldCorners(ignore_hold_corners)
 end
 
 function Gestures:onFlushSettings()
-    if self.settings_data and self._updated then
+    if self.settings_data and self.updated then
         self.settings_data:flush()
-        self._updated = false
+        self.updated = false
     end
 end
 

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -27,7 +27,7 @@ local Gestures = InputContainer:new{
     gestures = nil,
     defaults = nil,
     custom_multiswipes = nil,
-    _updated = nil,
+    _updated = false,
 }
 local gestures_path = FFIUtil.joinPath(DataStorage:getSettingsDir(), "gestures.lua")
 
@@ -224,7 +224,7 @@ function Gestures:genMenu(ges)
             self._updated = true
         end,
     })
-    Dispatcher:addSubMenu(sub_items, self.gestures, ges)
+    Dispatcher:addSubMenu(self, sub_items, self.gestures, ges)
     return sub_items
 end
 
@@ -1034,15 +1034,9 @@ function Gestures:onIgnoreHoldCorners(ignore_hold_corners)
 end
 
 function Gestures:onFlushSettings()
-    if self.settings_data then
-        if self.gestures._updated then
-            self._updated = true
-            self.gestures._updated = nil
-        end
-        if self._updated then
-            self.settings_data:flush()
-            self._updated = nil
-        end
+    if self.settings_data and self._updated then
+        self.settings_data:flush()
+        self._updated = false
     end
 end
 

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -15,7 +15,7 @@ local Profiles = WidgetContainer:new{
     profiles_file = DataStorage:getSettingsDir() .. "/profiles.lua",
     profiles = nil,
     data = nil,
-    _updated = false,
+    updated = false,
 }
 
 function Profiles:init()
@@ -31,9 +31,9 @@ function Profiles:loadProfiles()
 end
 
 function Profiles:onFlushSettings()
-    if self.profiles and self._updated then
+    if self.profiles and self.updated then
         self.profiles:flush()
-        self._updated = false
+        self.updated = false
     end
 end
 
@@ -122,7 +122,7 @@ end
 function Profiles:newProfile(name)
     if self.data[name] == nil then
         self.data[name] = {}
-        self._updated = true
+        self.updated = true
         return true
     else
         return false
@@ -131,7 +131,7 @@ end
 
 function Profiles:deleteProfile(name)
     self.data[name] = nil
-    self._updated = true
+    self.updated = true
 end
 
 return Profiles

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -31,7 +31,10 @@ end
 
 function Profiles:onFlushSettings()
     if self.profiles then
-        self.profiles:flush()
+        if self.data._updated then
+            self.profiles:flush()
+            self.data._updated = nil
+        end
     end
 end
 
@@ -87,32 +90,34 @@ function Profiles:getSubMenuItems()
         }
     }
     for k,v in orderedPairs(self.data) do
-        local sub_items = {
-            {
-                text = _("Delete profile"),
-                keep_menu_open = false,
-                separator = true,
-                callback = function()
-                    UIManager:show(ConfirmBox:new{
-                        text = _("Do you want to delete this profile?"),
-                        ok_text = _("Yes"),
-                        cancel_text = _("No"),
-                        ok_callback = function()
-                            self:deleteProfile(k)
-                        end,
-                    })
-                end,
+        if k ~= "_updated" then
+            local sub_items = {
+                {
+                    text = _("Delete profile"),
+                    keep_menu_open = false,
+                    separator = true,
+                    callback = function()
+                        UIManager:show(ConfirmBox:new{
+                            text = _("Do you want to delete this profile?"),
+                            ok_text = _("Yes"),
+                            cancel_text = _("No"),
+                            ok_callback = function()
+                                self:deleteProfile(k)
+                            end,
+                        })
+                    end,
+                }
             }
-        }
-        Dispatcher:addSubMenu(sub_items, self.data, k)
-        table.insert(sub_item_table, {
-            text = k,
-            hold_keep_menu_open = false,
-            sub_item_table = sub_items,
-            hold_callback = function()
-                Dispatcher:execute(self.ui, self.data[k])
-            end,
-        })
+            Dispatcher:addSubMenu(sub_items, self.data, k)
+            table.insert(sub_item_table, {
+                text = k,
+                hold_keep_menu_open = false,
+                sub_item_table = sub_items,
+                hold_callback = function()
+                    Dispatcher:execute(self.ui, self.data[k])
+                end,
+            })
+        end
     end
     return sub_item_table
 end
@@ -120,6 +125,7 @@ end
 function Profiles:newProfile(name)
     if self.data[name] == nil then
         self.data[name] = {}
+        self.data._updated = true
         return true
     else
         return false
@@ -128,6 +134,7 @@ end
 
 function Profiles:deleteProfile(name)
     self.data[name] = nil
+    self.data._updated = true
 end
 
 return Profiles


### PR DESCRIPTION
Should work, did not fully test every corner case.

one side effect, this invalidates a profile named `_updated`. it will fail to be created. (if a user had such a profile they will see very weird behavior)

based on @poire-z idea in https://github.com/koreader/koreader/pull/6441#issuecomment-668220743

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6471)
<!-- Reviewable:end -->
