### PR TITLE
Add columns to ReaderZooming paged_modes

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -730,12 +730,15 @@ function ReaderView:onSetFullScreen(full_screen)
 end
 
 function ReaderView:onSetScrollMode(page_scroll)
-    if self.ui.document.info.has_pages and page_scroll and self.ui.zooming.paged_modes[self.zoom_mode] then
+    if self.ui.document.info.has_pages and page_scroll
+            and self.ui.zooming.paged_modes[self.zoom_mode] then
         UIManager:show(InfoMessage:new{
             text = _([[
-Continuous view (scroll mode) works best with zoom to page width or zoom to content width.
+Continuous view (scroll mode) works best with zoom to page width, zoom to \
+content width or zoom to rows.
 
-In combination with zoom to fit page, page height, content height or content, continuous view can cause unexpected shifts when turning pages.]]),
+In combination with zoom to fit page, page height, content height, content or \
+columns, continuous view can cause unexpected shifts when turning pages.]]),
             timeout = 5,
         })
     end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -734,11 +734,9 @@ function ReaderView:onSetScrollMode(page_scroll)
             and self.ui.zooming.paged_modes[self.zoom_mode] then
         UIManager:show(InfoMessage:new{
             text = _([[
-Continuous view (scroll mode) works best with zoom to page width, zoom to \
-content width or zoom to rows.
+Continuous view (scroll mode) works best with zoom to page width, zoom to content width or zoom to rows.
 
-In combination with zoom to fit page, page height, content height, content or \
-columns, continuous view can cause unexpected shifts when turning pages.]]),
+In combination with zoom to fit page, page height, content height, content or columns, continuous view can cause unexpected shifts when turning pages.]]),
             timeout = 5,
         })
     end

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -53,6 +53,7 @@ local ReaderZooming = InputContainer:new{
         pageheight = _("Zoom to fit page height works best with page view."),
         contentheight = _("Zoom to fit content height works best with page view."),
         content = _("Zoom to fit content works best with page view."),
+        columns = _("Zoom to fit columns works best with page view."),
     },
 }
 


### PR DESCRIPTION
This means it will warn when changing to continuous mode while
zoom to columns is active.

----

This doesn't fix #6822 but it's related to a fix since probably all members of `paged_modes` probably should also warn/autofix in reverse (i.e. when changing the zoom mode)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6970)
<!-- Reviewable:end -->
