### PR TITLE
Pocketbook: waveform presets

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -91,7 +91,7 @@ function PocketBook:init()
             if fb:isB288() then
                 logger.dbg("mxcfb: Disabling hwinvert on B288 chipset")
                 self.canHWInvert = no
-                -- GL16 glitches with hwinvert
+                -- GL16 glitches with hwrot
                 if fb.wf_level == 3 then
                     logger.dbg("mxcfb: Disabling hwrot on fast waveforms (B288 glitch)")
                     fb.forced_rotation = nil

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -74,13 +74,6 @@ local function tryOpenBook()
     end
 end
 
-local function isB288(fb)
-    -- No real header exists for this, see https://github.com/koreader/koreader-base/issues/1202/
-    local B288_POLL_FOR_UPDATE_COMPLETE = 0x80044655
-    -- On NXT that has a real MXC driver, it returns -EINVAL
-    return C.ioctl(fb.fd, B288_POLL_FOR_UPDATE_COMPLETE, ffi.new("uint32_t[1]")) == 0
-end
-
 function PocketBook:init()
     local raw_input = self.raw_input
     local touch_rotation = raw_input and raw_input.touch_rotation or 0
@@ -88,17 +81,24 @@ function PocketBook:init()
     self.screen = require("ffi/framebuffer_mxcfb"):new {
         device = self,
         debug = logger.dbg,
+        wf_level = G_reader_settings:readSetting("wf_level") or 0,
         fbinfoOverride = function(fb, finfo, vinfo)
             -- Device model caps *can* set both to indicate that either will work to get correct orientation.
             -- But for FB backend, the flags are mutually exclusive, so we nuke one of em later.
             fb.is_always_portrait = self.isAlwaysPortrait()
             fb.forced_rotation = self.usingForcedRotation()
-            -- Tweak combination of alwaysPortrait/hwRot/hwInvert flags depending on probed HW.
-            if isB288(fb) then
-                logger.dbg("mxcfb: Detected B288 chipset, disabling HW rotation and invert")
-                fb.forced_rotation = nil
+            -- Tweak combination of alwaysPortrait/hwRot/hwInvert flags depending on probed HW and wf settings.
+            if fb:isB288() then
+                logger.dbg("mxcfb: Disabling hwinvert on B288 chipset")
                 self.canHWInvert = no
-            elseif fb.forced_rotation then
+                -- GL16 glitches with hwinvert
+                if fb.wf_level == 3 then
+                    logger.dbg("mxcfb: Disabling hwrot on fast waveforms (B288 glitch)")
+                    fb.forced_rotation = nil
+                end
+            end
+            -- if hwrot is still on, nuke swrot
+            if fb.forced_rotation then
                 fb.is_always_portrait = false
             end
             return self._fb_init(fb, finfo, vinfo)

--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -27,6 +27,9 @@ local eink_settings_table = {
 
 if Device:hasEinkScreen() then
     table.insert(eink_settings_table.sub_item_table, 1, require("ui/elements/refresh_menu_table"))
+    if (Screen.wf_level_max or 0) > 0 then
+        table.insert(eink_settings_table.sub_item_table, require("ui/elements/waveform_level"))
+    end
 end
 
 return eink_settings_table

--- a/frontend/ui/elements/waveform_level.lua
+++ b/frontend/ui/elements/waveform_level.lua
@@ -9,9 +9,9 @@ local items = {}
 for i=0, Screen.wf_level_max do
     local info
     if i == 0 then
-        info = _("Level 0: High quality, slow")
+        info = _("Level 0: high quality, slowest")
     elseif i == Screen.wf_level_max then
-        info = T(_("Level %1: Low quality, fast"), i)
+        info = T(_("Level %1: low quality, fastest"), i)
     else
         info = T(_("Level %1"), i)
     end
@@ -30,7 +30,7 @@ for i=0, Screen.wf_level_max do
 end
 
 return {
-    text = _("Update aggressiveness"),
+    text = _("Refresh speed/fidelity"),
     sub_item_table = items,
 }
 

--- a/frontend/ui/elements/waveform_level.lua
+++ b/frontend/ui/elements/waveform_level.lua
@@ -1,0 +1,36 @@
+local _ = require("gettext")
+local Device = require("device")
+local InfoMessage = require("ui/widget/infomessage")
+local UIManager = require("ui/uimanager")
+local Screen = Device.screen
+local T = require("ffi/util").template
+
+local items = {}
+for i=0, Screen.wf_level_max do
+    local info
+    if i == 0 then
+        info = _("Level 0: High quality, slow")
+    elseif i == Screen.wf_level_max then
+        info = T(_("Level %1: Low quality, fast"), i)
+    else
+        info = T(_("Level %1"), i)
+    end
+
+    table.insert(items, {
+        text = info,
+        checked_func = function() return Screen.wf_level == i end,
+        callback = function()
+            Screen.wf_level = i
+            G_reader_settings:saveSetting("wf_level", i)
+            UIManager:show(InfoMessage:new{
+                text = _("This will take effect on next restart."),
+            })
+        end,
+    })
+end
+
+return {
+    text = _("Update aggressiveness"),
+    sub_item_table = items,
+}
+


### PR DESCRIPTION
cf https://github.com/koreader/koreader-base/issues/1202

On pocketbook, update modes are not as clear cut due to overall
chipset and kernel version mess. Inkview solves this by always
using the slowest (and safe) GC16 waveform. We now do that too
by default.

Slow updates suck though, so there's now a menu entry to configure
it for speed (with mild artifacts at best, kernel panic at worst).

This is a generic interface (any eink Screen can announce support).
The driver may interpret the slow/fast range however they want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6794)
<!-- Reviewable:end -->
