### PR TITLE
Revert "Kosync network callback"

### DIFF
--- a/plugins/kosync.koplugin/KOSyncClient.lua
+++ b/plugins/kosync.koplugin/KOSyncClient.lua
@@ -1,4 +1,3 @@
-local NetworkMgr = require("ui/network/manager")
 local UIManager = require("ui/uimanager")
 local DEBUG = require("dbg")
 
@@ -104,21 +103,6 @@ function KOSyncClient:update_progress(
         device,
         device_id,
         callback)
-
-    local callback_ok = NetworkMgr:willRerunWhenOnline(function()
-            self:update_progress(
-            username,
-            password,
-            document,
-            progress,
-            percentage,
-            device,
-            device_id,
-            callback)
-        end)
-    if callback_ok then
-        return
-    end
     self.client:reset_middlewares()
     self.client:enable('Format.JSON')
     self.client:enable("GinClient")
@@ -153,11 +137,6 @@ function KOSyncClient:get_progress(
         password,
         document,
         callback)
-
-    if NetworkMgr:willRerunWhenOnline(function() self:get_progress(username, password, document, callback) end) then
-        return
-    end
-
     self.client:reset_middlewares()
     self.client:enable('Format.JSON')
     self.client:enable("GinClient")


### PR DESCRIPTION
Reverts koreader/koreader#6489 since it introduced problems for people having `[*]Auto sync now and in the furture` & `Action when wifi off: prompt`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6535)
<!-- Reviewable:end -->
