### PR TITLE
Reference page numbers list: highlight current page

### DIFF
--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -192,10 +192,19 @@ ReaderPageMap.onSetStatusLine = ReaderPageMap.updateVisibleLabels
 
 function ReaderPageMap:onShowPageList()
     -- build up item_table
+    local cur_page = self.ui.document:getCurrentPage()
+    local cur_page_idx = 0
     local page_list = self.ui.document:getPageMap()
     for k, v in ipairs(page_list) do
         v.text = v.label
         v.mandatory = v.page
+        if v.page <= cur_page then
+            cur_page_idx = k
+        end
+    end
+    if cur_page_idx > 0 then
+        -- Have Menu jump to the current page and show it in bold
+        page_list.current = cur_page_idx
     end
 
     local pl_menu = Menu:new{

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -821,6 +821,8 @@ function DictQuickLookup:onSwipe(arg, ges)
             self:changeToPrevDict()
         else
             if self.refresh_callback then self.refresh_callback() end
+            -- update footer (time & battery)
+            self.ui:handleEvent(Event:new("UpdateFooter", true))
             -- trigger a full-screen HQ flashing refresh
             UIManager:setDirty(nil, "full")
             -- a long diagonal swipe may also be used for taking a screenshot,


### PR DESCRIPTION
`Reference page numbers list: highlight current page` like it happens with the TOC

`Dict/Wiki: update footer on full refresh` so we can update the time (it currently isn't updated, although I think it used to work in the past) when reading a long definition or long Wikipedia lookup result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6888)
<!-- Reviewable:end -->
