### PR TITLE
[chore] Add authentication to Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: koreader/koappimage:0.1.7
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
         environment:
           EMULATE_READER: 1
           # this is for shellcheck 0.4.5 and lower; can be removed for 0.4.6


### PR DESCRIPTION
This will be required by November 1.

See <https://docs.docker.com/docker-hub/download-rate-limit/> and <https://discuss.circleci.com/t/authenticate-with-docker-to-avoid-impact-of-nov-1st-rate-limits/37567?mkt_tok=eyJpIjoiT1dVNE9EWmhNRFJtWTJObSIsInQiOiJOd1lnZHJidWpyU2ZqMG1JM21cL1Yxc1BsK1M1cWYwWnljeE43WlQ2K2tcL0ZKNnpXUElISjl6djlIM2FucTl4ekY3bjFBUVRxbXJ5XC93YTlZYlF2Z0pWeU1OM2FQR2RFNWFWOFBURk80RElsK3JabHZqT09qc3FYOE1aS0VUdFo4MiJ9> for more information.

<hr>

The only problem is I'm not sure if it's actually working or not based on the CirlceCI output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6764)
<!-- Reviewable:end -->
