### PR TITLE
Clean up C blitbuffer kludges.

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -332,18 +332,18 @@ function FileManagerMenu:setUpdateItemTable()
         })
     end
     if not Device.should_restrict_JIT then
-        local bb = require("ffi/blitbuffer")
+        local Blitbuffer = require("ffi/blitbuffer")
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Disable C blitter"),
             enabled_func = function()
-                return bb.has_cblitbuffer
+                return Blitbuffer.has_cblitbuffer
             end,
             checked_func = function()
                 return G_reader_settings:isTrue("dev_no_c_blitter")
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_no_c_blitter")
-                bb:enableCBB(G_reader_settings:nilOrFalse("dev_no_c_blitter"))
+                Blitbuffer:enableCBB(G_reader_settings:nilOrFalse("dev_no_c_blitter"))
             end,
         })
     end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -332,20 +332,18 @@ function FileManagerMenu:setUpdateItemTable()
         })
     end
     if not Device.should_restrict_JIT then
+        local bb = require("ffi/blitbuffer")
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Disable C blitter"),
             enabled_func = function()
-                return lfs.attributes("libs/libblitbuffer.so", "mode") == "file"
+                return bb.has_cblitbuffer
             end,
             checked_func = function()
                 return G_reader_settings:isTrue("dev_no_c_blitter")
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_no_c_blitter")
-                local InfoMessage = require("ui/widget/infomessage")
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                bb:enableCBB(G_reader_settings:nilOrFalse("dev_no_c_blitter"))
             end,
         })
     end

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -156,29 +156,7 @@ function Cervantes:initEventAdjustHooks()
     end
 end
 
--- Make sure the C BB cannot be used on devices with unsafe HW inversion, as otherwise NightMode would be ineffective.
-function Cervantes:blacklistCBB()
-    local ffi = require("ffi")
-    local dummy = require("ffi/posix_h")
-    local C = ffi.C
-
-    -- NOTE: canUseCBB is never no on Cervantes ;).
-    if not self:canUseCBB() or not self:canHWInvert() then
-        logger.info("Blacklisting the C BB on this device")
-        if ffi.os == "Windows" then
-            C._putenv("KO_NO_CBB=true")
-        else
-            C.setenv("KO_NO_CBB", "true", 1)
-        end
-        -- Enforce the global setting, too, so the Dev menu is accurate...
-        G_reader_settings:saveSetting("dev_no_c_blitter", true)
-    end
-end
-
 function Cervantes:init()
-    -- Blacklist the C BB before the first BB require...
-    self:blacklistCBB()
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
 
     -- Automagically set this so we never have to remember to do it manually ;p

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -134,6 +134,13 @@ function Device:init()
         error("screen/framebuffer must be implemented")
     end
 
+    -- opt-out of CBB if the device is broken with it
+    if not self.canUseCBB() then
+        local bb = require("ffi/blitbuffer")
+        bb.has_cblitbuffer = false
+        bb:enableCBB(false)
+    end
+
     if self.hasMultitouch == nil then
         -- default to assuming multitouch when dealing with a touch device
         self.hasMultitouch = self.isTouchDevice

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -258,25 +258,6 @@ function Kindle:ambientBrightnessLevel()
     return 4
 end
 
---- Makes sure the C BB cannot be used on devices with a 4bpp fb.
-function Kindle:blacklistCBB()
-    local ffi = require("ffi")
-    local dummy = require("ffi/posix_h")
-    local C = ffi.C
-
-    -- As well as on those than can't do HW inversion, as otherwise NightMode would be ineffective.
-    if not self:canUseCBB() or not self:canHWInvert() then
-        logger.info("Blacklisting the C BB on this device")
-        if ffi.os == "Windows" then
-            C._putenv("KO_NO_CBB=true")
-        else
-            C.setenv("KO_NO_CBB", "true", 1)
-        end
-        -- Enforce the global setting, too, so the Dev menu is accurate...
-        G_reader_settings:saveSetting("dev_no_c_blitter", true)
-    end
-end
-
 local Kindle2 = Kindle:new{
     model = "Kindle2",
     hasKeyboard = yes,
@@ -416,9 +397,6 @@ local KindleBasic3 = Kindle:new{
 }
 
 function Kindle2:init()
-    -- Blacklist the C BB before the first BB require...
-    self:blacklistCBB()
-
     self.screen = require("ffi/framebuffer_einkfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
         device = self,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -290,29 +290,7 @@ probeEvEpochTime = function(self, ev)
     end
 end
 
--- Make sure the C BB cannot be used on devices with unsafe HW inversion, as otherwise NightMode would be ineffective.
-function Kobo:blacklistCBB()
-    local ffi = require("ffi")
-    local dummy = require("ffi/posix_h")
-    local C = ffi.C
-
-    -- NOTE: canUseCBB is never no on Kobo ;).
-    if not self:canUseCBB() or not self:canHWInvert() then
-        logger.info("Blacklisting the C BB on this device")
-        if ffi.os == "Windows" then
-            C._putenv("KO_NO_CBB=true")
-        else
-            C.setenv("KO_NO_CBB", "true", 1)
-        end
-        -- Enforce the global setting, too, so the Dev menu is accurate...
-        G_reader_settings:saveSetting("dev_no_c_blitter", true)
-    end
-end
-
 function Kobo:init()
-    -- Blacklist the C BB before the first BB require...
-    self:blacklistCBB()
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     if self.screen.fb_bpp == 32 then
         -- Ensure we decode images properly, as our framebuffer is BGRA...

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -45,22 +45,6 @@ local PocketBook = Generic:new{
     _model_init = function() end,
 }
 
--- Make sure the C BB cannot be used on devices with a 24bpp fb
-function PocketBook:blacklistCBB()
-    -- As well as on those than can't do HW inversion, as otherwise NightMode would be ineffective.
-    --- @note: Since HWInvert is a no-go on PB, the C BB is essentially *always* blacklisted.
-    if not self:canUseCBB() or not self:canHWInvert() then
-        logger.info("Blacklisting the C BB on this device")
-        if ffi.os == "Windows" then
-            C._putenv("KO_NO_CBB=true")
-        else
-            C.setenv("KO_NO_CBB", "true", 1)
-        end
-        -- Enforce the global setting, too, so the Dev menu is accurate...
-        G_reader_settings:saveSetting("dev_no_c_blitter", true)
-    end
-end
-
 -- Helper to try load externally signalled book whenever we're brought to foreground
 local function tryOpenBook()
     local path = os.getenv("KO_PATH_OPEN_BOOK")
@@ -76,9 +60,6 @@ local function tryOpenBook()
 end
 
 function PocketBook:init()
-    -- Blacklist the C BB before the first BB require...
-    self:blacklistCBB()
-
     self.screen = require("ffi/framebuffer_mxcfb"):new {
         device = self,
         debug = logger.dbg,

--- a/reader.lua
+++ b/reader.lua
@@ -37,23 +37,12 @@ if lang_locale then
     _.changeLang(lang_locale)
 end
 
--- Make the C blitter optional (ffi/blitbuffer.lua will check that env var)
-local ffi = require("ffi")
 local dummy = require("ffi/posix_h")
-local C = ffi.C
-if G_reader_settings:isTrue("dev_no_c_blitter") then
-    if ffi.os == "Windows" then
-        C._putenv("KO_NO_CBB=true")
-    else
-        C.setenv("KO_NO_CBB", "true", 1)
-    end
-else
-    if ffi.os == "Windows" then
-        C._putenv("KO_NO_CBB=false")
-    else
-        C.unsetenv("KO_NO_CBB")
-    end
-end
+
+-- Try to turn the C blitter on/off, and synchronize setting so that UI config reflects real state
+local bb = require("ffi/blitbuffer")
+local is_cbb_enabled = bb:enableCBB(G_reader_settings:nilOrFalse("dev_no_c_blitter"))
+G_reader_settings:saveSetting("dev_no_c_blitter", not is_cbb_enabled)
 
 -- Should check DEBUG option in arg and turn on DEBUG before loading other
 -- modules, otherwise DEBUG in some modules may not be printed.


### PR DESCRIPTION
Needs https://github.com/koreader/koreader-base/pull/1195

CBB now handles nightmode correctly (by deferring to Lua), so we no longer
need to do monkey dances about disabling it when hw invert is missing.

canUseCBB cap is resolved by generic device re-configuring blitbuffer
on the go, so as to avoid repeating the same thing in every device driver.

The dev setting can now flip cbb on the go, so one can gloat at the near
meaningless perf difference - 2Mp draw is 15ms Lua / 10ms C on 1GHz Cortex A7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6696)
<!-- Reviewable:end -->
