### PR TITLE
Pocketbook: Try to auto-detect HW feature caps more precisely

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -84,11 +84,11 @@ local Device = {
     isAlwaysPortrait = no,
     -- On some devices (eg newer pocketbook) we can force HW rotation on the fly (before each update)
     -- The value here is table of 4 elements mapping the sensible linux constants to whatever
-    -- nonsense the device actually has. Canonically it should be { 0, 1, 2, 3 } if the device
+    -- nonsense the device actually has. Canonically it should return { 0, 1, 2, 3 } if the device
     -- matches <linux/fb.h> FB_ROTATE_* constants.
     -- See https://github.com/koreader/koreader-base/blob/master/ffi/framebuffer.lua for full template
     -- of the table expected.
-    usingForcedRotation = nil,
+    usingForcedRotation = function() return nil end,
     -- needs full screen refresh when resumed from screensaver?
     needsScreenRefreshAfterResume = yes,
 

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -37,8 +37,10 @@ local PocketBook = Generic:new{
     -- all devices that have warmth lights use inkview api
     hasNaturalLightApi = yes,
 
-    -- Apparently, HW inversion is a pipedream on PB (#6669)
-    canHWInvert = no,
+    -- NOTE: Apparently, HW inversion is a pipedream on PB (#6669), ... well, on sunxi chipsets anyway.
+    -- For which we now probe in fbinfoOverride() and tweak the flag to "no".
+    -- NXT/other chipsets *should* work (PB631), but in case it doesn't on your device, set this to "no" in here.
+    canHWInvert = yes,
 
     -- Private per-model kludges
     _fb_init = function() end,
@@ -59,13 +61,30 @@ local function tryOpenBook()
     end
 end
 
+local function isB288(fb)
+    -- No real header exists for this, see https://github.com/koreader/koreader-base/issues/1202/
+    local B288_POLL_FOR_UPDATE_COMPLETE = 0x80044655
+    -- On NXT that has a real MXC driver, it returns -EINVAL
+    return C.ioctl(fb.fd, B288_POLL_FOR_UPDATE_COMPLETE, ffi.new("uint32_t[1]")) == 0
+end
+
 function PocketBook:init()
     self.screen = require("ffi/framebuffer_mxcfb"):new {
         device = self,
         debug = logger.dbg,
-        is_always_portrait = self.isAlwaysPortrait(),
-        forced_rotation = self.usingForcedRotation,
-        fbinfoOverride = self._fb_init,
+        fbinfoOverride = function(fb, finfo, vinfo)
+            -- Tweak combination of alwaysPortrait/hwRot/hwInvert flags depending on probed HW.
+            fb.is_always_portrait = self.isAlwaysPortrait()
+            fb.forced_rotation = self.usingForcedRotation()
+            if isB288(fb) then
+                logger.dbg("mxcfb: Detected B288 chipset, disabling HW rotation and invert")
+                fb.forced_rotation = nil
+                self.canHWInvert = no
+            elseif fb.forced_rotation then
+                fb.is_always_portrait = false
+            end
+            return self._fb_init(fb, finfo, vinfo)
+        end,
     }
     self.powerd = require("device/pocketbook/powerd"):new{device = self}
 
@@ -252,12 +271,12 @@ function PocketBook:getDeviceModel()
 end
 
 -- Pocketbook HW rotation modes start from landsape, CCW
-local landscape_ccw = {
+local function landscape_ccw() return {
     1, 0, 3, 2,         -- PORTRAIT, LANDSCAPE, PORTRAIT_180, LANDSCAPE_180
     every_paint = true, -- inkview will try to steal the rot mode frequently
     restore = false,    -- no need, because everything using inkview forces 3 on focus
     default = nil,      -- usually 3
-}
+} end
 
 -- PocketBook Mini (515)
 local PocketBook515 = PocketBook:new{
@@ -371,6 +390,7 @@ local PocketBook627 = PocketBook:new{
 local PocketBook628 = PocketBook:new{
     model = "PBTouchLux5",
     display_dpi = 212,
+    isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
     hasNaturalLight = yes,
 }
@@ -393,6 +413,7 @@ local PocketBook631 = PocketBook:new{
 local PocketBook632 = PocketBook:new{
     model = "PBTouchHDPlus",
     display_dpi = 300,
+    isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
     hasNaturalLight = yes,
 }
@@ -403,6 +424,7 @@ local PocketBook633 = PocketBook:new{
     display_dpi = 300,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
+    isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
 }
 
@@ -436,6 +458,7 @@ local PocketBook740 = PocketBook:new{
 local PocketBook740_2 = PocketBook:new{
     model = "PBInkPad3Pro",
     display_dpi = 300,
+    isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
     hasNaturalLight = yes,
 }

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -39,7 +39,7 @@ local PocketBook = Generic:new{
 
     -- NOTE: Apparently, HW inversion is a pipedream on PB (#6669), ... well, on sunxi chipsets anyway.
     -- For which we now probe in fbinfoOverride() and tweak the flag to "no".
-    -- NXT/other chipsets *should* work (PB631), but in case it doesn't on your device, set this to "no" in here.
+    -- NTX chipsets *should* work (PB631), but in case it doesn't on your device, set this to "no" in here.
     canHWInvert = yes,
 
     -- Private per-model kludges
@@ -73,9 +73,11 @@ function PocketBook:init()
         device = self,
         debug = logger.dbg,
         fbinfoOverride = function(fb, finfo, vinfo)
-            -- Tweak combination of alwaysPortrait/hwRot/hwInvert flags depending on probed HW.
+            -- Device model caps *can* set both to indicate that either will work to get correct orientation.
+            -- But for FB backend, the flags are mutually exclusive, so we nuke one of em later.
             fb.is_always_portrait = self.isAlwaysPortrait()
             fb.forced_rotation = self.usingForcedRotation()
+            -- Tweak combination of alwaysPortrait/hwRot/hwInvert flags depending on probed HW.
             if isB288(fb) then
                 logger.dbg("mxcfb: Detected B288 chipset, disabling HW rotation and invert")
                 fb.forced_rotation = nil


### PR DESCRIPTION
The differences between Allwinner/MXC matter surprisingly little in practice (https://github.com/koreader/koreader-base/issues/1202), it's not even worth it to bother the base mxc driver with it. Instead, frontend can make some informed choice by probing for the hardware and tweaking requested device caps accordingly.

On Allwinner B288, we disable both hwrot (done in software in kernel and terribly, ie not worth it) and hwinverse (no support whatsoever). On NXT we'll keep both on, as the kernel driver seems to be [using the hardware properly](https://github.com/pocketbook/Platform_MX6/blob/master/Kernel_631/drivers/video/mxc/mxc_epdc_fb.c#L2218)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6721)
<!-- Reviewable:end -->
