### PR TITLE
Use Unicode minus in ButtonProgressWidget

### DIFF
--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -77,7 +77,7 @@ function ButtonProgressWidget:update()
         local margin = button_margin
         local extra_border_size = 0
         local button = Button:new{
-            text = "-",
+            text = "−",
             radius = 0,
             margin = margin,
             padding = button_padding,


### PR DESCRIPTION
Change the text in the button from a hypen (-) to a
Unicode minus size (−, U+2212). This is the same width
as the + sign.

The NaturalLightWidget and FrontLightWidget controls
already use minus signs in this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6939)
<!-- Reviewable:end -->
