### PR TITLE
Pocketbook: Add file associations into "Open with" menu

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -206,7 +206,7 @@ function PocketBook:associateFileExtensions(assoc)
         local t = info[k]
         if t then
             -- A system entry exists, so just change app, and reuse the rest
-            t[4] = app_name
+            t[4] = app_name .. "," .. t[4]
         else
             -- Doesn't exist, so hallucinate up something
             -- TBD: We have document opener in 'v', maybe consult mime in there?


### PR DESCRIPTION
We used to put koreader alone in there, but apparently other
handlers can be left in as optional - see #6415 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6624)
<!-- Reviewable:end -->
