### PR TITLE
android changes

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -227,8 +227,9 @@ function Device:init()
         local timeout = G_reader_settings:readSetting("android_screen_timeout")
         if timeout then
             if timeout == C.AKEEP_SCREEN_ON_ENABLED
-            or (timeout > C.AKEEP_SCREEN_ON_DISABLED
-                and android.settings.canWrite()) then
+                or timeout > C.AKEEP_SCREEN_ON_DISABLED
+                and android.settings.hasPermission("settings")
+            then
                 android.timeout.set(timeout)
             end
         end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -276,11 +276,11 @@ if Device:isAndroid() then
             checked_func = function() return not android.settings.hasPermission("battery") end,
             callback = function()
                 local text = _([[
-Do you want to go to android battery optimization settings?
+Go to Android battery optimization settings?
 
 You will be prompted with a permission management screen.
 
-Please don't change settings unless you know what you're doing]])
+Please don't change any settings unless you know what you're doing.]])
 
                 android.settings.requestPermission("battery", text, _("OK"), _("Cancel"))
             end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -268,6 +268,24 @@ if Device:isAndroid() then
             callback = function() require("ui/elements/screen_android"):toggleFullscreen() end,
         }
     end
+
+    -- ignore battery optimization
+    if Device.firmware_rev >= 23 then
+        common_settings.ignore_battery_optimizations = {
+            text = _("Battery optimizations"),
+            checked_func = function() return not android.settings.hasPermission("battery") end,
+            callback = function()
+                local text = _([[
+Do you want to go to android battery optimization settings?
+
+You will be prompted with a permission management screen.
+
+Please don't change settings unless you know what you're doing]])
+
+                android.settings.requestPermission("battery", text, _("OK"), _("Cancel"))
+            end,
+        }
+    end
 end
 
 if Device:isTouchDevice() then

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -47,6 +47,7 @@ local order = {
         "autoshutdown",
         "ignore_sleepcover",
         "ignore_open_sleepcover",
+        "ignore_battery_optimizations",
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",
         "screenshot",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -68,6 +68,7 @@ local order = {
         "autoshutdown",
         "ignore_sleepcover",
         "ignore_open_sleepcover",
+        "ignore_battery_optimizations",
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",
         "screenshot",

--- a/frontend/ui/elements/screen_android.lua
+++ b/frontend/ui/elements/screen_android.lua
@@ -37,7 +37,7 @@ local function canModifyTimeout(timeout)
     if timeout == system or timeout == screenOn then
         return true
     else
-        return android.settings.canWrite()
+        return android.settings.hasPermission("settings")
     end
 end
 
@@ -51,16 +51,12 @@ local function saveAndApplyTimeout(timeout)
 end
 
 local function requestWriteSettings()
-    local UIManager = require("ui/uimanager")
-    local ConfirmBox = require("ui/widget/confirmbox")
-    UIManager:show(ConfirmBox:new{
-        text = _("Allow KOReader to modify system settings?\n\nYou will be prompted with a permission management screen. You'll need to give KOReader permission and then restart the program."),
-        ok_text = _("Allow"),
-        ok_callback = function()
-            UIManager:scheduleIn(1, function() UIManager:quit() end)
-            android.settings.requestWritePermission()
-        end,
-    })
+    local text = _([[
+Allow KOReader to modify system settings?
+
+You will be prompted with a permission management screen. You'll need to give KOReader permission and then restart the program.]])
+
+    android.settings.requestPermission("settings", text, _("Allow"), _("Cancel"))
 end
 
 local ScreenHelper = {}
@@ -172,11 +168,11 @@ function ScreenHelper:getTimeoutMenuTable()
             },
         }
 
-    if not android.settings.canWrite() then
+    if not android.settings.hasPermission("settings") then
         table.insert(t, 1, {
             text = _("Allow system settings override"),
-            enabled_func = function() return not android.settings.canWrite() end,
-            checked_func = function() return android.settings.canWrite() end,
+            enabled_func = function() return not android.settings.hasPermission("settings") end,
+            checked_func = function() return android.settings.hasPermission("settings") end,
             callback = function() requestWriteSettings() end,
             separator = true,
         })


### PR DESCRIPTION
 - Lcd devices won't use the SurfaceView, just the good old native content/window (except AndroidTv and ChromeOS)
 - All android dialogs will be presented with Material Design on recent devices.
 - Added an option to device settings to manage application battery optimization.
 - Permissions that require the user to go to a settings page will be presented with a native android dialog.

Requires https://github.com/koreader/android-luajit-launcher/pull/257 (please go there to read the changes under the hood)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6821)
<!-- Reviewable:end -->
