### PR TITLE
Support for Apache WebDAV module

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -98,17 +98,11 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
         return nil
     end
 
-    local res = table.concat(sink)
-    --[[
-    Apache Webserver WebDAV mod_dav module adds this fragment to the XML tags
-    It also uses upper casing for the XML tags, amongst other things, which we
-    deal with in the pattern matching that follows
-    --]]
-    local res_data = res:gsub(' xmlns:lp1="DAV:"','')
+    local res_data = table.concat(sink)
 
     if res_data ~= "" then
         -- iterate through the <d:response> tags, each containing an entry
-        for item in res_data:gmatch("<[dD]:response>(.-)</[dD]:response>") do
+        for item in res_data:gmatch("<[^:]*:response[^>]*>(.-)</[^:]*:response>") do
             --logger.dbg("WebDav catalog item=", item)
             -- <d:href> is the path and filename of the entry.
             local item_fullpath = item:match("<[dD]:href>(.*)</[dD]:href>")
@@ -127,7 +121,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
                         type = "folder",
                     })
                 end
-            elseif item:find("<[dDlp1]+:resourcetype/>") and (DocumentRegistry:hasProvider(item_name)
+            elseif item:find("<[^:]*:resourcetype/>") and (DocumentRegistry:hasProvider(item_name)
                 or G_reader_settings:isTrue("show_unsupported")) then
                 table.insert(webdav_file, {
                     text = item_name,

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -105,14 +105,14 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
         for item in res_data:gmatch("<[^:]*:response[^>]*>(.-)</[^:]*:response>") do
             --logger.dbg("WebDav catalog item=", item)
             -- <d:href> is the path and filename of the entry.
-            local item_fullpath = item:match("<[dD]:href>(.*)</[dD]:href>")
+            local item_fullpath = item:match("<[^:]*:href[^>]*>(.*)</[^:]*:href>")
             if string.sub( item_fullpath, -1 ) == "/" then
                 item_fullpath = string.sub( item_fullpath, 1, -2 )
             end
             local is_current_dir = self:isCurrentDirectory( item_fullpath, address, path )
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
             local item_path = path .. "/" .. item_name
-            if item:find("<[dD]:collection/>") then
+            if item:find("<[^:]*:collection/>") then
                 item_name = item_name .. "/"
                 if not is_current_dir then
                     table.insert(webdav_list, {

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -99,7 +99,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
     end
 
     local res = table.concat(sink)
-    --[[ 
+    --[[
     Apache Webserver WebDAV mod_dav module adds this fragment to the XML tags
     It also uses upper casing for the XML tags, amongst other things, which we
     deal with in the pattern matching that follows

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -59,7 +59,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
 
     local has_trailing_slash = false
     local has_leading_slash = false
-    if string.sub( address, -1 ) ~= "/" then has_trailing_slash = true end
+    if string.sub( address, -1 ) == "/" then has_trailing_slash = true end
     if path == nil or path == "/" then
         path = ""
     elseif string.sub( path, 1, 2 ) == "/" then
@@ -73,6 +73,9 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
         address = address .. "/"
     end
     local webdav_url = address .. path
+    if not has_trailing_slash then
+        webdav_url = webdav_url .. "/"
+    end
 
     local request, sink = {}, {}
     local parsed = url.parse(webdav_url)
@@ -95,20 +98,27 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
         return nil
     end
 
-    local res_data = table.concat(sink)
+    local res = table.concat(sink)
+    --[[ 
+    Apache Webserver WebDAV mod_dav module adds this fragment to the XML tags
+    It also uses upper casing for the XML tags, amongst other things, which we
+    deal with in the pattern matching that follows
+    --]]
+    local res_data = res:gsub(' xmlns:lp1="DAV:"','')
+
     if res_data ~= "" then
         -- iterate through the <d:response> tags, each containing an entry
-        for item in res_data:gmatch("<d:response>(.-)</d:response>") do
+        for item in res_data:gmatch("<[dD]:response>(.-)</[dD]:response>") do
             --logger.dbg("WebDav catalog item=", item)
             -- <d:href> is the path and filename of the entry.
-            local item_fullpath = item:match("<d:href>(.*)</d:href>")
+            local item_fullpath = item:match("<[dD]:href>(.*)</[dD]:href>")
             if string.sub( item_fullpath, -1 ) == "/" then
                 item_fullpath = string.sub( item_fullpath, 1, -2 )
             end
             local is_current_dir = self:isCurrentDirectory( item_fullpath, address, path )
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
             local item_path = path .. "/" .. item_name
-            if item:find("<d:collection/>") then
+            if item:find("<[dD]:collection/>") then
                 item_name = item_name .. "/"
                 if not is_current_dir then
                     table.insert(webdav_list, {
@@ -117,7 +127,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
                         type = "folder",
                     })
                 end
-            elseif item:find("<d:resourcetype/>") and (DocumentRegistry:hasProvider(item_name)
+            elseif item:find("<[dDlp1]+:resourcetype/>") and (DocumentRegistry:hasProvider(item_name)
                 or G_reader_settings:isTrue("show_unsupported")) then
                 table.insert(webdav_file, {
                     text = item_name,


### PR DESCRIPTION
This change to the parser in `cloudstorage.lua` adds support for the [Apache WebDAV module][1]

It was manually tested using the [bytemark/webdav][2] docker container.

I developed this in Windows, with a docker container that hosted an extracted AppImage and a VNC server that I viewed using a VNC client.

I will write up my work flow at a later point.

Changes have not been tested against other webdav servers (what was this originally tested against?). Please could someone test against other webdav servers?

I also noticed a logic inversion error where we were looking for a slash at the end of the URL and if it exists, then we explicitly set `has_trailing_slash=false` - so I fixed it to set to `true`. I had to do this so that we weren't visiting the URL without a trailing slash - apache sends back a 301 redirect with a `location` header with a trailing slash, if you don't put a trailing slash.

As a side note, I think we should consider replacing this regexp pattern matching parser with the [XML parser in the newsreader plugin][3]

Also, I've never used Lua before.

[1]: https://httpd.apache.org/docs/2.4/mod/mod_dav.html
[2]: https://github.com/BytemarkHosting/docker-webdav
[3]: https://github.com/koreader/koreader/blob/master/plugins/newsdownloader.koplugin/lib/xml.lua

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6510)
<!-- Reviewable:end -->
