### PR TITLE
History: show last read date, adds Text editor to "Open with" dialog

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -356,10 +356,19 @@ function FileManager:init()
             table.insert(buttons, {
                 {
                     text = _("Open with…"),
-                    enabled = DocumentRegistry:getProviders(file) == nil or #(DocumentRegistry:getProviders(file)) > 1,
+                    enabled = DocumentRegistry:getProviders(file) == nil or #(DocumentRegistry:getProviders(file)) > 1 or fileManager.texteditor,
                     callback = function()
                         UIManager:close(self.file_dialog)
-                        self:showSetProviderButtons(file, FileManager.instance, ReaderUI)
+                        local one_time_providers = {}
+                        if fileManager.texteditor then
+                            table.insert(one_time_providers, {
+                                provider_name = _("Text editor"),
+                                callback = function()
+                                    fileManager.texteditor:checkEditFile(file)
+                                end,
+                            })
+                        end
+                        self:showSetProviderButtons(file, FileManager.instance, ReaderUI, one_time_providers)
                     end,
                 },
                 {

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -158,19 +158,7 @@ local footerTextGeneratorMap = {
     time = function(footer)
         local symbol_type = footer.settings.item_prefix or "icons"
         local prefix = symbol_prefix[symbol_type].time
-        local clock
-        if footer.settings.time_format == "12" then
-            if os.date("%p") == "AM" then
-                -- @translators This is the time in the morning in the 12-hour clock (%I is the hour, %M the minute).
-                clock = os.date(_("%I:%M AM"))
-            else
-                -- @translators This is the time in the afternoon in the 12-hour clock (%I is the hour, %M the minute).
-                clock = os.date(_("%I:%M PM"))
-            end
-        else
-            -- @translators This is the time in the 24-hour clock (%H is the hour, %M the minute).
-            clock = os.date(_("%H:%M"))
-        end
+        local clock = util.secondsToHour(os.time(), footer.settings.time_format == "12")
         if not prefix then
             return clock
         else

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -83,6 +83,13 @@ function DocSettings:getNameFromHistory(hist_name)
     return string.sub(hist_name, string.len(s)+2, -5)
 end
 
+function DocSettings:getLastSaveTime(doc_path)
+    local attr = lfs.attributes(self:getSidecarFile(doc_path))
+    if attr and attr.mode == "file" then
+        return attr.modification
+    end
+end
+
 function DocSettings:ensureSidecar(sidecar)
     if lfs.attributes(sidecar, "mode") ~= "directory" then
         lfs.mkdir(sidecar)

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -14,6 +14,7 @@ Example:
 
 ]]
 
+local Blitbuffer = require("ffi/blitbuffer")
 local CheckMark = require("ui/widget/checkmark")
 local Device = require("device")
 local Font = require("ui/font")
@@ -50,6 +51,7 @@ function CheckButton:initCheckButton(checked)
     self.checked = checked
     self._checkmark = CheckMark:new{
         checked = self.checked,
+        enabled = self.enabled,
         parent = self.parent or self,
         show_parent = self.show_parent or self,
     }
@@ -57,6 +59,7 @@ function CheckButton:initCheckButton(checked)
         text = self.text,
         face = self.face,
         max_width = self.max_width,
+        fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
     }
     self._horizontalgroup = HorizontalGroup:new{
         self._checkmark,
@@ -140,6 +143,23 @@ function CheckButton:unCheck()
     self:initCheckButton(false)
     UIManager:setDirty(self.parent, function()
         return "fast", self.dimen
+    end)
+end
+
+function CheckButton:enable()
+    self.enabled = true
+    self:initCheckButton(self.checked)
+    UIManager:setDirty(self.parent, function()
+        return "ui", self.dimen
+    end)
+end
+
+function CheckButton:disable()
+    self.enabled = false
+    self:initCheckButton(false)
+    UIManager:setDirty(self.parent, function()
+        return "ui", self.dimen
+        -- best to use "ui" instead of "fast" when we make things gray
     end)
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -455,7 +455,7 @@ function FileChooser:getNextFile(curr_file)
     return next_file
 end
 
-function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_ui)
+function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_ui, one_time_providers)
     local __, filename_pure = util.splitFilePathName(file)
     local filename_suffix = util.getFileNameSuffix(file)
 
@@ -486,6 +486,17 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             },
         })
     end
+    if one_time_providers and #one_time_providers > 0 then
+        for ___, provider in ipairs(one_time_providers) do
+            provider.one_time_provider = true
+            table.insert(radio_buttons, {
+                {
+                    text = provider.provider_name,
+                    provider = provider,
+                },
+            })
+        end
+    end
 
     table.insert(buttons, {
         {
@@ -499,6 +510,11 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
             is_enter_default = true,
             callback = function()
                 local provider = self.set_provider_dialog.radio_button_table.checked_button.provider
+                if provider.one_time_provider then
+                    UIManager:close(self.set_provider_dialog)
+                    provider.callback()
+                    return
+                end
 
                 -- always for this file
                 if self.set_provider_dialog._check_file_button.checked then

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -490,7 +490,7 @@ end
 
 function InputDialog:onCloseWidget()
     self:onClose()
-    UIManager:setDirty(nil, function()
+    UIManager:setDirty(nil, self.fullscreen and "full" or function()
         return "partial", self.dialog_frame.dimen
     end)
 end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -236,12 +236,13 @@ function MenuItem:init()
     -- Padding before mandatory
     local text_mandatory_padding = 0
     local text_ellipsis_mandatory_padding = 0
-    if self.mandatory then
+    local mandatory = self.mandatory_func and self.mandatory_func() or self.mandatory
+    if mandatory then
         text_mandatory_padding = Size.span.horizontal_default
         -- Smaller padding when ellipsis for better visual feeling
         text_ellipsis_mandatory_padding = Size.span.horizontal_small
     end
-    local mandatory = self.mandatory and ""..self.mandatory or ""
+    mandatory = mandatory and ""..mandatory or ""
     local mandatory_widget = TextWidget:new{
         text = mandatory,
         face = self.info_face,
@@ -1014,6 +1015,7 @@ function Menu:updateItems(select_number)
                 text = Menu.getMenuText(self.item_table[i]),
                 bidi_wrap_func = self.item_table[i].bidi_wrap_func,
                 mandatory = self.item_table[i].mandatory,
+                mandatory_func = self.item_table[i].mandatory_func,
                 bold = self.item_table.current == i or self.item_table[i].bold == true,
                 dim = self.item_table[i].dim,
                 font = "smallinfofont",

--- a/frontend/ui/widget/openwithdialog.lua
+++ b/frontend/ui/widget/openwithdialog.lua
@@ -13,6 +13,7 @@ local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local RadioButtonTable = require("ui/widget/radiobuttontable")
 local Size = require("ui/size")
+local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
@@ -24,6 +25,21 @@ local OpenWithDialog = InputDialog:extend{}
 function OpenWithDialog:init()
     -- init title and buttons in base class
     InputDialog.init(self)
+
+    -- replace single line title with a multiline one,
+    -- as the filename might be long
+    self.title_widget:free()
+    self.title_widget = FrameContainer:new{
+        padding = self.title_padding,
+        margin = self.title_margin,
+        bordersize = 0,
+        TextBoxWidget:new{
+            text = self.title,
+            width = self.width - 2*self.title_padding - 2*self.title_margin,
+            face = self.title_face,
+        },
+    }
+
     self.face = Font:getFace("cfont", 22)
 
     self.radio_button_table = RadioButtonTable:new{
@@ -33,6 +49,15 @@ function OpenWithDialog:init()
         scroll = false,
         parent = self,
         face = self.face,
+        button_select_callback = function(btn)
+            if btn.provider.one_time_provider then
+                self._check_file_button:disable()
+                self._check_global_button:disable()
+            else
+                self._check_file_button:enable()
+                self._check_global_button:enable()
+            end
+        end
     }
 
     self._check_file_button = self._check_file_button or CheckButton:new{

--- a/frontend/ui/widget/radiobuttontable.lua
+++ b/frontend/ui/widget/radiobuttontable.lua
@@ -27,6 +27,7 @@ local RadioButtonTable = FocusManager:new{
     face = Font:getFace("cfont", 22),
     _first_button = nil,
     checked_button = nil,
+    button_select_callback = nil,
 }
 
 function RadioButtonTable:init()
@@ -72,6 +73,9 @@ function RadioButtonTable:init()
             }
             local button_callback = function()
                 self:_checkButton(button)
+                if self.button_select_callback then
+                    self.button_select_callback(btn_entry)
+                end
             end
             button.callback = button_callback
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -27,6 +27,7 @@ local UIManager = require("ui/uimanager")
 local UnderlineContainer = require("ui/widget/container/underlinecontainer")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
+local util = require("util")
 local getMenuText = require("ui/widget/menu").getMenuText
 local _ = require("gettext")
 local T = require("ffi/util").template
@@ -620,19 +621,7 @@ function TouchMenu:updateItems()
     self.page_info_left_chev:enableDisable(self.page > 1)
     self.page_info_right_chev:enableDisable(self.page < self.page_num)
 
-    local time_info_txt
-    if G_reader_settings:nilOrTrue("twelve_hour_clock") then
-        if os.date("%p") == "AM" then
-            -- @translators This is the time in the morning in the 12-hour clock (%I is the hour, %M the minute).
-            time_info_txt = os.date(_("%I:%M AM"))
-        else
-            -- @translators This is the time in the afternoon in the 12-hour clock (%I is the hour, %M the minute).
-            time_info_txt = os.date(_("%I:%M PM"))
-        end
-    else
-        -- @translators This is the time in the 24-hour clock (%H is the hour, %M the minute).
-        time_info_txt = os.date(_("%H:%M"))
-    end
+    local time_info_txt = util.secondsToHour(os.time(), G_reader_settings:nilOrTrue("twelve_hour_clock"))
     local powerd = Device:getPowerDevice()
     local batt_lvl = powerd:getCapacity()
     local batt_symbol

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -194,6 +194,38 @@ function util.secondsToHClock(seconds, withoutSeconds, hmsFormat)
     end
 end
 
+--- Converts timestamp to an hour string
+---- @int seconds number of seconds
+---- @bool twelve_hour_clock
+---- @treturn string hour string
+function util.secondsToHour(seconds, twelve_hour_clock)
+    local time
+    if twelve_hour_clock then
+        if os.date("%p", seconds) == "AM" then
+            -- @translators This is the time in the morning in the 12-hour clock (%I is the hour, %M the minute).
+            time = os.date(_("%I:%M AM"), seconds)
+        else
+            -- @translators This is the time in the afternoon in the 12-hour clock (%I is the hour, %M the minute).
+            time = os.date(_("%I:%M PM"), seconds)
+        end
+    else
+        -- @translators This is the time in the 24-hour clock (%H is the hour, %M the minute).
+        time = os.date(_("%H:%M"), seconds)
+    end
+    return time
+end
+
+--- Converts timestamp to a date string
+---- @int seconds number of seconds
+---- @bool twelve_hour_clock
+---- @treturn string date string
+function util.secondsToDate(seconds, twelve_hour_clock)
+    local BD = require("ui/bidi")
+    local time = util.secondsToHour(seconds, twelve_hour_clock)
+    -- @translators This is the date (%Y is the year, %m the month, %d the day)
+    local day = os.date(_("%Y-%m-%d"), seconds)
+    return BD.wrap(day) .. " " .. BD.wrap(time)
+end
 
 --[[--
 Compares values in two different tables.

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -235,6 +235,9 @@ function ListMenuItem:update()
             width = wleft_width,
             alignment = "left",
             bold = true,
+            height = dimen.h,
+            height_adjust = true,
+            height_overflow_show_ellipsis = true,
         }
         widget = OverlapGroup:new{
             dimen = dimen,
@@ -317,10 +320,25 @@ function ListMenuItem:update()
                     self.menu._has_cover_images = true
                     self._has_cover_image = true
                 else
-                    -- empty element the size of an image
+                    local fake_cover_w = max_img_w * 0.6
+                    local fake_cover_h = max_img_h
                     wleft = CenterContainer:new{
                         dimen = Geom:new{ w = wleft_width, h = wleft_height },
-                        HorizontalSpan:new{ width = wleft_width },
+                        FrameContainer:new{
+                            width = fake_cover_w + 2*border_size,
+                            height = fake_cover_h + 2*border_size,
+                            margin = 0,
+                            padding = 0,
+                            bordersize = border_size,
+                            dim = self.file_deleted,
+                            CenterContainer:new{
+                                dimen = Geom:new{ w = fake_cover_w, h = fake_cover_h },
+                                TextWidget:new{
+                                    text = "⛶", -- U+26F6 Square four corners
+                                    face = Font:getFace("cfont",  _fontSize(20)),
+                                },
+                            },
+                        },
                     }
                 end
             end

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -224,7 +224,7 @@ function ListMenuItem:update()
         self.is_directory = true
         -- nb items on the right, directory name on the left
         local wright = TextWidget:new{
-            text = self.mandatory,
+            text = self.mandatory_func and self.mandatory_func() or self.mandatory,
             face = Font:getFace("infont", math.min(max_fontsize_fileinfo, _fontSize(15))),
         }
         local pad_width = Screen:scaleBySize(10) -- on the left, in between, and on the right
@@ -357,15 +357,23 @@ function ListMenuItem:update()
             --   pages read / nb of pages (not available for crengine doc not opened)
             local directory, filename = util.splitFilePathName(self.filepath) -- luacheck: no unused
             local filename_without_suffix, filetype = util.splitFileNameSuffix(filename)
-            local fileinfo_str = filetype
-            if self.mandatory then
-                fileinfo_str = self.mandatory .. "  " .. BD.wrap(fileinfo_str)
-            end
-            if bookinfo._no_provider then
-                -- for unspported files: don't show extension on the right,
-                -- keep it in filename
-                filename_without_suffix = filename
-                fileinfo_str = self.mandatory
+            local fileinfo_str
+            if self.mandatory_func then
+                -- Currently only provided by History, giving the last time read.
+                -- Just show this date, without the file extension
+                fileinfo_str = self.mandatory_func()
+            else
+                if self.mandatory then
+                    fileinfo_str = BD.wrap(self.mandatory) .. "  " .. BD.wrap(filetype)
+                else
+                    fileinfo_str = filetype
+                end
+                if bookinfo._no_provider then
+                    -- for unspported files: don't show extension on the right,
+                    -- keep it in filename
+                    filename_without_suffix = filename
+                    fileinfo_str = self.mandatory
+                end
             end
             -- Current page / pages are available or more accurate in .sdr/metadata.lua
             -- We use a cache (cleaned at end of this browsing session) to store
@@ -949,6 +957,7 @@ function ListMenu:_updateItemsBuildUI()
                 text = getMenuText(entry),
                 show_parent = self.show_parent,
                 mandatory = entry.mandatory,
+                mandatory_func = entry.mandatory_func,
                 dimen = self.item_dimen:new(),
                 shortcut = item_shortcut,
                 shortcut_style = shortcut_style,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -329,6 +329,7 @@ function TextEditor:chooseFile()
 end
 
 function TextEditor:checkEditFile(file_path, from_history, possibly_new_file)
+    self:loadSettings()
     local attr = lfs.attributes(file_path)
     if not possibly_new_file and not attr then
         UIManager:show(ConfirmBox:new{


### PR DESCRIPTION
`FileChooser: allow traversing unreadable directories`
See https://github.com/koreader/koreader/issues/6508#issuecomment-681991683. Closes #6508. Ref https://github.com/koreader/koreader/issues/6379#issuecomment-659344319 https://github.com/koreader/koreader/issues/4885#issuecomment-494314073

`CoverBrowser: list mode: show fake cover when no cover`
See https://github.com/koreader/koreader/issues/6058#issuecomment-682117096. Closes #6058.
Also bump base for lua-ljsqlite3 to use sqlite3_close_v2() https://github.com/koreader/koreader-base/pull/1174 and avoid possible crashes https://github.com/koreader/koreader/issues/5563#issuecomment-682980942 

`util: adds util.secondsToHour(), util.secondsToDate()`
`History: show last read date instead of file size`
See https://github.com/koreader/koreader/issues/6041#issuecomment-682222999. Closes #6041. 

<kbd>![image](https://user-images.githubusercontent.com/24273478/91641545-6658b300-ea25-11ea-863b-cfd9c360f48d.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/91641562-87b99f00-ea25-11ea-83dc-51bc8bfeff5b.png)</kbd>

`Open with: add Text Editor plugin`
See https://github.com/koreader/koreader/issues/5996#issuecomment-683078913. Implemented option B. Closes #5996. 
<kbd>![image](https://user-images.githubusercontent.com/24273478/91641647-17f7e400-ea26-11ea-899d-2049426b7e20.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6593)
<!-- Reviewable:end -->
