### PR TITLE
Statistics: speed up Calendar view

### DIFF
--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -96,6 +96,9 @@ function HistogramWidget:paintTo(bb, x, y)
         local i_w = self.item_widths[n]
         local ratio = self.ratios and self.ratios[n] or 0
         local i_h = Math.round(ratio * self.height)
+        if i_h == 0 and ratio > 0 then -- show at least 1px
+            i_h = 1
+        end
         local i_y = self.height - i_h
         if i_h > 0 then
             bb:paintRect(x + i_x, y + i_y, i_w, i_h, self.color)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2299,8 +2299,8 @@ function ReaderStatistics:getReadingRatioPerHourByDay(month)
             strftime('%H', start_time, 'unixepoch', 'localtime') hour,
             sum(duration)/3600.0 ratio
         FROM   page_stat
-        WHERE  start_time >= strftime('%s', ?, 'utc')
-          AND  start_time < strftime('%s', ?, 'utc', '33 days', 'start of month')
+        WHERE  start_time BETWEEN strftime('%s', ?, 'utc')
+                              AND strftime('%s', ?, 'utc', '+33 days', 'start of month', '-1 second')
         GROUP  BY
             strftime('%Y-%m-%d', start_time, 'unixepoch', 'localtime'),
             strftime('%H', start_time, 'unixepoch', 'localtime')
@@ -2333,8 +2333,8 @@ function ReaderStatistics:getReadBookByDay(month)
             book.title book_title
         FROM   page_stat
         JOIN   book ON book.id = page_stat.id_book
-        WHERE  start_time >= strftime('%s', ?, 'utc')
-          AND  start_time < strftime('%s', ?, 'utc', '33 days', 'start of month')
+        WHERE  start_time BETWEEN strftime('%s', ?, 'utc')
+                              AND strftime('%s', ?, 'utc', '+33 days', 'start of month', '-1 second')
         GROUP  BY
             strftime('%Y-%m-%d', start_time, 'unixepoch', 'localtime'),
             id_book,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -403,6 +403,7 @@ local STATISTICS_DB_PAGE_STAT_DATA_SCHEMA = [[
             UNIQUE (id_book, page, start_time),
             FOREIGN KEY(id_book) REFERENCES book(id)
         );
+    CREATE INDEX IF NOT EXISTS page_stat_data_start_time ON page_stat_data(start_time);
 ]]
 
 local STATISTICS_DB_PAGE_STAT_VIEW_SCHEMA = [[

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -510,6 +510,13 @@ function ReaderStatistics:upgradeDB(conn)
     ]]
     conn:exec(sql_stmt)
 
+    -- Get back the space taken by the deleted page_stat table
+    conn:exec("PRAGMA temp_store = 2;") -- use memory for temp files
+    local ok, errmsg = pcall(conn.exec, conn, "VACUUM;") -- this may take some time
+    if not ok then
+        logger.warn("Failed compacting statistics database:", errmsg)
+    end
+
     -- Create the new page_stat view stuff
     conn:exec(STATISTICS_DB_PAGE_STAT_VIEW_SCHEMA)
 


### PR DESCRIPTION
Just by tweaking the SQL queries.
Also, in the hourly histogram, show at least a 1px bar when there was any reading this hour.

I always thought the slowness of showing and browsing the calendar views was caused by the many little widgets to size and draw, but no, it was really the SQL queries (and it was as slow before the recent refactoring).
On my Kobo, each of the 2 SQL queries used to take 500ms (and the UI drawing around 20ms)- and it was quite noticable.
With these tweaks, each SQL query take around 100ms.

(By adding an index `CREATE INDEX zzz ON page_stat_data(start_time)`, we'd get even better results, 50ms + 30ms - but well, it makes the DB file size grow by 30%, and it's not worth again upgrading the schema.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6807)
<!-- Reviewable:end -->
