### PR TITLE
[RFC]: logviewer

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -17,11 +17,18 @@ local util  = require("util")
 local _ = require("gettext")
 local T = FFIUtil.template
 
+local crashlog = require("ui/elements/logviewer"):new{ file = "crash.log" }
+
 local FileManagerMenu = InputContainer:extend{
     tab_item_table = nil,
     menu_items = {},
     registered_widgets = nil,
 }
+
+function FileManagerMenu:onShowCrashlog()
+    crashlog:show()
+    return true
+end
 
 function FileManagerMenu:init()
     self.menu_items = {
@@ -300,6 +307,14 @@ function FileManagerMenu:setUpdateItemTable()
             },
         }
     }
+    if crashlog:exists() then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            text = _("Show crash.log"),
+            keep_menu_open = true,
+            callback = function() crashlog:show() end,
+        })
+    end
+
     if Device:isKobo() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Disable forced 8-bit pixel depth"),

--- a/frontend/logger.lua
+++ b/frontend/logger.lua
@@ -10,7 +10,12 @@ Example:
 ]]
 
 local dump = require("dump")
+local isSDL = require("ffi/util").isSDL()
 local isAndroid, android = pcall(require, "android")
+
+-- write to crash.log on SDL platform based on environment.
+-- on other platforms crash.log is generated redirecting stdout in init shell scripts.
+local logfile = isSDL and os.getenv("EMULATE_CRASH_LOG") and io.open("crash.log", "w+")
 
 local DEFAULT_DUMP_LVL = 10
 
@@ -60,8 +65,13 @@ local function log(log_lvl, dump_lvl, ...)
             android.LOGE(line)
         end
     else
-        io.stdout:write(os.date("%x-%X"), " ", LOG_PREFIX[log_lvl], line, "\n")
+        local msg = string.format("%s %s%s\n", os.date("%x-%X"), LOG_PREFIX[log_lvl], line)
+        io.stdout:write(msg)
         io.stdout:flush()
+        if logfile then
+            logfile:write(msg)
+            logfile:flush()
+        end
     end
 end
 

--- a/frontend/ui/elements/logviewer.lua
+++ b/frontend/ui/elements/logviewer.lua
@@ -1,0 +1,287 @@
+--[[ This module implements a log viewer.
+
+ Its intended usage is for crash.log, but you can repurpose it for your own file.
+ All logviewer instances share the same settings but you can override them if you wish.
+
+]]--
+
+local Font = require("ui/font")
+local TextViewer = require("ui/widget/textviewer")
+local UIManager = require("ui/uimanager")
+local util = require("util")
+local _ = require("gettext")
+local T = require("ffi/util").template
+
+local BUTTONS_IN_ROW = 4
+local MIN_FONT_SIZE, MAX_FONT_SIZE = 6, 40
+local MIN_FILE_SIZE, MAX_FILE_SIZE = 4 * 1024, 512 * 1024
+
+local function getSize(file)
+    if not file then return end
+    local handle, err = io.open(file, "r")
+    if handle then
+        local bytes = handle:seek("end")
+        handle:close()
+        return bytes
+    end
+end
+
+local function scaleFont(size, direction)
+    if type(size) ~= "number" then return end
+    if size < MAX_FONT_SIZE and direction == "up" then
+        return size + 1
+    elseif size > MIN_FONT_SIZE and direction == "down" then
+        return size - 1
+    else
+        return size
+    end
+end
+
+local function scaleBytes(file, bytes)
+    local full_size = getSize(file)
+    local max_size = full_size <= MAX_FILE_SIZE and full_size or MAX_FILE_SIZE
+    
+    if type(bytes) ~= "number" or bytes <= 0 then
+        if full_size >= MIN_FILE_SIZE then
+            return MIN_FILE_SIZE
+        else
+            return nil
+        end
+    else
+        local result = bytes * 2
+        if result >= max_size then
+            result = nil
+        end
+        return result
+    end
+end
+
+local LogViewer = {}
+
+function LogViewer:new(o)
+    setmetatable(o, self)
+    self.__index = self
+    return o:init(o.file)
+end
+
+function LogViewer:init(file)
+    if not file then return nil, "file not specified" end
+    local handle = io.open(file, "r")
+    if handle then
+        handle:close()
+        self._exists = true
+    end
+
+    -- default settings if there's no override
+    for k, v in pairs({
+        font_face = "infont",
+        font_size = 10,
+        tail_bytes = 512 * 1024,
+    }) do
+        if not self[k] then
+            self[k] = v
+        end
+    end
+    return self
+end
+
+-- getters and setters for G_reader_settings
+function LogViewer:getFontSize()
+    return G_reader_settings:readSetting("logviewer_font_size") or self.font_size
+end
+
+function LogViewer:setFontSize(size)
+    G_reader_settings:saveSetting("logviewer_font_size", size or self.font_size)
+end
+
+function LogViewer:getTailBytes()
+    return G_reader_settings:readSetting("logviewer_tail_bytes") or self.tail_bytes
+end
+
+function LogViewer:setTailBytes(bytes)
+    G_reader_settings:saveSetting("logviewer_tail_bytes", bytes or self.tail_bytes)
+end
+
+function LogViewer:exists()
+    return self._exists
+end
+
+function LogViewer:truncate()
+    if not self._exists then return end
+    UIManager:show(require("ui/widget/confirmbox"):new{
+        text = T(_("Really truncate %1?"), self.file),
+        ok_callback = function()
+            local handle, err = io.open(self.file, "w")
+            if not handle then return nil, err end
+            handle:write(T(_("%1 [%2 truncated]"), os.date("%x-%X"), self.file))
+            handle:close()
+        end,
+    })
+end
+
+function LogViewer:read(tail_bytes)
+    local handle, err = io.open(self.file, "r")
+    if not handle then return nil, err end
+    local tailOnly = type(tail_bytes) == "number"
+
+    if tailOnly then
+        handle:seek("end", -tail_bytes)
+    end
+
+    local content = handle:read("*all")
+    handle:close()
+
+    if tailOnly then
+        if content:len() == tail_bytes then
+            local first_cr = content:find("\n")
+            if first_cr then
+                content = content:sub(first_cr + 1)
+            end
+            content = T(_("[Start of %1 not shown]\n"), self.file) .. content
+        else
+            content = T(_("[Start of %1]\n"), self.file) .. content
+        end
+    end
+
+    return content
+end
+
+function LogViewer:show()
+    if not self._exists then return end
+    self:update()
+end
+
+function LogViewer:getTitle(bytes)
+    local path, fname = util.splitFilePathName(self.file)
+    if fname == "" then
+        fname = path
+    end
+
+    if bytes and bytes > 0 then
+        size = string.format("Last %dKB", bytes/1024)
+    else
+        size = string.format("All %dKB", getSize(self.file)/1024)
+    end
+    return string.format("%s (%s)", fname, size)
+end
+
+function LogViewer:update(bytes, size, filter)
+    if not size then
+        size = self:getFontSize() or self.font_size
+    else
+        self:setFontSize(size)
+    end
+    
+    if bytes then
+        self:setTailBytes(bytes)
+    end
+
+    local input_text = self:read(bytes)
+    local output_text = type(filter) == "function" and filter(input_text)
+        or input_text
+
+    -- UI buttons
+    local buttons_table = {
+        {
+            {
+                text = "▕◁",
+                callback = function()
+                    self.textviewer.scroll_text_w:scrollToTop()
+                end,
+            },
+            {
+                text = "◁",
+                callback = function()
+                    self.textviewer.scroll_text_w:scrollUp()
+                end,
+            },
+            {
+                text = "▷",
+                callback = function()
+                    self.textviewer.scroll_text_w:scrollDown()
+                end,
+            },
+            {
+                text = "▷▏",
+                callback = function()
+                    self.textviewer.scroll_text_w:scrollToBottom()
+                end,
+            }
+        },
+        {
+            {
+                text = _("A-"),
+                callback = function()
+                    UIManager:close(self.textviewer)
+                    self:update(bytes, scaleFont(size, "down"), filter)
+                end,
+            },
+            {
+                text = _("A+"),
+                callback = function()
+                    UIManager:close(self.textviewer)
+                    self:update(bytes, scaleFont(size, "up"), filter)
+                end,
+            },
+            {
+                text_func = function()
+                    if not bytes or bytes <= 0 then
+                        return _("All")
+                    else
+                        return T(_("%1 kb"), bytes / 1024)
+                    end
+                end,
+                callback = function()
+                    UIManager:close(self.textviewer)
+                    self:update(scaleBytes(self.file, bytes), size, filter)
+                end,
+            },
+            {
+                text = _("Close"),
+                callback = function()
+                    UIManager:close(self.textviewer)
+                end,
+            },
+        },
+    }
+
+    if self.disable_arrows then
+        table.remove(buttons_table, 1)
+    end
+
+    -- hook user-defined buttons in the UI
+    if type(self.user_buttons) == "table" then
+        local buttons = #self.user_buttons
+        local offset = #buttons_table - 1
+        local rows = math.ceil(buttons / BUTTONS_IN_ROW)
+        for row = #buttons_table, offset + rows do
+            table.insert(buttons_table, row, {})
+        end
+        for index, value in ipairs(self.user_buttons) do
+            local row
+            repeat
+                row = row and row + 1 or 1
+            until(index <= math.floor(math.ceil(buttons/rows) * row))
+            table.insert(buttons_table[row + offset], value)
+        end
+    end
+
+    if self.textviewer then
+        UIManager:close(self.textviewer)
+    end
+
+    self.textviewer = TextViewer:new{
+        title = self:getTitle(bytes),
+        text = output_text,
+        text_face = Font:getFace(self.font_face, size),
+        width = self.textviewer_width,
+        height = self.textviewer_height,
+        justified = false,
+        buttons_table = buttons_table
+    }
+
+    self.textviewer.scroll_text_w:scrollToBottom()
+    UIManager:show(self.textviewer)
+end
+
+return LogViewer

--- a/plugins/logtest.koplugin/_meta.lua
+++ b/plugins/logtest.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = 'logtest',
+    fullname = _("Log Test"),
+    description = _([[Test for logviewer]]),
+}

--- a/plugins/logtest.koplugin/dmesg.txt
+++ b/plugins/logtest.koplugin/dmesg.txt
@@ -1,0 +1,1047 @@
+[    0.000000] microcode: microcode updated early to revision 0x28, date = 2019-11-12
+[    0.000000] Linux version 5.4.0-52-generic (buildd@lgw01-amd64-060) (gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)) #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 (Ubuntu 5.4.0-52.57-generic 5.4.65)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-5.4.0-52-generic root=UUID=da8226ad-bab4-4674-9e21-6dbcc4093ca5 ro quiet
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Hygon HygonGenuine
+[    0.000000]   Centaur CentaurHauls
+[    0.000000]   zhaoxin   Shanghai  
+[    0.000000] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
+[    0.000000] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
+[    0.000000] x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
+[    0.000000] x86/fpu: xstate_offset[2]:  576, xstate_sizes[2]:  256
+[    0.000000] x86/fpu: Enabled xstate features 0x7, context size is 832 bytes, using 'standard' format.
+[    0.000000] BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x0000000000000fff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000001000-0x0000000000057fff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000000058000-0x0000000000058fff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000059000-0x000000000008ffff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000000090000-0x0000000000090fff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000091000-0x000000000009dfff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009e000-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000c864cfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000c864d000-0x00000000c8653fff] ACPI NVS
+[    0.000000] BIOS-e820: [mem 0x00000000c8654000-0x00000000c8aa7fff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000c8aa8000-0x00000000c8ecffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000c8ed0000-0x00000000dd68bfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000dd68c000-0x00000000dd715fff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000dd716000-0x00000000dd72cfff] ACPI data
+[    0.000000] BIOS-e820: [mem 0x00000000dd72d000-0x00000000ddc68fff] ACPI NVS
+[    0.000000] BIOS-e820: [mem 0x00000000ddc69000-0x00000000deffefff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000defff000-0x00000000deffffff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000f8000000-0x00000000fbffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fec00000-0x00000000fec00fff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fed00000-0x00000000fed03fff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fed1c000-0x00000000fed1ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fee00000-0x00000000fee00fff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000ff000000-0x00000000ffffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000021effffff] usable
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] e820: update [mem 0xc81ce018-0xc81ed857] usable ==> usable
+[    0.000000] e820: update [mem 0xc81ce018-0xc81ed857] usable ==> usable
+[    0.000000] extended physical RAM map:
+[    0.000000] reserve setup_data: [mem 0x0000000000000000-0x0000000000000fff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000000001000-0x0000000000057fff] usable
+[    0.000000] reserve setup_data: [mem 0x0000000000058000-0x0000000000058fff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000000059000-0x000000000008ffff] usable
+[    0.000000] reserve setup_data: [mem 0x0000000000090000-0x0000000000090fff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000000091000-0x000000000009dfff] usable
+[    0.000000] reserve setup_data: [mem 0x000000000009e000-0x000000000009ffff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000000100000-0x00000000c81ce017] usable
+[    0.000000] reserve setup_data: [mem 0x00000000c81ce018-0x00000000c81ed857] usable
+[    0.000000] reserve setup_data: [mem 0x00000000c81ed858-0x00000000c864cfff] usable
+[    0.000000] reserve setup_data: [mem 0x00000000c864d000-0x00000000c8653fff] ACPI NVS
+[    0.000000] reserve setup_data: [mem 0x00000000c8654000-0x00000000c8aa7fff] usable
+[    0.000000] reserve setup_data: [mem 0x00000000c8aa8000-0x00000000c8ecffff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000c8ed0000-0x00000000dd68bfff] usable
+[    0.000000] reserve setup_data: [mem 0x00000000dd68c000-0x00000000dd715fff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000dd716000-0x00000000dd72cfff] ACPI data
+[    0.000000] reserve setup_data: [mem 0x00000000dd72d000-0x00000000ddc68fff] ACPI NVS
+[    0.000000] reserve setup_data: [mem 0x00000000ddc69000-0x00000000deffefff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000defff000-0x00000000deffffff] usable
+[    0.000000] reserve setup_data: [mem 0x00000000f8000000-0x00000000fbffffff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000fec00000-0x00000000fec00fff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000fed00000-0x00000000fed03fff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000fed1c000-0x00000000fed1ffff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000fee00000-0x00000000fee00fff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000ff000000-0x00000000ffffffff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000100000000-0x000000021effffff] usable
+[    0.000000] efi: EFI v2.31 by American Megatrends
+[    0.000000] efi:  ESRT=0xdef56898  ACPI=0xdd71a000  ACPI 2.0=0xdd71a000  SMBIOS=0xdef56518 
+[    0.000000] secureboot: Secure boot disabled
+[    0.000000] SMBIOS 2.7 present.
+[    0.000000] DMI: ASUS All Series/B85M-G, BIOS 2108 08/11/2014
+[    0.000000] tsc: Fast TSC calibration using PIT
+[    0.000000] tsc: Detected 3092.755 MHz processor
+[    0.000066] e820: update [mem 0x00000000-0x00000fff] usable ==> reserved
+[    0.000067] e820: remove [mem 0x000a0000-0x000fffff] usable
+[    0.000072] last_pfn = 0x21f000 max_arch_pfn = 0x400000000
+[    0.000076] MTRR default type: uncachable
+[    0.000077] MTRR fixed ranges enabled:
+[    0.000078]   00000-9FFFF write-back
+[    0.000078]   A0000-DFFFF uncachable
+[    0.000079]   E0000-FFFFF write-protect
+[    0.000079] MTRR variable ranges enabled:
+[    0.000081]   0 base 0000000000 mask 7E00000000 write-back
+[    0.000081]   1 base 0200000000 mask 7FF0000000 write-back
+[    0.000082]   2 base 0210000000 mask 7FF8000000 write-back
+[    0.000083]   3 base 0218000000 mask 7FFC000000 write-back
+[    0.000083]   4 base 021C000000 mask 7FFE000000 write-back
+[    0.000084]   5 base 021E000000 mask 7FFF000000 write-back
+[    0.000084]   6 base 00E0000000 mask 7FE0000000 uncachable
+[    0.000085]   7 disabled
+[    0.000085]   8 disabled
+[    0.000085]   9 disabled
+[    0.000364] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT  
+[    0.000481] total RAM covered: 8176M
+[    0.000783] Found optimal setting for mtrr clean up
+[    0.000784]  gran_size: 64K 	chunk_size: 32M 	num_reg: 6  	lose cover RAM: 0G
+[    0.001029] e820: update [mem 0xe0000000-0xffffffff] usable ==> reserved
+[    0.001032] last_pfn = 0xdf000 max_arch_pfn = 0x400000000
+[    0.007705] esrt: Reserving ESRT space from 0x00000000def56898 to 0x00000000def568d0.
+[    0.007725] check: Scanning 1 areas for low memory corruption
+[    0.007729] Using GB pages for direct mapping
+[    0.008427] secureboot: Secure boot disabled
+[    0.008428] RAMDISK: [mem 0x3ccc3000-0x3fffdfff]
+[    0.008434] ACPI: Early table checksum verification disabled
+[    0.008437] ACPI: RSDP 0x00000000DD71A000 000024 (v02 ALASKA)
+[    0.008439] ACPI: XSDT 0x00000000DD71A080 00007C (v01 ALASKA A M I    01072009 AMI  00010013)
+[    0.008444] ACPI: FACP 0x00000000DD727690 00010C (v05 ALASKA A M I    01072009 AMI  00010013)
+[    0.008447] ACPI: DSDT 0x00000000DD71A198 00D4F5 (v02 ALASKA A M I    00000031 INTL 20091112)
+[    0.008450] ACPI: FACS 0x00000000DDC67080 000040
+[    0.008451] ACPI: APIC 0x00000000DD7277A0 000072 (v03 ALASKA A M I    01072009 AMI  00010013)
+[    0.008453] ACPI: FPDT 0x00000000DD727818 000044 (v01 ALASKA A M I    01072009 AMI  00010013)
+[    0.008455] ACPI: LPIT 0x00000000DD727860 00005C (v01 ALASKA A M I    00000000 AMI. 00000005)
+[    0.008457] ACPI: SSDT 0x00000000DD7278C0 000539 (v01 PmRef  Cpu0Ist  00003000 INTL 20091112)
+[    0.008460] ACPI: SSDT 0x00000000DD727E00 000AD8 (v01 PmRef  CpuPm    00003000 INTL 20091112)
+[    0.008462] ACPI: MCFG 0x00000000DD7288D8 00003C (v01 ALASKA A M I    01072009 MSFT 00000097)
+[    0.008464] ACPI: HPET 0x00000000DD728918 000038 (v01 ALASKA A M I    01072009 AMI. 00000005)
+[    0.008466] ACPI: SSDT 0x00000000DD728950 00036D (v01 SataRe SataTabl 00001000 INTL 20091112)
+[    0.008468] ACPI: SSDT 0x00000000DD728CC0 0034E1 (v01 SaSsdt SaSsdt   00003000 INTL 20091112)
+[    0.008470] ACPI: BGRT 0x00000000DD72C200 000038 (v00 ALASKA A M I    01072009 AMI  00010013)
+[    0.008475] ACPI: Local APIC address 0xfee00000
+[    0.008544] No NUMA configuration found
+[    0.008545] Faking a node at [mem 0x0000000000000000-0x000000021effffff]
+[    0.008554] NODE_DATA(0) allocated [mem 0x21efd5000-0x21effffff]
+[    0.008735] Zone ranges:
+[    0.008735]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.008736]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.008737]   Normal   [mem 0x0000000100000000-0x000000021effffff]
+[    0.008738]   Device   empty
+[    0.008738] Movable zone start for each node
+[    0.008741] Early memory node ranges
+[    0.008742]   node   0: [mem 0x0000000000001000-0x0000000000057fff]
+[    0.008743]   node   0: [mem 0x0000000000059000-0x000000000008ffff]
+[    0.008743]   node   0: [mem 0x0000000000091000-0x000000000009dfff]
+[    0.008744]   node   0: [mem 0x0000000000100000-0x00000000c864cfff]
+[    0.008744]   node   0: [mem 0x00000000c8654000-0x00000000c8aa7fff]
+[    0.008745]   node   0: [mem 0x00000000c8ed0000-0x00000000dd68bfff]
+[    0.008745]   node   0: [mem 0x00000000defff000-0x00000000deffffff]
+[    0.008746]   node   0: [mem 0x0000000100000000-0x000000021effffff]
+[    0.008869] Zeroed struct page in unavailable ranges: 15879 pages
+[    0.008870] Initmem setup node 0 [mem 0x0000000000001000-0x000000021effffff]
+[    0.008871] On node 0 totalpages: 2081273
+[    0.008872]   DMA zone: 64 pages used for memmap
+[    0.008873]   DMA zone: 21 pages reserved
+[    0.008873]   DMA zone: 3995 pages, LIFO batch:0
+[    0.008912]   DMA32 zone: 14090 pages used for memmap
+[    0.008913]   DMA32 zone: 901726 pages, LIFO batch:63
+[    0.017981]   Normal zone: 18368 pages used for memmap
+[    0.017982]   Normal zone: 1175552 pages, LIFO batch:63
+[    0.029235] ACPI: PM-Timer IO Port: 0x1808
+[    0.029238] ACPI: Local APIC address 0xfee00000
+[    0.029243] ACPI: LAPIC_NMI (acpi_id[0xff] high edge lint[0x1])
+[    0.029253] IOAPIC[0]: apic_id 8, version 32, address 0xfec00000, GSI 0-23
+[    0.029254] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.029255] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.029256] ACPI: IRQ0 used by override.
+[    0.029257] ACPI: IRQ9 used by override.
+[    0.029258] Using ACPI (MADT) for SMP configuration information
+[    0.029259] ACPI: HPET id: 0x8086a701 base: 0xfed00000
+[    0.029263] efi_bgrt: Ignoring BGRT: invalid image address
+[    0.029265] TSC deadline timer available
+[    0.029266] smpboot: Allowing 4 CPUs, 0 hotplug CPUs
+[    0.029289] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.029291] PM: Registered nosave memory: [mem 0x00058000-0x00058fff]
+[    0.029292] PM: Registered nosave memory: [mem 0x00090000-0x00090fff]
+[    0.029294] PM: Registered nosave memory: [mem 0x0009e000-0x0009ffff]
+[    0.029294] PM: Registered nosave memory: [mem 0x000a0000-0x000fffff]
+[    0.029296] PM: Registered nosave memory: [mem 0xc81ce000-0xc81cefff]
+[    0.029297] PM: Registered nosave memory: [mem 0xc81ed000-0xc81edfff]
+[    0.029299] PM: Registered nosave memory: [mem 0xc864d000-0xc8653fff]
+[    0.029300] PM: Registered nosave memory: [mem 0xc8aa8000-0xc8ecffff]
+[    0.029302] PM: Registered nosave memory: [mem 0xdd68c000-0xdd715fff]
+[    0.029302] PM: Registered nosave memory: [mem 0xdd716000-0xdd72cfff]
+[    0.029302] PM: Registered nosave memory: [mem 0xdd72d000-0xddc68fff]
+[    0.029303] PM: Registered nosave memory: [mem 0xddc69000-0xdeffefff]
+[    0.029304] PM: Registered nosave memory: [mem 0xdf000000-0xf7ffffff]
+[    0.029305] PM: Registered nosave memory: [mem 0xf8000000-0xfbffffff]
+[    0.029305] PM: Registered nosave memory: [mem 0xfc000000-0xfebfffff]
+[    0.029305] PM: Registered nosave memory: [mem 0xfec00000-0xfec00fff]
+[    0.029306] PM: Registered nosave memory: [mem 0xfec01000-0xfecfffff]
+[    0.029306] PM: Registered nosave memory: [mem 0xfed00000-0xfed03fff]
+[    0.029307] PM: Registered nosave memory: [mem 0xfed04000-0xfed1bfff]
+[    0.029307] PM: Registered nosave memory: [mem 0xfed1c000-0xfed1ffff]
+[    0.029307] PM: Registered nosave memory: [mem 0xfed20000-0xfedfffff]
+[    0.029308] PM: Registered nosave memory: [mem 0xfee00000-0xfee00fff]
+[    0.029308] PM: Registered nosave memory: [mem 0xfee01000-0xfeffffff]
+[    0.029309] PM: Registered nosave memory: [mem 0xff000000-0xffffffff]
+[    0.029310] [mem 0xdf000000-0xf7ffffff] available for PCI devices
+[    0.029311] Booting paravirtualized kernel on bare hardware
+[    0.029313] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.029319] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:4 nr_cpu_ids:4 nr_node_ids:1
+[    0.029461] percpu: Embedded 54 pages/cpu s184320 r8192 d28672 u524288
+[    0.029467] pcpu-alloc: s184320 r8192 d28672 u524288 alloc=1*2097152
+[    0.029468] pcpu-alloc: [0] 0 1 2 3 
+[    0.029495] Built 1 zonelists, mobility grouping on.  Total pages: 2048730
+[    0.029496] Policy zone: Normal
+[    0.029497] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-5.4.0-52-generic root=UUID=da8226ad-bab4-4674-9e21-6dbcc4093ca5 ro quiet
+[    0.029897] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes, linear)
+[    0.030086] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes, linear)
+[    0.030125] mem auto-init: stack:off, heap alloc:on, heap free:off
+[    0.032983] Calgary: detecting Calgary via BIOS EBDA area
+[    0.032984] Calgary: Unable to locate Rio Grande table in EBDA - bailing!
+[    0.052644] Memory: 7953872K/8325092K available (14339K kernel code, 2398K rwdata, 4956K rodata, 2716K init, 4988K bss, 371220K reserved, 0K cma-reserved)
+[    0.052650] random: get_random_u64 called from kmem_cache_open+0x2d/0x410 with crng_init=0
+[    0.052758] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
+[    0.052769] Kernel/User page tables isolation: enabled
+[    0.052780] ftrace: allocating 44527 entries in 174 pages
+[    0.066267] rcu: Hierarchical RCU implementation.
+[    0.066268] rcu: 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=4.
+[    0.066268] 	Tasks RCU enabled.
+[    0.066269] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
+[    0.066270] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
+[    0.068474] NR_IRQS: 524544, nr_irqs: 456, preallocated irqs: 16
+[    0.068739] random: crng done (trusting CPU's manufacturer)
+[    0.068757] Console: colour dummy device 80x25
+[    0.068761] printk: console [tty0] enabled
+[    0.068774] ACPI: Core revision 20190816
+[    0.068861] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 133484882848 ns
+[    0.068870] APIC: Switch to symmetric I/O mode setup
+[    0.068932] x2apic: IRQ remapping doesn't support X2APIC mode
+[    0.069324] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.088871] clocksource: tsc-early: mask: 0xffffffffffffffff max_cycles: 0x2c948b91124, max_idle_ns: 440795223511 ns
+[    0.088874] Calibrating delay loop (skipped), value calculated using timer frequency.. 6185.51 BogoMIPS (lpj=12371020)
+[    0.088876] pid_max: default: 32768 minimum: 301
+[    0.091463] LSM: Security Framework initializing
+[    0.091472] Yama: becoming mindful.
+[    0.091495] AppArmor: AppArmor initialized
+[    0.091532] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+[    0.091545] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+[    0.091556] *** VALIDATE tmpfs ***
+[    0.091668] *** VALIDATE proc ***
+[    0.091708] *** VALIDATE cgroup1 ***
+[    0.091709] *** VALIDATE cgroup2 ***
+[    0.091754] mce: CPU0: Thermal monitoring enabled (TM1)
+[    0.091766] process: using mwait in idle threads
+[    0.091768] Last level iTLB entries: 4KB 1024, 2MB 1024, 4MB 1024
+[    0.091769] Last level dTLB entries: 4KB 1024, 2MB 1024, 4MB 1024, 1GB 4
+[    0.091771] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.091772] Spectre V2 : Mitigation: Full generic retpoline
+[    0.091772] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.091772] Spectre V2 : Enabling Restricted Speculation for firmware calls
+[    0.091773] Spectre V2 : mitigation: Enabling conditional Indirect Branch Prediction Barrier
+[    0.091774] Speculative Store Bypass: Mitigation: Speculative Store Bypass disabled via prctl and seccomp
+[    0.091777] SRBDS: Mitigation: Microcode
+[    0.091778] MDS: Mitigation: Clear CPU buffers
+[    0.091920] Freeing SMP alternatives memory: 40K
+[    0.094271] smpboot: CPU0: Intel(R) Core(TM) i5-4440 CPU @ 3.10GHz (family: 0x6, model: 0x3c, stepping: 0x3)
+[    0.094364] Performance Events: PEBS fmt2+, Haswell events, 16-deep LBR, full-width counters, Intel PMU driver.
+[    0.094377] ... version:                3
+[    0.094378] ... bit width:              48
+[    0.094378] ... generic registers:      8
+[    0.094378] ... value mask:             0000ffffffffffff
+[    0.094379] ... max period:             00007fffffffffff
+[    0.094379] ... fixed-purpose events:   3
+[    0.094380] ... event mask:             00000007000000ff
+[    0.094405] rcu: Hierarchical SRCU implementation.
+[    0.095075] NMI watchdog: Enabled. Permanently consumes one hw-PMU counter.
+[    0.095116] smp: Bringing up secondary CPUs ...
+[    0.095181] x86: Booting SMP configuration:
+[    0.095182] .... node  #0, CPUs:      #1 #2 #3
+[    0.098450] smp: Brought up 1 node, 4 CPUs
+[    0.098450] smpboot: Max logical packages: 1
+[    0.098450] smpboot: Total of 4 processors activated (24742.04 BogoMIPS)
+[    0.098450] devtmpfs: initialized
+[    0.098450] x86/mm: Memory block size: 128MB
+[    0.100896] PM: Registering ACPI NVS region [mem 0xc864d000-0xc8653fff] (28672 bytes)
+[    0.100897] PM: Registering ACPI NVS region [mem 0xdd72d000-0xddc68fff] (5488640 bytes)
+[    0.100989] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.100989] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
+[    0.100989] pinctrl core: initialized pinctrl subsystem
+[    0.101011] PM: RTC time: 15:15:34, date: 2020-10-30
+[    0.101093] NET: Registered protocol family 16
+[    0.101147] audit: initializing netlink subsys (disabled)
+[    0.101151] audit: type=2000 audit(1604070934.032:1): state=initialized audit_enabled=0 res=1
+[    0.101151] EISA bus registered
+[    0.101151] cpuidle: using governor ladder
+[    0.101151] cpuidle: using governor menu
+[    0.101151] ACPI FADT declares the system doesn't support PCIe ASPM, so disable it
+[    0.101151] ACPI: bus type PCI registered
+[    0.101151] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.101151] PCI: MMCONFIG for domain 0000 [bus 00-3f] at [mem 0xf8000000-0xfbffffff] (base 0xf8000000)
+[    0.101151] PCI: MMCONFIG at [mem 0xf8000000-0xfbffffff] reserved in E820
+[    0.101151] PCI: Using configuration type 1 for base access
+[    0.101151] core: PMU erratum BJ122, BV98, HSD29 workaround disabled, HT off
+[    0.101305] ENERGY_PERF_BIAS: Set to 'normal', was 'performance'
+[    0.101988] HugeTLB registered 1.00 GiB page size, pre-allocated 0 pages
+[    0.101988] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.101988] ACPI: Added _OSI(Module Device)
+[    0.101988] ACPI: Added _OSI(Processor Device)
+[    0.101988] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.101988] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.101988] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.101988] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.101988] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.113521] ACPI: 5 ACPI AML tables successfully acquired and loaded
+[    0.114801] ACPI: [Firmware Bug]: BIOS _OSI(Linux) query ignored
+[    0.115702] ACPI: Dynamic OEM Table Load:
+[    0.115706] ACPI: SSDT 0xFFFF98AC95BEF000 0003D3 (v01 PmRef  Cpu0Cst  00003001 INTL 20091112)
+[    0.116654] ACPI: Dynamic OEM Table Load:
+[    0.116657] ACPI: SSDT 0xFFFF98AC95816000 0005AA (v01 PmRef  ApIst    00003000 INTL 20091112)
+[    0.117674] ACPI: Dynamic OEM Table Load:
+[    0.117676] ACPI: SSDT 0xFFFF98AC95339E00 000119 (v01 PmRef  ApCst    00003000 INTL 20091112)
+[    0.119544] ACPI: Interpreter enabled
+[    0.119569] ACPI: (supports S0 S3 S4 S5)
+[    0.119570] ACPI: Using IOAPIC for interrupt routing
+[    0.119596] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.120013] ACPI: Enabled 9 GPEs in block 00 to 3F
+[    0.129708] ACPI: Power Resource [FN00] (off)
+[    0.129779] ACPI: Power Resource [FN01] (off)
+[    0.129850] ACPI: Power Resource [FN02] (off)
+[    0.129924] ACPI: Power Resource [FN03] (off)
+[    0.129994] ACPI: Power Resource [FN04] (off)
+[    0.130819] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-3e])
+[    0.130823] acpi PNP0A08:00: _OSC: OS supports [ExtendedConfig ASPM ClockPM Segments MSI HPX-Type3]
+[    0.131105] acpi PNP0A08:00: _OSC: platform does not support [PCIeHotplug SHPCHotplug PME]
+[    0.131288] acpi PNP0A08:00: _OSC: OS now controls [AER PCIeCapability LTR]
+[    0.131288] acpi PNP0A08:00: FADT indicates ASPM is unsupported, using BIOS configuration
+[    0.131700] PCI host bridge to bus 0000:00
+[    0.131702] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.131703] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.131704] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.131705] pci_bus 0000:00: root bus resource [mem 0x000c0000-0x000c3fff window]
+[    0.131706] pci_bus 0000:00: root bus resource [mem 0x000c4000-0x000c7fff window]
+[    0.131707] pci_bus 0000:00: root bus resource [mem 0x000c8000-0x000cbfff window]
+[    0.131708] pci_bus 0000:00: root bus resource [mem 0x000cc000-0x000cffff window]
+[    0.131708] pci_bus 0000:00: root bus resource [mem 0x000d0000-0x000d3fff window]
+[    0.131709] pci_bus 0000:00: root bus resource [mem 0x000d4000-0x000d7fff window]
+[    0.131710] pci_bus 0000:00: root bus resource [mem 0x000d8000-0x000dbfff window]
+[    0.131711] pci_bus 0000:00: root bus resource [mem 0x000dc000-0x000dffff window]
+[    0.131712] pci_bus 0000:00: root bus resource [mem 0xe0000000-0xfeafffff window]
+[    0.131713] pci_bus 0000:00: root bus resource [bus 00-3e]
+[    0.131720] pci 0000:00:00.0: [8086:0c00] type 00 class 0x060000
+[    0.131797] pci 0000:00:01.0: [8086:0c01] type 01 class 0x060400
+[    0.131831] pci 0000:00:01.0: PME# supported from D0 D3hot D3cold
+[    0.131973] pci 0000:00:14.0: [8086:8c31] type 00 class 0x0c0330
+[    0.131991] pci 0000:00:14.0: reg 0x10: [mem 0xf7300000-0xf730ffff 64bit]
+[    0.132042] pci 0000:00:14.0: PME# supported from D3hot D3cold
+[    0.132113] pci 0000:00:16.0: [8086:8c3a] type 00 class 0x078000
+[    0.132131] pci 0000:00:16.0: reg 0x10: [mem 0xf7316000-0xf731600f 64bit]
+[    0.132184] pci 0000:00:16.0: PME# supported from D0 D3hot D3cold
+[    0.132254] pci 0000:00:1a.0: [8086:8c2d] type 00 class 0x0c0320
+[    0.132272] pci 0000:00:1a.0: reg 0x10: [mem 0xf7314000-0xf73143ff]
+[    0.132344] pci 0000:00:1a.0: PME# supported from D0 D3hot D3cold
+[    0.132418] pci 0000:00:1c.0: [8086:8c10] type 01 class 0x060400
+[    0.132486] pci 0000:00:1c.0: PME# supported from D0 D3hot D3cold
+[    0.132609] pci 0000:00:1c.1: [8086:8c12] type 01 class 0x060400
+[    0.132677] pci 0000:00:1c.1: PME# supported from D0 D3hot D3cold
+[    0.132800] pci 0000:00:1c.2: [8086:8c14] type 01 class 0x060400
+[    0.132868] pci 0000:00:1c.2: PME# supported from D0 D3hot D3cold
+[    0.132997] pci 0000:00:1d.0: [8086:8c26] type 00 class 0x0c0320
+[    0.133015] pci 0000:00:1d.0: reg 0x10: [mem 0xf7313000-0xf73133ff]
+[    0.133088] pci 0000:00:1d.0: PME# supported from D0 D3hot D3cold
+[    0.133166] pci 0000:00:1f.0: [8086:8c50] type 00 class 0x060100
+[    0.133326] pci 0000:00:1f.2: [8086:8c02] type 00 class 0x010601
+[    0.133339] pci 0000:00:1f.2: reg 0x10: [io  0xf070-0xf077]
+[    0.133345] pci 0000:00:1f.2: reg 0x14: [io  0xf060-0xf063]
+[    0.133351] pci 0000:00:1f.2: reg 0x18: [io  0xf050-0xf057]
+[    0.133356] pci 0000:00:1f.2: reg 0x1c: [io  0xf040-0xf043]
+[    0.133362] pci 0000:00:1f.2: reg 0x20: [io  0xf020-0xf03f]
+[    0.133367] pci 0000:00:1f.2: reg 0x24: [mem 0xf7312000-0xf73127ff]
+[    0.133396] pci 0000:00:1f.2: PME# supported from D3hot
+[    0.133462] pci 0000:00:1f.3: [8086:8c22] type 00 class 0x0c0500
+[    0.133477] pci 0000:00:1f.3: reg 0x10: [mem 0xf7311000-0xf73110ff 64bit]
+[    0.133493] pci 0000:00:1f.3: reg 0x20: [io  0xf000-0xf01f]
+[    0.133603] pci 0000:01:00.0: [10de:1c81] type 00 class 0x030000
+[    0.133620] pci 0000:01:00.0: reg 0x10: [mem 0xf6000000-0xf6ffffff]
+[    0.133630] pci 0000:01:00.0: reg 0x14: [mem 0xe0000000-0xefffffff 64bit pref]
+[    0.133639] pci 0000:01:00.0: reg 0x1c: [mem 0xf0000000-0xf1ffffff 64bit pref]
+[    0.133645] pci 0000:01:00.0: reg 0x24: [io  0xe000-0xe07f]
+[    0.133651] pci 0000:01:00.0: reg 0x30: [mem 0xf7000000-0xf707ffff pref]
+[    0.133665] pci 0000:01:00.0: BAR 1: assigned to efifb
+[    0.133720] pci 0000:01:00.0: 16.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s x8 link at 0000:00:01.0 (capable of 126.016 Gb/s with 8 GT/s x16 link)
+[    0.133768] pci 0000:01:00.1: [10de:0fb9] type 00 class 0x040300
+[    0.133780] pci 0000:01:00.1: reg 0x10: [mem 0xf7080000-0xf7083fff]
+[    0.133896] pci 0000:00:01.0: PCI bridge to [bus 01]
+[    0.133898] pci 0000:00:01.0:   bridge window [io  0xe000-0xefff]
+[    0.133899] pci 0000:00:01.0:   bridge window [mem 0xf6000000-0xf70fffff]
+[    0.133901] pci 0000:00:01.0:   bridge window [mem 0xe0000000-0xf1ffffff 64bit pref]
+[    0.133953] acpiphp: Slot [1] registered
+[    0.133956] pci 0000:00:1c.0: PCI bridge to [bus 02]
+[    0.134022] pci 0000:03:00.0: [168c:0032] type 00 class 0x028000
+[    0.134051] pci 0000:03:00.0: reg 0x10: [mem 0xf7200000-0xf727ffff 64bit]
+[    0.134085] pci 0000:03:00.0: reg 0x30: [mem 0xf7280000-0xf728ffff pref]
+[    0.134156] pci 0000:03:00.0: supports D1 D2
+[    0.134157] pci 0000:03:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.134251] pci 0000:00:1c.1: PCI bridge to [bus 03]
+[    0.134255] pci 0000:00:1c.1:   bridge window [mem 0xf7200000-0xf72fffff]
+[    0.134317] pci 0000:04:00.0: [10ec:8168] type 00 class 0x020000
+[    0.134345] pci 0000:04:00.0: reg 0x10: [io  0xd000-0xd0ff]
+[    0.134370] pci 0000:04:00.0: reg 0x18: [mem 0xf7100000-0xf7100fff 64bit]
+[    0.134386] pci 0000:04:00.0: reg 0x20: [mem 0xf2100000-0xf2103fff 64bit pref]
+[    0.134483] pci 0000:04:00.0: supports D1 D2
+[    0.134484] pci 0000:04:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.134589] pci 0000:00:1c.2: PCI bridge to [bus 04]
+[    0.134592] pci 0000:00:1c.2:   bridge window [io  0xd000-0xdfff]
+[    0.134594] pci 0000:00:1c.2:   bridge window [mem 0xf7100000-0xf71fffff]
+[    0.134598] pci 0000:00:1c.2:   bridge window [mem 0xf2100000-0xf21fffff 64bit pref]
+[    0.135499] ACPI: PCI Interrupt Link [LNKA] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.135557] ACPI: PCI Interrupt Link [LNKB] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.135614] ACPI: PCI Interrupt Link [LNKC] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.135671] ACPI: PCI Interrupt Link [LNKD] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.135729] ACPI: PCI Interrupt Link [LNKE] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.135786] ACPI: PCI Interrupt Link [LNKF] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.135844] ACPI: PCI Interrupt Link [LNKG] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.135902] ACPI: PCI Interrupt Link [LNKH] (IRQs 3 4 5 6 7 10 11 12 14 15) *0, disabled.
+[    0.136269] iommu: Default domain type: Translated 
+[    0.136269] SCSI subsystem initialized
+[    0.136269] libata version 3.00 loaded.
+[    0.136269] pci 0000:01:00.0: vgaarb: setting as boot VGA device
+[    0.136269] pci 0000:01:00.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.136269] pci 0000:01:00.0: vgaarb: bridge control possible
+[    0.136269] vgaarb: loaded
+[    0.136269] ACPI: bus type USB registered
+[    0.136269] usbcore: registered new interface driver usbfs
+[    0.136269] usbcore: registered new interface driver hub
+[    0.136269] usbcore: registered new device driver usb
+[    0.136269] pps_core: LinuxPPS API ver. 1 registered
+[    0.136269] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[    0.136269] PTP clock support registered
+[    0.136269] EDAC MC: Ver: 3.0.0
+[    0.136269] Registered efivars operations
+[    0.136269] PCI: Using ACPI for IRQ routing
+[    0.136269] PCI: pci_cache_line_size set to 64 bytes
+[    0.136269] e820: reserve RAM buffer [mem 0x00058000-0x0005ffff]
+[    0.136269] e820: reserve RAM buffer [mem 0x0009e000-0x0009ffff]
+[    0.136269] e820: reserve RAM buffer [mem 0xc81ce018-0xcbffffff]
+[    0.136269] e820: reserve RAM buffer [mem 0xc864d000-0xcbffffff]
+[    0.136269] e820: reserve RAM buffer [mem 0xc8aa8000-0xcbffffff]
+[    0.136269] e820: reserve RAM buffer [mem 0xdd68c000-0xdfffffff]
+[    0.136269] e820: reserve RAM buffer [mem 0xdf000000-0xdfffffff]
+[    0.136269] e820: reserve RAM buffer [mem 0x21f000000-0x21fffffff]
+[    0.136876] NetLabel: Initializing
+[    0.136876] NetLabel:  domain hash size = 128
+[    0.136876] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.136876] NetLabel:  unlabeled traffic allowed by default
+[    0.137359] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0, 0, 0, 0, 0, 0
+[    0.137362] hpet0: 8 comparators, 64-bit 14.318180 MHz counter
+[    0.137362] clocksource: Switched to clocksource tsc-early
+[    0.146518] *** VALIDATE bpf ***
+[    0.146577] VFS: Disk quotas dquot_6.6.0
+[    0.146589] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.146609] *** VALIDATE ramfs ***
+[    0.146612] *** VALIDATE hugetlbfs ***
+[    0.146675] AppArmor: AppArmor Filesystem Enabled
+[    0.146699] pnp: PnP ACPI init
+[    0.146815] system 00:00: [mem 0xfed40000-0xfed44fff] has been reserved
+[    0.146819] system 00:00: Plug and Play ACPI device, IDs PNP0c01 (active)
+[    0.147003] system 00:01: [io  0x0680-0x069f] has been reserved
+[    0.147004] system 00:01: [io  0xffff] has been reserved
+[    0.147005] system 00:01: [io  0xffff] has been reserved
+[    0.147006] system 00:01: [io  0xffff] has been reserved
+[    0.147008] system 00:01: [io  0x1c00-0x1cfe] has been reserved
+[    0.147009] system 00:01: [io  0x1d00-0x1dfe] has been reserved
+[    0.147010] system 00:01: [io  0x1e00-0x1efe] has been reserved
+[    0.147011] system 00:01: [io  0x1f00-0x1ffe] has been reserved
+[    0.147012] system 00:01: [io  0x1800-0x18fe] has been reserved
+[    0.147012] system 00:01: [io  0x164e-0x164f] has been reserved
+[    0.147015] system 00:01: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.147033] pnp 00:02: Plug and Play ACPI device, IDs PNP0b00 (active)
+[    0.147075] system 00:03: [io  0x1854-0x1857] has been reserved
+[    0.147078] system 00:03: Plug and Play ACPI device, IDs INT3f0d PNP0c02 (active)
+[    0.147161] system 00:04: [io  0x0290-0x029f] has been reserved
+[    0.147163] system 00:04: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.147306] system 00:05: [io  0x04d0-0x04d1] has been reserved
+[    0.147309] system 00:05: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.147822] system 00:06: [mem 0xfed1c000-0xfed1ffff] has been reserved
+[    0.147823] system 00:06: [mem 0xfed10000-0xfed17fff] has been reserved
+[    0.147824] system 00:06: [mem 0xfed18000-0xfed18fff] has been reserved
+[    0.147825] system 00:06: [mem 0xfed19000-0xfed19fff] has been reserved
+[    0.147826] system 00:06: [mem 0xf8000000-0xfbffffff] has been reserved
+[    0.147827] system 00:06: [mem 0xfed20000-0xfed3ffff] has been reserved
+[    0.147828] system 00:06: [mem 0xfed90000-0xfed93fff] has been reserved
+[    0.147829] system 00:06: [mem 0xfed45000-0xfed8ffff] has been reserved
+[    0.147830] system 00:06: [mem 0xff000000-0xffffffff] has been reserved
+[    0.147831] system 00:06: [mem 0xfee00000-0xfeefffff] could not be reserved
+[    0.147832] system 00:06: [mem 0xf7fdf000-0xf7fdffff] has been reserved
+[    0.147833] system 00:06: [mem 0xf7fe0000-0xf7feffff] has been reserved
+[    0.147836] system 00:06: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.148071] pnp: PnP ACPI: found 7 devices
+[    0.149273] thermal_sys: Registered thermal governor 'fair_share'
+[    0.149274] thermal_sys: Registered thermal governor 'bang_bang'
+[    0.149274] thermal_sys: Registered thermal governor 'step_wise'
+[    0.149275] thermal_sys: Registered thermal governor 'user_space'
+[    0.149275] thermal_sys: Registered thermal governor 'power_allocator'
+[    0.153760] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.153785] pci 0000:00:1c.0: bridge window [io  0x1000-0x0fff] to [bus 02] add_size 1000
+[    0.153786] pci 0000:00:1c.0: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 02] add_size 200000 add_align 100000
+[    0.153787] pci 0000:00:1c.0: bridge window [mem 0x00100000-0x000fffff] to [bus 02] add_size 200000 add_align 100000
+[    0.153794] pci 0000:00:1c.0: BAR 14: assigned [mem 0xf2200000-0xf23fffff]
+[    0.153799] pci 0000:00:1c.0: BAR 15: assigned [mem 0xf2400000-0xf25fffff 64bit pref]
+[    0.153801] pci 0000:00:1c.0: BAR 13: assigned [io  0x2000-0x2fff]
+[    0.153803] pci 0000:00:01.0: PCI bridge to [bus 01]
+[    0.153804] pci 0000:00:01.0:   bridge window [io  0xe000-0xefff]
+[    0.153806] pci 0000:00:01.0:   bridge window [mem 0xf6000000-0xf70fffff]
+[    0.153808] pci 0000:00:01.0:   bridge window [mem 0xe0000000-0xf1ffffff 64bit pref]
+[    0.153810] pci 0000:00:1c.0: PCI bridge to [bus 02]
+[    0.153812] pci 0000:00:1c.0:   bridge window [io  0x2000-0x2fff]
+[    0.153815] pci 0000:00:1c.0:   bridge window [mem 0xf2200000-0xf23fffff]
+[    0.153817] pci 0000:00:1c.0:   bridge window [mem 0xf2400000-0xf25fffff 64bit pref]
+[    0.153821] pci 0000:00:1c.1: PCI bridge to [bus 03]
+[    0.153824] pci 0000:00:1c.1:   bridge window [mem 0xf7200000-0xf72fffff]
+[    0.153829] pci 0000:00:1c.2: PCI bridge to [bus 04]
+[    0.153831] pci 0000:00:1c.2:   bridge window [io  0xd000-0xdfff]
+[    0.153834] pci 0000:00:1c.2:   bridge window [mem 0xf7100000-0xf71fffff]
+[    0.153836] pci 0000:00:1c.2:   bridge window [mem 0xf2100000-0xf21fffff 64bit pref]
+[    0.153840] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
+[    0.153841] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
+[    0.153842] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
+[    0.153843] pci_bus 0000:00: resource 7 [mem 0x000c0000-0x000c3fff window]
+[    0.153844] pci_bus 0000:00: resource 8 [mem 0x000c4000-0x000c7fff window]
+[    0.153845] pci_bus 0000:00: resource 9 [mem 0x000c8000-0x000cbfff window]
+[    0.153845] pci_bus 0000:00: resource 10 [mem 0x000cc000-0x000cffff window]
+[    0.153846] pci_bus 0000:00: resource 11 [mem 0x000d0000-0x000d3fff window]
+[    0.153847] pci_bus 0000:00: resource 12 [mem 0x000d4000-0x000d7fff window]
+[    0.153848] pci_bus 0000:00: resource 13 [mem 0x000d8000-0x000dbfff window]
+[    0.153848] pci_bus 0000:00: resource 14 [mem 0x000dc000-0x000dffff window]
+[    0.153849] pci_bus 0000:00: resource 15 [mem 0xe0000000-0xfeafffff window]
+[    0.153850] pci_bus 0000:01: resource 0 [io  0xe000-0xefff]
+[    0.153851] pci_bus 0000:01: resource 1 [mem 0xf6000000-0xf70fffff]
+[    0.153852] pci_bus 0000:01: resource 2 [mem 0xe0000000-0xf1ffffff 64bit pref]
+[    0.153852] pci_bus 0000:02: resource 0 [io  0x2000-0x2fff]
+[    0.153853] pci_bus 0000:02: resource 1 [mem 0xf2200000-0xf23fffff]
+[    0.153854] pci_bus 0000:02: resource 2 [mem 0xf2400000-0xf25fffff 64bit pref]
+[    0.153855] pci_bus 0000:03: resource 1 [mem 0xf7200000-0xf72fffff]
+[    0.153856] pci_bus 0000:04: resource 0 [io  0xd000-0xdfff]
+[    0.153856] pci_bus 0000:04: resource 1 [mem 0xf7100000-0xf71fffff]
+[    0.153857] pci_bus 0000:04: resource 2 [mem 0xf2100000-0xf21fffff 64bit pref]
+[    0.153959] NET: Registered protocol family 2
+[    0.154074] tcp_listen_portaddr_hash hash table entries: 4096 (order: 4, 65536 bytes, linear)
+[    0.154109] TCP established hash table entries: 65536 (order: 7, 524288 bytes, linear)
+[    0.154209] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes, linear)
+[    0.154270] TCP: Hash tables configured (established 65536 bind 65536)
+[    0.154293] UDP hash table entries: 4096 (order: 5, 131072 bytes, linear)
+[    0.154312] UDP-Lite hash table entries: 4096 (order: 5, 131072 bytes, linear)
+[    0.154346] NET: Registered protocol family 1
+[    0.154349] NET: Registered protocol family 44
+[    0.176957] pci 0000:00:1a.0: quirk_usb_early_handoff+0x0/0x662 took 21905 usecs
+[    0.200952] pci 0000:00:1d.0: quirk_usb_early_handoff+0x0/0x662 took 23422 usecs
+[    0.200968] pci 0000:01:00.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.200976] pci 0000:01:00.1: D0 power state depends on 0000:01:00.0
+[    0.200984] PCI: CLS 64 bytes, default 64
+[    0.201042] Trying to unpack rootfs image as initramfs...
+[    0.296466] Initramfs unpacking failed: Decoding failed
+[    0.296476] fbcon: Taking over console
+[    0.300746] Freeing initrd memory: 52460K
+[    0.300794] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    0.300795] software IO TLB: mapped [mem 0xd441f000-0xd841f000] (64MB)
+[    0.300967] check: Scanning for low memory corruption every 60 seconds
+[    0.301303] Initialise system trusted keyrings
+[    0.301312] Key type blacklist registered
+[    0.301334] workingset: timestamp_bits=36 max_order=21 bucket_order=0
+[    0.302333] zbud: loaded
+[    0.302600] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    0.302712] fuse: init (API version 7.31)
+[    0.302723] *** VALIDATE fuse ***
+[    0.302724] *** VALIDATE fuse ***
+[    0.302793] Platform Keyring initialized
+[    0.306090] Key type asymmetric registered
+[    0.306090] Asymmetric key parser 'x509' registered
+[    0.306095] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 244)
+[    0.306125] io scheduler mq-deadline registered
+[    0.306705] shpchp: Standard Hot Plug PCI Controller Driver version: 0.4
+[    0.306743] efifb: probing for efifb
+[    0.306755] efifb: No BGRT, not showing boot graphics
+[    0.306756] efifb: framebuffer at 0xe0000000, using 3072k, total 3072k
+[    0.306757] efifb: mode is 1024x768x32, linelength=4096, pages=1
+[    0.306757] efifb: scrolling: redraw
+[    0.306758] efifb: Truecolor: size=8:8:8:8, shift=24:16:8:0
+[    0.306820] Console: switching to colour frame buffer device 128x48
+[    0.308908] fb0: EFI VGA frame buffer device
+[    0.308914] intel_idle: MWAIT substates: 0x42120
+[    0.308914] intel_idle: v0.4.1 model 0x3C
+[    0.309031] intel_idle: lapic_timer_reliable_states 0xffffffff
+[    0.309132] input: Power Button as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0C:00/input/input0
+[    0.309147] ACPI: Power Button [PWRB]
+[    0.309173] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input1
+[    0.309194] ACPI: Power Button [PWRF]
+[    0.309769] thermal LNXTHERM:00: registered as thermal_zone0
+[    0.309770] ACPI: Thermal Zone [TZ00] (28 C)
+[    0.309996] thermal LNXTHERM:01: registered as thermal_zone1
+[    0.309997] ACPI: Thermal Zone [TZ01] (30 C)
+[    0.310104] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    0.311266] Linux agpgart interface v0.103
+[    0.312687] loop: module loaded
+[    0.312822] libphy: Fixed MDIO Bus: probed
+[    0.312822] tun: Universal TUN/TAP device driver, 1.6
+[    0.312840] PPP generic driver version 2.4.2
+[    0.312871] VFIO - User Level meta-driver version: 0.3
+[    0.312937] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    0.312939] ehci-pci: EHCI PCI platform driver
+[    0.313033] ehci-pci 0000:00:1a.0: EHCI Host Controller
+[    0.313038] ehci-pci 0000:00:1a.0: new USB bus registered, assigned bus number 1
+[    0.313046] ehci-pci 0000:00:1a.0: debug port 2
+[    0.316941] ehci-pci 0000:00:1a.0: cache line size of 64 is not supported
+[    0.316949] ehci-pci 0000:00:1a.0: irq 20, io mem 0xf7314000
+[    0.332912] ehci-pci 0000:00:1a.0: USB 2.0 started, EHCI 1.00
+[    0.332942] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.04
+[    0.332943] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    0.332944] usb usb1: Product: EHCI Host Controller
+[    0.332945] usb usb1: Manufacturer: Linux 5.4.0-52-generic ehci_hcd
+[    0.332945] usb usb1: SerialNumber: 0000:00:1a.0
+[    0.333097] hub 1-0:1.0: USB hub found
+[    0.333101] hub 1-0:1.0: 2 ports detected
+[    0.333285] ehci-pci 0000:00:1d.0: EHCI Host Controller
+[    0.333288] ehci-pci 0000:00:1d.0: new USB bus registered, assigned bus number 2
+[    0.333296] ehci-pci 0000:00:1d.0: debug port 2
+[    0.337205] ehci-pci 0000:00:1d.0: cache line size of 64 is not supported
+[    0.337212] ehci-pci 0000:00:1d.0: irq 23, io mem 0xf7313000
+[    0.352910] ehci-pci 0000:00:1d.0: USB 2.0 started, EHCI 1.00
+[    0.352936] usb usb2: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.04
+[    0.352937] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    0.352938] usb usb2: Product: EHCI Host Controller
+[    0.352939] usb usb2: Manufacturer: Linux 5.4.0-52-generic ehci_hcd
+[    0.352939] usb usb2: SerialNumber: 0000:00:1d.0
+[    0.353083] hub 2-0:1.0: USB hub found
+[    0.353087] hub 2-0:1.0: 2 ports detected
+[    0.353195] ehci-platform: EHCI generic platform driver
+[    0.353201] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    0.353204] ohci-pci: OHCI PCI platform driver
+[    0.353209] ohci-platform: OHCI generic platform driver
+[    0.353216] uhci_hcd: USB Universal Host Controller Interface driver
+[    0.353310] xhci_hcd 0000:00:14.0: xHCI Host Controller
+[    0.353313] xhci_hcd 0000:00:14.0: new USB bus registered, assigned bus number 3
+[    0.354354] xhci_hcd 0000:00:14.0: hcc params 0x200077c1 hci version 0x100 quirks 0x0000000000009810
+[    0.354357] xhci_hcd 0000:00:14.0: cache line size of 64 is not supported
+[    0.354466] usb usb3: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.04
+[    0.354467] usb usb3: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    0.354468] usb usb3: Product: xHCI Host Controller
+[    0.354469] usb usb3: Manufacturer: Linux 5.4.0-52-generic xhci-hcd
+[    0.354470] usb usb3: SerialNumber: 0000:00:14.0
+[    0.354610] hub 3-0:1.0: USB hub found
+[    0.354624] hub 3-0:1.0: 12 ports detected
+[    0.356628] xhci_hcd 0000:00:14.0: xHCI Host Controller
+[    0.356631] xhci_hcd 0000:00:14.0: new USB bus registered, assigned bus number 4
+[    0.356632] xhci_hcd 0000:00:14.0: Host supports USB 3.0 SuperSpeed
+[    0.356657] usb usb4: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 5.04
+[    0.356658] usb usb4: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    0.356659] usb usb4: Product: xHCI Host Controller
+[    0.356659] usb usb4: Manufacturer: Linux 5.4.0-52-generic xhci-hcd
+[    0.356660] usb usb4: SerialNumber: 0000:00:14.0
+[    0.356738] hub 4-0:1.0: USB hub found
+[    0.356748] hub 4-0:1.0: 6 ports detected
+[    0.357241] i8042: PNP: No PS/2 controller found.
+[    0.357433] mousedev: PS/2 mouse device common for all mice
+[    0.357626] rtc_cmos 00:02: RTC can wake from S4
+[    0.357783] rtc_cmos 00:02: registered as rtc0
+[    0.357793] rtc_cmos 00:02: alarms up to one month, y3k, 242 bytes nvram, hpet irqs
+[    0.357797] i2c /dev entries driver
+[    0.357822] device-mapper: uevent: version 1.0.3
+[    0.357861] device-mapper: ioctl: 4.41.0-ioctl (2019-09-16) initialised: dm-devel@redhat.com
+[    0.357875] platform eisa.0: Probing EISA bus 0
+[    0.357876] platform eisa.0: EISA: Cannot allocate resource for mainboard
+[    0.357877] platform eisa.0: Cannot allocate resource for EISA slot 1
+[    0.357877] platform eisa.0: Cannot allocate resource for EISA slot 2
+[    0.357878] platform eisa.0: Cannot allocate resource for EISA slot 3
+[    0.357879] platform eisa.0: Cannot allocate resource for EISA slot 4
+[    0.357879] platform eisa.0: Cannot allocate resource for EISA slot 5
+[    0.357880] platform eisa.0: Cannot allocate resource for EISA slot 6
+[    0.357880] platform eisa.0: Cannot allocate resource for EISA slot 7
+[    0.357881] platform eisa.0: Cannot allocate resource for EISA slot 8
+[    0.357882] platform eisa.0: EISA: Detected 0 cards
+[    0.357886] intel_pstate: Intel P-state driver initializing
+[    0.358057] ledtrig-cpu: registered to indicate activity on CPUs
+[    0.358060] EFI Variables Facility v0.08 2004-May-17
+[    0.361814] drop_monitor: Initializing network drop monitor service
+[    0.361964] NET: Registered protocol family 10
+[    0.366770] Segment Routing with IPv6
+[    0.366786] NET: Registered protocol family 17
+[    0.366815] Key type dns_resolver registered
+[    0.367041] RAS: Correctable Errors collector initialized.
+[    0.367076] microcode: sig=0x306c3, pf=0x2, revision=0x28
+[    0.367114] microcode: Microcode Update Driver: v2.2.
+[    0.367116] IPI shorthand broadcast: enabled
+[    0.367122] sched_clock: Marking stable (366884408, 226819)->(372326122, -5214895)
+[    0.367187] registered taskstats version 1
+[    0.367198] Loading compiled-in X.509 certificates
+[    0.367818] Loaded X.509 cert 'Build time autogenerated kernel key: 9587b8cca0bd5e3ad1c932f4859e23820e37ff94'
+[    0.367839] zswap: loaded using pool lzo/zbud
+[    0.367887] Key type ._fscrypt registered
+[    0.367888] Key type .fscrypt registered
+[    0.372080] Key type big_key registered
+[    0.374293] Key type encrypted registered
+[    0.374295] AppArmor: AppArmor sha1 policy hashing enabled
+[    0.374579] integrity: Loading X.509 certificate: UEFI:db
+[    0.374953] integrity: Loaded X.509 cert 'ASUSTeK MotherBoard SW Key Certificate: da83b990422ebc8c441f8d8b039a65a2'
+[    0.374954] integrity: Loading X.509 certificate: UEFI:db
+[    0.375136] integrity: Loaded X.509 cert 'ASUSTeK Notebook SW Key Certificate: b8e581e4df77a5bb4282d5ccfc00c071'
+[    0.375136] integrity: Loading X.509 certificate: UEFI:db
+[    0.375153] integrity: Loaded X.509 cert 'Microsoft Corporation UEFI CA 2011: 13adbf4309bd82709c8cd54f316ed522988a1bd4'
+[    0.375153] integrity: Loading X.509 certificate: UEFI:db
+[    0.375168] integrity: Loaded X.509 cert 'Microsoft Windows Production PCA 2011: a92902398e16c49778cd90f99e4f9ae17c55af53'
+[    0.375169] integrity: Loading X.509 certificate: UEFI:db
+[    0.375342] integrity: Loaded X.509 cert 'Canonical Ltd. Master Certificate Authority: ad91990bc22ab1f517048c23b6655a268e345a63'
+[    0.375463] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.375642] integrity: Loaded X.509 cert 'kubuntu Secure Boot Module Signature key: b5746e60c352fdee061069af9159208063c4fc1c'
+[    0.375642] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.375816] integrity: Loaded X.509 cert 'ubuntu-mate Secure Boot Module Signature key: abb4127b0f8f9fa60d371cc36a250c97b4216e86'
+[    0.375816] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.375989] integrity: Loaded X.509 cert 'ubuntu Secure Boot Module Signature key: 0619be7a5a14fec884cadafe66e09f84a63c4c87'
+[    0.375989] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.376167] integrity: Loaded X.509 cert 'xubuntu Secure Boot Module Signature key: 7f9e7aba95173d457686171b3aed14569caab853'
+[    0.376167] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.376332] integrity: Loaded X.509 cert 'ubuntu-mate Secure Boot Module Signature key: a214aa8cb73bfdfe93dd52b7a9046f16f0dc380a'
+[    0.376333] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.376495] integrity: Loaded X.509 cert 'ubuntu Secure Boot Module Signature key: a843a4b378b6d34318cc0baf9d7cb36e27bc38b9'
+[    0.376496] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.376507] integrity: Loaded X.509 cert 'SomeOrg: shim: a01ee84e9b37ace407961cc468c5909447878469'
+[    0.376507] integrity: Loading X.509 certificate: UEFI:MokListRT
+[    0.376675] integrity: Loaded X.509 cert 'Canonical Ltd. Master Certificate Authority: ad91990bc22ab1f517048c23b6655a268e345a63'
+[    0.377508] ima: No TPM chip found, activating TPM-bypass!
+[    0.377511] ima: Allocated hash algorithm: sha1
+[    0.377516] ima: No architecture policies found
+[    0.377523] evm: Initialising EVM extended attributes:
+[    0.377524] evm: security.selinux
+[    0.377524] evm: security.SMACK64
+[    0.377524] evm: security.SMACK64EXEC
+[    0.377525] evm: security.SMACK64TRANSMUTE
+[    0.377525] evm: security.SMACK64MMAP
+[    0.377525] evm: security.apparmor
+[    0.377525] evm: security.ima
+[    0.377526] evm: security.capability
+[    0.377526] evm: HMAC attrs: 0x1
+[    0.377958] PM:   Magic number: 8:590:286
+[    0.377965] ppp ppp: hash matches
+[    0.378066] rtc_cmos 00:02: setting system clock to 2020-10-30T15:15:34 UTC (1604070934)
+[    0.378926] Freeing unused decrypted memory: 2040K
+[    0.379272] Freeing unused kernel image memory: 2716K
+[    0.400962] Write protecting the kernel read-only data: 22528k
+[    0.401361] Freeing unused kernel image memory: 2008K
+[    0.401532] Freeing unused kernel image memory: 1188K
+[    0.409210] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    0.409210] x86/mm: Checking user space page tables
+[    0.416434] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    0.416435] Run /init as init process
+[    0.481486] ACPI Warning: SystemIO range 0x0000000000001828-0x000000000000182F conflicts with OpRegion 0x0000000000001800-0x000000000000187F (\PMIO) (20190816/utaddress-204)
+[    0.481490] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    0.481492] ACPI Warning: SystemIO range 0x0000000000001C40-0x0000000000001C4F conflicts with OpRegion 0x0000000000001C00-0x0000000000001FFF (\GPR) (20190816/utaddress-204)
+[    0.481494] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    0.481494] ACPI Warning: SystemIO range 0x0000000000001C30-0x0000000000001C3F conflicts with OpRegion 0x0000000000001C00-0x0000000000001C3F (\GPRL) (20190816/utaddress-204)
+[    0.481496] ACPI Warning: SystemIO range 0x0000000000001C30-0x0000000000001C3F conflicts with OpRegion 0x0000000000001C00-0x0000000000001FFF (\GPR) (20190816/utaddress-204)
+[    0.481498] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    0.481499] ACPI Warning: SystemIO range 0x0000000000001C00-0x0000000000001C2F conflicts with OpRegion 0x0000000000001C00-0x0000000000001C3F (\GPRL) (20190816/utaddress-204)
+[    0.481501] ACPI Warning: SystemIO range 0x0000000000001C00-0x0000000000001C2F conflicts with OpRegion 0x0000000000001C00-0x0000000000001FFF (\GPR) (20190816/utaddress-204)
+[    0.481502] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    0.481503] lpc_ich: Resource conflict(s) found affecting gpio_ich
+[    0.482630] r8169 0000:04:00.0: can't disable ASPM; OS doesn't have ASPM control
+[    0.483071] ahci 0000:00:1f.2: version 3.0
+[    0.483225] ahci 0000:00:1f.2: AHCI 0001.0300 32 slots 6 ports 6 Gbps 0xf impl SATA mode
+[    0.483227] ahci 0000:00:1f.2: flags: 64bit ncq led clo pio slum part ems apst 
+[    0.484594] i801_smbus 0000:00:1f.3: SMBus using PCI interrupt
+[    0.495372] libphy: r8169: probed
+[    0.495534] r8169 0000:04:00.0 eth0: RTL8168g/8111g, 38:2c:4a:e9:1b:0f, XID 4c0, IRQ 30
+[    0.495535] r8169 0000:04:00.0 eth0: jumbo features [frames: 9200 bytes, tx checksumming: ko]
+[    0.496684] r8169 0000:04:00.0 enp4s0: renamed from eth0
+[    0.517572] scsi host0: ahci
+[    0.517722] scsi host1: ahci
+[    0.517867] scsi host2: ahci
+[    0.517964] scsi host3: ahci
+[    0.518023] scsi host4: ahci
+[    0.518088] scsi host5: ahci
+[    0.518132] ata1: SATA max UDMA/133 abar m2048@0xf7312000 port 0xf7312100 irq 29
+[    0.518133] ata2: SATA max UDMA/133 abar m2048@0xf7312000 port 0xf7312180 irq 29
+[    0.518134] ata3: SATA max UDMA/133 abar m2048@0xf7312000 port 0xf7312200 irq 29
+[    0.518135] ata4: SATA max UDMA/133 abar m2048@0xf7312000 port 0xf7312280 irq 29
+[    0.518136] ata5: DUMMY
+[    0.518136] ata6: DUMMY
+[    0.668911] usb 1-1: new high-speed USB device number 2 using ehci-pci
+[    0.688913] usb 3-3: new low-speed USB device number 2 using xhci_hcd
+[    0.688918] usb 2-1: new high-speed USB device number 2 using ehci-pci
+[    0.825300] usb 1-1: New USB device found, idVendor=8087, idProduct=8008, bcdDevice= 0.05
+[    0.825302] usb 1-1: New USB device strings: Mfr=0, Product=0, SerialNumber=0
+[    0.825534] hub 1-1:1.0: USB hub found
+[    0.825624] hub 1-1:1.0: 6 ports detected
+[    0.832921] ata4: SATA link up 1.5 Gbps (SStatus 113 SControl 300)
+[    0.832934] ata1: SATA link up 3.0 Gbps (SStatus 123 SControl 300)
+[    0.832946] ata3: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
+[    0.832956] ata2: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
+[    0.833180] ata3.00: ATA-11: TOSHIBA-TL100, SBFZ10.3, max UDMA/133
+[    0.833181] ata3.00: 468862128 sectors, multi 16: LBA48 NCQ (depth 32), AA
+[    0.833523] ata2.00: ATA-9: WDC WD30EFRX-68EUZN0, 82.00A82, max UDMA/133
+[    0.833524] ata2.00: 5860533168 sectors, multi 16: LBA48 NCQ (depth 32), AA
+[    0.833539] ata3.00: configured for UDMA/133
+[    0.834098] ata1.00: ATA-8: ST31000520AS, CC32, max UDMA/133
+[    0.834099] ata1.00: 1953525168 sectors, multi 16: LBA48 NCQ (depth 32)
+[    0.834107] ata2.00: configured for UDMA/133
+[    0.835456] ata1.00: configured for UDMA/133
+[    0.835561] scsi 0:0:0:0: Direct-Access     ATA      ST31000520AS     CC32 PQ: 0 ANSI: 5
+[    0.835695] sd 0:0:0:0: Attached scsi generic sg0 type 0
+[    0.835756] sd 0:0:0:0: [sda] 1953525168 512-byte logical blocks: (1.00 TB/932 GiB)
+[    0.835766] sd 0:0:0:0: [sda] Write Protect is off
+[    0.835767] sd 0:0:0:0: [sda] Mode Sense: 00 3a 00 00
+[    0.835778] scsi 1:0:0:0: Direct-Access     ATA      WDC WD30EFRX-68E 0A82 PQ: 0 ANSI: 5
+[    0.835780] sd 0:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+[    0.835874] sd 1:0:0:0: Attached scsi generic sg1 type 0
+[    0.835907] sd 1:0:0:0: [sdb] 5860533168 512-byte logical blocks: (3.00 TB/2.73 TiB)
+[    0.835908] sd 1:0:0:0: [sdb] 4096-byte physical blocks
+[    0.835913] sd 1:0:0:0: [sdb] Write Protect is off
+[    0.835914] sd 1:0:0:0: [sdb] Mode Sense: 00 3a 00 00
+[    0.835922] sd 1:0:0:0: [sdb] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+[    0.835954] ata4.00: ATAPI: HL-DT-ST DVDRAM GH22NS50, TN02, max UDMA/100
+[    0.835962] scsi 2:0:0:0: Direct-Access     ATA      TOSHIBA-TL100    10.3 PQ: 0 ANSI: 5
+[    0.836098] sd 2:0:0:0: Attached scsi generic sg2 type 0
+[    0.836125] sd 2:0:0:0: [sdc] 468862128 512-byte logical blocks: (240 GB/224 GiB)
+[    0.836133] sd 2:0:0:0: [sdc] Write Protect is off
+[    0.836134] sd 2:0:0:0: [sdc] Mode Sense: 00 3a 00 00
+[    0.836147] sd 2:0:0:0: [sdc] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+[    0.839781] ata4.00: configured for UDMA/100
+[    0.842625] usb 3-3: New USB device found, idVendor=045e, idProduct=07f8, bcdDevice= 3.00
+[    0.842626] usb 3-3: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+[    0.842627] usb 3-3: Product: Wired Keyboard 600
+[    0.842628] usb 3-3: Manufacturer: Microsoft
+[    0.845268] usb 2-1: New USB device found, idVendor=8087, idProduct=8000, bcdDevice= 0.05
+[    0.845280] usb 2-1: New USB device strings: Mfr=0, Product=0, SerialNumber=0
+[    0.845892] hidraw: raw HID events driver (C) Jiri Kosina
+[    0.845895] hub 2-1:1.0: USB hub found
+[    0.846084] hub 2-1:1.0: 6 ports detected
+[    0.848985] scsi 3:0:0:0: CD-ROM            HL-DT-ST DVDRAM GH22NS50  TN02 PQ: 0 ANSI: 5
+[    0.850826]  sdc: sdc1 sdc2 sdc3
+[    0.851131] usbcore: registered new interface driver usbhid
+[    0.851131] usbhid: USB HID core driver
+[    0.851178] sd 2:0:0:0: [sdc] Attached SCSI disk
+[    0.852825] input: Microsoft Wired Keyboard 600 as /devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3:1.0/0003:045E:07F8.0001/input/input2
+[    0.853046]  sda: sda1
+[    0.853421] sd 0:0:0:0: [sda] Attached SCSI disk
+[    0.890603]  sdb: sdb1
+[    0.891084] sd 1:0:0:0: [sdb] Attached SCSI disk
+[    0.909078] hid-generic 0003:045E:07F8.0001: input,hidraw0: USB HID v1.11 Keyboard [Microsoft Wired Keyboard 600] on usb-0000:00:14.0-3/input0
+[    0.909203] input: Microsoft Wired Keyboard 600 Consumer Control as /devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3:1.1/0003:045E:07F8.0002/input/input3
+[    0.916645] sr 3:0:0:0: [sr0] scsi3-mmc drive: 48x/48x writer dvd-ram cd/rw xa/form2 cdda tray
+[    0.916646] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    0.929080] sr 3:0:0:0: Attached scsi CD-ROM sr0
+[    0.929162] sr 3:0:0:0: Attached scsi generic sg3 type 5
+[    0.968903] usb 3-4: new high-speed USB device number 3 using xhci_hcd
+[    0.968994] input: Microsoft Wired Keyboard 600 System Control as /devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3:1.1/0003:045E:07F8.0002/input/input4
+[    0.969114] hid-generic 0003:045E:07F8.0002: input,hidraw1: USB HID v1.11 Device [Microsoft Wired Keyboard 600] on usb-0000:00:14.0-3/input1
+[    1.117473] usb 3-4: New USB device found, idVendor=1397, idProduct=0508, bcdDevice= 1.12
+[    1.117475] usb 3-4: New USB device strings: Mfr=1, Product=3, SerialNumber=0
+[    1.117476] usb 3-4: Product: UMC204HD 192k
+[    1.117476] usb 3-4: Manufacturer: BEHRINGER
+[    1.244898] usb 3-6: new full-speed USB device number 4 using xhci_hcd
+[    1.312900] tsc: Refined TSC clocksource calibration: 3092.837 MHz
+[    1.312903] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x2c94d933972, max_idle_ns: 440795249834 ns
+[    1.312924] clocksource: Switched to clocksource tsc
+[    1.470010] usb 3-6: New USB device found, idVendor=1038, idProduct=1702, bcdDevice= 0.65
+[    1.470011] usb 3-6: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+[    1.470012] usb 3-6: Product: SteelSeries Rival 100 Gaming Mouse
+[    1.470013] usb 3-6: Manufacturer: SteelSeries
+[    1.472412] hid-generic 0003:1038:1702.0003: hiddev0,hidraw2: USB HID v1.11 Device [SteelSeries SteelSeries Rival 100 Gaming Mouse] on usb-0000:00:14.0-6/input0
+[    1.474721] input: SteelSeries SteelSeries Rival 100 Gaming Mouse as /devices/pci0000:00/0000:00:14.0/usb3/3-6/3-6:1.1/0003:1038:1702.0004/input/input5
+[    1.474895] hid-generic 0003:1038:1702.0004: input,hidraw3: USB HID v1.11 Mouse [SteelSeries SteelSeries Rival 100 Gaming Mouse] on usb-0000:00:14.0-6/input1
+[    1.600899] usb 3-7: new high-speed USB device number 5 using xhci_hcd
+[    1.760257] usb 3-7: New USB device found, idVendor=05e3, idProduct=0745, bcdDevice= 9.03
+[    1.760259] usb 3-7: New USB device strings: Mfr=0, Product=1, SerialNumber=2
+[    1.760260] usb 3-7: Product: USB Storage
+[    1.760260] usb 3-7: SerialNumber: 000000000903
+[    1.763920] usb-storage 3-7:1.0: USB Mass Storage device detected
+[    1.764147] scsi host6: usb-storage 3-7:1.0
+[    1.764214] usbcore: registered new interface driver usb-storage
+[    1.765251] usbcore: registered new interface driver uas
+[    1.888908] usb 3-8: new full-speed USB device number 6 using xhci_hcd
+[    2.039010] usb 3-8: New USB device found, idVendor=0a5c, idProduct=21e8, bcdDevice= 1.12
+[    2.039012] usb 3-8: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+[    2.039013] usb 3-8: Product: BCM20702A0
+[    2.039014] usb 3-8: Manufacturer: Broadcom Corp
+[    2.039014] usb 3-8: SerialNumber: 00190E18C633
+[    2.611060] EXT4-fs (sdc2): mounted filesystem with ordered data mode. Opts: (null)
+[    2.786185] scsi 6:0:0:0: Direct-Access     Generic  STORAGE DEVICE   0903 PQ: 0 ANSI: 6
+[    2.786375] sd 6:0:0:0: Attached scsi generic sg4 type 0
+[    2.788437] systemd[1]: Inserted module 'autofs4'
+[    2.803127] sd 6:0:0:0: [sdd] Attached SCSI removable disk
+[    2.809547] systemd[1]: systemd 245.4-4ubuntu3.2 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=hybrid)
+[    2.828956] systemd[1]: Detected architecture x86-64.
+[    2.845779] systemd[1]: Set hostname to <bowie>.
+[    2.974769] systemd[1]: /lib/systemd/system/dbus.socket:5: ListenStream= references a path below legacy directory /var/run/, updating /var/run/dbus/system_bus_socket → /run/dbus/system_bus_socket; please update the unit file accordingly.
+[    3.040337] systemd[1]: Created slice Virtual Machine and Container Slice.
+[    3.040666] systemd[1]: Created slice system-modprobe.slice.
+[    3.040820] systemd[1]: Created slice system-systemd\x2dfsck.slice.
+[    3.041033] systemd[1]: Created slice User and Session Slice.
+[    3.041080] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+[    3.041229] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
+[    3.041272] systemd[1]: Reached target User and Group Name Lookups.
+[    3.041281] systemd[1]: Reached target Remote File Systems.
+[    3.041287] systemd[1]: Reached target Slices.
+[    3.041304] systemd[1]: Reached target Libvirt guests shutdown.
+[    3.041366] systemd[1]: Listening on Device-mapper event daemon FIFOs.
+[    3.041439] systemd[1]: Listening on LVM2 poll daemon socket.
+[    3.042932] systemd[1]: Listening on Syslog Socket.
+[    3.044332] systemd[1]: Listening on fsck to fsckd communication Socket.
+[    3.044374] systemd[1]: Listening on initctl Compatibility Named Pipe.
+[    3.045506] systemd[1]: Listening on Journal Audit Socket.
+[    3.045581] systemd[1]: Listening on Journal Socket (/dev/log).
+[    3.045663] systemd[1]: Listening on Journal Socket.
+[    3.045744] systemd[1]: Listening on udev Control Socket.
+[    3.045797] systemd[1]: Listening on udev Kernel Socket.
+[    3.046449] systemd[1]: Mounting Huge Pages File System...
+[    3.047137] systemd[1]: Mounting POSIX Message Queue File System...
+[    3.047875] systemd[1]: Mounting Kernel Debug File System...
+[    3.048609] systemd[1]: Mounting Kernel Trace File System...
+[    3.049671] systemd[1]: Starting Journal Service...
+[    3.050427] systemd[1]: Starting Availability of block devices...
+[    3.051149] systemd[1]: Starting Set the console keyboard layout...
+[    3.051875] systemd[1]: Starting Create list of static device nodes for the current kernel...
+[    3.052557] systemd[1]: Starting Monitoring of LVM2 mirrors, snapshots etc. using dmeventd or progress polling...
+[    3.053242] systemd[1]: Starting Load Kernel Module drm...
+[    3.055185] systemd[1]: Condition check resulted in Set Up Additional Binary Formats being skipped.
+[    3.055213] systemd[1]: Condition check resulted in File System Check on Root Device being skipped.
+[    3.059384] systemd[1]: Starting Load Kernel Modules...
+[    3.060053] systemd[1]: Starting Remount Root and Kernel File Systems...
+[    3.060752] systemd[1]: Starting udev Coldplug all Devices...
+[    3.061422] systemd[1]: Starting Uncomplicated firewall...
+[    3.062853] systemd[1]: Mounted Huge Pages File System.
+[    3.062963] systemd[1]: Mounted POSIX Message Queue File System.
+[    3.063057] systemd[1]: Mounted Kernel Debug File System.
+[    3.063145] systemd[1]: Mounted Kernel Trace File System.
+[    3.063501] systemd[1]: Finished Availability of block devices.
+[    3.063914] systemd[1]: Finished Create list of static device nodes for the current kernel.
+[    3.068234] systemd[1]: Finished Uncomplicated firewall.
+[    3.069616] EXT4-fs (sdc2): re-mounted. Opts: errors=remount-ro
+[    3.071010] systemd[1]: Finished Remount Root and Kernel File Systems.
+[    3.080868] systemd[1]: Condition check resulted in Rebuild Hardware Database being skipped.
+[    3.080918] systemd[1]: Condition check resulted in Platform Persistent Storage Archival being skipped.
+[    3.081599] systemd[1]: Starting Load/Save Random Seed...
+[    3.082312] systemd[1]: Starting Create System Users...
+[    3.082586] systemd[1]: modprobe@drm.service: Succeeded.
+[    3.082840] systemd[1]: Finished Load Kernel Module drm.
+[    3.095354] lp: driver loaded but no devices found
+[    3.097681] systemd[1]: Finished Create System Users.
+[    3.098425] systemd[1]: Starting Create Static Device Nodes in /dev...
+[    3.101632] systemd[1]: Finished Load/Save Random Seed.
+[    3.107141] ppdev: user-space parallel port driver
+[    3.110647] systemd[1]: Finished Load Kernel Modules.
+[    3.111455] systemd[1]: Mounting FUSE Control File System...
+[    3.112196] systemd[1]: Mounting Kernel Configuration File System...
+[    3.112865] systemd[1]: Starting Apply Kernel Variables...
+[    3.114772] systemd[1]: Mounted Kernel Configuration File System.
+[    3.115933] systemd[1]: Mounted FUSE Control File System.
+[    3.117963] systemd[1]: Finished Create Static Device Nodes in /dev.
+[    3.118723] systemd[1]: Starting udev Kernel Device Manager...
+[    3.123311] systemd[1]: Finished Monitoring of LVM2 mirrors, snapshots etc. using dmeventd or progress polling.
+[    3.126576] systemd[1]: Finished Set the console keyboard layout.
+[    3.126669] systemd[1]: Reached target Local File Systems (Pre).
+[    3.126699] systemd[1]: Condition check resulted in Virtual Machine and Container Storage (Compatibility) being skipped.
+[    3.126710] systemd[1]: Reached target Containers.
+[    3.134255] systemd[1]: Finished Apply Kernel Variables.
+[    3.138992] systemd[1]: Started Journal Service.
+[    3.144364] systemd-journald[294]: Received client request to flush runtime journal.
+[    3.156437] systemd-journald[294]: File /var/log/journal/8b25da9003254e51842e6093353c5bfa/system.journal corrupted or uncleanly shut down, renaming and replacing.
+[    3.470271] cfg80211: Loading compiled-in X.509 certificates for regulatory database
+[    3.470465] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
+[    3.587144] Bluetooth: Core ver 2.22
+[    3.587157] NET: Registered protocol family 31
+[    3.587158] Bluetooth: HCI device and connection manager initialized
+[    3.587160] Bluetooth: HCI socket layer initialized
+[    3.587162] Bluetooth: L2CAP socket layer initialized
+[    3.587164] Bluetooth: SCO socket layer initialized
+[    3.588780] ath9k 0000:03:00.0: enabling device (0000 -> 0002)
+[    3.596338] ath: EEPROM regdomain: 0x21
+[    3.596340] ath: EEPROM indicates we should expect a direct regpair map
+[    3.596341] ath: Country alpha2 being used: BB
+[    3.596341] ath: Regpair used: 0x21
+[    3.597510] ieee80211 phy0: Selected rate control algorithm 'minstrel_ht'
+[    3.598955] ieee80211 phy0: Atheros AR9485 Rev:1 mem=0xffffae3482400000, irq=17
+[    3.603481] asus_wmi: ASUS WMI generic driver loaded
+[    3.719859] asus_wmi: Initialization: 0x0
+[    3.719889] asus_wmi: BIOS WMI version: 0.9
+[    3.719938] asus_wmi: SFUN value: 0x0
+[    3.719940] eeepc-wmi eeepc-wmi: Detected ASUSWMI, use DCTS
+[    3.720423] input: Eee PC WMI hotkeys as /devices/platform/eeepc-wmi/input/input6
+[    3.824216] RAPL PMU: API unit is 2^-32 Joules, 3 fixed counters, 655360 ms ovfl timer
+[    3.824217] RAPL PMU: hw unit of domain pp0-core 2^-14 Joules
+[    3.824218] RAPL PMU: hw unit of domain package 2^-14 Joules
+[    3.824218] RAPL PMU: hw unit of domain dram 2^-14 Joules
+[    3.824584] usbcore: registered new interface driver btusb
+[    3.826330] nvidia: loading out-of-tree module taints kernel.
+[    3.826337] nvidia: module license 'NVIDIA' taints kernel.
+[    3.826338] Disabling lock debugging due to kernel taint
+[    3.849815] ath9k 0000:03:00.0 wlp3s0: renamed from wlan0
+[    3.864940] Adding 13930492k swap on /dev/sdc3.  Priority:-2 extents:1 across:13930492k SSFS
+[    3.879108] nvidia-nvlink: Nvlink Core is being initialized, major device number 238
+[    3.879518] cryptd: max_cpu_qlen set to 1000
+[    3.880193] nvidia 0000:01:00.0: vgaarb: changed VGA decodes: olddecodes=io+mem,decodes=none:owns=io+mem
+[    3.946930] Bluetooth: hci0: BCM: chip id 63
+[    3.947931] Bluetooth: hci0: BCM: features 0x07
+[    3.963968] Bluetooth: hci0: BCM20702A
+[    3.964969] Bluetooth: hci0: BCM20702A1 (001.002.014) build 0000
+[    3.979591] NVRM: loading NVIDIA UNIX x86_64 Kernel Module  450.80.02  Wed Sep 23 01:13:39 UTC 2020
+[    3.988517] bluetooth hci0: Direct firmware load for brcm/BCM20702A1-0a5c-21e8.hcd failed with error -2
+[    3.988520] Bluetooth: hci0: BCM: Patch brcm/BCM20702A1-0a5c-21e8.hcd not found
+[    3.993794] AVX2 version of gcm_enc/dec engaged.
+[    3.993795] AES CTR mode by8 optimization enabled
+[    4.010954] nvidia-modeset: Loading NVIDIA Kernel Mode Setting Driver for UNIX platforms  450.80.02  Wed Sep 23 00:48:09 UTC 2020
+[    4.015811] mc: Linux media interface: v0.10
+[    4.022967] [drm] [nvidia-drm] [GPU ID 0x00000100] Loading driver
+[    4.022969] [drm] Initialized nvidia-drm 0.0.0 20160202 for 0000:01:00.0 on minor 0
+[    4.055699] snd_hda_intel 0000:01:00.1: enabling device (0000 -> 0002)
+[    4.055774] snd_hda_intel 0000:01:00.1: Disabling MSI
+[    4.055778] snd_hda_intel 0000:01:00.1: Handle vga_switcheroo audio client
+[    4.057651] nvidia-uvm: Loaded the UVM driver, major device number 235.
+[    4.078705] intel_rapl_common: Found RAPL domain package
+[    4.078706] intel_rapl_common: Found RAPL domain core
+[    4.078708] intel_rapl_common: Found RAPL domain dram
+[    4.866868] EXT4-fs (sda1): mounted filesystem with ordered data mode. Opts: (null)
+[    5.312511] usbcore: registered new interface driver snd-usb-audio
+[    5.533363] input: HDA NVidia HDMI/DP,pcm=3 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card0/input7
+[    5.533402] input: HDA NVidia HDMI/DP,pcm=7 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card0/input8
+[    5.533434] input: HDA NVidia HDMI/DP,pcm=8 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card0/input9
+[    5.533467] input: HDA NVidia HDMI/DP,pcm=9 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card0/input10
+[    5.533499] input: HDA NVidia HDMI/DP,pcm=10 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card0/input11
+[    5.533531] input: HDA NVidia HDMI/DP,pcm=11 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card0/input12
+[    5.933359] EXT4-fs (sdb1): mounted filesystem with ordered data mode. Opts: (null)
+[    5.986500] audit: type=1400 audit(1604070940.102:2): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libreoffice-xpdfimport" pid=660 comm="apparmor_parser"
+[    5.986793] audit: type=1400 audit(1604070940.102:3): apparmor="STATUS" operation="profile_load" profile="unconfined" name="nvidia_modprobe" pid=659 comm="apparmor_parser"
+[    5.986795] audit: type=1400 audit(1604070940.102:4): apparmor="STATUS" operation="profile_load" profile="unconfined" name="nvidia_modprobe//kmod" pid=659 comm="apparmor_parser"
+[    5.987612] audit: type=1400 audit(1604070940.102:5): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libvirtd" pid=661 comm="apparmor_parser"
+[    5.987614] audit: type=1400 audit(1604070940.102:6): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libvirtd//qemu_bridge_helper" pid=661 comm="apparmor_parser"
+[    5.991280] audit: type=1400 audit(1604070940.106:7): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/bin/lxc-start" pid=665 comm="apparmor_parser"
+[    5.991370] audit: type=1400 audit(1604070940.106:8): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libreoffice-oopslash" pid=664 comm="apparmor_parser"
+[    5.996501] audit: type=1400 audit(1604070940.110:9): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/bin/man" pid=667 comm="apparmor_parser"
+[    5.996503] audit: type=1400 audit(1604070940.110:10): apparmor="STATUS" operation="profile_load" profile="unconfined" name="man_filter" pid=667 comm="apparmor_parser"
+[    5.996505] audit: type=1400 audit(1604070940.110:11): apparmor="STATUS" operation="profile_load" profile="unconfined" name="man_groff" pid=667 comm="apparmor_parser"
+[    6.443663] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
+[    6.443664] Bluetooth: BNEP filters: protocol multicast
+[    6.443668] Bluetooth: BNEP socket layer initialized
+[    6.469978] NET: Registered protocol family 38
+[    6.695894] Generic FE-GE Realtek PHY r8169-400:00: attached PHY driver [Generic FE-GE Realtek PHY] (mii_bus:phy_addr=r8169-400:00, irq=IGNORE)
+[    6.821762] r8169 0000:04:00.0 enp4s0: Link is Down
+[    6.895966] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
+[    6.900315] virbr0: port 1(virbr0-nic) entered blocking state
+[    6.900317] virbr0: port 1(virbr0-nic) entered disabled state
+[    6.900359] device virbr0-nic entered promiscuous mode
+[    6.919064] Started bpfilter
+[    6.919339] bpfilter: Loaded bpfilter_umh pid 910
+[    7.170188] virbr0: port 1(virbr0-nic) entered blocking state
+[    7.170190] virbr0: port 1(virbr0-nic) entered listening state
+[    7.213105] virbr0: port 1(virbr0-nic) entered disabled state
+[    9.187054] r8169 0000:04:00.0 enp4s0: Link is Up - 100Mbps/Full - flow control rx/tx
+[    9.187066] IPv6: ADDRCONF(NETDEV_CHANGE): enp4s0: link becomes ready
+[   10.761838] rfkill: input handler disabled
+[ 5025.190546] Bluetooth: RFCOMM TTY layer initialized
+[ 5025.190551] Bluetooth: RFCOMM socket layer initialized
+[ 5025.190554] Bluetooth: RFCOMM ver 1.11
+[ 5025.470493] rfkill: input handler enabled
+[22277.215799] hid-generic 0003:1038:1702.0005: hiddev0,hidraw2: USB HID v1.11 Device [SteelSeries SteelSeries Rival 100 Gaming Mouse] on usb-0000:00:14.0-6/input0
+[27891.402210] kauditd_printk_skb: 38 callbacks suppressed
+[27891.402212] audit: type=1400 audit(1604098825.289:42): apparmor="DENIED" operation="capable" profile="/usr/sbin/cups-browsed" pid=7994 comm="cups-browsed" capability=23  capname="sys_nice"

--- a/plugins/logtest.koplugin/main.lua
+++ b/plugins/logtest.koplugin/main.lua
@@ -1,0 +1,75 @@
+--[[
+
+sample plugin that showcases how to use the log viewer,
+with some extra buttons that do custom stuff
+
+]]  
+
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+
+-- a sample function that excludes lines that don't match a tag
+local function filterByTag(text, tag)
+    local output
+    for line in text:gmatch("([^\n]*)\n?") do
+        if line:match(tag) then
+            output = string.format("%s\n%s", output or "", line)
+        end
+    end
+    return output
+end
+
+local LogTest = WidgetContainer:new{
+    name = 'hello',
+    is_doc_only = false,
+}
+
+function LogTest:init()
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function LogTest:getButtonsTable()
+    local t = {}
+    local addFilterButton = function(name, tag)
+        table.insert(t, #t + 1, {
+            text = name,
+            callback = function()
+                self.viewer:update(nil, nil, function(text)
+                    return filterByTag(text, tag)
+                end)
+            end,
+        })
+    end
+    addFilterButton("BIOS", "BIOS-e820")
+    addFilterButton("VBOX", "virbr0")
+    addFilterButton("MMAP", "reserve")
+    addFilterButton("BASE", "base")
+    addFilterButton("ACPI", "ACPI")
+    table.insert(t, #t + 1, {
+        text = "full log",
+        callback = function()
+            self.viewer:update()
+        end,
+    })
+    return t
+end
+
+function LogTest:addToMainMenu(menu_items)
+    self.viewer = require("ui/elements/logviewer"):new {
+        file = "plugins/logtest.koplugin/dmesg.txt",
+        disable_arrows = true,
+        user_buttons = self:getButtonsTable(),
+    }
+
+    menu_items.test_logviewer = {
+        text = _("Custom logviewer"),
+        callback = function()
+            if self.viewer then
+                self.viewer:show()
+            end
+        end,
+    }
+end
+
+return LogTest


### PR DESCRIPTION
I would like to try hacking on top of #6608 in the emulator, but the emulator lacks a proper crash.log

If this patch doesn't sound stupid I can include it on top of the changes and enable the crash.log viewer on the emulator too. If it sounds stupid I will keep it to myself, hack the code on the emulator, and disable the crashlog viewer on all platforms without a crash.log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6756)
<!-- Reviewable:end -->
