### PR TITLE
Better zipping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,15 +354,16 @@ androidupdate: all
 	# in runtime luajit-launcher's libluajit.so will be loaded
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
 
-	# assets are compressed manually and stored inside the APK.
-	cd $(INSTALL_DIR)/koreader && zip -r9 \
+	cd $(INSTALL_DIR)/koreader && 7z a -l -mx=9 -mfb=256 -mmt=on \
 		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).zip * \
-		--exclude=*resources/fonts* \
-		--exclude=*resources/icons/src* \
-		--exclude=*share/man* \
-		--exclude=*spec* \
-		--exclude=*COPYING* \
-		--exclude=*README.md*
+		-xr!*resources/fonts* \
+		-xr!*resources/icons/src* \
+		-xr!*share/man* \
+		-xr!*spec$ \
+		-xr!*COPYING$ \
+		-xr!*README.md$ \
+		-xr!git$ \
+		-xr!gitiginore$ 
 
 	# make the android APK
 	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) $(if $(KODEBUG), debug, release) \

--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,7 @@ androidupdate: all
 	# in runtime luajit-launcher's libluajit.so will be loaded
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
 
+	# assets are compressed manually and stored inside the APK.
 	cd $(INSTALL_DIR)/koreader && 7z a -l -mx=9 -mfb=256 -mmt=on \
 		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).zip * \
 		-xr!*resources/fonts* \


### PR DESCRIPTION
This gives about 1Meg smaller apk.
Compression time on a quad-core is about twice as `zip -r9`, when using `mx=7` its about the same time (of course then the compression is not as good, but saves 800k)
Decompression memory usage does not seem to be bigger: Tested with grep `grep VmPeak /proc/$PID/status` and `grep VmHWM /proc/$PID/status` showed almost identical values.

I have used this compression the last weeks on Tolino and phone without strange effects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6587)
<!-- Reviewable:end -->
