### PR TITLE
Another round of ReaderFooter fixes

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -665,8 +665,14 @@ function ReaderFooter:resetLayout(force_reset)
 end
 
 function ReaderFooter:getHeight()
+    print("ReaderFooter:getHeight", self.footer_content:getSize().h, self.vertical_frame:getSize().h, self.bottom_padding)
     if self.footer_content then
-        return self.footer_content:getSize().h
+        if self.view.footer_visible then
+            return self.vertical_frame:getSize().h + self.bottom_padding
+        else
+            -- When going invisible, the text is no longer visible, so the frame's height is off by self.height
+            return self.vertical_frame:getSize().h + self.height + self.bottom_padding
+        end
     else
         return 0
     end
@@ -1830,6 +1836,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
                 refresh_dim.h = self.vertical_frame:getSize().h + self.height + self.bottom_padding
             end
             refresh_dim.y = self._saved_screen_height - refresh_dim.h
+            print("_updateFooterText ->", self:getHeight())
         end
         -- If we're making the footer visible (or it already is), we don't need to repaint ReaderUI behind it
         if self.view.footer_visible then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -586,11 +586,9 @@ function ReaderFooter:setupAutoRefreshTime()
         self.autoRefreshTime = function()
             -- Only actually repaint the footer if nothing's being shown over ReaderUI (#6616)
             if UIManager:getTopWidget() == "ReaderUI" then
+                -- And that only if it's actually visible
                 if self.view.footer_visible then
                     self:onUpdateFooter(true)
-                else
-                    -- Just keep it up to date, don't refresh
-                    self:onUpdateFooter()
                 end
             else
                 logger.dbg("Skipping ReaderFooter repaint, because ReaderUI is not the top-level widget")

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1796,10 +1796,11 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
         if self.has_no_mode or text == "" then
             self.text_width = 0
             self.footer_text.height = 0
+        else
+            self.text_width = self.footer_text:getSize().w
+            self.footer_text.height = self.footer_text:getSize().h
         end
         self.progress_bar.width = math.floor(self._saved_screen_width - 2 * self.settings.progress_margin_width)
-        self.text_width = self.footer_text:getSize().w
-        self.footer_text.height = self.footer_text:getSize().h
     else
         if self.has_no_mode or text == "" then
             self.text_width = 0

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1817,9 +1817,10 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
     if force_repaint then
         -- NOTE: Getting the dimensions of the widget is impossible without having drawn it first,
         --       so, we'll fudge it if need be...
+        --       i.e., when it's no longer visible, because there's nothing to draw ;).
         local refresh_dim = self.footer_content.dimen
-        -- No content yet...
-        if not refresh_dim then
+        -- No more content...
+        if not self.view.footer_visible and not refresh_dim then
             -- So, instead, compute self.footer_content's height ourselves: i.e., self.vertical_frame + self.bottom_padding...
             refresh_dim = self.dimen
             if self.view.footer_visible then
@@ -1835,11 +1836,13 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
             -- Unfortunately, it's not a modal (we never show() it), so it's not in the window stack,
             -- instead, it's baked inside ReaderUI, so it gets slightly trickier...
             -- NOTE: self.view.footer -> self ;).
-            UIManager:setDirty(self.view.footer, function()
-                return "ui", refresh_dim
-            end)
+
             -- c.f., ReaderView:paintTo()
             UIManager:widgetRepaint(self.view.footer, 0, 0)
+            -- We've painted it first to ensure self.footer_content.dimen is sane
+            UIManager:setDirty(self.view.footer, function()
+                return "ui", self.footer_content.dimen
+            end)
         else
             UIManager:setDirty(self.view.dialog, function()
                 return "ui", refresh_dim

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1835,7 +1835,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
     if force_repaint then
         -- If there was a visibility change, notify ReaderView
         if self.visibility_change then
-            self.ui:handleEvent(Event:new("ReaderFooterVisibilityChange", percentage))
+            self.ui:handleEvent(Event:new("ReaderFooterVisibilityChange"))
             self.visibility_change = nil
         end
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -672,7 +672,7 @@ function ReaderFooter:resetLayout(force_reset)
     self._saved_screen_height = new_screen_height
 end
 
-function ReaderFooter:getHeight(before_paint)
+function ReaderFooter:getHeight()
     if self.footer_content then
         -- NOTE: self.footer_content is self.vertical_frame + self.bottom_padding,
         --       self.vertical_frame includes self.text_container (which includes self.footer_text)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1776,8 +1776,6 @@ end
 function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
     -- footer is invisible, we need neither a repaint nor a recompute, go away.
     if not self.view.footer_visible and not force_repaint and not force_recompute then
-        self.text_width = 0
-        self.footer_text.height = 0
         return
     end
     local text = self:genFooterText()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -673,12 +673,6 @@ function ReaderFooter:resetLayout(force_reset)
 end
 
 function ReaderFooter:getHeight(before_paint)
-    print("ReaderFooter:getHeight")
-    print("self.height:", self.height)
-    print("self.footer_text.height:", self.footer_text.height)
-    print("self.footer_text:getSize().h:", self.footer_text:getSize().h)
-    print("self.text_container:getSize().h:", self.text_container:getSize().h)
-    print("return", self.footer_content:getSize().h)
     if self.footer_content then
         -- NOTE: self.footer_content is self.vertical_frame + self.bottom_padding,
         --       self.vertical_frame includes self.text_container (which includes self.footer_text)
@@ -1972,7 +1966,7 @@ function ReaderFooter:applyFooterMode(mode)
         self:updateFooterContainer()
         -- NOTE: _updateFooterText does a resetLayout, but not a forced one!
         self:resetLayout(true)
-        -- Notify ReaderView to recalculate the visible_area!
+        -- Flag _updateFooterText to notify ReaderView to recalculate the visible_area!
         self.visibility_change = true
     end
 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -586,7 +586,12 @@ function ReaderFooter:setupAutoRefreshTime()
         self.autoRefreshTime = function()
             -- Only actually repaint the footer if nothing's being shown over ReaderUI (#6616)
             if UIManager:getTopWidget() == "ReaderUI" then
-                self:onUpdateFooter(true)
+                if self.view.footer_visible then
+                    self:onUpdateFooter(true)
+                else
+                    -- Just keep it up to date, don't refresh
+                    self:onUpdateFooter()
+                end
             else
                 logger.dbg("Skipping ReaderFooter repaint, because ReaderUI is not the top-level widget")
                 -- NOTE: We *do* keep its content up-to-date, though

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -665,13 +665,13 @@ function ReaderFooter:resetLayout(force_reset)
 end
 
 function ReaderFooter:getHeight()
-    print("ReaderFooter:getHeight", self.footer_content:getSize().h, self.vertical_frame:getSize().h, self.bottom_padding)
     if self.footer_content then
         if self.view.footer_visible then
-            return self.vertical_frame:getSize().h + self.bottom_padding
+            -- NOTE: self.footer_content is self.vertical_frame + self.bottom_padding
+            return self.footer_content:getSize().h
         else
-            -- When going invisible, the text is no longer visible, so the frame's height is off by self.height
-            return self.vertical_frame:getSize().h + self.height + self.bottom_padding
+            -- When going invisible, the text is no longer visible, so the content's frame's height is off by self.height
+            return self.footer_content:getSize().h + self.height
         end
     else
         return 0
@@ -1827,16 +1827,10 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
         local refresh_dim = self.footer_content.dimen
         -- No more content...
         if not self.view.footer_visible and not refresh_dim then
-            -- So, instead, compute self.footer_content's height ourselves: i.e., self.vertical_frame + self.bottom_padding...
+            -- So, instead, rely on self:getHeight to compute self.footer_content's height early...
             refresh_dim = self.dimen
-            if self.view.footer_visible then
-                refresh_dim.h = self.vertical_frame:getSize().h + self.bottom_padding
-            else
-                -- When going invisible, the text is no longer visible, so the frame's height is off by self.height
-                refresh_dim.h = self.vertical_frame:getSize().h + self.height + self.bottom_padding
-            end
+            refresh_dim.h = self:getHeight()
             refresh_dim.y = self._saved_screen_height - refresh_dim.h
-            print("_updateFooterText ->", self:getHeight())
         end
         -- If we're making the footer visible (or it already is), we don't need to repaint ReaderUI behind it
         if self.view.footer_visible then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1948,6 +1948,8 @@ function ReaderFooter:applyFooterMode(mode)
         self:updateFooterContainer()
         -- NOTE: _updateFooterText does a resetLayout, but not a forced one!
         self:resetLayout(true)
+        -- Notify ReaderView to recalculate the visible_area!
+        self.ui:handleEvent(Event:new("ReaderFooterVisibilityChange", percentage))
     end
 end
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -675,18 +675,11 @@ function ReaderFooter:getHeight(before_paint)
     print("self.footer_text.height:", self.footer_text.height)
     print("self.footer_text:getSize().h:", self.footer_text:getSize().h)
     print("self.text_container:getSize().h:", self.text_container:getSize().h)
+    print("return", self.footer_content:getSize().h)
     if self.footer_content then
-        if self.view.footer_visible then
-            -- NOTE: self.footer_content is self.vertical_frame + self.bottom_padding
-            print("Visible:", self.footer_content:getSize().h)
-            print("Visible:", self.vertical_frame:getSize().h, "+", self.bottom_padding)
-            return self.footer_content:getSize().h
-        else
-            -- When going invisible, the text is no longer visible, so the content's frame's height is off by text_contianer's height
-            print("Invisible:", self.footer_content:getSize().h, "+", self.height)
-            print("Invisible:", self.vertical_frame:getSize().h, "+", self.bottom_padding)
-            return self.footer_content:getSize().h + self.text_container:getSize().h
-        end
+        -- NOTE: self.footer_content is self.vertical_frame + self.bottom_padding,
+        --       self.vertical_frame includes self.text_container (which includes self.footer_text)
+        return self.footer_content:getSize().h
     else
         return 0
     end

--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -133,7 +133,7 @@ function ReaderPageMap:updateVisibleLabels()
     end
     self.container:clear()
     local page_labels = self.ui.document:getPageMapVisiblePageLabels()
-    local footer_height = (self.view.footer_visible and 1 or 0) * self.view.footer:getHeight()
+    local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()
     local max_y = Screen:getHeight() - footer_height
     local last_label_bottom_y = 0
     for _, page in ipairs(page_labels) do

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -693,7 +693,7 @@ end
 function ReaderRolling:onGotoViewRel(diff)
     logger.dbg("goto relative screen:", diff, ", in mode: ", self.view.view_mode)
     if self.view.view_mode == "scroll" then
-        local footer_height = (self.view.footer_visible and 1 or 0) * self.view.footer:getHeight()
+        local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()
         local page_visible_height = self.ui.dimen.h - footer_height
         local pan_diff = diff * page_visible_height
         if self.show_overlap_enable then
@@ -869,7 +869,7 @@ function ReaderRolling:_gotoPos(new_pos, do_dim_area)
     if new_pos > max_pos then new_pos = max_pos end
     -- adjust dim_area according to new_pos
     if self.view.view_mode ~= "page" and self.show_overlap_enable and do_dim_area then
-        local footer_height = (self.view.footer_visible and 1 or 0) * self.view.footer:getHeight()
+        local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()
         local page_visible_height = self.ui.dimen.h - footer_height
         local panned_step = new_pos - self.current_pos
         self.view.dim_area.x = 0

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -793,7 +793,7 @@ end
 
 function ReaderView:onReaderFooterVisibilityChange()
     -- NOTE: Simply relying on recalculate would be a wee bit too much: it'd reset the in-page offsets,
-    --       which isn't necessary, since the footer is at the bottom of the screen ;).
+    --       which would be wrong, and is also not necessary, since the footer is at the bottom of the screen ;).
     --       So, simply mangle visible_area's height ourselves...
     if not self.ui.view.footer.settings.reclaim_height then
         -- NOTE: Yes, this means that toggling reclaim_height requires a page switch (for a proper recalculate).

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -571,7 +571,7 @@ function ReaderView:recalculate(skip_repaint)
         -- reset our size
         self.visible_area:setSizeTo(self.dimen)
         print("ReaderView:recalculate", self.visible_area.h, self.ui.view.footer:getHeight())
-        if self.ui.view.footer_visible then
+        if self.ui.view.footer_visible and not self.ui.view.footer.settings.reclaim_height then
             self.visible_area.h = self.visible_area.h - self.ui.view.footer:getHeight()
         end
         print("ReaderView:recalculate ->", self.visible_area.h)
@@ -598,7 +598,7 @@ function ReaderView:recalculate(skip_repaint)
     end
     self.state.offset = Geom:new{x = 0, y = 0}
     if self.dimen.h > self.visible_area.h then
-        if self.ui.view.footer_visible then
+        if self.ui.view.footer_visible and not self.ui.view.footer.settings.reclaim_height then
             self.state.offset.y = (self.dimen.h - (self.visible_area.h + self.ui.view.footer:getHeight())) / 2
         else
             self.state.offset.y = (self.dimen.h - self.visible_area.h) / 2

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -558,7 +558,7 @@ end
 --[[
 This method is supposed to be only used by ReaderPaging
 --]]
-function ReaderView:recalculate(skip_repaint)
+function ReaderView:recalculate()
     print("ReaderView:recalculate")
     -- Start by resetting the dithering flag early, so it doesn't carry over from the previous page.
     self.dialog.dithered = nil
@@ -611,12 +611,9 @@ function ReaderView:recalculate(skip_repaint)
     if self.dimen.w > self.visible_area.w then
         self.state.offset.x = (self.dimen.w - self.visible_area.w) / 2
     end
-    -- If necessary (i.e., basically always except when triggered via onReaderFooterVisibilityChange),
-    -- flag a repaint so self:paintTo will be called
+    -- Flag a repaint so self:paintTo will be called
     -- NOTE: This is also unfortunately called during panning, essentially making sure we'll never be using "fast" for pans ;).
-    if not skip_repaint then
-        UIManager:setDirty(self.dialog, "partial")
-    end
+    UIManager:setDirty(self.dialog, "partial")
 end
 
 function ReaderView:PanningUpdate(dx, dy)
@@ -804,12 +801,10 @@ end
 
 function ReaderView:onReaderFooterVisibilityChange()
     print("ReaderView:onReaderFooterVisibilityChange")
-    -- NOTE: We'll skip the setDirty call in this case, because ReaderFooter already takes care of repainting ReaderUI as-needed.
-    --self:recalculate(true)
 
-    -- NOTE: recalculate is a wee bit too much: it'll reset the in-page offsets, so, simply mangle visible_area's height ourselves...
-    --       The downside is that things are a wee bit wonky until the next recalculate (i.e., the next page).
-    --       But I'm not really sure how to handle that without losing the offsets...
+    -- NOTE: Simply relying on recalculate would be a wee bit too much: it'd reset the in-page offsets,
+    --       which isn't necessary, since the footer is at the bottom of the screen ;).
+    --       So, simply mangle visible_area's height ourselves...
     print("self.visible_area.y:", self.visible_area.y)
     print("self.visible_area.h:", self.visible_area.h)
     print("self.state.offset.y:", self.state.offset.y)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -792,19 +792,22 @@ function ReaderView:onRotationUpdate(rotation)
 end
 
 function ReaderView:onReaderFooterVisibilityChange()
-    -- NOTE: Simply relying on recalculate would be a wee bit too much: it'd reset the in-page offsets,
-    --       which would be wrong, and is also not necessary, since the footer is at the bottom of the screen ;).
-    --       So, simply mangle visible_area's height ourselves...
-    if not self.ui.view.footer.settings.reclaim_height then
-        -- NOTE: Yes, this means that toggling reclaim_height requires a page switch (for a proper recalculate).
-        --       Thankfully, most of the time, the quirks are barely noticeable ;).
-        if self.ui.view.footer_visible then
-            self.visible_area.h = self.visible_area.h - self.ui.view.footer:getHeight()
-        else
-            self.visible_area.h = self.visible_area.h + self.ui.view.footer:getHeight()
+    -- Don't bother ReaderRolling with this nonsense, the footer's height is NOT handled via visible_area there ;)
+    if self.ui.document.info.has_pages and self.state.page then
+        -- NOTE: Simply relying on recalculate would be a wee bit too much: it'd reset the in-page offsets,
+        --       which would be wrong, and is also not necessary, since the footer is at the bottom of the screen ;).
+        --       So, simply mangle visible_area's height ourselves...
+        if not self.ui.view.footer.settings.reclaim_height then
+            -- NOTE: Yes, this means that toggling reclaim_height requires a page switch (for a proper recalculate).
+            --       Thankfully, most of the time, the quirks are barely noticeable ;).
+            if self.ui.view.footer_visible then
+                self.visible_area.h = self.visible_area.h - self.ui.view.footer:getHeight()
+            else
+                self.visible_area.h = self.visible_area.h + self.ui.view.footer:getHeight()
+            end
         end
+        self.ui:handleEvent(Event:new("ViewRecalculate", self.visible_area, self.page_area))
     end
-    self.ui:handleEvent(Event:new("ViewRecalculate", self.visible_area, self.page_area))
 end
 
 function ReaderView:onGammaUpdate(gamma)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -300,7 +300,6 @@ function ReaderView:drawPageBackground(bb, x, y)
 end
 
 function ReaderView:drawPageSurround(bb, x, y)
-    print("ReaderView:drawPageSurround", self.dimen.h, self.visible_area.h, self.ui.view.footer:getHeight())
     if self.dimen.h > self.visible_area.h then
         bb:paintRect(x, y, self.dimen.w, self.state.offset.y, self.outer_page_color)
         local bottom_margin = y + self.visible_area.h + self.state.offset.y
@@ -559,7 +558,6 @@ end
 This method is supposed to be only used by ReaderPaging
 --]]
 function ReaderView:recalculate()
-    print("ReaderView:recalculate")
     -- Start by resetting the dithering flag early, so it doesn't carry over from the previous page.
     self.dialog.dithered = nil
 
@@ -570,12 +568,9 @@ function ReaderView:recalculate()
             self.state.rotation)
         -- reset our size
         self.visible_area:setSizeTo(self.dimen)
-        print("ReaderView:recalculate", self.visible_area.h, self.ui.view.footer:getHeight())
         if self.ui.view.footer_visible and not self.ui.view.footer.settings.reclaim_height then
-            print("Do not draw under footer")
             self.visible_area.h = self.visible_area.h - self.ui.view.footer:getHeight()
         end
-        print("ReaderView:recalculate ->", self.visible_area.h)
         if self.ui.document.configurable.writing_direction == 0 then
             -- starts from left top of page_area
             self.visible_area.x = self.page_area.x
@@ -600,14 +595,11 @@ function ReaderView:recalculate()
     self.state.offset = Geom:new{x = 0, y = 0}
     if self.dimen.h > self.visible_area.h then
         if self.ui.view.footer_visible and not self.ui.view.footer.settings.reclaim_height then
-            print("Do not draw under footer")
             self.state.offset.y = (self.dimen.h - (self.visible_area.h + self.ui.view.footer:getHeight())) / 2
         else
-            print("Draw under footer")
             self.state.offset.y = (self.dimen.h - self.visible_area.h) / 2
         end
     end
-    print("ReaderView:recalculate:", self.state.offset.y)
     if self.dimen.w > self.visible_area.w then
         self.state.offset.x = (self.dimen.w - self.visible_area.w) / 2
     end
@@ -800,24 +792,18 @@ function ReaderView:onRotationUpdate(rotation)
 end
 
 function ReaderView:onReaderFooterVisibilityChange()
-    print("ReaderView:onReaderFooterVisibilityChange")
-
     -- NOTE: Simply relying on recalculate would be a wee bit too much: it'd reset the in-page offsets,
     --       which isn't necessary, since the footer is at the bottom of the screen ;).
     --       So, simply mangle visible_area's height ourselves...
-    print("self.visible_area.y:", self.visible_area.y)
-    print("self.visible_area.h:", self.visible_area.h)
-    print("self.state.offset.y:", self.state.offset.y)
     if not self.ui.view.footer.settings.reclaim_height then
+        -- NOTE: Yes, this means that toggling reclaim_height requires a page switch (for a proper recalculate).
+        --       Thankfully, most of the time, the quirks are barely noticeable ;).
         if self.ui.view.footer_visible then
-            print("Visible")
             self.visible_area.h = self.visible_area.h - self.ui.view.footer:getHeight()
         else
-            print("Invisible")
             self.visible_area.h = self.visible_area.h + self.ui.view.footer:getHeight()
         end
     end
-    print("->", self.visible_area.h)
     self.ui:handleEvent(Event:new("ViewRecalculate", self.visible_area, self.page_area))
 end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -810,7 +810,9 @@ function ReaderView:onReaderFooterVisibilityChange()
     -- NOTE: recalculate is a wee bit too much: it'll reset the in-page offsets, so, simply mangle visible_area's height ourselves...
     --       The downside is that things are a wee bit wonky until the next recalculate (i.e., the next page).
     --       But I'm not really sure how to handle that without losing the offsets...
+    print("self.visible_area.y:", self.visible_area.y)
     print("self.visible_area.h:", self.visible_area.h)
+    print("self.state.offset.y:", self.state.offset.y)
     if not self.ui.view.footer.settings.reclaim_height then
         if self.ui.view.footer_visible then
             print("Visible")
@@ -821,6 +823,7 @@ function ReaderView:onReaderFooterVisibilityChange()
         end
     end
     print("->", self.visible_area.h)
+    self.ui:handleEvent(Event:new("ViewRecalculate", self.visible_area, self.page_area))
 end
 
 function ReaderView:onGammaUpdate(gamma)

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -263,7 +263,7 @@ function ReaderZooming:getZoom(pageno)
     -- calculate zoom value:
     local zoom_w = self.dimen.w
     local zoom_h = self.dimen.h
-    if self.ui.view.footer_visible then
+    if self.ui.view.footer_visible and not self.ui.view.footer.settings.reclaim_height then
         zoom_h = zoom_h - self.ui.view.footer:getHeight()
     end
     if self.rotation % 180 == 0 then


### PR DESCRIPTION
(Some of this is related to the last one, #6540)

* When auto_refresh_time is enabled, don't actually refresh anything when the footer is hidden.
* Fix a bunch of state tracking related to height computations, meaning `getHeight()` is now actually accurate, always, and we don't need shitty workarounds anymore.
  * `footer_container.dimen.h` *includes* the progress bar, so, never reset it to 0 unless the progress bar is disabled (some `settings.progress_bar_position` codepaths were mistakenly doing just that).
  * More aggressively set/reset `footer_text.height` (not sure this one makes much of a difference, and/or if it's actually useful at all, but, the tracking was already there, but hella inconsistent, so, just fix it).
* Honor `settings.reclaim_height` in other bits of code that were only checking `footer_visible` to figure out the visible page area.
* Ask ReaderView to update the `visible_area` *now* when toggling the footer's visibility (for ReaderPaging).

This, among probably other minor quirks, makes the `_updateFooterText` repaint/refresh hacks mostly unnecessary, and fixes a whole lot of inconsistencies with the footer & ReaderPaging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6830)
<!-- Reviewable:end -->
