### PR TITLE
FileManager: don't load already loaded plugins

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -479,19 +479,22 @@ function FileManager:init()
     table.insert(self, DeviceListener:new{ ui = self })
 
     -- koreader plugins
-    for _,plugin_module in ipairs(PluginLoader:loadPlugins()) do
-        if not plugin_module.is_doc_only then
-            local ok, plugin_or_err = PluginLoader:createPluginInstance(
-                plugin_module, { ui = self, })
-            -- Keep references to the modules which do not register into menu.
-            if ok then
-                local name = plugin_module.name
-                if name then self[name] = plugin_or_err end
-                table.insert(self, plugin_or_err)
-                logger.info("FM loaded plugin", name,
-                            "at", plugin_module.path)
+    if not self._plugins_loaded then
+        for _,plugin_module in ipairs(PluginLoader:loadPlugins()) do
+            if not plugin_module.is_doc_only then
+                local ok, plugin_or_err = PluginLoader:createPluginInstance(
+                    plugin_module, { ui = self, })
+                -- Keep references to the modules which do not register into menu.
+                if ok then
+                    local name = plugin_module.name
+                    if name then self[name] = plugin_or_err end
+                    table.insert(self, plugin_or_err)
+                    logger.info("FM loaded plugin", name,
+                                "at", plugin_module.path)
+                end
             end
         end
+        self._plugins_loaded = true
     end
 
     if Device:hasWifiToggle() then


### PR DESCRIPTION
`FileManager:init` is called by `FileManager:reinit`, which caused duplicate
loads. Those can't be useful (for example to re-load a modified plugin
on runtime), as `PluginLoader:loadPlugins` memoizes loaded plugins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6958)
<!-- Reviewable:end -->
