### PR TITLE
[CRe] Ensure toggling nightmode invalidates the drawCurrentView cache

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -192,7 +192,6 @@ function ReaderHighlight:getClearId()
 end
 
 function ReaderHighlight:clear(clear_id)
-    print("ReaderHighlight:clear", clear_id or "nil")
     if clear_id then -- should be provided by delayed call to clear()
         if clear_id ~= self.clear_id then
             -- if clear_id is no more valid, highlight has already been

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -302,11 +302,17 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     -- or removed).
     local cur_view_top, cur_view_bottom
     local pos = self.view:screenToPageTransform(ges.pos)
+    -- NOTE: By now, pos.page is set, but if a highlight spans across multiple pages,
+    --       it's stored under the hash of its *starting* point,
+    --       so we can't just check the current page, hence the giant hashwalk of death...
+    --       We can't even limit the walk to page <= pos.page,
+    --       because pos.page isn't super accurate in continuous mode...
+    print("Current page ought to be", pos.page)
     for page, items in pairs(self.view.highlight.saved) do
         print("looping on highlights from page", page)
         if items then
             for i = 1, #items do
-                print("looping on item", i, "of", #items)
+                print("looping on item", i, "of", #items, "for page", page)
                 local pos0, pos1 = items[i].pos0, items[i].pos1
                 -- document:getScreenBoxesFromPositions() is expensive, so we
                 -- first check this item is on current page

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -306,7 +306,9 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     --       it's stored under the hash of its *starting* point,
     --       so we can't just check the current page, hence the giant hashwalk of death...
     --       We can't even limit the walk to page <= pos.page,
-    --       because pos.page isn't super accurate in continuous mode...
+    --       because pos.page isn't super accurate in continuous mode
+    --       (it's the page number for what's it the topleft corner of the screen,
+    --       i.e., often a bit earlier)...
     print("Current page ought to be", pos.page)
     for page, items in pairs(self.view.highlight.saved) do
         print("looping on highlights from page", page)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -315,7 +315,8 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
         if items then
             for i = 1, #items do
                 print("looping on item", i, "of", #items, "for page", page)
-                local pos0, pos1 = items[i].pos0, items[i].pos1
+                local item = items[i]
+                local pos0, pos1 = item.pos0, item.pos1
                 -- document:getScreenBoxesFromPositions() is expensive, so we
                 -- first check this item is on current page
                 if not cur_view_top then

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -9,7 +9,6 @@ local Notification = require("ui/widget/notification")
 local TimeVal = require("ui/timeval")
 local Translator = require("ui/translator")
 local UIManager = require("ui/uimanager")
-local dump = require("dump")
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
@@ -216,7 +215,6 @@ function ReaderHighlight:clear(clear_id)
         self.hold_pos = nil
         self.selected_text = nil
         UIManager:setDirty(self.dialog, "ui")
-        print("Cleared something, refreshing ReaderUI")
         return true
     end
 end
@@ -230,18 +228,10 @@ function ReaderHighlight:onTap(_, ges)
     -- We only actually need to clear if we have something to clear in the first place.
     -- (We mainly want to avoid CRe's clearSelection,
     -- which may incur a redraw as it invalidates the cache, c.f., #6854)
-    print("ReaderHighlight:onTap")
-    print("ges =", ges or "nil")
-    print("self.hold_pos =", self.hold_pos or "nil")
-    -- ReaderHighlight:clear can only return true if self.hold_pos was set anyway
+    -- ReaderHighlight:clear can only return true if self.hold_pos was set anyway.
     local cleared = self.hold_pos and self:clear()
-    print("cleared =", cleared)
-    if ges then
-        print(dump(ges))
-    end
     -- We only care about potential taps on existing highlights, not on taps that closed a highlight menu.
     if not cleared and ges and ges.ges == "tap" then
-        print("Do the thing")
         if self.ui.document.info.has_pages then
             return self:onTapPageSavedHighlight(ges)
         else
@@ -309,12 +299,9 @@ function ReaderHighlight:onTapXPointerSavedHighlight(ges)
     --       because pos.page isn't super accurate in continuous mode
     --       (it's the page number for what's it the topleft corner of the screen,
     --       i.e., often a bit earlier)...
-    print("Current page ought to be", pos.page)
     for page, items in pairs(self.view.highlight.saved) do
-        print("looping on highlights from page", page)
         if items then
             for i = 1, #items do
-                print("looping on item", i, "of", #items, "for page", page)
                 local item = items[i]
                 local pos0, pos1 = item.pos0, item.pos1
                 -- document:getScreenBoxesFromPositions() is expensive, so we

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -192,6 +192,7 @@ function ReaderHighlight:getClearId()
 end
 
 function ReaderHighlight:clear(clear_id)
+    print("ReaderHighlight:clear", clear_id or "nil")
     if clear_id then -- should be provided by delayed call to clear()
         if clear_id ~= self.clear_id then
             -- if clear_id is no more valid, highlight has already been
@@ -224,7 +225,14 @@ function ReaderHighlight:onClearHighlight()
 end
 
 function ReaderHighlight:onTap(_, ges)
-    if not self:clear() and ges then
+    print("ReaderHighlight:onTap", self.hold_pos, ges)
+    -- We only actually need to clear if we have something to clear in the first place.
+    -- (We mainly want to avoid CRe's clearSelection,
+    -- which may incur a redraw as it invalidates the cache, c.f., #6854)
+    local cleared_nothing = self.hold_pos and not self:clear()
+    -- But we *do* want to be able to tap on existing highlights ;)
+    if cleared_nothing or ges then
+        print("Actual tap, checking if it was on a HL")
         if self.ui.document.info.has_pages then
             return self:onTapPageSavedHighlight(ges)
         else
@@ -643,6 +651,7 @@ function ReaderHighlight:onPanelZoom(arg, ges)
 end
 
 function ReaderHighlight:onHold(arg, ges)
+    print("ReaderHighlight:onHold")
     if self.document.info.has_pages and self.panel_zoom_enabled then
         return self:onPanelZoom(arg, ges)
     end
@@ -709,6 +718,7 @@ function ReaderHighlight:onHold(arg, ges)
 end
 
 function ReaderHighlight:onHoldPan(_, ges)
+    print("ReaderHighlight:onHoldPan")
     if self.hold_pos == nil then
         logger.dbg("no previous hold position")
         self:_resetHoldTimer(true)
@@ -1039,6 +1049,7 @@ function ReaderHighlight:onTranslateText(text)
 end
 
 function ReaderHighlight:onHoldRelease()
+    print("ReaderHighlight:onHoldRelease")
     local long_final_hold = false
     if self.hold_last_tv then
         local hold_duration = TimeVal.now() - self.hold_last_tv

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1355,8 +1355,9 @@ end
 function ReaderHighlight:deleteHighlight(page, i, bookmark_item)
     self.ui:handleEvent(Event:new("DelHighlight"))
     logger.dbg("delete highlight", page, i)
+    -- The per-page table is a pure array
     local removed = table.remove(self.view.highlight.saved[page], i)
-    -- Clear the hash if there aren't any more highlights on this page
+    -- But the main, outer table is a hash, so clear the table for this page if there are no longer any highlights on it
     if #self.view.highlight.saved[page] == 0 then
         self.view.highlight.saved[page] = nil
     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -192,7 +192,6 @@ function ReaderHighlight:getClearId()
 end
 
 function ReaderHighlight:clear(clear_id)
-    print("ReaderHighlight:clear", clear_id or "nil")
     if clear_id then -- should be provided by delayed call to clear()
         if clear_id ~= self.clear_id then
             -- if clear_id is no more valid, highlight has already been
@@ -225,14 +224,12 @@ function ReaderHighlight:onClearHighlight()
 end
 
 function ReaderHighlight:onTap(_, ges)
-    print("ReaderHighlight:onTap", self.hold_pos, ges)
     -- We only actually need to clear if we have something to clear in the first place.
     -- (We mainly want to avoid CRe's clearSelection,
     -- which may incur a redraw as it invalidates the cache, c.f., #6854)
     local cleared_nothing = self.hold_pos and not self:clear()
     -- But we *do* want to be able to tap on existing highlights ;)
     if cleared_nothing or ges then
-        print("Actual tap, checking if it was on a HL")
         if self.ui.document.info.has_pages then
             return self:onTapPageSavedHighlight(ges)
         else
@@ -651,7 +648,6 @@ function ReaderHighlight:onPanelZoom(arg, ges)
 end
 
 function ReaderHighlight:onHold(arg, ges)
-    print("ReaderHighlight:onHold")
     if self.document.info.has_pages and self.panel_zoom_enabled then
         return self:onPanelZoom(arg, ges)
     end
@@ -718,7 +714,6 @@ function ReaderHighlight:onHold(arg, ges)
 end
 
 function ReaderHighlight:onHoldPan(_, ges)
-    print("ReaderHighlight:onHoldPan")
     if self.hold_pos == nil then
         logger.dbg("no previous hold position")
         self:_resetHoldTimer(true)
@@ -1049,7 +1044,6 @@ function ReaderHighlight:onTranslateText(text)
 end
 
 function ReaderHighlight:onHoldRelease()
-    print("ReaderHighlight:onHoldRelease")
     local long_final_hold = false
     if self.hold_last_tv then
         local hold_duration = TimeVal.now() - self.hold_last_tv

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -230,7 +230,7 @@ function ReaderHighlight:onTap(_, ges)
     -- ReaderHighlight:clear can only return true if self.hold_pos was set anyway.
     local cleared = self.hold_pos and self:clear()
     -- We only care about potential taps on existing highlights, not on taps that closed a highlight menu.
-    if not cleared and ges and ges.ges == "tap" then
+    if not cleared and ges then
         if self.ui.document.info.has_pages then
             return self:onTapPageSavedHighlight(ges)
         else

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -108,6 +108,7 @@ function ReaderTypeset:onReadSettings(config)
     end
     self:toggleImageScaling(self.smooth_scaling)
 
+    self.ui.document:setNightMode(Screen.night_mode)
     -- default to automagic nightmode-friendly handling of images
     self.nightmode_images = config:readSetting("nightmode_images")
     if self.nightmode_images == nil then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -492,8 +492,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
     -- clear that cache when page layout change or highlights are added
     -- or removed).
     local cur_view_top, cur_view_bottom
-    for page, _ in pairs(self.highlight.saved) do
-        local items = self.highlight.saved[page]
+    for page, items in pairs(self.highlight.saved) do
         if not items then items = {} end
         for j = 1, #items do
             local item = items[j]

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -469,20 +469,21 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
     local pages = self:getCurrentPageList()
     for _, page in pairs(pages) do
         local items = self.highlight.saved[page]
-        if not items then items = {} end
-        for i = 1, #items do
-            local item = items[i]
-            local pos0, pos1 = item.pos0, item.pos1
-            local boxes = self.ui.document:getPageBoxesFromPositions(page, pos0, pos1)
-            if boxes then
-                for _, box in pairs(boxes) do
-                    local rect = self:pageToScreenTransform(page, box)
-                    if rect then
-                        self:drawHighlightRect(bb, x, y, rect, item.drawer or self.highlight.saved_drawer)
-                    end
-                end -- end for each box
-            end -- end if boxes
-        end -- end for each highlight
+        if items then
+            for i = 1, #items do
+                local item = items[i]
+                local pos0, pos1 = item.pos0, item.pos1
+                local boxes = self.ui.document:getPageBoxesFromPositions(page, pos0, pos1)
+                if boxes then
+                    for _, box in pairs(boxes) do
+                        local rect = self:pageToScreenTransform(page, box)
+                        if rect then
+                            self:drawHighlightRect(bb, x, y, rect, item.drawer or self.highlight.saved_drawer)
+                        end
+                    end -- end for each box
+                end -- end if boxes
+            end -- end for each highlight
+        end
     end -- end for each page
 end
 
@@ -493,39 +494,40 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
     -- or removed).
     local cur_view_top, cur_view_bottom
     for page, items in pairs(self.highlight.saved) do
-        if not items then items = {} end
-        for j = 1, #items do
-            local item = items[j]
-            local pos0, pos1 = item.pos0, item.pos1
-            -- document:getScreenBoxesFromPositions() is expensive, so we
-            -- first check this item is on current page
-            if not cur_view_top then
-                -- Even in page mode, it's safer to use pos and ui.dimen.h
-                -- than pages' xpointers pos, even if ui.dimen.h is a bit
-                -- larger than pages' heights
-                cur_view_top = self.ui.document:getCurrentPos()
-                if self.view_mode == "page" and self.ui.document:getVisiblePageCount() > 1 then
-                    cur_view_bottom = cur_view_top + 2 * self.ui.dimen.h
-                else
-                    cur_view_bottom = cur_view_top + self.ui.dimen.h
+        if items then
+            for j = 1, #items do
+                local item = items[j]
+                local pos0, pos1 = item.pos0, item.pos1
+                -- document:getScreenBoxesFromPositions() is expensive, so we
+                -- first check this item is on current page
+                if not cur_view_top then
+                    -- Even in page mode, it's safer to use pos and ui.dimen.h
+                    -- than pages' xpointers pos, even if ui.dimen.h is a bit
+                    -- larger than pages' heights
+                    cur_view_top = self.ui.document:getCurrentPos()
+                    if self.view_mode == "page" and self.ui.document:getVisiblePageCount() > 1 then
+                        cur_view_bottom = cur_view_top + 2 * self.ui.dimen.h
+                    else
+                        cur_view_bottom = cur_view_top + self.ui.dimen.h
+                    end
                 end
-            end
-            local spos0 = self.ui.document:getPosFromXPointer(pos0)
-            local spos1 = self.ui.document:getPosFromXPointer(pos1)
-            local start_pos = math.min(spos0, spos1)
-            local end_pos = math.max(spos0, spos1)
-            if start_pos <= cur_view_bottom and end_pos >= cur_view_top then
-                local boxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1, true) -- get_segments=true
-                if boxes then
-                    for _, box in pairs(boxes) do
-                        local rect = self:pageToScreenTransform(page, box)
-                        if rect then
-                            self:drawHighlightRect(bb, x, y, rect, item.drawer or self.highlight.saved_drawer)
-                        end
-                    end -- end for each box
-                end -- end if boxes
-            end
-        end -- end for each highlight
+                local spos0 = self.ui.document:getPosFromXPointer(pos0)
+                local spos1 = self.ui.document:getPosFromXPointer(pos1)
+                local start_pos = math.min(spos0, spos1)
+                local end_pos = math.max(spos0, spos1)
+                if start_pos <= cur_view_bottom and end_pos >= cur_view_top then
+                    local boxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1, true) -- get_segments=true
+                    if boxes then
+                        for _, box in pairs(boxes) do
+                            local rect = self:pageToScreenTransform(page, box)
+                            if rect then
+                                self:drawHighlightRect(bb, x, y, rect, item.drawer or self.highlight.saved_drawer)
+                            end
+                        end -- end for each box
+                    end -- end if boxes
+                end
+            end -- end for each highlight
+        end
     end -- end for all saved highlight
 end
 

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -24,8 +24,13 @@ local function _toggleSetting(name)
 end
 
 function DeviceListener:onToggleNightMode()
+    print("DeviceListener:onToggleNightMode")
     local night_mode = G_reader_settings:isTrue("night_mode")
     Screen:toggleNightMode()
+    -- Make sure CRe will bypass the call cache
+    if self.ui and self.ui.document and self.ui.document.info and self.ui.document.info.has_pages == false then
+        self.ui.document:setNightMode(not night_mode)
+    end
     UIManager:setDirty("all", "full")
     UIManager:ToggleNightMode(not night_mode)
     G_reader_settings:saveSetting("night_mode", not night_mode)

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -28,7 +28,7 @@ function DeviceListener:onToggleNightMode()
     local night_mode = G_reader_settings:isTrue("night_mode")
     Screen:toggleNightMode()
     -- Make sure CRe will bypass the call cache
-    if self.ui and self.ui.document and self.ui.document.info and self.ui.document.info.has_pages == false then
+    if self.ui and self.ui.document and self.ui.document.provider == "crengine" then
         self.ui.document:setNightMode(not night_mode)
     end
     UIManager:setDirty("all", "full")

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -24,7 +24,6 @@ local function _toggleSetting(name)
 end
 
 function DeviceListener:onToggleNightMode()
-    print("DeviceListener:onToggleNightMode")
     local night_mode = G_reader_settings:isTrue("night_mode")
     Screen:toggleNightMode()
     -- Make sure CRe will bypass the call cache

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1067,7 +1067,7 @@ function CreDocument:setupCallCache()
     local do_stats = G_reader_settings:isTrue("use_cre_call_cache_log_stats")
     -- Tune these when debugging
     local do_stats_include_not_cached = false
-    local do_log = true
+    local do_log = false
 
     -- Beware below for luacheck warnings "shadowing upvalue argument 'self'":
     -- the 'self' we got and use here, and the one we may get implicitely

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -25,6 +25,7 @@ local CreDocument = Document:new{
     _view_mode = nil,
     _smooth_scaling = false,
     _nightmode_images = true,
+    _nightmode = Screen.night_mode,
 
     line_space_percent = 100,
     default_font = "Noto Serif",
@@ -400,6 +401,7 @@ function CreDocument:getNextVisibleChar(xp)
 end
 
 function CreDocument:drawCurrentView(target, x, y, rect, pos)
+    print("CreDocument:drawCurrentView", target, x, y, rect, pos)
     if self.buffer and (self.buffer.w ~= rect.w or self.buffer.h ~= rect.h) then
         self.buffer:free()
         self.buffer = nil
@@ -421,16 +423,21 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
     -- We also honor the current smooth scaling setting,
     -- as well as the global SW dithering setting.
 
-    --local start_ts = FFIUtil.getTimestamp()
+    print("CreDocument:drawCurrentView w/ night_mode:", self._nightmode)
+    local start_ts = FFIUtil.getTimestamp()
     self._drawn_images_count, self._drawn_images_surface_ratio =
-        self._document:drawCurrentPage(self.buffer, self.render_color, Screen.night_mode and self._nightmode_images, self._smooth_scaling, Screen.sw_dithering)
-    --local end_ts = FFIUtil.getTimestamp()
-    --print(string.format("CreDocument:drawCurrentView: Rendering took %9.3f ms", (end_ts - start_ts) * 1000))
+        self._document:drawCurrentPage(self.buffer, self.render_color, self._nightmode and self._nightmode_images, self._smooth_scaling, Screen.sw_dithering)
+    local end_ts = FFIUtil.getTimestamp()
+    print(string.format("CreDocument:drawCurrentView: Rendering took %9.3f ms", (end_ts - start_ts) * 1000))
 
-    --start_ts = FFIUtil.getTimestamp()
+    start_ts = FFIUtil.getTimestamp()
     target:blitFrom(self.buffer, x, y, 0, 0, rect.w, rect.h)
-    --end_ts = FFIUtil.getTimestamp()
-    --print(string.format("CreDocument:drawCurrentView: Blitting took  %9.3f ms", (end_ts - start_ts) * 1000))
+    end_ts = FFIUtil.getTimestamp()
+    print(string.format("CreDocument:drawCurrentView: Blitting took  %9.3f ms", (end_ts - start_ts) * 1000))
+
+    if self._toggled_nightmode then
+        self._toggled_nightmode = false
+    end
 end
 
 function CreDocument:drawCurrentViewByPos(target, x, y, rect, pos)
@@ -877,6 +884,11 @@ function CreDocument:setNightmodeImages(toggle)
     self._nightmode_images = toggle
 end
 
+function CreDocument:setNightMode(toggle)
+    logger.dbg("CreDocument: set nightmode", toggle)
+    self._nightmode = toggle
+end
+
 function CreDocument:setFloatingPunctuation(enabled)
     --- @fixme occasional segmentation fault when toggling floating punctuation
     logger.dbg("CreDocument: set floating punctuation", enabled)
@@ -1053,6 +1065,7 @@ end
 -- either globally, or per page/pos for those whose result may depend on
 -- current page number or y-position.
 function CreDocument:setupCallCache()
+    print("CreDocument:setupCallCache")
     if not G_reader_settings:nilOrTrue("use_cre_call_cache") then
         logger.dbg("CreDocument: not using cre call cache")
         return
@@ -1061,7 +1074,7 @@ function CreDocument:setupCallCache()
     local do_stats = G_reader_settings:isTrue("use_cre_call_cache_log_stats")
     -- Tune these when debugging
     local do_stats_include_not_cached = false
-    local do_log = false
+    local do_log = true
 
     -- Beware below for luacheck warnings "shadowing upvalue argument 'self'":
     -- the 'self' we got and use here, and the one we may get implicitely
@@ -1072,6 +1085,7 @@ function CreDocument:setupCallCache()
 
     -- reset full cache
     self._callCacheReset = function()
+        print("_callCacheReset")
         self._call_cache = {}
         self._call_cache_tags_lru = {}
     end
@@ -1403,15 +1417,21 @@ function CreDocument:setupCallCache()
     self.drawCurrentView = function(_self, target, x, y, rect, pos)
         local do_draw = false
         local current_tag = self._callCacheGetCurrentTag()
+        if do_log then logger.dbg("Current tag", current_tag) end
         local current_buffer_tag = self._callCacheGet("current_buffer_tag")
+        if do_log then logger.dbg("current_buffer_tag", current_buffer_tag or "nil") end
         if _self.buffer and (_self.buffer.w ~= rect.w or _self.buffer.h ~= rect.h) then
             do_draw = true
+            if do_log then logger.dbg("Full draw because buffer geometry change") end
         elseif not _self.buffer then
             do_draw = true
+            if do_log then logger.dbg("Full draw because new buffer") end
         elseif not current_buffer_tag then
             do_draw = true
+            if do_log then logger.dbg("Full draw because no current buffer tag") end
         elseif current_buffer_tag ~= current_tag then
             do_draw = true
+            if do_log then logger.dbg("Full draw because different buffer tag", current_buffer_tag, current_tag) end
         end
         local starttime = FFIUtil.getTimestamp()
         if do_draw then
@@ -1419,6 +1439,8 @@ function CreDocument:setupCallCache()
             CreDocument.drawCurrentView(_self, target, x, y, rect, pos)
             addStatMiss("drawCurrentView", starttime)
             self._callCacheSet("current_buffer_tag", current_tag)
+            if do_log then logger.dbg("Setting current_buffer_tag to", current_tag) end
+            if do_log then logger.dbg("Checking current_buffer_tag:", self._callCacheGet("current_buffer_tag") or "nil") end
         else
             if do_log then logger.dbg("callCache: ---------- drawCurrentView: light draw") end
             target:blitFrom(_self.buffer, x, y, 0, 0, rect.w, rect.h)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1067,7 +1067,7 @@ function CreDocument:setupCallCache()
     local do_stats = G_reader_settings:isTrue("use_cre_call_cache_log_stats")
     -- Tune these when debugging
     local do_stats_include_not_cached = false
-    local do_log = false
+    local do_log = true
 
     -- Beware below for luacheck warnings "shadowing upvalue argument 'self'":
     -- the 'self' we got and use here, and the one we may get implicitely
@@ -1278,8 +1278,6 @@ function CreDocument:setupCallCache()
             -- These may have crengine do native highlight or unhighlight
             -- (we could keep the original buffer and use a scratch buffer while
             -- these are used, but not worth bothering)
-            -- The only real interest would be for clearSelection, which can trigger
-            -- without actual content change (e.g., toggling menus/footer).
             elseif name == "clearSelection" then add_buffer_trash = true
             elseif name == "highlightXPointer" then add_buffer_trash = true
             elseif name == "getWordFromPosition" then add_buffer_trash = true

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -25,7 +25,7 @@ local CreDocument = Document:new{
     _view_mode = nil,
     _smooth_scaling = false,
     _nightmode_images = true,
-    _nightmode = Screen.night_mode,
+    _nightmode = false,
 
     line_space_percent = 100,
     default_font = "Noto Serif",

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -756,6 +756,7 @@ function UIManager:getRefreshRate()
 end
 
 function UIManager:ToggleNightMode(night_mode)
+    print("UIManager:ToggleNightMode", night_mode)
     if night_mode then
         self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT
     else

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -756,7 +756,6 @@ function UIManager:getRefreshRate()
 end
 
 function UIManager:ToggleNightMode(night_mode)
-    print("UIManager:ToggleNightMode", night_mode)
     if night_mode then
         self.FULL_REFRESH_COUNT = G_reader_settings:readSetting("night_full_refresh_count") or G_reader_settings:readSetting("full_refresh_count") or DEFAULT_FULL_REFRESH_COUNT
     else


### PR DESCRIPTION
Instead of relying on `Screen.night_mode` at the actual call site, rely on an internal flag, toggled via a set* function, which ensures the cache framework will reset the cache, allowing the page to be re-rendered (and the image counter-inverted properly, and, more importantly, reliably ^^).

Fix #6845 (at least as far as I'm concerned, as I couldn't find anything else going awry on Kobo either with HW or SW invert ^^).

Now also includes minor ReaderHighlight tweaks to avoid spurious cache invalidations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6854)
<!-- Reviewable:end -->
