### PR TITLE
KOSync improvements

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -715,9 +715,7 @@ function KOSync:_onPageUpdate(page)
         self.last_page = page
         self.last_page_turn_ticks = os.time()
         self.page_update_times = self.page_update_times + 1
-        if self.kosync_pages_before_update ~= nil
-        and (self.kosync_pages_before_update <= 0
-             or self.page_update_times == self.kosync_pages_before_update) then
+        if self.kosync_pages_before_update and self.page_update_times == self.kosync_pages_before_update then
             self.page_update_times = 0
             UIManager:scheduleIn(1, function() self:updateProgress() end)
         end

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -272,10 +272,10 @@ function KOSync:addToMainMenu(menu_items)
                 text = _("Sync every # pages"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require('ui/widget/spinwidget')
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local items = SpinWidget:new{
-                        text = _([[This value decides how many pages it takes to update book progress.
-If set to 0, disables updating progress based on page turns.]]),
+                        text = _([[This value determines how many page turns it takes to update book progress.
+If set to 0, updating progress based on page turns will be disabled.]]),
                         width = math.floor(Screen:getWidth() * 0.6),
                         value = self.kosync_pages_before_update or 0,
                         value_min = 0,

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -494,6 +494,10 @@ function KOSync:updateProgress(manual)
         return
     end
 
+    if manual and NetworkMgr:willRerunWhenOnline(function() self:updateProgress(manual) end) then
+        return
+    end
+
     local KOSyncClient = require("KOSyncClient")
     local client = KOSyncClient:new{
         custom_url = self.kosync_custom_server,
@@ -535,6 +539,10 @@ function KOSync:getProgress(manual)
         if manual then
             promptLogin()
         end
+        return
+    end
+
+    if manual and NetworkMgr:willRerunWhenOnline(function() self:getProgress(manual) end) then
         return
     end
 

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -18,11 +18,6 @@ if not G_reader_settings:readSetting("device_id") then
     G_reader_settings:saveSetting("device_id", random.uuid())
 end
 
--- DAUTO_SAVE_PAGING_COUNT was set to nil in defaults.lua, but
--- could be overriden in defaults.persistent.lua with a value
--- that was also used here as the interval for auto sync.
--- DAUTO_SAVE_PAGING_COUNT has been removed, but let's allow
--- this plugin to still pick it from defaults.persistent.lua.
 local KOSync = InputContainer:new{
     name = "kosync",
     is_doc_only = true,
@@ -108,7 +103,7 @@ function KOSync:onReaderReady()
     self.kosync_username = settings.username
     self.kosync_userkey = settings.userkey
     self.kosync_auto_sync = not (settings.auto_sync == false)
-    self.kosync_pages_before_update = settings.pages_before_update or DAUTO_SAVE_PAGING_COUNT
+    self.kosync_pages_before_update = settings.pages_before_update
     self.kosync_whisper_forward = settings.whisper_forward or SYNC_STRATEGY.DEFAULT_FORWARD
     self.kosync_whisper_backward = settings.whisper_backward or SYNC_STRATEGY.DEFAULT_BACKWARD
     self.kosync_device_id = G_reader_settings:readSetting("device_id")
@@ -280,16 +275,16 @@ function KOSync:addToMainMenu(menu_items)
                     local SpinWidget = require('ui/widget/spinwidget')
                     local items = SpinWidget:new{
                         text = _([[This value decides how many pages it takes to update book progress.
-If set to 0, it'll sync progress every page.]]),
+If set to 0, disables updating progress based on page turns.]]),
                         width = math.floor(Screen:getWidth() * 0.6),
-                        value = self.kosync_pages_before_update,
+                        value = self.kosync_pages_before_update or 0,
                         value_min = 0,
                         value_max = 999,
                         value_step = 1,
                         value_hold_step = 10,
                         ok_text = _("Set"),
                         title_text = _("Number of pages before update"),
-                        default_value = DAUTO_SAVE_PAGING_COUNT or 10,
+                        default_value = 0,
                         callback = function(spin)
                             self:setPagesBeforeUpdate(spin.value)
                         end
@@ -302,7 +297,7 @@ If set to 0, it'll sync progress every page.]]),
 end
 
 function KOSync:setPagesBeforeUpdate(pages_before_update)
-    self.kosync_pages_before_update = pages_before_update
+    self.kosync_pages_before_update = pages_before_update > 0 and pages_before_update or nil
     self:saveSettings()
 end
 


### PR DESCRIPTION
If user manually triggered update, allow for automatically enabling WiFi, add new menu entry "Sync every # pages", so users don't have to rely on modifying `defaults.lua.persistent` and set global variable `DAUTO_SAVE_PAGING_COUNT`. It won't break like #6489, because we check if user triggered the update. Some discussion in https://github.com/koreader/koreader/issues/6726#issuecomment-700679676. It should be alright, but I'll go over it once again after I get some sleep ;P

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6733)
<!-- Reviewable:end -->
