### PR TITLE
Remove sourceror.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,6 @@ Right now we only support [liberapay](https://liberapay.com/KOReader) donations,
 [![Last commit][badge-last-commit]][link-gh-commits]
 [![Commit activity][badge-commit-activity]][link-gh-insights]
 
-[![0](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/0)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/0)
-[![1](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/1)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/1)
-[![2](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/2)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/2)
-[![3](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/3)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/3)
-[![4](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/4)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/4)
-[![5](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/5)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/5)
-[![6](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/6)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/6)
-[![7](https://sourcerer.io/fame/Frenzie/koreader/koreader/images/7)](https://sourcerer.io/fame/Frenzie/koreader/koreader/links/7)
-
 [badge-bountysource]:https://img.shields.io/bountysource/team/koreader/activity?color=red
 [badge-circleci]:https://circleci.com/gh/koreader/koreader.svg?style=shield
 [badge-coverage]:https://codecov.io/gh/koreader/koreader/branch/master/graph/badge.svg


### PR DESCRIPTION
The images stopped working, so they no longer look nice like they used to. Here's an excerpt from an e-mail they sent me on November 18, 2020.

> We’ve made the very difficult decision to shut down Sourcerer and have sold our intellectual property rights and trademarks to another organization. We are not disclosing the acquiring organization at this time, but, have discussed extensively how they may be used in the future and couldn’t be more impressed with how thoughtfully they’ve communicated with us their vision for the future.
>
> Sourcerer profiles will be live until March 31, 2021. We will not be updating the platform, fixing bugs, or accepting new signups effective immediately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6986)
<!-- Reviewable:end -->
