### PR TITLE
Statistics: Tone down the insanity going on in the PageUpdate handler

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -209,8 +209,8 @@ function ReaderFont:onSetFontSize(new_size)
         timeout = 2,
     })
 
-    -- Let it propagate, to allow stuff to react to font size changes!
-    --return true
+    --- @note: Shouldn't we let this propagate, to allow stuff to react to font size changes?
+    return true
 end
 
 function ReaderFont:onSetLineSpace(space)

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -209,7 +209,8 @@ function ReaderFont:onSetFontSize(new_size)
         timeout = 2,
     })
 
-    return true
+    -- Let it propagate, to allow stuff to react to font size changes!
+    --return true
 end
 
 function ReaderFont:onSetLineSpace(space)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1723,7 +1723,7 @@ function ReaderFooter:getAvgTimePerPage()
 end
 
 function ReaderFooter:getDataFromStatistics(title, pages)
-    local sec = 'na'
+    local sec = "N/A"
     local average_time_per_page = self:getAvgTimePerPage()
     if average_time_per_page then
         if self.settings.duration_format == "classic" then

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -62,7 +62,9 @@ end
 
 function ReaderToc:onUpdateToc()
     self:resetToc()
-    return true
+
+    --- @note: Let this propagate, plugins/statistics uses it to react to changes in document pagination
+    --return true
 end
 
 function ReaderToc:onPageUpdate(pageno)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -188,17 +188,20 @@ function ReaderStatistics:initData()
     end
 end
 
--- Reset the stats on significant page count changes after a font size update (> 10%)
+-- Reset the (volatile) stats on significant page count changes after a font size update (> 10%)
 function ReaderStatistics:onFontSizeUpdate()
     local new_pagecount = self.view.document:getPageCount()
 
     local page_diff = math.abs(new_pagecount - self.data.pages)
     if page_diff >= math.floor(PAGECOUNT_DIFF_THRESHOLD * self.data.pages) then
-        -- Clear DB & volatile stats for current book
-        self:deleteBook(self.id_curr_book)
+        -- Clear volatile stats for current book
         self:resetVolatileStats()
+        -- NOTE: If we were to clear the DB stats, too:
+        --[[
+        self:deleteBook(self.id_curr_book)
         -- Re-create empty entry for the book
         self.id_curr_book = self:getIdBookDB()
+        --]]
     end
 
     -- Update our copy of the page count

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -27,6 +27,7 @@ local T = FFIUtil.template
 local statistics_dir = DataStorage:getDataDir() .. "/statistics/"
 local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
 local PAGE_INSERT = 50
+local PAGECOUNT_DIFF_THRESHOLD = 0.10
 local DEFAULT_MIN_READ_SEC = 5
 local DEFAULT_MAX_READ_SEC = 120
 local DEFAULT_CALENDAR_START_DAY_OF_WEEK = 2 -- Monday
@@ -192,7 +193,7 @@ function ReaderStatistics:onFontSizeUpdate()
     local new_pagecount = self.view.document:getPageCount()
 
     local page_diff = math.abs(new_pagecount - self.data.pages)
-    if page_diff >= math.floor(0.1 * self.data.pages) then
+    if page_diff >= math.floor(PAGECOUNT_DIFF_THRESHOLD * self.data.pages) then
         -- Clear DB & volatile stats for current book
         self:deleteBook(self.id_curr_book)
         self:resetVolatileStats()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -43,8 +43,6 @@ local ReaderStatistics = Widget:extend{
     start_current_period = 0,
     curr_page = nil,
     id_curr_book = nil,
-    curr_total_time = 0,
-    curr_total_pages = 0,
     is_enabled = nil,
     convert_to_db = nil, -- true when migration to DB has been done
     pageturn_count = 0
@@ -180,8 +178,6 @@ function ReaderStatistics:initData()
     -- Update these numbers to what's actually stored in the settings
     -- (not that "notes" is invalid and does not represent edited highlights)
     self.data.highlights, self.data.notes = self.ui.bookmark:getNumberOfHighlightsAndNotes()
-    self.curr_total_time = 0
-    self.curr_total_pages = 0
     self.id_curr_book = self:getIdBookDB()
     self.total_read_pages, self.total_read_time = self:getPageTimeTotalStats(self.id_curr_book)
     if self.total_read_pages > 0 then
@@ -539,7 +535,7 @@ function ReaderStatistics:getIdBookDB()
         stmt = conn:prepare("INSERT INTO book VALUES(NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
         stmt:reset():bind(self.data.title, self.data.authors, self.data.notes,
             TimeVal:now().sec, self.data.highlights, self.data.pages,
-            self.data.series, self.data.language, self.data.md5, self.curr_total_time, self.curr_total_pages):step()
+            self.data.series, self.data.language, self.data.md5, 0, 0):step()
         sql_stmt = [[
             SELECT last_insert_rowid() AS num;
         ]]

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -27,6 +27,7 @@ local T = FFIUtil.template
 local statistics_dir = DataStorage:getDataDir() .. "/statistics/"
 local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
 local MAX_PAGETURNS_BEFORE_FLUSH = 50
+local MIN_PAGES_READ_TO_FLUSH = 2
 local DEFAULT_MIN_READ_SEC = 5
 local DEFAULT_MAX_READ_SEC = 120
 local DEFAULT_CALENDAR_START_DAY_OF_WEEK = 2 -- Monday
@@ -193,7 +194,7 @@ function ReaderStatistics:onUpdateToc()
 
     if new_pagecount ~= self.data.pages then
         -- NOTE: insertDB does the exact same check
-        if not self.id_curr_book or self.mem_read_pages < 2 then
+        if not self.id_curr_book or self.mem_read_pages < MIN_PAGES_READ_TO_FLUSH then
             logger.info("ReaderStatistics: Pagecount change, clearing volatile book statistics")
             -- Clear volatile stats
             self:resetVolatileStats()
@@ -579,7 +580,7 @@ function ReaderStatistics:getIdBookDB()
 end
 
 function ReaderStatistics:insertDB(id_book)
-    if id_book == nil or self.mem_read_pages < 2 then
+    if id_book == nil or self.mem_read_pages < MIN_PAGES_READ_TO_FLUSH then
         return
     end
     local now_ts = TimeVal:now().sec

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1915,17 +1915,19 @@ function ReaderStatistics:onPageUpdate(pageno)
     if diff_time >= self.page_min_read_sec and diff_time <= self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + diff_time
         duration = duration + diff_time
+        -- If the page hadn't been read already, count it as read
+        if not self.pages_stat_duration[self.curr_page] then
+            self.mem_read_pages = self.mem_read_pages + 1
+        end
         -- Update the reading duration for the current page for this session
         self.pages_stat_duration[self.curr_page] = duration
     elseif diff_time > self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + self.page_max_read_sec
         duration = duration + self.page_max_read_sec
+        if not self.pages_stat_duration[self.curr_page] then
+            self.mem_read_pages = self.mem_read_pages + 1
+        end
         self.pages_stat_duration[self.curr_page] = duration
-    end
-
-    -- If the page hadn't been read already, count it as read
-    if duration > 0 then
-        self.mem_read_pages = self.mem_read_pages + 1
     end
 
     -- See if we'll want to flush volatile stats to the DB...

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1940,7 +1940,7 @@ function ReaderStatistics:onPageUpdate(pageno)
         duration = duration + self.page_max_read_sec
         self.read_pages_set[pageno] = true
     end
-    self.mem_read_pages = #self.read_pages_set
+    self.mem_read_pages = util.tableSize(self.read_pages_set)
 
     -- Update the total read duration for the *current* page for this session
     self.pages_stat_duration[self.curr_page] = duration

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -192,7 +192,12 @@ function ReaderStatistics:onUpdateToc()
     local new_pagecount = self.view.document:getPageCount()
 
     if new_pagecount ~= self.data.pages then
-        if self.id_curr_book then
+        -- NOTE: insertDB does the exact same check
+        if not self.id_curr_book or self.mem_read_pages < 2 then
+            logger.info("ReaderStatistics: Pagecount change, clearing volatile book statistics")
+            -- Clear volatile stats
+            self:resetVolatileStats()
+        else
             logger.info("ReaderStatistics: Pagecount change, flushing volatile book statistics")
             -- Flush volatile stats to DB for current book
             self:insertDB(self.id_curr_book)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -580,7 +580,7 @@ function ReaderStatistics:getIdBookDB()
 end
 
 function ReaderStatistics:insertDB(id_book)
-    if id_book == nil or util.tableSize(self.pages_stat_ts) < 2 then
+    if id_book == nil or self.mem_read_pages < 2 then
         return
     end
     local now_ts = TimeVal:now().sec

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1901,8 +1901,7 @@ function ReaderStatistics:onPageUpdate(pageno)
     -- If we don't have a previous timestamp to compare to, abort early
     if not then_ts then
         logger.dbg("ReaderStatistics: No timestamp for previous page", self.curr_page)
-        table.insert(curr_page_ts_list, now_ts)
-        self.pages_stat_ts[pageno] = curr_page_ts_list
+        self.pages_stat_ts[pageno] = { now_ts }
         self.curr_page = pageno
         return
     end

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -201,6 +201,8 @@ function ReaderStatistics:onUpdateToc()
         -- Re-create empty entry for the book
         self.id_curr_book = self:getIdBookDB()
         --]]
+        --- @fixme: This does mean that you may end up with conflicting page numbers in the database...
+        ---         On the other hand, wiping the book off the db on every minor pagination change feels a bit harsh...
     end
 
     -- Update our copy of the page count

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -27,7 +27,7 @@ local T = FFIUtil.template
 local statistics_dir = DataStorage:getDataDir() .. "/statistics/"
 local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
 local PAGE_INSERT = 50
-local PAGECOUNT_DIFF_THRESHOLD = 0.10
+local PAGECOUNT_DIFF_THRESHOLD = 0.075
 local DEFAULT_MIN_READ_SEC = 5
 local DEFAULT_MAX_READ_SEC = 120
 local DEFAULT_CALENDAR_START_DAY_OF_WEEK = 2 -- Monday
@@ -189,7 +189,7 @@ function ReaderStatistics:initData()
     end
 end
 
--- Reset the (volatile) stats on significant page count changes after a font size update (> 10%)
+-- Reset the (volatile) stats on significant page count changes after a font size update
 function ReaderStatistics:onSetFontSize()
     local new_pagecount = self.view.document:getPageCount()
 

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -212,6 +212,7 @@ end
 function ReaderStatistics:resetVolatileStats()
     -- Computed by onPageUpdate
     self.pageturn_count = 0
+    self.pageturn_ts = 0
     self.mem_read_time = 0
     self.read_pages_set = {}
     self.mem_read_pages = 0
@@ -628,6 +629,7 @@ function ReaderStatistics:insertDB(id_book)
     self:resetVolatileStats()
     -- last page must be added once more
     self.pages_stat_ts[self.curr_page] = now_ts
+    self.pageturn_ts = now_ts
     conn:close()
 end
 
@@ -685,6 +687,7 @@ function ReaderStatistics:getStatisticEnabledMenuItem()
                 self.start_current_period = TimeVal:now().sec
                 self.curr_page = self.ui:getCurrentPage()
                 self.pages_stat_ts[self.curr_page] = self.start_current_period
+                self.pageturn_ts = self.start_current_period
             end
             self:saveSettings()
             if not self:isDocless() then
@@ -2020,6 +2023,7 @@ function ReaderStatistics:onResume()
     self.start_current_period = TimeVal:now().sec
     self:resetVolatileStats()
     self.pages_stat_ts[self.self.curr_page] = self.start_current_period
+    self.pageturn_ts = self.start_current_period
 end
 
 function ReaderStatistics:saveSettings()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1918,19 +1918,20 @@ function ReaderStatistics:onPageUpdate(pageno)
 
     -- By now, we're sure that we actually have a tuple (and the rest of the code ensures they're sane, i.e., zero-initialized)
     local curr_duration = data_tuple[2]
+    -- NOTE: If all goes well, given the earlier curr_page != pageno check, curr_duration should always be 0 here.
     -- Compute the difference between now and the previous page's last timestamp
     local diff_time = now_ts - then_ts
     if diff_time >= self.page_min_read_sec and diff_time <= self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + diff_time
-        -- If the page hadn't been read already, count it as read
-        if curr_duration == 0 then
+        -- If it's the first time we're computing a duration for this page, count it as read
+        if #page_data == 1 and curr_duration == 0 then
             self.mem_read_pages = self.mem_read_pages + 1
         end
         -- Update the tuple with the computed duration
         data_tuple[2] = curr_duration + diff_time
     elseif diff_time > self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + self.page_max_read_sec
-        if curr_duration == 0 then
+        if #page_data == 1 and curr_duration == 0 then
             self.mem_read_pages = self.mem_read_pages + 1
         end
         -- Update the tuple with the computed duration

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -42,7 +42,7 @@ local ReaderStatistics = Widget:extend{
     calendar_show_histogram = true,
     calendar_browse_future_months = false,
     start_current_period = 0,
-    curr_page = nil,
+    curr_page = 0,
     id_curr_book = nil,
     is_enabled = nil,
     convert_to_db = nil, -- true when migration to DB has been done
@@ -1885,7 +1885,7 @@ end
 
 
 function ReaderStatistics:onPosUpdate(pos, pageno)
-    if not self.curr_page or self.curr_page ~= pageno then
+    if self.curr_page ~= pageno then
         self:onPageUpdate(pageno)
     end
 end
@@ -1900,15 +1900,6 @@ function ReaderStatistics:onPageUpdate(pageno)
 
     local now_ts = TimeVal:now().sec
 
-    -- First page update of the session, just update the current page's timestamp
-    if not self.curr_page then
-        logger.dbg("First PageUpdate of the statistics session")
-        self.pages_stat_ts[pageno] = now_ts
-        self.curr_page = pageno
-        self.pageturn_ts = now_ts
-        return
-    end
-
     -- Compute the difference between the previous page's timestamp (if there is one)
     local then_ts
     if self.pages_stat_ts[self.curr_page] then
@@ -1917,7 +1908,7 @@ function ReaderStatistics:onPageUpdate(pageno)
 
     -- If we don't have a previous timestamp to compare to, abort early
     if not then_ts then
-        logger.dbg("No timestamp for previous page", self.curr_page)
+        logger.dbg("ReaderStatistics: No timestamp for previous page", self.curr_page)
         self.pages_stat_ts[pageno] = now_ts
         self.curr_page = pageno
         self.pageturn_ts = now_ts

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -187,6 +187,23 @@ function ReaderStatistics:initData()
     end
 end
 
+-- Reset the stats on significant page count changes after a font size update (> 10%)
+function ReaderStatistics:onFontSizeUpdate()
+    local new_pagecount = self.view.document:getPageCount()
+
+    local page_diff = math.abs(new_pagecount - self.data.pages)
+    if page_diff >= math.floor(0.1 * self.data.pages) then
+        -- Clear DB & volatile stats for current book
+        self:deleteBook(self.id_curr_book)
+        self:resetVolatileStats()
+        -- Re-create empty entry for the book
+        self.id_curr_book = self:getIdBookDB()
+    end
+
+    -- Update our copy of the page count
+    self.data.pages = new_pagecount
+end
+
 function ReaderStatistics:resetVolatileStats()
     -- Computed by onPageUpdate
     self.pageturn_count = 0

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -26,7 +26,7 @@ local T = FFIUtil.template
 
 local statistics_dir = DataStorage:getDataDir() .. "/statistics/"
 local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
-local PAGE_INSERT = 50
+local MAX_PAGETURNS_BEFORE_FLUSH = 50
 local DEFAULT_MIN_READ_SEC = 5
 local DEFAULT_MAX_READ_SEC = 120
 local DEFAULT_CALENDAR_START_DAY_OF_WEEK = 2 -- Monday
@@ -1939,7 +1939,7 @@ function ReaderStatistics:onPageUpdate(pageno)
     end
 
     -- We want a flush to db every 50 page turns
-    if self.pageturn_count >= PAGE_INSERT then
+    if self.pageturn_count >= MAX_PAGETURNS_BEFORE_FLUSH then
         self:insertDB(self.id_curr_book)
         -- insertDB will call resetVolatileStats for us ;)
     end

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1904,10 +1904,8 @@ function ReaderStatistics:onPageUpdate(pageno)
     local then_ts
     if self.pages_stat_ts[self.curr_page] then
         then_ts = self.pages_stat_ts[self.curr_page]
-    end
-
-    -- If we don't have a previous timestamp to compare to, abort early
-    if not then_ts then
+    else
+        -- If we don't have a previous timestamp to compare to, abort early
         logger.dbg("ReaderStatistics: No timestamp for previous page", self.curr_page)
         self.pages_stat_ts[pageno] = now_ts
         self.curr_page = pageno

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -192,17 +192,13 @@ function ReaderStatistics:onUpdateToc()
     local new_pagecount = self.view.document:getPageCount()
 
     if new_pagecount ~= self.data.pages then
-        logger.info("ReaderStatistics: Pagecount change, clearing volatile book statistics")
-        -- Clear volatile stats for current book
-        self:resetVolatileStats()
-        -- NOTE: If we were to clear the DB stats, too:
-        --[[
-        self:deleteBook(self.id_curr_book)
-        -- Re-create empty entry for the book
-        self.id_curr_book = self:getIdBookDB()
-        --]]
-        --- @fixme: This does mean that you may end up with conflicting page numbers in the database...
-        ---         On the other hand, wiping the book off the db on every minor pagination change feels a bit harsh...
+        if self.id_curr_book then
+            logger.info("ReaderStatistics: Pagecount change, flushing volatile book statistics")
+            -- Flush volatile stats to DB for current book
+            self:insertDB(self.id_curr_book)
+            --- @fixme: This does mean that you may end up with conflicting page numbers in the database...
+            ---         On the other hand, wiping the book off the db on every minor pagination change feels a bit harsh...
+        end
     end
 
     -- Update our copy of the page count

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1895,9 +1895,7 @@ function ReaderStatistics:onPageUpdate(pageno)
         return
     end
 
-    -- Increment the counter
     self.pageturn_count = self.pageturn_count + 1
-
     local now_ts = TimeVal:now().sec
 
     -- Get the previous page's timestamp (if there is one)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1930,20 +1930,14 @@ function ReaderStatistics:onPageUpdate(pageno)
     -- Update the total read duration for the *current* page for this session (will be 0 if below page_min_read_sec)
     self.pages_stat_duration[self.curr_page] = duration
 
-    -- See if we'll want to flush volatile stats to the DB
-    local flush_stats = false
+    -- See if we'll want to flush volatile stats to the DB...
     -- We want a flush to db every 50 page turns
-    if self.pageturn_count >= PAGE_INSERT then
-        flush_stats = true
-    end
+    -- OR
     -- We also want a flush to DB on the hour, to allow CalendarView to accurately track per-hour stats in the DB,
     -- since we only keep track of a single timestamp per page in memory, unlike in the DB.
-    if os.date("%H", now_ts) ~= os.date("%H", self.pageturn_ts) then
-        flush_stats = true
-    end
-
-    -- Do we need a flush to db?
-    if flush_stats then
+    if self.pageturn_count >= PAGE_INSERT
+    or os.date("%H", now_ts) ~= os.date("%H", self.pageturn_ts)
+    then
         self:insertDB(self.id_curr_book)
         -- insertDB will call resetVolatileStats for us ;)
     end

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -195,6 +195,7 @@ function ReaderStatistics:onFontSizeUpdate()
 
     local page_diff = math.abs(new_pagecount - self.data.pages)
     if page_diff >= math.floor(PAGECOUNT_DIFF_THRESHOLD * self.data.pages) then
+        logger.dbg("Significant pagecount change, clearing volatile book statistics")
         -- Clear volatile stats for current book
         self:resetVolatileStats()
         -- NOTE: If we were to clear the DB stats, too:

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -190,7 +190,7 @@ function ReaderStatistics:initData()
 end
 
 -- Reset the (volatile) stats on significant page count changes after a font size update (> 10%)
-function ReaderStatistics:onFontSizeUpdate()
+function ReaderStatistics:onSetFontSize()
     local new_pagecount = self.view.document:getPageCount()
 
     local page_diff = math.abs(new_pagecount - self.data.pages)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1900,7 +1900,7 @@ function ReaderStatistics:onPageUpdate(pageno)
 
     local now_ts = TimeVal:now().sec
 
-    -- Compute the difference between the previous page's timestamp (if there is one)
+    -- Get the previous page's timestamp (if there is one)
     local then_ts
     if self.pages_stat_ts[self.curr_page] then
         then_ts = self.pages_stat_ts[self.curr_page]
@@ -1915,6 +1915,7 @@ function ReaderStatistics:onPageUpdate(pageno)
         return
     end
 
+    -- Compute the difference between now and the previous page's timestamp
     local duration = self.pages_stat_duration[self.curr_page] or 0
     local diff_time = now_ts - then_ts
     if diff_time >= self.page_min_read_sec and diff_time <= self.page_max_read_sec then
@@ -1928,7 +1929,7 @@ function ReaderStatistics:onPageUpdate(pageno)
     end
     self.mem_read_pages = util.tableSize(self.read_pages_set)
 
-    -- Update the total read duration for the *current* page for this session
+    -- Update the total read duration for the *current* page for this session (will be 0 if below page_min_read_sec)
     self.pages_stat_duration[self.curr_page] = duration
 
     -- See if we'll want to flush volatile stats to the DB
@@ -1949,7 +1950,7 @@ function ReaderStatistics:onPageUpdate(pageno)
         -- insertDB will call resetVolatileStats for us ;)
     end
 
-    -- Update average time per page (if need be, insertDB will have updated the totals)
+    -- Update average time per page (if need be, insertDB will have updated the totals and cleared the volatiles)
     if self.total_read_pages > 0 or self.mem_read_pages > 0 then
         self.avg_time = (self.total_read_time + self.mem_read_time) / (self.total_read_pages + self.mem_read_pages)
     end

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -532,6 +532,7 @@ function ReaderStatistics:getIdBookDB()
     local result = stmt:reset():bind(self.data.title, self.data.authors, self.data.md5):step()
     local nr_id = tonumber(result[1])
     if nr_id == 0 then
+        -- Not in the DB yet, initialize it
         stmt = conn:prepare("INSERT INTO book VALUES(NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
         stmt:reset():bind(self.data.title, self.data.authors, self.data.notes,
             TimeVal:now().sec, self.data.highlights, self.data.pages,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1910,24 +1910,22 @@ function ReaderStatistics:onPageUpdate(pageno)
     end
 
     -- Compute the difference between now and the previous page's timestamp
-    local duration = self.pages_stat_duration[self.curr_page] or 0
+    local curr_duration = self.pages_stat_duration[self.curr_page] or 0
     local diff_time = now_ts - then_ts
     if diff_time >= self.page_min_read_sec and diff_time <= self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + diff_time
-        duration = duration + diff_time
         -- If the page hadn't been read already, count it as read
-        if not self.pages_stat_duration[self.curr_page] then
+        if curr_duration == 0 then
             self.mem_read_pages = self.mem_read_pages + 1
         end
         -- Update the reading duration for the current page for this session
-        self.pages_stat_duration[self.curr_page] = duration
+        self.pages_stat_duration[self.curr_page] = curr_duration + diff_time
     elseif diff_time > self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + self.page_max_read_sec
-        duration = duration + self.page_max_read_sec
-        if not self.pages_stat_duration[self.curr_page] then
+        if curr_duration == 0 then
             self.mem_read_pages = self.mem_read_pages + 1
         end
-        self.pages_stat_duration[self.curr_page] = duration
+        self.pages_stat_duration[self.curr_page] = curr_duration + self.page_max_read_sec
     end
 
     -- See if we'll want to flush volatile stats to the DB...

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1905,10 +1905,8 @@ function ReaderStatistics:onPageUpdate(pageno)
         return
     end
 
-    local curr_duration = data_tuple[2] or 0
-    -- Make sure our tuple is sane
-    data_tuple = { then_ts, curr_duration }
-
+    -- By now, we're sure that we actually have a tuple (and the rest of the code ensures they're sane, i.e., zero-initialized)
+    local curr_duration = data_tuple[2]
     -- Compute the difference between now and the previous page's last timestamp
     local diff_time = now_ts - then_ts
     if diff_time >= self.page_min_read_sec and diff_time <= self.page_max_read_sec then

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1915,19 +1915,17 @@ function ReaderStatistics:onPageUpdate(pageno)
     if diff_time >= self.page_min_read_sec and diff_time <= self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + diff_time
         duration = duration + diff_time
-        -- If the page hadn't been read already, count it as read
-        if not self.pages_stat_duration[self.curr_page] then
-            self.mem_read_pages = self.mem_read_pages + 1
-        end
         -- Update the reading duration for the current page for this session
         self.pages_stat_duration[self.curr_page] = duration
     elseif diff_time > self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + self.page_max_read_sec
         duration = duration + self.page_max_read_sec
-        if not self.pages_stat_duration[self.curr_page] then
-            self.mem_read_pages = self.mem_read_pages + 1
-        end
         self.pages_stat_duration[self.curr_page] = duration
+    end
+
+    -- If the page hadn't been read already, count it as read
+    if duration > 0 then
+        self.mem_read_pages = self.mem_read_pages + 1
     end
 
     -- See if we'll want to flush volatile stats to the DB...

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -182,7 +182,9 @@ function ReaderStatistics:initData()
     if self.total_read_pages > 0 then
         self.avg_time = self.total_read_time / self.total_read_pages
     else
-        self.avg_time = 0
+        -- NOTE: Possibly less weird-looking than initializing this to 0?
+        self.avg_time = math.floor(0.75 * self.page_max_read_sec)
+        logger.info("Initializing average time per page at 75% of the max value, i.e.,", self.avg_time)
     end
 end
 
@@ -1967,7 +1969,7 @@ function ReaderStatistics:onPageUpdate(pageno)
     -- We're done, update the current page tracker
     self.curr_page = pageno
     -- And, in the new page's list, append a new tuple with the current timestamp and a placeholder duration
-    -- (duration will be computed next pageturn)
+    -- (duration will be computed on next pageturn)
     local new_page_data = self.page_stat[pageno] or {}
     table.insert(new_page_data, { now_ts, 0 })
     self.page_stat[pageno] = new_page_data

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1903,11 +1903,11 @@ function ReaderStatistics:onPageUpdate(pageno)
     local now_ts = TimeVal:now().sec
 
     -- Get the previous page's last timestamp (if there is one)
-    local page_data = self.page_stat[self.curr_page] or {}
+    local page_data = self.page_stat[self.curr_page]
     -- This is a list of tuples, in insertion order, we want the last one
-    local data_tuple = page_data[#page_data] or {}
+    local data_tuple = page_data and page_data[#page_data]
     -- Tuple layout is { timestamp, duration }
-    local then_ts = data_tuple[1]
+    local then_ts = data_tuple and data_tuple[1]
     -- If we don't have a previous timestamp to compare to, abort early
     if not then_ts then
         logger.dbg("ReaderStatistics: No timestamp for previous page", self.curr_page)
@@ -1952,9 +1952,12 @@ function ReaderStatistics:onPageUpdate(pageno)
     self.curr_page = pageno
     -- And, in the new page's list, append a new tuple with the current timestamp and a placeholder duration
     -- (duration will be computed on next pageturn)
-    local new_page_data = self.page_stat[pageno] or {}
-    table.insert(new_page_data, { now_ts, 0 })
-    self.page_stat[pageno] = new_page_data
+    local new_page_data = self.page_stat[pageno]
+    if new_page_data then
+        table.insert(new_page_data, { now_ts, 0 })
+    else
+        self.page_stat[pageno] = { { now_ts, 0 } }
+    end
 end
 
 -- For backward compatibility

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1930,7 +1930,7 @@ function ReaderStatistics:onPageUpdate(pageno)
         self.mem_read_time = self.mem_read_time + diff_time
         duration = duration + diff_time
         self.read_pages_set[pageno] = true
-    elseif diff_time > self.page_max_read_sec
+    elseif diff_time > self.page_max_read_sec then
         self.mem_read_time = self.mem_read_time + self.page_max_read_sec
         duration = duration + self.page_max_read_sec
         self.read_pages_set[pageno] = true

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -193,7 +193,7 @@ function ReaderStatistics:onSetFontSize()
     local new_pagecount = self.view.document:getPageCount()
 
     local page_diff = math.abs(new_pagecount - self.data.pages)
-    if page_diff >= math.floor(PAGECOUNT_DIFF_THRESHOLD * self.data.pages) then
+    if page_diff >= math.floor(PAGECOUNT_DIFF_THRESHOLD * math.max(self.data.pages, new_pagecount)) then
         logger.dbg("Significant pagecount change, clearing volatile book statistics")
         -- Clear volatile stats for current book
         self:resetVolatileStats()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1902,6 +1902,7 @@ function ReaderStatistics:onPageUpdate(pageno)
 
     -- First page update of the session, just update the current page's timestamp
     if not self.curr_page then
+        logger.dbg("No previous page")
         self.pages_stat_ts[pageno] = now_ts
         self.curr_page = pageno
         self.pageturn_ts = now_ts
@@ -1916,6 +1917,7 @@ function ReaderStatistics:onPageUpdate(pageno)
 
     -- If we don't have a previous timestamp to compare to, abort early
     if not then_ts then
+        logger.dbg("No timestamp for previous page", self.curr_page)
         self.pages_stat_ts[pageno] = now_ts
         self.curr_page = pageno
         self.pageturn_ts = now_ts

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -215,6 +215,7 @@ function ReaderStatistics:resetVolatileStats()
 
     -- Volatile storage pending flush to db
     self.page_stat = {}
+    logger.info("ReaderStatistics:resetVolatileStats")
 end
 
 function ReaderStatistics:getStatsBookStatus(id_curr_book, stat_enable)
@@ -584,7 +585,13 @@ function ReaderStatistics:insertDB(id_book)
     conn:exec('BEGIN')
     local stmt = conn:prepare("INSERT OR IGNORE INTO page_stat VALUES(?, ?, ?, ?)")
     for page, data_list in pairs(self.page_stat) do
-        for ts, duration in ipairs(data_list) do
+        logger.info("ReaderStatistics:insertDB: Iterating on page", page)
+        for _, data_tuple in ipairs(data_list) do
+            -- See self.page_stat declaration above about the tuple's layout
+            local ts = data_tuple[1]
+            local duration = data_tuple[2]
+            logger.info("ReaderStatistics:insertDB: opened @", ts, "read in", duration)
+            -- Skip placeholder durations
             if duration > 0 then
                 stmt:reset():bind(id_book, page, ts, duration):step()
             end
@@ -625,6 +632,7 @@ function ReaderStatistics:insertDB(id_book)
     self:resetVolatileStats()
     -- Re-seed the volatile stats with minimal data about the current page
     self.page_stat[self.curr_page] = { { now_ts, 0 } }
+    logger.info("ReaderStatistics:insertDB: Inserted a placeholder duration for page", self.curr_page, "@ ts", now_ts)
     conn:close()
 end
 
@@ -682,6 +690,7 @@ function ReaderStatistics:getStatisticEnabledMenuItem()
                 self.start_current_period = TimeVal:now().sec
                 self.curr_page = self.ui:getCurrentPage()
                 self.page_stat[self.curr_page] = { { self.start_current_period, 0 } }
+                logger.info("ReaderStatistics:getStatisticEnabledMenuItem: Inserted a placeholder duration for page", self.curr_page, "@ ts", self.start_current_period)
             end
             self:saveSettings()
             if not self:isDocless() then
@@ -1888,6 +1897,13 @@ function ReaderStatistics:onPageUpdate(pageno)
         return
     end
 
+    logger.info("ReaderStatistics:onPageUpdate: From page", self.curr_page, "to page", pageno)
+
+    -- We only care about *actual* page turns ;)
+    if self.curr_page == pageno then
+        return
+    end
+
     self.pageturn_count = self.pageturn_count + 1
     local now_ts = TimeVal:now().sec
 
@@ -1901,9 +1917,13 @@ function ReaderStatistics:onPageUpdate(pageno)
     if not then_ts then
         logger.dbg("ReaderStatistics: No timestamp for previous page", self.curr_page)
         self.page_stat[pageno] = { { now_ts, 0 } }
+        logger.info("ReaderStatistics:onPageUpdate: Inserted a placeholder duration for page", pageno, "@ ts", now_ts)
         self.curr_page = pageno
         return
     end
+
+    local dump = require("dump")
+    logger.info("self.page_stat[self.curr_page]:", dump(self.page_stat[self.curr_page]))
 
     -- By now, we're sure that we actually have a tuple (and the rest of the code ensures they're sane, i.e., zero-initialized)
     local curr_duration = data_tuple[2]
@@ -1937,12 +1957,23 @@ function ReaderStatistics:onPageUpdate(pageno)
         self.avg_time = (self.total_read_time + self.mem_read_time) / (self.total_read_pages + self.mem_read_pages)
     end
 
+    logger.info("data_tuple:", dump(data_tuple))
+    logger.info("page_data[#page_data]:", dump(page_data[#page_data]))
+    logger.info("page_data:", dump(page_data))
+    logger.info("self.page_stat[self.curr_page]:", dump(self.page_stat[self.curr_page]))
+
+    logger.info("self.page_stat[pageno]:", dump(self.page_stat[pageno]))
+
     -- We're done, update the current page tracker
     self.curr_page = pageno
-    -- And, in the new page's list, append a new tuple with the current timestamp (duration will be computed next pageturn)
+    -- And, in the new page's list, append a new tuple with the current timestamp and a placeholder duration
+    -- (duration will be computed next pageturn)
     local new_page_data = self.page_stat[pageno] or {}
     table.insert(new_page_data, { now_ts, 0 })
     self.page_stat[pageno] = new_page_data
+
+    logger.info("new_page_data:", dump(new_page_data))
+    logger.info("self.page_stat[pageno]:", dump(self.page_stat[pageno]))
 end
 
 -- For backward compatibility
@@ -2002,7 +2033,8 @@ end
 function ReaderStatistics:onResume()
     self.start_current_period = TimeVal:now().sec
     self:resetVolatileStats()
-    self.page_stat[self.self.curr_page] = { { self.start_current_period, 0 } }
+    logger.info("ReaderStatistics:onResume: Inserted a placeholder duration for page", self.curr_page, "@ ts", self.start_current_period)
+    self.page_stat[self.curr_page] = { { self.start_current_period, 0 } }
 end
 
 function ReaderStatistics:saveSettings()

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -173,8 +173,8 @@ describe("Readerfooter module", function()
         footer:onUpdateFooter()
         local timeinfo = footer.textGeneratorMap.time(footer)
         local page_count = readerui.document:getPageCount()
-        -- stats has not been initialized here, so we get na TB and TC
-        assert.are.same('1 / '..page_count..' | '..timeinfo..' | ⇒ 0 | 0% | ⤠ 0% | ⏳ na | ⤻ na',
+        -- stats has not been initialized here, so we get N/A TB and TC
+        assert.are.same('1 / '..page_count..' | '..timeinfo..' | ⇒ 0 | 0% | ⤠ 0% | ⏳ N/A | ⤻ N/A',
                         footer.footer_text.text)
     end)
 
@@ -190,7 +190,7 @@ describe("Readerfooter module", function()
         local footer = readerui.view.footer
         readerui.view.footer:onUpdateFooter()
         local timeinfo = readerui.view.footer.textGeneratorMap.time(footer)
-        assert.are.same('1 / 2 | '..timeinfo..' | ⇒ 1 | 0% | ⤠ 50% | ⏳ na | ⤻ na',
+        assert.are.same('1 / 2 | '..timeinfo..' | ⇒ 1 | 0% | ⤠ 50% | ⏳ N/A | ⤻ N/A',
                         readerui.view.footer.footer_text.text)
     end)
 
@@ -209,7 +209,7 @@ describe("Readerfooter module", function()
         footer:resetLayout()
         footer:onUpdateFooter()
         local timeinfo = footer.textGeneratorMap.time(footer)
-        assert.are.same('1 / 2 | '..timeinfo..' | ⇒ 1 | 0% | ⤠ 50% | ⏳ na | ⤻ na',
+        assert.are.same('1 / 2 | '..timeinfo..' | ⇒ 1 | 0% | ⤠ 50% | ⏳ N/A | ⤻ N/A',
                         footer.footer_text.text)
 
         -- disable show all at once, page progress should be on the first


### PR DESCRIPTION
Basically invert the tracking logic: index on pages, instead of timestamps.

This simplifies the logic a great deal, at the cost of losing a tiny bit of granularity in the timestamp tracking in some edge cases (mainly as interpreted by CalendarView), so we force flushes to DB every hour to hide the implementation details away without much effect on the visible results ;).

Also, reset in-memory stats if a font size change has significantly changed the amount of total pages (> 10%).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6761)
<!-- Reviewable:end -->
