### PR TITLE
KOSync doesn't save "Auto sync now and future"

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -165,6 +165,7 @@ function KOSync:addToMainMenu(menu_items)
                         -- current progress now to avoid to lose it silently.
                         self:updateProgress(true)
                     end
+                    self:saveSettings()
                 end,
             },
             {


### PR DESCRIPTION
Currently you can toggle it, but it doesn't persist after restart. This should fix this and prevent any more "lags"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6488)
<!-- Reviewable:end -->
