### PR TITLE
Pocketbook: Fix silly rotation bug on PB1040

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -494,6 +494,7 @@ local PocketBook840 = PocketBook:new{
 local PocketBook1040 = PocketBook:new{
     model = "PB1040",
     display_dpi = 227,
+    isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
     hasNaturalLight = yes,
 }


### PR DESCRIPTION
Ditto as PB740

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6735)
<!-- Reviewable:end -->
