### PR TITLE
Update PocketBook device definitions

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -246,7 +246,7 @@ local PocketBook614W = PocketBook:new{
     hasFewKeys = yes,
 }
 
--- PocketBook Basic Lux (615)
+-- PocketBook Basic Lux / 615 Plus (615/615W)
 local PocketBook615 = PocketBook:new{
     model = "PBBLux",
     display_dpi = 212,
@@ -255,7 +255,7 @@ local PocketBook615 = PocketBook:new{
     hasFewKeys = yes,
 }
 
--- PocketBook Basic Lux 2 (616)
+-- PocketBook Basic Lux 2 (616/616W)
 local PocketBook616 = PocketBook:new{
     model = "PBBLux2",
     display_dpi = 212,
@@ -402,12 +402,13 @@ elseif codename == "PocketBook 611" then
     return PocketBook611
 elseif codename == "PocketBook 613" then
     return PocketBook613
-elseif codename == "PocketBook 614W" or codename == "PocketBook 614" then
+elseif codename == "PocketBook 614" or codename == "PocketBook 614W" then
     return PocketBook614W
-elseif codename == "PocketBook 615" or codename == "PB615" then
+elseif codename == "PB615" or codename == "PB615W" then
+    codename == "PocketBook 615" or codename == "PocketBook 615W" or
     return PocketBook615
-elseif codename == "PB616W" or
-    codename == "PocketBook 616" then
+elseif codename == "PB616" or codename == "PB616W" or
+    codename == "PocketBook 616" or codename == "PocketBook 616W" then
     return PocketBook616
 elseif codename == "PocketBook 622" then
     return PocketBook622

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -334,7 +334,6 @@ local PocketBook633 = PocketBook:new{
     model = "PBColor",
     display_dpi = 300,
     hasColorScreen = yes,
-    has3BytesWideFrameBuffer = yes,
     canUseCBB = no, -- 24bpp
 }
 

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -404,8 +404,8 @@ elseif codename == "PocketBook 613" then
     return PocketBook613
 elseif codename == "PocketBook 614" or codename == "PocketBook 614W" then
     return PocketBook614W
-elseif codename == "PB615" or codename == "PB615W" then
-    codename == "PocketBook 615" or codename == "PocketBook 615W" or
+elseif codename == "PB615" or codename == "PB615W" or
+    codename == "PocketBook 615" or codename == "PocketBook 615W" then
     return PocketBook615
 elseif codename == "PB616" or codename == "PB616W" or
     codename == "PocketBook 616" or codename == "PocketBook 616W" then


### PR DESCRIPTION
**Changes:**
- [x] Added PocketBook 615 Plus definition. (Fixes #4141?)
- [x] Added PocketBook 616 definition.

**Reasons:**
- It seems like the 615 Plus is a CIS-only device, there's a [manual](http://support.pocketbook-int.com/fw/615-2/u/5.17.999/manual/cis/User_manual_PocketBook_615_Plus_RU.pdf).
- 616 is a CIS-only device ([manual](http://support.pocketbook-int.com/fw/616/u/0/manual/cis/User_Manual_PocketBook_616_RU.pdf)), while the Basic Lux 2 is a worldwide device that goes under 616W ([manual](http://support.pocketbook-int.com/fw/616/u/0/manual/ww/User_Manual_Basic_Lux_2_BG.pdf)).

**Other:**
- @NiLuJe @Frenzie Should I get rid of the hasColorScreen and has3BytesWideFrameBuffer lines for the Color (633)?
- #6505 fixes might be included in this, if there's an answer.

Besides that, this is ready for review, can't test as always.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6525)
<!-- Reviewable:end -->
