### PR TITLE
ReaderDictionary: Avoid an irritating refresh when dismissing the InfoMessage

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -857,7 +857,7 @@ function ReaderDictionary:showDict(word, results, box, link)
         }
         if self.lookup_progress_msg then
             -- If we have a lookup InfoMessage, and it's taller than us, make it refresh on close
-            if self.lookup_progress_msg[1][1].dimen.h >= self.dict_window.height then
+            if self.lookup_progress_msg[1][1] and self.lookup_progress_msg[1][1].dimen and self.lookup_progress_msg[1][1].dimen.h >= self.dict_window.height then
                 self.lookup_progress_msg.no_refresh_on_close = nil
             end
         end

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -647,9 +647,9 @@ end
 
 function ReaderDictionary:showLookupInfo(word)
     local text = T(self.lookup_msg, word)
-    self.lookup_progress_msg = InfoMessage:new{text=text}
+    self.lookup_progress_msg = InfoMessage:new{text=text, no_refresh_on_close=true}
     UIManager:show(self.lookup_progress_msg)
-    UIManager:forceRePaint()
+    -- UIManager:forceRePaint()
 end
 
 function ReaderDictionary:dismissLookupInfo()

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -827,7 +827,6 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, box, li
 end
 
 function ReaderDictionary:showDict(word, results, box, link)
-    self:dismissLookupInfo()
     if results and results[1] then
         logger.dbg("showing quick lookup window", word, results)
         self.dict_window = DictQuickLookup:new{
@@ -856,7 +855,19 @@ function ReaderDictionary:showDict(word, results, box, link)
                 self:onHtmlDictionaryLinkTapped(dictionary, html_link)
             end,
         }
+        if self.lookup_progress_msg then
+            -- If we have a lookup InfoMessage, and it's taller than us, make it refresh on close
+            if self.lookup_progress_msg[1][1].dimen.h >= self.dict_window.height then
+                self.lookup_progress_msg.no_refresh_on_close = nil
+            end
+        end
         table.insert(self.dict_window_list, self.dict_window)
+        UIManager:show(self.dict_window)
+    end
+
+    -- Delay the dismiss, so we can flip the no_refresh_on_close flag if the InfoMessage is taller than the DictQuickLookup...
+    self:dismissLookupInfo()
+    if results and results[1] then
         UIManager:show(self.dict_window)
     end
 end

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -231,7 +231,7 @@ function DictQuickLookup:update()
         -- bigger window if fullpage being shown - this will let
         -- some room anyway for footer display (time, battery...)
         -- In Landscape, we have less room available for the UI bits, so, chop it off some more
-        if Screen:getHeight() < Screen:getWidth() then
+        if Screen:getScreenMode() == "landscape" then
             self.height = Screen:getHeight() - Screen:scaleBySize(80)
         else
             self.height = Screen:getHeight()

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -230,7 +230,12 @@ function DictQuickLookup:update()
     if self.is_fullpage or G_reader_settings:isTrue("dict_largewindow") then
         -- bigger window if fullpage being shown - this will let
         -- some room anyway for footer display (time, battery...)
-        self.height = Screen:getHeight()
+        -- In Landscape, we have less room available for the UI bits, so, chop it off some more
+        if Screen:getHeight() < Screen:getWidth() then
+            self.height = Screen:getHeight() - Screen:scaleBySize(80)
+        else
+            self.height = Screen:getHeight()
+        end
         self.width = Screen:getWidth() - Screen:scaleBySize(40)
     else
         -- smaller window otherwise

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -64,7 +64,8 @@ local InfoMessage = InputContainer:new{
     lang = nil,
     para_direction_rtl = nil,
     auto_para_direction = nil,
-
+    -- Don't call setDirty when closing the widget
+    no_refresh_on_close = nil,
 }
 
 function InfoMessage:init()
@@ -185,6 +186,10 @@ function InfoMessage:init()
 end
 
 function InfoMessage:onCloseWidget()
+    if self.no_refresh_on_close then
+        return true
+    end
+
     UIManager:setDirty(nil, function()
         return "ui", self[1][1].dimen
     end)


### PR DESCRIPTION
Provided said InfoMessage exists, and is not taller than the Dict/Wiki popup itself.

Re #6932

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6934)
<!-- Reviewable:end -->
