### PR TITLE
Add menu item allowing users to disable "hold on footer to show Skim Widget"

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2043,7 +2043,6 @@ function ReaderFooter:onHoldFooter()
         self.ui:handleEvent(Event:new("ShowSkimtoDialog"))
         return true
     end
-    return false
 end
 
 function ReaderFooter:setVisible(visible)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -945,7 +945,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Show SkimWidget by holding the footer"),
+                text = _("Hold (footer) to skim"),
                 checked_func = function()
                     return self.settings.skim_widget_on_hold
                 end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -428,6 +428,9 @@ function ReaderFooter:init()
     if not self.settings.book_chapter_max_width_pct then
         self.settings.book_chapter_max_width_pct = 30
     end
+    if self.settings.skim_widget_on_hold == nil then
+        self.settings.skim_widget_on_hold = true
+    end
     self.mode_list = {}
     for i = 0, #self.mode_index do
         self.mode_list[self.mode_index[i]] = i
@@ -939,6 +942,16 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
                 callback = function()
                     self.settings.lock_tap = not self.settings.lock_tap
+                end,
+            },
+            {
+                text = _("Show SkimWidget by holding the footer"),
+                checked_func = function()
+                    return self.settings.skim_widget_on_hold
+                end,
+                callback = function()
+                    self.settings.skim_widget_on_hold = not self.settings.skim_widget_on_hold
+                    G_reader_settings:saveSetting("footer", self.settings)
                 end,
             },
             {
@@ -2026,7 +2039,9 @@ end
 
 function ReaderFooter:onHoldFooter()
     if self.mode == self.mode_list.off then return end
-    self.ui:handleEvent(Event:new("ShowSkimtoDialog"))
+    if self.settings.skim_widget_on_hold then
+        self.ui:handleEvent(Event:new("ShowSkimtoDialog"))
+    end
     return true
 end
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2041,8 +2041,9 @@ function ReaderFooter:onHoldFooter()
     if self.mode == self.mode_list.off then return end
     if self.settings.skim_widget_on_hold then
         self.ui:handleEvent(Event:new("ShowSkimtoDialog"))
+        return true
     end
-    return true
+    return false
 end
 
 function ReaderFooter:setVisible(visible)


### PR DESCRIPTION
Rationale: 
Today I learned that there are system-wide gestures on Onyx devices, and while performing those, skim widget kept popping up and there is no way to disable it.
![image](https://user-images.githubusercontent.com/10298730/98315830-6a7eef00-1fd9-11eb-8e2d-de9a3bdb52ba.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6852)
<!-- Reviewable:end -->
