### PR TITLE
correct bug introduced with #6641

### DIFF
--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -39,10 +39,10 @@ function AndroidPowerD:init()
     end
 
     if self.device:hasNaturalLight() then
-        self.fl_warmth = self:getWarmth()
         self.fl_warmth_min = android.getScreenMinWarmth()
         self.fl_warmth_max = android.getScreenMaxWarmth()
         self.warm_diff = self.fl_warmth_max - self.fl_warmth_min
+        self.fl_warmth = self:getWarmth()
     end
 end
 


### PR DESCRIPTION
getWarmth must not be called before warm_diff is initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6665)
<!-- Reviewable:end -->
