### PR TITLE
ImageViewer: allow saving current view as an image

### DIFF
--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -237,8 +237,18 @@ function Font:getFace(font, size)
     local hash = realname..size
 
     local face_obj = self.faces[hash]
-    -- build face if not found
-    if not face_obj then
+    if face_obj then
+        -- Font found
+        if face_obj.orig_size ~= orig_size then
+            -- orig_size has changed (which may happen on small orig_size variations
+            -- mapping to a same final size, but more importantly when geometry
+            -- or dpi has changed): keep it updated, so code that would re-use
+            -- it to fetch another font get the current original font size and
+            -- not one from the past
+            face_obj.orig_size = orig_size
+        end
+    else
+        -- Build face if not found
         local builtin_font_location = FontList.fontdir.."/"..realname
         local ok, face = pcall(Freetype.newFace, builtin_font_location, size)
 


### PR DESCRIPTION
`Font: fix possible messy font sizes when geometry/dpi change`
Fix issue noticed at https://github.com/koreader/koreader/pull/6729#issuecomment-700822079

`ImageViewer: allow saving current view as an image`
And to make it the screensaver image.  Done on two-finger large diagonal tap on multitouch devices (like regular ScreenShoter) as long-diagonal swipe is reserved for panning.
Fallback to tap in the bottom left corner on non-multitouch devices.
(Might not be super obvious, but I don't want anything more intrusive in the ImageViewer.)

See https://github.com/koreader/koreader/issues/1914#issuecomment-702927965 and https://github.com/koreader/koreader/issues/3637#issuecomment-362107711.
Closes #1914. Closes #6699.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6745)
<!-- Reviewable:end -->
