### PR TITLE
Always update the table of footer text generators

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -466,7 +466,6 @@ function ReaderFooter:init()
         self.footer_text.height = 0
     end
     if self.settings.all_at_once then
-        print("ReaderFooter:init w/ all_at_once")
         self.view.footer_visible = (self.mode ~= self.mode_list.off)
         self:updateFooterTextGenerator()
         if self.settings.progress_bar_position and self.has_no_mode then
@@ -474,7 +473,6 @@ function ReaderFooter:init()
             self.footer_text.height = 0
         end
     else
-        print("ReaderFooter:init w/o all_at_once")
         self:applyFooterMode()
     end
     if self.settings.auto_refresh_time then
@@ -658,7 +656,6 @@ function ReaderFooter:disableFooter()
 end
 
 function ReaderFooter:updateFooterTextGenerator()
-    print("ReaderFooter:updateFooterTextGenerator")
     local footerTextGenerators = {}
     for i, m in pairs(self.mode_index) do
         if self.settings[m] then
@@ -1646,7 +1643,6 @@ function ReaderFooter:genAllFooterText()
     -- We need to BD.wrap() all items and separators, so we're
     -- sure they are laid out in our order (reversed in RTL),
     -- without ordering by the RTL Bidi algorithm.
-    print("@ReaderFooter:genAllFooterText, self.footerTextGenerators:", self.footerTextGenerators)
     for _, gen in ipairs(self.footerTextGenerators) do
         table.insert(info, BD.wrap(gen(self)))
     end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -466,6 +466,7 @@ function ReaderFooter:init()
         self.footer_text.height = 0
     end
     if self.settings.all_at_once then
+        print("ReaderFooter:init w/ all_at_once")
         self.view.footer_visible = (self.mode ~= self.mode_list.off)
         self:updateFooterTextGenerator()
         if self.settings.progress_bar_position and self.has_no_mode then
@@ -473,6 +474,7 @@ function ReaderFooter:init()
             self.footer_text.height = 0
         end
     else
+        print("ReaderFooter:init w/o all_at_once")
         self:applyFooterMode()
     end
     if self.settings.auto_refresh_time then
@@ -656,6 +658,7 @@ function ReaderFooter:disableFooter()
 end
 
 function ReaderFooter:updateFooterTextGenerator()
+    print("ReaderFooter:updateFooterTextGenerator")
     local footerTextGenerators = {}
     for i, m in pairs(self.mode_index) do
         if self.settings[m] then
@@ -676,9 +679,12 @@ function ReaderFooter:updateFooterTextGenerator()
         -- function to that one
         self.genFooterText = footerTextGenerators[1]
     else
-        self.footerTextGenerators = footerTextGenerators
         self.genFooterText = self.genAllFooterText
     end
+
+    -- Even if there's no or a single mode enabled, all_at_once requires this to be set
+     self.footerTextGenerators = footerTextGenerators
+
     -- notify caller that UI needs update
     return true
 end
@@ -1640,6 +1646,7 @@ function ReaderFooter:genAllFooterText()
     -- We need to BD.wrap() all items and separators, so we're
     -- sure they are laid out in our order (reversed in RTL),
     -- without ordering by the RTL Bidi algorithm.
+    print("@ReaderFooter:genAllFooterText, self.footerTextGenerators:", self.footerTextGenerators)
     for _, gen in ipairs(self.footerTextGenerators) do
         table.insert(info, BD.wrap(gen(self)))
     end


### PR DESCRIPTION
It's only used by `all_at_once`, but it needs to actually reflect the settings at all times, so as to actually track them, and avoid issues with no or a single mode enabled.

Fix #6561

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6563)
<!-- Reviewable:end -->
