### PR TITLE
ReaderFooter: update FL on toggle

### DIFF
--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -21,7 +21,7 @@ function KindlePowerD:init()
 end
 
 -- If we start with the light off (fl_intensity is fl_min), ensure a toggle will set it to the lowest "on" step,
--- and that we update fl_intensity (by using setIntensity and not _setIntensity).
+-- and that we update fl_intensity (by using setIntensity and not setIntensityHW).
 function KindlePowerD:turnOnFrontlightHW()
     self:setIntensity(self.fl_intensity == self.fl_min and self.fl_min + 1 or self.fl_intensity)
 end
@@ -32,6 +32,7 @@ function BasePowerD:turnOnFrontlight()
     if self:isFrontlightOn() then return false end
     self:turnOnFrontlightHW()
     self.is_fl_on = true
+    self:stateChanged()
     return true
 end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -327,8 +327,7 @@ function KoboPowerD:turnOffFrontlightHW()
     end
     ffiUtil.runInSubProcess(function()
         for i = 1,5 do
-            -- NOTE: Make sure _setIntensity doesn't send a FrontlightStateChanged event for those!
-            self:_setIntensity(math.floor(self.fl_intensity - ((self.fl_intensity / 5) * i)), true)
+            self:setIntensityHW(math.floor(self.fl_intensity - ((self.fl_intensity / 5) * i)))
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then
@@ -338,21 +337,15 @@ function KoboPowerD:turnOffFrontlightHW()
             end
         end
     end, false, true)
-    -- NOTE: This is essentially what _setIntensity does, except we don't actually touch the FL,
+    -- NOTE: This is essentially what setIntensityHW does, except we don't actually touch the FL,
     --       we only sync the state of the main process with the final state of what we're doing in the forks.
     -- And update hw_intensity in our actual process ;).
     self.hw_intensity = self.fl_min
-    -- NOTE: And don't forget to update sysfs_light, too, as a real _setIntensity would via setBrightness
+    -- NOTE: And don't forget to update sysfs_light, too, as a real setIntensityHW would via setBrightness
     if self.fl then
         self.fl.current_brightness = self.fl_min
     end
     self:_decideFrontlightState()
-    -- And let the footer know of the change
-    if package.loaded["ui/uimanager"] ~= nil then
-        local Event = require("ui/event")
-        local UIManager = require("ui/uimanager")
-        UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))
-    end
 end
 
 function KoboPowerD:turnOnFrontlightHW()
@@ -367,8 +360,7 @@ function KoboPowerD:turnOnFrontlightHW()
     end
     ffiUtil.runInSubProcess(function()
         for i = 1,5 do
-            -- NOTE: Make sure _setIntensity doesn't send a FrontlightStateChanged event for those!
-            self:_setIntensity(math.ceil(self.fl_min + ((self.fl_intensity / 5) * i)), true)
+            self:setIntensityHW(math.ceil(self.fl_min + ((self.fl_intensity / 5) * i)))
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then
@@ -378,21 +370,15 @@ function KoboPowerD:turnOnFrontlightHW()
             end
         end
     end, false, true)
-    -- NOTE: This is essentially what _setIntensity does, except we don't actually touch the FL,
+    -- NOTE: This is essentially what setIntensityHW does, except we don't actually touch the FL,
     --       we only sync the state of the main process with the final state of what we're doing in the forks.
     -- And update hw_intensity in our actual process ;).
     self.hw_intensity = self.fl_intensity
-    -- NOTE: And don't forget to update sysfs_light, too, as a real _setIntensity would via setBrightness
+    -- NOTE: And don't forget to update sysfs_light, too, as a real setIntensityHW would via setBrightness
     if self.fl then
         self.fl.current_brightness = self.fl_intensity
     end
     self:_decideFrontlightState()
-    -- And let the footer know of the change
-    if package.loaded["ui/uimanager"] ~= nil then
-        local Event = require("ui/event")
-        local UIManager = require("ui/uimanager")
-        UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))
-    end
 end
 
 -- Turn off front light before suspend.

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -11,6 +11,10 @@ local SDLPowerD = BasePowerD:new{
     fl_warmth_max = 100,
 }
 
+function SDLPowerD:frontlightIntensityHW()
+    return self.hw_intensity
+end
+
 function SDLPowerD:setIntensityHW(intensity)
     require("logger").info("set brightness to", intensity)
     self.hw_intensity = intensity or self.hw_intensity


### PR DESCRIPTION
`isFrontlightOnHW()` was returning a value from powerd not from hardware before powerd was updated, therefore `_decideFrontlightState()` would have the old state.

The `FrontlightStateChanged` event used by `ReaderFooter` was called by `_setIntensity` before `powerd.is_fl_on` was toggled by `_decideFrontlightState()`

Also add `isFrontlightOnHW()` for the emulator (it was broken)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6664)
<!-- Reviewable:end -->
