### PR TITLE
FileManager: fix Plus menu override

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -122,7 +122,6 @@ function FileManager:init()
         padding_right = Size.padding.large,
         padding_bottom = 0,
         callback = function() self:onShowPlusMenu() end,
-        hold_callback = function() self:onShowPlusMenu() end,
     }
 
     self.path_text = TextWidget:new{

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -121,8 +121,8 @@ function FileManager:init()
         padding_left = Size.padding.large,
         padding_right = Size.padding.large,
         padding_bottom = 0,
-        callback = nil, -- top right corner callback handled by gesture manager
-        hold_callback = nil, -- top right corner hold_callback handled by gesture manager
+        callback = function() self:onShowPlusMenu() end,
+        hold_callback = function() self:onShowPlusMenu() end,
     }
 
     self.path_text = TextWidget:new{

--- a/plugins/gestures.koplugin/defaults.lua
+++ b/plugins/gestures.koplugin/defaults.lua
@@ -4,7 +4,7 @@ local Device = require("device")
 return {
     gesture_fm = {
         tap_top_left_corner = nil,
-        tap_top_right_corner = {show_plus_menu = true,},
+        tap_top_right_corner = nil,
         tap_right_bottom_corner = nil,
         tap_left_bottom_corner = Device:hasFrontlight() and {toggle_frontlight = true,} or nil,
         hold_top_left_corner = nil,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -231,7 +231,8 @@ function Gestures:genMenu(ges)
 end
 
 function Gestures:genSubItem(ges, separator, hold_callback)
-    local reader_only = {tap_top_left_corner=true, hold_top_left_corner=true}
+    local reader_only = {tap_top_left_corner=true, hold_top_left_corner=true,
+                         tap_top_right_corner=true, hold_top_right_corner=true}
     local enabled_func
     if reader_only[ges] then
        enabled_func = function() return self.ges_mode == "gesture_reader" end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -232,7 +232,7 @@ end
 
 function Gestures:genSubItem(ges, separator, hold_callback)
     local reader_only = {tap_top_left_corner=true, hold_top_left_corner=true,
-                         tap_top_right_corner=true, hold_top_right_corner=true}
+                         tap_top_right_corner=true,}
     local enabled_func
     if reader_only[ges] then
        enabled_func = function() return self.ges_mode == "gesture_reader" end


### PR DESCRIPTION
manage it in FM not in gestures, as  #6918 made the menu tap zone the entire width so the tap is not passed through to the gesture plugin

also do not allow changing the top right corner gesture in FM, as it does not do anything any more.

This is also in line with the home button handling.

regression caused by  #6918, touching the tap zones always manages to break something :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6957)
<!-- Reviewable:end -->
