### PR TITLE
Apply CSS tweaks for links to all elements below a elements.

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -520,35 +520,35 @@ table, tcaption, tr, th, td { border: black solid 1px; border-collapse: collapse
         {
             id = "a_black";
             title = _("Links always black"),
-            css = [[a { color: black !important; }]],
+            css = [[a, a * { color: black !important; }]],
         },
         {
             id = "a_blue";
             title = _("Links always blue"),
-            css = [[a { color: blue !important; }]],
+            css = [[a, a * { color: blue !important; }]],
             separator = true,
         },
         {
             id = "a_bold";
             title = _("Links always bold"),
-            css = [[a { font-weight: bold !important; }]],
+            css = [[a, a * { font-weight: bold !important; }]],
         },
         {
             id = "a_not_bold";
             title = _("Links never bold"),
-            css = [[a { font-weight: normal !important; }]],
+            css = [[a, a * { font-weight: normal !important; }]],
             separator = true,
         },
         {
             id = "a_underline";
             title = _("Links always underlined"),
-            css = [[a[href] { text-decoration: underline !important; }]],
+            css = [[a[href], a[href] * { text-decoration: underline !important; }]],
             -- Have it apply only on real links with a href=, not on anchors
         },
         {
             id = "a_not_underline";
             title = _("Links never underlined"),
-            css = [[a { text-decoration: none !important; }]],
+            css = [[a, a * { text-decoration: none !important; }]],
         },
     },
     {


### PR DESCRIPTION
This is for ebooks that have `<span>` inside of `<a>`.

I've come across ebooks with hyperlinks like this: `<a href="fn.html#fn-1"><span class="a">1</span></span></a>`. The span has CSS that changes the color and overrides the “a_black” CSS fix. With this PR, the CSS for the span gets overridden too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6856)
<!-- Reviewable:end -->
