### PR TITLE
GestureDetector: add Tap interval on keyboard setting

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -154,12 +154,12 @@ end
 --[[
 tap2 is the later tap
 --]]
-function GestureDetector:isTapBounce(tap1, tap2)
+function GestureDetector:isTapBounce(tap1, tap2, interval)
     local tv_diff = tap2.timev - tap1.timev
     return (
         math.abs(tap1.x - tap2.x) < self.SINGLE_TAP_BOUNCE_DISTANCE and
         math.abs(tap1.y - tap2.y) < self.SINGLE_TAP_BOUNCE_DISTANCE and
-        (tv_diff.sec == 0 and (tv_diff.usec) < ges_tap_interval)
+        (tv_diff.sec == 0 and (tv_diff.usec) < interval)
     )
 end
 
@@ -393,9 +393,11 @@ function GestureDetector:handleDoubleTap(tev)
         timev = tev.timev,
     }
 
+    -- Tap interval / bounce detection may be tweaked by widget (i.e. VirtualKeyboard)
+    local tap_interval = self.input.tap_interval_override or ges_tap_interval
     -- We do tap bounce detection even when double tap is enabled (so, double tap
     -- is triggered when: ges_tap_interval <= delay < ges_double_tap_interval)
-    if ges_tap_interval > 0 and self.last_taps[slot] ~= nil and self:isTapBounce(self.last_taps[slot], cur_tap) then
+    if tap_interval > 0 and self.last_taps[slot] ~= nil and self:isTapBounce(self.last_taps[slot], cur_tap, tap_interval) then
         logger.dbg("tap bounce detected in slot", slot, ": ignored")
         -- Simply ignore it, and clear state as this is the end of a touch event
         -- (this doesn't clear self.last_taps[slot], so a 3rd tap can be detected

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -126,6 +126,7 @@ local Input = {
 
     timer_callbacks = {},
     disable_double_tap = true,
+    tap_interval_override = nil,
 
     -- keyboard state:
     modifiers = {

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -785,14 +785,14 @@ ol.references > li > .mw-cite-backlink { display: none; }
                 ]],
                 separator = true,
             },
-            -- We can add other classic class names to the 2 following
+            -- We can add other classic classnames to the 2 following
             -- tweaks (except when named 'calibreN', as the N number is
             -- usually random across books).
             {
                 id = "footnote-inpage_classic_classnames";
                 title = _("In-page classic classname footnotes"),
                 description = _([[
-Show footnotes with classic class names at the bottom of pages.
+Show footnotes with classic classnames at the bottom of pages.
 This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
                 css = [[
 .footnote, .footnotes, .fn,
@@ -808,7 +808,7 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
                 id = "footnote-inpage_classic_classnames_smaller";
                 title = _("In-page classic classname footnotes (smaller)"),
                 description = _([[
-Show footnotes with classic classname at the bottom of pages.
+Show footnotes with classic classnames at the bottom of pages.
 This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
                 css = [[
 .footnote, .footnotes, .fn,

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -399,6 +399,8 @@ function UIManager:show(widget, refreshtype, refreshregion, x, y, refreshdither)
     else
         Input.disable_double_tap = true
     end
+    -- a widget may override tap interval (when it doesn't, nil restores the default)
+    Input.tap_interval_override = widget.tap_interval_override
 end
 
 --[[--
@@ -459,6 +461,10 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
     end
     if requested_disable_double_tap ~= nil then
         Input.disable_double_tap = requested_disable_double_tap
+    end
+    if #self._window_stack > 0 then
+        -- set tap interval override to what the topmost widget specifies (when it doesn't, nil restores the default)
+        Input.tap_interval_override = self._window_stack[#self._window_stack].widget.tap_interval_override
     end
     if dirty and not widget.invisible then
         -- schedule the remaining visible (i.e., uncovered) widgets to be painted

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -587,6 +587,7 @@ function VirtualKeyPopup:init()
             }
         },
     }
+    self.tap_interval_override = G_reader_settings:readSetting("ges_tap_interval_on_keyboard") or 0
 
     if Device:hasDPad() then
         self.key_events.PressKey = { {"Press"}, doc = "select key" }
@@ -693,6 +694,7 @@ function VirtualKeyboard:init()
     self.min_layer = keyboard.min_layer
     self.max_layer = keyboard.max_layer
     self:initLayer(self.keyboard_layer)
+    self.tap_interval_override = G_reader_settings:readSetting("ges_tap_interval_on_keyboard") or 0
     if Device:hasDPad() then
         self.key_events.PressKey = { {"Press"}, doc = "select key" }
     end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -498,6 +498,33 @@ Default value: %1]]), GestureDetector.TAP_INTERVAL/1000),
                 end,
             },
             {
+                text = _("Tap interval on keyboard"),
+                keep_menu_open = true,
+                callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local items = SpinWidget:new{
+                        title_text = _("Tap interval on keyboard"),
+                        info_text = _([[
+Any other taps made within this interval after a first tap will be considered accidental and ignored.
+
+The interval value is in milliseconds and can range from 0 (0 second) to 2000 (2 seconds).
+Default value: 0]]),
+                        width = math.floor(Screen:getWidth() * 0.75),
+                        value = (G_reader_settings:readSetting("ges_tap_interval_on_keyboard") or 0)/1000,
+                        value_min = 0,
+                        value_max = 2000,
+                        value_step = 50,
+                        value_hold_step = 200,
+                        ok_text = _("Set interval"),
+                        default_value = 0,
+                        callback = function(spin)
+                            G_reader_settings:saveSetting("ges_tap_interval_on_keyboard", spin.value*1000)
+                        end
+                    }
+                    UIManager:show(items)
+                end,
+            },
+            {
                 text = _("Double tap interval"),
                 keep_menu_open = true,
                 callback = function()


### PR DESCRIPTION
`Style tweaks: fix some wording`
See https://github.com/koreader/koreader/issues/6836#issuecomment-717910988. Closes #6836. 

`GestureDetector: add Tap interval on keyboard setting`
Follow up to #6798: allow specifying an other value for tap interval when the keyboard is shown
(a good value for tap interval on reader and UI elements might be too long on the keyboard, and prevent typing fast). (And may be some other people will want a bigger one on the keyboard and 0 in the UI/Reader.)
See https://github.com/koreader/koreader/pull/6798#issuecomment-716852598

<kbd>![image](https://user-images.githubusercontent.com/24273478/97500845-9b737a00-1970-11eb-8550-d09a584029ae.png)</kbd>
(same description text as on the other one)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6838)
<!-- Reviewable:end -->
