### PR TITLE
[Kobo] Don't send a flood a FrontlightStateChanged events during the FL ramps

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1704,6 +1704,7 @@ function ReaderFooter:getDataFromStatistics(title, pages)
 end
 
 function ReaderFooter:onUpdateFooter(force_repaint, force_recompute)
+    print("ReaderFooter:onUpdateFooter", force_repaint, force_recompute)
     if self.pageno then
         self:updateFooterPage(force_repaint, force_recompute)
     else
@@ -1730,6 +1731,7 @@ end
 
 -- only call this function after document is fully loaded
 function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
+    print("ReaderFooter:_updateFooterText", force_repaint, force_recompute)
     -- footer is invisible, we need neither a repaint nor a recompute, go away.
     if not self.view.footer_visible and not force_repaint and not force_recompute then
         return
@@ -2014,7 +2016,9 @@ function ReaderFooter:onSuspend()
 end
 
 function ReaderFooter:onFrontlightStateChanged()
+    print("ReaderFooter:onFrontlightStateChanged")
     if self.settings.frontlight then
+        --self:refreshFooter(true)
         self:onUpdateFooter(true)
     end
 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1704,7 +1704,6 @@ function ReaderFooter:getDataFromStatistics(title, pages)
 end
 
 function ReaderFooter:onUpdateFooter(force_repaint, force_recompute)
-    print("ReaderFooter:onUpdateFooter", force_repaint, force_recompute)
     if self.pageno then
         self:updateFooterPage(force_repaint, force_recompute)
     else
@@ -1731,7 +1730,6 @@ end
 
 -- only call this function after document is fully loaded
 function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
-    print("ReaderFooter:_updateFooterText", force_repaint, force_recompute)
     -- footer is invisible, we need neither a repaint nor a recompute, go away.
     if not self.view.footer_visible and not force_repaint and not force_recompute then
         return
@@ -2016,9 +2014,7 @@ function ReaderFooter:onSuspend()
 end
 
 function ReaderFooter:onFrontlightStateChanged()
-    print("ReaderFooter:onFrontlightStateChanged")
     if self.settings.frontlight then
-        --self:refreshFooter(true)
         self:onUpdateFooter(true)
     end
 end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -141,11 +141,11 @@ function BasePowerD:isCharging()
     return self:isChargingHW()
 end
 
-function BasePowerD:_setIntensity(intensity)
+function BasePowerD:_setIntensity(intensity, silent)
     self:setIntensityHW(intensity)
-    -- BasePowerD is loaded before UIManager. So we cannot broadcast events before UIManager has
-    -- been loaded.
-    if package.loaded["ui/uimanager"] ~= nil then
+    -- BasePowerD is loaded before UIManager. So we cannot broadcast events before UIManager has been loaded.
+    -- NOTE: If silent is set, inhibit the Event (useful for platforms that do a ramp-up/ramp-down on toggle).
+    if not silent and package.loaded["ui/uimanager"] ~= nil then
         local Event = require("ui/event")
         local UIManager = require("ui/uimanager")
         UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -327,7 +327,8 @@ function KoboPowerD:turnOffFrontlightHW()
     end
     ffiUtil.runInSubProcess(function()
         for i = 1,5 do
-            self:_setIntensity(math.floor(self.fl_intensity - ((self.fl_intensity / 5) * i)))
+            -- NOTE: Make sure _setIntensity doesn't send a FrontlightStateChanged event for those!
+            self:_setIntensity(math.floor(self.fl_intensity - ((self.fl_intensity / 5) * i)), true)
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then
@@ -366,7 +367,8 @@ function KoboPowerD:turnOnFrontlightHW()
     end
     ffiUtil.runInSubProcess(function()
         for i = 1,5 do
-            self:_setIntensity(math.ceil(self.fl_min + ((self.fl_intensity / 5) * i)))
+            -- NOTE: Make sure _setIntensity doesn't send a FrontlightStateChanged event for those!
+            self:_setIntensity(math.ceil(self.fl_min + ((self.fl_intensity / 5) * i)), true)
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then


### PR DESCRIPTION
This made the ReaderFooter refresh go super-wonky...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6667)
<!-- Reviewable:end -->
