### PR TITLE
[Kobo] Don't attempt to restart Nickel when asking for a reboot/shutdown

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -64,6 +64,7 @@ function UIManager:init()
         end
         UIManager:nextTick(function()
             Device:saveSettings()
+            self._exit_code = 88
             self:broadcastEvent(Event:new("Close"))
             Device:powerOff()
         end)
@@ -77,6 +78,7 @@ function UIManager:init()
         end
         UIManager:nextTick(function()
             Device:saveSettings()
+            self._exit_code = 88
             self:broadcastEvent(Event:new("Close"))
             Device:reboot()
         end)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -64,7 +64,9 @@ function UIManager:init()
         end
         UIManager:nextTick(function()
             Device:saveSettings()
-            self._exit_code = 88
+            if Device:isKobo() then
+                self._exit_code = 88
+            end
             self:broadcastEvent(Event:new("Close"))
             Device:powerOff()
         end)
@@ -78,7 +80,9 @@ function UIManager:init()
         end
         UIManager:nextTick(function()
             Device:saveSettings()
-            self._exit_code = 88
+            if Device:isKobo() then
+                self._exit_code = 88
+            end
             self:broadcastEvent(Event:new("Close"))
             Device:reboot()
         end)

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -445,7 +445,7 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
 
     # Did we request a reboot/shutdown?
     if [ ${RETURN_VALUE} -eq ${KO_RC_HALT} ]; then
-        break;
+        break
     fi
 done
 


### PR DESCRIPTION
I'm not quite sure why I never actually noticed this brainfart before, but it's been stupid like this since basically ever.

(It was made obvious by the inittab changes in FW 4.25, which does a few more things on halt, which gave more time for the on-animator call from our nickel restart script to pop up...).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6880)
<!-- Reviewable:end -->
