### PR TITLE
wip: hardened issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,15 +7,37 @@ assignees: ''
 
 ---
 
+# Bug report
+
+**Please note we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to KOReader again.**
+
+- [ ] checked that my device is actually supported?
+- [ ] updated to [last release](https://github.com/koreader/koreader/releases) or [last nightly](http://build.koreader.rocks/download/nightly/) and can still reproduce the bug?
+
+<!-- To help us debug your issue, please complete these sections: -->
+
+<!-- the full KOReader version, for example v2020.11 or v2020.11-55-ge0ac00f
+     saying "last stable" or "last nightly" doesn't age well. -->
 * KOReader version:
 * Device:
 
-#### Issue
+#### What you were trying to do
 
-#### Steps to reproduce
+A clear and concise description of the action that triggered the bug
 
-##### `crash.log` (if applicable)
-`crash.log` is a file that is automatically created when KOReader crashes. It can
+#### What happened
+
+A clear and concise description of what happened
+
+#### Step-by-step reproduction instructions
+
+All steps needed to reproduce the bug
+
+#### `crash.log`
+
+<!--
+
+`crash.log` is a file that is automatically created when KOReader runs. It can
 normally be found in the KOReader directory:
 
 * `/mnt/private/koreader` for Cervantes
@@ -25,7 +47,21 @@ normally be found in the KOReader directory:
 
 Android won't have a crash.log file because Google restricts what apps can log, so you'll need to obtain logs using `adb logcat KOReader:I ActivityManager:* AndroidRuntime:* DEBUG:* *:F`.
 
+Unless you're reporting a crash you need to enable debug logs first.
+To do that go to the `KOReader's file manager` -> `Tools` -> `More Tools` -> `Developer options` and check `enable debug logging`.
 
-Please try to include the relevant sections in your issue description.
-You can upload the whole `crash.log` file on GitHub by dragging and
-dropping it onto this textbox.
+You need to reproduce the issue again *once* debug logs are enabled.
+
+You can upload the whole `crash.log` file on GitHub by dragging and dropping it onto this textbox.
+-->
+
+#### test case (if applicable)
+
+<!--
+
+If you're reporting a bug that happens on a given document you need to attach that document to this issue or, better yet, create a test case that showcases the issue you're having.
+
+For copyright materials you'll need to scramble the document before: have a look at [ScrambleEbook calibre plugin](https://www.mobileread.com/forums/showthread.php?t=267998)
+
+-->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,21 @@ assignees: ''
 
 ---
 
+# Feature request
+
+**Please note we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to KOReader again.**
+
+- [ ] checked that the feature wasn't yet requested
+
+<!-- There're a few labels that help you to understand what's the status of a ticket
+
+     Please check that your feature request doesn't match any ticket labeled as 'enhancement'.
+     Also keep in mind that some feature requests can be labeled 'wontfix' or 'out-of-scope', so
+     check these two. 
+-->
+
+- [ ] checked that the feature wasn't yet requested
+
 **Does your feature request involve difficulty completing a task? Please describe.**
 A clear and concise description of what the problem is. Ex. I think it takes too many steps to [...]
 


### PR DESCRIPTION
Shameless copy from [`brew`'s bug template](https://github.com/Homebrew/brew/blob/master/.github/ISSUE_TEMPLATE/bug.md)

Adapted to document crash.log creation and test case reports for documents. The main idea is to make our lives easier.

1. avoid incomplete bug reports
2. avoid out-of-date bug reports
3. avoid including our own instructions on the body of the new ticket
4. prevent us from explaining how-to get debug logs on each ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/6988)
<!-- Reviewable:end -->
