### PR TITLE
Fancier Wi-Fi status icons in ReaderFooter

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -75,6 +75,7 @@ local symbol_prefix = {
         frontlight = "☼",
         mem_usage = "",
         wifi_status = "",
+        wifi_status_off = "",
     }
 }
 if BD.mirroredUILayout() then
@@ -239,13 +240,22 @@ local footerTextGeneratorMap = {
         return ""
     end,
     wifi_status = function(footer)
+        -- NOTE: This one deviates a bit from the mold because, in icons mode, we simply use two different icons and no text.
         local symbol_type = footer.settings.item_prefix or "icons"
-        local prefix = symbol_prefix[symbol_type].wifi_status
         local NetworkMgr = require("ui/network/manager")
-        if NetworkMgr:isWifiOn() then
-            return T(_("%1 On"), prefix)
+        if symbol_type == "icons" then
+            if NetworkMgr:isWifiOn() then
+                return symbol_prefix.icons.wifi_status
+            else
+                return symbol_prefix.icons.wifi_status_off
+            end
         else
-            return T(_("%1 Off"), prefix)
+            local prefix = symbol_prefix[symbol_type].wifi_status
+            if NetworkMgr:isWifiOn() then
+                return T(_("%1 On"), prefix)
+            else
+                return T(_("%1 Off"), prefix)
+            end
         end
     end,
     book_title = function(footer)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -344,7 +344,7 @@ function ReaderFooter:init()
     }
 
     -- Remove items not supported by the current device
-    if not Device:isAndroid() then
+    if not Device:hasFastWifiStatusQuery() then
         MODE.wifi_status = nil
     end
     if not Device:hasFrontlight() then
@@ -1643,7 +1643,7 @@ function ReaderFooter:addToMainMenu(menu_items)
         table.insert(sub_items, getMinibarOption("frontlight"))
     end
     table.insert(sub_items, getMinibarOption("mem_usage"))
-    if Device:isAndroid() then
+    if Device:hasFastWifiStatusQuery() then
         table.insert(sub_items, getMinibarOption("wifi_status"))
     end
     table.insert(sub_items, getMinibarOption("book_title"))

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2026,6 +2026,18 @@ function ReaderFooter:onFrontlightStateChanged()
     end
 end
 
+function ReaderFooter:onNetworkConnected()
+    if self.settings.wifi_status then
+        self:onUpdateFooter(true)
+    end
+end
+
+function ReaderFooter:onNetworkDisconnected()
+    if self.settings.wifi_status then
+        self:onUpdateFooter(true)
+    end
+end
+
 function ReaderFooter:onSetRotationMode()
     self:updateFooterContainer()
     self:resetLayout(true)

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -86,6 +86,7 @@ local Device = Generic:new{
     isHapticFeedbackEnabled = yes,
     hasClipboard = yes,
     hasOTAUpdates = canUpdateApk,
+    hasFastWifiStatusQuery = yes,
     canOpenLink = yes,
     openLink = function(self, link)
         if not link or type(link) ~= "string" then return end

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -58,6 +58,7 @@ local Cervantes = Generic:new{
     touch_mirrored_x = true,
     touch_probe_ev_epoch_time = true,
     hasOTAUpdates = yes,
+    hasFastWifiStatusQuery = yes,
     hasKeys = yes,
     hasWifiManager = yes,
     canReboot = yes,

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -95,6 +95,10 @@ local Device = {
     -- set to yes on devices that support over-the-air incremental updates.
     hasOTAUpdates = no,
 
+    -- set to yes on devices that have a non-blocking isWifiOn implementation
+    -- (c.f., https://github.com/koreader/koreader/pull/5211#issuecomment-521304139)
+    hasFastWifiStatusQuery = no,
+
     canOpenLink = no,
     openLink = no,
     canExternalDictLookup = no,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -25,6 +25,7 @@ local Kobo = Generic:new{
     isKobo = yes,
     isTouchDevice = yes, -- all of them are
     hasOTAUpdates = yes,
+    hasFastWifiStatusQuery = yes,
     hasWifiManager = yes,
     canReboot = yes,
     canPowerOff = yes,


### PR DESCRIPTION
And also allow enabling said icon on Kobo & Cervantes.

(Supersedes #6656, see discussions over there ;)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6725)
<!-- Reviewable:end -->
