### PR TITLE
Add Latin hyphenation

### DIFF
--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -66,6 +66,7 @@ local LANGUAGES = {
     { "it",               {"ita"},   "H   ",   _("Italian"),                "Italian.pattern" },
     { "ja",                    {},   "    ",   _("Japanese") },
     { "ko",                    {},   "    ",   _("Korean") },
+    { "la-lit",       {"lat-lit"},   "H   ",   _("Latin (liturgical)"),     "Latin.pattern" },
     { "la",               {"lat"},   "H   ",   _("Latin"),                  "Latin.pattern" },
     { "lv",               {"lav"},   "H   ",   _("Latvian"),                "Latvian.pattern" },
     { "lt",               {"lit"},   "H   ",   _("Lithuanian"),             "Lithuanian.pattern" },

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -66,6 +66,7 @@ local LANGUAGES = {
     { "it",               {"ita"},   "H   ",   _("Italian"),                "Italian.pattern" },
     { "ja",                    {},   "    ",   _("Japanese") },
     { "ko",                    {},   "    ",   _("Korean") },
+    { "la",               {"lat"},   "H   ",   _("Latin"),                  "Latin.pattern" },
     { "lv",               {"lav"},   "H   ",   _("Latvian"),                "Latvian.pattern" },
     { "lt",               {"lit"},   "H   ",   _("Lithuanian"),             "Lithuanian.pattern" },
     { "mk",                  {""},   "H   ",   _("Macedonian"),             "Macedonian.pattern" },


### PR DESCRIPTION
This PR is also an issue: some months ago (I don't record exactly when), it was possible to choose hyphenation from a big list, an latin hyphenation thanks to [this file](https://jperon.github.io/latin/Latin.pattern), generated from [this project](https://github.com/gregorio-project/hyphen-la) was possible.

Since the only option depends on "typographical rules":

- I tried to add the modification proposed in this PR;

- I edited `data/hyph/languages.json`, adding following lines:
```json
    {
        "name": "Latin",
        "filename": "Latin.pattern",
        "language": "la",
        "left_hyphen_min": 2,
        "right_hyphen_min": 2,
        "aliases": ["lat"]
    },
```
- I added [Latin.pattern](https://jperon.github.io/latin/Latin.pattern) into `data/hyph`.

I'd have expected `Latin.pattern` to be used as hyphen dictionary; but the only option I have is `English-US`, although `typographical rules` are correctly set to `la`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6910)
<!-- Reviewable:end -->
