### PR TITLE
Pocketbook: use raw input I/O

### DIFF
--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -14,7 +14,6 @@ local PocketBookPowerD = BasePowerD:new{
 
 function PocketBookPowerD:init()
     -- needed for SetFrontlightState / GetFrontlightState
-    inkview.OpenScreen()
     if self.device:hasNaturalLight() then
         local color = inkview.GetFrontlightColor()
         self.fl_warmth = color >= 0 and color or 0

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1321,6 +1321,8 @@ function UIManager:suspend()
         self.event_handlers["Suspend"]()
     elseif Device:isKindle() then
         Device.powerd:toggleSuspend()
+    elseif Device.isPocketBook() and Device.canSuspend() then
+        Device:suspend()
     end
 end
 

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -14,6 +14,9 @@ if [ "${INSTANCE_PID}" != "" ] && [ -e "/proc/${INSTANCE_PID}" ]; then
     exec /usr/bin/iv2sh SetActiveTask "${INSTANCE_PID}" 0
 fi
 
+# try to bring in raw device input (on rooted devices)
+/mnt/secure/su /bin/chmod 644 /dev/input/*
+
 # we're first, so publish our instance
 echo $$ >/tmp/koreader.pid
 


### PR DESCRIPTION
This allows for better energy efficiency (no more 50Hz tick poll),
as well as lower input lag / higher precision - touch events are
native linux ones.

In addition, auto off/suspend plugin is used in this mode, as we need
to trigger (timed) sleep / poweroff on our own, since the OS ones
will no longer work whenever koreader has focus.

This is for rooted devices only, and possibly somewhat FW
specific, so enabled only on PB740-2 where it's reasonably tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6791)
<!-- Reviewable:end -->
