### PR TITLE
ReaderFooter: Cleanup some more messy dimensions handling

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -692,6 +692,7 @@ function ReaderFooter:resetLayout(force_reset)
 end
 
 function ReaderFooter:getHeight()
+    print("ReaderFooter:getHeight")
     if self.footer_content then
         -- NOTE: self.footer_content is self.vertical_frame + self.bottom_padding,
         --       self.vertical_frame includes self.text_container (which includes self.footer_text)
@@ -1876,13 +1877,6 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
         self.progress_bar.width = math.floor(
             self._saved_screen_width - self.text_width - self.settings.progress_margin_width*2)
     end
-    local bar_height
-    if self.settings.progress_style_thin then
-        bar_height = self.settings.progress_style_thin_height or PROGRESS_BAR_STYLE_THIN_DEFAULT_HEIGHT
-    else
-        bar_height = self.settings.progress_style_thick_height or PROGRESS_BAR_STYLE_THICK_DEFAULT_HEIGHT
-    end
-    self.progress_bar:setHeight(bar_height)
 
     if self.separator_line then
         self.separator_line.dimen.w = self._saved_screen_width - 2 * self.horizontal_margin
@@ -1909,6 +1903,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
             -- So, instead, rely on self:getHeight to compute self.footer_content's height early...
             refresh_dim = self.dimen
             refresh_dim.h = self:getHeight()
+            print("self:getHeight ->", refresh_dim.h)
             refresh_dim.y = self._saved_screen_height - refresh_dim.h
         end
         -- If we're making the footer visible (or it already is), we don't need to repaint ReaderUI behind it

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -840,8 +840,6 @@ function ReaderFooter:addToMainMenu(menu_items)
                     self.genFooterText = footerTextGeneratorMap.empty
                     self.mode = self.mode_list.off
                 elseif prev_has_no_mode then
-                    self.footer_container.dimen.h = self.height
-                    self.footer_text.height = self.height
                     if self.settings.all_at_once then
                         self.mode = self.mode_list.page_progress
                         self:applyFooterMode()
@@ -1379,8 +1377,6 @@ function ReaderFooter:addToMainMenu(menu_items)
                 callback = function()
                     self.settings.disable_progress_bar = not self.settings.disable_progress_bar
                     if not self.settings.disable_progress_bar then
-                        self.footer_container.dimen.h = self.height
-                        self.footer_text.height = self.height
                         self:setTocMarkers()
                         self.mode = self.mode_list.page_progress
                         self:applyFooterMode()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -504,7 +504,6 @@ function ReaderFooter:init()
         self.mode = self.mode_list.off
         self.view.footer_visible = false
         self:resetLayout()
-        self.footer_container.dimen.h = 0
         self.footer_text.height = 0
     end
     if self.settings.all_at_once then
@@ -512,9 +511,6 @@ function ReaderFooter:init()
         self:updateFooterTextGenerator()
         if self.settings.progress_bar_position and self.has_no_mode then
             self.footer_text.height = 0
-            if self.settings.disable_progress_bar then
-                self.footer_container.dimen.h = 0
-            end
         end
     else
         self:applyFooterMode()
@@ -839,9 +835,6 @@ function ReaderFooter:addToMainMenu(menu_items)
                 self.reclaim_height = self.settings.reclaim_height or false
                 -- refresh margins position
                 if self.has_no_mode then
-                    if self.settings.disable_progress_bar then
-                        self.footer_container.dimen.h = 0
-                    end
                     self.footer_text.height = 0
                     should_signal = true
                     self.genFooterText = footerTextGeneratorMap.empty
@@ -1852,12 +1845,12 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
     if self.settings.disable_progress_bar then
         if self.has_no_mode or text == "" then
             self.text_width = 0
-            self.footer_container.dimen.h = 0
             self.footer_text.height = 0
         else
             self.text_width = self.footer_text:getSize().w
             self.footer_text.height = self.footer_text:getSize().h
         end
+        self.progress_bar.height = 0
         self.progress_bar.width = 0
     elseif self.settings.progress_bar_position then
         if self.has_no_mode or text == "" then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2118,19 +2118,15 @@ end
 function ReaderFooter:refreshFooter(refresh, signal)
     self:updateFooterContainer()
     self:resetLayout(true)
-    -- With CRe, if we signal, the event we send will trigger a full repaint anyway, so we should be able to skip this one.
+    -- If we signal, the event we send will trigger a full repaint anyway, so we should be able to skip this one.
     -- We *do* need to ensure we at least re-compute the footer layout, though, especially when going from visible to invisible...
-    if self.ui.document.provider == "crengine" then
-        self:onUpdateFooter(refresh and not signal, refresh and signal)
-        if signal then
+    self:onUpdateFooter(refresh and not signal, refresh and signal)
+    if signal then
+        if self.ui.document.provider == "crengine" then
+            -- This will ultimately trigger an UpdatePos, hence a ReaderUI repaint.
             self.ui:handleEvent(Event:new("SetPageBottomMargin", self.ui.document.configurable.b_page_margin))
-        end
-    else
-        -- Otherwise, we do need a real refresh *now*, as only with CRe will SetPageBottomMargin ultimately trigger an UpdatePos...
-        self:onUpdateFooter(refresh, refresh and signal)
-        -- And, if signal, we need to repaint ReaderUI, too, in case the new footer is smaller than in its previous state.
-        if signal then
-            --self.ui:handleEvent(Event:new("RedrawCurrentPage", self.ui.document.configurable.b_page_margin))
+        else
+            -- No fancy chain of events outside of CRe, just ask for a ReaderUI repaint ourselves ;).
             UIManager:setDirty(self.view.dialog, "partial")
         end
     end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1796,7 +1796,6 @@ function ReaderFooter:getDataFromStatistics(title, pages)
 end
 
 function ReaderFooter:onUpdateFooter(force_repaint, force_recompute)
-    print("ReaderFooter:onUpdateFooter", force_repaint, force_recompute)
     if self.pageno then
         self:updateFooterPage(force_repaint, force_recompute)
     else
@@ -1830,7 +1829,6 @@ end
 
 -- only call this function after document is fully loaded
 function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
-    print("ReaderFooter:_updateFooterText", force_repaint, force_recompute)
     -- footer is invisible, we need neither a repaint nor a recompute, go away.
     if not self.view.footer_visible and not force_repaint and not force_recompute then
         return

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -692,7 +692,6 @@ function ReaderFooter:resetLayout(force_reset)
 end
 
 function ReaderFooter:getHeight()
-    print("ReaderFooter:getHeight")
     if self.footer_content then
         -- NOTE: self.footer_content is self.vertical_frame + self.bottom_padding,
         --       self.vertical_frame includes self.text_container (which includes self.footer_text)
@@ -1896,7 +1895,6 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
             -- So, instead, rely on self:getHeight to compute self.footer_content's height early...
             refresh_dim = self.dimen
             refresh_dim.h = self:getHeight()
-            print("self:getHeight ->", refresh_dim.h)
             refresh_dim.y = self._saved_screen_height - refresh_dim.h
         end
         -- If we're making the footer visible (or it already is), we don't need to repaint ReaderUI behind it

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -673,13 +673,17 @@ function ReaderFooter:resetLayout(force_reset)
     if self.separator_line then
         self.separator_line.dimen.w = new_screen_width - 2 * self.horizontal_margin
     end
-    local bar_height
-    if self.settings.progress_style_thin then
-        bar_height = self.settings.progress_style_thin_height or PROGRESS_BAR_STYLE_THIN_DEFAULT_HEIGHT
+    if self.settings.disable_progress_bar then
+        self.progress_bar.height = 0
     else
-        bar_height = self.settings.progress_style_thick_height or PROGRESS_BAR_STYLE_THICK_DEFAULT_HEIGHT
+        local bar_height
+        if self.settings.progress_style_thin then
+            bar_height = self.settings.progress_style_thin_height or PROGRESS_BAR_STYLE_THIN_DEFAULT_HEIGHT
+        else
+            bar_height = self.settings.progress_style_thick_height or PROGRESS_BAR_STYLE_THICK_DEFAULT_HEIGHT
+        end
+        self.progress_bar:setHeight(bar_height)
     end
-    self.progress_bar:setHeight(bar_height)
 
     self.horizontal_group:resetLayout()
     self.footer_positioner.dimen.w = new_screen_width

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -155,7 +155,6 @@ function ProgressWidget:getPercentageFromPosition(pos)
 end
 
 function ProgressWidget:setHeight(height)
-    print("ProgressWidget:setHeight", height)
     self.height = Screen:scaleBySize(height)
     -- Adjust vertical margin and border size to ensure there's
     -- at least 1 pixel left for the actual bar

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -155,6 +155,7 @@ function ProgressWidget:getPercentageFromPosition(pos)
 end
 
 function ProgressWidget:setHeight(height)
+    print("ProgressWidget:setHeight", height)
     self.height = Screen:scaleBySize(height)
     -- Adjust vertical margin and border size to ensure there's
     -- at least 1 pixel left for the actual bar


### PR DESCRIPTION
Some stuff was still hacked on manually instead of trusting the widget system to do things right, which it does, if you update the right stuff at the right time the right way ;). *This Is The Way*.

Fix #6893 (and address https://github.com/koreader/koreader/pull/6878#discussion_r523411883, because it was indeed redundant ^^).

Includes a bonus fix for a number of settings not being applied immediately in PDFs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6898)
<!-- Reviewable:end -->
