### PR TITLE
create ota dir

### DIFF
--- a/datastorage.lua
+++ b/datastorage.lua
@@ -54,7 +54,7 @@ local function initDataDir()
     local sub_data_dirs = {
         "cache", "clipboard",
         "data", "data/dict", "data/tessdata",
-        "history", "plugins",
+        "history", "ota", "plugins",
         "screenshots", "settings", "styletweaks",
     }
     for _, dir in ipairs(sub_data_dirs) do


### PR DESCRIPTION
Partially reverts https://github.com/koreader/koreader/pull/6849

Needed for new installs, mainly in https://github.com/koreader/koreader/blob/master/frontend/ui/otamanager.lua#L173.
Fix https://github.com/koreader/koreader/pull/6849#issuecomment-723491945

Hopefully the issue won't affect many users as it needs an empty data_dir to begin with. It is easily fixable with `mkdir koreader/ota`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6857)
<!-- Reviewable:end -->
