### PR TITLE
PocketBook: Improve existing and add new device definitions

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -211,7 +211,6 @@ local PocketBook515 = PocketBook:new{
     model = "PB515",
     display_dpi = 200,
     isTouchDevice = no,
-    hasWifiToggle = no,
     hasDPad = yes,
     hasFewKeys = yes,
 }
@@ -221,7 +220,6 @@ local PocketBook611 = PocketBook:new{
     model = "PB611",
     display_dpi = 167,
     isTouchDevice = no,
-    hasWifiToggle = no,
     hasFrontlight = no,
     hasDPad = yes,
     hasFewKeys = yes,
@@ -243,7 +241,6 @@ local PocketBook614W = PocketBook:new{
     model = "PB614W",
     display_dpi = 167,
     isTouchDevice = no,
-    hasWifiToggle = no,
     hasFrontlight = no,
     hasDPad = yes,
     hasFewKeys = yes,
@@ -254,8 +251,6 @@ local PocketBook615 = PocketBook:new{
     model = "PBBLux",
     display_dpi = 212,
     isTouchDevice = no,
-    hasWifiToggle = no,
-    hasFrontlight = yes,
     hasDPad = yes,
     hasFewKeys = yes,
 }
@@ -265,8 +260,6 @@ local PocketBook616 = PocketBook:new{
     model = "PBBLux2",
     display_dpi = 212,
     isTouchDevice = no,
-    hasWifiToggle = no,
-    hasFrontlight = yes,
     hasDPad = yes,
     hasFewKeys = yes,
 }
@@ -275,7 +268,6 @@ local PocketBook616 = PocketBook:new{
 local PocketBook622 = PocketBook:new{
     model = "PBTouch",
     display_dpi = 167,
-    isTouchDevice = yes,
     hasFrontlight = no,
 }
 
@@ -283,15 +275,12 @@ local PocketBook622 = PocketBook:new{
 local PocketBook623 = PocketBook:new{
     model = "PBTouchLux",
     display_dpi = 212,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Basic Touch (624)
 local PocketBook624 = PocketBook:new{
     model = "PBBasicTouch",
     display_dpi = 167,
-    isTouchDevice = yes,
     hasFrontlight = no,
 }
 
@@ -299,7 +288,6 @@ local PocketBook624 = PocketBook:new{
 local PocketBook625 = PocketBook:new{
     model = "PBBasicTouch2",
     display_dpi = 167,
-    isTouchDevice = yes,
     hasFrontlight = no,
 }
 
@@ -307,16 +295,12 @@ local PocketBook625 = PocketBook:new{
 local PocketBook626 = PocketBook:new{
     model = "PBLux3",
     display_dpi = 212,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Touch Lux 4 (627)
 local PocketBook627 = PocketBook:new{
     model = "PBLux4",
     display_dpi = 212,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Touch Lux 5 (628)
@@ -324,24 +308,18 @@ local PocketBook628 = PocketBook:new{
     model = "PBTouchLux5",
     display_dpi = 212,
     isAlwaysPortrait = yes,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Sense / Sense 2 (630)
 local PocketBook630 = PocketBook:new{
     model = "PBSense",
     display_dpi = 212,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Touch HD / Touch HD 2 (631)
 local PocketBook631 = PocketBook:new{
     model = "PBTouchHD",
     display_dpi = 300,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Touch HD Plus / Touch HD 3 (632)
@@ -349,40 +327,31 @@ local PocketBook632 = PocketBook:new{
     model = "PBTouchHDPlus",
     display_dpi = 300,
     isAlwaysPortrait = yes,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Color (633)
 local PocketBook633 = PocketBook:new{
     model = "PBColor",
     display_dpi = 300,
-    isTouchDevice = yes,
     hasColorScreen = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Aqua (640)
 local PocketBook640 = PocketBook:new{
     model = "PBAqua"
     display_dpi = 167,
-    isTouchDevice = yes,
 }
 
 -- PocketBook Aqua 2 (641)
 local PocketBook641 = PocketBook:new{
     model = "PBAqua2",
     display_dpi = 212,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Ultra (650)
 local PocketBook650 = PocketBook:new{
     model = "PBUltra",
     display_dpi = 212,
-    isTouchDevice = yes,
-    hasFrontlight = yes
 }
 
 -- PocketBook InkPad 3 (740)
@@ -390,8 +359,7 @@ local PocketBook740 = PocketBook:new{
     model = "PBInkPad3",
     display_dpi = 300,
     isAlwaysPortrait = yes,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
+    hasGSensor = yes,
 }
 
 -- PocketBook InkPad 3 Pro (740_2)
@@ -399,8 +367,7 @@ local PocketBook740_2 = PocketBook:new{
     model = "PBInkPad3Pro",
     display_dpi = 300,
     isAlwaysPortrait = yes,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
+    hasGSensor = yes,
 }
 
 -- PocketBook Color Lux (801)
@@ -408,9 +375,7 @@ local PocketBookColorLux = PocketBook:new{
     model = "PBColorLux",
     display_dpi = 125,
     isAlwaysPortrait = yes,
-    isTouchDevice = yes,
     hasColorScreen = yes,
-    hasFrontlight = yes,
     has3BytesWideFrameBuffer = yes,
     canUseCBB = no, -- 24bpp
 }
@@ -419,8 +384,6 @@ local PocketBookColorLux = PocketBook:new{
 local PocketBook840 = PocketBook:new{
     model = "PBInkPad",
     display_dpi = 250,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook InkPad X (1040)
@@ -428,8 +391,7 @@ local PocketBook1040 = PocketBook:new{
     model = "PB1040",
     display_dpi = 227,
     isAlwaysPortrait = yes,
-    isTouchDevice = yes,
-    hasFrontlight = yes,
+    hasGSensor = yes,
 }
 
 logger.info('SoftwareVersion: ', PocketBook:getSoftwareVersion())

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -338,7 +338,7 @@ local PocketBook633 = PocketBook:new{
 
 -- PocketBook Aqua (640)
 local PocketBook640 = PocketBook:new{
-    model = "PBAqua"
+    model = "PBAqua",
     display_dpi = 167,
 }
 
@@ -359,7 +359,6 @@ local PocketBook740 = PocketBook:new{
     model = "PBInkPad3",
     display_dpi = 300,
     isAlwaysPortrait = yes,
-    hasGSensor = yes,
 }
 
 -- PocketBook InkPad 3 Pro (740_2)
@@ -367,7 +366,6 @@ local PocketBook740_2 = PocketBook:new{
     model = "PBInkPad3Pro",
     display_dpi = 300,
     isAlwaysPortrait = yes,
-    hasGSensor = yes,
 }
 
 -- PocketBook Color Lux (801)
@@ -391,7 +389,6 @@ local PocketBook1040 = PocketBook:new{
     model = "PB1040",
     display_dpi = 227,
     isAlwaysPortrait = yes,
-    hasGSensor = yes,
 }
 
 logger.info('SoftwareVersion: ', PocketBook:getSoftwareVersion())

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -334,6 +334,8 @@ local PocketBook633 = PocketBook:new{
     model = "PBColor",
     display_dpi = 300,
     hasColorScreen = yes,
+    has3BytesWideFrameBuffer = yes,
+    canUseCBB = no, -- 24bpp
 }
 
 -- PocketBook Aqua (640)
@@ -372,7 +374,6 @@ local PocketBook740_2 = PocketBook:new{
 local PocketBookColorLux = PocketBook:new{
     model = "PBColorLux",
     display_dpi = 125,
-    isAlwaysPortrait = yes,
     hasColorScreen = yes,
     has3BytesWideFrameBuffer = yes,
     canUseCBB = no, -- 24bpp
@@ -401,11 +402,9 @@ elseif codename == "PocketBook 611" then
     return PocketBook611
 elseif codename == "PocketBook 613" then
     return PocketBook613
-elseif codename == "PocketBook 614W" or
-    codename == "PocketBook 614" then
+elseif codename == "PocketBook 614W" or codename == "PocketBook 614" then
     return PocketBook614W
-elseif codename == "PocketBook 615" or
-    codename == "PB615" then
+elseif codename == "PocketBook 615" or codename == "PB615" then
     return PocketBook615
 elseif codename == "PB616W" or
     codename == "PocketBook 616" then
@@ -427,8 +426,7 @@ elseif codename == "PB628" then
     return PocketBook628
 elseif codename == "PocketBook 630" then
     return PocketBook630
-elseif codename == "PB631" or
-    codename == "PocketBook 631" then
+elseif codename == "PB631" or codename == "PocketBook 631" then
     return PocketBook631
 elseif codename == "PB632" then
     return PocketBook632

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -206,13 +206,7 @@ function PocketBook:getDeviceModel()
     return ffi.string(inkview.GetDeviceModel())
 end
 
--- PocketBook InkPad
-local PocketBook840 = PocketBook:new{
-    model = "PBInkPad",
-    display_dpi = 250,
-}
-
--- PocketBook 515
+-- PocketBook Mini (515)
 local PocketBook515 = PocketBook:new{
     model = "PB515",
     display_dpi = 200,
@@ -222,17 +216,29 @@ local PocketBook515 = PocketBook:new{
     hasFewKeys = yes,
 }
 
--- PocketBoot 613 Basic
+-- PocketBook Basic (611)
+local PocketBook611 = PocketBook:new{
+    model = "PB611",
+    display_dpi = 167,
+    isTouchDevice = no,
+    hasWifiToggle = no,
+    hasFrontlight = no,
+    hasDPad = yes,
+    hasFewKeys = yes,
+}
+
+-- PocketBook Basic (613)
 local PocketBook613 = PocketBook:new{
     model = "PB613B",
     display_dpi = 167,
     isTouchDevice = no,
     hasWifiToggle = no,
+    hasFrontlight = no,
     hasDPad = yes,
     hasFewKeys = yes,
 }
 
--- PocketBook 614W Basic
+-- PocketBook Basic 2 / Basic 3 (614/614W)
 local PocketBook614W = PocketBook:new{
     model = "PB614W",
     display_dpi = 167,
@@ -243,107 +249,187 @@ local PocketBook614W = PocketBook:new{
     hasFewKeys = yes,
 }
 
--- PocketBook Basic Lux 2
+-- PocketBook Basic Lux (615)
+local PocketBook615 = PocketBook:new{
+    model = "PBBLux",
+    display_dpi = 212,
+    isTouchDevice = no,
+    hasWifiToggle = no,
+    hasFrontlight = yes,
+    hasDPad = yes,
+    hasFewKeys = yes,
+}
+
+-- PocketBook Basic Lux 2 (616)
 local PocketBook616 = PocketBook:new{
     model = "PBBLux2",
     display_dpi = 212,
     isTouchDevice = no,
     hasWifiToggle = no,
+    hasFrontlight = yes,
     hasDPad = yes,
     hasFewKeys = yes,
 }
 
--- PocketBook Lux 4
+-- PocketBook Touch (622)
+local PocketBook622 = PocketBook:new{
+    model = "PBTouch",
+    display_dpi = 167,
+    isTouchDevice = yes,
+    hasFrontlight = no,
+}
+
+-- PocketBook Touch Lux (623)
+local PocketBook623 = PocketBook:new{
+    model = "PBTouchLux",
+    display_dpi = 212,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+}
+
+-- PocketBook Basic Touch (624)
+local PocketBook624 = PocketBook:new{
+    model = "PBBasicTouch",
+    display_dpi = 167,
+    isTouchDevice = yes,
+    hasFrontlight = no,
+}
+
+-- PocketBook Basic Touch 2 (625)
+local PocketBook625 = PocketBook:new{
+    model = "PBBasicTouch2",
+    display_dpi = 167,
+    isTouchDevice = yes,
+    hasFrontlight = no,
+}
+
+-- PocketBook Touch Lux 2 / Touch Lux 3 (626)
+local PocketBook626 = PocketBook:new{
+    model = "PBLux3",
+    display_dpi = 212,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+}
+
+-- PocketBook Touch Lux 4 (627)
 local PocketBook627 = PocketBook:new{
     model = "PBLux4",
     display_dpi = 212,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
 }
 
--- PocketBook Touch HD
+-- PocketBook Touch Lux 5 (628)
+local PocketBook628 = PocketBook:new{
+    model = "PBTouchLux5",
+    display_dpi = 212,
+    isAlwaysPortrait = yes,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+}
+
+-- PocketBook Sense / Sense 2 (630)
+local PocketBook630 = PocketBook:new{
+    model = "PBSense",
+    display_dpi = 212,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+}
+
+-- PocketBook Touch HD / Touch HD 2 (631)
 local PocketBook631 = PocketBook:new{
     model = "PBTouchHD",
     display_dpi = 300,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
 }
 
--- PocketBook Touch HD Plus
+-- PocketBook Touch HD Plus / Touch HD 3 (632)
 local PocketBook632 = PocketBook:new{
     model = "PBTouchHDPlus",
     display_dpi = 300,
     isAlwaysPortrait = yes,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
 }
 
--- PocketBook Lux 3
-local PocketBook626 = PocketBook:new{
-    model = "PBLux3",
-    display_dpi = 212,
-}
-
--- PocketBook Basic Touch
-local PocketBook624 = PocketBook:new{
-    model = "PBBasicTouch",
-    hasFrontlight = no,
-    display_dpi = 166,
-}
-
--- PocketBook Basic Touch 2
-local PocketBook625 = PocketBook:new{
-    model = "PBBasicTouch2",
-    hasFrontlight = no,
-    display_dpi = 166,
-}
-
--- PocketBook Touch
-local PocketBook622 = PocketBook:new{
-    model = "PBTouch",
-    hasFrontlight = no,
-    display_dpi = 166,
-}
-
--- PocketBook Touch Lux
-local PocketBook623 = PocketBook:new{
-    model = "PBTouchLux",
-    display_dpi = 212,
-}
-
--- PocketBook InkPad 3
-local PocketBook740 = PocketBook:new{
-    model = "PBInkPad3",
-    isAlwaysPortrait = yes,
+-- PocketBook Color (633)
+local PocketBook633 = PocketBook:new{
+    model = "PBColor",
     display_dpi = 300,
+    isTouchDevice = yes,
+    hasColorScreen = yes,
+    hasFrontlight = yes,
 }
 
--- PocketBook InkPad 3 Pro
-local PocketBook740_2 = PocketBook:new{
-    model = "PBInkPad3Pro",
-    isAlwaysPortrait = yes,
-    display_dpi = 300,
+-- PocketBook Aqua (640)
+local PocketBook640 = PocketBook:new{
+    model = "PBAqua"
+    display_dpi = 167,
+    isTouchDevice = yes,
 }
 
--- PocketBook InkPad X
-local PocketBook1040 = PocketBook:new{
-    model = "PB1040",
-    isAlwaysPortrait = yes,
-    display_dpi = 227,
-}
-
--- PocketBook Sense
-local PocketBook630 = PocketBook:new{
-    model = "PBSense",
-    display_dpi = 212,
-}
-
--- PocketBook Aqua 2
+-- PocketBook Aqua 2 (641)
 local PocketBook641 = PocketBook:new{
     model = "PBAqua2",
     display_dpi = 212,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
 }
 
--- PocketBook Color Lux
+-- PocketBook Ultra (650)
+local PocketBook650 = PocketBook:new{
+    model = "PBUltra",
+    display_dpi = 212,
+    isTouchDevice = yes,
+    hasFrontlight = yes
+}
+
+-- PocketBook InkPad 3 (740)
+local PocketBook740 = PocketBook:new{
+    model = "PBInkPad3",
+    display_dpi = 300,
+    isAlwaysPortrait = yes,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+}
+
+-- PocketBook InkPad 3 Pro (740_2)
+local PocketBook740_2 = PocketBook:new{
+    model = "PBInkPad3Pro",
+    display_dpi = 300,
+    isAlwaysPortrait = yes,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+}
+
+-- PocketBook Color Lux (801)
 local PocketBookColorLux = PocketBook:new{
     model = "PBColorLux",
+    display_dpi = 125,
+    isAlwaysPortrait = yes,
+    isTouchDevice = yes,
     hasColorScreen = yes,
+    hasFrontlight = yes,
     has3BytesWideFrameBuffer = yes,
     canUseCBB = no, -- 24bpp
+}
+
+-- PocketBook InkPad / InkPad 2 (840)
+local PocketBook840 = PocketBook:new{
+    model = "PBInkPad",
+    display_dpi = 250,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+}
+
+-- PocketBook InkPad X (1040)
+local PocketBook1040 = PocketBook:new{
+    model = "PB1040",
+    display_dpi = 227,
+    isAlwaysPortrait = yes,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
 }
 
 logger.info('SoftwareVersion: ', PocketBook:getSoftwareVersion())
@@ -352,10 +438,16 @@ local codename = PocketBook:getDeviceModel()
 
 if codename == "PocketBook 515" then
     return PocketBook515
+elseif codename == "PocketBook 611" then
+    return PocketBook611
 elseif codename == "PocketBook 613" then
     return PocketBook613
-elseif codename == "PocketBook 614W" then
+elseif codename == "PocketBook 614W" or
+    codename == "PocketBook 614" then
     return PocketBook614W
+elseif codename == "PocketBook 615" or
+    codename == "PB615" then
+    return PocketBook615
 elseif codename == "PB616W" or
     codename == "PocketBook 616" then
     return PocketBook616
@@ -372,22 +464,31 @@ elseif codename == "PB626" or codename == "PB626(2)-TL3" or
     return PocketBook626
 elseif codename == "PB627" then
     return PocketBook627
+elseif codename == "PB628" then
+    return PocketBook628
 elseif codename == "PocketBook 630" then
     return PocketBook630
-elseif codename == "PB631" then
+elseif codename == "PB631" or
+    codename == "PocketBook 631" then
     return PocketBook631
 elseif codename == "PB632" then
     return PocketBook632
+elseif codename == "PB633" then
+    return PocketBook633
+elseif codename == "PB640" then
+    return PocketBook640
 elseif codename == "PB641" then
     return PocketBook641
+elseif codename == "PB650" then
+    return PocketBook650
 elseif codename == "PB740" then
     return PocketBook740
 elseif codename == "PB740-2" then
     return PocketBook740_2
-elseif codename == "PB1040" then
-    return PocketBook1040
 elseif codename == "PocketBook 840" then
     return PocketBook840
+elseif codename == "PB1040" then
+    return PocketBook1040
 elseif codename == "PocketBook Color Lux" then
     return PocketBookColorLux
 else


### PR DESCRIPTION
Proposed changes:
- [x] Added Pocketbook Basic 611 definition
- [x] Added PocketBook Basic Lux definition
- [x] Added PocketBook Touch Lux 5 definition (#6475)
- [x] Added PocketBook Color definition (#6479)
- [x] Added PocketBook Aqua definition
- [x] Added PocketBook Ultra definition
- [x] Rearranged devices based on their FW numbers.
- [x] Fixed device name comments.
- [x] Added more device settings and rearranged them across all devices.

Notes:
1. PocketBook Basic 611 runs on the v16 firmware that predates the current OS, so compatibility needs to be tested.
2. Codenames were created based on similarity. To get the true codenames, I'd need users with said devices to check a file available in all PocketBooks that lists the proper codename. Not sure how to otherwise find the proper codenames.
3. Several of the previously added devices actually cover more than 1 device that shares the same firmware, but their codenames might differ. This should be further explored.
4. None of these definitions were tested, as I don't have the devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6481)
<!-- Reviewable:end -->
