### PR TITLE
Terminal: add placeholders

### DIFF
--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -102,7 +102,7 @@ function Terminal:showHelp()
         local placeholder = v[2]
         message = message .. "\n%" .. placeholder .. " = " .. label
     end
-    message = message .. _('\n%v = add value from prompt\n\nExample:\ncat "%s"\nto display sidecar file for current ebook')
+    message = message .. _('\n%v = add value from prompt\n\nExample:\ncat "%s/%v"\nto get a prompt for displaying a file in the settings dir')
     UIManager:show(InfoMessage:new{
         text = message
     })

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -29,6 +29,13 @@ local Terminal = WidgetContainer:new{
     -- placeholders in commands are marked with "%[placeholder]":
     placeholders = {
         {
+            _("sidecar file current ebook"),
+            "c",
+            function(command)
+                return command:gsub("%%c", DocSettings:getSidecarFile(G_reader_settings:readSetting("lastfile")))
+            end
+        },
+        {
             _("directory of current ebook"),
             "d",
             function(command)
@@ -51,10 +58,10 @@ local Terminal = WidgetContainer:new{
             end
         },
         {
-            _("sidecar file current ebook"),
+            _("settings dir"),
             "s",
             function(command)
-                return command:gsub("%%s", DocSettings:getSidecarFile(G_reader_settings:readSetting("lastfile")))
+                return command:gsub("%%s", DataStorage:getSettingsDir())
             end
         },
         -- there is also a "%v" placeholder, which prompts for a value; but that special case is being handled in Terminal:commandHandler()

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -333,31 +333,33 @@ function Terminal:editCommands(item)
         allow_newline = true,
         cursor_at_end = true,
         fullscreen = true,
-        buttons = { { {
-                          text = "Help",
-                          callback = function()
-                              self:showHelp()
-                          end,
-                      }, {
-                          text = _("Cancel"),
-                          callback = function()
-                              UIManager:close(edit_dialog)
-                              edit_dialog = nil
-                              self:manageShortcuts()
-                          end,
-                      }, {
-                          text = _("Save"),
-                          callback = function()
-                              local input = edit_dialog:getInputText()
-                              UIManager:close(edit_dialog)
-                              edit_dialog = nil
-                              if input:match("[A-Za-z]") then
-                                  self.shortcuts[item.nr]["commands"] = input
-                                  self:saveShortcuts()
-                                  self:manageShortcuts()
-                              end
-                          end,
-                      } } },
+        buttons = {{
+          {
+              text = "Help",
+              callback = function()
+                  self:showHelp()
+              end,
+          }, {
+              text = _("Cancel"),
+              callback = function()
+                  UIManager:close(edit_dialog)
+                  edit_dialog = nil
+                  self:manageShortcuts()
+              end,
+          }, {
+              text = _("Save"),
+              callback = function()
+                  local input = edit_dialog:getInputText()
+                  UIManager:close(edit_dialog)
+                  edit_dialog = nil
+                  if input:match("[A-Za-z]") then
+                      self.shortcuts[item.nr]["commands"] = input
+                      self:saveShortcuts()
+                      self:manageShortcuts()
+                  end
+              end,
+          }}
+        },
     }
     UIManager:show(edit_dialog)
     edit_dialog:onShowKeyboard()
@@ -374,26 +376,28 @@ function Terminal:editName(item)
         allow_newline = false,
         cursor_at_end = true,
         fullscreen = true,
-        buttons = { { {
-                          text = _("Cancel"),
-                          callback = function()
-                              UIManager:close(edit_dialog)
-                              edit_dialog = nil
-                              self:manageShortcuts()
-                          end,
-                      }, {
-                          text = _("Save"),
-                          callback = function()
-                              local input = edit_dialog:getInputText()
-                              UIManager:close(edit_dialog)
-                              edit_dialog = nil
-                              if input:match("[A-Za-z]") then
-                                  self.shortcuts[item.nr]["text"] = input
-                                  self:saveShortcuts()
-                                  self:manageShortcuts()
-                              end
-                          end,
-                      } } },
+        buttons = {{
+             {
+                  text = _("Cancel"),
+                  callback = function()
+                      UIManager:close(edit_dialog)
+                      edit_dialog = nil
+                      self:manageShortcuts()
+                  end,
+              }, {
+                  text = _("Save"),
+                  callback = function()
+                      local input = edit_dialog:getInputText()
+                      UIManager:close(edit_dialog)
+                      edit_dialog = nil
+                      if input:match("[A-Za-z]") then
+                          self.shortcuts[item.nr]["text"] = input
+                          self:saveShortcuts()
+                          self:manageShortcuts()
+                      end
+                  end,
+              }}
+        },
     }
     UIManager:show(edit_dialog)
     edit_dialog:onShowKeyboard()

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -33,6 +33,7 @@ local Terminal = WidgetContainer:new{
     -- placeholders in commands are marked with "%[placeholder]":
     placeholders = {
         {
+            -- is it wise to translate these labels? It would have to have consequences for the placeholder strings:
             "directory of current ebook",
             function(command)
                 return command:gsub("%%d", BaseUtil.dirname(G_reader_settings:readSetting("lastfile")))
@@ -74,13 +75,13 @@ end
 
 -- other place where placeholders are used: Terminal:substitutions():
 function Terminal:showHelp()
-    local message = "PLACEHOLDERS\n"
+    local message = _("PLACEHOLDERS\n")
     for _, v in pairs(self.placeholders) do
         local label = v[1]
         local placeholder = getPlaceholder(label)
         message = message .. "\n%" .. placeholder .. " = " .. label
     end
-    message = message .. _('\n%v = add value from prompt\n\nVoorbeeld:\ncat "%s"\nom sidecar bestand huidige ebook weer te geven')
+    message = message .. _('\n%v = add value from prompt\n\nExample:\ncat "%s"\nto display sidecar file for current ebook')
     UIManager:show(InfoMessage:new{
         text = message
     })
@@ -188,7 +189,7 @@ function Terminal:commandHandler(commands)
             title = _("Value for %v placeholder"),
             input = self.last_substitution,
             input_type = "text",
-            description = "Vervang placeholder %v door deze term:",
+            description = _("Substitute placeholder %v with this:"),
             fullscreen = true,
             condensed = true,
             allow_newline = false,

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -20,10 +20,6 @@ local N_ = _.ngettext
 local Screen = require("device").screen
 local T = util.template
 
-local function getPlaceholder(label)
-    return string.lower(string.sub(label, 1, 1))
-end
-
 local Terminal = WidgetContainer:new{
     name = "terminal",
     command = "",
@@ -33,27 +29,30 @@ local Terminal = WidgetContainer:new{
     -- placeholders in commands are marked with "%[placeholder]":
     placeholders = {
         {
-            -- is it wise to translate these labels? It would have to have consequences for the placeholder strings:
-            "directory of current ebook",
+            _("directory of current ebook"),
+            "d",
             function(command)
                 return command:gsub("%%d", BaseUtil.dirname(G_reader_settings:readSetting("lastfile")))
             end
         },
         {
-            "home dir",
+            _("home dir"),
+            "h",
             function(command)
                 local home_dir = G_reader_settings:readSetting("home_dir") or Device.home_dir
                 return command:gsub("%%h", home_dir)
             end
         },
         {
-            "KOReader dir",
+            _("KOReader dir"),
+            "k",
             function(command)
                 return command:gsub("%%k", DataStorage:getDataDir())
             end
         },
         {
-            "sidecar file current ebook",
+            _("sidecar file current ebook"),
+            "s",
             function(command)
                 return command:gsub("%%s", DocSettings:getSidecarFile(G_reader_settings:readSetting("lastfile")))
             end
@@ -78,7 +77,7 @@ function Terminal:showHelp()
     local message = _("PLACEHOLDERS\n")
     for _, v in pairs(self.placeholders) do
         local label = v[1]
-        local placeholder = getPlaceholder(label)
+        local placeholder = v[2]
         message = message .. "\n%" .. placeholder .. " = " .. label
     end
     message = message .. _('\n%v = add value from prompt\n\nExample:\ncat "%s"\nto display sidecar file for current ebook')
@@ -172,9 +171,9 @@ end
 -- other place where placeholders are used: Terminal:showHelp():
 local function substitutePlaceHolders(command, placeholders)
     for _, v in pairs(placeholders) do
-        local placeholder = getPlaceholder(v[1])
+        local placeholder = v[2]
         if command:match("%%" .. placeholder) then
-            local substitution = v[2]
+            local substitution = v[3]
             command = substitution(command)
         end
     end

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -73,7 +73,7 @@ function Terminal:init()
     self.shortcuts = self.settings:readSetting("shortcuts") or {}
 end
 
--- other place where placeholders are used: Terminal:substitutions():
+-- other place where placeholders are used: substitutePlaceHolders():
 function Terminal:showHelp()
     local message = _("PLACEHOLDERS\n")
     for _, v in pairs(self.placeholders) do
@@ -170,19 +170,20 @@ function Terminal:updateItemTable()
 end
 
 -- other place where placeholders are used: Terminal:showHelp():
-function Terminal:substitutions()
-    for _, v in pairs(self.placeholders) do
+local function substitutePlaceHolders(command, placeholders)
+    for _, v in pairs(placeholders) do
         local placeholder = getPlaceholder(v[1])
-        if self.command:match("%%" .. placeholder) then
+        if command:match("%%" .. placeholder) then
             local substitution = v[2]
-            self.command = substitution(self.command)
+            command = substitution(command)
         end
     end
+    return command
 end
 
 function Terminal:commandHandler(commands)
     self.command = self:ensureWhitelineAfterCommands(commands)
-    self:substitutions()
+    self.command = substitutePlaceHolders(self.command, self.substitutions)
     if self.command:match("%%v") then
         local prompt
         prompt = InputDialog:new{

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -248,58 +248,58 @@ function Terminal:onMenuHoldShortcuts(item)
     if item.deletable or item.editable then
         local shortcut_shortcuts_dialog
         shortcut_shortcuts_dialog = ButtonDialog:new {
-            buttons = { {
-                            {
-                                text = _("Edit name"),
-                                enabled = item.editable,
-                                callback = function()
-                                    UIManager:close(shortcut_shortcuts_dialog)
-                                    if self._manager.shortcuts_dialog ~= nil then
-                                        UIManager:close(self._manager.shortcuts_dialog)
-                                        self._manager.shortcuts_dialog = nil
-                                    end
-                                    self._manager:editName(item)
-                                end
-                            },
-                            {
-                                text = _("Edit commands"),
-                                enabled = item.editable,
-                                callback = function()
-                                    UIManager:close(shortcut_shortcuts_dialog)
-                                    if self._manager.shortcuts_dialog ~= nil then
-                                        UIManager:close(self._manager.shortcuts_dialog)
-                                        self._manager.shortcuts_dialog = nil
-                                    end
-                                    self._manager:editCommands(item)
-                                end
-                            },
-                        },
-                        {
-                            {
-                                text = _("Copy"),
-                                enabled = item.editable,
-                                callback = function()
-                                    UIManager:close(shortcut_shortcuts_dialog)
-                                    if self._manager.shortcuts_dialog ~= nil then
-                                        UIManager:close(self._manager.shortcuts_dialog)
-                                        self._manager.shortcuts_dialog = nil
-                                    end
-                                    self._manager:copyCommands(item)
-                                end
-                            },
-                            {
-                                text = _("Delete"),
-                                enabled = item.deletable,
-                                callback = function()
-                                    UIManager:close(shortcut_shortcuts_dialog)
-                                    if self._manager.shortcuts_dialog ~= nil then
-                                        UIManager:close(self._manager.shortcuts_dialog)
-                                        self._manager.shortcuts_dialog = nil
-                                    end
-                                    self._manager:deleteShortcut(item)
-                                end
-                            }
-                        } }
+            buttons = {{
+                {
+                    text = _("Edit name"),
+                    enabled = item.editable,
+                    callback = function()
+                        UIManager:close(shortcut_shortcuts_dialog)
+                        if self._manager.shortcuts_dialog ~= nil then
+                            UIManager:close(self._manager.shortcuts_dialog)
+                            self._manager.shortcuts_dialog = nil
+                        end
+                        self._manager:editName(item)
+                    end
+                },
+                {
+                    text = _("Edit commands"),
+                    enabled = item.editable,
+                    callback = function()
+                        UIManager:close(shortcut_shortcuts_dialog)
+                        if self._manager.shortcuts_dialog ~= nil then
+                            UIManager:close(self._manager.shortcuts_dialog)
+                            self._manager.shortcuts_dialog = nil
+                        end
+                        self._manager:editCommands(item)
+                    end
+                },
+            },
+            {
+                {
+                    text = _("Copy"),
+                    enabled = item.editable,
+                    callback = function()
+                        UIManager:close(shortcut_shortcuts_dialog)
+                        if self._manager.shortcuts_dialog ~= nil then
+                            UIManager:close(self._manager.shortcuts_dialog)
+                            self._manager.shortcuts_dialog = nil
+                        end
+                        self._manager:copyCommands(item)
+                    end
+                },
+                {
+                    text = _("Delete"),
+                    enabled = item.deletable,
+                    callback = function()
+                        UIManager:close(shortcut_shortcuts_dialog)
+                        if self._manager.shortcuts_dialog ~= nil then
+                            UIManager:close(self._manager.shortcuts_dialog)
+                            self._manager.shortcuts_dialog = nil
+                        end
+                        self._manager:deleteShortcut(item)
+                    end
+                }
+            }}
         }
         UIManager:show(shortcut_shortcuts_dialog)
         return true
@@ -427,70 +427,73 @@ function Terminal:terminal()
         allow_newline = true,
         cursor_at_end = true,
         fullscreen = true,
-        buttons = { { {
-                          text = _("Cancel"),
-                          callback = function()
-                              UIManager:close(self.input)
-                          end,
-                      }, {
-                          text = _("Shortcuts"),
-                          callback = function()
-                              UIManager:close(self.input)
-                              self:manageShortcuts()
-                          end,
-                      }, {
-                          text = _("Save"),
-                          callback = function()
-                              local input = self.input:getInputText()
-                              if input:match("[A-Za-z]") then
+        buttons = {{
+          {
+              text = _("Cancel"),
+              callback = function()
+                  UIManager:close(self.input)
+              end,
+          }, {
+              text = _("Shortcuts"),
+              callback = function()
+                  UIManager:close(self.input)
+                  self:manageShortcuts()
+              end,
+          }, {
+              text = _("Save"),
+              callback = function()
+                  local input = self.input:getInputText()
+                  if input:match("[A-Za-z]") then
 
-                                  local function callback(name)
-                                      local new_shortcut = {
-                                          text = name,
-                                          commands = input,
-                                      }
-                                      table.insert(self.shortcuts, new_shortcut)
-                                      self:saveShortcuts()
-                                  end
+                      local function callback(name)
+                          local new_shortcut = {
+                              text = name,
+                              commands = input,
+                          }
+                          table.insert(self.shortcuts, new_shortcut)
+                          self:saveShortcuts()
+                      end
 
-                                  local prompt
-                                  prompt = InputDialog:new {
-                                      title = _("Name"),
-                                      input = "",
-                                      input_type = "text",
-                                      fullscreen = true,
-                                      condensed = true,
-                                      allow_newline = false,
-                                      cursor_at_end = true,
-                                      buttons = { { {
-                                                        text = _("Cancel"),
-                                                        callback = function()
-                                                            UIManager:close(prompt)
-                                                        end,
-                                                    },
-                                                    {
-                                                        text = _("Save"),
-                                                        is_enter_default = true,
-                                                        callback = function()
-                                                            local newval = prompt:getInputText()
-                                                            UIManager:close(prompt)
-                                                            callback(newval)
-                                                        end,
-                                                    } } }
-                                  }
-                                  UIManager:show(prompt)
-                                  prompt:onShowKeyboard()
-                              end
-                          end,
-                      }, {
-                          text = _("Execute"),
-                          callback = function()
-                              UIManager:close(self.input)
-                              -- so we know which middle button to display in the results:
-                              self.source = "terminal"
-                              self:commandHandler(self.input:getInputText())
-                          end,
-                      } } },
+                      local prompt
+                      prompt = InputDialog:new {
+                          title = _("Name"),
+                          input = "",
+                          input_type = "text",
+                          fullscreen = true,
+                          condensed = true,
+                          allow_newline = false,
+                          cursor_at_end = true,
+                          buttons = {{
+                              {
+                                    text = _("Cancel"),
+                                    callback = function()
+                                        UIManager:close(prompt)
+                                    end,
+                                },
+                                {
+                                    text = _("Save"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        local newval = prompt:getInputText()
+                                        UIManager:close(prompt)
+                                        callback(newval)
+                                    end,
+                                }}
+                          }
+                      }
+                      UIManager:show(prompt)
+                      prompt:onShowKeyboard()
+                  end
+              end,
+          }, {
+              text = _("Execute"),
+              callback = function()
+                  UIManager:close(self.input)
+                  -- so we know which middle button to display in the results:
+                  self.source = "terminal"
+                  self:commandHandler(self.input:getInputText())
+              end,
+          } } },
     }
     UIManager:show(self.input)
     self.input:onShowKeyboard()

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -193,8 +193,7 @@ function Terminal:commandHandler(commands)
             condensed = true,
             allow_newline = false,
             cursor_at_end = true,
-            buttons = {{
-               {
+            buttons = {{{
                   text = _("Cancel"),
                   callback = function()
                       if self.source == "terminal" then
@@ -215,8 +214,7 @@ function Terminal:commandHandler(commands)
                           self:execute()
                       end)
                   end,
-              }}
-            }
+              }}},
         }
         UIManager:show(prompt)
         prompt:onShowKeyboard()
@@ -250,8 +248,7 @@ function Terminal:onMenuHoldShortcuts(item)
     if item.deletable or item.editable then
         local shortcut_shortcuts_dialog
         shortcut_shortcuts_dialog = ButtonDialog:new{
-            buttons = {{
-                {
+            buttons = {{{
                     text = _("Edit name"),
                     enabled = item.editable,
                     callback = function()
@@ -300,8 +297,7 @@ function Terminal:onMenuHoldShortcuts(item)
                         end
                         self._manager:deleteShortcut(item)
                     end
-                }
-            }}
+                }}},
         }
         UIManager:show(shortcut_shortcuts_dialog)
         return true
@@ -333,8 +329,7 @@ function Terminal:editCommands(item)
         allow_newline = true,
         cursor_at_end = true,
         fullscreen = true,
-        buttons = {{
-          {
+        buttons = {{{
               text = "Help",
               callback = function()
                   self:showHelp()
@@ -358,8 +353,7 @@ function Terminal:editCommands(item)
                       self:manageShortcuts()
                   end
               end,
-          }}
-        },
+          }}},
     }
     UIManager:show(edit_dialog)
     edit_dialog:onShowKeyboard()
@@ -376,8 +370,7 @@ function Terminal:editName(item)
         allow_newline = false,
         cursor_at_end = true,
         fullscreen = true,
-        buttons = {{
-             {
+        buttons = {{{
                   text = _("Cancel"),
                   callback = function()
                       UIManager:close(edit_dialog)
@@ -396,8 +389,7 @@ function Terminal:editName(item)
                           self:manageShortcuts()
                       end
                   end,
-              }}
-        },
+              }}},
     }
     UIManager:show(edit_dialog)
     edit_dialog:onShowKeyboard()
@@ -433,8 +425,7 @@ function Terminal:terminal()
         allow_newline = true,
         cursor_at_end = true,
         fullscreen = true,
-        buttons = {{
-          {
+        buttons = {{{
               text = _("Cancel"),
               callback = function()
                   UIManager:close(self.input)
@@ -469,23 +460,21 @@ function Terminal:terminal()
                           condensed = true,
                           allow_newline = false,
                           cursor_at_end = true,
-                          buttons = {{
-                              {
-                                    text = _("Cancel"),
-                                    callback = function()
-                                        UIManager:close(prompt)
-                                    end,
-                                },
-                                {
-                                    text = _("Save"),
-                                    is_enter_default = true,
-                                    callback = function()
-                                        local newval = prompt:getInputText()
-                                        UIManager:close(prompt)
-                                        callback(newval)
-                                    end,
-                                }}
-                          }
+                          buttons = {{{
+                                text = _("Cancel"),
+                                callback = function()
+                                    UIManager:close(prompt)
+                                end,
+                            },
+                            {
+                                text = _("Save"),
+                                is_enter_default = true,
+                                callback = function()
+                                    local newval = prompt:getInputText()
+                                    UIManager:close(prompt)
+                                    callback(newval)
+                                end,
+                            }}},
                       }
                       UIManager:show(prompt)
                       prompt:onShowKeyboard()
@@ -499,7 +488,7 @@ function Terminal:terminal()
                   self.source = "terminal"
                   self:commandHandler(self.input:getInputText())
               end,
-          } } },
+          }}},
     }
     UIManager:show(self.input)
     self.input:onShowKeyboard()

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -24,7 +24,7 @@ local function getPlaceholder(label)
     return string.lower(string.sub(label, 1, 1))
 end
 
-local Terminal = WidgetContainer:new {
+local Terminal = WidgetContainer:new{
     name = "terminal",
     command = "",
     dump_file = util.realpath(DataStorage:getDataDir()) .. "/terminal_output.txt",
@@ -81,7 +81,7 @@ function Terminal:showHelp()
         message = message .. "\n%" .. placeholder .. " = " .. label
     end
     message = message .. _('\n%v = add value from prompt\n\nVoorbeeld:\ncat "%s"\nom sidecar bestand huidige ebook weer te geven')
-    UIManager:show(InfoMessage:new {
+    UIManager:show(InfoMessage:new{
         text = message
     })
 end
@@ -89,17 +89,17 @@ end
 function Terminal:saveShortcuts()
     self.settings:saveSetting("shortcuts", self.shortcuts)
     self.settings:flush()
-    UIManager:show(InfoMessage:new {
+    UIManager:show(InfoMessage:new{
         text = _("Shortcuts saved"),
         timeout = 2
     })
 end
 
 function Terminal:manageShortcuts()
-    self.shortcuts_dialog = CenterContainer:new {
+    self.shortcuts_dialog = CenterContainer:new{
         dimen = Screen:getSize(),
     }
-    self.shortcuts_menu = Menu:new {
+    self.shortcuts_menu = Menu:new{
         show_parent = self.ui,
         width = Screen:getWidth(),
         height = Screen:getHeight(),
@@ -184,7 +184,7 @@ function Terminal:commandHandler(commands)
     self:substitutions()
     if self.command:match("%%v") then
         local prompt
-        prompt = InputDialog:new {
+        prompt = InputDialog:new{
             title = _("Value for %v placeholder"),
             input = self.last_substitution,
             input_type = "text",
@@ -193,28 +193,30 @@ function Terminal:commandHandler(commands)
             condensed = true,
             allow_newline = false,
             cursor_at_end = true,
-            buttons = {{{
-                              text = _("Cancel"),
-                              callback = function()
-                                  if self.source == "terminal" then
-                                      self:terminal()
-                                  else
-                                      self:manageShortcuts()
-                                  end
-                              end,
-                          },
-                          {
-                              text = _("Execute"),
-                              is_enter_default = true,
-                              callback = function()
-                                  local newval = prompt:getInputText()
-                                  self.command = self.command:gsub("%%v", newval)
-                                  self.last_substitution = newval
-                                  Trapper:wrap(function()
-                                      self:execute()
-                                  end)
-                              end,
-                          }}}
+            buttons = {{
+               {
+                  text = _("Cancel"),
+                  callback = function()
+                      if self.source == "terminal" then
+                          self:terminal()
+                      else
+                          self:manageShortcuts()
+                      end
+                  end,
+              },
+              {
+                  text = _("Execute"),
+                  is_enter_default = true,
+                  callback = function()
+                      local newval = prompt:getInputText()
+                      self.command = self.command:gsub("%%v", newval)
+                      self.last_substitution = newval
+                      Trapper:wrap(function()
+                          self:execute()
+                      end)
+                  end,
+              }}
+            }
         }
         UIManager:show(prompt)
         prompt:onShowKeyboard()
@@ -247,7 +249,7 @@ end
 function Terminal:onMenuHoldShortcuts(item)
     if item.deletable or item.editable then
         local shortcut_shortcuts_dialog
-        shortcut_shortcuts_dialog = ButtonDialog:new {
+        shortcut_shortcuts_dialog = ButtonDialog:new{
             buttons = {{
                 {
                     text = _("Edit name"),
@@ -312,7 +314,7 @@ function Terminal:copyCommands(item)
         commands = item.commands
     }
     table.insert(self.shortcuts, new_item)
-    UIManager:show(InfoMessage:new {
+    UIManager:show(InfoMessage:new{
         text = _("Shortcut copied"),
         timeout = 2
     })
@@ -322,7 +324,7 @@ end
 
 function Terminal:editCommands(item)
     local edit_dialog
-    edit_dialog = InputDialog:new {
+    edit_dialog = InputDialog:new{
         title = T(_('Edit commands for "%1"'), item.text),
         input = item.commands,
         width = Screen:getWidth() * 0.9,
@@ -363,7 +365,7 @@ end
 
 function Terminal:editName(item)
     local edit_dialog
-    edit_dialog = InputDialog:new {
+    edit_dialog = InputDialog:new{
         title = _("Edit name"),
         input = item.text,
         width = Screen:getWidth() * 0.9,
@@ -419,7 +421,7 @@ function Terminal:onTerminalStart()
 end
 
 function Terminal:terminal()
-    self.input = InputDialog:new {
+    self.input = InputDialog:new{
         title = _("Enter a command and press \"Execute\""),
         input = self.command:gsub("\n+$", ""),
         para_direction_rtl = false, -- force LTR
@@ -455,7 +457,7 @@ function Terminal:terminal()
                       end
 
                       local prompt
-                      prompt = InputDialog:new {
+                      prompt = InputDialog:new{
                           title = _("Name"),
                           input = "",
                           input_type = "text",
@@ -508,7 +510,7 @@ function Terminal:ensureWhitelineAfterCommands(commands)
 end
 
 function Terminal:execute()
-    local wait_msg = InfoMessage:new {
+    local wait_msg = InfoMessage:new{
         text = _("Executing…"),
     }
     UIManager:show(wait_msg)
@@ -574,7 +576,7 @@ function Terminal:execute()
             },
         }
     end
-    viewer = TextViewer:new {
+    viewer = TextViewer:new{
         title = _("Command output"),
         text = table.concat(entries, "\n"),
         justified = false,

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -33,7 +33,7 @@ local Terminal = WidgetContainer:new{
             "c",
             function(command)
                 local file = G_reader_settings:readSetting("lastfile")
-                if DocSettings:hasSidecarFile() then
+                if DocSettings:hasSidecarFile(file) then
                     return command:gsub("%%c", DocSettings:getSidecarFile(file))
                 end
                 return string.format(_("echo 'File \"%s\" has no sidecar file'"), BaseUtil.basename(file))

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -86,12 +86,14 @@ local Terminal = WidgetContainer:new{
     shortcuts_menu = nil,
     --    shortcuts_file = DataStorage:getSettingsDir() .. "/terminal_shortcuts.lua",
     shortcuts = {},
+    show_sizes = false,
     source = "terminal",
 }
 
 function Terminal:init()
     self.ui.menu:registerToMainMenu(self)
     self.shortcuts = self.settings:readSetting("shortcuts") or {}
+    self.show_sizes = self.settings:readSetting("show_sizes") or false
 end
 
 -- other place where placeholders are used: substitutePlaceHolders():
@@ -115,6 +117,20 @@ function Terminal:saveShortcuts()
         text = _("Shortcuts saved"),
         timeout = 2
     })
+end
+
+function Terminal:saveSizesSetting()
+    self.show_sizes = not self.show_sizes
+    self.settings:saveSetting("show_sizes", self.show_sizes)
+    self.settings:flush()
+    self:reloadShortcutsDialog()
+end
+
+function Terminal:reloadShortcutsDialog()
+    if self.shortcuts_dialog then
+        UIManager:close(self.shortcuts_dialog)
+    end
+    self:manageShortcuts()
 end
 
 function Terminal:manageShortcuts()
@@ -149,7 +165,7 @@ end
 function Terminal:updateItemTable()
     local item_table = {}
     if #self.shortcuts > 0 then
-        local actions_count = 3 -- separator + actions
+        local actions_count = 4 -- separator + actions
         for nr, f in ipairs(self.shortcuts) do
             local item = {
                 nr = nr,
@@ -202,9 +218,19 @@ local function substitutePlaceHolders(command, placeholders)
     return command
 end
 
+-- if self.show_sizes == true, then curry ls commands with -lh option:
+local function showFileSizes(commands, show_sizes)
+    if show_sizes then
+        -- %f[%w_] ... %f[^%w_]: emulate word boundaries:
+        commands = commands:gsub("%f[%w_]ls%f[^%w_]", "ls -lh")
+    end
+    return commands
+end
+
 function Terminal:commandHandler(commands)
     self.command = self:ensureWhitelineAfterCommands(commands)
     self.command = substitutePlaceHolders(self.command, self.substitutions)
+    self.command = showFileSizes(self.command, self.show_sizes)
     if self.command:match("%%v") then
         local prompt
         prompt = InputDialog:new{
@@ -249,6 +275,20 @@ function Terminal:commandHandler(commands)
 end
 
 function Terminal:insertPageActions(item_table)
+    table.insert(item_table, {
+        text_func = function()
+            if self.show_sizes then
+                return "   " .. _("don't show sizes for ls commands…")
+            else
+                return "   " .. _("show sizes for ls commands…")
+            end
+        end,
+        deletable = false,
+        editable = false,
+        callback = function()
+            self:saveSizesSetting()
+        end,
+    })
     table.insert(item_table, {
         text = "   " .. _("to terminal…"),
         deletable = false,

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -32,7 +32,11 @@ local Terminal = WidgetContainer:new{
             _("sidecar file current ebook"),
             "c",
             function(command)
-                return command:gsub("%%c", DocSettings:getSidecarFile(G_reader_settings:readSetting("lastfile")))
+                local file = G_reader_settings:readSetting("lastfile")
+                if DocSettings:hasSidecarFile() then
+                    return command:gsub("%%c", DocSettings:getSidecarFile(file))
+                end
+                return string.format(_("echo 'File \"%s\" has no sidecar file'"), BaseUtil.basename(file))
             end
         },
         {

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -29,12 +29,23 @@ local Terminal = WidgetContainer:new{
     -- placeholders in commands are marked with "%[placeholder]":
     placeholders = {
         {
-            _("sidecar file current ebook"),
-            "c",
+            _("sidecar directory of current ebook"),
+            "cd",
             function(command)
                 local file = G_reader_settings:readSetting("lastfile")
                 if DocSettings:hasSidecarFile(file) then
-                    return command:gsub("%%c", DocSettings:getSidecarFile(file))
+                    return command:gsub("%%cd", DocSettings:getSidecarDir(file))
+                end
+                return string.format(_("echo 'File \"%s\" has no sidecar file'"), BaseUtil.basename(file))
+            end
+        },
+        {
+            _("sidecar file of current ebook"),
+            "cf",
+            function(command)
+                local file = G_reader_settings:readSetting("lastfile")
+                if DocSettings:hasSidecarFile(file) then
+                    return command:gsub("%%cf", DocSettings:getSidecarFile(file))
                 end
                 return string.format(_("echo 'File \"%s\" has no sidecar file'"), BaseUtil.basename(file))
             end


### PR DESCRIPTION
Typing on an e-reader (e.g. a Kobo device) is not the most pleasant experience. Placeholders for terminal commands take away some of that pain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6737)
<!-- Reviewable:end -->
