### PR TITLE
Kindle: Make ReaderActivityIndicator a stub

### DIFF
--- a/frontend/apps/reader/modules/readeractivityindicator.lua
+++ b/frontend/apps/reader/modules/readeractivityindicator.lua
@@ -1,16 +1,43 @@
-local EventListener = require("ui/widget/eventlistener")
+-- Start with a empty stub, because 99.9% of users won't actually need this.
+local ReaderActivityIndicator = {}
+
+function ReaderActivityIndicator:isStub() return true end
+function ReaderActivityIndicator:init() end
+function ReaderActivityIndicator:onStartActivityIndicator() end
+function ReaderActivityIndicator:onStopActivityIndicator() end
+function ReaderActivityIndicator:coda() end
+
+-- Now, if we're on Kindle, and we haven't actually murdered Pillow, see what we can do...
 local Device = require("device")
+
+if Device:isKindle() then
+    if os.getenv("PILLOW_HARD_DISABLED") or os.getenv("PILLOW_SOFT_DISABLED") then
+        -- Pillow is dead, bye!
+        return ReaderActivityIndicator
+    end
+
+    if not Device:isTouchDevice() then
+        -- No lipc, bye!
+        return ReaderActivityIndicator
+    end
+else
+    -- Not on Kindle, bye!
+    return ReaderActivityIndicator
+end
+
+
+-- Okay, if we're here, it's basically because we're running on a Kindle on FW 5.x under KPV
+local EventListener = require("ui/widget/eventlistener")
 local util = require("ffi/util")
 -- lipc
 
-local ReaderActivityIndicator = EventListener:new{}
+function ReaderActivityIndicator:isStub() return false end
+
+ReaderActivityIndicator = EventListener:new{}
 
 function ReaderActivityIndicator:init()
-    local dev_mod = Device.model
-    if dev_mod == "KindlePaperWhite" or dev_mod == "KindlePaperWhite2" or dev_mod == "KindleVoyage" or dev_mod == "KindleBasic" or dev_mod == "KindlePaperWhite3" or dev_mod == "KindleOasis" or dev_mod == "KindleBasic2" or dev_mod == "KindleTouch" then
-        if (pcall(require, "liblipclua")) then
-            self.lipc_handle = lipc.init("com.github.koreader.activityindicator")
-        end
+    if (pcall(require, "liblipclua")) then
+        self.lipc_handle = lipc.init("com.github.koreader.activityindicator")
     end
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -222,13 +222,15 @@ function ReaderUI:init()
                 document = self.document,
             })
         end
-        -- activity indicator when some configurations take long take to affect
-        self:registerModule("activityindicator", ReaderActivityIndicator:new{
-            dialog = self.dialog,
-            view = self.view,
-            ui = self,
-            document = self.document,
-        })
+        -- activity indicator for when some settings take time to take effect (Kindle under KPV)
+        if not ReaderActivityIndicator:isStub() then
+            self:registerModule("activityindicator", ReaderActivityIndicator:new{
+                dialog = self.dialog,
+                view = self.view,
+                ui = self,
+                document = self.document,
+            })
+        end
     end
     -- for page specific controller
     if self.document.info.has_pages then

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -236,7 +236,7 @@ if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "upstart" ]; then
         FW_VERSION="$(grep '^Kindle 5' /etc/prettyversion.txt 2>&1 | sed -n -r 's/^(Kindle)([[:blank:]]*)([[:digit:]\.]*)(.*?)$/\3/p')"
         # NOTE: We want to disable the status bar (at the very least). Unfortunately, the soft hide/unhide method doesn't work properly anymore since FW 5.6.5...
         if [ "$(version "${FW_VERSION}")" -ge "$(version "5.6.5")" ]; then
-            PILLOW_HARD_DISABLED="yes"
+            export PILLOW_HARD_DISABLED="yes"
             # FIXME: So we resort to killing pillow completely on FW >= 5.6.5...
             logmsg "Disabling pillow . . ."
             lipc-set-prop com.lab126.pillow disableEnablePillow disable
@@ -262,7 +262,7 @@ if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "upstart" ]; then
             logmsg "Hiding the status bar . . ."
             # NOTE: One more great find from eureka (http://www.mobileread.com/forums/showpost.php?p=2454141&postcount=34)
             lipc-set-prop com.lab126.pillow interrogatePillow '{"pillowId": "default_status_bar", "function": "nativeBridge.hideMe();"}'
-            PILLOW_SOFT_DISABLED="yes"
+            export PILLOW_SOFT_DISABLED="yes"
         fi
         # NOTE: We don't need to sleep at all if we've already SIGSTOPped awesome ;)
         if [ "${NO_SLEEP}" = "no" ] && [ "${AWESOME_STOPPED}" = "no" ]; then


### PR DESCRIPTION
And only actually flesh it out and register it in the very few cases
where it can actually do something (i.e., old FW 5.x with KPV).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7002)
<!-- Reviewable:end -->
