### PR TITLE
Add fallback text selection to panel zoom

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -710,8 +710,7 @@ end
 function ReaderHighlight:onHold(arg, ges)
     if self.document.info.has_pages and self.panel_zoom_enabled then
         local res = self:onPanelZoom(arg, ges)
-        -- TODO: make sure it cover all situations
-        if res and not self.panel_zoom_fallback_to_text_selection then
+        if res or not self.panel_zoom_fallback_to_text_selection then
             return res
         end
     end

--- a/frontend/luasettings.lua
+++ b/frontend/luasettings.lua
@@ -156,6 +156,29 @@ function LuaSettings:flipFalse(key)
     return self
 end
 
+-- Initializes settings per extension with default values
+function LuaSettings:initializeExtSettings(key, defaults, force_init)
+    local curr = self:readSetting(key)
+    if not curr or force_init then
+        self:saveSetting(key, defaults)
+        return true
+    end
+    return false
+end
+
+-- Returns saved setting for given extension
+function LuaSettings:getSettingForExt(key, ext)
+    local saved_settings = self:readSetting(key) or {}
+    return saved_settings[ext]
+end
+
+-- Sets setting for given extension
+function LuaSettings:saveSettingForExt(key, value, ext)
+    local saved_settings = self:readSetting(key) or {}
+    saved_settings[ext] = value
+    self:saveSetting(key, saved_settings)
+end
+
 --- Adds item to table.
 function LuaSettings:addTableItem(key, value)
     local settings_table = self:has(key) and self:readSetting(key) or {}


### PR DESCRIPTION
Attempts to do what was discussed in https://github.com/koreader/koreader/pull/6511#issuecomment-739545598 - should allow zooming images in PDFs.

TODO:
Make the defaults per extension and simplify extension handling (avoid duplicated code)

@poire-z any comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6960)
<!-- Reviewable:end -->
