### PR TITLE
bug template: [android] log native crashes too

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ normally be found in the KOReader directory:
 * `.adds/koreader/` directory for Kobo
 * `applications/koreader/` directory for Pocketbook
 
-Android won't have a crash.log file because Google restricts what apps can log, so you'll need to obtain logs using `adb logcat KOReader:I ActivityManager:* AndroidRuntime:* *:F`.
+Android won't have a crash.log file because Google restricts what apps can log, so you'll need to obtain logs using `adb logcat KOReader:I ActivityManager:* AndroidRuntime:* DEBUG:* *:F`.
 
 
 Please try to include the relevant sections in your issue description.


### PR DESCRIPTION
So we can get the whole picture since the beginning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6920)
<!-- Reviewable:end -->
