### PR TITLE
kodev: Use getopt instead of a hand-rolled hack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Homebrew install dependencies
         # Compared to the README, adds ccache for faster compilation times and removes sh5sum to prevent some conflict with coreutils
         # Compared to the emulator, adds p7zip and removes sdl2.
-        run: brew install ccache nasm ragel binutils coreutils libtool autoconf automake cmake makedepend lua@5.1 luarocks gettext pkg-config wget p7zip
+        run: brew install ccache nasm ragel binutils coreutils libtool autoconf automake cmake makedepend lua@5.1 luarocks gettext gnu-getopt pkg-config wget p7zip
 
       - name: Building in progress…
-        run: export MACOSX_DEPLOYMENT_TARGET=10.14 PATH="/usr/local/opt/gettext/bin:$PATH" && ./kodev release macos
+        run: export MACOSX_DEPLOYMENT_TARGET=10.14 PATH="$(brew --prefix)/opt/gettext/bin:$(brew --prefix)/opt/gnu-getopt/bin:${PATH}" && ./kodev release macos
 
       - name: Uploading artifacts
         uses: actions/upload-artifact@v2

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -41,12 +41,12 @@ Install the prerequisites using [Homebrew](https://brew.sh/):
 
 ```
 brew install nasm ragel binutils coreutils libtool autoconf automake cmake makedepend \
-sdl2 lua@5.1 luarocks gettext pkg-config wget
+sdl2 lua@5.1 luarocks gettext pkg-config wget gnu-getopt
 ```
 
-You will also have to ensure Homebrew's gettext is in your path, e.g., via
+You will also have to ensure Homebrew's gettext & gnu-getopt are in your path, e.g., via
 ```
-export PATH="/usr/local/opt/gettext/bin:${PATH}"
+export PATH="$(brew --prefix)/opt/gettext/bin:$(brew --prefix)/opt/gnu-getopt/bin:${PATH}"
 ```
 See also `brew info gettext` for details on how to make that permanent in your shell.
 

--- a/kodev
+++ b/kodev
@@ -780,7 +780,6 @@ TARGET:
                 ;;
             -r | --sane-return)
                 export SANE_RETURN=1
-                shift
                 ;;
             -H | --help)
                 echo "${RUN_HELP_MSG}"

--- a/kodev
+++ b/kodev
@@ -563,7 +563,8 @@ OPTIONS:
                              supported model: kobo-aura-one, kindle3, hidpi
     --gdb=X                  run with debugger (default: nemiver)
     --graph                  graph memory use (requires gnuplot)
-    --valgrind=X             run with valgrind (default: valgrind --trace-children=yes)
+    --valgrind=X             run with valgrind (default: valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes)
+    --callgrind              run with valgrind's callgrind (valgrind --tool=callgrind --trace-children=yes)
 
 TARGET:
 
@@ -622,6 +623,15 @@ TARGET:
                         echo "Couldn't find valgrind."
                         exit 1
                     fi
+                fi
+                ;;
+            --callgrind)
+                # Try to use sensible defaults for valgrind
+                if command -v valgrind >/dev/null; then
+                    valgrind="valgrind --tool=callgrind --trace-children=yes"
+                else
+                    echo "Couldn't find valgrind."
+                    exit 1
                 fi
                 ;;
             -w | --screen-width)

--- a/kodev
+++ b/kodev
@@ -590,15 +590,15 @@ TARGET:
                     gdb=${VALUE}
                 else
                     # Try to use friendly defaults for gdb
-                    if command -v znemiver >/dev/null; then
+                    if command -v nemiver >/dev/null; then
                         # Nemiver is a nice GUI
-                        gdb=nemiver
+                        gdb="nemiver"
                     elif command -v ddd >/dev/null; then
                         # DDD is a slightly less nice GUI
-                        gdb=ddd
+                        gdb="ddd"
                     elif command -v cgdb >/dev/null; then
                         # cgdb is a nice curses-based gdb front
-                        gdb=cgdb
+                        gdb="cgdb"
                     elif command -v gdb >/dev/null; then
                         # gdb -tui is a slightly less nice terminal user interface
                         gdb="gdb -tui"
@@ -720,19 +720,10 @@ TARGET:
             # run with catchsegv by default when it is available
             # see https://github.com/koreader/koreader/issues/2878#issuecomment-326796777
             if command -v catchsegv >/dev/null; then
-                CATCHSEGV=$(command -v catchsegv)
+                CATCHSEGV="$(command -v catchsegv)"
             fi
 
             KOREADER_COMMAND="${CATCHSEGV} ./reader.lua -d"
-
-            if [ -n "${gdb}" ]; then
-                if [ "${gdb}" == gdb* ]; then
-                    # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
-                    KOREADER_COMMAND="${gdb} --args ./luajit reader.lua -d"
-                else
-                    KOREADER_COMMAND="${gdb} ./luajit reader.lua -d"
-                fi
-            fi
 
             if [ -n "${valgrind}" ]; then
                 KOREADER_COMMAND="${valgrind} ./luajit reader.lua -d"
@@ -741,12 +732,22 @@ TARGET:
             echo "[*] Running KOReader with arguments: $*..."
             pushd "${EMU_DIR}" && {
                 if [ $# -lt 1 ]; then
-                    args=${CURDIR}/test
+                    args="${CURDIR}/test"
                 else
                     args="$*"
                     [[ "${args}" != /* ]] && args="${CURDIR}/${args}"
                 fi
-                KOREADER_COMMAND="${KOREADER_COMMAND} ${args}"
+
+                if [ -n "${gdb}" ]; then
+                    if [[ "${gdb}" == gdb* ]]; then
+                        # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
+                        KOREADER_COMMAND="${gdb} --args ./luajit reader.lua -d ${args}"
+                    else
+                        KOREADER_COMMAND="${gdb} ./luajit reader.lua -d ${args}"
+                    fi
+                else
+                    KOREADER_COMMAND="${KOREADER_COMMAND} ${args}"
+                fi
 
                 RETURN_VALUE=85
                 while [ "${RETURN_VALUE}" -eq 85 ]; do

--- a/kodev
+++ b/kodev
@@ -627,6 +627,7 @@ OPTIONS:
     -p, --graph              graph memory use (requires gnuplot)
     -v X, --valgrind=X       run with valgrind (default: \"valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes\")
     -c, --callgrind          run with valgrind's callgrind (valgrind --tool=callgrind --trace-children=yes)
+    -r, --sane-return        force KOReader to exit sanely, instead of calling os.exit. This ensures a saner teardown of the Lua state. (enabled by default when running under valgrind/gdb).
 
 TARGET:
 
@@ -643,8 +644,8 @@ TARGET:
 
     declare opt
     declare -r E_OPTERR=85
-    declare -r short_opts="tbng::pv::cw:h:d:s:H"
-    declare -r long_opts="disable-touch,no-build,gdb::,graph,valgrind::,callgrind,screen-width:,screen-height:,screen-dpi:,simulate:,help"
+    declare -r short_opts="tbng::pv::cw:h:d:s:rH"
+    declare -r long_opts="disable-touch,no-build,gdb::,graph,valgrind::,callgrind,screen-width:,screen-height:,screen-dpi:,simulate:,sane-return,help"
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
@@ -670,6 +671,7 @@ TARGET:
                 export KODEBUG=
                 ;;
             -g | --gdb)
+                export SANE_RETURN=1
                 if [ -n "${VALUE}" ]; then
                     gdb="${VALUE}"
                 else
@@ -697,6 +699,7 @@ TARGET:
                 graph_memory=1
                 ;;
             -v | --valgrind)
+                export SANE_RETURN=1
                 if [ -n "${VALUE}" ]; then
                     valgrind="${VALUE}"
                 else
@@ -711,6 +714,7 @@ TARGET:
                 shift
                 ;;
             -c | --callgrind)
+                export SANE_RETURN=1
                 # Try to use sensible defaults for valgrind
                 if command -v valgrind >/dev/null; then
                     valgrind="valgrind --tool=callgrind --trace-children=yes"
@@ -769,6 +773,10 @@ TARGET:
                         echo "ERROR: spec unknown for ${device_model}."
                         ;;
                 esac
+                shift
+                ;;
+            -r | --sane-return)
+                export SANE_RETURN=1
                 shift
                 ;;
             -H | --help)
@@ -831,7 +839,13 @@ TARGET:
                 gnuplot_wrapper "--parent $$" "reader.lua"
             fi
 
-            KOREADER_COMMAND="env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./reader.lua -d"
+            if [ -n "${SANE_RETURN}" ]; then
+                KOREADER_ARGS="-d -t"
+            else
+                KOREADER_ARGS="-d"
+            fi
+
+            KOREADER_COMMAND="env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./reader.lua ${KOREADER_ARGS}"
 
             # run with catchsegv by default when it is available
             # see https://github.com/koreader/koreader/issues/2878#issuecomment-326796777
@@ -840,7 +854,7 @@ TARGET:
             fi
 
             if [ -n "${valgrind}" ]; then
-                KOREADER_COMMAND="${valgrind} env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua -d"
+                KOREADER_COMMAND="${valgrind} env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua ${KOREADER_ARGS}"
             fi
 
             echo "[*] Running KOReader with arguments: $*..."
@@ -856,9 +870,9 @@ TARGET:
                     # We don't want to stack valgrind/catchsegv on top of GDB ;).
                     if [[ "${gdb}" == gdb* ]]; then
                         # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
-                        KOREADER_COMMAND="${gdb} --args env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua -d ${args}"
+                        KOREADER_COMMAND="${gdb} --args env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua ${KOREADER_ARGS} ${args}"
                     else
-                        KOREADER_COMMAND="${gdb} env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua -d ${args}"
+                        KOREADER_COMMAND="${gdb} env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua ${KOREADER_ARGS} ${args}"
                     fi
                 else
                     KOREADER_COMMAND="${KOREADER_COMMAND} ${args}"

--- a/kodev
+++ b/kodev
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 is_mac() {
     if [ "$(uname -s)" != "Darwin" ]; then
         echo "You need a mac to build this package"
@@ -177,7 +175,7 @@ usage: build <OPTIONS> <TARGET>
 
 OPTIONS:
 
-    -v, --verbose   Build in verbose mode.
+    -v, --verbose   make the buildsystem more verbose
     -d, --debug     include debugging symbols (default for emulator)
     -n, --no-debug  no debugging symbols (default for target devices)
 
@@ -335,26 +333,44 @@ usage: clean <TARGET>
 TARGET:
 ${SUPPORTED_TARGETS}"
 
-    while [[ "${1}" == '-'* ]]; do
-        PARAM=$(echo "${1}" | awk -F= '{print $1}')
-        VALUE=$(echo "${1}" | awk -F= '{print $2}')
+    declare opt
+    declare -r E_OPTERR=85
+    declare -r short_opts="nd"
+    declare -r long_opts="no-debug,debug"
+
+    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
+
+    if [[ $? -ne 0 ]]; then
+        echo "${CLEAN_HELP_MSG}"
+        exit ${E_OPTERR}
+    fi
+
+    eval set -- "${opt}"
+
+    while true; do
+        PARAM="${1}"
+        VALUE="${2}"
         case "${PARAM}" in
-            --no-debug)
+            -n | --no-debug)
                 export KODEBUG=
                 KODEBUG_NO_DEFAULT=1
                 ;;
-            --debug)
+            -d | --debug)
                 export KODEBUG=1
                 KODEBUG_NO_DEFAULT=1
+                ;;
+            --)
+                break
                 ;;
             *)
                 echo "ERROR: unknown option \"${PARAM}\""
                 echo "${BUILD_HELP_MSG}"
-                exit 1
+                exit 8
                 ;;
         esac
-        shift 1
+        shift
     done
+    shift
 
     case "${1}" in
         -h | --help)
@@ -434,8 +450,9 @@ usage: release <OPTIONS> <TARGET>
 
 OPTIONS:
 
-    --debug               debug-enabled release (for remote gdb)
-    --ignore-translation  do not fetch translation for release
+    -d, --debug               debug-enabled release (for remote gdb)
+    -i, --ignore-translation  do not fetch translation for release
+    -v, --verbose             make the buildsystem more verbose
 
 TARGET:
 ${SUPPORTED_RELEASE_TARGETS}"
@@ -444,16 +461,31 @@ ${SUPPORTED_RELEASE_TARGETS}"
         exit 1
     }
 
+    # Defaults
     ignore_translation=0
 
-    while [[ "${1}" == '-'* ]]; do
-        PARAM=$(echo "${1}" | awk -F= '{print $1}')
-        VALUE=$(echo "${1}" | awk -F= '{print $2}')
+    declare opt
+    declare -r E_OPTERR=85
+    declare -r short_opts="divh"
+    declare -r long_opts="debug,ignore-translation,verbose,help"
+
+    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
+
+    if [[ $? -ne 0 ]]; then
+        echo "${RELEASE_HELP_MSG}"
+        exit ${E_OPTERR}
+    fi
+
+    eval set -- "${opt}"
+
+    while true; do
+        PARAM="${1}"
+        VALUE="${2}"
         case "${PARAM}" in
-            --debug)
+            -d | --debug)
                 export KODEBUG=1
                 ;;
-            --ignore-translation)
+            -i | --ignore-translation)
                 ignore_translation=1
                 ;;
             -v | --verbose)
@@ -463,14 +495,18 @@ ${SUPPORTED_RELEASE_TARGETS}"
                 echo "${RELEASE_HELP_MSG}"
                 exit 0
                 ;;
+            --)
+                break
+                ;;
             *)
                 echo "ERROR: unknown option \"${PARAM}\""
                 echo "${RELEASE_HELP_MSG}"
                 exit 1
                 ;;
         esac
-        shift 1
+        shift
     done
+    shift
 
     check_submodules
     if [ "${ignore_translation}" -eq 0 ]; then
@@ -518,7 +554,7 @@ ${SUPPORTED_RELEASE_TARGETS}"
             }
             ANDROID_HOME=$(dirname "$(dirname "$(command -v android)")")
             export ANDROID_HOME
-            export PATH=${PATH}:${NDK}
+            export PATH="${PATH}:${NDK}"
             make TARGET=android update
             ;;
         pocketbook)
@@ -612,14 +648,6 @@ TARGET:
     fi
 
     eval set -- "${opt}"
-
-    #-----------------------------------------------
-    echo "++ Test: Number of arguments: [${#}]"
-    echo '++ Test: Looping through "$@"'
-    for a in "${@}"; do
-        echo "  ++ [${a}]"
-    done
-    #-----------------------------------------------
 
     while true; do
         PARAM="${1}"
@@ -752,14 +780,6 @@ TARGET:
         shift
     done
     shift
-
-    #----------------------------------------------------------------------
-    echo "++ Test: Number of arguments after \"--\" is [${#}] They are: [${@}]"
-    echo '++ Test: Looping through "$@"'
-    for a in "$@"; do
-        echo "  ++ [$a]"
-    done
-    #----------------------------------------------------------------------
 
     case "${1}" in
         android)

--- a/kodev
+++ b/kodev
@@ -804,7 +804,7 @@ TARGET:
                 gnuplot_wrapper "--parent $$" "reader.lua"
             fi
 
-            KOREADER_COMMAND="./reader.lua -d"
+            KOREADER_COMMAND="env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./reader.lua -d"
 
             # run with catchsegv by default when it is available
             # see https://github.com/koreader/koreader/issues/2878#issuecomment-326796777
@@ -813,7 +813,7 @@ TARGET:
             fi
 
             if [ -n "${valgrind}" ]; then
-                KOREADER_COMMAND="${valgrind} ./luajit reader.lua -d"
+                KOREADER_COMMAND="${valgrind} env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./luajit reader.lua -d"
             fi
 
             echo "[*] Running KOReader with arguments: $*..."
@@ -829,9 +829,9 @@ TARGET:
                     # We don't want to stack valgrind/catchsegv on top of GDB ;).
                     if [[ "${gdb}" == gdb* ]]; then
                         # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
-                        KOREADER_COMMAND="${gdb} --args ./luajit reader.lua -d ${args}"
+                        KOREADER_COMMAND="${gdb} --args env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./luajit reader.lua -d ${args}"
                     else
-                        KOREADER_COMMAND="${gdb} ./luajit reader.lua -d ${args}"
+                        KOREADER_COMMAND="${gdb} env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./luajit reader.lua -d ${args}"
                     fi
                 else
                     KOREADER_COMMAND="${KOREADER_COMMAND} ${args}"
@@ -840,7 +840,7 @@ TARGET:
                 RETURN_VALUE=85
                 while [ "${RETURN_VALUE}" -eq 85 ]; do
                     # shellcheck disable=SC2086
-                    env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" EMULATE_READER_W="${screen_width}" EMULATE_READER_H="${screen_height}" EMULATE_READER_DPI="${screen_dpi}" \
+                    env EMULATE_READER_W="${screen_width}" EMULATE_READER_H="${screen_height}" EMULATE_READER_DPI="${screen_dpi}" \
                         ${KOREADER_COMMAND}
                     RETURN_VALUE=$?
                 done

--- a/kodev
+++ b/kodev
@@ -187,10 +187,7 @@ ${SUPPORTED_TARGETS}"
     declare -r short_opts="vhnd"
     declare -r long_opts="verbose,help,no-debug,debug"
 
-    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
-
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]]; then
+    if ! opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}"); then
         echo "${BUILD_HELP_MSG}"
         exit ${E_OPTERR}
     fi
@@ -339,10 +336,7 @@ ${SUPPORTED_TARGETS}"
     declare -r short_opts="nd"
     declare -r long_opts="no-debug,debug"
 
-    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
-
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]]; then
+    if ! opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}"); then
         echo "${CLEAN_HELP_MSG}"
         exit ${E_OPTERR}
     fi
@@ -471,10 +465,7 @@ ${SUPPORTED_RELEASE_TARGETS}"
     declare -r short_opts="divh"
     declare -r long_opts="debug,ignore-translation,verbose,help"
 
-    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
-
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]]; then
+    if ! opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}"); then
         echo "${RELEASE_HELP_MSG}"
         exit ${E_OPTERR}
     fi
@@ -647,10 +638,7 @@ TARGET:
     declare -r short_opts="tbng::pv::cw:h:d:s:rH"
     declare -r long_opts="disable-touch,no-build,gdb::,graph,valgrind::,callgrind,screen-width:,screen-height:,screen-dpi:,simulate:,sane-return,help"
 
-    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
-
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]]; then
+    if ! opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}"); then
         echo "${RUN_HELP_MSG}"
         exit ${E_OPTERR}
     fi
@@ -914,10 +902,7 @@ OPTIONS:
     declare -r short_opts="pt:nh"
     declare -r long_opts="graph,tags:,no-debug,help"
 
-    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
-
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]]; then
+    if ! opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}"); then
         echo "${TEST_HELP_MSG}"
         exit ${E_OPTERR}
     fi
@@ -1009,10 +994,7 @@ OPTIONS:
     declare -r short_opts="fsn"
     declare -r long_opts="full,show-previous,no-debug"
 
-    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
-
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]]; then
+    if ! opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}"); then
         echo "${COV_HELP_MSG}"
         exit ${E_OPTERR}
     fi

--- a/kodev
+++ b/kodev
@@ -963,7 +963,7 @@ OPTIONS:
 
         echo "Running tests in" "${test_path}"
         env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" \
-        busted --lua="./luajit" "${opts}" \
+            busted --lua="./luajit" "${opts}" \
             --output=gtest \
             --lpath="${test_path_basedir}/?.lua" \
             --exclude-tags=notest "${test_path}"
@@ -1041,7 +1041,7 @@ OPTIONS:
         if [ "${show_previous}" -eq 0 ]; then
             echo "Running tests in" ${test_path}
             env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" \
-            busted --lua="./luajit" \
+                busted --lua="./luajit" \
                 --sort-files \
                 -o "./spec/${target}/unit/verbose_print" \
                 --coverage \
@@ -1157,7 +1157,7 @@ case "${1}" in
         kodev-build
         pushd "${EMU_DIR}" && {
             env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" \
-            ./luajit -i setupkoenv.lua
+                ./luajit -i setupkoenv.lua
         } && popd || exit
         ;;
     log)

--- a/kodev
+++ b/kodev
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 is_mac() {
     if [ "$(uname -s)" != "Darwin" ]; then
         echo "You need a mac to build this package"
@@ -189,9 +191,9 @@ ${SUPPORTED_TARGETS}"
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
-    if [[ ($? -ne 0) || ($# -eq 0) ]]; then
+    if [[ $? -ne 0 ]]; then
         echo "${BUILD_HELP_MSG}"
-        exit $E_OPTERR
+        exit ${E_OPTERR}
     fi
 
     eval set -- "${opt}"
@@ -215,6 +217,9 @@ ${SUPPORTED_TARGETS}"
                 export KODEBUG=1
                 KODEBUG_NO_DEFAULT=1
                 ;;
+            --)
+                break
+                ;;
             *)
                 echo "ERROR: unknown option \"${PARAM}\""
                 echo "${BUILD_HELP_MSG}"
@@ -223,6 +228,7 @@ ${SUPPORTED_TARGETS}"
         esac
         shift
     done
+    shift
 
     check_submodules
     case "${1}" in
@@ -570,42 +576,68 @@ usage: run <OPTIONS> <TARGET>
 
 OPTIONS:
 
-    -h=X, --screen-height=X  set height of the emulator screen (default: 720)
-    -w=X, --screen-width=X   set width of the emulator screen (default: 540)
-    -d=X, --screen-dpi=X     set DPI of the emulator screen (default: 160)
-    --no-build               run reader without rebuilding
-    --no-debug               no debugging symbols (requires rebuilding)
-    --disable-touch          use this if you want to simulate keyboard only devices
-    -s=FOO --simulate=FOO    simulate dimension and other specs for a given device model
-                             supported model: kobo-aura-one, kindle3, hidpi
-    --gdb=X                  run with debugger (default: nemiver)
-    --graph                  graph memory use (requires gnuplot)
-    --valgrind=X             run with valgrind (default: valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes)
-    --callgrind              run with valgrind's callgrind (valgrind --tool=callgrind --trace-children=yes)
+    -h X, --screen-height=X  set height of the emulator screen (default: 720)
+    -w X, --screen-width=X   set width of the emulator screen (default: 540)
+    -d X, --screen-dpi=X     set DPI of the emulator screen (default: 160)
+    -b, --no-build           run reader without rebuilding
+    -n, --no-debug           no debugging symbols (requires rebuilding)
+    -t, --disable-touch      use this if you want to simulate keyboard only devices
+    -s FOO --simulate=FOO    simulate dimension and other specs for a given device model
+                             supported model: kobo-forma, kobo-aura-one, kobo-h2o, kindle3, hidpi
+    -g X, --gdb=X            run with debugger (default: nemiver)
+    -p, --graph              graph memory use (requires gnuplot)
+    -v X, --valgrind=X       run with valgrind (default: valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes)
+    -c, --callgrind          run with valgrind's callgrind (valgrind --tool=callgrind --trace-children=yes)
 
 TARGET:
 
     android         install and run KOReader on an Android device connected through ADB
     "
+
+    # Defaults
     screen_width=540
     screen_height=720
     export KODEBUG=1
-    while [[ "${1}" == '-'* ]]; do
-        PARAM=$(echo "${1}" | awk -F= '{print $1}')
-        VALUE=$(echo "${1}" | awk -F= '{print $2}')
+
+    declare opt
+    declare -r E_OPTERR=85
+    declare -r short_opts="tbng:pv:cw:h:d:s:H"
+    declare -r long_opts="disable-touch,no-build,gdb:,graph,valgrind:,callgrind,screen-width:,screen-height:,screen-dpi:,simulate:,help"
+
+    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
+
+    if [[ $? -ne 0 ]]; then
+        echo "${RUN_HELP_MSG}"
+        exit ${E_OPTERR}
+    fi
+
+    eval set -- "${opt}"
+
+    #-----------------------------------------------
+    echo "++ Test: Number of arguments: [${#}]"
+    echo '++ Test: Looping through "$@"'
+    for a in "${@}"; do
+        echo "  ++ [${a}]"
+    done
+    #-----------------------------------------------
+
+    while true; do
+        PARAM="${1}"
+        VALUE="${2}"
         case "${PARAM}" in
-            --disable-touch)
+            -t | --disable-touch)
                 export DISABLE_TOUCH=1
                 ;;
-            --no-build)
+            -b | --no-build)
                 no_build=1
                 ;;
-            --no-debug)
+            -n | --no-debug)
                 export KODEBUG=
                 ;;
-            --gdb)
+            -g | --gdb)
                 if [ -n "${VALUE}" ]; then
-                    gdb=${VALUE}
+                    gdb="${VALUE}"
+                    shift
                 else
                     # Try to use friendly defaults for gdb
                     if command -v nemiver >/dev/null; then
@@ -626,12 +658,13 @@ TARGET:
                     fi
                 fi
                 ;;
-            --graph)
+            -p | --graph)
                 graph_memory=1
                 ;;
-            --valgrind)
+            -v | --valgrind)
                 if [ -n "${VALUE}" ]; then
-                    valgrind=${VALUE}
+                    valgrind="${VALUE}"
+                    shift
                 else
                     # Try to use sensible defaults for valgrind
                     if command -v valgrind >/dev/null; then
@@ -642,7 +675,7 @@ TARGET:
                     fi
                 fi
                 ;;
-            --callgrind)
+            -c | --callgrind)
                 # Try to use sensible defaults for valgrind
                 if command -v valgrind >/dev/null; then
                     valgrind="valgrind --tool=callgrind --trace-children=yes"
@@ -653,6 +686,7 @@ TARGET:
                 ;;
             -w | --screen-width)
                 screen_width=${VALUE}
+                shift
                 ;;
             -h | --screen-height)
                 # simple numeric check due to overlap between -h for help and height
@@ -662,21 +696,33 @@ TARGET:
                     echo "${RUN_HELP_MSG}"
                     exit 1
                 fi
+                shift
                 ;;
             -d | --screen-dpi)
                 screen_dpi=${VALUE}
+                shift
                 ;;
             -s | --simulate)
-                device_model=${VALUE}
+                device_model="${VALUE}"
                 case "${device_model}" in
                     kindle3)
                         screen_width=600
                         screen_height=800
                         ;;
+                    kobo-forma)
+                        screen_width=1440
+                        screen_height=1920
+                        screen_dpi=300
+                        ;;
                     kobo-aura-one)
                         screen_width=1404
                         screen_height=1872
                         screen_dpi=300
+                        ;;
+                    kobo-h2o)
+                        screen_width=1080
+                        screen_height=1429
+                        screen_dpi=265
                         ;;
                     hidpi)
                         screen_width=1500
@@ -687,19 +733,32 @@ TARGET:
                         echo "ERROR: spec unknown for ${device_model}."
                         ;;
                 esac
+                shift
                 ;;
-            --help)
+            -H | --help)
                 echo "${RUN_HELP_MSG}"
                 exit 0
+                ;;
+            --)
+                break
                 ;;
             *)
                 echo "ERROR: unknown option \"${PARAM}\""
                 echo "${RUN_HELP_MSG}"
-                exit 1
+                exit 8
                 ;;
         esac
         shift
     done
+    shift
+
+    #----------------------------------------------------------------------
+    echo "++ Test: Number of arguments after \"--\" is [${#}] They are: [${@}]"
+    echo '++ Test: Looping through "$@"'
+    for a in "$@"; do
+        echo "  ++ [$a]"
+    done
+    #----------------------------------------------------------------------
 
     case "${1}" in
         android)

--- a/kodev
+++ b/kodev
@@ -828,7 +828,7 @@ TARGET:
                 gnuplot_wrapper "--parent $$" "reader.lua"
             fi
 
-            KOREADER_COMMAND="env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./reader.lua -d"
+            KOREADER_COMMAND="env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./reader.lua -d"
 
             # run with catchsegv by default when it is available
             # see https://github.com/koreader/koreader/issues/2878#issuecomment-326796777
@@ -837,7 +837,7 @@ TARGET:
             fi
 
             if [ -n "${valgrind}" ]; then
-                KOREADER_COMMAND="${valgrind} env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./luajit reader.lua -d"
+                KOREADER_COMMAND="${valgrind} env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua -d"
             fi
 
             echo "[*] Running KOReader with arguments: $*..."
@@ -853,9 +853,9 @@ TARGET:
                     # We don't want to stack valgrind/catchsegv on top of GDB ;).
                     if [[ "${gdb}" == gdb* ]]; then
                         # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
-                        KOREADER_COMMAND="${gdb} --args env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./luajit reader.lua -d ${args}"
+                        KOREADER_COMMAND="${gdb} --args env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua -d ${args}"
                     else
-                        KOREADER_COMMAND="${gdb} env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" ./luajit reader.lua -d ${args}"
+                        KOREADER_COMMAND="${gdb} env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua -d ${args}"
                     fi
                 else
                     KOREADER_COMMAND="${KOREADER_COMMAND} ${args}"

--- a/kodev
+++ b/kodev
@@ -881,35 +881,56 @@ usage: test <OPTIONS> [front|base] <TEST_NAME>
 
 OPTIONS:
 
-    --tags=TAGS     only run tests with given tags
-    --no-debug      no debugging symbols (default for target devices)
+    -p, --graph         graph memory use (requires gnuplot)
+    -n, --no-debug      no debugging symbols (default for target devices)
+    -t, --tags=TAGS     only run tests with given tags
     "
-    while [[ "${1}" == '-'* ]]; do
-        PARAM=$(echo "${1}" | awk -F= '{print $1}')
-        VALUE=$(echo "${1}" | awk -F= '{print $2}')
+
+    declare opt
+    declare -r E_OPTERR=85
+    declare -r short_opts="pt:nh"
+    declare -r long_opts="graph,tags:,no-debug,help"
+
+    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
+
+    if [[ $? -ne 0 ]]; then
+        echo "${TEST_HELP_MSG}"
+        exit ${E_OPTERR}
+    fi
+
+    eval set -- "${opt}"
+
+    while true; do
+        PARAM="${1}"
+        VALUE="${2}"
         case "${PARAM}" in
-            --graph)
+            -p | --graph)
                 graph_memory=1
                 ;;
-            --no-debug)
+            -n | --no-debug)
                 export KODEBUG=
                 KODEBUG_NO_DEFAULT=1
                 ;;
-            --tags)
+            -t | --tags)
                 opts="--tags=${VALUE}"
+                shift
                 ;;
             -h | --help)
                 echo "${TEST_HELP_MSG}"
                 exit 0
                 ;;
+            --)
+                break
+                ;;
             *)
                 echo "ERROR: unknown option \"${PARAM}\""
                 echo "${TEST_HELP_MSG}"
-                exit 1
+                exit 8
                 ;;
         esac
         shift
     done
+    shift
 
     [ $# -lt 1 ] && {
         echo "${TEST_HELP_MSG}"

--- a/kodev
+++ b/kodev
@@ -890,6 +890,8 @@ TARGET:
             if [ -n "${graph_memory}" ]; then
                 capture_ctrl_c
             fi
+
+            exit ${RETURN_VALUE}
             ;;
     esac
 }

--- a/kodev
+++ b/kodev
@@ -189,6 +189,7 @@ ${SUPPORTED_TARGETS}"
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then
         echo "${BUILD_HELP_MSG}"
         exit ${E_OPTERR}
@@ -340,6 +341,7 @@ ${SUPPORTED_TARGETS}"
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then
         echo "${CLEAN_HELP_MSG}"
         exit ${E_OPTERR}
@@ -471,6 +473,7 @@ ${SUPPORTED_RELEASE_TARGETS}"
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then
         echo "${RELEASE_HELP_MSG}"
         exit ${E_OPTERR}
@@ -642,6 +645,7 @@ TARGET:
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then
         echo "${RUN_HELP_MSG}"
         exit ${E_OPTERR}
@@ -893,6 +897,7 @@ OPTIONS:
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then
         echo "${TEST_HELP_MSG}"
         exit ${E_OPTERR}
@@ -987,6 +992,7 @@ OPTIONS:
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then
         echo "${COV_HELP_MSG}"
         exit ${E_OPTERR}

--- a/kodev
+++ b/kodev
@@ -586,7 +586,7 @@ OPTIONS:
                              supported model: kobo-forma, kobo-aura-one, kobo-h2o, kindle3, hidpi
     -g X, --gdb=X            run with debugger (default: nemiver)
     -p, --graph              graph memory use (requires gnuplot)
-    -v X, --valgrind=X       run with valgrind (default: valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes)
+    -v X, --valgrind=X       run with valgrind (default: \"valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes\")
     -c, --callgrind          run with valgrind's callgrind (valgrind --tool=callgrind --trace-children=yes)
 
 TARGET:
@@ -693,6 +693,7 @@ TARGET:
                 if [ -n "${VALUE##*[!0-9]*}" ]; then
                     screen_height=${VALUE}
                 else
+                    echo "ERROR: Invalid value: \"${VALUE}\""
                     echo "${RUN_HELP_MSG}"
                     exit 1
                 fi

--- a/kodev
+++ b/kodev
@@ -8,21 +8,21 @@ is_mac() {
 }
 
 CURDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VERSION=$(git describe HEAD)
+VERSION="$(git describe HEAD)"
 # Only append date if we're not on a whole version, like v2018.11
-if echo "${VERSION}" | grep -; then
-    VERSION=${VERSION}_$(git describe HEAD | xargs git show -s --format=format:"%cd" --date=short)
+if echo "${VERSION}" | grep -q -- "-"; then
+    VERSION="${VERSION}_$(git describe HEAD | xargs git show -s --format=format:"%cd" --date=short)"
 fi
 
 # Default Android build to arm.
 ANDROID_ARCH="${ANDROID_ARCH:-arm}"
 
 # Default to Android 4.0+; required for NDK 15 but with a custom NDK the strict minimum is 9.
-NDKABI=${NDKABI:-14}
+NDKABI="${NDKABI:-14}"
 export NDKABI
 
 # Default android flavor
-ANDROID_FLAVOR=${ANDROID_FLAVOR:-rocks}
+ANDROID_FLAVOR="${ANDROID_FLAVOR:-rocks}"
 export ANDROID_FLAVOR
 
 function assert_ret_zero() {
@@ -46,7 +46,7 @@ function check_submodules() {
 function gnuplot_wrapper() {
     # inspired by https://gist.github.com/nicolasazrak/32d68ed6c845a095f75f037ecc2f0436
     trap capture_ctrl_c INT
-    TEMP_DIR=$(mktemp --directory /tmp/tmp.koreaderXXX)
+    TEMP_DIR="$(mktemp --directory /tmp/tmp.koreaderXXX)"
     LOG="${TEMP_DIR}/memory.log"
     SCRIPT_PNG="${TEMP_DIR}/script_png.p"
     SCRIPT_SHOW="${TEMP_DIR}/script_show.p"
@@ -140,6 +140,8 @@ function setup_env() {
     EMU_DIR="${files[${idx}]}/koreader"
     export EMU_DIR
     KO_LD_LIBRARY_PATH="$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}"
+    # Don't export it to avoid messing with tools (e.g., debuggers).
+    # We'll pass it to LuaJIT via env
 }
 
 function kodev-fetch-thirdparty() {
@@ -174,15 +176,29 @@ usage: build <OPTIONS> <TARGET>
 OPTIONS:
 
     -v, --verbose   Build in verbose mode.
-    --debug         include debugging symbols (default for emulator)
-    --no-debug      no debugging symbols (default for target devices)
+    -d, --debug     include debugging symbols (default for emulator)
+    -n, --no-debug  no debugging symbols (default for target devices)
 
 TARGET:
 ${SUPPORTED_TARGETS}"
 
-    while [[ "${1}" == '-'* ]]; do
-        PARAM=$(echo "${1}" | awk -F= '{print $1}')
-        VALUE=$(echo "${1}" | awk -F= '{print $2}')
+    declare opt
+    declare -r E_OPTERR=85
+    declare -r short_opts="vhnd"
+    declare -r long_opts="verbose,help,no-debug,debug"
+
+    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
+
+    if [[ ($? -ne 0) || ($# -eq 0) ]]; then
+        echo "${BUILD_HELP_MSG}"
+        exit $E_OPTERR
+    fi
+
+    eval set -- "${opt}"
+
+    while true; do
+        PARAM="${1}"
+        VALUE="${2}"
         case "${PARAM}" in
             -v | --verbose)
                 export VERBOSE=1
@@ -191,21 +207,21 @@ ${SUPPORTED_TARGETS}"
                 echo "${BUILD_HELP_MSG}"
                 exit 0
                 ;;
-            --no-debug)
+            -n | --no-debug)
                 export KODEBUG=
                 KODEBUG_NO_DEFAULT=1
                 ;;
-            --debug)
+            -d | --debug)
                 export KODEBUG=1
                 KODEBUG_NO_DEFAULT=1
                 ;;
             *)
                 echo "ERROR: unknown option \"${PARAM}\""
                 echo "${BUILD_HELP_MSG}"
-                exit 1
+                exit 8
                 ;;
         esac
-        shift 1
+        shift
     done
 
     check_submodules
@@ -393,8 +409,9 @@ ${SUPPORTED_TARGETS}"
             make TARGET=win32 clean
             ;;
         *)
-            if [ -z "${KODEBUG_NO_DEFAULT}" ]; then # no explicit --debug / --no-debug
-                # builds a debug build by default, like kodev-run
+            if [ -z "${KODEBUG_NO_DEFAULT}" ]; then
+                # No explicit --debug / --no-debug
+                # Builds a debug build by default, like kodev-run
                 export KODEBUG=1
             fi
 

--- a/kodev
+++ b/kodev
@@ -1099,6 +1099,7 @@ Supported commands:
     check               Run luacheck static-analysis
     cov                 Run busted tests for coverage
     wbuilder            Run wbuilder.lua script (useful for building new UI widget)
+    prompt              Run a LuaJIT shell within KOReader's environment
 "
 [ $# -lt 1 ] && {
     echo "Missing command."
@@ -1149,6 +1150,7 @@ case "${1}" in
     prompt)
         kodev-build
         pushd "${EMU_DIR}" && {
+            env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" \
             ./luajit -i setupkoenv.lua
         } && popd || exit
         ;;
@@ -1156,13 +1158,13 @@ case "${1}" in
         shift 1
         kodev-log "$@"
         ;;
-    --help | -h)
+    -h | --help)
         echo "${HELP_MSG}"
         exit 0
         ;;
     *)
         echo "Unknown command: $1."
         echo "${HELP_MSG}"
-        exit 1
+        exit 8
         ;;
 esac

--- a/kodev
+++ b/kodev
@@ -601,8 +601,8 @@ TARGET:
 
     declare opt
     declare -r E_OPTERR=85
-    declare -r short_opts="tbng:pv:cw:h:d:s:H"
-    declare -r long_opts="disable-touch,no-build,gdb:,graph,valgrind:,callgrind,screen-width:,screen-height:,screen-dpi:,simulate:,help"
+    declare -r short_opts="tbng::pv::cw:h:d:s:H"
+    declare -r long_opts="disable-touch,no-build,gdb::,graph,valgrind::,callgrind,screen-width:,screen-height:,screen-dpi:,simulate:,help"
 
     opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
 
@@ -637,7 +637,6 @@ TARGET:
             -g | --gdb)
                 if [ -n "${VALUE}" ]; then
                     gdb="${VALUE}"
-                    shift
                 else
                     # Try to use friendly defaults for gdb
                     if command -v nemiver >/dev/null; then
@@ -657,6 +656,7 @@ TARGET:
                         exit 1
                     fi
                 fi
+                shift
                 ;;
             -p | --graph)
                 graph_memory=1
@@ -664,7 +664,6 @@ TARGET:
             -v | --valgrind)
                 if [ -n "${VALUE}" ]; then
                     valgrind="${VALUE}"
-                    shift
                 else
                     # Try to use sensible defaults for valgrind
                     if command -v valgrind >/dev/null; then
@@ -674,6 +673,7 @@ TARGET:
                         exit 1
                     fi
                 fi
+                shift
                 ;;
             -c | --callgrind)
                 # Try to use sensible defaults for valgrind

--- a/kodev
+++ b/kodev
@@ -139,8 +139,7 @@ function setup_env() {
     fi
     EMU_DIR="${files[${idx}]}/koreader"
     export EMU_DIR
-    LD_LIBRARY_PATH="$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}"
-    export LD_LIBRARY_PATH
+    KO_LD_LIBRARY_PATH="$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}"
 }
 
 function kodev-fetch-thirdparty() {
@@ -591,7 +590,7 @@ TARGET:
                     gdb=${VALUE}
                 else
                     # Try to use friendly defaults for gdb
-                    if command -v nemiver >/dev/null; then
+                    if command -v znemiver >/dev/null; then
                         # Nemiver is a nice GUI
                         gdb=nemiver
                     elif command -v ddd >/dev/null; then
@@ -727,12 +726,11 @@ TARGET:
             KOREADER_COMMAND="${CATCHSEGV} ./reader.lua -d"
 
             if [ -n "${gdb}" ]; then
-                # Don't pollute the debugger's library search path with KOReader's
                 if [ "${gdb}" == gdb* ]; then
                     # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
-                    KOREADER_COMMAND="env --unset=LD_LIBRARY_PATH ${gdb} --args env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" ./luajit reader.lua -d"
+                    KOREADER_COMMAND="${gdb} --args ./luajit reader.lua -d"
                 else
-                    KOREADER_COMMAND="env --unset=LD_LIBRARY_PATH ${gdb} env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" ./luajit reader.lua -d"
+                    KOREADER_COMMAND="${gdb} ./luajit reader.lua -d"
                 fi
             fi
 
@@ -752,7 +750,7 @@ TARGET:
 
                 RETURN_VALUE=85
                 while [ "${RETURN_VALUE}" -eq 85 ]; do
-                    EMULATE_READER_W=${screen_width} EMULATE_READER_H=${screen_height} EMULATE_READER_DPI=${screen_dpi} \
+                    env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" EMULATE_READER_W="${screen_width}" EMULATE_READER_H="${screen_height}" EMULATE_READER_DPI="${screen_dpi}" \
                         ${KOREADER_COMMAND}
                     RETURN_VALUE=$?
                 done

--- a/kodev
+++ b/kodev
@@ -196,7 +196,8 @@ ${SUPPORTED_TARGETS}"
 
     while true; do
         PARAM="${1}"
-        VALUE="${2}"
+        # Support using an = assignment with short options (e.g., -f=blah instead of -f blah).
+        VALUE="${2/#=/}"
         case "${PARAM}" in
             -v | --verbose)
                 export VERBOSE=1
@@ -345,7 +346,8 @@ ${SUPPORTED_TARGETS}"
 
     while true; do
         PARAM="${1}"
-        VALUE="${2}"
+        # Support using an = assignment with short options (e.g., -f=blah instead of -f blah).
+        VALUE="${2/#=/}"
         case "${PARAM}" in
             -n | --no-debug)
                 export KODEBUG=
@@ -474,7 +476,8 @@ ${SUPPORTED_RELEASE_TARGETS}"
 
     while true; do
         PARAM="${1}"
-        VALUE="${2}"
+        # Support using an = assignment with short options (e.g., -f=blah instead of -f blah).
+        VALUE="${2/#=/}"
         case "${PARAM}" in
             -d | --debug)
                 export KODEBUG=1
@@ -647,7 +650,8 @@ TARGET:
 
     while true; do
         PARAM="${1}"
-        VALUE="${2}"
+        # Support using an = assignment with short options (e.g., -f=blah instead of -f blah).
+        VALUE="${2/#=/}"
         case "${PARAM}" in
             -t | --disable-touch)
                 export DISABLE_TOUCH=1
@@ -922,7 +926,8 @@ OPTIONS:
 
     while true; do
         PARAM="${1}"
-        VALUE="${2}"
+        # Support using an = assignment with short options (e.g., -f=blah instead of -f blah).
+        VALUE="${2/#=/}"
         case "${PARAM}" in
             -p | --graph)
                 graph_memory=1
@@ -1014,7 +1019,8 @@ OPTIONS:
 
     while true; do
         PARAM="${1}"
-        VALUE="${2}"
+        # Support using an = assignment with short options (e.g., -f=blah instead of -f blah).
+        VALUE="${2/#=/}"
         case "${PARAM}" in
             -f | --full)
                 show_full=1

--- a/kodev
+++ b/kodev
@@ -717,13 +717,13 @@ TARGET:
                 gnuplot_wrapper "--parent $$" "reader.lua"
             fi
 
+            KOREADER_COMMAND="./reader.lua -d"
+
             # run with catchsegv by default when it is available
             # see https://github.com/koreader/koreader/issues/2878#issuecomment-326796777
             if command -v catchsegv >/dev/null; then
-                CATCHSEGV="$(command -v catchsegv)"
+                KOREADER_COMMAND="$(command -v catchsegv) ${KOREADER_COMMAND}"
             fi
-
-            KOREADER_COMMAND="${CATCHSEGV} ./reader.lua -d"
 
             if [ -n "${valgrind}" ]; then
                 KOREADER_COMMAND="${valgrind} ./luajit reader.lua -d"
@@ -739,6 +739,7 @@ TARGET:
                 fi
 
                 if [ -n "${gdb}" ]; then
+                    # We don't want to stack valgrind/catchsegv on top of GDB ;).
                     if [[ "${gdb}" == gdb* ]]; then
                         # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
                         KOREADER_COMMAND="${gdb} --args ./luajit reader.lua -d ${args}"

--- a/kodev
+++ b/kodev
@@ -617,7 +617,7 @@ TARGET:
                 else
                     # Try to use sensible defaults for valgrind
                     if command -v valgrind >/dev/null; then
-                        valgrind="valgrind --trace-children=yes"
+                        valgrind="valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes"
                     else
                         echo "Couldn't find valgrind."
                         exit 1

--- a/kodev
+++ b/kodev
@@ -915,7 +915,7 @@ TARGET:
             exit 0
             ;;
         android)
-            adb logcat 'luajit-launcher:D KOReader:D *:S'
+            adb logcat 'KOReader:I ActivityManager:* AndroidRuntime:* DEBUG:* *:F'
             ;;
         *)
             echo "Unsupported target: $1."

--- a/kodev
+++ b/kodev
@@ -633,6 +633,9 @@ TARGET:
     android         install and run KOReader on an Android device connected through ADB
     "
 
+    # NOTE: Speaking of Valgrind, if your libdrm/mesa isn't built w/ valgrind markings, there's a Valgrind suppression file for AMD cards in the tools folder.
+    #       Just append --suppressions=${PWD/tools/valgrind_amd.supp to your valgrind command.
+
     # Defaults
     screen_width=540
     screen_height=720

--- a/kodev
+++ b/kodev
@@ -957,6 +957,7 @@ OPTIONS:
         fi
 
         echo "Running tests in" "${test_path}"
+        env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" \
         busted --lua="./luajit" "${opts}" \
             --output=gtest \
             --lpath="${test_path_basedir}/?.lua" \
@@ -970,23 +971,40 @@ usage: cov <OPTIONS>
 
 OPTIONS:
 
-    --show-previous     show coverage stats from previous run
-    --full              show full coverage report (down to each line)
-    --no-debug          no debugging symbols (default for target devices)
+    -f, --full              show full coverage report (down to each line)
+    -s, --show-previous     show coverage stats from previous run
+    -n, --no-debug          no debugging symbols (default for target devices)
     "
+
+    # Defaults
     show_full=0
     show_previous=0
-    while [[ "${1}" == '-'* ]]; do
-        PARAM=$(echo "${1}" | awk -F= '{print $1}')
-        VALUE=$(echo "${1}" | awk -F= '{print $2}')
+
+    declare opt
+    declare -r E_OPTERR=85
+    declare -r short_opts="fsn"
+    declare -r long_opts="full,show-previous,no-debug"
+
+    opt=$(getopt -o "${short_opts}" --long "${long_opts}" --name "kodev" -- "${@}")
+
+    if [[ $? -ne 0 ]]; then
+        echo "${COV_HELP_MSG}"
+        exit ${E_OPTERR}
+    fi
+
+    eval set -- "${opt}"
+
+    while true; do
+        PARAM="${1}"
+        VALUE="${2}"
         case "${PARAM}" in
-            --full)
+            -f | --full)
                 show_full=1
                 ;;
-            --show-previous)
+            -s | --show-previous)
                 show_previous=1
                 ;;
-            --no-debug)
+            -n | --no-debug)
                 export KODEBUG=
                 KODEBUG_NO_DEFAULT=1
                 ;;
@@ -994,14 +1012,18 @@ OPTIONS:
                 echo "${COV_HELP_MSG}"
                 exit 0
                 ;;
+            --)
+                break
+                ;;
             *)
                 echo "ERROR: unknown option \"${PARAM}\""
                 echo "${COV_HELP_MSG}"
-                exit 1
+                exit 8
                 ;;
         esac
         shift
     done
+    shift
 
     set -e
     check_submodules && kodev-build
@@ -1012,6 +1034,7 @@ OPTIONS:
         test_path="./spec/${target}/unit"
         if [ "${show_previous}" -eq 0 ]; then
             echo "Running tests in" ${test_path}
+            env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" \
             busted --lua="./luajit" \
                 --sort-files \
                 -o "./spec/${target}/unit/verbose_print" \

--- a/kodev
+++ b/kodev
@@ -139,7 +139,7 @@ function setup_env() {
     fi
     EMU_DIR="${files[${idx}]}/koreader"
     export EMU_DIR
-    LD_LIBRARY_PATH=$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}
+    LD_LIBRARY_PATH="$(realpath "${EMU_DIR}")/libs:${LD_LIBRARY_PATH}"
     export LD_LIBRARY_PATH
 }
 
@@ -727,7 +727,13 @@ TARGET:
             KOREADER_COMMAND="${CATCHSEGV} ./reader.lua -d"
 
             if [ -n "${gdb}" ]; then
-                KOREADER_COMMAND="${gdb} ./luajit reader.lua -d"
+                # Don't pollute the debugger's library search path with KOReader's
+                if [ "${gdb}" == gdb* ]; then
+                    # The standard CLI needs a little hand holding to properly pass arguments to the process it'll monitor
+                    KOREADER_COMMAND="env --unset=LD_LIBRARY_PATH ${gdb} --args env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" ./luajit reader.lua -d"
+                else
+                    KOREADER_COMMAND="env --unset=LD_LIBRARY_PATH ${gdb} env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" ./luajit reader.lua -d"
+                fi
             fi
 
             if [ -n "${valgrind}" ]; then

--- a/kodev
+++ b/kodev
@@ -613,7 +613,7 @@ OPTIONS:
     -n, --no-debug           no debugging symbols (requires rebuilding)
     -t, --disable-touch      use this if you want to simulate keyboard only devices
     -s FOO --simulate=FOO    simulate dimension and other specs for a given device model
-                             supported model: kobo-forma, kobo-aura-one, kobo-h2o, kindle3, hidpi
+                             supported model: hidpi, kobo-forma, kobo-aura-one, kobo-clara, kindle-paperwhite, kobo-h2o, legacy-paperwhite, kindle
     -g X, --gdb=X            run with debugger (default: nemiver)
     -p, --graph              graph memory use (requires gnuplot)
     -v X, --valgrind=X       run with valgrind (default: \"valgrind --tool=memcheck --trace-children=yes --leak-check=full --track-origins=yes --show-reachable=yes\")
@@ -733,9 +733,15 @@ TARGET:
             -s | --simulate)
                 device_model="${VALUE}"
                 case "${device_model}" in
-                    kindle3)
+                    kindle)
                         screen_width=600
                         screen_height=800
+                        screen_dpi=167
+                        ;;
+                    legacy-paperwhite)
+                        screen_width=758
+                        screen_height=1024
+                        screen_dpi=212
                         ;;
                     kobo-forma)
                         screen_width=1440
@@ -745,6 +751,11 @@ TARGET:
                     kobo-aura-one)
                         screen_width=1404
                         screen_height=1872
+                        screen_dpi=300
+                        ;;
+                    kobo-clara | kindle-paperwhite)
+                        screen_width=1072
+                        screen_height=1448
                         screen_dpi=300
                         ;;
                     kobo-h2o)

--- a/kodev
+++ b/kodev
@@ -751,6 +751,7 @@ TARGET:
 
                 RETURN_VALUE=85
                 while [ "${RETURN_VALUE}" -eq 85 ]; do
+                    # shellcheck disable=SC2086
                     env LD_LIBRARY_PATH="${KO_LD_LIBRARY_PATH}" EMULATE_READER_W="${screen_width}" EMULATE_READER_H="${screen_height}" EMULATE_READER_DPI="${screen_dpi}" \
                         ${KOREADER_COMMAND}
                     RETURN_VALUE=$?

--- a/tools/valgrind_amd.supp
+++ b/tools/valgrind_amd.supp
@@ -1,0 +1,18 @@
+{
+    ignore_sdl2
+    Memcheck:Leak
+    ...
+    obj:*/libSDL2-*.so.*
+}
+{
+    ignore_radeon_dri
+    Memcheck:Leak
+    ...
+    obj:*/radeonsi_dri.so
+}
+{
+    ignore_llvm
+    Memcheck:Leak
+    ...
+    obj:*/libLLVM-*.so
+}

--- a/tools/valgrind_amd.supp
+++ b/tools/valgrind_amd.supp
@@ -16,3 +16,21 @@
     ...
     obj:*/libLLVM-*.so
 }
+{
+    ignore_x11
+    Memcheck:Leak
+    ...
+    obj:*/libX11.so.*
+}
+{
+    ignore_glx_mesa
+    Memcheck:Leak
+    ...
+    obj:*/libGLX_mesa.so.*
+}
+{
+    ignore_dbus
+    Memcheck:Leak
+    ...
+    obj:*/libdbus-1.so.*
+}


### PR DESCRIPTION
* This means that stuff like passing a custom gdb frontend or custom valgrind args is now actually usable ;).
* Fixed the stock GDB invocation (passing args to the debuggee is... not straightforward).
* Only pass LD_LIBRARY_PATH to LuaJIT, not the script's env, because some GDB frontends (hi, nemiver) may have dependencies on libraries we ship, causing ABI breakages (e.g., happened for glib).
* Made the valgrind defaults slightly more aggressive
* Added a --callgrind shortcut for... callgrind
* Documented how to use a valgrind suppression file to tame mesa/drm on distros that don't build it w/ valgrind markings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6980)
<!-- Reviewable:end -->
