### PR TITLE
Tame BackgroundRunner: stop running when no more job

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -137,6 +137,7 @@ files["spec/unit/*"].globals = {
     "package",
     "requireBackgroundRunner",
     "stopBackgroundRunner",
+    "notifyBackgroundJobsUpdated",
 }
 
 -- TODO: clean up and enforce max line width (631)

--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -178,6 +178,11 @@ function CervantesPowerD:calculateAutoWarmth()
                              end
                          end,
         })
+        if package.loaded["ui/uimanager"] ~= nil then
+            local Event = require("ui/event")
+            local UIManager = require("ui/uimanager")
+            UIManager:broadcastEvent(Event:new("BackgroundJobsUpdated"))
+        end
         self.autowarmth_job_running = true
     end
 end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -303,6 +303,11 @@ function KoboPowerD:calculateAutoWarmth()
                              end
                          end,
         })
+        if package.loaded["ui/uimanager"] ~= nil then
+            local Event = require("ui/event")
+            local UIManager = require("ui/uimanager")
+            UIManager:broadcastEvent(Event:new("BackgroundJobsUpdated"))
+        end
         self.autowarmth_job_running = true
     end
 end

--- a/frontend/ui/plugin/background_task_plugin.lua
+++ b/frontend/ui/plugin/background_task_plugin.lua
@@ -26,6 +26,9 @@ function BackgroundTaskPlugin:_schedule(settings_id)
         repeated = enabled,
         executable = self.executable,
     })
+    local Event = require("ui/event")
+    local UIManager = require("ui/uimanager")
+    UIManager:broadcastEvent(Event:new("BackgroundJobsUpdated"))
 end
 
 function BackgroundTaskPlugin:_start()

--- a/plugins/autofrontlight.koplugin/main.lua
+++ b/plugins/autofrontlight.koplugin/main.lua
@@ -48,6 +48,8 @@ function AutoFrontlight:_schedule(settings_id)
             end
         end
     })
+    local Event = require("ui/event")
+    UIManager:broadcastEvent(Event:new("BackgroundJobsUpdated"))
 end
 
 function AutoFrontlight:_action()

--- a/plugins/backgroundrunner.koplugin/main.lua
+++ b/plugins/backgroundrunner.koplugin/main.lua
@@ -171,7 +171,6 @@ function BackgroundRunner:_execute()
         local round = 0
         while #self.jobs > 0 do
             local job = table.remove(self.jobs, 1)
-            logger.dbg("BackgroundRunner: run job ", job, " @ ", os.time())
             if job.insert_sec == nil then
                 -- Jobs are first inserted to jobs table from external users. So
                 -- they may not have insert_sec field.
@@ -206,6 +205,7 @@ function BackgroundRunner:_execute()
             end
 
             if should_execute then
+                logger.dbg("BackgroundRunner: run job ", job, " @ ", os.time())
                 assert(not should_ignore)
                 self:_executeJob(job)
                 break
@@ -220,7 +220,11 @@ function BackgroundRunner:_execute()
 
     self.running = false
     if PluginShare.stopBackgroundRunner == nil then
-        self:_schedule()
+        if #self.jobs == 0 then
+            logger.dbg("BackgroundRunnerWidget: no job, stop running @ ", os.time())
+        else
+            self:_schedule()
+        end
     else
         logger.dbg("BackgroundRunnerWidget: stop running @ ", os.time())
     end
@@ -229,9 +233,13 @@ end
 function BackgroundRunner:_schedule()
     assert(self ~= nil)
     if self.running == false then
-        logger.dbg("BackgroundRunnerWidget: start running @ ", os.time())
-        self.running = true
-        UIManager:scheduleIn(2, function() self:_execute() end)
+        if #self.jobs == 0 then
+            logger.dbg("BackgroundRunnerWidget: no job, not running @ ", os.time())
+        else
+            logger.dbg("BackgroundRunnerWidget: start running @ ", os.time())
+            self.running = true
+            UIManager:scheduleIn(2, function() self:_execute() end)
+        end
     else
         logger.dbg("BackgroundRunnerWidget: a schedule is pending @ ",
                    os.time())
@@ -258,6 +266,12 @@ end
 
 function BackgroundRunnerWidget:onResume()
     logger.dbg("BackgroundRunnerWidget:onResume() @ ", os.time())
+    PluginShare.stopBackgroundRunner = nil
+    BackgroundRunner:_schedule()
+end
+
+function BackgroundRunnerWidget:onBackgroundJobsUpdated()
+    logger.dbg("BackgroundRunnerWidget:onBackgroundJobsUpdated() @ ", os.time())
     PluginShare.stopBackgroundRunner = nil
     BackgroundRunner:_schedule()
 end

--- a/plugins/backgroundrunner.koplugin/main.lua
+++ b/plugins/backgroundrunner.koplugin/main.lua
@@ -220,7 +220,7 @@ function BackgroundRunner:_execute()
 
     self.running = false
     if PluginShare.stopBackgroundRunner == nil then
-        if #self.jobs == 0 then
+        if #self.jobs == 0 and not CommandRunner:pending() then
             logger.dbg("BackgroundRunnerWidget: no job, stop running @ ", os.time())
         else
             self:_schedule()
@@ -233,7 +233,7 @@ end
 function BackgroundRunner:_schedule()
     assert(self ~= nil)
     if self.running == false then
-        if #self.jobs == 0 then
+        if #self.jobs == 0 and not CommandRunner:pending() then
             logger.dbg("BackgroundRunnerWidget: no job, not running @ ", os.time())
         else
             logger.dbg("BackgroundRunnerWidget: start running @ ", os.time())

--- a/spec/unit/autofrontlight_spec.lua
+++ b/spec/unit/autofrontlight_spec.lua
@@ -49,6 +49,7 @@ describe("AutoFrontlight widget tests", function()
 
         requireBackgroundRunner()
         class = dofile("plugins/autofrontlight.koplugin/main.lua")
+        notifyBackgroundJobsUpdated()
 
         -- Ensure the background runner has succeeded set the job.insert_sec.
         MockTime:increase(2)

--- a/spec/unit/background_runner_spec.lua
+++ b/spec/unit/background_runner_spec.lua
@@ -35,6 +35,8 @@ describe("BackgroundRunner widget tests", function()
                 executed = true
             end,
         })
+        notifyBackgroundJobsUpdated()
+
         MockTime:increase(2)
         UIManager:handleInput()
         MockTime:increase(9)
@@ -54,6 +56,7 @@ describe("BackgroundRunner widget tests", function()
                 executed = executed + 1
             end,
         })
+        notifyBackgroundJobsUpdated()
 
         MockTime:increase(2)
         UIManager:handleInput()
@@ -77,6 +80,7 @@ describe("BackgroundRunner widget tests", function()
                 executed = executed + 1
             end,
         })
+        notifyBackgroundJobsUpdated()
 
         MockTime:increase(2)
         UIManager:handleInput()
@@ -102,6 +106,7 @@ describe("BackgroundRunner widget tests", function()
             end,
         }
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         MockTime:increase(2)
         UIManager:handleInput()
@@ -125,6 +130,7 @@ describe("BackgroundRunner widget tests", function()
             end,
         }
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         while job.end_sec == nil do
             MockTime:increase(2)
@@ -149,6 +155,7 @@ describe("BackgroundRunner widget tests", function()
             }
         }
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         while job.end_sec == nil do
             MockTime:increase(2)
@@ -166,6 +173,7 @@ describe("BackgroundRunner widget tests", function()
         }
         job.end_sec = nil
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         while job.end_sec == nil do
             MockTime:increase(2)
@@ -196,6 +204,7 @@ describe("BackgroundRunner widget tests", function()
             end,
         }
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         while job.end_sec == nil do
             MockTime:increase(2)
@@ -210,6 +219,7 @@ describe("BackgroundRunner widget tests", function()
         job.end_sec = nil
         env2 = "no"
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         while job.end_sec == nil do
             MockTime:increase(2)
@@ -232,6 +242,7 @@ describe("BackgroundRunner widget tests", function()
             }
         }
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         while job.end_sec == nil do
             MockTime:increase(2)
@@ -253,6 +264,7 @@ describe("BackgroundRunner widget tests", function()
                 executed = executed + 1
             end,
         })
+        notifyBackgroundJobsUpdated()
 
         MockTime:increase(2)
         UIManager:handleInput()
@@ -281,6 +293,7 @@ describe("BackgroundRunner widget tests", function()
                 executed = executed + 1
             end,
         })
+        notifyBackgroundJobsUpdated()
 
         MockTime:increase(2)
         UIManager:handleInput()
@@ -305,6 +318,7 @@ describe("BackgroundRunner widget tests", function()
             end,
         }
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         MockTime:increase(2)
         UIManager:handleInput()
@@ -338,6 +352,7 @@ describe("BackgroundRunner widget tests", function()
             end,
         }
         table.insert(PluginShare.backgroundJobs, job)
+        notifyBackgroundJobsUpdated()
 
         for i = 1, 10 do
             requireBackgroundRunner():onResume()

--- a/spec/unit/commonrequire.lua
+++ b/spec/unit/commonrequire.lua
@@ -103,3 +103,9 @@ stopBackgroundRunner = function()
     background_runner = nil
     require("pluginshare").stopBackgroundRunner = true
 end
+
+notifyBackgroundJobsUpdated = function()
+    if background_runner then
+        background_runner:onBackgroundJobsUpdated()
+    end
+end


### PR DESCRIPTION
(I really don't like this plugin, and for a few years I've been having bad sleep, knowing that it _is_ running for nothing on thousands of devices and that users don't even know it - and it _is_ surely responsible for climate change and global warming :/ So, may be it's not too late... :)

A BackgroundRunner plugin instance will stop running (rescheduling a check every 2 seconds) when there is no (or no more) job to run.
Clients of this service now have to emit an event after adding a job into PluginShare.backgroundJobs, so an already loaded but stopped BackgroundRunner can notice it and start running again.
Ref https://github.com/koreader/koreader/pull/3608#issuecomment-357929349

Not tested on devices where it is really used: some kindle for autofrontlight, some kobo and cervantes for autowarmth. So, please do if you can (or report once it's merged).
Tested with this and a click on the Version menu item:
```diff
--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -20,6 +20,15 @@ common_info.version = {
         UIManager:show(InfoMessage:new{
             text = Version:getCurrentRevision(),
         })
+        table.insert(require("pluginshare").backgroundJobs, {
+                         when = 10,
+                         repeated = 3,
+                         executable = function()
+                            print("test")
+                         end,
+        })
+        local Event = require("ui/event")
+        UIManager:broadcastEvent(Event:new("BackgroundJobsUpdated"))
     end
 }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6605)
<!-- Reviewable:end -->
