### PR TITLE
Comics: zoom to panel

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -583,6 +583,21 @@ function ReaderHighlight:onPanelZoom(arg, ges)
     local hold_pos = self.view:screenToPageTransform(ges.pos)
     local res = self.ui.document:getPanelFromPage(hold_pos.page, ges)
     logger.dbg("result: ", res)
+    logger.dbg(hold_pos)
+    local image = self.ui.document:getImageFromPosition(self.hold_pos, true)
+
+    if rendered_page then
+        local img = rendered_page.bb:copy()
+        local ImageViewer = require("ui/widget/imageviewer")
+        local imgviewer = ImageViewer:new{
+            image = img,
+            -- title_text = _("Document embedded image"),
+            -- No title, more room for image
+            with_title_bar = false,
+            fullscreen = true,
+        }
+        UIManager:show(imgviewer)
+    end
     return true
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -620,7 +620,6 @@ end
 function ReaderHighlight:onTogglePanelZoomSetting(arg, ges)
     if not self.document.info.has_pages then return end
     self.panel_zoom_enabled = not self.panel_zoom_enabled
-    self:onSaveSettings()
 end
 
 function ReaderHighlight:onPanelZoom(arg, ges)
@@ -644,7 +643,7 @@ function ReaderHighlight:onPanelZoom(arg, ges)
 end
 
 function ReaderHighlight:onHold(arg, ges)
-    if self.panel_zoom_enabled and self.document.info.has_pages then
+    if self.document.info.has_pages and self.panel_zoom_enabled then
         return self:onPanelZoom(arg, ges)
     end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -99,10 +99,12 @@ function ReaderHighlight:addToMainMenu(menu_items)
         text = _("Highlighting"),
         sub_item_table = self:genHighlightDrawerMenu(),
     }
-    menu_items.panel_zoom_options = {
-        text = _("Panel zoom (manga/comic)"),
-        sub_item_table = self:genPanelZoomMenu(),
-    }
+    if self.document.info.has_pages then
+        menu_items.panel_zoom_options = {
+            text = _("Panel zoom (manga/comic)"),
+            sub_item_table = self:genPanelZoomMenu(),
+        }
+    end
     menu_items.translation_settings = Translator:genSettingsMenu()
 end
 
@@ -158,15 +160,21 @@ function ReaderHighlight:genPanelZoomMenu()
             checked_func = isPanelZoomEnabled,
             callback = function()
                 local toggled = not isPanelZoomEnabled()
-                G_reader_settings:saveSetting("panel_zoom_enabled", toggled)
+                DocSettings:saveSetting("panel_zoom_enabled", toggled)
+            end,
+            hold_callback = function()
+                local ext = util.getFileNameSuffix(self.ui.document.file)
+                local supported_ext = getPanelZoomSupportedExt()
+                supported_ext[ext] = not supported_ext[ext]
+                G_reader_settings:saveSetting("panel_zoom_ext", supported_ext)
             end,
             separator = true,
         },
-        genExtension("cbz"),
-        genExtension("cbt"),
-        genExtension("zip"),
-        genExtension("pdf"),
-        genExtension("djvu"),
+        -- genExtension("cbz"),
+        -- genExtension("cbt"),
+        -- genExtension("zip"),
+        -- genExtension("pdf"),
+        -- genExtension("djvu"),
     }
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -121,7 +121,7 @@ local function getPanelZoomSupportedExt()
     return G_reader_settings:readSetting("panel_zoom_ext") or default_supported_ext
 end
 
-local function isDocumentComicOrManga(file)
+local function isPanelZoomSupported(file)
     local filetype = util.getFileNameSuffix(file)
     local supported_filetypes = getPanelZoomSupportedExt()
     return supported_filetypes[filetype]
@@ -1374,7 +1374,7 @@ function ReaderHighlight:onReadSettings(config)
     if self.document.info.has_pages then
         self.panel_zoom_enabled = config:readSetting("panel_zoom_enabled")
         if self.panel_zoom_enabled == nil then
-            self.panel_zoom_enabled = isDocumentComicOrManga(self.ui.document.file)
+            self.panel_zoom_enabled = isPanelZoomSupported(self.ui.document.file)
         end
     end
 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -606,7 +606,6 @@ function ReaderHighlight:onHold(arg, ges)
 
     -- disable hold gesture if highlighting is disabled
     if self.view.highlight.disabled then return false end
-
     self:clear() -- clear previous highlight (delayed clear may not have done it yet)
     self.hold_ges_pos = ges.pos -- remember hold original gesture position
     self.hold_pos = self.view:screenToPageTransform(ges.pos)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -613,7 +613,7 @@ end
 
 local function isDocumentComicOrManga(file)
     local filetype = util.getFileNameSuffix(file)
-    return filetype == "cbz" or filetype == "djvu"
+    return filetype == "cbz" or filetype == "cbt" or filetype == "zip"
 end
 
 function ReaderHighlight:onHold(arg, ges)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -107,6 +107,10 @@ local highlight_style = {
     invert = _("Invert"),
 }
 
+local function isPanelZoomAllowed()
+    return G_reader_settings:nilOrTrue("panel_zoom_allowed")
+end
+
 function ReaderHighlight:genHighlightDrawerMenu()
     local get_highlight_style = function(style)
         return {
@@ -133,6 +137,17 @@ function ReaderHighlight:genHighlightDrawerMenu()
             end,
             hold_callback = function(touchmenu_instance)
                 self:toggleDefault()
+            end,
+            separator = true,
+        },
+        {
+            text = _("Allow panel zoom in manga/comic"),
+            checked_func = function()
+                return isPanelZoomAllowed()
+            end,
+            callback = function()
+                local toggled = not isPanelZoomAllowed()
+                G_reader_settings:saveSetting("panel_zoom_allowed", toggled)
             end,
             separator = true,
         },
@@ -596,10 +611,13 @@ function ReaderHighlight:onPanelZoom(arg, ges)
     return true
 end
 
+local function isDocumentComicOrManga(file)
+    local filetype = util.getFileNameSuffix(file)
+    return filetype == "cbz" or filetype == "djvu"
+end
+
 function ReaderHighlight:onHold(arg, ges)
-    -- if it's manga/comic, panel zoom
-    local filetype = util.getFileNameSuffix(self.ui.document.file)
-    if filetype == "cbz" or filetype == "djvu" then
+    if isDocumentComicOrManga(self.ui.document.file) and isPanelZoomAllowed() then
         self:onPanelZoom(arg, ges)
         return false
     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -603,7 +603,7 @@ end
 function ReaderHighlight:onHold(arg, ges)
     -- if it's manga/comic, panel zoom
     local filetype = util.getFileNameSuffix(self.ui.document.file)
-    if filetype == 'cbz' or filetype == 'djvu' then
+    if filetype == "cbz" or filetype == "djvu" then
         self:onPanelZoom(arg, ges)
         return false
     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -577,10 +577,12 @@ function ReaderHighlight:_resetHoldTimer(clear)
 end
 
 function ReaderHighlight:onPanelZoom(arg, ges)
-    -- @todo: add necessary checks
     self:clear()
+    -- if not pdf/cbz return
+    if not self.ui.document.info.has_pages then return false end
     local hold_ges_pos = ges.pos
     local hold_pos = self.view:screenToPageTransform(ges.pos)
+    if not hold_pos then return false end
     local rect = self.ui.document:getPanelFromPage(hold_pos.page, hold_pos)
     if not rect then return false end
     local image = self.ui.document:getPagePart(hold_pos.page, rect, 0)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1,7 +1,6 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local Device = require("device")
-local DocSettings = require("docsettings")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -580,7 +580,6 @@ function ReaderHighlight:onPanelZoom(arg, ges)
     self:clear()
     -- if not pdf/cbz return
     if not self.ui.document.info.has_pages then return false end
-    local hold_ges_pos = ges.pos
     local hold_pos = self.view:screenToPageTransform(ges.pos)
     if not hold_pos then return false end
     local rect = self.ui.document:getPanelFromPage(hold_pos.page, hold_pos)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -581,16 +581,15 @@ function ReaderHighlight:onPanelZoom(arg, ges)
     self:clear()
     local hold_ges_pos = ges.pos
     local hold_pos = self.view:screenToPageTransform(ges.pos)
-    local res = self.ui.document:getPanelFromPage(hold_pos.page, ges)
+    local rect = self.ui.document:getPanelFromPage(hold_pos.page, ges)
+    if not rect then return false end
     logger.dbg("result: ", res)
-    logger.dbg(hold_pos)
-    local image = self.ui.document:getImageFromPosition(self.hold_pos, true)
+    local image = self.ui.document:getPagePart(hold_pos.page, rect, 0)
 
-    if rendered_page then
-        local img = rendered_page.bb:copy()
+    if image then
         local ImageViewer = require("ui/widget/imageviewer")
         local imgviewer = ImageViewer:new{
-            image = img,
+            image = image,
             -- title_text = _("Document embedded image"),
             -- No title, more room for image
             with_title_bar = false,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -595,13 +595,21 @@ function ReaderHighlight:onPanelZoom(arg, ges)
         }
         UIManager:show(imgviewer)
     end
+    logger.dbg("File:", self.ui.document.file)
+    logger.dbg("Extension:", util.getFileNameSuffix(self.ui.document.file))
     return true
 end
 
 function ReaderHighlight:onHold(arg, ges)
+    -- if it's manga/comic, panel zoom
+    local filetype = util.getFileNameSuffix(self.ui.document.file)
+    if filetype == 'cbz' or filetype == 'djvu' then
+        self:onPanelZoom(arg, ges)
+        return false
+    end
+
     -- disable hold gesture if highlighting is disabled
     if self.view.highlight.disabled then
-        self:onPanelZoom(arg, ges)
         return false
     end
     self:clear() -- clear previous highlight (delayed clear may not have done it yet)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -577,11 +577,12 @@ function ReaderHighlight:_resetHoldTimer(clear)
 end
 
 function ReaderHighlight:onPanelZoom(arg, ges)
-    -- TODO: add necessary checks
+    -- @todo: add necessary checks
     self:clear()
     local hold_ges_pos = ges.pos
     local hold_pos = self.view:screenToPageTransform(ges.pos)
-    self.ui.document:getPanelFromPage(hold_pos.page, ges.pos)
+    local res = self.ui.document:getPanelFromPage(hold_pos.page, ges)
+    logger.dbg("result: ", res)
     return true
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -135,8 +135,7 @@ function ReaderHighlight:genPanelZoomMenu()
                 return self.panel_zoom_enabled
             end,
             callback = function()
-                self.panel_zoom_enabled = not self.panel_zoom_enabled
-                self:onSaveSettings()
+                self:onTogglePanelZoomSetting()
             end,
             hold_callback = function()
                 local ext = util.getFileNameSuffix(self.ui.document.file)
@@ -616,6 +615,11 @@ function ReaderHighlight:_resetHoldTimer(clear)
     else
         self.hold_last_tv = TimeVal.now()
     end
+end
+
+function ReaderHighlight:onTogglePanelZoomSetting(arg, ges)
+    self.panel_zoom_enabled = not self.panel_zoom_enabled
+    self:onSaveSettings()
 end
 
 function ReaderHighlight:onPanelZoom(arg, ges)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -576,9 +576,21 @@ function ReaderHighlight:_resetHoldTimer(clear)
     end
 end
 
+function ReaderHighlight:onPanelZoom(arg, ges)
+    -- TODO: add necessary checks
+    self:clear()
+    local hold_ges_pos = ges.pos
+    local hold_pos = self.view:screenToPageTransform(ges.pos)
+    self.ui.document:getPanelFromPage(hold_pos.page, ges.pos)
+    return true
+end
+
 function ReaderHighlight:onHold(arg, ges)
     -- disable hold gesture if highlighting is disabled
-    if self.view.highlight.disabled then return false end
+    if self.view.highlight.disabled then
+        self:onPanelZoom(arg, ges)
+        return false
+    end
     self:clear() -- clear previous highlight (delayed clear may not have done it yet)
     self.hold_ges_pos = ges.pos -- remember hold original gesture position
     self.hold_pos = self.view:screenToPageTransform(ges.pos)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -581,17 +581,14 @@ function ReaderHighlight:onPanelZoom(arg, ges)
     self:clear()
     local hold_ges_pos = ges.pos
     local hold_pos = self.view:screenToPageTransform(ges.pos)
-    local rect = self.ui.document:getPanelFromPage(hold_pos.page, ges)
+    local rect = self.ui.document:getPanelFromPage(hold_pos.page, hold_pos)
     if not rect then return false end
-    logger.dbg("result: ", res)
     local image = self.ui.document:getPagePart(hold_pos.page, rect, 0)
 
     if image then
         local ImageViewer = require("ui/widget/imageviewer")
         local imgviewer = ImageViewer:new{
             image = image,
-            -- title_text = _("Document embedded image"),
-            -- No title, more room for image
             with_title_bar = false,
             fullscreen = true,
         }

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1369,7 +1369,7 @@ function ReaderHighlight:onReadSettings(config)
     end
     self.view.highlight.disabled = disable_highlight
 
-    -- panel zoom settings shouldn't work in EPUB
+    -- panel zoom settings isn't supported in EPUB
     if self.document.info.has_pages then
         self.panel_zoom_enabled = config:readSetting("panel_zoom_enabled")
         if self.panel_zoom_enabled == nil then

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -578,12 +578,10 @@ end
 
 function ReaderHighlight:onPanelZoom(arg, ges)
     self:clear()
-    -- if not pdf/cbz return
-    if not self.ui.document.info.has_pages then return false end
     local hold_pos = self.view:screenToPageTransform(ges.pos)
-    if not hold_pos then return false end
+    if not hold_pos then return false end -- outside page boundary
     local rect = self.ui.document:getPanelFromPage(hold_pos.page, hold_pos)
-    if not rect then return false end
+    if not rect then return false end -- panel not found, return
     local image = self.ui.document:getPagePart(hold_pos.page, rect, 0)
 
     if image then
@@ -595,8 +593,6 @@ function ReaderHighlight:onPanelZoom(arg, ges)
         }
         UIManager:show(imgviewer)
     end
-    logger.dbg("File:", self.ui.document.file)
-    logger.dbg("Extension:", util.getFileNameSuffix(self.ui.document.file))
     return true
 end
 
@@ -609,9 +605,8 @@ function ReaderHighlight:onHold(arg, ges)
     end
 
     -- disable hold gesture if highlighting is disabled
-    if self.view.highlight.disabled then
-        return false
-    end
+    if self.view.highlight.disabled then return false end
+
     self:clear() -- clear previous highlight (delayed clear may not have done it yet)
     self.hold_ges_pos = ges.pos -- remember hold original gesture position
     self.hold_pos = self.view:screenToPageTransform(ges.pos)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1,6 +1,7 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local Device = require("device")
+local DocSettings = require("docsettings")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
@@ -125,8 +126,12 @@ local function isDocumentComicOrManga(file)
     return supported_filetypes[filetype]
 end
 
-local function isPanelZoomEnabled()
-    return G_reader_settings:nilOrTrue("panel_zoom_allowed")
+local function isPanelZoomEnabled(file)
+    local doc_setting = DocSettings:readSetting("panel_zoom_enabled")
+    if doc_setting == nil then
+        return G_reader_settings:nilOrTrue("panel_zoom_enabled")
+    end
+    return doc_setting
 end
 
 function ReaderHighlight:genPanelZoomMenu()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -618,6 +618,7 @@ function ReaderHighlight:_resetHoldTimer(clear)
 end
 
 function ReaderHighlight:onTogglePanelZoomSetting(arg, ges)
+    if not self.document.info.has_pages then return end
     self.panel_zoom_enabled = not self.panel_zoom_enabled
     self:onSaveSettings()
 end
@@ -643,9 +644,8 @@ function ReaderHighlight:onPanelZoom(arg, ges)
 end
 
 function ReaderHighlight:onHold(arg, ges)
-    if self.panel_zoom_enabled then
-        self:onPanelZoom(arg, ges)
-        return false
+    if self.panel_zoom_enabled and self.document.info.has_pages then
+        return self:onPanelZoom(arg, ges)
     end
 
     -- disable hold gesture if highlighting is disabled
@@ -1370,10 +1370,12 @@ function ReaderHighlight:onReadSettings(config)
     end
     self.view.highlight.disabled = disable_highlight
 
-    -- panel zoom settings
-    self.panel_zoom_enabled = config:readSetting("panel_zoom_enabled")
-    if self.panel_zoom_enabled == nil then
-        self.panel_zoom_enabled = isDocumentComicOrManga(self.ui.document.file)
+    -- panel zoom settings shouldn't work in EPUB
+    if self.document.info.has_pages then
+        self.panel_zoom_enabled = config:readSetting("panel_zoom_enabled")
+        if self.panel_zoom_enabled == nil then
+            self.panel_zoom_enabled = isDocumentComicOrManga(self.ui.document.file)
+        end
     end
 end
 

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -100,7 +100,7 @@ local settingsList = {
     toggle_bookmark = { category="none", event="ToggleBookmark", title=_("Toggle bookmark"), rolling=true, paging=true,},
     toggle_inverse_reading_order = { category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), rolling=true, paging=true,},
     cycle_highlight_action = { category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), rolling=true, paging=true,},
-    cycle_highlight_style = { category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), rolling=true, paging=true, separator=true,},
+    cycle_highlight_style = { category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), rolling=true, paging=true,},
     kosync_push_progress = { category="none", event="KOSyncPushProgress", title=_("Push progress from this device"), rolling=true, paging=true,},
     kosync_pull_progress = { category="none", event="KOSyncPullProgress", title=_("Pull progress from other devices"), rolling=true, paging=true, separator=true,},
     page_jmp = { category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true,},

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -103,8 +103,8 @@ local settingsList = {
     cycle_highlight_style = { category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), rolling=true, paging=true, separator=true,},
     kosync_push_progress = { category="none", event="KOSyncPushProgress", title=_("Push progress from this device"), rolling=true, paging=true,},
     kosync_pull_progress = { category="none", event="KOSyncPullProgress", title=_("Pull progress from other devices"), rolling=true, paging=true, separator=true,},
-    page_jmp = { category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true, separator=true,},
-    panel_zoom_toggle = { category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), rolling=false, paging=true,},
+    page_jmp = { category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true,},
+    panel_zoom_toggle = { category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), rolling=false, paging=true, separator=true,},
 
     -- rolling reader settings
     increase_font = { category="incrementalnumber", event="IncreaseFontSize", min=1, max=255, title=_("Increase font size"), rolling=true,},
@@ -207,7 +207,6 @@ local dispatcher_menu_order = {
     "back",
     "previous_location",
     "latest_bookmark",
-    "panel_zoom_toggle",
     "follow_nearest_link",
     "follow_nearest_internal_link",
     "clear_location_history",
@@ -236,6 +235,7 @@ local dispatcher_menu_order = {
     "zoom",
     "cycle_highlight_action",
     "cycle_highlight_style",
+    "panel_zoom_toggle",
 
     "kosync_push_progress",
     "kosync_pull_progress",

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -104,7 +104,7 @@ local settingsList = {
     kosync_push_progress = { category="none", event="KOSyncPushProgress", title=_("Push progress from this device"), rolling=true, paging=true,},
     kosync_pull_progress = { category="none", event="KOSyncPullProgress", title=_("Pull progress from other devices"), rolling=true, paging=true, separator=true,},
     page_jmp = { category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true,},
-    panel_zoom_toggle = { category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), rolling=false, paging=true, separator=true,},
+    panel_zoom_toggle = { category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), paging=true, separator=true,},
 
     -- rolling reader settings
     increase_font = { category="incrementalnumber", event="IncreaseFontSize", min=1, max=255, title=_("Increase font size"), rolling=true,},

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -103,7 +103,8 @@ local settingsList = {
     cycle_highlight_style = { category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), rolling=true, paging=true, separator=true,},
     kosync_push_progress = { category="none", event="KOSyncPushProgress", title=_("Push progress from this device"), rolling=true, paging=true,},
     kosync_pull_progress = { category="none", event="KOSyncPullProgress", title=_("Pull progress from other devices"), rolling=true, paging=true, separator=true,},
-    page_jmp = { category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true,},
+    page_jmp = { category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true, separator=true,},
+    panel_zoom_toggle = { category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), rolling=false, paging=true,},
 
     -- rolling reader settings
     increase_font = { category="incrementalnumber", event="IncreaseFontSize", min=1, max=255, title=_("Increase font size"), rolling=true,},
@@ -206,6 +207,7 @@ local dispatcher_menu_order = {
     "back",
     "previous_location",
     "latest_bookmark",
+    "panel_zoom_toggle",
     "follow_nearest_link",
     "follow_nearest_internal_link",
     "clear_location_history",

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -72,6 +72,10 @@ function DjvuDocument:getPageTextBoxes(pageno)
     return self._document:getPageText(pageno)
 end
 
+function DjvuDocument:getPanelFromPage(pageno, pos)
+    return self.koptinterface:getPanelFromPage(self, pageno, pos)
+end
+
 function DjvuDocument:getWordFromPosition(spos)
     return self.koptinterface:getWordFromPosition(self, spos)
 end

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -413,6 +413,13 @@ function Document:getDrawnImagesStatistics()
     return self._drawn_images_count, self._drawn_images_surface_ratio
 end
 
+function Document:getPagePart(pageno, rect, rotation)
+    local tile = self:renderPage(pageno, rect, 1, rotation, 1, 0)
+    local target = Blitbuffer.new(rect.w, rect.h, self.render_color and self.color_bb_type or nil)
+    target:blitFrom(tile.bb, 0, 0, rect.x, rect.y, rect.w, rect.h)
+    return target
+end
+
 function Document:getPageText(pageno)
     -- is this worth caching? not done yet.
     local page = self._document:openPage(pageno)

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -550,7 +550,7 @@ function KoptInterface:getPanelFromPage(doc, pageno, ges)
     kc:setZoom(1.0)
     local page = doc._document:openPage(pageno)
     page:getPagePix(kc)
-    local panel = kc:getPanelFromPage(ges.pos)
+    local panel = kc:getPanelFromPage(ges)
     page:close()
     kc:free()
     return panel

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -539,6 +539,23 @@ function KoptInterface:getReflowedTextBoxesFromScratch(doc, pageno)
     end
 end
 
+function KoptInterface:getPanelFromPage(doc, pageno, ges)
+    local page_size = Document.getNativePageDimensions(doc, pageno)
+    local bbox = {
+        x0 = 0, y0 = 0,
+        x1 = page_size.w,
+        y1 = page_size.h,
+    }
+    local kc = self:createContext(doc, pageno, bbox)
+    kc:setZoom(1.0)
+    local page = doc._document:openPage(pageno)
+    page:getPagePix(kc)
+    local boxes = kc:getPanelFromPage(ges.pos)
+    page:close()
+    kc:free()
+    return boxes
+end
+
 --[[--
 Get text boxes in native page via optical method.
 

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -550,10 +550,10 @@ function KoptInterface:getPanelFromPage(doc, pageno, ges)
     kc:setZoom(1.0)
     local page = doc._document:openPage(pageno)
     page:getPagePix(kc)
-    local boxes = kc:getPanelFromPage(ges.pos)
+    local panel = kc:getPanelFromPage(ges.pos)
     page:close()
     kc:free()
-    return boxes
+    return panel
 end
 
 --[[--

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -105,6 +105,10 @@ function PdfDocument:getPageTextBoxes(pageno)
     return text
 end
 
+function PdfDocument:getPanelFromPage(pageno, pos)
+    return self.koptinterface:getPanelFromPage(self, pageno, pos)
+end
+
 function PdfDocument:getWordFromPosition(spos)
     return self.koptinterface:getWordFromPosition(self, spos)
 end

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -37,6 +37,7 @@ local order = {
         "speed_reading_module_perception_expander",
         "----------------------------",
         "highlight_options",
+        "panel_zoom_options"
     },
     setting = {
         -- common settings


### PR DESCRIPTION
This pull requests aims to provide convenient way to zoom in comics. The idea is when user holds/double taps (not decided yet) on a manga/comic panel, it gets cut out from the rest of the image and zoomed. More details in https://github.com/koreader/koreader-base/issues/1148. Depends on https://github.com/koreader/koreader-base/pull/1159

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6511)
<!-- Reviewable:end -->
