### PR TITLE
Support for hiding (skipping) non-linear EPUB fragments

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -257,6 +257,13 @@ function ReaderBookmark:onShowBookmark()
                 page = self.ui.pagemap:getXPointerPageLabel(page, true)
             else
                 page = self.ui.document:getPageFromXPointer(page)
+                if self.ui.document:hasHiddenFlows() then
+                    local flow = self.ui.document:getPageFlow(page)
+                    page = self.ui.document:getPageNumberInFlow(page)
+                    if flow > 0 then
+                        page = T("[%1]%2", page, flow)
+                    end
+                end
             end
         end
         if v.text == nil or v.text == "" then
@@ -491,6 +498,13 @@ function ReaderBookmark:updateBookmark(item)
     for i=1, #self.bookmarks do
         if item.datetime == self.bookmarks[i].datetime and item.page == self.bookmarks[i].page then
             local page = self.ui.document:getPageFromXPointer(item.updated_highlight.pos0)
+            if self.ui.document:hasHiddenFlows() then
+                local flow = self.ui.document:getPageFlow(page)
+                page = self.ui.document:getPageNumberInFlow(page)
+                if flow > 0 then
+                    page = T("[%1]%2", page, flow)
+                end
+            end
             local new_text = item.updated_highlight.text
             self.bookmarks[i].page = item.updated_highlight.pos0
             self.bookmarks[i].pos0 = item.updated_highlight.pos0
@@ -517,6 +531,13 @@ function ReaderBookmark:renameBookmark(item, from_highlight)
                     local page = item.page
                     if not self.ui.document.info.has_pages then
                         page = self.ui.document:getPageFromXPointer(page)
+                        if self.ui.document:hasHiddenFlows() then
+                            local flow = self.ui.document:getPageFlow(page)
+                            page = self.ui.document:getPageNumberInFlow(page)
+                            if flow > 0 then
+                                page = T("[%1]%2", page, flow)
+                            end
+                        end
                     end
                     item.text = T(_("Page %1 %2 @ %3"), page, item.notes, item.datetime)
                 end

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -1034,7 +1034,7 @@ end
 -- mode, and other zoom modes than Fit page
 function ReaderPaging:onGotoNextChapter()
     local pageno = self.current_page
-    local new_page = self.ui.toc:getNextChapter(pageno, 0)
+    local new_page = self.ui.toc:getNextChapter(pageno)
     if new_page then
         self.ui.link:addCurrentLocationToStack()
         self:onGotoPage(new_page)
@@ -1044,7 +1044,7 @@ end
 
 function ReaderPaging:onGotoPrevChapter()
     local pageno = self.current_page
-    local new_page = self.ui.toc:getPreviousChapter(pageno, 0)
+    local new_page = self.ui.toc:getPreviousChapter(pageno)
     if new_page then
         self.ui.link:addCurrentLocationToStack()
         self:onGotoPage(new_page)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -764,7 +764,7 @@ function ReaderRolling:onUpdatePos()
     -- so updatePos() has good info and can reposition
     -- the previous xpointer accurately:
     self.ui.document:getCurrentPos()
-    -- Otherwise, _readMetadata() would do that, but the positionning
+    -- Otherwise, _readMetadata() would do that, but the positioning
     -- would not work as expected, for some reason (it worked
     -- previously because of some bad setDirty() in ConfigDialog widgets
     -- that were triggering a full repaint of crengine (so, the needed

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -185,7 +185,7 @@ function ReaderToc:validateAndFixToc()
                     nb_next = nb_next + 1
                 end
             end
-            logger.dbg("BOGUS TOC:", i, page, ">", i-1, cur_page, "-", nb_prev, nb_next)
+            logger.dbg("BOGUS TOC:", i, page, "<", i-1, cur_page, "-", nb_prev, nb_next)
             if nb_prev <= nb_next then -- less changes when fixing previous pages
                 local fixed_page
                 if i-nb_prev-1 >= 1 then

--- a/frontend/apps/reader/skimtowidget.lua
+++ b/frontend/apps/reader/skimtowidget.lua
@@ -92,6 +92,7 @@ function SkimToWidget:init()
         ticks = self.ticks_flattened,
         tick_width = Size.line.medium,
         last = self.page_count,
+        alt = self.ui.document.flows,
     }
     self.skimto_progress = FrameContainer:new{
         padding = Size.padding.button,

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1290,7 +1290,7 @@ function CreDocument:setupCallCache()
             -- gotoXPointer() is for cre internal fixup, we always use gotoPage/Pos
             -- (goBack, goForward, gotoLink are not used)
 
-            -- For some, we prefer no cache (if they costs nothing, return some huge
+            -- For some, we prefer no cache (if they cost nothing, return some huge
             -- data that we'd rather not cache, are called with many different args,
             -- or we'd rather have up to date crengine state)
             elseif name == "getCurrentPage" then no_wrap = true

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -188,6 +188,48 @@ function Document:getPageCount()
     return self.info.number_of_pages
 end
 
+-- Some functions that look quite silly, but they can be
+-- overridden for document types that support separate flows
+-- (e.g. CreDocument)
+function Document:hasNonLinearFlows()
+    return false
+end
+
+function Document:hasHiddenFlows()
+    return false
+end
+
+function Document:getNextPage(page)
+    local new_page = page + 1
+    return (new_page > 0 and new_page < self.info.number_of_pages) and new_page or 0
+end
+
+function Document:getPrevPage(page)
+    if page == 0 then return self.info.number_of_pages end
+    local new_page = page - 1
+    return (new_page > 0 and new_page < self.info.number_of_pages) and new_page or 0
+end
+
+function Document:getTotalPagesLeft(page)
+    return self.info.number_of_pages - page
+end
+
+function Document:getPageFlow(page)
+    return 0
+end
+
+function Document:getFirstPageInFlow(flow)
+    return 1
+end
+
+function Document:getTotalPagesInFlow(flow)
+    return self.info.number_of_pages
+end
+
+function Document:getPageNumberInFlow(page)
+    return page
+end
+
 -- calculates page dimensions
 function Document:getPageDimensions(pageno, zoom, rotation)
     local native_dimen = self:getNativePageDimensions(pageno):copy()

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -16,6 +16,7 @@ local order = {
         "toggle_bookmark",
         "bookmark_browsing_mode",
         "page_map",
+        "hide_nonlinear_flows",
         "----------------------------",
         "go_to",
         "skim_to",

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -98,7 +98,7 @@ local ImageWidget = Widget:new{
     -- Whether to use former blitbuffer:scale() (default to using MuPDF)
     use_legacy_image_scaling = G_reader_settings:isTrue("legacy_image_scaling"),
 
-    -- For initial positionning, if (possibly scaled) image overflows width/height
+    -- For initial positioning, if (possibly scaled) image overflows width/height
     center_x_ratio = 0.5, -- default is centered on image's center
     center_y_ratio = 0.5,
 
@@ -258,7 +258,7 @@ function ImageWidget:_render()
     end
     bb_w, bb_h = self._bb:getWidth(), self._bb:getHeight()
 
-    -- deal with positionning
+    -- deal with positioning
     if self.width and self.height then
         -- if image is bigger than paint area, allow center_ratio variation
         -- around 0.5 so we can pan till image border

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -332,7 +332,7 @@ function TextBoxWidget:_splitToLines()
             end
             if line.hard_newline_at_eot and not line.next_start_offset then
                 -- Add an empty line to reprensent the \n at end of text
-                -- and allow positionning cursor after it
+                -- and allow positioning cursor after it
                 self.vertical_string_list[ln+1] = {
                     offset = size+1,
                     end_offset = nil,
@@ -483,7 +483,7 @@ function TextBoxWidget:_getLinePads(vertical_string)
     return pads
 end
 
--- XText: shape a line into positionned glyphs
+-- XText: shape a line into positioned glyphs
 function TextBoxWidget:_shapeLine(line)
     -- line is an item from self.vertical_string_list
     if line._shaped then
@@ -494,7 +494,7 @@ function TextBoxWidget:_shapeLine(line)
         -- Empty line (first check above is for hard newline at end of file,
         -- second check is for hard newline while not at end of file).
         -- We need to set a direction on this line, so the cursor can be
-        -- positionned accordingly, on the left or on the right of the line
+        -- positioned accordingly, on the left or on the right of the line
         -- (for convenience, we have an empty line inherit the direction
         -- of the previous line if non-empty)
         local offset = line.offset
@@ -721,7 +721,7 @@ function TextBoxWidget:_shapeLine(line)
         xglyph.w = xglyph.x1 - xglyph.x0
         -- Because of glyph substitution and merging (one to many, many to one, many to many,
         -- with advance or zero-advance...), glyphs may not always be fine to position
-        -- the cursor caret. For X/Y/Charpos positionning/guessing, we'll ignore
+        -- the cursor caret. For X/Y/Charpos positioning/guessing, we'll ignore
         -- glyphs that are not cluster_start, and we build here the full cluster x0/x1/w
         -- by merging them from all glyphs part of this cluster
         if xglyph.is_cluster_start then
@@ -732,7 +732,7 @@ function TextBoxWidget:_shapeLine(line)
                 prev_cluster_start_xglyph.w = prev_cluster_start_xglyph.x1 - prev_cluster_start_xglyph.x0
             end
             -- We don't update/decrease prev_cluster_start_xglyph.x0, even if one of its glyph
-            -- has a backward advance that go back the 1st glyph x0, to not mess positionning.
+            -- has a backward advance that go back the 1st glyph x0, to not mess positioning.
         end
         if xglyph.is_tab then
             xglyph.no_drawing = true

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -141,7 +141,7 @@ function TextWidget:updateSize()
     -- We never need to draw/size more than one screen width, so limit computation
     -- to that width in case we are given some huge string
     local tsize = RenderText:sizeUtf8Text(0, Screen:getWidth(), self.face, self._text_to_draw, true, self.bold)
-    -- As text length includes last glyph pen "advance" (for positionning
+    -- As text length includes last glyph pen "advance" (for positioning
     -- next char), it's best to use math.floor() instead of math.ceil()
     -- to get rid of a fraction of it in case this text is to be
     -- horizontally centered


### PR DESCRIPTION
This is the frontend implementation of https://github.com/koreader/koreader/issues/6809, to be merged after https://github.com/koreader/koreader-base/pull/1228 (see https://github.com/koreader/crengine/pull/391/ too)

The core of the implementation is pretty basic: just create `Document:getPrevPage` and `Document:getNextPage`, which return the prev/next page number. By default they are `page-1` and `page+1`, but if a document contains non-linear flows, they can be skipped. If already inside a non-linear flow, paging works normally, until the boundary is reached, where it continues on the main (linear) flow, skipping other non-linear flows that may be in-between. The non-linear pages are still accessible through links, goto, skim, bookmarks... it's only page back/forward that are affected (if enabled).

Some conventions (that can be discussed and changed):

* In the footer, pages on the linear flow as indicated as `x // y` (double slash), and `x` and `y` refer only to the linear pages (non-linear pages are not counted here). The intent is to succinctly indicate that there are uncounted pages.
* When inside a non-linear flow, the footer shows `[x / y]z`, where `x` and `y` refer only to this particular non-linear flow, and `z` is the number of the flow.
* Pages/time to end of chapter/book are counted as if paging through.
* In toc and bookmarks, page numbers refer to the linear flow. Pages in non-linear flows are indicated as `[x]y` where `x` is the "local" page number and "y" is the number of the flow.
* In goto, a plain number leads to the "global" number. The `[x]y` format is supported, in which case `y=0` corresponds to the linear flow.
* In the skim bar, non-linear pages are marked with a darker background.
* ... and maybe something else I'm forgetting.

Setting help
![Screenshot_20201104_184445](https://user-images.githubusercontent.com/7943459/98150378-d6c0fc00-1ece-11eb-9f7d-93ffa7eb5ec2.png)

Footer, linear
![Screenshot_20201104_184303](https://user-images.githubusercontent.com/7943459/98150214-9a8d9b80-1ece-11eb-8dce-2ca3c5f4b16f.png)

Footer, non-linear
![Screenshot_20201104_184419](https://user-images.githubusercontent.com/7943459/98150237-a1b4a980-1ece-11eb-8db3-aca43fcc4ed4.png)

Go to window
![Screenshot_20201104_184503](https://user-images.githubusercontent.com/7943459/98150442-f22c0700-1ece-11eb-9865-c538090e55b2.png)

Skim window
![Screenshot_20201107_161725](https://user-images.githubusercontent.com/7943459/98445108-2ba28380-2116-11eb-9799-f07d4c54ca26.png)

Bookmarks
![Screenshot_20201104_184521](https://user-images.githubusercontent.com/7943459/98150479-05d76d80-1ecf-11eb-9c0c-6d080de35f79.png)

Closes #6809

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6847)
<!-- Reviewable:end -->
