### PR TITLE
Footnote popups: allow setting an absolute font size

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -641,13 +641,14 @@ function ReaderLink:onGoToExternalLink(link_url)
         -- wikipedia page saved as epub, full of wikipedia links, it's
         -- too easy to click on links when wanting to change page...)
         -- But first check if this wikipedia article has been saved as EPUB
-        local epub_filename = util.getSafeFilename(wiki_page:gsub("_", " ")) .. "."..string.upper(wiki_lang)..".epub"
+        local epub_filename = wiki_page .. "."..string.upper(wiki_lang)..".epub"
         local epub_fullpath
         -- either in current book directory
         local last_file = G_reader_settings:readSetting("lastfile")
         if last_file then
             local current_book_dir = last_file:match("(.*)/")
-            local epub_path = current_book_dir .. "/" .. epub_filename
+            local safe_filename = util.getSafeFilename(epub_filename, current_book_dir):gsub("_", " ")
+            local epub_path = current_book_dir .. "/" .. safe_filename
             if util.pathExists(epub_path) then
                 epub_fullpath = epub_path
             end
@@ -658,7 +659,8 @@ function ReaderLink:onGoToExternalLink(link_url)
             if not dir then dir = G_reader_settings:readSetting("home_dir") end
             if not dir then dir = require("apps/filemanager/filemanagerutil").getDefaultDir() end
             if dir then
-                local epub_path = dir .. "/" .. epub_filename
+                local safe_filename = util.getSafeFilename(epub_filename, dir):gsub("_", " ")
+                local epub_path = dir .. "/" .. safe_filename
                 if util.pathExists(epub_path) then
                     epub_fullpath = epub_path
                 end

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -355,10 +355,6 @@ function DictQuickLookup:update()
                         -- if forced_lang was specified, it may not be in our wiki_languages,
                         -- but ReaderWikipedia will have put it in result.lang
                         local lang = self.lang or self.wiki_languages_copy[1]
-                        -- Just to be safe (none of the invalid chars, except ':' for uninteresting
-                        -- Portal: or File: wikipedia pages, should be in lookup_word)
-                        local cleaned_lookupword = util.getSafeFilename(self.lookupword:gsub("_", " "))
-                        local filename = cleaned_lookupword .. "."..string.upper(lang)..".epub"
                         -- Find a directory to save file into
                         local dir
                         if G_reader_settings:isTrue("wikipedia_save_in_book_dir") and not self:isDocless() then
@@ -376,6 +372,10 @@ function DictQuickLookup:update()
                             })
                             return
                         end
+                        -- Just to be safe (none of the invalid chars, except ':' for uninteresting
+                        -- Portal: or File: wikipedia pages, should be in lookupword)
+                        local filename = self.lookupword .. "."..string.upper(lang)..".epub"
+                        filename = util.getSafeFilename(filename, dir):gsub("_", " ")
                         local epub_path = dir .. "/" .. filename
                         UIManager:show(ConfirmBox:new{
                             text = T(_("Save as %1?"), BD.filename(filename)),

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -91,9 +91,19 @@ body > li { list-style-type: none; }
 .noprint { display: none; }
 
 /* Style some FB2 tags not known to MuPDF */
-emphasis { font-style: italic; }
-strikethrough { text-decoration: line-through; }
-underline { text-decoration: underline; }
+strike, strikethrough { text-decoration: line-through; }
+underline   { text-decoration: underline; }
+emphasis    { font-style: italic; }
+small       { font-size: 80%; }
+big         { font-size: 130%; }
+empty-line  { display: block; padding: 0.5em; }
+image       { display: block; padding: 0.4em; border: 0.1em solid black; width: 0; }
+date        { display: block; font-style: italic; }
+epigraph    { display: block; font-style: italic; }
+poem        { display: block; }
+stanza      { display: block; font-style: italic; }
+v           { display: block; text-align: left; hyphenate: none; }
+text-author { display: block; font-weight: bold; font-style: italic; }
 
 /* Attempt to display FB2 footnotes as expected (as crengine does, putting
  * the footnote number on the same line as the first paragraph via its

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -225,7 +225,12 @@ function FootnoteWidget:init()
     -- We may use a font size a bit smaller than the document one (because
     -- footnotes are usually smaller, and because NotoSans is a bit on the
     -- larger size when compared to other fonts at the same size)
-    local font_size = self.doc_font_size + (G_reader_settings:readSetting("footnote_popup_relative_font_size") or -2)
+    local font_size = G_reader_settings:readSetting("footnote_popup_absolute_font_size")
+    if font_size then
+        font_size = Screen:scaleBySize(font_size)
+    else
+        font_size = self.doc_font_size + (G_reader_settings:readSetting("footnote_popup_relative_font_size") or -2)
+    end
 
     -- We want to display the footnote text with the same margins as
     -- the document, but keep the scrollbar in the right margin, so


### PR DESCRIPTION
#### `Wikpedia EPUBs: fix failure saving some files`

Since 8815cbe0 and getSafeFilename() taking additional parameters, and :gsub() returning multiple values, filesystem type wasn't really checked and replacements were not ensured, so saving articles like "Portal:Stuff" failed on VFAT devices as ':' wasn't replaced.

#### `Footnote popups: CSS: add more styles for FB2 elements`

Add styles for some more non-HTML FB2 tags, so MuPDF can render them as expected.
According to https://github.com/koreader/koreader/issues/6622#issuecomment-686328228. Closes #6622. 

#### `Footnote popups: allow setting an absolute font size`

In the "Set footnote popup font size", allow toggling between setting a relative (to the document) font size and setting an absolute font size (that won't change with the document font size).
Closes #6642.
![image](https://user-images.githubusercontent.com/24273478/93590033-1af34e00-f9ae-11ea-9ade-3b20e594e2ed.png)
![image](https://user-images.githubusercontent.com/24273478/93590013-12027c80-f9ae-11ea-86c8-0de332603211.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6674)
<!-- Reviewable:end -->
