### PR TITLE
bump crengine: TextLang, hyphenation: add Serbian

### DIFF
--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -87,7 +87,7 @@ local LANGUAGES = {
     { "ru-GB",                 {},   "Hb  ",   _("Russian + English (UK)") },
     { "ru-US",                 {},   "Hb  ",   _("Russian + English (US)") },
     { "ru",               {"rus"},   "Hb  ",   _("Russian") },
-    { "sr",               {"srp"},   "H   ",   _("Serbian") },
+    { "sr",               {"srp"},   "HB  ",   _("Serbian") },
     { "sk",               {"slk"},   "HB  ",   _("Slovak") },
     { "sl",               {"slv"},   "H   ",   _("Slovenian") },
     { "es",               {"spa"},   "Hb  ",   _("Spanish") },


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/372 : TextLang, hyphenation: add Serbian
Follow up to #6596.

Also fix CoverBrowser list mode with History, to show the last read date of deleted files. See https://github.com/koreader/koreader/issues/6041#issuecomment-684762928

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6618)
<!-- Reviewable:end -->
