### PR TITLE
[fix] Always initiate empty context table

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -23,6 +23,7 @@ local isAndroid, android = pcall(require, "android")
 local logger = require("logger")
 
 local GetText = {
+    context = {},
     translation = {},
     current_lang = "C",
     dirname = "l10n",


### PR DESCRIPTION
In case of no environment language. I suppose that doesn't tend to happen much in the wild since I added the offending code early in 2020. ;-)

Fixes <https://github.com/koreader/koreader/issues/6873>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6874)
<!-- Reviewable:end -->
