### PR TITLE
remarkable: fix fbdepth use in startup script

### DIFF
--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -108,7 +108,7 @@ ko_do_fbdepth() {
         # Swap to 8bpp if things look sane
         if [ -n "${ORIG_FB_BPP}" ]; then
             echo "Switching fb bitdepth to 8bpp & rotation to Portrait" >>crash.log 2>&1
-            ./fbdepth -d 8 -r -1 >>crash.log 2>&1
+            ./fbdepth -d 8 -r 1 >>crash.log 2>&1
         fi
     fi
 }


### PR DESCRIPTION
The reMarkable version of fbdepth doesn't support the -1 rotation so
this was actually not setting the rotation at all. I didn't notice this
as I was always launching koreader from xochitl so the rotation was
already set correctly.

This means that if koreader is started up as the default UI then the
display actually gets set up correctly!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6658)
<!-- Reviewable:end -->
