### PR TITLE
fontlist: Cache categorized font info (for mupdf)

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -4,6 +4,7 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
 local Font = require("ui/font")
+local FontList = require("fontlist")
 local Input = Device.input
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Menu = require("ui/widget/menu")
@@ -61,12 +62,17 @@ function ReaderFont:init()
     -- Font list
     local face_list = cre.getFontFaces()
     for k,v in ipairs(face_list) do
+        local font_filename, font_faceindex = cre.getFontFaceFilenameAndFaceIndex(v)
         table.insert(self.face_table, {
             text_func = function()
                 -- defaults are hardcoded in credocument.lua
                 local default_font = G_reader_settings:readSetting("cre_font") or self.ui.document.default_font
                 local fallback_font = G_reader_settings:readSetting("fallback_font") or self.ui.document.fallback_fonts[1]
                 local text = v
+                if font_filename and font_faceindex then
+                    text = FontList:getLocalizedFontName(font_filename, font_faceindex) or text
+                end
+
                 if v == default_font then
                     text = text .. "   ★"
                 end
@@ -77,7 +83,6 @@ function ReaderFont:init()
             end,
             font_func = function(size)
                 if G_reader_settings:nilOrTrue("font_menu_use_font_face") then
-                    local font_filename, font_faceindex = cre.getFontFaceFilenameAndFaceIndex(v)
                     if font_filename and font_faceindex then
                         return Font:getFace(font_filename, size, font_faceindex)
                     end

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -580,6 +580,28 @@ function util.getFilesystemType(path)
     return type
 end
 
+--- Recursively scan directory for files inside
+-- @string path
+-- @function callback(fullpath, name, attr)
+function util.findFiles(dir, cb)
+    local function scan(current)
+        local ok, iter, dir_obj = pcall(lfs.dir, current)
+        if not ok then return end
+        for f in iter, dir_obj do
+            local path = current.."/"..f
+            local attr = lfs.attributes(path)
+            if attr.mode == "directory" then
+                if f ~= "." and f ~= ".." then
+                    scan(path)
+                end
+            else
+                cb(path, f, attr)
+            end
+        end
+    end
+    scan(dir)
+end
+
 --- Checks if directory is empty.
 ---- @string path
 ---- @treturn bool


### PR DESCRIPTION
Info about each face (l10n, name, family, style etc) is
now cached offline, so fonts can be queried ahead of time.

Fixes https://github.com/koreader/koreader/issues/6763
needs https://github.com/koreader/koreader-base/pull/1215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6786)
<!-- Reviewable:end -->
