### PR TITLE
update Stausline immediately when toggling a bookmark

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -185,6 +185,7 @@ function ReaderBookmark:onToggleBookmark()
     self.ui:handleEvent(Event:new("SetDogearVisibility",
                                   not self.view.dogear_visible))
     UIManager:setDirty(self.view.dialog, "ui")
+    UIManager:broadcastEvent(Event:new("BookmarksChanged"))
     return true
 end
 

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -185,7 +185,7 @@ function ReaderBookmark:onToggleBookmark()
     self.ui:handleEvent(Event:new("SetDogearVisibility",
                                   not self.view.dogear_visible))
     UIManager:setDirty(self.view.dialog, "ui")
-    UIManager:broadcastEvent(Event:new("BookmarksChanged"))
+    self.ui:handleEvent(Event:new("BookmarksChanged"))
     return true
 end
 
@@ -419,6 +419,7 @@ function ReaderBookmark:addBookmark(item)
         end
     end
     table.insert(self.bookmarks, _middle + direction, item)
+    self.ui:handleEvent(Event:new("BookmarksChanged"))
 end
 
 -- binary search of sorted bookmarks
@@ -461,7 +462,9 @@ function ReaderBookmark:removeBookmark(item)
         _middle = math.floor((_start + _end)/2)
         local v = self.bookmarks[_middle]
         if item.datetime == v.datetime and item.page == v.page then
-            return table.remove(self.bookmarks, _middle)
+            local retval = table.remove(self.bookmarks, _middle)
+            self.ui:handleEvent(Event:new("BookmarksChanged"))
+            return retval
         elseif self:isBookmarkInPageOrder(item, v) then
             _end = _middle - 1
         else
@@ -476,7 +479,9 @@ function ReaderBookmark:removeBookmark(item)
     for i=1, #self.bookmarks do
         local v = self.bookmarks[i]
         if item.datetime == v.datetime and item.page == v.page then
-            return table.remove(self.bookmarks, i)
+            local retval = table.remove(self.bookmarks, i)
+            self.ui:handleEvent(Event:new("BookmarksChanged"))
+            return retval
         end
     end
     logger.warn("removeBookmark: full scan search didn't find bookmark")

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -182,10 +182,10 @@ function ReaderBookmark:onToggleBookmark()
         pn_or_xp = self.ui.document:getXPointer()
     end
     self:toggleBookmark(pn_or_xp)
+    self.view.footer:onUpdateFooter(true)
     self.ui:handleEvent(Event:new("SetDogearVisibility",
                                   not self.view.dogear_visible))
     UIManager:setDirty(self.view.dialog, "ui")
-    self.ui:handleEvent(Event:new("BookmarksChanged"))
     return true
 end
 
@@ -419,7 +419,7 @@ function ReaderBookmark:addBookmark(item)
         end
     end
     table.insert(self.bookmarks, _middle + direction, item)
-    self.ui:handleEvent(Event:new("BookmarksChanged"))
+    self.view.footer:onUpdateFooter(true)
 end
 
 -- binary search of sorted bookmarks
@@ -462,9 +462,9 @@ function ReaderBookmark:removeBookmark(item)
         _middle = math.floor((_start + _end)/2)
         local v = self.bookmarks[_middle]
         if item.datetime == v.datetime and item.page == v.page then
-            local retval = table.remove(self.bookmarks, _middle)
-            self.ui:handleEvent(Event:new("BookmarksChanged"))
-            return retval
+            table.remove(self.bookmarks, _middle)
+            self.view.footer:onUpdateFooter(true)
+            return
         elseif self:isBookmarkInPageOrder(item, v) then
             _end = _middle - 1
         else
@@ -479,9 +479,9 @@ function ReaderBookmark:removeBookmark(item)
     for i=1, #self.bookmarks do
         local v = self.bookmarks[i]
         if item.datetime == v.datetime and item.page == v.page then
-            local retval = table.remove(self.bookmarks, i)
-            self.ui:handleEvent(Event:new("BookmarksChanged"))
-            return retval
+            table.remove(self.bookmarks, i)
+            self.view.footer:onUpdateFooter(true)
+            return
         end
     end
     logger.warn("removeBookmark: full scan search didn't find bookmark")

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2119,8 +2119,4 @@ function ReaderFooter:onScreenResize()
     self:resetLayout(true)
 end
 
-function ReaderFooter:onBookmarksChanged()
-    self:onUpdateFooter(true)
-end
-
 return ReaderFooter

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2120,9 +2120,7 @@ function ReaderFooter:onScreenResize()
 end
 
 function ReaderFooter:onBookmarksChanged()
-    if self.settings.frontlight then
-        self:onUpdateFooter(true)
-    end
+    self:onUpdateFooter(true)
 end
 
 return ReaderFooter

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2119,4 +2119,10 @@ function ReaderFooter:onScreenResize()
     self:resetLayout(true)
 end
 
+function ReaderFooter:onBookmarksChanged()
+    if self.settings.frontlight then
+        self:onUpdateFooter(true)
+    end
+end
+
 return ReaderFooter


### PR DESCRIPTION
When toggling a bookmark, the status line should be updated, so that the actual bookmark count (if enabled) is shown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6872)
<!-- Reviewable:end -->
