### PR TITLE
AutoSave: Delay I/O until after the pageturn

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -959,10 +959,12 @@ function ReaderView:checkAutoSaveSettings()
     if not interval then -- no auto save
         return
     end
+
     local now_ts = os.time()
     if now_ts - self.settings_last_save_ts >= interval*60 then
         self.settings_last_save_ts = now_ts
-        UIManager:nextTick(function()
+        -- I/O, delay until after the pageturn
+        UIManager:tickAfterNext(function()
             self.ui:saveSettings()
         end)
     end

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2173,8 +2173,12 @@ function ReaderStatistics:onPageUpdate(pageno)
 
     -- We want a flush to db every 50 page turns
     if self.pageturn_count >= MAX_PAGETURNS_BEFORE_FLUSH then
-        self:insertDB(self.id_curr_book)
-        -- insertDB will call resetVolatileStats for us ;)
+        -- I/O, delay until after the pageturn, but reset the count now, to avoid potentially scheduling multiple inserts...
+        self.pageturn_count = 0
+        UIManager:tickAfterNext(function()
+            self:insertDB(self.id_curr_book)
+            -- insertDB will call resetVolatileStats for us ;)
+        end)
     end
 
     -- Update average time per page (if need be, insertDB will have updated the totals and cleared the volatiles)


### PR DESCRIPTION
`nextTick` was too early ;).

Prevents small hitches when turning the page for the page where this
triggers.

Apply the same trickery to the Stats DB insert, even if that one probably
had a much smaller impact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6917)
<!-- Reviewable:end -->
