### PR TITLE
Only show Wi-Fi icon/symbol in footer when Wi-Fi has been enabled

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -245,10 +245,11 @@ local footerTextGeneratorMap = {
         local prefix = symbol_prefix[symbol_type].wifi_status
         local NetworkMgr = require("ui/network/manager")
         if NetworkMgr:isWifiOn() then
-            return T(_("%1 On"), prefix)
-        else
-            return T(_("%1 Off"), prefix)
+            -- only show wifi-icon/symbol when wifi enabled:
+            return prefix
         end
+        -- wifi off, so no icon/symbol:
+        return ""
     end,
     book_title = function(footer)
         local doc_info = footer.ui.document:getProps()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -245,10 +245,10 @@ local footerTextGeneratorMap = {
         local prefix = symbol_prefix[symbol_type].wifi_status
         local NetworkMgr = require("ui/network/manager")
         if NetworkMgr:isWifiOn() then
-            -- only show wifi-icon/symbol when wifi enabled:
+            -- only show Wi-Fi-icon/symbol when Wi-Fi enabled:
             return prefix
         end
-        -- wifi off, so no icon/symbol:
+        -- Wi-Fi off, so no icon/symbol:
         return ""
     end,
     book_title = function(footer)


### PR DESCRIPTION
The Wi-Fi icon is very visible in the footer. So I think it better to hide it when Wi-Fi has been disabled. In which case the "on" and "off" status indications in the footer are also unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6656)
<!-- Reviewable:end -->
