### PR TITLE
Text/HTML widgets: allow scrolling with the scrollbar

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1010,6 +1010,7 @@ function FileManager:getStartWithMenuTable()
     local start_withs = {
         filemanager = {_("file browser"), _("Start with file browser")},
         history = {_("history"), _("Start with history")},
+        favorites = {_("favorites"), _("Start with favorites")},
         folder_shortcuts = {_("folder shortcuts"), _("Start with folder shortcuts")},
         last = {_("last file"), _("Start with last file")},
     }
@@ -1035,6 +1036,7 @@ function FileManager:getStartWithMenuTable()
         sub_item_table = {
             set_sw_table("filemanager"),
             set_sw_table("history"),
+            set_sw_table("favorites"),
             set_sw_table("folder_shortcuts"),
             set_sw_table("last"),
         }

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -391,7 +391,8 @@ end
 function ReaderBookmark:isBookmarkSame(item1, item2)
     if item1.notes ~= item2.notes then return false end
     if self.ui.document.info.has_pages then
-        return item2.pos0 and item2.pos1 and item1.pos0.page == item2.pos0.page
+        return item1.pos0 and item1.pos1 and item2.pos0 and item2.pos1
+        and item1.pos0.page == item2.pos0.page
         and item1.pos0.x == item2.pos0.x and item1.pos0.y == item2.pos0.y
         and item1.pos1.x == item2.pos1.x and item1.pos1.y == item2.pos1.y
     else

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -12,7 +12,6 @@ local HorizontalSpan = require("ui/widget/horizontalspan")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
 local VerticalScrollBar = require("ui/widget/verticalscrollbar")
-local Math = require("optmath")
 local Input = Device.input
 local Screen = Device.screen
 
@@ -46,6 +45,9 @@ function ScrollHtmlWidget:init()
         enable = self.htmlbox_widget.page_count > 1,
         width = self.scroll_bar_width,
         height = self.height,
+        scroll_callback = function(ratio)
+            self:scrollToRatio(ratio)
+        end
     }
 
     self.v_scroll_bar:set((self.htmlbox_widget.page_number-1) / self.htmlbox_widget.page_count, self.htmlbox_widget.page_number / self.htmlbox_widget.page_count)
@@ -89,7 +91,10 @@ end
 
 function ScrollHtmlWidget:scrollToRatio(ratio)
     ratio = math.max(0, math.min(1, ratio)) -- ensure ratio is between 0 and 1 (100%)
-    local page_num = 1 + Math.round((self.htmlbox_widget.page_count - 1) * ratio)
+    local page_num = 1 + math.floor((self.htmlbox_widget.page_count) * ratio)
+    if page_num > self.htmlbox_widget.page_count then
+        page_num = self.htmlbox_widget.page_count
+    end
     if page_num == self.htmlbox_widget.page_number then
         return
     end

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -71,6 +71,9 @@ function ScrollTextWidget:init()
         high = visible_line_count / total_line_count,
         width = self.scroll_bar_width,
         height = self.text_widget:getTextHeight(),
+        scroll_callback = function(ratio)
+            self:scrollToRatio(ratio, false)
+        end
     }
     self:updateScrollBar()
     local horizontal_group = HorizontalGroup:new{ align = "top" }
@@ -219,8 +222,14 @@ function ScrollTextWidget:scrollText(direction)
     self:updateScrollBar(true)
 end
 
-function ScrollTextWidget:scrollToRatio(ratio)
-    self.text_widget:scrollToRatio(ratio)
+function ScrollTextWidget:scrollToRatio(ratio, force_to_page)
+    if force_to_page == nil then
+        -- default to force to page, for consistency with
+        -- ScrollHtmlWidget that always forces to page (for
+        -- DictQuickLookup when going back to previous dict)
+        force_to_page = true
+    end
+    self.text_widget:scrollToRatio(ratio, force_to_page)
     self:updateScrollBar(true)
 end
 

--- a/frontend/ui/widget/verticalscrollbar.lua
+++ b/frontend/ui/widget/verticalscrollbar.lua
@@ -1,9 +1,12 @@
 local Blitbuffer = require("ffi/blitbuffer")
+local Device = require("device")
 local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local InputContainer = require("ui/widget/container/inputcontainer")
 local Size = require("ui/size")
-local Widget = require("ui/widget/widget")
+local Screen = require("device").screen
 
-local VerticalScrollBar = Widget:new{
+local VerticalScrollBar = InputContainer:new{
     enable = true,
     low = 0,
     high = 1,
@@ -16,7 +19,71 @@ local VerticalScrollBar = Widget:new{
     -- minimal height of the thumb/knob/grip (usually showing the current
     -- view size and position relative to the whole scrollable height):
     min_thumb_size = Size.line.thick,
+    scroll_callback = nil,
+    -- extra touchable width (for scrolling with pan) can be larger than
+    -- the provided width (this is added on each side)
+    extra_touch_on_side_width_ratio = 1, -- make it 3 x width
 }
+
+function VerticalScrollBar:init()
+    self.extra_touch_on_side = math.ceil( self.extra_touch_on_side_width_ratio * self.width )
+    if Device:isTouchDevice() then
+        local pan_rate = Screen.low_pan_rate and 2.0 or 5.0
+        self.ges_events = {
+            TapScroll = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = function() return self.touch_dimen end,
+                },
+            },
+            HoldScroll = {
+                GestureRange:new{
+                    ges = "hold",
+                    range = function() return self.touch_dimen end,
+                },
+            },
+            HoldPanScroll = {
+                GestureRange:new{
+                    ges = "hold_pan",
+                    rate = pan_rate,
+                    range = function() return self.touch_dimen end,
+                },
+            },
+            HoldReleaseScroll = {
+                GestureRange:new{
+                    ges = "hold_release",
+                    range = function() return self.touch_dimen end,
+                },
+            },
+            PanScroll = {
+                GestureRange:new{
+                    ges = "pan",
+                    rate = pan_rate,
+                    range = function() return self.touch_dimen end,
+                },
+            },
+            PanScrollRelease = {
+                GestureRange:new{
+                    ges = "pan_release",
+                    range = function() return self.touch_dimen end,
+                },
+            }
+        }
+    end
+end
+
+function VerticalScrollBar:onTapScroll(arg, ges)
+    if self.scroll_callback then
+        local ratio = (ges.pos.y - self.touch_dimen.y) / self.height
+        self.scroll_callback(ratio)
+        return true
+    end
+end
+VerticalScrollBar.onHoldScroll = VerticalScrollBar.onTapScroll
+VerticalScrollBar.onHoldPanScroll = VerticalScrollBar.onTapScroll
+VerticalScrollBar.onHoldReleaseScroll = VerticalScrollBar.onTapScroll
+VerticalScrollBar.onPanScroll = VerticalScrollBar.onTapScroll
+VerticalScrollBar.onPanScrollRelease = VerticalScrollBar.onTapScroll
 
 function VerticalScrollBar:getSize()
     return Geom:new{
@@ -32,6 +99,12 @@ end
 
 function VerticalScrollBar:paintTo(bb, x, y)
     if not self.enable then return end
+    self.touch_dimen = Geom:new{
+        x = x - self.extra_touch_on_side,
+        y = y,
+        w = self.width + 2 * self.extra_touch_on_side,
+        h = self.height,
+    }
     bb:paintBorder(x, y, self.width, self.height,
                    self.bordersize, self.bordercolor, self.radius)
     bb:paintRect(x + self.bordersize, y + self.bordersize + self.low * self.height,

--- a/reader.lua
+++ b/reader.lua
@@ -292,6 +292,13 @@ if ARGV[argidx] and ARGV[argidx] ~= "" then
             UIManager:nextTick(function()
                 FileManagerHistory:onShowHist(last_file)
             end)
+        elseif start_with == "favorites" then
+            local FileManagerCollection = require("apps/filemanager/filemanagercollection")
+            UIManager:nextTick(function()
+                FileManagerCollection:new{
+                    ui = FileManager.instance,
+                }:onShowColl("favorites")
+            end)
         elseif start_with == "folder_shortcuts" then
             local FileManagerShortcuts = require("apps/filemanager/filemanagershortcuts")
             UIManager:nextTick(function()


### PR DESCRIPTION
- Bookmarks: avoid possible crash. See https://github.com/koreader/koreader/issues/5387#issuecomment-675551293. Closes #5387 
- Start with: adds Favorites. Closes #6487 
- Text/HTML widgets: allows scrolling with the scrollbar. Closes #5308 
Little difference from what we are used to on computers: tapping jumps to where we tap, instead of paging just one page in that direction as on computers - as we can already page one page by tapping in the text or via other buttons (and it makes it a little easier to use).
Not super easy with dictionaries and Wikipedia (I made the touch area 3 times the width of the scrollbar, to not make the scrollbar larger and ugly, so I hope people were not tapping that near the scrollbar for browsing down current result or going to next...)
But quite fine with the TextEditor where the scrollbar is near the screen edge. May be easier on sunken screen like on my GloHD where we can follow the screen edge, dunno about flush screens.

(Just closing a few issues. 317 left to go at :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6577)
<!-- Reviewable:end -->
