### PR TITLE
Quote PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifeq ($(TARGET), android)
 	PATH:=$(ANDROID_TOOLCHAIN)/bin:$(PATH)
 endif
 
-MACHINE=$(shell PATH=$(PATH) $(CC) -dumpmachine 2>/dev/null)
+MACHINE=$(shell PATH='$(PATH)' $(CC) -dumpmachine 2>/dev/null)
 ifdef KODEBUG
 	MACHINE:=$(MACHINE)-debug
 	KODEDUG_SUFFIX:=-debug


### PR DESCRIPTION
Should be done regardless, not sure why it was in base but not in front, but also somewhat related to #6354 and #6947. Otherwise a value like `c/Program Files (x86)` causes a syntax error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6948)
<!-- Reviewable:end -->
