### PR TITLE
Make sure getting rid of a DPI override actually restores default behavior

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -205,9 +205,12 @@ function Device:init()
 end
 
 function Device:setScreenDPI(dpi_override)
-    self.screen:setDPI(dpi_override)
+    if dpi_override then
+        self.screen:setDPI(dpi_override)
+    else
+        self.screen:clearDPI(dpi_override)
+    end
     self.input.gesture_detector:init()
-    self.screen_dpi_override = dpi_override
 end
 
 function Device:getPowerDevice()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -205,11 +205,8 @@ function Device:init()
 end
 
 function Device:setScreenDPI(dpi_override)
-    if dpi_override then
-        self.screen:setDPI(dpi_override)
-    else
-        self.screen:clearDPI(dpi_override)
-    end
+    -- Passing a nil resets to defaults and clears the override flag
+    self.screen:setDPI(dpi_override)
     self.input.gesture_detector:init()
 end
 

--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -16,7 +16,9 @@ local function setDPI(_dpi)
         text = _dpi and T(_("DPI set to %1. This will take effect after restarting."), _dpi)
                or _("DPI set to auto. This will take effect after restarting."),
     })
+    -- If this is set to nil, reader.lua doesn't call setScreenDPI
     G_reader_settings:saveSetting("screen_dpi", _dpi)
+    -- Passing a nil properly resets to defaults/auto
     Device:setScreenDPI(_dpi)
 end
 

--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -3,7 +3,7 @@ local Device = require("device")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
-local function isAutoDPI() return Device.screen_dpi_override == nil end
+local function isAutoDPI() return Screen.dpi_override == nil end
 
 local function dpi() return Screen:getDPI() end
 


### PR DESCRIPTION
This was... not quite the case before.

Requires https://github.com/koreader/koreader-base/pull/1258

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6984)
<!-- Reviewable:end -->
