### PR TITLE
[Android] update status bar on toggle of frontlight switch on Tolinos and status bar integration with native light dialog on all Android

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -25,6 +25,7 @@ local _ = require("gettext")
 local C_ = _.pgettext
 local Screen = Device.screen
 
+
 local MODE = {
     off = 0,
     page_progress = 1,
@@ -106,7 +107,7 @@ local footerTextGeneratorMap = {
         local symbol_type = footer.settings.item_prefix or "icons"
         local prefix = symbol_prefix[symbol_type].frontlight
         local powerd = Device:getPowerDevice()
-        if powerd:isFrontlightOn() then
+        if powerd:isFrontlightOn() and powerd:getFrontlightSwitchState() then
             if Device:isCervantes() or Device:isKobo() then
                 return (prefix .. " %d%%"):format(powerd:frontlightIntensity())
             else
@@ -114,6 +115,7 @@ local footerTextGeneratorMap = {
             end
         else
             return T(_("%1 Off"), prefix)
+
         end
     end,
     battery = function(footer)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -107,7 +107,7 @@ local footerTextGeneratorMap = {
         local symbol_type = footer.settings.item_prefix or "icons"
         local prefix = symbol_prefix[symbol_type].frontlight
         local powerd = Device:getPowerDevice()
-        if powerd:isFrontlightOn() and powerd:getFrontlightSwitchState() then
+        if powerd:isFrontlightOn() then
             if Device:isCervantes() or Device:isKobo() then
                 return (prefix .. " %d%%"):format(powerd:frontlightIntensity())
             else

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -418,6 +418,7 @@ function Device:showLightDialog()
             self.powerd.fl_warmth = self.powerd:getWarmth()
             logger.dbg("Dialog OK, warmth: " .. self.powerd.fl_warmth)
         end
+        self.powerd:broadcastLightChanges()
         return true
     elseif action == C.ALIGHTS_DIALOG_CANCEL then
         logger.dbg("Dialog Cancel, brightness: " .. self.powerd.fl_intensity)

--- a/frontend/device/android/event_map.lua
+++ b/frontend/device/android/event_map.lua
@@ -27,6 +27,7 @@ return {
     [84] = "Search",--SEARCH
     [92] = "LPgBack", -- PAGE_UP
     [93] = "LPgFwd",  -- PAGE_DOWN
+    [96] = "FLSwitch", -- BUTTON_A
 
     [104] = "LPgBack", -- T68 PageUp
     [109] = "LPgFwd",  -- T68 PageDown

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -12,7 +12,7 @@ end
 
 function AndroidPowerD:setIntensityHW(intensity)
     -- if frontlight switch was toggled of, turn it on
-    if not self.is_fl_sw_off then
+    if not self.is_fl_sw_on then
         android:enableFrontlightSwitch()
         self.is_fl_sw_on = true
     end
@@ -56,6 +56,11 @@ end
 
 function AndroidPowerD:isChargingHW()
     return android.isCharging()
+end
+
+function BasePowerD:isFrontlightOn()
+    assert(self ~= nil)
+    return self.is_fl_on and self.is_fl_sw_on
 end
 
 function AndroidPowerD:turnOffFrontlightHW()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -232,9 +232,7 @@ if Device:hasFrontlight() then
     end
 
     function DeviceListener:onShowFlDialog()
-        if Device:showLightDialog() then
-            UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))
-        end
+        Device:showLightDialog()
     end
 
 end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -212,12 +212,17 @@ if Device:hasFrontlight() then
 
     function DeviceListener:onToggleFrontlight()
         local powerd = Device:getPowerDevice()
-        powerd:toggleFrontlight()
         local new_text
-        if powerd.is_fl_on then
+        if not powerd:getFrontlightSwitchState() then
+            powerd:turnOnFrontlightHW()
             new_text = _("Frontlight enabled.")
         else
-            new_text = _("Frontlight disabled.")
+            powerd:toggleFrontlight()
+            if powerd.is_fl_on then
+                new_text = _("Frontlight enabled.")
+            else
+                new_text = _("Frontlight disabled.")
+            end
         end
         UIManager:show(Notification:new{
             text = new_text,
@@ -227,7 +232,9 @@ if Device:hasFrontlight() then
     end
 
     function DeviceListener:onShowFlDialog()
-        Device:showLightDialog()
+        if Device:showLightDialog() then
+            UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))
+        end
     end
 
 end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -66,7 +66,7 @@ end
 function BasePowerD:toggleFrontlight()
     assert(self ~= nil)
     if not self.device:hasFrontlight() then return false end
-    if self:isFrontlightOn() then
+    if self:isFrontlightOn() and self:getFrontlightSwitchState() then
         return self:turnOffFrontlight()
     else
         return self:turnOnFrontlight()
@@ -145,6 +145,18 @@ function BasePowerD:_setIntensity(intensity)
     self:setIntensityHW(intensity)
     -- BasePowerD is loaded before UIManager. So we cannot broadcast events before UIManager has
     -- been loaded.
+    self:broadcastLightChanges()
+end
+
+function BasePowerD:getFrontlightSwitchState()
+    return true
+end
+function BasePowerD:detectedFrontlightSwitchToggle()
+    return true
+end
+
+-- Let the footer know of the change
+function BasePowerD:broadcastLightChanges()
     if package.loaded["ui/uimanager"] ~= nil then
         local Event = require("ui/event")
         local UIManager = require("ui/uimanager")

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -341,6 +341,14 @@ function Input:handleKeyBoardEv(ev)
         return
     end
 
+    -- A Button to turn on/off the frontlight
+    if keycode == "FLSwitch" and ev.value == EVENT_VALUE_KEY_RELEASE then
+        local Device = require("device")
+        local powerd = Device:getPowerDevice()
+        powerd:detectedFrontlightSwitchToggle()
+        return "FLSwitch"
+    end
+
     if keycode == "Power" then
         -- Kobo generates Power keycode only, we need to decide whether it's
         -- power-on or power-off ourselves.

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -346,7 +346,7 @@ function Input:handleKeyBoardEv(ev)
         local Device = require("device")
         local powerd = Device:getPowerDevice()
         powerd:detectedFrontlightSwitchToggle()
-        return "FLSwitch"
+        return
     end
 
     if keycode == "Power" then


### PR DESCRIPTION
This is an extensive change, focused mainly on the status bar updates.
It can only applied together/after with https://github.com/koreader/android-luajit-launcher/pull/249

Only Android systems which have a frontlight toggle switch should be affected by this PR. On the other Androids is_fl_sw_on (is frontligh switch on) is always true.
Just as a remainder: Tolino Epos 2 has a software toggle (which emulates a keypress) and Tolino Vision4Hd has the same software toggle (in addition there is a hardware button, too).

So we have two different toggles. Our KOReader thing and that software/hardware button on the Tolinos.

On each keypress, change of intensity the statusline has to be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6594)
<!-- Reviewable:end -->
