### PR TITLE
Plugin for saving the cover image to file

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -382,11 +382,6 @@ function Device:isValidPath(path)
     return android.isPathInsideSandbox(path)
 end
 
-function Device:isValidFile(filename)
-    local path, name = util.splitFilePathName(filename)
-    return Device:isValidPath(path) and name ~= "" and lfs.attributes(filename, "mode") ~= "directory"
-end
-
 --swallow all events
 local function processEvents()
     local events = ffi.new("int[1]")

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -375,18 +375,11 @@ function Device:canExecuteScript(file)
     end
 end
 
-function Device:isValidPath(name)
-    local path, _ = util.splitFilePathName(name)
-    if android.isPathInsideSandbox(name) then
+function Device:isValidPath(path)
+    if path:find("^/sdcard") ~= nil then
         return true
-    else -- test if name is a symlink to the sandbox
-        path = path:gsub("/$", "") -- lua does not like trailing slash
-        if lfs.symlinkattributes(path, "mode") == "link" then
-            return android.isPathInsideSandbox(lfs.symlinkattributes(path, "target"))
-        else
-            return false
-        end
     end
+    return android.isPathInsideSandbox(path)
 end
 
 --swallow all events

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -376,9 +376,6 @@ function Device:canExecuteScript(file)
 end
 
 function Device:isValidPath(path)
-    if path:find("^/sdcard") ~= nil then
-        return true
-    end
     return android.isPathInsideSandbox(path)
 end
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -382,6 +382,11 @@ function Device:isValidPath(path)
     return android.isPathInsideSandbox(path)
 end
 
+function Device:isValidFile(filename)
+    local path, name = util.splitFilePathName(filename)
+    return Device:isValidPath(path) and name ~= "" and lfs.attributes(filename, "mode") ~= "directory"
+end
+
 --swallow all events
 local function processEvents()
     local events = ffi.new("int[1]")

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -491,4 +491,9 @@ function Device:isValidPath(path)
     return util.pathExists(path)
 end
 
+function Device:isValidFile(filename)
+    local path, name = util.splitFilePathName(filename)
+    return Device:isValidPath(path) and name ~= "" and lfs.attributes(filename, "mode") ~= "directory"
+end
+
 return Device

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -487,9 +487,7 @@ function Device:canExecuteScript(file)
     end
 end
 
-function Device:isValidPath(name)
-    local path, _ = util.splitFilePathName(name)
-    -- pathExists wants trailing slash
+function Device:isValidPath(path)
     return util.pathExists(path)
 end
 

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -487,4 +487,10 @@ function Device:canExecuteScript(file)
     end
 end
 
+function Device:isValidPath(name)
+    local path, _ = util.splitFilePathName(name)
+    -- pathExists wants trailing slash
+    return util.pathExists(path)
+end
+
 return Device

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -491,9 +491,4 @@ function Device:isValidPath(path)
     return util.pathExists(path)
 end
 
-function Device:isValidFile(filename)
-    local path, name = util.splitFilePathName(filename)
-    return Device:isValidPath(path) and name ~= "" and lfs.attributes(filename, "mode") ~= "directory"
-end
-
 return Device

--- a/plugins/coverimage.koplugin/_meta.lua
+++ b/plugins/coverimage.koplugin/_meta.lua
@@ -2,5 +2,5 @@ local _ = require("gettext")
 return {
     name = "coverimage",
     fullname = _("Cover Image"),
-    description = _([[Stores cover image to a file]]),
+    description = _([[Stores cover image to a file.]]),
 }

--- a/plugins/coverimage.koplugin/_meta.lua
+++ b/plugins/coverimage.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = "coverimage",
+    fullname = _("Cover Image"),
+    description = _([[Stores cover image to a file]]),
+}

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -7,6 +7,7 @@ end
 local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local ffiutil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local util = require("util")
@@ -19,7 +20,7 @@ local function pathOk(filename)
 end
 
 local CoverImage = WidgetContainer:new{
-    name = 'coverimage',
+    name = "coverimage",
     is_doc_only = true,
 }
 
@@ -56,8 +57,8 @@ function CoverImage:cleanUpImage()
             timeout = 10,
         })
         os.remove(self.cover_image_path)
-    else
-        os.execute("cp \"" .. self.cover_image_fallback_path .. "\" \"" .. self.cover_image_path .. "\"")
+    elseif Device:isValidFile(self.cover_image_path) then
+        ffiutil.copyFile(self.cover_image_fallback_path, self.cover_image_path)
     end
 end
 

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -87,6 +87,9 @@ function CoverImage:addToMainMenu(menu_items)
                 text_func = function()
                     return self.cover_image_path and _("Set system screensaver image")
                 end,
+                checked_func = function()
+                    return self.cover_image_path ~= ""
+                end,
                 keep_menu_open = true,
                 callback = function(menu)
                     local InputDialog = require("ui/widget/inputdialog")
@@ -176,6 +179,9 @@ function CoverImage:addToMainMenu(menu_items)
             {
                 text_func = function()
                     return self.cover_image_path and _("Set fallback image when no cover or excl. book")
+                end,
+                checked_func = function()
+                    return self.cover_image_fallback_path ~= ""
                 end,
                 keep_menu_open = true,
                 callback = function(menu)

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -1,0 +1,134 @@
+local Device = require("device")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local logger = require("logger")
+local _ = require("gettext")
+local T = require("ffi/util").template
+
+local CoverImage = WidgetContainer:new{
+    name = 'coverimage',
+    is_doc_only = true,
+    settings_id = 0,
+}
+
+function CoverImage:_enabled()
+    return self.enabled
+end
+
+function CoverImage:_restore()
+    return self.enabled and self.restore
+end
+
+function CoverImage:init()
+    self.cover_image_path = G_reader_settings:readSetting("cover_image_path") or "Cover.jpg"
+    self.enabled = G_reader_settings:isTrue("cover_image_enabled")
+    self.restore = G_reader_settings:isTrue("cover_image_restore") and self.enabled
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function CoverImage:onCloseDocument()
+    logger.dbg("CoverImage: onCloseDocument")
+    local lfs = require("libs/libkoreader-lfs")
+    -- Try to restore the state before start of KOReader.
+    -- If KOReader gets updated during operation (at least on Android) the backup survives.
+    -- Under normal conditions this should not happen.
+    if self.restore then
+        -- Delete image unconditionally, so if no backup exists, there will be no cover file.
+        -- This is useful on Tolino to use the system sleep image after KOReader exit.
+        if lfs.attributes(self.cover_image_path) then
+            os.execute("rm " .. self.cover_image_path)
+        end
+        -- Restore backup if it exists, so we can use the last image.
+        -- On Tolino a user defined /sdcard/tolino_others.jgp can be used as screensaver on system sleep.
+        if lfs.attributes(self.cover_image_path ..".bak") then
+            os.execute("mv " .. self.cover_image_path .. ".bak " .. self.cover_image_path)
+        end
+    end
+end
+
+function CoverImage:onDocSettingsLoad(doc_settings, document)
+   logger.dbg("CoverImage: onDocSettingsLoad")
+   if self.enabled then
+        local lfs = require("libs/libkoreader-lfs")
+        local image = document:getCoverPageImage()
+        if image then
+            -- Do not override an existing backup, as this only exists on a crash or abnormal update of KOReader.
+            -- This is very usefull, if an image shall be used as a system screensaver (e.g. on Tolino as /sdcard/suspend_other.jpg)
+            if not lfs.attributes(self.cover_image_path ..".bak") then
+                os.execute("cp " .. self.cover_image_path .. " " .. self.cover_image_path .. ".bak" )
+            end
+            Device.screen.bb.writePNG(image, self.cover_image_path, false)
+        end
+    end
+end
+
+function CoverImage:addToMainMenu(menu_items)
+    menu_items.coverimage = {
+--        sorting_hint = "device", -- maybe this plugin is better situated in device?
+        text_func = function() return _("Cover Image") end,
+        checked_func = function() return self:_enabled() end,
+        sub_item_table = {
+            {
+                text_func = function() return self.cover_image_path and T(_("Cover Image (%1)"), self.cover_image_path)
+                    or _("Cover Image (none)") end,
+                checked_func = function() return self:_enabled() end,
+                callback = function(menu)
+                local InputDialog = require("ui/widget/inputdialog")
+                local sample_input
+                sample_input = InputDialog:new{
+                    title = _("Filename for Cover-Image"),
+                    input = self.cover_image_path,
+                    input_type = "string",
+                    description = _("You can enter the filename of the cover image here."),
+                    buttons = {
+                        {
+                            {
+                                text = _("Cancel"),
+                                callback = function()
+                                    UIManager:close(sample_input)
+                                    menu:updateItems()
+                                end,
+                            },
+                            {
+                                text = _("Disable"),
+                                callback = function()
+                                    self.cover_image_path = sample_input:getInputText()
+                                    G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
+                                    self.enabled = false
+                                    G_reader_settings:saveSetting("cover_image_enabled", false)
+                                    UIManager:close(sample_input)
+                                    menu:updateItems()
+                                end,
+                            },
+                            {
+                                text = _("Enable"),
+                                is_enter_default = true,
+                                callback = function()
+                                    self.cover_image_path = sample_input:getInputText()
+                                    G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
+                                    self.enabled = true
+                                    G_reader_settings:saveSetting("cover_image_enabled", true)
+                                    UIManager:close(sample_input)
+                                    menu:updateItems()
+                                end,
+                            },
+                        }
+                    },
+                }
+                UIManager:show(sample_input)
+                sample_input:onShowKeyboard()
+                end
+            },
+            {
+                text_func = function() return _("Restore image on exit") end,
+                checked_func = function() return self:_restore() end,
+                callback = function()
+                self.restore = not self.restore and self.enabled
+                G_reader_settings:saveSetting("cover_image_restore", self.restore)
+                end,
+            },
+        },
+    }
+end
+
+return CoverImage

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -62,7 +62,7 @@ function CoverImage:onReaderReady(doc_settings)
             if not lfs.attributes(self.cover_image_path ..".bak") then
                 os.rename(self.cover_image_path, self.cover_image_path .. ".bak" )
             end
-            Device.screen.bb.writePNG(image, self.cover_image_path, false)
+            image:writePNG(self.cover_image_path, false)
         end
     end
 end

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -30,8 +30,12 @@ function CoverImage:excluded()
     local lastfile = G_reader_settings:readSetting("lastfile")
     local exclude_ss = false -- consider it not excluded if there's no docsetting
     if DocSettings:hasSidecarFile(lastfile) then
-        local doc_settings = DocSettings:open(lastfile)
-        exclude_ss = doc_settings:readSetting("exclude_cover_image")
+        if self and self.ui then
+            exclude_ss = self.ui.doc_settings:readSetting("exclude_cover_image")
+        else
+            local doc_settings = DocSettings:open(lastfile)
+            exclude_ss = doc_settings:readSetting("exclude_cover_image")
+        end
     end
     return exclude_ss or false
 end

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -19,7 +19,7 @@ local function pathOk(filename)
     if not Device:isValidPath(path) then -- isValidPath expects a trailing slash
         return false, T(_("Path \"%1\" isn't in a writable location."), path)
     elseif not util.pathExists(path:gsub("/$", "")) then -- pathExists expects no trailing slash
-        return false, T(_("The path \"%1\" doesn't exist"), path)
+        return false, T(_("The path \"%1\" doesn't exist."), path)
     elseif name == "" then
         return false, _("Please enter a filename at the end of the path.")
     elseif lfs.attributes(filename, "mode") == "directory" then

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -65,6 +65,16 @@ function CoverImage:cleanUpImage()
     end
 end
 
+function CoverImage:createCoverImage(doc_settings)
+   if self.enabled and not doc_settings:readSetting("exclude_cover_image") == true then
+        local image = self.ui.document:getCoverPageImage()
+        if image then
+            image:writePNG(self.cover_image_path, false)
+            logger.dbg("CoverImage: image written to " .. self.cover_image_path)
+        end
+    end
+end
+
 function CoverImage:onCloseDocument()
     logger.dbg("CoverImage: onCloseDocument")
     if self.fallback then
@@ -73,14 +83,8 @@ function CoverImage:onCloseDocument()
 end
 
 function CoverImage:onReaderReady(doc_settings)
-   logger.dbg("CoverImage: onReaderReady")
-   if self.enabled and not doc_settings:readSetting("exclude_cover_image") == true then
-        local image = self.ui.document:getCoverPageImage()
-        if image then
-            image:writePNG(self.cover_image_path, false)
-            logger.dbg("CoverImage: image written to " .. self.cover_image_path)
-        end
-    end
+    logger.dbg("CoverImage: onReaderReady")
+    self:createCoverImage(doc_settings)
 end
 
 local about_text = _([[
@@ -148,7 +152,7 @@ function CoverImage:addToMainMenu(menu_items)
                                             G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
                                             local is_path_ok, is_path_ok_message = pathOk(self.cover_image_path)
                                             if self.cover_image_path ~= "" and is_path_ok then
-                                                self:onReaderReady(self.ui.doc_settings) -- with new filename
+                                                self:createCoverImage(self.ui.doc_settings) -- with new filename
                                             else
                                                 self.enabled = false
                                                 UIManager:show(InfoMessage:new{
@@ -182,7 +186,7 @@ function CoverImage:addToMainMenu(menu_items)
                         self.enabled = not self.enabled
                         G_reader_settings:saveSetting("cover_image_enabled", self.enabled)
                         if self.enabled then
-                            self:onReaderReady(self.ui.doc_settings)
+                            self:createCoverImage(self.ui.doc_settings)
                         else
                             self:cleanUpImage()
                         end
@@ -198,7 +202,7 @@ function CoverImage:addToMainMenu(menu_items)
                 callback = function()
                     if self.ui.doc_settings:readSetting("exclude_cover_image") == true then
                         self.ui.doc_settings:saveSetting("exclude_cover_image", false)
-                        self:onReaderReady(self.ui.doc_settings)
+                        self:createCoverImage(self.ui.doc_settings)
                     else
                         self.ui.doc_settings:saveSetting("exclude_cover_image", true)
                         self:cleanUpImage()

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -1,4 +1,9 @@
 local Device = require("device")
+
+if Device.isKindle == nil and Device.isKobo == nil then
+    return { disabled = true }
+end
+
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local logger = require("logger")
@@ -20,7 +25,7 @@ function CoverImage:_restore()
 end
 
 function CoverImage:init()
-    self.cover_image_path = G_reader_settings:readSetting("cover_image_path") or "Cover.jpg"
+    self.cover_image_path = G_reader_settings:readSetting("cover_image_path") or "Cover.png"
     self.enabled = G_reader_settings:isTrue("cover_image_enabled")
     self.restore = G_reader_settings:isTrue("cover_image_restore") and self.enabled
     self.ui.menu:registerToMainMenu(self)
@@ -36,26 +41,26 @@ function CoverImage:onCloseDocument()
         -- Delete image unconditionally, so if no backup exists, there will be no cover file.
         -- This is useful on Tolino to use the system sleep image after KOReader exit.
         if lfs.attributes(self.cover_image_path) then
-            os.execute("rm " .. self.cover_image_path)
+            os.remove(self.cover_image_path)
         end
         -- Restore backup if it exists, so we can use the last image.
         -- On Tolino a user defined /sdcard/tolino_others.jgp can be used as screensaver on system sleep.
         if lfs.attributes(self.cover_image_path ..".bak") then
-            os.execute("mv " .. self.cover_image_path .. ".bak " .. self.cover_image_path)
+            os.rename(self.cover_image_path .. ".bak", self.cover_image_path)
         end
     end
 end
 
-function CoverImage:onDocSettingsLoad(doc_settings, document)
-   logger.dbg("CoverImage: onDocSettingsLoad")
-   if self.enabled then
+function CoverImage:onReaderReady(doc_settings)
+   logger.dbg("CoverImage: onReaderReady")
+   if self.enabled and self.ui and self.ui.document then
         local lfs = require("libs/libkoreader-lfs")
-        local image = document:getCoverPageImage()
+        local image = self.ui.document:getCoverPageImage()
         if image then
             -- Do not override an existing backup, as this only exists on a crash or abnormal update of KOReader.
             -- This is very usefull, if an image shall be used as a system screensaver (e.g. on Tolino as /sdcard/suspend_other.jpg)
             if not lfs.attributes(self.cover_image_path ..".bak") then
-                os.execute("cp " .. self.cover_image_path .. " " .. self.cover_image_path .. ".bak" )
+                os.rename(self.cover_image_path, self.cover_image_path .. ".bak" )
             end
             Device.screen.bb.writePNG(image, self.cover_image_path, false)
         end
@@ -65,66 +70,80 @@ end
 function CoverImage:addToMainMenu(menu_items)
     menu_items.coverimage = {
 --        sorting_hint = "device", -- maybe this plugin is better situated in device?
-        text_func = function() return _("Cover Image") end,
-        checked_func = function() return self:_enabled() end,
+        sorting_hint = "document",
+        text_func = function()
+            return _("Cover Image")
+        end,
+        checked_func = function()
+            return self:_enabled()
+        end,
         sub_item_table = {
+            -- menu entry: filename dialog
             {
-                text_func = function() return self.cover_image_path and T(_("Cover Image (%1)"), self.cover_image_path)
-                    or _("Cover Image (none)") end,
-                checked_func = function() return self:_enabled() end,
+                text_func = function()
+                    return self.cover_image_path and T(_("Cover Image (%1)"), self.cover_image_path)
+                        or _("Cover Image (none)")
+                end,
+                keep_menu_open = true,
                 callback = function(menu)
-                local InputDialog = require("ui/widget/inputdialog")
-                local sample_input
-                sample_input = InputDialog:new{
-                    title = _("Filename for Cover-Image"),
-                    input = self.cover_image_path,
-                    input_type = "string",
-                    description = _("You can enter the filename of the cover image here."),
-                    buttons = {
-                        {
+                    local InputDialog = require("ui/widget/inputdialog")
+                    local sample_input
+                    sample_input = InputDialog:new{
+                        title = _("Filename for Cover-Image"),
+                        input = self.cover_image_path,
+                        input_type = "string",
+                        description = _("You can enter the filename of the cover image here."),
+                        buttons = {
                             {
-                                text = _("Cancel"),
-                                callback = function()
-                                    UIManager:close(sample_input)
-                                    menu:updateItems()
-                                end,
-                            },
-                            {
-                                text = _("Disable"),
-                                callback = function()
-                                    self.cover_image_path = sample_input:getInputText()
-                                    G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
-                                    self.enabled = false
-                                    G_reader_settings:saveSetting("cover_image_enabled", false)
-                                    UIManager:close(sample_input)
-                                    menu:updateItems()
-                                end,
-                            },
-                            {
-                                text = _("Enable"),
-                                is_enter_default = true,
-                                callback = function()
-                                    self.cover_image_path = sample_input:getInputText()
-                                    G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
-                                    self.enabled = true
-                                    G_reader_settings:saveSetting("cover_image_enabled", true)
-                                    UIManager:close(sample_input)
-                                    menu:updateItems()
-                                end,
-                            },
-                        }
-                    },
-                }
-                UIManager:show(sample_input)
-                sample_input:onShowKeyboard()
+                                {
+                                    text = _("Cancel"),
+                                    callback = function()
+                                        UIManager:close(sample_input)
+                                    end,
+                                },
+                                {
+                                    text = _("Save"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        self.cover_image_path = sample_input:getInputText()
+                                        G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
+                                        self.enabled = true
+                                        G_reader_settings:saveSetting("cover_image_enabled", true)
+                                        UIManager:close(sample_input)
+                                        menu:updateItems()
+                                    end,
+                                },
+                            }
+                        },
+                    }
+                    UIManager:show(sample_input)
+                    sample_input:onShowKeyboard()
                 end
             },
+            -- menu entry: enable
             {
-                text_func = function() return _("Restore image on exit") end,
-                checked_func = function() return self:_restore() end,
+                text_func = function()
+                    return _("Save cover on book opening")
+                end,
+                checked_func = function()
+                    return self:_enabled()
+                end,
                 callback = function()
-                self.restore = not self.restore and self.enabled
-                G_reader_settings:saveSetting("cover_image_restore", self.restore)
+                    self.enabled = not self.enabled
+                    G_reader_settings:saveSetting("cover_image_restore", self.enabled)
+                end,
+            },
+            -- menu entry: restore
+            {
+                text_func = function()
+                    return _("Restore image on exit")
+                end,
+                checked_func = function()
+                    return self:_restore()
+                end,
+                callback = function()
+                    self.restore = not self.restore and self.enabled
+                    G_reader_settings:saveSetting("cover_image_restore", self.restore)
                 end,
             },
         },

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -76,9 +76,20 @@ function CoverImage:showWrongPath( path )
     })
 end
 
+local about_text = _([[
+This plugin saves the current book cover to a file, so it can be used as a screensaver, if your android version and firmware supports it (e.g: Tolinos).
+
+If enabled the cover image of the actual file is stored to the selected screensaver file. Certain books can be excluded.
+
+If fallback is activated, the fallback file will be copied to the screensaver file on book closing. If the filename is empty or the file does not exist the system screensaver is used.
+
+If fallback is not activated the screensaver image remains on closing a book.
+    ]])
+
 function CoverImage:addToMainMenu(menu_items)
     menu_items.coverimage = {
-        sorting_hint = "document",
+--        sorting_hint = "document",
+        sorting_hint = "screen",
         text_func = function()
             return _("Cover Image")
         end,
@@ -86,6 +97,19 @@ function CoverImage:addToMainMenu(menu_items)
             return self.enabled or self.fallback
         end,
         sub_item_table = {
+            -- menu entry: about cover image
+            {
+                text_func = function()
+                    return _("About cover image")
+                end,
+                keep_menu_open = true,
+                callback = function()
+                    UIManager:show(InfoMessage:new{
+                        text = about_text,
+                    })
+                end,
+                separator = true,
+            },
             -- menu entry: filename dialog
             {
                 text_func = function()
@@ -138,7 +162,7 @@ function CoverImage:addToMainMenu(menu_items)
                     }
                     UIManager:show(sample_input)
                     sample_input:onShowKeyboard()
-                end
+                end,
             },
             -- menu entry: enable
             {
@@ -161,7 +185,7 @@ function CoverImage:addToMainMenu(menu_items)
                             self:cleanUpImage()
                         end
                     end
-                end
+                end,
             },
             -- menu entry: exclude this cover
             {

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -57,7 +57,7 @@ function CoverImage:cleanUpImage()
             timeout = 10,
         })
         os.remove(self.cover_image_path)
-    elseif Device:isValidFile(self.cover_image_path) then
+    elseif pathOk(self.cover_image_path) then
         ffiutil.copyFile(self.cover_image_fallback_path, self.cover_image_path)
     end
 end

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -90,18 +90,14 @@ function CoverImage:addToMainMenu(menu_items)
     menu_items.coverimage = {
 --        sorting_hint = "document",
         sorting_hint = "screen",
-        text_func = function()
-            return _("Cover Image")
-        end,
+        text = _("Cover Image"),
         checked_func = function()
             return self.enabled or self.fallback
         end,
         sub_item_table = {
             -- menu entry: about cover image
             {
-                text_func = function()
-                    return _("About cover image")
-                end,
+                text = _("About cover image"),
                 keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{
@@ -112,9 +108,7 @@ function CoverImage:addToMainMenu(menu_items)
             },
             -- menu entry: filename dialog
             {
-                text_func = function()
-                    return _("Set system screensaver image")
-                end,
+                text = _("Set system screensaver image"),
                 checked_func = function()
                     return self.cover_image_path ~= ""
                 end,
@@ -166,9 +160,7 @@ function CoverImage:addToMainMenu(menu_items)
             },
             -- menu entry: enable
             {
-                text_func = function()
-                    return _("Save current book cover as screensaver image")
-                end,
+                text = _("Save current book cover as screensaver image"),
                 checked_func = function()
                     return self:_enabled()
                 end,
@@ -189,9 +181,7 @@ function CoverImage:addToMainMenu(menu_items)
             },
             -- menu entry: exclude this cover
             {
-                text_func = function()
-                    return _("Exclude this book cover")
-                end,
+                text = _("Exclude this book cover"),
                 checked_func = function()
                     return self.ui and self.ui.doc_settings and self.ui.doc_settings:readSetting("exclude_cover_image") == true
                 end,
@@ -209,9 +199,7 @@ function CoverImage:addToMainMenu(menu_items)
             },
             -- menu entry: set fallback image
             {
-                text_func = function()
-                    return _("Set fallback image when no cover or excl. book")
-                end,
+                text = _("Set fallback image when no cover or excl. book"),
                 checked_func = function()
                     return lfs.attributes(self.cover_image_fallback_path, "mode") == "file"
                 end,
@@ -252,13 +240,11 @@ function CoverImage:addToMainMenu(menu_items)
                     }
                     UIManager:show(sample_input)
                     sample_input:onShowKeyboard()
-                end
+                end,
             },
             -- menu entry: fallback
             {
-                text_func = function()
-                    return _("Use fallback image when leaving book")
-                end,
+                text = _("Use fallback image when leaving book"),
                 checked_func = function()
                     return self:_fallback()
                 end,

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -7,14 +7,19 @@ end
 local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
-local ffiutil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
+local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
+local function pathOk(filename)
+    local path, name = util.splitFilePathName(filename)
+    return Device:isValidPath(path) and name ~= "" and lfs.attributes(filename, "mode") ~= "directory"
+end
+
 local CoverImage = WidgetContainer:new{
-    name = "coverimage",
+    name = 'coverimage',
     is_doc_only = true,
 }
 
@@ -51,8 +56,8 @@ function CoverImage:cleanUpImage()
             timeout = 10,
         })
         os.remove(self.cover_image_path)
-    elseif Device:isValidFile(self.cover_image_path) then
-        ffiutil.copyFile(self.cover_image_fallback_path, self.cover_image_path)
+    else
+        os.execute("cp \"" .. self.cover_image_fallback_path .. "\" \"" .. self.cover_image_path .. "\"")
     end
 end
 
@@ -108,7 +113,7 @@ function CoverImage:addToMainMenu(menu_items)
             {
                 text = _("Set system screensaver image"),
                 checked_func = function()
-                    return self.cover_image_path ~= "" and Device:isValidFile(self.cover_image_path)
+                    return self.cover_image_path ~= "" and pathOk(self.cover_image_path)
                 end,
                 help_text = _("The cover of the current book will be stored in this file."),
                 keep_menu_open = true,
@@ -137,7 +142,7 @@ function CoverImage:addToMainMenu(menu_items)
                                             self:cleanUpImage() -- with old filename
                                             self.cover_image_path = new_cover_image_path -- update filename
                                             G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
-                                            if self.cover_image_path ~= "" and Device:isValidFile(self.cover_image_path) then
+                                            if self.cover_image_path ~= "" and pathOk(self.cover_image_path) then
                                                 self:onReaderReady(self.ui.doc_settings) -- with new filename
                                             else
                                                 self.enabled = false
@@ -159,10 +164,10 @@ function CoverImage:addToMainMenu(menu_items)
             {
                 text = _("Save book cover"),
                 checked_func = function()
-                    return self:_enabled() and Device:isValidFile(self.cover_image_path)
+                    return self:_enabled() and pathOk(self.cover_image_path)
                 end,
                 enabled_func = function()
-                    return self.cover_image_path ~= "" and Device:isValidFile(self.cover_image_path)
+                    return self.cover_image_path ~= "" and pathOk(self.cover_image_path)
                 end,
                 callback = function()
                     if self.cover_image_path ~= "" then

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -34,15 +34,16 @@ end
 
 function CoverImage:cleanUpImage()
     local lfs = require("libs/libkoreader-lfs")
-    local has_bak = lfs.attributes(self.cover_image_path .. ".bak")
-    -- Delete image if backup exists, the backup could contain a user defined sleep image
-    if lfs.attributes(self.cover_image_path) and has_bak then
+    -- Delete image the backup (if it exits) will contain a user defined sleep image
+    if lfs.attributes(self.cover_image_path) then
         os.remove(self.cover_image_path)
     end
-    -- Restore backup if it exists, so we can use the last image.
     -- On Tolino a user defined /sdcard/suspend_others.jgp can be used as screensaver on system sleep.
-    if has_bak then
-        os.rename(self.cover_image_path .. ".bak", self.cover_image_path)
+    -- Restore backup if it exists, so we can use it as sleep image
+    -- If no backup exists, there is no file and the native sleep image is used
+    local bak_file_name = self.cover_image_path .. ".bak"
+    if lfs.attributes(bak_file_name) then
+        os.rename(bak_file_name, self.cover_image_path)
     end
 end
 
@@ -133,7 +134,6 @@ function CoverImage:addToMainMenu(menu_items)
                 callback = function()
                     self.enabled = not self.enabled
                     G_reader_settings:saveSetting("cover_image_enabled", self.enabled)
-                    G_reader_settings:flush()
                 end,
             },
             -- menu entry: restore
@@ -147,7 +147,6 @@ function CoverImage:addToMainMenu(menu_items)
                 callback = function()
                     self.restore = not self.restore and self.enabled
                     G_reader_settings:saveSetting("cover_image_restore", self.restore)
-                    G_reader_settings:flush()
                 end,
                 separator = true,
             },

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -269,8 +269,8 @@ function CoverImage:addToMainMenu(menu_items)
                 callback = function()
                     self.fallback = not self.fallback
                     G_reader_settings:saveSetting("cover_image_fallback", self.fallback)
-                    self:cleanUpImage()
-                    self:onReaderReady(self.ui.doc_settings)
+--                    self:cleanUpImage()
+--                    self:onReaderReady(self.ui.doc_settings)
                 end,
                 separator = true,
             },

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -34,10 +34,9 @@ function CoverImage:init()
 end
 
 function CoverImage:cleanUpImage()
-    if self.cover_image_fallback_path == "" then
+    if self.cover_image_fallback_path == "" or not self.fallback then
         os.remove(self.cover_image_path)
     elseif lfs.attributes(self.cover_image_fallback_path, "mode") ~= "file" then
-        logger.dbg("xxxxxxxxxxxxxxxxxx")
         UIManager:show(InfoMessage:new{
             text = T(_("\"%1\" \nis not a valid image file!\nPlease correct fallback image in Cover-Image"), self.cover_image_fallback_path),
             show_icon = true,
@@ -80,7 +79,7 @@ function CoverImage:addToMainMenu(menu_items)
             return _("Cover Image")
         end,
         checked_func = function()
-            return self:_enabled()
+            return self.enabled or self.fallback
         end,
         sub_item_table = {
             -- menu entry: filename dialog
@@ -176,7 +175,7 @@ function CoverImage:addToMainMenu(menu_items)
             -- menu entry: set fallback image
             {
                 text_func = function()
-                    return self.cover_image_path and _("Set fallback image when no cover")
+                    return self.cover_image_path and _("Set fallback image when no cover or excl. book")
                 end,
                 keep_menu_open = true,
                 callback = function(menu)
@@ -187,7 +186,7 @@ function CoverImage:addToMainMenu(menu_items)
                         input = self.cover_image_fallback_path,
                         input_type = "string",
                         description = _("You can enter the filename of the fallback image here.\n" ..
-                            "Leave it empty to clean up on close"),
+                            "Leave it empty to clean up on close."),
                         buttons = {
                             {
                                 {
@@ -224,6 +223,8 @@ function CoverImage:addToMainMenu(menu_items)
                 callback = function()
                     self.fallback = not self.fallback
                     G_reader_settings:saveSetting("cover_image_fallback", self.fallback)
+                    self:cleanUpImage()
+                    self:onReaderReady(self.ui.doc_settings)
                 end,
                 separator = true,
             },

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -4,8 +4,10 @@ if not Device.isAndroid() and not Device.isEmulator() then
     return { disabled = true }
 end
 
+local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local _ = require("gettext")
 local T = require("ffi/util").template
@@ -13,7 +15,6 @@ local T = require("ffi/util").template
 local CoverImage = WidgetContainer:new{
     name = 'coverimage',
     is_doc_only = true,
-    settings_id = 0,
 }
 
 function CoverImage:_enabled()
@@ -21,36 +22,35 @@ function CoverImage:_enabled()
 end
 
 function CoverImage:_restore()
-    return self.enabled and self.restore
+    return self.restore
 end
 
 function CoverImage:init()
     self.cover_image_path = G_reader_settings:readSetting("cover_image_path") or "Cover.png"
+    self.cover_restore_image_path = G_reader_settings:readSetting("cover_restore_image_path") or "Cover_restore.png"
     self.enabled = G_reader_settings:isTrue("cover_image_enabled")
-    self.restore = G_reader_settings:isTrue("cover_image_restore") and self.enabled
+    self.restore = G_reader_settings:isTrue("cover_image_restore")
     self.ui.menu:registerToMainMenu(self)
 end
 
 function CoverImage:cleanUpImage()
-    if not self.ui.doc_settings:readSetting("exclude_cover_image") == true then
-        local lfs = require("libs/libkoreader-lfs")
-        -- Delete image the backup (if it exits) will contain a user defined sleep image
-        if lfs.attributes(self.cover_image_path) then
-            os.remove(self.cover_image_path)
-        end
-        -- On Tolino a user defined /sdcard/suspend_others.jgp can be used as screensaver on system sleep.
-        -- Restore backup if it exists, so we can use it as sleep image
-        -- If no backup exists, there is no file and the native sleep image is used
-        local bak_file_name = self.cover_image_path .. ".bak"
-        if lfs.attributes(bak_file_name) then
-            os.rename(bak_file_name, self.cover_image_path)
-        end
+    if self.cover_restore_image_path == "" then
+        os.remove(self.cover_image_path)
+    elseif lfs.attributes(self.cover_restore_image_path, "mode") ~= "file" then
+        logger.dbg("xxxxxxxxxxxxxxxxxx")
+        UIManager:show(InfoMessage:new{
+            text = T(_("\"%1\" \nis not a valid image file!\nPlease correct it in Cover Image."), self.cover_restore_image_path),
+            show_icon = true,
+            timeout = 10,
+        })
+        os.remove(self.cover_image_path)
+    else
+        os.execute("cp " ..self.cover_restore_image_path .. " " .. self.cover_image_path)
     end
 end
 
 function CoverImage:onCloseDocument()
     logger.dbg("CoverImage: onCloseDocument")
-    -- Try to restore the state before opening of a document.
     if self.restore then
         self:cleanUpImage()
     end
@@ -59,17 +59,18 @@ end
 function CoverImage:onReaderReady(doc_settings)
    logger.dbg("CoverImage: onReaderReady")
    if self.enabled and not doc_settings:readSetting("exclude_cover_image") == true then
-        local lfs = require("libs/libkoreader-lfs")
         local image = self.ui.document:getCoverPageImage()
         if image then
-            -- Do not override an existing backup, as this only exists on a crash or abnormal update of KOReader.
-            -- This is very usefull, if an image shall be used as a system screensaver (e.g. on Tolino as /sdcard/suspend_other.jpg)
-            if not lfs.attributes(self.cover_image_path .. ".bak") then
-                os.rename(self.cover_image_path, self.cover_image_path .. ".bak" )
-            end
             image:writePNG(self.cover_image_path, false)
         end
     end
+end
+
+function CoverImage:showWrongPath( path )
+    UIManager:show(InfoMessage:new{
+        text = T(_("Path \"%1\" is not accessible."), path),
+        show_icon = true,
+    })
 end
 
 function CoverImage:addToMainMenu(menu_items)
@@ -85,8 +86,8 @@ function CoverImage:addToMainMenu(menu_items)
             -- menu entry: filename dialog
             {
                 text_func = function()
-                    return self.cover_image_path and T(_("Cover Image (%1)"), self.cover_image_path)
-                        or _("Cover Image (none)")
+                    return self.cover_image_path and T(_("Cover Image: %1"), self.cover_image_path)
+                        or _("Cover Image: none")
                 end,
                 keep_menu_open = true,
                 callback = function(menu)
@@ -114,7 +115,13 @@ function CoverImage:addToMainMenu(menu_items)
                                             self:cleanUpImage() -- with old filename
                                             self.cover_image_path = new_cover_image_path -- update filename
                                             G_reader_settings:saveSetting("cover_image_path", self.cover_image_path)
-                                            self:onReaderReady(self.ui.doc_settings) -- with new filename
+                                            if self.cover_image_path ~= "" or Device.isValidPath
+                                                and not Device.isValidPath(self.cover_image_path) then
+                                                self:onReaderReady(self.ui.doc_settings) -- with new filename
+                                            else
+                                                self.enabled = false
+                                                CoverImage:showWrongPath(self.cover_image_path)
+                                            end
                                         end
                                         UIManager:close(sample_input)
                                         menu:updateItems()
@@ -136,31 +143,16 @@ function CoverImage:addToMainMenu(menu_items)
                     return self:_enabled()
                 end,
                 callback = function()
-                    self.enabled = not self.enabled
-                    G_reader_settings:saveSetting("cover_image_enabled", self.enabled)
-                    if self.enabled then
-                        self.restore = true
-                        self:onReaderReady(self.ui.doc_settings)
-                    else
-                        self.restore = false
-                        self:cleanUpImage()
+                    if self.cover_image_path ~= "" then
+                        self.enabled = not self.enabled
+                        G_reader_settings:saveSetting("cover_image_enabled", self.enabled)
+                        if self.enabled then
+                            self:onReaderReady(self.ui.doc_settings)
+                        else
+                            self:cleanUpImage()
+                        end
                     end
-                    G_reader_settings:saveSetting("cover_image_restore", self.restore)
-                end,
-            },
-            -- menu entry: restore
-            {
-                text_func = function()
-                    return _("Restore image on book closing")
-                end,
-                checked_func = function()
-                    return self:_restore()
-                end,
-                callback = function()
-                    self.restore = not self.restore and self.enabled
-                    G_reader_settings:saveSetting("cover_image_restore", self.restore)
-                end,
-                separator = true,
+                end
             },
             -- menu entry: exclude this cover
             {
@@ -175,14 +167,68 @@ function CoverImage:addToMainMenu(menu_items)
                         self.ui.doc_settings:saveSetting("exclude_cover_image", false)
                         self:onReaderReady(self.ui.doc_settings)
                     else
-                        if self.enabled then
-                            self:cleanUpImage()
-                        end
                         self.ui.doc_settings:saveSetting("exclude_cover_image", true)
+                        self:cleanUpImage()
                     end
                     self.ui:saveSettings()
                 end,
-            }
+                separator = true,
+            },
+            -- menu entry: filename dialog
+            {
+                text_func = function()
+                    return self.cover_image_path and T(_("Restore image from: %1"), self.cover_restore_image_path)
+                        or _("Restore image from system")
+                end,
+                keep_menu_open = true,
+                callback = function(menu)
+                    local InputDialog = require("ui/widget/inputdialog")
+                    local sample_input
+                    sample_input = InputDialog:new{
+                        title = _("Filename of restore image"),
+                        input = self.cover_restore_image_path,
+                        input_type = "string",
+                        description = _("You can enter the filename of the restore image here.\n" ..
+                            "Leave it empty to clean up on close"),
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    callback = function()
+                                        UIManager:close(sample_input)
+                                    end,
+                                },
+                                {
+                                    text = _("Save"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        self.cover_restore_image_path = sample_input:getInputText()
+                                        G_reader_settings:saveSetting("cover_restore_image_path", self.cover_restore_image_path)
+                                        UIManager:close(sample_input)
+                                        menu:updateItems()
+                                    end,
+                                },
+                            }
+                        },
+                    }
+                    UIManager:show(sample_input)
+                    sample_input:onShowKeyboard()
+                end
+            },
+            -- menu entry: restore
+            {
+                text_func = function()
+                    return _("Restore image on book closing")
+                end,
+                checked_func = function()
+                    return self:_restore()
+                end,
+                callback = function()
+                    self.restore = not self.restore
+                    G_reader_settings:saveSetting("cover_image_restore", self.restore)
+                end,
+                separator = true,
+            },
         },
     }
 end

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -1,6 +1,6 @@
 local Device = require("device")
 
-if Device.isKindle == nil and Device.isKobo == nil then
+if not Device.isAndroid() and not Device.isEmulator() then
     return { disabled = true }
 end
 
@@ -136,7 +136,7 @@ function CoverImage:addToMainMenu(menu_items)
             -- menu entry: restore
             {
                 text_func = function()
-                    return _("Restore image on exit")
+                    return _("Restore image on book closing")
                 end,
                 checked_func = function()
                     return self:_restore()


### PR DESCRIPTION
If the plugin is enabled the following actions can be selected:

1. On opening of a document, the cover is saved to a file (format png). 
If the filename exists, a backup of the original is created.

2. On closing of the document this file can be deleted and the original file can be restored.

3. Certain documents can be excluded from image generation.

This plugin can be used to change the sleep-screen on Tolinos (filename: /sdcard/suspend_others.jpg) as long KOReader has an opened document. On close of KOReader the original sleep screen is restored.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6813)
<!-- Reviewable:end -->
