### PR TITLE
Fix crash with RTL UI

### DIFF
--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -551,7 +551,7 @@ if BD.mirroredUILayout() then
     -- be mirrored - but that's not enough: we need to swap LEFT and RIGHT,
     -- so they appear in a more expected and balanced order to RTL users:
     -- {JUSTIFY, LEFT, CENTER, RIGHT, AUTO}
-    local j = KoptOptions[3].options[5]
+    local j = KoptOptions[4].options[5]
     assert(j.name == "justification")
     j.item_icons[2], j.item_icons[4] = j.item_icons[4], j.item_icons[2]
     j.values[2], j.values[4] = j.values[4], j.values[2]

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -1,6 +1,7 @@
 local BD = require("ui/bidi")
 local Device = require("device")
 local optionsutil = require("ui/data/optionsutil")
+local util = require("util")
 local _ = require("gettext")
 local C_ = _.pgettext
 local Screen = Device.screen
@@ -556,6 +557,16 @@ if BD.mirroredUILayout() then
     j.item_icons[2], j.item_icons[4] = j.item_icons[4], j.item_icons[2]
     j.values[2], j.values[4] = j.values[4], j.values[2]
     j.labels[2], j.labels[4] = j.labels[4], j.labels[2]
+    -- The zoom direction items will be mirrored, but we want them to
+    -- stay as is, as the RTL diretions are at the end of the arrays.
+    -- By reverting the mirroring, RTL directions will be on the right,
+    -- so, at the start of the options for a RTL reader.
+    j = KoptOptions[3].options[7]
+    assert(j.name == "zoom_direction")
+    util.arrayReverse(j.item_icons)
+    util.arrayReverse(j.values)
+    util.arrayReverse(j.args)
+    j.default_value = 0
 end
 
 return KoptOptions

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -198,9 +198,14 @@ function ConfigOption:init()
         local show_default = not self.options[c].advanced or show_advanced
         local show = self.options[c].show
         -- Prefer show_func over show if there's one
+        -- Or may be not, as show_func is always used to show/hide some widget depending
+        -- on the value of another widget: it's best to keep it accounted for the names
+        -- max width, and avoid stuff moving when toggling options.
+        --[[
         if self.options[c].show_func then
             show = self.options[c].show_func(self.config.configurable, self.config.document)
         end
+        ]]--
         if show ~= false and show_default then
             local name_font_face = self.options[c].name_font_face and self.options[c].name_font_face or "cfont"
             local name_font_size = self.options[c].name_font_size and self.options[c].name_font_size or default_name_font_size


### PR DESCRIPTION
Fix crash with RTL UI (little RTL UI specific layout bit not updated after #6885).

Also don't check show_func when sizing the names on the bottom menu, to avoid icons moving or resizing when toggling options. See https://github.com/koreader/koreader/pull/6885#issuecomment-735443154 and above:
> E minor aesthetically annyoing thing: when toggling Zoom to because of the different name_text show on the left, and their possibly different text size (Horizontal overlap is long :), the zoom for these names vs the room available for the widget may change: so, you have the widget images moving a bit, possibly changeing sizes to fit. I guess this will vary with language translation :)
May be we should take into account all the not enabled options' name_text into account to compute the left width?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6975)
<!-- Reviewable:end -->
