### PR TITLE
Make dictionary lookup order configurable via SortWidget

### DIFF
--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -120,7 +120,7 @@ function SortItemWidget:init()
         item_checkable = true
         item_checked = self.item.checked_func()
     end
-    local checkmark_widget = CheckMark:new{
+    self.checkmark_widget = CheckMark:new{
         checkable = item_checkable,
         checked = item_checked,
     }
@@ -138,7 +138,7 @@ function SortItemWidget:init()
             align = "center",
             CenterContainer:new{
                 dimen = Geom:new{ w = checked_widget:getSize().w },
-                checkmark_widget,
+                self.checkmark_widget,
             },
             TextWidget:new{
                 text = self.item.text,
@@ -150,8 +150,12 @@ function SortItemWidget:init()
     self[1].invert = self.invert
 end
 
-function SortItemWidget:onTap()
-    if self.show_parent.marked == self.index then
+function SortItemWidget:onTap(_, ges)
+    if self.item.checked_func and ges.pos:intersectWith(self.checkmark_widget.dimen) then
+        if self.item.callback then
+            self.item:callback()
+        end
+    elseif self.show_parent.marked == self.index then
         self.show_parent.marked = 0
     else
         self.show_parent.marked = self.index

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -416,8 +416,9 @@ end
 function SortWidget:moveItem(diff)
     local move_to = self.marked + diff
     if move_to > 0 and move_to <= #self.item_table then
+        table.insert(self.item_table, move_to, table.remove(self.item_table, self.marked))
         self.show_page = math.ceil(move_to/self.items_per_page)
-        self:swapItems(self.marked, move_to)
+        self.marked = move_to
         self:_populateItems()
     end
 end
@@ -473,15 +474,6 @@ function SortWidget:_populateItems()
     UIManager:setDirty(self, function()
         return "ui", self.dimen
     end)
-end
-
-function SortWidget:swapItems(pos1, pos2)
-    if pos1 > 0 or pos2 <= #self.item_table then
-        local entry = self.item_table[pos1]
-        self.marked = pos2
-        self.item_table[pos1] = self.item_table[pos2]
-        self.item_table[pos2] = entry
-    end
 end
 
 function SortWidget:onAnyKeyPressed()


### PR DESCRIPTION
Previously you on had move files in and out of the dictionary directory to change the order in which dictionaries are queried.
With the changes in this pull request, the dictionary order can instead be configured via a SortWidget based menu.

Since I thought it would be impractical to have two menus for managing dictionaries, one for switching between enable/disable and one for the sorting order, I decided to add checkbox support to SortWidget. The check mark is toggled with a long press.

New dictionaries, i.e. those that were not present when the sort menu was last called, are placed at the end of the dictionary list.

### Breaking changes
The previous implementation relied on file order provided the filesystem implementation. Opposing to that the new implementation sorts the dictionaries by their name.
Users that sorted their dictionaries by moving files in and out of the dictionary directory, will experience their existing dictionary order being messed up.

### Screenshots
<details>
  <summary>Old interface</summary>

  ![DictBefore](https://user-images.githubusercontent.com/9250103/95028138-69873480-069e-11eb-885a-bbccd3784240.png)
</details>

<details>
  <summary>New interface</summary>

  ![DictAfter](https://user-images.githubusercontent.com/9250103/95028137-68560780-069e-11eb-8127-15a81499c64e.png)
</details>

---
Resolves  #4504 and #5417

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6751)
<!-- Reviewable:end -->
