### PR TITLE
allow clearing CreDocument's callcache from frontend

### DIFF
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -108,7 +108,6 @@ function ReaderTypeset:onReadSettings(config)
     end
     self:toggleImageScaling(self.smooth_scaling)
 
-    self.ui.document:setNightMode(Screen.night_mode)
     -- default to automagic nightmode-friendly handling of images
     self.nightmode_images = config:readSetting("nightmode_images")
     if self.nightmode_images == nil then

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -28,7 +28,7 @@ function DeviceListener:onToggleNightMode()
     Screen:toggleNightMode()
     -- Make sure CRe will bypass the call cache
     if self.ui and self.ui.document and self.ui.document.provider == "crengine" then
-        self.ui.document:setNightMode(not night_mode)
+        self.ui.document:resetCallCache()
     end
     UIManager:setDirty("all", "full")
     UIManager:ToggleNightMode(not night_mode)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -877,9 +877,9 @@ function CreDocument:setNightmodeImages(toggle)
     self._nightmode_images = toggle
 end
 
+-- no-op that will be wrapped by setupCallCache
 function CreDocument:resetCallCache()
     logger.dbg("CreDocument: reset call cache")
-    self._callCacheReset()
 end
 
 function CreDocument:setFloatingPunctuation(enabled)
@@ -1273,6 +1273,7 @@ function CreDocument:setupCallCache()
             elseif name:sub(1,6) == "update" then add_reset = true
             elseif name:sub(1,6) == "enable" then add_reset = true
             elseif name == "zoomFont" then add_reset = true -- not used by koreader
+            elseif name == "resetCallCache" then add_reset = true
 
             -- These may have crengine do native highlight or unhighlight
             -- (we could keep the original buffer and use a scratch buffer while

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -877,11 +877,6 @@ function CreDocument:setNightmodeImages(toggle)
     self._nightmode_images = toggle
 end
 
--- no-op that will be wrapped by setupCallCache
-function CreDocument:resetCallCache()
-    logger.dbg("CreDocument: reset call cache")
-end
-
 function CreDocument:setFloatingPunctuation(enabled)
     --- @fixme occasional segmentation fault when toggling floating punctuation
     logger.dbg("CreDocument: set floating punctuation", enabled)
@@ -1053,6 +1048,9 @@ function CreDocument:register(registry)
     registry:addProvider("sh", "application/x-shellscript", self, 90)
     registry:addProvider("py", "text/x-python", self, 90)
 end
+
+-- no-op that will be wrapped by setupCallCache
+function CreDocument:resetCallCache() end
 
 -- Optimise usage of some of the above methods by caching their results,
 -- either globally, or per page/pos for those whose result may depend on

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -25,7 +25,6 @@ local CreDocument = Document:new{
     _view_mode = nil,
     _smooth_scaling = false,
     _nightmode_images = true,
-    _nightmode = false,
 
     line_space_percent = 100,
     default_font = "Noto Serif",
@@ -424,7 +423,7 @@ function CreDocument:drawCurrentView(target, x, y, rect, pos)
 
     --local start_ts = FFIUtil.getTimestamp()
     self._drawn_images_count, self._drawn_images_surface_ratio =
-        self._document:drawCurrentPage(self.buffer, self.render_color, self._nightmode and self._nightmode_images, self._smooth_scaling, Screen.sw_dithering)
+        self._document:drawCurrentPage(self.buffer, self.render_color, Screen.night_mode and self._nightmode_images, self._smooth_scaling, Screen.sw_dithering)
     --local end_ts = FFIUtil.getTimestamp()
     --print(string.format("CreDocument:drawCurrentView: Rendering took %9.3f ms", (end_ts - start_ts) * 1000))
 
@@ -878,9 +877,9 @@ function CreDocument:setNightmodeImages(toggle)
     self._nightmode_images = toggle
 end
 
-function CreDocument:setNightMode(toggle)
-    logger.dbg("CreDocument: set nightmode", toggle)
-    self._nightmode = toggle
+function CreDocument:resetCallCache()
+    logger.dbg("CreDocument: reset call cache")
+    self._callCacheReset()
 end
 
 function CreDocument:setFloatingPunctuation(enabled)


### PR DESCRIPTION
I think this should be a simpler fix for #6854 allowing us not to track nightmode in 2 places.

unless there is a specific reason not to export `_callCacheReset()`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6859)
<!-- Reviewable:end -->
