### PR TITLE
Autostandby: Fix variable ref.

### DIFF
--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -93,7 +93,7 @@ function AutoStandby:onInputEvent()
         -- all standbys forbidden, always prevent
         self:prevent()
         return
-    elseif delay == 0 then
+    elseif self.delay == 0 then
         -- If delay is 0 now, just allow straight
         self:allow()
         return


### PR DESCRIPTION
Since circleci decided to ignore everything I spam around until it's too late for some reason, I'll run luacheck manually from now on, pinky promise.

(./kodev is unfortunately badly broken on archlinux, so have to go a little blind wrt testing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6612)
<!-- Reviewable:end -->
