### PR TITLE
Pocketbook: Launcher OS integration

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -321,6 +321,14 @@ end
 
 -- Exit
 local function exitReader()
+    -- Exit code can be shoddy on some platforms due to broken library dtors calling _exit(0) from os.exit(N)
+    local ko_exit = os.getenv("KO_EXIT_CODE")
+    if ko_exit then
+        local fo = io.open(ko_exit, "w+")
+        fo:write(tostring(exit_code))
+        fo:close()
+    end
+
     local ReaderActivityIndicator =
         require("apps/reader/modules/readeractivityindicator")
 


### PR DESCRIPTION
* Bring in restart koreader & shutdown device exit options
* Selecting books in stock explorer reuses running instance

ref #6597

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6620)
<!-- Reviewable:end -->
