### PR TITLE
Make UIManager track prevent/allowStandby state.

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -300,6 +300,11 @@ function Device:info()
     return self.model
 end
 
+-- Hardware specific method for UI to signal allowed/disallowed standby.
+-- The device is allowed to enter standby only from within waitForEvents,
+-- and only if allowed state is true at the time of waitForEvents() invocation.
+function Device:setAutoStandby(isAllowed) end
+
 -- Hardware specific method to handle usb plug in event
 function Device:usbPlugIn() end
 

--- a/frontend/ui/trapper.lua
+++ b/frontend/ui/trapper.lua
@@ -43,8 +43,10 @@ function Trapper:wrap(func)
     -- Catch and log any error happening in func (an error happening
     -- in a coroutine just aborts silently the coroutine)
     local pcalled_func = function()
+        UIManager:preventStandby()
         -- we use xpcall as it can give a whole stacktrace, unlike pcall
         local ok, err = xpcall(func, debug.traceback)
+        UIManager:allowStandby()
         if not ok then
             logger.warn("error in wrapped function:", err)
             return false

--- a/plugins/backgroundrunner.koplugin/commandrunner.lua
+++ b/plugins/backgroundrunner.koplugin/commandrunner.lua
@@ -1,4 +1,5 @@
 local logger = require("logger")
+local UIManager = require("ui/uimanager")
 
 local CommandRunner = {
     pio = nil,
@@ -41,6 +42,7 @@ function CommandRunner:start(job)
                     "sh plugins/backgroundrunner.koplugin/luawrapper.sh " ..
                     "\"" .. self.job.executable .. "\""
     logger.dbg("CommandRunner: Will execute command " .. command)
+    UIManager:preventStandby()
     self.pio = io.popen(command)
 end
 
@@ -71,6 +73,7 @@ function CommandRunner:poll()
                 self.job.result = 222
             end
         end
+        UIManager:allowStandby()
         self.pio:close()
         self.pio = nil
         self.job.end_sec = os.time()

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -544,6 +544,8 @@ function BookInfoManager:collectSubprocesses()
             local pid = self.subprocesses_pids[i]
             if util.isSubProcessDone(pid) then
                 table.remove(self.subprocesses_pids, i)
+                -- Prevent has been issued for each bg task spawn, we must allow for each death too.
+                UIManager:allowStandby()
             else
                 i = i + 1
             end
@@ -621,6 +623,9 @@ function BookInfoManager:extractInBackground(files)
         logger.warn("Failed lauching background extraction sub-process (fork failed)")
         return false -- let caller know it failed
     end
+    -- No straight control flow exists for background task completion here, so we bump prevent
+    -- counter on each task, and undo that inside collectSubprocesses() zombie reaper.
+    UIManager:preventStandby()
     table.insert(self.subprocesses_pids, task_pid)
     self.subprocesses_last_added_ts = util.gettime()
 


### PR DESCRIPTION
Conversely, Trapper and plugins report standby interruptability.

Ground work for #6545, effectively no-op now. To test it, run in debug mode and see if the usual places trigger standby bans as they should, fe for covers:

```
$ strings crash.log |egrep 'standby|BG'
08/25/20-01:31:51 DEBUG prevent standby
08/25/20-01:31:51 DEBUG   BG extraction started
08/25/20-01:31:51 DEBUG   BG extracting: ...
08/25/20-01:31:51 DEBUG   BG extracting: ...
08/25/20-01:31:56 DEBUG   BG extraction done
08/25/20-01:32:01 DEBUG allow standby
```

~Of special note is Trapper:info() - while not background process stuff like the rest, it is used for "tap me to abort this" of unattended loops, so we need to prevent standby in there as well.~ Trapper now nukes standby wholesale. This is coarse, but simple and probably safer to catch possible corner cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6558)
<!-- Reviewable:end -->
