### PR TITLE
Fixes and changes to PocketBook definitions

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -220,6 +220,16 @@ local PocketBook515 = PocketBook:new{
     hasFewKeys = yes,
 }
 
+-- PocketBook 606 (606)
+local PocketBook606 = PocketBook:new{
+    model = "PB606",
+    display_dpi = 212,
+    isTouchDevice = no,
+    hasFrontlight = no,
+    hasDPad = yes,
+    hasFewKeys = yes,
+}
+
 -- PocketBook Basic (611)
 local PocketBook611 = PocketBook:new{
     model = "PB611",
@@ -410,6 +420,8 @@ local codename = PocketBook:getDeviceModel()
 
 if codename == "PocketBook 515" then
     return PocketBook515
+elseif codename == "PB606" or codename == "PocketBook 606" then
+    return PocketBook606
 elseif codename == "PocketBook 611" then
     return PocketBook611
 elseif codename == "PocketBook 613" then
@@ -445,11 +457,11 @@ elseif codename == "PB632" then
     return PocketBook632
 elseif codename == "PB633" then
     return PocketBook633
-elseif codename == "PB640" then
+elseif codename == "PB640" or codename == "PocketBook 640" then
     return PocketBook640
 elseif codename == "PB641" then
     return PocketBook641
-elseif codename == "PB650" then
+elseif codename == "PB650" or codename == "PocketBook 650" then
     return PocketBook650
 elseif codename == "PB740" then
     return PocketBook740


### PR DESCRIPTION
**Changes:**
- [x] Added new CIS-unique device definition for PocketBook 606 - [News article](https://pocketbook.ru/news/novyy-pocketbook-606/)
- [x] Added new CIS-unique codename for PocketBook Aqua (640) - [Russian manual](http://support.pocketbook-int.com/fw/640/ru/4.4.1853/manual/User_Guide_PocketBook_640_RU.pdf) (last page)
- [x] Added new CIS-unique codename for PocketBook Ultra (650) - [Russian manual](http://support.pocketbook-int.com/fw/650/ru/5.14.789/manual/User_Guide_PocketBook_650_RU.pdf) (last page)

Can't test as usual, but should be good to go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6533)
<!-- Reviewable:end -->
