### PR TITLE
Statistics plugin: fix in-memory statistics.

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1867,21 +1867,24 @@ function ReaderStatistics:onPageUpdate(pageno)
     local mem_read_pages = 0
     local mem_read_time = 0
     if util.tableSize(self.pages_stats) > 1 then
-        mem_read_pages = util.tableSize(self.pages_stats) - 1
         local sorted_performance = {}
         for time, page in pairs(self.pages_stats) do
             table.insert(sorted_performance, time)
         end
         table.sort(sorted_performance)
+        local read_pages_set = {}
         local diff_time
         for i=1, #sorted_performance - 1 do
             diff_time = sorted_performance[i + 1] - sorted_performance[i]
             if diff_time <= self.page_max_read_sec and diff_time >= self.page_min_read_sec  then
                 mem_read_time = mem_read_time + diff_time
+                read_pages_set[self.pages_stats[sorted_performance[i]]] = true
             elseif diff_time > self.page_max_read_sec then
                 mem_read_time = mem_read_time + self.page_max_read_sec
+                read_pages_set[self.pages_stats[sorted_performance[i]]] = true
             end
         end
+        mem_read_pages = util.tableSize(read_pages_set)
     end
     -- every 50 pages we write stats to database
     if util.tableSize(self.pages_stats) % PAGE_INSERT == 0 then


### PR DESCRIPTION
I have found a new bug in statistics plugin. The remaining time to read (both for a book & for a chapter) is decreasing a way too fast when navigating betweeg the same set of pages (for example going forward and backward a few times), especially on newly opened books, so it becomes useless very quickly.

**The reason:**

The `mem_read_pages` is calculated wrongly in `ReaderStatistics:onPageUpdate(pageno)` method for two reasons:
- it counts duplicated page numbers (every visit of the same page as it was a "new page")
- it counts pages even if you spent less time on them than `self.page_min_read_sec`

This fix solves the bug.

---

_P.S. This is my first contribution to KOReader. It's currently my favorite reader app. I'm really excited that it was so easy to fix something myself that was bothering me for some time :-)._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6759)
<!-- Reviewable:end -->
