### PR TITLE
Save document settings before activating USBMS

### DIFF
--- a/frontend/ui/elements/mass_storage.lua
+++ b/frontend/ui/elements/mass_storage.lua
@@ -46,6 +46,14 @@ function MassStorage:getActionsMenuTable()
     }
 end
 
+local function saveDocSettings()
+    local
+    readerui_instance = require("apps/reader/readerui"):_getRunningInstance()
+    if readerui_instance then
+        readerui_instance:saveSettings()
+    end
+end
+
 -- exit KOReader and start mass storage mode.
 function MassStorage:start(never_ask)
     if not Device:canToggleMassStorage() or not self:isEnabled() then
@@ -54,15 +62,19 @@ function MassStorage:start(never_ask)
 
     if not never_ask and self:requireConfirmation() then
         local ConfirmBox = require("ui/widget/confirmbox")
-        UIManager:show(ConfirmBox:new{
+        UIManager:show(ConfirmBox:new {
             text = _("Share storage via USB?"),
             ok_text = _("Share"),
             ok_callback = function()
+                -- save document settings before activating USBMS:
+                saveDocSettings()
                 UIManager:quit()
                 UIManager._exit_code = 86
             end,
         })
     else
+        -- save document settings before activating USBMS:
+        saveDocSettings()
         UIManager:quit()
         UIManager._exit_code = 86
     end

--- a/frontend/ui/elements/mass_storage.lua
+++ b/frontend/ui/elements/mass_storage.lua
@@ -46,14 +46,6 @@ function MassStorage:getActionsMenuTable()
     }
 end
 
-local function saveDocSettings()
-    local
-    readerui_instance = require("apps/reader/readerui"):_getRunningInstance()
-    if readerui_instance then
-        readerui_instance:saveSettings()
-    end
-end
-
 -- exit KOReader and start mass storage mode.
 function MassStorage:start(never_ask)
     if not Device:canToggleMassStorage() or not self:isEnabled() then
@@ -66,15 +58,15 @@ function MassStorage:start(never_ask)
             text = _("Share storage via USB?"),
             ok_text = _("Share"),
             ok_callback = function()
-                -- save document settings before activating USBMS:
-                saveDocSettings()
+                -- save settings before activating USBMS:
+                UIManager:flushSettings()
                 UIManager:quit()
                 UIManager._exit_code = 86
             end,
         })
     else
-        -- save document settings before activating USBMS:
-        saveDocSettings()
+        -- save settings before activating USBMS:
+        UIManager:flushSettings()
         UIManager:quit()
         UIManager._exit_code = 86
     end

--- a/frontend/ui/elements/mass_storage.lua
+++ b/frontend/ui/elements/mass_storage.lua
@@ -54,7 +54,7 @@ function MassStorage:start(never_ask)
 
     if not never_ask and self:requireConfirmation() then
         local ConfirmBox = require("ui/widget/confirmbox")
-        UIManager:show(ConfirmBox:new {
+        UIManager:show(ConfirmBox:new{
             text = _("Share storage via USB?"),
             ok_text = _("Share"),
             ok_callback = function()


### PR DESCRIPTION
As things were, when I activated USBMS, any bookmarks recently added and not yet stored in the sidecar file would be lost after returning to the reader. These changes fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6713)
<!-- Reviewable:end -->
