### PR TITLE
Dispatcher: allow registering actions at runtime

### DIFF
--- a/doc/config.ld
+++ b/doc/config.ld
@@ -20,7 +20,12 @@ format = 'markdown'
 sort_modules = true
 file = {
     '../frontend',
+    '../plugins',
     '../base/ffi',
     '../platform/android/luajit-launcher/assets',
-    exclude = {'../base/ffi/sha2.lua'},
+    exclude = {'../base/ffi/sha2.lua',
+        '../plugins/evernote.koplugin/slt2.lua',
+        '../plugins/newsdownloader.koplugin/lib/handler.lua',
+        '../plugins/newsdownloader.koplugin/lib/xml.lua',
+    },
 }

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1,5 +1,28 @@
 --[[--
-    Dispatcher module
+This module is responsible for dispatching events.
+
+To add a new action an entry must be added to `settingsList` & `dispatcher_menu_order`
+This can also be done at runtime via @{registerAction}().
+
+`settingsList` contains the list of dispatchable settings.
+
+Each setting contains:
+
+* category: one of:
+    * none: a direct event call
+    * arg: a event that expects a gesture object or an argument
+    * absolutenumber: event that sets a number
+    * incrementalnumber: event that increments a number & accepts a gesture object
+    * string: event with a list of arguments to chose from
+* event: what to call.
+* title: for use in ui.
+* section: under which menu to display (currently: device, filemanager, rolling, paging)
+    and optionally
+* min/max: for number
+* default
+* args: allowed values for string.
+* toggle: display name for args
+* separator: put a separator after in the menu list
 --]]--
 
 local CreOptions = require("ui/data/creoptions")
@@ -15,25 +38,7 @@ local Dispatcher = {
     initialized = false,
 }
 
---[[--
-contains a list of a dispatchable settings
-each setting contains:
-    category: one of
-       none: a direct event call
-       arg: a event that expects a gesture object or an argument
-       absolutenumber: event that sets a number
-       incrementalnumber: event that increments a number & accepts a gesture object
-       string: event with a list of arguments to chose from
-    event: what to call.
-    title: for use in ui.
-    section: under which menu to display (currently: device, filemanager, rolling, paging)
-and optionally
-    min/max: for number
-    default
-    args: allowed values for string.
-    toggle: display name for args
-    separator: put a separator after in the menu list
---]]--
+-- See above for description.
 local settingsList = {
     -- Device settings
     show_frontlight_dialog = { category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), device=true, condition=Device:hasFrontlight(),},
@@ -322,10 +327,20 @@ function Dispatcher:init()
 end
 
 --[[--
-    add settings at runtime
-    @param name: the key to use in the table
-    @param value: a table per settingsList above.
-    see helloworld plugin for an example.
+Adds settings at runtime.
+
+@usage
+    function Hello:onDispatcherRegisterActions()
+        Dispatcher:registerAction("helloworld_action", {category="none", event="HelloWorld", title=_("Hello World"), filemanager=true,})
+    end
+
+    function Hello:init()
+        self:onDispatcherRegisterActions()
+    end
+
+
+@param name the key to use in the table
+@param value a table per settingsList above
 --]]--
 function Dispatcher:registerAction(name, value)
     if settingsList[name] == nil then

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -10,6 +10,7 @@
 local BD = require("ui/bidi")
 local CalibreSearch = require("search")
 local CalibreWireless = require("wireless")
+local Dispatcher = require("dispatcher")
 local InfoMessage = require("ui/widget/infomessage")
 local LuaSettings = require("luasettings")
 local UIManager = require("ui/uimanager")
@@ -57,8 +58,15 @@ function Calibre:closeWirelessConnection()
     end
 end
 
+function Calibre:onDispatcherRegisterActions()
+    Dispatcher:registerAction("calibre_search", { category="none", event="CalibreSearch", title=_("Search in calibre metadata"), device=true,})
+    Dispatcher:registerAction("calibre_browse_tags", { category="none", event="CalibreBrowseTags", title=_("Browse all calibre tags"), device=true,})
+    Dispatcher:registerAction("calibre_browse_series", { category="none", event="CalibreBrowseSeries", title=_("Browse all calibre series"), device=true, separator=true,})
+end
+
 function Calibre:init()
     CalibreWireless:init()
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
 end
 

--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -1,10 +1,12 @@
---[[
-    This module implements functions for loading, saving and editing calibre metadata files.
+--[[--
+This module implements functions for loading, saving and editing calibre metadata files.
 
-    Calibre uses JSON to store metadata on device after each wired transfer.
-    In wireless transfers calibre sends the same metadata to the client, which is in charge
-    of storing it.
---]]
+Calibre uses JSON to store metadata on device after each wired transfer.
+In wireless transfers calibre sends the same metadata to the client, which is in charge
+of storing it.
+
+@module koplugin.calibre.metadata
+--]]--
 
 local rapidjson = require("rapidjson")
 local logger = require("logger")

--- a/plugins/hello.koplugin/main.lua
+++ b/plugins/hello.koplugin/main.lua
@@ -3,7 +3,8 @@ if true then
     return { disabled = true, }
 end
 
-local InfoMessage = require("ui/widget/infomessage")  -- luacheck:ignore
+local Dispatcher = require("dispatcher")  -- luacheck:ignore
+local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
@@ -13,7 +14,12 @@ local Hello = WidgetContainer:new{
     is_doc_only = false,
 }
 
+function Hello:onDispatcherRegisterActions()
+    Dispatcher:registerAction("helloworld_action", {category="none", event="HelloWorld", title=_("Hello World"), filemanager=true,})
+end
+
 function Hello:init()
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
 end
 
@@ -21,7 +27,7 @@ function Hello:addToMainMenu(menu_items)
     menu_items.hello_world = {
         text = _("Hello World"),
         -- in which menu this should be appended
-        sorting_hint = "more_plugins",
+        sorting_hint = "more_tools",
         -- a callback when tapping
         callback = function()
             UIManager:show(InfoMessage:new{
@@ -29,6 +35,13 @@ function Hello:addToMainMenu(menu_items)
             })
         end,
     }
+end
+
+function Hello:onHelloWorld()
+    local popup = InfoMessage:new{
+        text = _("Hello World"),
+    }
+    UIManager:show(popup)
 end
 
 return Hello

--- a/plugins/hello.koplugin/main.lua
+++ b/plugins/hello.koplugin/main.lua
@@ -1,3 +1,9 @@
+--[[--
+This is a debug plugin to test Plugin functionality.
+
+@module koplugin.HelloWorld
+--]]--
+
 -- This is a debug plugin, remove the following if block to enable it
 if true then
     return { disabled = true, }

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -1,3 +1,4 @@
+local Dispatcher = require("dispatcher")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LoginDialog = require("ui/widget/logindialog")
 local InfoMessage = require("ui/widget/infomessage")
@@ -97,6 +98,11 @@ local function validateUser(user, pass)
     end
 end
 
+function KOSync:onDispatcherRegisterActions()
+    Dispatcher:registerAction("kosync_push_progress", { category="none", event="KOSyncPushProgress", title=_("Push progress from this device"), rolling=true, paging=true,})
+    Dispatcher:registerAction("kosync_pull_progress", { category="none", event="KOSyncPullProgress", title=_("Pull progress from other devices"), rolling=true, paging=true, separator=true,})
+end
+
 function KOSync:onReaderReady()
     local settings = G_reader_settings:readSetting("kosync") or {}
     self.kosync_custom_server = settings.custom_server
@@ -112,6 +118,7 @@ function KOSync:onReaderReady()
         self:_onResume()
     end
     self:registerEvents()
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
     -- Make sure checksum has been calculated at the very first time a document has been opened, to
     -- avoid document saving feature to impact the checksum, and eventually impact the document

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -1,6 +1,7 @@
 local ButtonDialog = require("ui/widget/buttondialog")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local DataStorage = require("datastorage")
+local Dispatcher = require("dispatcher")
 local Font = require("ui/font")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
@@ -30,7 +31,12 @@ local Terminal = WidgetContainer:new{
     source = "terminal",
 }
 
+function Terminal:onDispatcherRegisterActions()
+    Dispatcher:registerAction("show_terminal", { category = "none", event = "TerminalStart", title = _("Show terminal"), device = true, })
+end
+
 function Terminal:init()
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
     self.shortcuts = self.settings:readSetting("shortcuts") or {}
 end

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -1,6 +1,7 @@
 local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
+local Dispatcher = require("dispatcher")
 local Font = require("ui/font")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
@@ -29,7 +30,12 @@ local TextEditor = WidgetContainer:new{
     min_file_size_warn = 200000, -- warn/ask when opening files bigger than this
 }
 
+function TextEditor:onDispatcherRegisterActions()
+    Dispatcher:registerAction("edit_last_edited_file", { category = "none", event = "OpenLastEditedFile", title = _("Texteditor: open last file"), device = true, separator = true, })
+end
+
 function TextEditor:init()
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
 end
 

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -4,6 +4,7 @@
 
 local BD = require("ui/bidi")
 local DataStorage = require("datastorage")
+local Dispatcher = require("dispatcher")
 local DocSettings = require("docsettings")
 local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
@@ -38,6 +39,10 @@ local Wallabag = WidgetContainer:new{
     name = "wallabag",
 }
 
+function Wallabag:onDispatcherRegisterActions()
+    Dispatcher:registerAction("wallabag_download", { category="none", event="SynchronizeWallabag", title=_("Wallabag retrieval"), device=true,})
+end
+
 function Wallabag:init()
     self.token_expiry = 0
     -- default values so that user doesn't have to explicitely set them
@@ -50,6 +55,7 @@ function Wallabag:init()
     self.ignore_tags = ""
     self.articles_per_sync = 30
 
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
     self.wb_settings = self.readSettings()
     self.server_url = self.wb_settings.data.wallabag.server_url


### PR DESCRIPTION
as discussed in #6768 and elsewhere.

Dispatcher was updated as not to crash on not existent entries.

I extended the Hello World Plugin to serve as an example.

the important parts.

the plugin must define a `DispatcherRegisterActions` event like so, and call it on init in case the plugin is loaded after Dispatcher:
```lua
function Hello:onDispatcherRegisterActions()
    Dispatcher:RegisterAction("helloworld_action", {category="none", event="HelloWorld", title=_("Hello World"), filemanager=true,})
end
```

If there is a non registered item attached to a gesture/profile (someone enabled a gesture and then disabled the appropriate plugin). then the menu will keep that item, but it will not show in any of the sections as there is no corresponding entry. However the `None` box will **not** be checked so one will realize that something is different. Also one can at any time click on `None` and clear out the gesture/profile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6785)
<!-- Reviewable:end -->
