### PR TITLE
android: switch between internal and external sdcard

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -641,11 +641,37 @@ function FileManager:tapPlus()
         table.insert(buttons, 3, {
             {
                 text = _("Import files here"),
-                enabled = Device.isValidPath(self.file_chooser.path),
+                enabled = Device:isValidPath(self.file_chooser.path),
                 callback = function()
                     local current_dir = self.file_chooser.path
                     UIManager:close(self.file_dialog)
                     Device.importFile(current_dir)
+                end,
+            },
+        })
+    end
+
+    if Device:hasExternalSD() then
+        table.insert(buttons, 4, {
+            {
+                text_func = function()
+                    if Device:isValidPath(self.file_chooser.path) then
+                        return _("Switch to SDCard")
+                    else
+                        return _("Switch to internal storage")
+                    end
+                end,
+                callback = function()
+                    if Device:isValidPath(self.file_chooser.path) then
+                        local ok, sd_path = Device:hasExternalSD()
+                        UIManager:close(self.file_dialog)
+                        if ok then
+                            self.file_chooser:changeToPath(sd_path)
+                        end
+                    else
+                        UIManager:close(self.file_dialog)
+                        self.file_chooser:changeToPath(Device.home_dir)
+                    end
                 end,
             },
         })

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -93,6 +93,7 @@ local Device = Generic:new{
         return android.openLink(link) == 0
     end,
     canImportFiles = function() return android.app.activity.sdkVersion >= 19 end,
+    hasExternalSD = function() return android.getExternalSdPath() end,
     importFile = function(path) android.importFile(path) end,
     canShareText = yes,
     doShareText = function(text) android.sendText(text) end,

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -45,6 +45,7 @@ local Device = {
     needsTouchScreenProbe = no,
     hasClipboard = yes, -- generic internal clipboard on all devices
     hasEinkScreen = yes,
+    hasExternalSD = no, -- or other storage volume that cannot be accessed using the File Manager
     canHWDither = no,
     canHWInvert = no,
     canUseCBB = yes, -- The C BB maintains a 1:1 feature parity with the Lua BB, except that is has NO support for BB4, and limited support for BBRGB24


### PR DESCRIPTION
Android nonsense nº 1458349

Switch between two storage volumes that cannot be accesed directly using the filemanager.

![test](https://user-images.githubusercontent.com/975883/100480820-a4cc3f80-30f2-11eb-9a22-5c5024929122.gif)

Fixes #6912 

Requires some changes in luajit-launcher. I will push them once I get a confirmation of https://github.com/koreader/koreader/issues/6912#issuecomment-734943107

Please review naming while we're waiting :smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6919)
<!-- Reviewable:end -->
