### PR TITLE
OPDS*: Mangle Calibre feeds some more so that they don't confuse luxl/us

### DIFF
--- a/frontend/luxl.lua
+++ b/frontend/luxl.lua
@@ -226,7 +226,6 @@ local STATE_FUNCS = {}
 local function next_char(ps, state, verbose)
     local i = ps.ix
     if i >= ps.bufsz then
-        print("luxl:next_char i >= ps.bufsz", i, ps.bufsz)
         return EVENT_END_DOC, 0, i, state
     end
     ps.i = i
@@ -341,10 +340,6 @@ local luxl = {
 }
 local luxl_mt = { __index = luxl }
 
-function luxl_err_handler(index, state, c)
-    print("luxl:ErrHandler @", index, state, c)
-end
-
 function luxl.new(buffer, bufflen)
     local newone = {
         buf = ffi.cast("const uint8_t *", buffer); -- pointer to "uint8_t *" buffer (0 based)
@@ -355,7 +350,7 @@ function luxl.new(buffer, bufflen)
         markix = 0;            -- offset of current item of interest
         marksz = 0;            -- size of current item of interest
         MsgHandler = nil;      -- Routine to handle messages
-        ErrHandler = luxl_err_handler;      -- Routine to call when there's an error
+        ErrHandler = nil;      -- Routine to call when there's an error
         EventHandler = nil;
         ps = ffi.new('struct parse_state', {
             buf = buffer,
@@ -414,9 +409,6 @@ function luxl:GetNext()
         event, state_f, c = next_char(ps, state_f, self.MsgHandler)
         -- update state id.
         self.state = STATE_FUNCS[state_f]
-        print("luxl:GetNext self.state:", self.state)
-        print("luxl:GetNext event:", event)
-        print("luxl:GetNext c:", c)
         if not event then
             -- handle error
             -- default to start state

--- a/frontend/luxl.lua
+++ b/frontend/luxl.lua
@@ -226,6 +226,7 @@ local STATE_FUNCS = {}
 local function next_char(ps, state, verbose)
     local i = ps.ix
     if i >= ps.bufsz then
+        print("luxl:next_char i >= ps.bufsz", i, ps.bufsz)
         return EVENT_END_DOC, 0, i, state
     end
     ps.i = i
@@ -340,6 +341,10 @@ local luxl = {
 }
 local luxl_mt = { __index = luxl }
 
+function luxl_err_handler(index, state, c)
+    print("luxl:ErrHandler @", index, state, c)
+end
+
 function luxl.new(buffer, bufflen)
     local newone = {
         buf = ffi.cast("const uint8_t *", buffer); -- pointer to "uint8_t *" buffer (0 based)
@@ -350,7 +355,7 @@ function luxl.new(buffer, bufflen)
         markix = 0;            -- offset of current item of interest
         marksz = 0;            -- size of current item of interest
         MsgHandler = nil;      -- Routine to handle messages
-        ErrHandler = nil;      -- Routine to call when there's an error
+        ErrHandler = luxl_err_handler;      -- Routine to call when there's an error
         EventHandler = nil;
         ps = ffi.new('struct parse_state', {
             buf = buffer,
@@ -409,6 +414,9 @@ function luxl:GetNext()
         event, state_f, c = next_char(ps, state_f, self.MsgHandler)
         -- update state id.
         self.state = STATE_FUNCS[state_f]
+        print("luxl:GetNext self.state:", self.state)
+        print("luxl:GetNext event:", event)
+        print("luxl:GetNext c:", c)
         if not event then
             -- handle error
             -- default to start state

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -31,7 +31,6 @@ local function unescape(str)
 end
 
 function OPDSParser:createFlatXTable(xlex, curr_element)
-    print("OPDSParser:createFlatXTable", xlex, curr_element)
     curr_element = curr_element or {}
 
     local curr_attr_name
@@ -39,9 +38,7 @@ function OPDSParser:createFlatXTable(xlex, curr_element)
 
     -- start reading the thing
     for event, offset, size in xlex:Lexemes() do
-        print("event, offset, size:", event, offset, size)
         local txt = ffi.string(xlex.buf + offset, size)
-        print("txt:", txt)
         if event == luxl.EVENT_START then
             if txt ~= "xml" then
                 -- does current element already have something
@@ -75,9 +72,6 @@ function OPDSParser:createFlatXTable(xlex, curr_element)
 end
 
 function OPDSParser:parse(text)
-    print("OPDSParser:parse")
-    print("Orig text:")
-    print(text)
     -- Murder Calibre's whole "content" block, because it's not XML, it's XHTML, and luxl doesn't like it one bit...
     text = text:gsub('<content type="xhtml">(.-)%</content>', '')
     -- luxl cannot properly handle xml comments and we need first remove them
@@ -93,11 +87,7 @@ function OPDSParser:parse(text)
     text = text:gsub("<!%[CDATA%[(.-)%]%]>", function (s)
         return s:gsub( "%p", {["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;" } )
     end )
-    print("text:")
-    print(text)
     local xlex = luxl.new(text, #text)
-    print("xlex:")
-    print(xlex)
     return assert(self:createFlatXTable(xlex))
 end
 

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -76,9 +76,9 @@ function OPDSParser:parse(text)
     -- as the list of crappy replacements below attests to...
     -- There's also a high probability of finding orphaned tags or badly nested ones in there, which will screw everything up.
     text = text:gsub('<content type="xhtml">.-</content>', '')
-    -- luxl cannot properly handle xml comments and we need first remove them
+    -- luxl doesn't handle XML comments, so strip them
     text = text:gsub("<!%-%-.-%-%->", "")
-    -- luxl prefers <br />, other two forms are valid in HTML, but will kick luxl's ass
+    -- luxl prefers <br />, the other two forms are valid in HTML, but will kick luxl's ass
     text = text:gsub("<br>", "<br />")
     text = text:gsub("<br/>", "<br />")
     -- Same deal with hr
@@ -88,7 +88,7 @@ function OPDSParser:parse(text)
     text = text:gsub("<em/>", "")
     -- Let's assume it might also happen to strong...
     text = text:gsub("<strong/>", "")
-    -- some OPDS catalogs wrap text in a CDATA section, remove it as it causes parsing problems
+    -- Some OPDS catalogs wrap text in a CDATA section, remove it as it causes parsing problems
     text = text:gsub("<!%[CDATA%[(.-)%]%]>", function (s)
         return s:gsub( "%p", {["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;" } )
     end )

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -73,7 +73,7 @@ end
 
 function OPDSParser:parse(text)
     -- Murder Calibre's whole "content" block, because it's not XML, it's XHTML, and luxl doesn't like it one bit...
-    text = text:gsub('<content type="xhtml">(.-)%</content>', '')
+    text = text:gsub('<content type="xhtml">.-</content>', '')
     -- luxl cannot properly handle xml comments and we need first remove them
     text = text:gsub("<!--.--->", "")
     -- luxl prefers <br />, other two forms are valid in HTML,

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -72,17 +72,20 @@ function OPDSParser:createFlatXTable(xlex, curr_element)
 end
 
 function OPDSParser:parse(text)
-    -- Murder Calibre's whole "content" block, because it's not XML, it's XHTML, and luxl doesn't like it one bit...
+    -- Murder Calibre's whole "content" block, because luxl doesn't really deal well with various XHTML quirks,
+    -- and orphaned tags, as the list of crappy replacements below attests to...
     text = text:gsub('<content type="xhtml">.-</content>', '')
     -- luxl cannot properly handle xml comments and we need first remove them
     text = text:gsub("<!--.--->", "")
-    -- luxl prefers <br />, other two forms are valid in HTML,
+    -- luxl prefers <br />, other two forms are valid in HTML, but will kick luxl's ass
     -- but will kick the ass of luxl
     text = text:gsub("<br>", "<br />")
     text = text:gsub("<br/>", "<br />")
     -- Same deal with hr
     text = text:gsub("<hr>", "<hr />")
     text = text:gsub("<hr/>", "<hr />")
+    -- It's also allergic to orphaned <em/> (As opposed to a balanced <em></em> pair)...
+    text = text:gsub("<em/>", "")
     -- some OPDS catalogs wrap text in a CDATA section, remove it as it causes parsing problems
     text = text:gsub("<!%[CDATA%[(.-)%]%]>", function (s)
         return s:gsub( "%p", {["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;" } )

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -74,7 +74,7 @@ end
 function OPDSParser:parse(text)
     -- Murder Calibre's whole "content" block, because luxl doesn't really deal well with various XHTML quirks,
     -- as the list of crappy replacements below attests to...
-    -- There's also a high probability of finding orphaned tags in there, which will screw everything up.
+    -- There's also a high probability of finding orphaned tags or badly nested ones in there, which will screw everything up.
     text = text:gsub('<content type="xhtml">.-</content>', '')
     -- luxl cannot properly handle xml comments and we need first remove them
     text = text:gsub("<!--.--->", "")

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -73,12 +73,12 @@ end
 
 function OPDSParser:parse(text)
     -- Murder Calibre's whole "content" block, because luxl doesn't really deal well with various XHTML quirks,
-    -- and orphaned tags, as the list of crappy replacements below attests to...
+    -- as the list of crappy replacements below attests to...
+    -- There's also a high probability of finding orphaned tags in there, which will screw everything up.
     text = text:gsub('<content type="xhtml">.-</content>', '')
     -- luxl cannot properly handle xml comments and we need first remove them
     text = text:gsub("<!--.--->", "")
     -- luxl prefers <br />, other two forms are valid in HTML, but will kick luxl's ass
-    -- but will kick the ass of luxl
     text = text:gsub("<br>", "<br />")
     text = text:gsub("<br/>", "<br />")
     -- Same deal with hr

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -77,7 +77,7 @@ function OPDSParser:parse(text)
     -- There's also a high probability of finding orphaned tags or badly nested ones in there, which will screw everything up.
     text = text:gsub('<content type="xhtml">.-</content>', '')
     -- luxl cannot properly handle xml comments and we need first remove them
-    text = text:gsub("<!--.--->", "")
+    text = text:gsub("<!%-%-.-%-%->", "")
     -- luxl prefers <br />, other two forms are valid in HTML, but will kick luxl's ass
     text = text:gsub("<br>", "<br />")
     text = text:gsub("<br/>", "<br />")

--- a/frontend/ui/opdsparser.lua
+++ b/frontend/ui/opdsparser.lua
@@ -86,6 +86,8 @@ function OPDSParser:parse(text)
     text = text:gsub("<hr/>", "<hr />")
     -- It's also allergic to orphaned <em/> (As opposed to a balanced <em></em> pair)...
     text = text:gsub("<em/>", "")
+    -- Let's assume it might also happen to strong...
+    text = text:gsub("<strong/>", "")
     -- some OPDS catalogs wrap text in a CDATA section, remove it as it causes parsing problems
     text = text:gsub("<!%[CDATA%[(.-)%]%]>", function (s)
         return s:gsub( "%p", {["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;" } )

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -87,7 +87,7 @@ function OPDSBrowser:init()
           },
           {
              title = "Feedbooks",
-             url = "http://www.feedbooks.com/publicdomain/catalog.atom",
+             url = "https://catalog.feedbooks.com/catalog/public_domain.atom",
           },
           {
              title = "ManyBooks",

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -23,8 +23,6 @@ local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
-local dump = require("dump")
-
 local CatalogCacheItem = CacheItem:new{
     size = 1024,  -- fixed size for catalog item
 }
@@ -308,7 +306,6 @@ function OPDSBrowser:genItemTableFromRoot()
 end
 
 function OPDSBrowser:fetchFeed(item_url, username, password, method)
-    print("OPDSBrowser:fetchFeed", item_url, username, password, method)
     local request, sink = {}, {}
     local parsed = url.parse(item_url)
     local hostname = parsed.host
@@ -364,7 +361,6 @@ function OPDSBrowser:fetchFeed(item_url, username, password, method)
 end
 
 function OPDSBrowser:parseFeed(item_url, username, password)
-    print("OPDSBrowser:parseFeed", item_url, username, password)
     local feed
     local feed_last_modified = self:fetchFeed(item_url, username, password, "HEAD")
     local hash = "opds|catalog|" .. item_url
@@ -385,13 +381,11 @@ function OPDSBrowser:parseFeed(item_url, username, password)
         end
     end
     if feed then
-        print("Pre-parse:", dump(feed))
         return OPDSParser:parse(feed)
     end
 end
 
 function OPDSBrowser:getCatalog(item_url, username, password)
-    print("OPDSBrowser:getCatalog", item_url, username, password)
     local ok, catalog = pcall(self.parseFeed, self, item_url, username, password)
     if not ok and catalog then
         logger.info("cannot get catalog info from", item_url or "nil", catalog)
@@ -407,7 +401,6 @@ function OPDSBrowser:getCatalog(item_url, username, password)
 end
 
 function OPDSBrowser:genItemTableFromURL(item_url, username, password)
-    print("OPDSBrowser:genItemTableFromURL", item_url, username, password)
     local catalog = self:getCatalog(item_url, username, password)
     return self:genItemTableFromCatalog(catalog, item_url, username, password)
 end
@@ -525,7 +518,6 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url, username, passwo
 end
 
 function OPDSBrowser:updateCatalog(item_url, username, password)
-    print("OPDSBrowser:updateCatalog", item_url, username, password)
     local menu_table = self:genItemTableFromURL(item_url, username, password)
     if #menu_table > 0 then
         self:switchItemTable(nil, menu_table)
@@ -537,7 +529,6 @@ function OPDSBrowser:updateCatalog(item_url, username, password)
 end
 
 function OPDSBrowser:appendCatalog(item_url, username, password)
-    print("OPDSBrowser:appendCatalog", item_url, username, password)
     local new_table = self:genItemTableFromURL(item_url, username, password)
     if #new_table == 0 then return false end
 
@@ -697,7 +688,6 @@ function OPDSBrowser:browse(browse_url, username, password)
 end
 
 function OPDSBrowser:browseSearchable(browse_url, username, password)
-    print("OPDSBrowser:browseSearchable", browse_url, username, password)
     self.search_server_dialog = InputDialog:new{
         title = _("Search OPDS catalog"),
         input = "",
@@ -721,7 +711,6 @@ function OPDSBrowser:browseSearchable(browse_url, username, password)
                         UIManager:close(self.search_server_dialog)
                         local search = self.search_server_dialog:getInputText():gsub(" ", "+")
                         local searched_url = browse_url:gsub("%%s", search)
-                        print("OPDSBrowser:browseSearchable on Search", searched_url, search)
                         self:browse(searched_url, username, password)
                     end,
                 },
@@ -745,12 +734,10 @@ function OPDSBrowser:onMenuSelect(item)
         local connect_callback
         if item.searchable then
             connect_callback = function()
-                print("OPDSBrowser:onMenuSelect() on searchable item ->", item.url)
                 self:browseSearchable(item.url, item.username, item.password)
             end
         else
             connect_callback = function()
-                print("OPDSBrowser:onMenuSelect() on !searchable item ->", item.url)
                 self:browse(item.url, item.username, item.password)
             end
         end
@@ -876,7 +863,6 @@ function OPDSBrowser:onReturn()
         local path = self.paths[#self.paths]
         if path then
             -- return to last path
-            print("OPDSBrowser:onReturn to path.url:", path.url)
             self:updateCatalog(path.url, path.username, path.password)
         else
             -- return to root path, we simply reinit opdsbrowser
@@ -893,7 +879,6 @@ function OPDSBrowser:onNext()
     while page_num == self.page_num do
         local hrefs = self.item_table.hrefs
         if hrefs and hrefs.next then
-            print("OPDSBrowser:onNext: hrefs.next", hrefs.next)
             if not self:appendCatalog(hrefs.next, self.item_table.username, self.item_table.password) then
                 break  -- reach end of paging
             end

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -498,7 +498,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url, username, passwo
                 end
             end
             if author then
-                item.text = title .. "\n" .. author
+                item.text = title .. " - " .. author
             end
         end
         item.title = title

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -23,6 +23,8 @@ local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
+local dump = require("dump")
+
 local CatalogCacheItem = CacheItem:new{
     size = 1024,  -- fixed size for catalog item
 }
@@ -306,6 +308,7 @@ function OPDSBrowser:genItemTableFromRoot()
 end
 
 function OPDSBrowser:fetchFeed(item_url, username, password, method)
+    print("OPDSBrowser:fetchFeed", item_url, username, password, method)
     local request, sink = {}, {}
     local parsed = url.parse(item_url)
     local hostname = parsed.host
@@ -361,6 +364,7 @@ function OPDSBrowser:fetchFeed(item_url, username, password, method)
 end
 
 function OPDSBrowser:parseFeed(item_url, username, password)
+    print("OPDSBrowser:parseFeed", item_url, username, password)
     local feed
     local feed_last_modified = self:fetchFeed(item_url, username, password, "HEAD")
     local hash = "opds|catalog|" .. item_url
@@ -381,14 +385,16 @@ function OPDSBrowser:parseFeed(item_url, username, password)
         end
     end
     if feed then
+        print("Pre-parse:", dump(feed))
         return OPDSParser:parse(feed)
     end
 end
 
 function OPDSBrowser:getCatalog(item_url, username, password)
+    print("OPDSBrowser:getCatalog", item_url, username, password)
     local ok, catalog = pcall(self.parseFeed, self, item_url, username, password)
     if not ok and catalog then
-        logger.info("cannot get catalog info from", item_url, catalog)
+        logger.info("cannot get catalog info from", item_url or "nil", catalog)
         UIManager:show(InfoMessage:new{
             text = T(_("Cannot get catalog info from %1"), (item_url and BD.url(item_url) or "nil")),
         })
@@ -401,6 +407,7 @@ function OPDSBrowser:getCatalog(item_url, username, password)
 end
 
 function OPDSBrowser:genItemTableFromURL(item_url, username, password)
+    print("OPDSBrowser:genItemTableFromURL", item_url, username, password)
     local catalog = self:getCatalog(item_url, username, password)
     return self:genItemTableFromCatalog(catalog, item_url, username, password)
 end
@@ -518,6 +525,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url, username, passwo
 end
 
 function OPDSBrowser:updateCatalog(item_url, username, password)
+    print("OPDSBrowser:updateCatalog", item_url, username, password)
     local menu_table = self:genItemTableFromURL(item_url, username, password)
     if #menu_table > 0 then
         self:switchItemTable(nil, menu_table)
@@ -529,6 +537,7 @@ function OPDSBrowser:updateCatalog(item_url, username, password)
 end
 
 function OPDSBrowser:appendCatalog(item_url, username, password)
+    print("OPDSBrowser:appendCatalog", item_url, username, password)
     local new_table = self:genItemTableFromURL(item_url, username, password)
     if #new_table == 0 then return false end
 
@@ -676,7 +685,7 @@ function OPDSBrowser:showDownloads(item)
 end
 
 function OPDSBrowser:browse(browse_url, username, password)
-    logger.dbg("Browse opds url", browse_url)
+    logger.dbg("Browse opds url", browse_url or "nil")
     table.insert(self.paths, {
         url = browse_url,
         username = username,
@@ -688,6 +697,7 @@ function OPDSBrowser:browse(browse_url, username, password)
 end
 
 function OPDSBrowser:browseSearchable(browse_url, username, password)
+    print("OPDSBrowser:browseSearchable", browse_url, username, password)
     self.search_server_dialog = InputDialog:new{
         title = _("Search OPDS catalog"),
         input = "",
@@ -711,6 +721,7 @@ function OPDSBrowser:browseSearchable(browse_url, username, password)
                         UIManager:close(self.search_server_dialog)
                         local search = self.search_server_dialog:getInputText():gsub(" ", "+")
                         local searched_url = browse_url:gsub("%%s", search)
+                        print("OPDSBrowser:browseSearchable on Search", searched_url, search)
                         self:browse(searched_url, username, password)
                     end,
                 },
@@ -734,10 +745,12 @@ function OPDSBrowser:onMenuSelect(item)
         local connect_callback
         if item.searchable then
             connect_callback = function()
+                print("OPDSBrowser:onMenuSelect() on searchable item ->", item.url)
                 self:browseSearchable(item.url, item.username, item.password)
             end
         else
             connect_callback = function()
+                print("OPDSBrowser:onMenuSelect() on !searchable item ->", item.url)
                 self:browse(item.url, item.username, item.password)
             end
         end
@@ -863,6 +876,7 @@ function OPDSBrowser:onReturn()
         local path = self.paths[#self.paths]
         if path then
             -- return to last path
+            print("OPDSBrowser:onReturn to path.url:", path.url)
             self:updateCatalog(path.url, path.username, path.password)
         else
             -- return to root path, we simply reinit opdsbrowser
@@ -879,6 +893,7 @@ function OPDSBrowser:onNext()
     while page_num == self.page_num do
         local hrefs = self.item_table.hrefs
         if hrefs and hrefs.next then
+            print("OPDSBrowser:onNext: hrefs.next", hrefs.next)
             if not self:appendCatalog(hrefs.next, self.item_table.username, self.item_table.password) then
                 break  -- reach end of paging
             end

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -390,7 +390,7 @@ function OPDSBrowser:getCatalog(item_url, username, password)
     if not ok and catalog then
         logger.info("cannot get catalog info from", item_url, catalog)
         UIManager:show(InfoMessage:new{
-            text = T(_("Cannot get catalog info from %1"), (BD.url(item_url) or "")),
+            text = T(_("Cannot get catalog info from %1"), (item_url and BD.url(item_url) or "nil")),
         })
         return
     end

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -78,7 +78,7 @@ function OPDSBrowser:init()
         servers = {
           {
             title = "Project Gutenberg",
-            url = "http://m.gutenberg.org/ebooks.opds/?format=opds",
+            url = "https://m.gutenberg.org/ebooks.opds/?format=opds",
           },
           {
             title = "Project Gutenberg [Searchable]",
@@ -91,7 +91,7 @@ function OPDSBrowser:init()
           },
           {
              title = "ManyBooks",
-             url = "http://manybooks.net/opds/index.php",
+             url = "https://manybooks.net/opds/index.php",
           },
           {
              title = "Internet Archive",
@@ -99,11 +99,11 @@ function OPDSBrowser:init()
           },
           {
              title = "Flibusta (Russian)",
-             url = "http://www.flibusta.is/opds",
+             url = "https://www.flibusta.is/opds",
           },
           {
              title = "Flibusta [Ru] [Searchable]",
-             url = "http://www.flibusta.is/opds/search?searchTerm=%s",
+             url = "https://www.flibusta.is/opds/search?searchTerm=%s",
              searchable = true,
           },
           {


### PR DESCRIPTION
By essentially dropping the whole XHTML block, instead of trying to salvage each and every tag one by one as we did before.

Also, as that's usually the result after broken parsing, handle nil URLs slightly better in the frontend, so that they get caught/reported properly instead of doing nothing and/or crashing half the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6902)
<!-- Reviewable:end -->
