### PR TITLE
Ensure minimum height for the in-fill in progress bar

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -660,7 +660,7 @@ function ReaderFooter:resetLayout(force_reset)
     else
         bar_height = self.settings.progress_style_thick_height or PROGRESS_BAR_STYLE_THICK_DEFAULT_HEIGHT
     end
-    self.progress_bar.height = Screen:scaleBySize(bar_height)
+    self.progress_bar:setHeight(bar_height)
 
     self.horizontal_group:resetLayout()
     self.footer_positioner.dimen.w = new_screen_width
@@ -1820,7 +1820,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
     else
         bar_height = self.settings.progress_style_thick_height or PROGRESS_BAR_STYLE_THICK_DEFAULT_HEIGHT
     end
-    self.progress_bar.height = Screen:scaleBySize(bar_height)
+    self.progress_bar:setHeight(bar_height)
 
     if self.separator_line then
         self.separator_line.dimen.w = self._saved_screen_width - 2 * self.horizontal_margin

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -50,6 +50,8 @@ local ProgressWidget = Widget:new{
     fill_from_right = false,
     allow_mirroring = true,
     _mirroredUI = BD.mirroredUILayout(),
+    _orig_margin_v = nil,
+    _orig_bordersize = nil,
 }
 
 function ProgressWidget:getSize()
@@ -124,26 +126,44 @@ function ProgressWidget:getPercentageFromPosition(pos)
     return x / width
 end
 
+function ProgressWidget:setHeight(height)
+    self.height = Screen:scaleBySize(height)
+    -- Adjust vertical margin and border size to ensure there's
+    -- at least 1 pixel left for the actual bar
+    self._orig_margin_v = self._orig_margin_v or self.margin_v
+    self._orig_bordersize = self._orig_bordersize or self.bordersize
+    local margin_v_min = self._orig_margin_v > 0 and 1 or 0
+    local bordersize_min = self._orig_bordersize > 0 and 1 or 0
+    self.margin_v = math.min(self._orig_margin_v, math.floor((self.height - 2*self._orig_bordersize - 1) / 2))
+    self.margin_v = math.max(self.margin_v, margin_v_min)
+    self.bordersize = math.min(self._orig_bordersize, math.floor((self.height - 2*self.margin_v - 1) / 2))
+    self.bordersize = math.max(self.bordersize, bordersize_min)
+end
+
 function ProgressWidget:updateStyle(thick, height)
     if thick then
-        if height then
-            self.height = Screen:scaleBySize(height)
-        end
         self.margin_h = Screen:scaleBySize(3)
         self.margin_v = Screen:scaleBySize(1)
         self.bordersize = Screen:scaleBySize(1)
         self.radius = Screen:scaleBySize(2)
         self.bgcolor = Blitbuffer.COLOR_WHITE
-    else
+        self._orig_margin_v = nil
+        self._orig_bordersize = nil
         if height then
-            self.height = Screen:scaleBySize(height)
+            self:setHeight(height)
         end
+    else
         self.margin_h = 0
         self.margin_v = 0
         self.bordersize = 0
         self.radius = 0
         self.bgcolor = Blitbuffer.COLOR_GRAY
         self.ticks = nil
+        self._orig_margin_v = nil
+        self._orig_bordersize = nil
+        if height then
+            self:setHeight(height)
+        end
     end
 end
 


### PR DESCRIPTION
With some screen sizes, the footer progress bar (in thick style) may be empty, because margins and borders take the full height. This should ensure that does not happen, by reserving at least 1 pixel for the actual progress bar.

Left: before the PR. Right: after
![Screenshot_20201114_115606](https://user-images.githubusercontent.com/7943459/99146132-83d90880-2675-11eb-8d94-ae2ddaf7d631.png) ![Screenshot_20201114_115723](https://user-images.githubusercontent.com/7943459/99145819-15df1200-2672-11eb-8853-560ada690eb7.png)
with `./kodev run -h=720 -w=1024`, for sizes 5 to 9 (which get scaled to 6 to 10, and the default border and margin are scaled to 2)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6878)
<!-- Reviewable:end -->
