### PR TITLE
bump crengine: new HTML parser, libRu and FB2 tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1203,6 +1203,12 @@ function ReaderRolling:checkXPointersAndProposeDOMVersionUpgrade()
 
         -- Set latest DOM version, to be used at next load
         local latest_dom_version = self.ui.document:getLatestDomVersion()
+        -- For some formats, DOM version 20200824 uses a new HTML parser that may build
+        -- a different DOM tree. So, migrate these to a lower version
+        local doc_format = self.ui.document:getDocumentFormat()
+        if doc_format == "HTML" or doc_format == "CHM" or doc_format == "PDB" then
+            latest_dom_version = self.ui.document:getDomVersionWithNormalizedXPointers()
+        end
         self.ui.doc_settings:saveSetting("cre_dom_version", latest_dom_version)
         logger.info("  cre_dom_version updated to", latest_dom_version)
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -180,6 +180,10 @@ function CreDocument:requestDomVersion(version)
     cre.requestDomVersion(version)
 end
 
+function CreDocument:getDocumentFormat()
+    return self._document:getDocumentFormat()
+end
+
 function CreDocument:setupDefaultView()
     if self.loaded then
         -- Don't apply defaults if the document has already been loaded


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/370 https://github.com/koreader/koreader-base/pull/1166 : 
- Revert "FB2: don't draw cover in scroll mode"
- (Upstream) FB2: fix coverpage drawing in scroll mode (properly fix #6490)
- FB2 footnotes: only merge run-in when next is erm_final
- fb2.css: use OTF tabular-nums for footnote numbers
- Text: ignore ascii and unicode control chars
- Fix HR positionning when floats involved
- writeNodeEx(): minor tweaks
- OnTagClose(): add self_closing_tag parameter
- HTML format detection: accept HTML5 doctype
- HTML parser: rework Lib.ru specific handling
- HTML parser: new more conforming implementation
- HTML parser: ensure foster parenting inside tables

This new HTML parser should close #6482 - and with #6521, might have solved a few other CHM related issues (that have been closed for lack of hope): #76 #102 #130 #1074 #2834 #6202.

Also includes:
- SDL: don't bypass X11 WM compositor https://github.com/koreader/koreader-base/pull/1158

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6560)
<!-- Reviewable:end -->
