### PR TITLE
wip: pocketbook fixes

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -82,10 +82,10 @@ function UIManager:init()
     if Device:isPocketBook() then
         self.event_handlers["Suspend"] = function()
             self:_beforeSuspend()
-            Device:onPowerEvent("Power")
         end
         self.event_handlers["Resume"] = function()
-            Device:onPowerEvent("Power")
+            self:setDirty("all", "full")
+            self:forceRePaint()
             self:_afterResume()
         end
     end


### PR DESCRIPTION
Requires https://github.com/koreader/koreader-base/pull/1164

Fixes #6536
Fixes #5140
Fixes #3561
Fixes #3477

Should fix #5114 (but a confirmation is needed :))

Changes:

- Pocketbook suspend behaviour is disabled when app is on the foreground. It can be reenabled based on user preferences (still need to implement that on menus). Probably that's not needed for most users since the Pocketbook cpu suspend stub won't save much power compared to a sensible user management.

- Read state is saved each time the system is going to poweroff

- Screensaver is disabled since we don't manage power states.

~~I will upload a test build soon~~

Test build: https://www.dropbox.com/s/wouijkf0g8989xu/koreader-pocketbook-v2020.03.2-260-ga4cfdf3f_2020-08-22.zip?dl=0

It should fix all issues reported in https://github.com/koreader/koreader/issues/5550#issuecomment-670827065 (except the slowness of cpu/io compared to modern Kobos/Cervantes and even Android). Pinging @Cellaris, feel free to test and report. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6541)
<!-- Reviewable:end -->
