### PR TITLE
reMarkable: add environment variable to tell koreader.sh to not set bpp

### DIFF
--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -97,7 +97,7 @@ esac
 # The actual swap is done in a function, because we can disable it in the Developer settings, and we want to honor it on restart.
 ko_do_fbdepth() {
     if [ -n "${KO_DONT_SET_DEPTH}" ]; then
-      return
+        return
     fi
 
     # Check if the swap has been disabled...

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -96,6 +96,10 @@ esac
 
 # The actual swap is done in a function, because we can disable it in the Developer settings, and we want to honor it on restart.
 ko_do_fbdepth() {
+    if [ -n "${KO_DONT_SET_DEPTH}" ]; then
+      return
+    fi
+
     # Check if the swap has been disabled...
     if grep -q '\["dev_startup_no_fbdepth"\] = true' 'settings.reader.lua' 2>/dev/null; then
         # Swap back to the original bitdepth (in case this was a restart)


### PR DESCRIPTION
related to https://github.com/Eeems/oxide/issues/69, this diff adds an env variable to remarkable platform's koreader.sh to allow someone to tell koreader to not set the bpp to 8 from outside koreader.sh. the env variable is called `KO_DONT_SET_DEPTH`

we don't use the dev setting because someone might change the dev setting without realizing what it does

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6685)
<!-- Reviewable:end -->
