### PR TITLE
Add an option to *always* flash on chapter boundaries

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -63,7 +63,10 @@ function ReaderToc:onPageUpdate(pageno)
     if UIManager.FULL_REFRESH_COUNT == -1 then
         if self:isChapterEnd(pageno, 0) then
             self.chapter_refresh = true
-        elseif self:isChapterBegin(pageno, 0) and self.chapter_refresh then
+        elseif self:isChapterStart(pageno, 0) and self.chapter_refresh then
+            UIManager:setDirty(nil, "full")
+            self.chapter_refresh = true
+        elseif self:isChapterSecondPage(pageno, 0) and self.chapter_refresh then
             UIManager:setDirty(nil, "full")
             self.chapter_refresh = false
         else
@@ -356,7 +359,7 @@ function ReaderToc:getPreviousChapter(cur_pageno, level)
     return previous_chapter
 end
 
-function ReaderToc:isChapterBegin(cur_pageno, level)
+function ReaderToc:isChapterStart(cur_pageno, level)
     local ticks = self:getTocTicks(level)
     local _begin = false
     for i = 1, #ticks do
@@ -368,9 +371,21 @@ function ReaderToc:isChapterBegin(cur_pageno, level)
     return _begin
 end
 
+function ReaderToc:isChapterSecondPage(cur_pageno, level)
+    local ticks = self:getTocTicks(level)
+    local _end = false
+    for i = 1, #ticks do
+        if ticks[i] + 1 == cur_pageno then
+            _end = true
+            break
+        end
+    end
+    return _end
+end
+
 function ReaderToc:isChapterEnd(cur_pageno, level)
     local ticks = self:getTocTicks(level)
-    local _end= false
+    local _end = false
     for i = 1, #ticks do
         if ticks[i] - 1 == cur_pageno then
             _end = true
@@ -390,7 +405,7 @@ function ReaderToc:getChapterPagesLeft(pageno, level)
 end
 
 function ReaderToc:getChapterPagesDone(pageno, level)
-    if self:isChapterBegin(pageno, level) then return 0 end
+    if self:isChapterStart(pageno, level) then return 0 end
     local previous_chapter = self:getPreviousChapter(pageno, level)
     if previous_chapter then
         previous_chapter = pageno - previous_chapter

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -60,7 +60,7 @@ end
 
 function ReaderToc:onPageUpdate(pageno)
     self.pageno = pageno
-    if UIManager.FULL_REFRESH_COUNT == -1 then
+    if UIManager.FULL_REFRESH_COUNT == -1 or G_reader_settings:isTrue("refresh_on_chapter_boundaries") then
         if self:isChapterEnd(pageno, 0) then
             self.chapter_refresh = true
         elseif self:isChapterStart(pageno, 0) and self.chapter_refresh then
@@ -361,26 +361,26 @@ end
 
 function ReaderToc:isChapterStart(cur_pageno, level)
     local ticks = self:getTocTicks(level)
-    local _begin = false
+    local _start = false
     for i = 1, #ticks do
         if ticks[i] == cur_pageno then
-            _begin = true
+            _start = true
             break
         end
     end
-    return _begin
+    return _start
 end
 
 function ReaderToc:isChapterSecondPage(cur_pageno, level)
     local ticks = self:getTocTicks(level)
-    local _end = false
+    local _second = false
     for i = 1, #ticks do
         if ticks[i] + 1 == cur_pageno then
-            _end = true
+            _second = true
             break
         end
     end
-    return _end
+    return _second
 end
 
 function ReaderToc:isChapterEnd(cur_pageno, level)

--- a/frontend/ui/elements/refresh_menu_table.lua
+++ b/frontend/ui/elements/refresh_menu_table.lua
@@ -105,6 +105,12 @@ return {
             text = _("Every chapter"),
             checked_func = function() return refreshChecked(-1, -1) end,
             callback = function() UIManager:setRefreshRate(-1, -1) end,
+            separator = true,
+        },
+        {
+            text = _("Always refresh on chapter boundaries"),
+            checked_func = function() return G_reader_settings:isTrue("refresh_on_chapter_boundaries") end,
+            callback = function() G_reader_settings:flipNilOrFalse("refresh_on_chapter_boundaries") end,
         },
     }
 }


### PR DESCRIPTION
Minor QoL change, because I like the concept ;).

Also, when this (or refresh rate is set to chapter) is enabled, also flash on the *second* page of a chapter, as chapter headings usually mean extra whitespace, meaning more chnace for visible ghosting/contrast deviations.

(Note that the current algo only flashes when paging *forward*, I didn't touch that).