### PR TITLE
Disable HW inversion on rM

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -15,8 +15,8 @@ local Remarkable = Generic:new{
     isTouchDevice = yes,
     hasFrontlight = no,
     display_dpi = 226,
-    -- It's a recent NXP SoC, I see no reason why HW inversion would be buggy there ;).
-    canHWInvert = yes,
+    -- Despite the SoC supporting it, it's finicky in practice (#6772)
+    canHWInvert = no,
     home_dir = "/mnt/root",
 }
 


### PR DESCRIPTION
Turns out it's being weird like on Mk. 7 Kobos with a crapload of PxP
processing flags.
Except without the "crapload of flags", part :D.

Re: #6772

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6779)
<!-- Reviewable:end -->
