### PR TITLE
Fix point release and revision detection in Version:getShortVersion

### DIFF
--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -57,10 +57,10 @@ function Version:getShortVersion()
         local rev = self:getCurrentRevision()
         local year, month, point, revision = rev:match("v(%d%d%d%d)%.(%d%d)%.?(%d?%d?)-?(%d*)")
         self.short = year .. "." .. month
-        if point then
+        if point and point ~= "" then
             self.short = self.short .. "." .. point
         end
-        if revision then
+        if revision and revision ~= "" then
             self.short = self.short .. "-" .. revision
         end
     end


### PR DESCRIPTION
Turns out match returns an empty string instead of nil for unmatched groups?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6693)
<!-- Reviewable:end -->
