### PR TITLE
[wip]: Turn the bookmark detail dialog into a bookmark navigator, with search button

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -452,7 +452,7 @@ function ReaderBookmark:onShowBookmark()
                     end,
                     save_button_text = _("Search")
                 }
-                self:prompt(arguments)
+                bookmark:prompt(arguments)
             end,
         })
         if bookmark.search_value ~= "" then

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -14,6 +14,7 @@ local TextViewer = require("ui/widget/textviewer")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
+local util = require("util")
 local Screen = require("device").screen
 local T = require("ffi/util").template
 
@@ -317,25 +318,6 @@ function ReaderBookmark:updateHighlightsIfNeeded()
     self.ui.doc_settings:saveSetting("bookmarks_version", 20200615)
 end
 
-local function split(str, pat)
-    local t = {}  -- NOTE: use {n = 0} in Lua-5.0
-    local fpat = "(.-)" .. pat
-    local last_end = 1
-    local s, e, cap = str:find(fpat, 1)
-    while s do
-        if s ~= 1 or cap ~= "" then
-            table.insert(t, cap)
-        end
-        last_end = e + 1
-        s, e, cap = str:find(fpat, last_end)
-    end
-    if last_end <= #str then
-        cap = str:sub(last_end)
-        table.insert(t, cap)
-    end
-    return t
-end
-
 local function substrCount(subject, needle)
     return select(2, subject:gsub(needle, ""))
 end
@@ -355,9 +337,8 @@ local function isPoem(itext)
     local requisition1 = line_endings_count > 3
 
     -- check whether lines are not too long:
-    local lines = split(itext, "\n")
     local requisition2 = true
-    for _, line in ipairs(lines) do
+    for line in util.gsplit(itext, "\n", true, true) do
         if string.len(line) > 52 then
             requisition2 = false
             break
@@ -369,8 +350,8 @@ end
 local function indent(itext)
     -- only for non poetic text indent para's:
     if not isPoem(itext) then
-        local paras = split(itext, "\n")
         local skip_next_para = false
+        local paras = util.splitToArray(itext, "\n", true)
         for nr, para in ipairs(paras) do
             if nr > 1 and para:match("[A-Za-z]") then
                 if not skip_next_para then

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -447,16 +447,15 @@ function ReaderBookmark:onShowBookmark()
         table.insert(first_button_row, {
             text = _("Search"),
             callback = function()
-                local arguments = {
-                    title = _("Search in bookmarks"),
+                bookmark:prompt({
+                    title = _("Bookmark search"),
                     value = bookmark.search_value,
                     hint = _("Needle"),
                     callback = function(query)
                         bookmark:search(string.lower(query), bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
                     end,
                     save_button_text = _("Search")
-                }
-                bookmark:prompt(arguments)
+                })
             end,
         })
         table.insert(first_button_row, {

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -64,6 +64,8 @@ function ReaderBookmark:addToMainMenu(menu_items)
 end
 
 function ReaderBookmark:search(query, bookmarks, current_bookmark, bm_menu, viewer_instance, direction)
+    -- make sure query doesn't fail on special characters:
+    query = query:gsub("%.", "%."):gsub("%-", "%-")
     self.search_value = query
     local content
     local found_index = 0

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -64,6 +64,11 @@ function ReaderBookmark:addToMainMenu(menu_items)
 end
 
 function ReaderBookmark:search(query, bookmarks, current_bookmark, bm_menu, viewer_instance, direction)
+    -- handle empty queries:
+    if query == "" then
+        self.search_value = ""
+        return
+    end
     -- make sure query doesn't fail on special characters:
     query = query:gsub("%.", "%."):gsub("%-", "%-")
     self.search_value = query

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -448,11 +448,11 @@ function ReaderBookmark:onShowBookmark(open_navigator)
             page = bookmark.ui.document:getPageFromXPointer(ipage)
         end
         if page ~= "" then
-            title = title .. "  -  " .. _("page") .. " " .. page
+            title = T("%1  -  %2 %3", title, _("page"), page)
         end
         -- show search term in title:
         if bookmark.search_value and bookmark.search_value ~= "" then
-            title = title .. '  -  "' .. bookmark.search_value .. '"'
+            title = T('%1  -  "%2"', title, bookmark.search_value)
         end
         local from_start_text = "▕◁"
         local backward_text = "◁"

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -432,14 +432,13 @@ function ReaderBookmark:onShowBookmark()
             -- Keep the LTR order of |< and >|:
             from_start_text, from_end_text = BD.ltr(from_end_text), BD.ltr(from_start_text)
         end
-        if bookmark.search_value ~= "" then
-            table.insert(first_button_row, {
-                text = backward_text,
-                callback = function()
-                    bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, -1)
-                end,
-            })
-        end
+        table.insert(first_button_row, {
+            text = backward_text,
+            enabled = bookmark.search_value ~= "",
+            callback = function()
+                bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, -1)
+            end,
+        })
         table.insert(first_button_row, {
             text = _("Search"),
             callback = function()
@@ -455,14 +454,13 @@ function ReaderBookmark:onShowBookmark()
                 bookmark:prompt(arguments)
             end,
         })
-        if bookmark.search_value ~= "" then
-            table.insert(first_button_row, {
-                text = forward_text,
-                callback = function()
-                    bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
-                end,
-            })
-        end
+        table.insert(first_button_row, {
+            text = forward_text,
+            enabled = bookmark.search_value ~= "",
+            callback = function()
+                bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
+            end,
+        })
         table.insert(first_button_row, {
             text = _("Go to"),
             callback = function()

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -394,6 +394,15 @@ function ReaderBookmark:onShowBookmark()
         if bookmark.search_value and bookmark.search_value ~= "" then
             title = title .. '  -  "' .. bookmark.search_value .. '"'
         end
+        local from_start_text = "▕◁"
+        local backward_text = "◁"
+        local forward_text = "▷"
+        local from_end_text = "▷▏"
+        if BD.mirroredUILayout() then
+            backward_text, forward_text = forward_text, backward_text
+            -- Keep the LTR order of |< and >|:
+            from_start_text, from_end_text = BD.ltr(from_end_text), BD.ltr(from_start_text)
+        end
         local first_button_row = {
             {
                 text = _("Remove"),
@@ -427,53 +436,44 @@ function ReaderBookmark:onShowBookmark()
                     UIManager:close(self.textviewer)
                 end,
             },
+            {
+                text = backward_text,
+                enabled = bookmark.search_value ~= "",
+                callback = function()
+                    bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, -1)
+                end,
+            },
+            {
+                text = _("Search"),
+                callback = function()
+                    bookmark:prompt({
+                        title = _("Bookmark search"),
+                        value = bookmark.search_value,
+                        hint = _("Needle"),
+                        callback = function(query)
+                            bookmark:search(string.lower(query), bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
+                        end,
+                        save_button_text = _("Search")
+                    })
+                end,
+            },
+            {
+                text = forward_text,
+                enabled = bookmark.search_value ~= "",
+                callback = function()
+                    bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
+                end,
+            },
+            {
+                text = _("Go to"),
+                callback = function()
+                    UIManager:close(self.textviewer)
+                    UIManager:close(bookmark.bookmark_menu)
+                    bookmark.ui.link:addCurrentLocationToStack()
+                    bookmark:gotoBookmark(item.page)
+                end,
+            },
         }
-        local from_start_text = "▕◁"
-        local backward_text = "◁"
-        local forward_text = "▷"
-        local from_end_text = "▷▏"
-        if BD.mirroredUILayout() then
-            backward_text, forward_text = forward_text, backward_text
-            -- Keep the LTR order of |< and >|:
-            from_start_text, from_end_text = BD.ltr(from_end_text), BD.ltr(from_start_text)
-        end
-        table.insert(first_button_row, {
-            text = backward_text,
-            enabled = bookmark.search_value ~= "",
-            callback = function()
-                bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, -1)
-            end,
-        })
-        table.insert(first_button_row, {
-            text = _("Search"),
-            callback = function()
-                bookmark:prompt({
-                    title = _("Bookmark search"),
-                    value = bookmark.search_value,
-                    hint = _("Needle"),
-                    callback = function(query)
-                        bookmark:search(string.lower(query), bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
-                    end,
-                    save_button_text = _("Search")
-                })
-            end,
-        })
-        table.insert(first_button_row, {
-            text = forward_text,
-            enabled = bookmark.search_value ~= "",
-            callback = function()
-                bookmark:search(bookmark.search_value, bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
-            end,
-        })
-        table.insert(first_button_row, {
-            text = _("Go to"),
-            callback = function()
-                UIManager:close(self.textviewer)
-                UIManager:close(bookmark.bookmark_menu)
-                bookmark.ui.link:addCurrentLocationToStack()
-                bookmark:gotoBookmark(item.page)
-            end,
-        })
         local second_button_row = {
             {
                 text = from_start_text,

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -63,14 +63,16 @@ function ReaderBookmark:addToMainMenu(menu_items)
     end
 end
 
-function ReaderBookmark:search(query, bookmarks, current_bookmark, bm_menu, viewer_instance, direction)
+function ReaderBookmark:search(query, bookmarks, current_bookmark, bm_menu, viewer_instance, direction, manual_search)
     -- handle empty queries:
     if query == "" then
         self.search_value = ""
         return
     end
-    -- make sure query doesn't fail on special characters:
-    query = query:gsub("%.", "%."):gsub("%-", "%-")
+    -- make sure query doesn't fail on special characters. Only applied for manually searched terms, not for searching previous or next hits with buttons:
+    if manual_search then
+        query = query:gsub("%.", "%."):gsub("%-", "%-"):gsub("%%", "%%")
+    end
     self.search_value = query
     local content
     local found_index = 0
@@ -456,10 +458,10 @@ function ReaderBookmark:onShowBookmark(open_navigator)
                 callback = function()
                     bookmark:prompt({
                         title = _("Bookmark search"),
-                        value = bookmark.search_value,
+                        value = bookmark.search_value:gsub("%%", ""),
                         hint = _("Needle"),
                         callback = function(query)
-                            bookmark:search(string.lower(query), bookmarks, current_bookmark, bm_menu, self.textviewer, 1)
+                            bookmark:search(string.lower(query), bookmarks, current_bookmark, bm_menu, self.textviewer, 1, true)
                         end,
                         save_button_text = _("Search")
                     })

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -386,8 +386,13 @@ function ReaderBookmark:onShowBookmark()
             end
         end
         local title = T(_("Bookmark details  -  %1/%2"), tostring(current_bookmark), tostring(#bookmarks))
+        -- show page of bookmark in title:
         if page ~= "" then
             title = title .. "  -  " .. string.lower(page)
+        end
+        -- show search term in title:
+        if bookmark.search_value and bookmark.search_value ~= "" then
+            title = title .. '  -  "' .. bookmark.search_value .. '"'
         end
         local first_button_row = {
             {

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -308,7 +308,8 @@ function ReaderBookmark:updateHighlightsIfNeeded()
     self.ui.doc_settings:saveSetting("bookmarks_version", 20200615)
 end
 
-function ReaderBookmark:onShowBookmark()
+-- make bookmark navigator available for gesture through open_navigator (if set, then open navigator):
+function ReaderBookmark:onShowBookmark(open_navigator)
     self:updateHighlightsIfNeeded()
     -- build up item_table
     for k, v in ipairs(self.bookmarks) do
@@ -356,7 +357,7 @@ function ReaderBookmark:onShowBookmark()
         bm_menu,
     }
 
-    -- buid up menu widget method as closure
+    -- build up menu widget method as closure
     local bookmark = self
     function bm_menu:onMenuChoice(item)
         bookmark.ui.link:addCurrentLocationToStack()
@@ -557,6 +558,14 @@ function ReaderBookmark:onShowBookmark()
     end
 
     UIManager:show(self.bookmark_menu)
+    if open_navigator then
+        if #self.bookmarks > 0 then
+            -- open first bookmark in page order:
+            bm_menu:onMenuHold(self.bookmarks[#self.bookmarks])
+        else
+            UIManager:show(InfoMessage:new { text = _('Bookmarks navigator: no bookmarks defined yet') })
+        end
+    end
     return true
 end
 

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -311,7 +311,7 @@ end
 function ReaderBookmark:onShowBookmark()
     self:updateHighlightsIfNeeded()
     -- build up item_table
-    for _, v in ipairs(self.bookmarks) do
+    for k, v in ipairs(self.bookmarks) do
         local page = v.page
         -- for CREngine, bookmark page is xpointer
         if not self.ui.document.info.has_pages then
@@ -322,6 +322,7 @@ function ReaderBookmark:onShowBookmark()
             end
         end
         if v.text == nil or v.text == "" then
+            self.garbage = k
             v.text = T(_("Page %1 %2 @ %3"), page, v.notes, v.datetime)
         end
     end
@@ -377,18 +378,17 @@ function ReaderBookmark:onShowBookmark()
         for nr, bmk in ipairs(bookmarks) do
             if item.index == bmk.index then
                 current_bookmark = nr
-                -- grep the "page" string and page number:
-                page = item.text:match("^([A-Za-z]+ [0-9]+)")
-                if page == nil then
-                    page = ""
-                end
                 break
             end
         end
         local title = T(_("Bookmark details  -  %1/%2"), tostring(current_bookmark), tostring(#bookmarks))
         -- show page of bookmark in title:
+        local ipage = item.page
+        if not bookmark.ui.document.info.has_pages then
+            page = bookmark.ui.document:getPageFromXPointer(ipage)
+        end
         if page ~= "" then
-            title = title .. "  -  " .. string.lower(page)
+            title = title .. "  -  " .. _("page") .. " " .. page
         end
         -- show search term in title:
         if bookmark.search_value and bookmark.search_value ~= "" then
@@ -527,10 +527,6 @@ function ReaderBookmark:onShowBookmark()
         }
         local text = item.notes
         if not item.highlighted then
-            local ipage = item.page
-            if not bookmark.ui.document.info.has_pages then
-                ipage = bookmark.ui.document:getPageFromXPointer(ipage)
-            end
             text = T(_("Page %1 %2 @ %3"), ipage, item.notes, item.datetime)
         end
         self.textviewer = TextViewer:new{

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -570,7 +570,7 @@ function ReaderBookmark:prompt(args)
     local value = args.value
     local description = args.description
     local callback = args.callback
-    local cancel_callback = args.cancel_callback or nil
+    local cancel_callback = args.cancel_callback
     local title = args.title or _("Edit")
     local save_button_text = args.save_button_text or _("Save")
     local prompt_dialog

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -609,13 +609,14 @@ function ReaderBookmark:onShowBookmark(open_navigator)
             text = T(_("Page %1 %2 @ %3"), ipage, item.notes, item.datetime)
         end
 
+        local font_size = G_reader_settings:readSetting("dict_font_size") or 20
         self.textviewer = TextViewer:new{
             title = title,
             -- add indentation for better readability:
             text = indent(text),
             -- make text easier to read:
             justified = false,
-            text_face = Font:getFace("xx_smallinfofont"),
+            text_face = Font:getFace("cfont", font_size),
             width = self.textviewer_width,
             height = self.textviewer_height,
             buttons_table = {

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -539,9 +539,46 @@ function ReaderBookmark:onShowBookmark(open_navigator)
         if not item.highlighted then
             text = T(_("Page %1 %2 @ %3"), ipage, item.notes, item.datetime)
         end
+
+        local function split(str, pat)
+            local t = {}  -- NOTE: use {n = 0} in Lua-5.0
+            local fpat = "(.-)" .. pat
+            local last_end = 1
+            local s, e, cap = str:find(fpat, 1)
+            while s do
+                if s ~= 1 or cap ~= "" then
+                    table.insert(t, cap)
+                end
+                last_end = e + 1
+                s, e, cap = str:find(fpat, last_end)
+            end
+            if last_end <= #str then
+                cap = str:sub(last_end)
+                table.insert(t, cap)
+            end
+            return t
+        end
+        local function indent(itext)
+            local paras = split(itext, "\n")
+            local skip_next_para = false
+            for nr, para in ipairs(paras) do
+                if nr > 1 and para:match("[A-Za-z]") then
+                    if not skip_next_para then
+                        paras[nr] = "     " .. para
+                    else
+                        skip_next_para = false
+                    end
+                elseif nr > 1 then
+                    skip_next_para = true
+                end
+            end
+            return table.concat(paras, "\n")
+        end
+
         self.textviewer = TextViewer:new{
             title = title,
-            text = text,
+            -- add indentation for better readability:
+            text = indent(text),
             -- make text easier to read:
             justified = false,
             text_face = Font:getFace("xx_smallinfofont"),

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -102,6 +102,7 @@ local settingsList = {
     clear_location_history = { category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), rolling=true, paging=true, separator=true,},
     toc = { category="none", event="ShowToc", title=_("Table of contents"), rolling=true, paging=true,},
     bookmarks = { category="none", event="ShowBookmark", title=_("Bookmarks"), rolling=true, paging=true,},
+    bookmarks_navigator = { category = "none", event = "ShowBookmark", arg = true, title = _("Bookmarks navigator"), rolling = true, paging = true, },
     book_statistics = { category="none", event="ShowBookStats", title=_("Book statistics"), rolling=true, paging=true, separator=true,},
     book_status = { category="none", event="ShowBookStatus", title=_("Book status"), rolling=true, paging=true,},
     book_info = { category="none", event="ShowBookInfo", title=_("Book information"), rolling=true, paging=true,},
@@ -236,6 +237,7 @@ local dispatcher_menu_order = {
 
     "toc",
     "bookmarks",
+    "bookmarks_navigator",
     "book_statistics",
 
     "book_status",


### PR DESCRIPTION
With this changes you can easily navigate between bookmarks, without the need to jump to them in the text. When search term entered, easily navigate between bookmarks with hits for that term (then arrow buttons available).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6627)
<!-- Reviewable:end -->
