### PR TITLE
Move numeric sort up, so it looks better

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -992,13 +992,13 @@ function FileManager:getSortingMenuTable()
         end,
         sub_item_table = {
             set_collate_table("strcoll"),
+            set_collate_table("numeric"),
             set_collate_table("strcoll_mixed"),
             set_collate_table("access"),
             set_collate_table("change"),
             set_collate_table("modification"),
             set_collate_table("size"),
             set_collate_table("type"),
-            set_collate_table("numeric"),
             {
                 text_func =  get_collate_percent,
                 checked_func = function()


### PR DESCRIPTION
Somehow I placed it at the bottom of the menu by accident, it should've been 2nd, with other "Sort by filename" entry
![image](https://user-images.githubusercontent.com/10298730/95617392-a7ec6d00-0a6b-11eb-92c1-3cb52e702ad4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6777)
<!-- Reviewable:end -->
