### PR TITLE
Frontend for mupdf / kopt update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "koreader-base"]
 	path = base
-	url = https://github.com/koreader/koreader-base.git
+	url = https://github.com/ezdiy/koreader-base
 [submodule "platform/android/luajit-launcher"]
 	path = platform/android/luajit-launcher
 	url = https://github.com/koreader/android-luajit-launcher.git
@@ -13,7 +13,7 @@
 	shallow = true
 [submodule "resources/fonts"]
 	path = resources/fonts
-	url = https://github.com/koreader/koreader-fonts.git
+	url = https://github.com/ezdiy/koreader-fonts
 	shallow = true
 [submodule "l10n"]
 	path = l10n

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -55,6 +55,13 @@ local CreDocument = Document:new{
         "Noto Sans",
     },
 
+    -- lua patterns
+    blacklist_fonts = {
+        "/urw/",
+        "/sil/",
+        "/nerdfonts/symbols%.",
+    },
+
     default_css = "./data/cr3.css",
     provider = "crengine",
     provider_name = "Cool Reader Engine",
@@ -94,6 +101,13 @@ function CreDocument:cacheInit()
         G_reader_settings:readSetting("cre_storage_size_factor") or default_cre_storage_size_factor)
 end
 
+function CreDocument:isFontBlacklisted(name)
+    for _, v in ipairs(self.blacklist_fonts) do
+        if name:match(v) then return true end
+    end
+    return false
+end
+
 function CreDocument:engineInit()
     if not engine_initialized then
         require "libs/libkoreader-cre"
@@ -106,7 +120,7 @@ function CreDocument:engineInit()
         -- we need to initialize the CRE font list
         local fonts = FontList:getFontList()
         for _k, _v in ipairs(fonts) do
-            if not _v:find("/urw/") and not _v:find("/nerdfonts/symbols.ttf") then
+            if not self:isFontBlacklisted(_v) then
                 local ok, err = pcall(cre.registerFont, _v)
                 if not ok then
                     logger.err("failed to register crengine font:", err)

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -19,8 +19,21 @@ local PdfDocument = Document:new{
     provider_name = "MuPDF",
 }
 
+local function userFont(ctx, name, bold, italic, exact)
+end
+
+local function cjkFont(ctx, name, ordering, serif)
+end
+
+local function fallbackFont(ctx, script, language, serif, bold, italic)
+end
+
+
 function PdfDocument:init()
-    if not pdf then pdf = require("ffi/mupdf") end
+    if not pdf then
+        pdf = require("ffi/mupdf")
+        pdf:setFontCallbacks(userFont, cjkFont, fallbackFont)
+    end
     -- mupdf.color has to stay false for kopt to work correctly
     -- and be accurate (including its job about showing highlight
     -- boxes). We will turn it on and off in PdfDocument:preRenderPage()
@@ -190,19 +203,26 @@ function PdfDocument:saveHighlight(pageno, item)
     self.is_edited = true
     -- will also need mupdf_h.lua to be evaluated once
     -- but this is guaranteed at this point
-    local n = #item.pboxes
-    local quadpoints = ffi.new("float[?]", 8*n)
-    for i=1, n do
-        -- The order must be left bottom, right bottom, left top, right top.
-        -- https://bugs.ghostscript.com/show_bug.cgi?id=695130
-        quadpoints[8*i-8] = item.pboxes[i].x
-        quadpoints[8*i-7] = item.pboxes[i].y + item.pboxes[i].h
-        quadpoints[8*i-6] = item.pboxes[i].x + item.pboxes[i].w
-        quadpoints[8*i-5] = item.pboxes[i].y + item.pboxes[i].h
-        quadpoints[8*i-4] = item.pboxes[i].x
-        quadpoints[8*i-3] = item.pboxes[i].y
-        quadpoints[8*i-2] = item.pboxes[i].x + item.pboxes[i].w
-        quadpoints[8*i-1] = item.pboxes[i].y
+    local quadpoints = ffi.new("fz_quad[?]", #item.pboxes)
+    for i, pb in ipairs(item.pboxes) do
+        quadpoints[i-1] = ffi.new("fz_quad", {
+            ul = {
+                x = pb.x,
+                y = pb.y,
+            },
+            ur = {
+                x = pb.x + pb.w,
+                y = pb.y,
+            },
+            ll = {
+                x = pb.x,
+                y = pb.y + pb.h,
+            },
+            lr = {
+                x = pb.x + pb.w,
+                y = pb.y + pb.h,
+            },
+        })
     end
     local page = self._document:openPage(pageno)
     local annot_type = C.PDF_ANNOT_HIGHLIGHT
@@ -211,9 +231,9 @@ function PdfDocument:saveHighlight(pageno, item)
     elseif item.drawer == "underscore" then
         annot_type = C.PDF_ANNOT_UNDERLINE
     elseif item.drawer == "strikeout" then
-        annot_type = C.PDF_ANNOT_STRIKEOUT
+        annot_type = C.PDF_ANNOT_STRIKE_OUT
     end
-    page:addMarkupAnnotation(quadpoints, n, annot_type)
+    page:addMarkupAnnotation(quadpoints, #item.pboxes, annot_type)
     page:close()
 end
 


### PR DESCRIPTION
Relating to:

https://github.com/koreader/koreader-base/pull/1203 and https://github.com/ezdiy/koreader-fonts

This is a starting point of a "branch" that builds koreader with new mupdf.

Regarding font stuff:

~The idea here is to delegate to mupdf for near-universal set of fallback fonts. But why? New mupdf comes with no brutalist font rerouting the old patch used to do. Meaning fallback noto sans fonts for exotic languages are now expected to actually exist. This isn't as heavy as it looks (adds about 5M, almost nothing compared to ginormous CJK).~

Too much rocking of the boat. [The approach taken now](https://github.com/ezdiy/mupdf/blob/koreader/source/fitz/noto.c#L70) is make mupdf *try* use our own fonts, and complain about it in log, so that one could troubleshoot what's wrong (mupdf tends to happpily fall on its face as it expects builtin fonts to be well .. builtin). This means things need to be fixed up on case-by-case basis, but we can avoid the bloat of carrying all fonts.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6738)
<!-- Reviewable:end -->
