### PR TITLE
Kobo: Warn on restart if the startup script is outdated

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -6,6 +6,7 @@ local Device = require("device")
 local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local InfoMessage = require("ui/widget/infomessage")
 local PluginLoader = require("pluginloader")
 local SetDefaults = require("apps/filemanager/filemanagersetdefaults")
 local UIManager = require("ui/uimanager")
@@ -567,6 +568,14 @@ dbg:guard(FileManagerMenu, 'setUpdateItemTable',
 
 function FileManagerMenu:exitOrRestart(callback)
     UIManager:close(self.menu_container)
+
+    -- Only restart sets a callback, which suits us just fine for this check ;)
+    if callback and not Device:isStartupScriptUpToDate() then
+        UIManager:show(InfoMessage:new{
+            text = _("KOReader's startup script has been updated. You'll need to completely exit KOReader to finalize the update."),
+        })
+    end
+
     self.ui:onClose()
     if callback then
         callback()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -6,7 +6,6 @@ local Device = require("device")
 local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local InfoMessage = require("ui/widget/infomessage")
 local PluginLoader = require("pluginloader")
 local SetDefaults = require("apps/filemanager/filemanagersetdefaults")
 local UIManager = require("ui/uimanager")
@@ -566,13 +565,17 @@ dbg:guard(FileManagerMenu, 'setUpdateItemTable',
         end
     end)
 
-function FileManagerMenu:exitOrRestart(callback)
+function FileManagerMenu:exitOrRestart(callback, force)
     UIManager:close(self.menu_container)
 
     -- Only restart sets a callback, which suits us just fine for this check ;)
-    if callback and not Device:isStartupScriptUpToDate() then
-        UIManager:show(InfoMessage:new{
+    if callback and not force and not Device:isStartupScriptUpToDate() then
+        UIManager:show(ConfirmBox:new{
             text = _("KOReader's startup script has been updated. You'll need to completely exit KOReader to finalize the update."),
+            ok_text = _("Restart anyway"),
+            ok_callback = function()
+                self:exitOrRestart(callback, true)
+            end,
         })
         return
     end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -574,6 +574,7 @@ function FileManagerMenu:exitOrRestart(callback)
         UIManager:show(InfoMessage:new{
             text = _("KOReader's startup script has been updated. You'll need to completely exit KOReader to finalize the update."),
         })
+        return
     end
 
     self.ui:onClose()

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -4,6 +4,7 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local InfoMessage = require("ui/widget/infomessage")
 local Screensaver = require("ui/screensaver")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
@@ -264,6 +265,12 @@ function ReaderMenu:exitOrRestart(callback)
     UIManager:nextTick(function()
         self.ui:onClose()
         if callback ~= nil then
+            -- Only restart sets a callback, which suits us just fine for this check ;)
+            if not Device:isStartupScriptUpToDate() then
+                UIManager:show(InfoMessage:new{
+                    text = _("KOReader's startup script has been updated. You'll need to completely exit KOReader to finalize the update."),
+                })
+            end
             -- show an empty widget so that the callback always happens
             local Widget = require("ui/widget/widget")
             local widget = Widget:new{

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -262,15 +262,18 @@ dbg:guard(ReaderMenu, 'setUpdateItemTable',
 
 function ReaderMenu:exitOrRestart(callback)
     if self.menu_container then self:onTapCloseMenu() end
+
+    -- Only restart sets a callback, which suits us just fine for this check ;)
+    if callback and not Device:isStartupScriptUpToDate() then
+        UIManager:show(InfoMessage:new{
+            text = _("KOReader's startup script has been updated. You'll need to completely exit KOReader to finalize the update."),
+        })
+        return
+    end
+
     UIManager:nextTick(function()
         self.ui:onClose()
         if callback ~= nil then
-            -- Only restart sets a callback, which suits us just fine for this check ;)
-            if not Device:isStartupScriptUpToDate() then
-                UIManager:show(InfoMessage:new{
-                    text = _("KOReader's startup script has been updated. You'll need to completely exit KOReader to finalize the update."),
-                })
-            end
             -- show an empty widget so that the callback always happens
             local Widget = require("ui/widget/widget")
             local widget = Widget:new{

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -4,7 +4,6 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local InfoMessage = require("ui/widget/infomessage")
 local Screensaver = require("ui/screensaver")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
@@ -260,13 +259,17 @@ dbg:guard(ReaderMenu, 'setUpdateItemTable',
         end
     end)
 
-function ReaderMenu:exitOrRestart(callback)
+function ReaderMenu:exitOrRestart(callback, force)
     if self.menu_container then self:onTapCloseMenu() end
 
     -- Only restart sets a callback, which suits us just fine for this check ;)
-    if callback and not Device:isStartupScriptUpToDate() then
-        UIManager:show(InfoMessage:new{
+    if callback and not force and not Device:isStartupScriptUpToDate() then
+        UIManager:show(ConfirmBox:new{
             text = _("KOReader's startup script has been updated. You'll need to completely exit KOReader to finalize the update."),
+            ok_text = _("Restart anyway"),
+            ok_callback = function()
+                self:exitOrRestart(callback, true)
+            end,
         })
         return
     end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -491,4 +491,9 @@ function Device:isValidPath(path)
     return util.pathExists(path)
 end
 
+-- Device specific method to check if the startup script has been updated
+function Device:isStartupScriptUpToDate()
+    return true
+end
+
 return Device

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -819,6 +819,15 @@ function Kobo:toggleChargingLED(toggle)
     io.close(f)
 end
 
+function Kobo:isStartupScriptUpToDate()
+    -- Compare the hash of the *active* script (i.e., the one in /tmp) to the *potential* one (i.e., the one in KOREADER_DIR)
+    local current_script = "/tmp/koreader.sh"
+    local new_script = os.getenv("KOREADER_DIR") .. "/" .. "koreader.sh"
+
+    local md5 = require("ffi/MD5")
+    return (md5.sumFile(current_script) == md5.sumFile(new_script))
+end
+
 -------------- device probe ------------
 
 local codename = Kobo:getCodeName()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -825,7 +825,7 @@ function Kobo:isStartupScriptUpToDate()
     local new_script = os.getenv("KOREADER_DIR") .. "/" .. "koreader.sh"
 
     local md5 = require("ffi/MD5")
-    return (md5.sumFile(current_script) == md5.sumFile(new_script))
+    return md5.sumFile(current_script) == md5.sumFile(new_script)
 end
 
 -------------- device probe ------------

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -100,6 +100,11 @@ ko_update_check() {
             mv "${NEWUPDATE}" "${INSTALLED}"
             ./fbink -q -y -6 -pm "Update successful :)"
             ./fbink -q -y -5 -pm "KOReader will start momentarily . . ."
+
+            # Warn if the startup script has been updated...
+            if [ "$(md5sum "/tmp/koreader.sh" | cut -f1 -d' ')" != "$(md5sum "${KOREADER_DIR}/koreader.sh" | cut -f1 -d' ')" ]; then
+                ./fbink -q -pmMh "Update contains a startup script update!"
+            fi
         else
             # Uh oh...
             ./fbink -q -y -6 -pmh "Update failed :("


### PR DESCRIPTION
Should help prevent potentially puzzling issues whenever significant changes are made that require startup script tweaks (e.g., USBMS).

Also print a warning right after the update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6916)
<!-- Reviewable:end -->
