### PR TITLE
android: switch compression to lzma2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,8 +356,8 @@ androidupdate: all
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
 
 	# assets are compressed manually and stored inside the APK.
-	cd $(INSTALL_DIR)/koreader && 7z a -l -mx=9 -mfb=256 -mmt=on \
-		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).zip * \
+	cd $(INSTALL_DIR)/koreader && 7z a -l -m0=lzma2 -mx=9 \
+		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).7z * \
 		-xr!*cache$ \
 		-xr!*clipboard$ \
 		-xr!*data/dict$ \

--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,10 @@ androidupdate: all
 	# in runtime luajit-launcher's libluajit.so will be loaded
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
 
+	# shared libraries are stored as raw assets
+	rm -rf $(ANDROID_LAUNCHER_DIR)assets/libs
+	cp -pR $(INSTALL_DIR)/koreader/libs $(ANDROID_LAUNCHER_DIR)/assets
+
 	# assets are compressed manually and stored inside the APK.
 	cd $(INSTALL_DIR)/koreader && 7z a -l -m0=lzma2 -mx=9 \
 		../../$(ANDROID_LAUNCHER_DIR)/assets/module/koreader-$(VERSION).7z * \
@@ -364,6 +368,7 @@ androidupdate: all
 		-xr!*data/tessdata$ \
 		-xr!*history$ \
 		-xr!*l10n/templates$ \
+		-xr!*libs$ \
 		-xr!*ota$ \
 		-xr!*resources/fonts* \
 		-xr!*resources/icons/src* \


### PR DESCRIPTION
requires https://github.com/koreader/android-luajit-launcher/pull/264

I will upload slightly modified versions of 2020.11 with LZMA/ZIP that show a toast with the milliseconds spent uncompressing, for users to benchmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6881)
<!-- Reviewable:end -->
