### PR TITLE
Sort folder shortcuts

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -63,7 +63,7 @@ function FileManagerShortcuts:updateItemTable()
     end
 
     self.fm_bookmark:switchItemTable(nil,
-        item_table, select_number)
+                                     item_table, select_number)
 end
 
 function FileManagerShortcuts:addNewFolder()

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -48,16 +48,12 @@ function FileManagerShortcuts:updateItemTable()
     table.sort(item_table, function(l, r)
         return l.text < r.text
     end)
-    local item_table_sorted = {}
-    table.insert(item_table_sorted, {
+    table.insert(item_table, 1, {
         text = _("Add new folder shortcut"),
         callback = function()
             self:addNewFolder()
         end,
     })
-    for _, item in ipairs(item_table) do
-        table.insert(item_table_sorted, item)
-    end
 
     -- try to stay on current page
     local select_number
@@ -67,7 +63,7 @@ function FileManagerShortcuts:updateItemTable()
     end
 
     self.fm_bookmark:switchItemTable(nil,
-        item_table_sorted, select_number)
+        item_table, select_number)
 end
 
 function FileManagerShortcuts:addNewFolder()

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -13,12 +13,6 @@ local T = util.template
 
 local FileManagerShortcuts = InputContainer:extend{}
 
-local function tableSortByTextProp(subject)
-    table.sort(subject, function (v1, v2)
-        return v1.text < v2.text
-    end)
-end
-
 function FileManagerShortcuts:updateItemTable()
     local item_table = {}
     local folder_shortcuts = G_reader_settings:readSetting("folder_shortcuts") or {}
@@ -51,7 +45,9 @@ function FileManagerShortcuts:updateItemTable()
         })
     end
 
-    tableSortByTextProp(item_table)
+    table.sort(item_table, function(l, r)
+        return l.text < r.text
+    end)
     local item_table_sorted = {}
     table.insert(item_table_sorted, {
         text = _("Add new folder shortcut"),


### PR DESCRIPTION
In the current KOReader version the folder shortcuts are sorted by date of addition. When a user has many folder shortcuts (like I do 😊 ) they are easier to find again when sorted alphabetically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6707)
<!-- Reviewable:end -->
