### PR TITLE
Add Developer Tools plugin

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -77,6 +77,8 @@ local settingsList = {
     calibre_search = { category="none", event="CalibreSearch", title=_("Search in calibre metadata"), device=true,},
     calibre_browse_tags = { category="none", event="CalibreBrowseTags", title=_("Browse all calibre tags"), device=true,},
     calibre_browse_series = { category="none", event="CalibreBrowseSeries", title=_("Browse all calibre series"), device=true, separator=true,},
+
+    show_developer_tools = { category = "none", event = "ShowDeveloperTools", title = _("Show developer tools"), device = true, },
     show_terminal = { category = "none", event = "TerminalStart", title = _("Show terminal"), device = true, },
     edit_last_edited_file = { category = "none", event = "OpenLastEditedFile", title = _("Texteditor: open last file"), device = true, separator = true, },
     favorites = { category="none", event="ShowColl", arg="favorites", title=_("Favorites"), device=true,},
@@ -210,6 +212,7 @@ local dispatcher_menu_order = {
     "calibre_browse_tags",
     "calibre_browse_series",
 
+    "show_developer_tools",
     "show_terminal",
     "edit_last_edited_file",
 

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -139,6 +139,7 @@ local order = {
         "synchronize_time",
         "keep_alive",
         "doc_setting_tweak",
+        "show_developer_tools",
         "terminal",
         "----------------------------",
         "plugin_management",

--- a/plugins/developertools.koplugin/_meta.lua
+++ b/plugins/developertools.koplugin/_meta.lua
@@ -1,0 +1,7 @@
+local _ = require("gettext")
+return {
+    name = "developertools",
+    fullname = _("Developer Tools"),
+    description = _("Buttondialog linking to tools for developers"),
+    sorting_hint = "more_tools",
+}

--- a/plugins/developertools.koplugin/main.lua
+++ b/plugins/developertools.koplugin/main.lua
@@ -1,0 +1,52 @@
+-- overview of available modules: http://koreader.rocks/doc/index.html
+local ButtonDialog = require("ui/widget/buttondialog")
+local Event = require("ui/event")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+
+local DeveloperTools = WidgetContainer:new{
+    name = "developertools",
+}
+
+function DeveloperTools:init()
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function DeveloperTools:onShowDeveloperTools()
+    local tools_dialog
+    local buttons = {
+        {
+            {
+                text = _("Terminal"),
+                callback = function()
+                    --UIManager:close(tools_dialog)
+                    self.ui:handleEvent(Event:new("TerminalStart"))
+                end
+            },
+            {
+                text = "Crash.log",
+                callback = function()
+                    --UIManager:close(tools_dialog)
+                    -- points to crash.log viewer:
+                    self.ui:handleEvent(Event:new("ShowCrashlog"))
+                end
+            },
+        },
+    }
+    tools_dialog = ButtonDialog:new {
+        buttons = buttons
+    }
+    UIManager:show(tools_dialog)
+end
+
+function DeveloperTools:addToMainMenu(menu_items)
+    menu_items.developertools = {
+        text = _("Developer tools"),
+        callback = function()
+            self:onShowDeveloperTools()
+        end
+    }
+end
+
+return DeveloperTools


### PR DESCRIPTION
A simple buttondialog to start Developer Tools. In this example I've linked to the terminal and to de crash.log viewer I pushed in another commit.

The idea is that other developers can link other useful tools via this plugin. Or should all tools be made part of this plugin?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6743)
<!-- Reviewable:end -->
