### PR TITLE
android: handle onDestroy

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -134,6 +134,9 @@ function Device:init()
             logger.dbg("Android application event", ev.code)
             if ev.code == C.APP_CMD_SAVE_STATE then
                 return "SaveState"
+            elseif ev.code == C.APP_CMD_DESTROY then
+                self:exit()
+                os.exit()
             elseif ev.code == C.APP_CMD_GAINED_FOCUS
                 or ev.code == C.APP_CMD_INIT_WINDOW
                 or ev.code == C.APP_CMD_WINDOW_REDRAW_NEEDED then

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -135,8 +135,7 @@ function Device:init()
             if ev.code == C.APP_CMD_SAVE_STATE then
                 return "SaveState"
             elseif ev.code == C.APP_CMD_DESTROY then
-                self:exit()
-                os.exit()
+                UIManager:quit()
             elseif ev.code == C.APP_CMD_GAINED_FOCUS
                 or ev.code == C.APP_CMD_INIT_WINDOW
                 or ev.code == C.APP_CMD_WINDOW_REDRAW_NEEDED then


### PR DESCRIPTION
We need it to exit the lua state and return from android_main. This avoid a *zombie state** on the following scenarios:

- App is killed by the activity manager  (ie: battery optimizations or OOM)
- We call finish() from Kotlin

**zombie state**: app is running, does nothing, won't easily trigger ANRs and needs to be killed manually by the user

In the real world the only related bug I found was on android10+, when running KO ocassionally and leaving the activity in the background for a week. The app is then destroyed by the system to "save battery".

As android has a way to "upgrade" or "downgrade" app battery optimization based on usage, YMMV.



Requires https://github.com/koreader/koreader-base/pull/1224

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6811)
<!-- Reviewable:end -->
