### PR TITLE
kodev: Make the directory finding code work as intended (probably?)

### DIFF
--- a/kodev
+++ b/kodev
@@ -107,7 +107,7 @@ function setup_env() {
     fi
     local files=()
     while IFS=  read -r -d $'\0'; do
-        files+=("$REPLY")
+        files+=("${REPLY}")
     done < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
     assert_ret_zero $? "Emulator not found. Please build it first."
     local idx=0
@@ -116,7 +116,7 @@ function setup_env() {
         echo "Multiple emulator builds found:"
         local ts=()
         # Store list of ts at the same index
-        for i in ${!files[@]}; do
+        for i in "${!files[@]}"; do
             local file="${files[${i}]}/koreader"
             if [ -d "${file}/koreader" ]; then
                 echo "${file} (last modified on $(date -c %y "${file}"))"
@@ -127,7 +127,7 @@ function setup_env() {
         local sorted_ts=()
         IFS=$'\n' read -d '' -r -a sorted_ts < <(printf '%s\n' "${ts[@]}" | sort -r)
         # Find the id of the most recent ts
-        for i in ${!ts[@]}; do
+        for i in "${!ts[@]}"; do
             if [ "${ts[${i}]}" == "${sorted_ts[0]}" ]; then
                 idx="${i}"
                 break

--- a/kodev
+++ b/kodev
@@ -107,6 +107,9 @@ function setup_env() {
     fi
     readarray -d '' files < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
     assert_ret_zero $? "Emulator not found. Please build it first."
+    # Warn if multiple match were found
+    test ${#files[@]} -eq 1
+    assert_ret_zero $? "Multiple emulator builds found! Pare that down to one."
     EMU_DIR="${files[0]}/koreader"
     export EMU_DIR
     LD_LIBRARY_PATH=$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}

--- a/kodev
+++ b/kodev
@@ -118,9 +118,9 @@ function setup_env() {
         # Store list of ts at the same index
         for i in "${!files[@]}"; do
             local file="${files[${i}]}/koreader"
-            if [ -d "${file}/koreader" ]; then
-                echo "${file} (last modified on $(date -c %y "${file}"))"
-                ts[${i}]="$(date -c %Y "${file}")"
+            if [ -d "${file}" ]; then
+                echo "${file} (last modified on $(stat -c %y "${file}"))"
+                ts[${i}]="$(stat -c %Y "${file}")"
             fi
         done
         # Sort the list of ts

--- a/kodev
+++ b/kodev
@@ -105,15 +105,38 @@ function setup_env() {
         # for android adb install
         KODEBUG_SUFFIX=-debug
     fi
-    files=()
+    local files=()
     while IFS=  read -r -d $'\0'; do
         files+=("$REPLY")
     done < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
     assert_ret_zero $? "Emulator not found. Please build it first."
+    local idx=0
     # Warn if multiple matches were found
-    test ${#files[@]} -eq 1
-    assert_ret_zero $? "Multiple emulator builds found! Pare that down to one."
-    EMU_DIR="${files[0]}/koreader"
+    if [ ${#files[@]} -gt 1 ]; then
+        echo "Multiple emulator builds found:"
+        local ts=()
+        # Store list of ts at the same index
+        for i in ${!files[@]}; do
+            local file="${files[${i}]}/koreader"
+            if [ -d "${file}/koreader" ]; then
+                echo "${file} (last modified on $(date -c %y "${file}"))"
+                ts[${i}]="$(date -c %Y "${file}")"
+            fi
+        done
+        # Sort the list of ts
+        local sorted_ts=()
+        IFS=$'\n' read -d '' -r -a sorted_ts < <(printf '%s\n' "${ts[@]}" | sort -r)
+        # Find the id of the most recent ts
+        for i in ${!ts[@]}; do
+            if [ "${ts[${i}]}" == "${sorted_ts[0]}" ]; then
+                idx="${i}"
+                break
+            fi
+        done
+        # Recap
+        echo "Picking the most recent one: ${files[${idx}]}/koreader"
+    fi
+    EMU_DIR="${files[${idx}]}/koreader"
     export EMU_DIR
     LD_LIBRARY_PATH=$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}
     export LD_LIBRARY_PATH

--- a/kodev
+++ b/kodev
@@ -107,7 +107,7 @@ function setup_env() {
     fi
     readarray -d '' files < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
     assert_ret_zero $? "Emulator not found. Please build it first."
-    # Warn if multiple match were found
+    # Warn if multiple matches were found
     test ${#files[@]} -eq 1
     assert_ret_zero $? "Multiple emulator builds found! Pare that down to one."
     EMU_DIR="${files[0]}/koreader"

--- a/kodev
+++ b/kodev
@@ -106,7 +106,7 @@ function setup_env() {
         KODEBUG_SUFFIX=-debug
     fi
     local files=()
-    while IFS=  read -r -d $'\0'; do
+    while IFS= read -r -d $'\0'; do
         files+=("${REPLY}")
     done < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
     assert_ret_zero $? "Emulator not found. Please build it first."

--- a/kodev
+++ b/kodev
@@ -99,15 +99,15 @@ EOL
 }
 
 function setup_env() {
-    SETUP_ENV_GREP_COMMAND="grep -v debug"
+    SETUP_ENV_GREP_COMMAND="grep -z -v debug"
     if [ -n "${KODEBUG}" ]; then
-        SETUP_ENV_GREP_COMMAND="grep debug"
+        SETUP_ENV_GREP_COMMAND="grep -z debug"
         # for android adb install
         KODEBUG_SUFFIX=-debug
     fi
-    files=$(find . -maxdepth 1 -name 'koreader-emulator-*' | ${SETUP_ENV_GREP_COMMAND})/koreader
+    readarray -d '' files < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
     assert_ret_zero $? "Emulator not found. Please build it first."
-    EMU_DIR=${files[0]}
+    EMU_DIR="${files[0]}/koreader"
     export EMU_DIR
     LD_LIBRARY_PATH=$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}
     export LD_LIBRARY_PATH

--- a/kodev
+++ b/kodev
@@ -105,7 +105,10 @@ function setup_env() {
         # for android adb install
         KODEBUG_SUFFIX=-debug
     fi
-    readarray -d '' files < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
+    files=()
+    while IFS=  read -r -d $'\0'; do
+        files+=("$REPLY")
+    done < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
     assert_ret_zero $? "Emulator not found. Please build it first."
     # Warn if multiple matches were found
     test ${#files[@]} -eq 1

--- a/kodev
+++ b/kodev
@@ -126,7 +126,7 @@ function setup_env() {
         # Sort the list of ts
         local sorted_ts=()
         IFS=$'\n' read -d '' -r -a sorted_ts < <(printf '%s\n' "${ts[@]}" | sort -r)
-        # Find the id of the most recent ts
+        # Find the id of the most recent ts (spoiler: it's going to be the one currently targeted by this invocation of kodev)
         for i in "${!ts[@]}"; do
             if [ "${ts[${i}]}" == "${sorted_ts[0]}" ]; then
                 idx="${i}"

--- a/kodev
+++ b/kodev
@@ -109,6 +109,7 @@ function setup_env() {
     while IFS= read -r -d $'\0'; do
         files+=("${REPLY}")
     done < <(find . -maxdepth 1 -name 'koreader-emulator-*' -print0 | ${SETUP_ENV_GREP_COMMAND})
+    test ${#files[@]} -gt 0
     assert_ret_zero $? "Emulator not found. Please build it first."
     local idx=0
     # Warn if multiple matches were found


### PR DESCRIPTION
It was blowing up when find found multiple matches (c.f., gitter).

Warning: requires bash 4.4. It's not in Ubuntu 16.04, it is in 18.04. Is that good enough?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6935)
<!-- Reviewable:end -->
