### PR TITLE
bump crengine: better linebreaks at em-dash, fb2 fixes

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -652,6 +652,8 @@ This is just an example, that will need to be adapted into a user style tweak.]]
 Show FB2 footnote text at the bottom of pages that contain links to them.]]),
                     -- Restrict this to FB2 documents, even if we won't probably
                     -- match in any other kind of document
+                    -- (Last selector avoids title bottom margin from collapsing
+                    -- into the first footnote by substituting it with padding.)
                     css = [[
 body[name="notes"] section {
     -cr-only-if: fb2-document;
@@ -661,6 +663,11 @@ body[name="notes"] section {
 body[name="notes"] > section {
     -cr-only-if: fb2-document;
         font-size: 0.75rem;
+}
+body[name="notes"] > title {
+    -cr-only-if: fb2-document;
+        margin-bottom: 0;
+        padding-bottom: 0.5em;
 }
                     ]],
                 },
@@ -678,6 +685,11 @@ body[name="comments"] section {
 body[name="comments"] > section {
     -cr-only-if: fb2-document;
         font-size: 0.85rem;
+}
+body[name="comments"] > title {
+    -cr-only-if: fb2-document;
+        margin-bottom: 0;
+        padding-bottom: 0.5em;
 }
                     ]],
                     separator = true,


### PR DESCRIPTION
Includes:
- (Upstream) LVBase64NodeStream: fix possible segfault https://github.com/koreader/crengine/pull/366
- (Upstream) Fix getting encoding from HTML META tags (solves the characters encoding issue of #6482)
- FB2: also look for cover in `<src-title-info>` (closes #6493)
- FB2: fix cover image colors (see https://github.com/koreader/koreader/issues/6490#issuecomment-671768171)
- FB2: don't draw cover in scroll mode (shamelessly closes #6490)
- TextLang: better linebreaks at em-dash (EN/ES/FR) https://github.com/koreader/crengine/pull/365
- TextLang: increase _lb_props static array size https://github.com/koreader/crengine/pull/368

FB2 footnotes style tweaks: avoid gap above first footnote, caused by the title bottom margin collapsing into it. Solves https://github.com/koreader/koreader/issues/6344#issuecomment-672599125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6521)
<!-- Reviewable:end -->
