### PR TITLE
linuxfb: frontends need to pass is_always_portrait

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -157,7 +157,7 @@ function Cervantes:initEventAdjustHooks()
 end
 
 function Cervantes:init()
-    self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
+    self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg, is_always_portrait = self.isAlwaysPortrait()}
 
     -- Automagically set this so we never have to remember to do it manually ;p
     if self:hasNaturalLight() and self.frontlight_settings and self.frontlight_settings.frontlight_mixer then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -291,7 +291,7 @@ probeEvEpochTime = function(self, ev)
 end
 
 function Kobo:init()
-    self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
+    self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg, is_always_portrait = self.isAlwaysPortrait()}
     if self.screen.fb_bpp == 32 then
         -- Ensure we decode images properly, as our framebuffer is BGRA...
         logger.info("Enabling Kobo @ 32bpp BGR tweaks")

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -152,6 +152,7 @@ function Device:init()
         h = self.window.height,
         x = self.window.left,
         y = self.window.top,
+        is_always_portrait = self.isAlwaysPortrait(),
     }
     self.powerd = require("device/sdl/powerd"):new{device = self}
 


### PR DESCRIPTION
This is because fb driver should not be inspecting self.device for low level
caps anymore.

Fixes #6711

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6712)
<!-- Reviewable:end -->
