### PR TITLE
FM: rotation flush setting before reinit

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -61,6 +61,7 @@ function FileManager:onSetRotationMode(rotation)
     if rotation ~= nil and rotation ~= Screen:getRotationMode() then
         Screen:setRotationMode(rotation)
         if self.instance then
+            UIManager:flushSettings()
             self:reinit(self.instance.path, self.instance.focused_file)
             UIManager:setDirty(self.instance.banner, function()
                 return "ui", self.instance.banner.dimen

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -61,7 +61,6 @@ function FileManager:onSetRotationMode(rotation)
     if rotation ~= nil and rotation ~= Screen:getRotationMode() then
         Screen:setRotationMode(rotation)
         if self.instance then
-            UIManager:flushSettings()
             self:reinit(self.instance.path, self.instance.focused_file)
             UIManager:setDirty(self.instance.banner, function()
                 return "ui", self.instance.banner.dimen
@@ -644,6 +643,7 @@ function FileManager:tapPlus()
 end
 
 function FileManager:reinit(path, focused_file)
+    UIManager:flushSettings()
     self.dimen = Screen:getSize()
     -- backup the root path and path items
     self.root_path = path or self.file_chooser.path


### PR DESCRIPTION
when rotation was caused by a gesture the gesture settings were not flushed leading to weird state when the FM reinit reloaded the gestures plugin

discovered in #6530
caused by #6309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6532)
<!-- Reviewable:end -->
