### PR TITLE
[Pocketbook]: enable usage of system fonts

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -353,7 +353,7 @@ end
 function ReaderFont:getFontSettingsTable()
     local settings_table = {}
 
-    if Device:isAndroid() or Device:isDesktop() or Device:isEmulator() then
+    if Device:isAndroid() or Device:isDesktop() or Device:isEmulator() or Device:isPocketBook() then
         for _, item in ipairs(require("ui/elements/font_settings"):getSystemFontMenuItems()) do
             table.insert(settings_table, item)
         end

--- a/frontend/document/canvascontext.lua
+++ b/frontend/document/canvascontext.lua
@@ -40,6 +40,7 @@ function CanvasContext:init(device)
     self.isDesktop = device.isDesktop
     self.isEmulator = device.isEmulator
     self.isKindle = device.isKindle
+    self.isPocketBook = device.isPocketBook
     self.should_restrict_JIT = device.should_restrict_JIT
     self:setColorRenderingEnabled(device.screen.isColorEnabled())
 

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -84,7 +84,11 @@ local function isInFontsBlacklist(f)
 end
 
 local function getExternalFontDir()
-    if CanvasContext.isAndroid() or CanvasContext.isDesktop() or CanvasContext.isEmulator() then
+    if CanvasContext.isAndroid() or
+        CanvasContext.isDesktop() or
+        CanvasContext.isEmulator() or
+        CanvasContext.isPocketBook()
+    then
         return require("frontend/ui/elements/font_settings"):getPath()
     else
         return os.getenv("EXT_FONT_DIR")

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -14,6 +14,12 @@ local function getDir(isUser)
         else
             return "/system/fonts"
         end
+    elseif Device:isPocketBook() then
+        if isUser then
+            return "/mnt/ext1/system/fonts"
+        else
+            return "/ebrmain/adobefonts;/ebrmain/fonts"
+        end
     elseif Device:isDesktop() or Device:isEmulator() then
         if jit.os == "OSX" then
             return isUser and home .. "/Library/fonts" or "/Library/fonts"

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -26,9 +26,6 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# export external font directory
-export EXT_FONT_DIR="/mnt/ext1/system/fonts"
-
 # shellcheck disable=2000
 if [ "$(echo "$@" | wc -c)" -eq 1 ]; then
     args="/mnt/ext1/"


### PR DESCRIPTION
They're not encrypted, so we can use them.

By default "use system fonts" is disabled, like in other platforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6567)
<!-- Reviewable:end -->
