### PR TITLE
add Screenshot to Dispatcher

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -459,8 +459,11 @@ function FileManager:init()
     self.menu = FileManagerMenu:new{
         ui = self
     }
-    self.active_widgets = { Screenshoter:new{ prefix = 'FileManager' } }
-    table.insert(self, self.active_widgets[1])
+
+    local screenshoter = Screenshoter:new{ prefix = 'FileManager' }
+    table.insert(self, screenshoter) -- for regular events
+    self.active_widgets = { screenshoter } -- to get events even when hidden
+
     table.insert(self, self.menu)
     table.insert(self, FileManagerHistory:new{
         ui = self,

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -460,6 +460,7 @@ function FileManager:init()
         ui = self
     }
     self.active_widgets = { Screenshoter:new{ prefix = 'FileManager' } }
+    table.insert(self, self.active_widgets[1])
     table.insert(self, self.menu)
     table.insert(self, FileManagerHistory:new{
         ui = self,

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -81,7 +81,10 @@ local ReaderUI = InputContainer:new{
 function ReaderUI:registerModule(name, ui_module, always_active)
     if name then self[name] = ui_module end
     ui_module.name = "reader" .. name
-    table.insert(always_active and self.active_widgets or self, ui_module)
+    if always_active then
+        table.insert(self.active_widgets, ui_module)
+    end
+    table.insert(self, ui_module)
 end
 
 function ReaderUI:registerPostInitCallback(callback)

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -81,10 +81,11 @@ local ReaderUI = InputContainer:new{
 function ReaderUI:registerModule(name, ui_module, always_active)
     if name then self[name] = ui_module end
     ui_module.name = "reader" .. name
+    table.insert(self, ui_module)
     if always_active then
+        -- to get events even when hidden
         table.insert(self.active_widgets, ui_module)
     end
-    table.insert(self, ui_module)
 end
 
 function ReaderUI:registerPostInitCallback(callback)

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -83,6 +83,7 @@ local settingsList = {
     set_no_flash_on_second_chapter_page = { category="string", event="SetNoFlashOnSecondChapterPage", title=_("Never flash on chapter's 2nd page"), device=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("On"), _("Off")},},
     toggle_no_flash_on_second_chapter_page = { category="none", event="ToggleNoFlashOnSecondChapterPage", title=_("Toggle flashing on chapter's 2nd page"), device=true, condition=Device:hasEinkScreen(), separator=true,},
     favorites = { category="none", event="ShowColl", arg="favorites", title=_("Favorites"), device=true,},
+    screenshot = { category="none", event="Screenshot", title=_("Screenshot"), device=true, separator=true,},
 
     -- filemanager settings
     folder_up = { category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
@@ -207,6 +208,7 @@ local dispatcher_menu_order = {
     "toggle_wifi",
 
     "rotation_mode",
+    "screenshot",
 
     -- filemanager
     "folder_up",


### PR DESCRIPTION
Fixes #6592

I needed to add `Screenshoter` to `self` as until now it was just listed as a `active_widget` and would only receive `sendEvent` but not regular `handleEvent` like other widget children. this shouldn't cause too much overhead as they should point to the same table. If there is a better way to fix this please let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6858)
<!-- Reviewable:end -->
