### PR TITLE
Implement proper alpha-blending of SVG icons

### DIFF
--- a/frontend/ui/widget/iconwidget.lua
+++ b/frontend/ui/widget/iconwidget.lua
@@ -35,7 +35,7 @@ local IconWidget = ImageWidget:extend{
     -- be overriden by callers.
     width = Screen:scaleBySize(DGENERIC_ICON_SIZE), -- our icons are square
     height = Screen:scaleBySize(DGENERIC_ICON_SIZE),
-    alpha = true, -- our icons have a transparent background
+    alpha = false, --- @note: our icons have a transparent background, but we flatten them at caching time.
     is_icon = true, -- avoid dithering in ImageWidget:paintTo()
 }
 

--- a/frontend/ui/widget/iconwidget.lua
+++ b/frontend/ui/widget/iconwidget.lua
@@ -35,7 +35,7 @@ local IconWidget = ImageWidget:extend{
     -- be overriden by callers.
     width = Screen:scaleBySize(DGENERIC_ICON_SIZE), -- our icons are square
     height = Screen:scaleBySize(DGENERIC_ICON_SIZE),
-    alpha = false, --- @note: our icons have a transparent background, but we flatten them at caching time.
+    alpha = false, --- @note: our icons have a transparent background, but we flatten them at caching time, and this flag is only checked at blitting time.
     is_icon = true, -- avoid dithering in ImageWidget:paintTo()
 }
 

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -426,7 +426,7 @@ function ImageWidget:paintTo(bb, x, y)
         -- NOTE: MuPDF feeds us premultiplied alpha (and we don't care w/ GifLib, as alpha is all or nothing),
         --       while NanoSVG feeds us straight alpha.
         --       SVG icons are currently flattened at caching time, so we'll only go through the straight alpha
-        --       codepath for non-icons PNGs.
+        --       codepath for non-icons SVGs.
         if self._is_straight_alpha then
             -- NOTE: Our icons are already dithered properly, either at encoding time, or at caching time.
             if Screen.sw_dithering and not self.is_icon then

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -419,7 +419,10 @@ function ImageWidget:paintTo(bb, x, y)
         -- Only actually try to alpha-blend if the image really has an alpha channel...
         local bbtype = self._bb:getType()
         if bbtype == Blitbuffer.TYPE_BB8A or bbtype == Blitbuffer.TYPE_BBRGB32 then
-            do_alpha = true
+            -- NOTE: Icons are flattened at caching time!
+            if not self.is_icon then
+                do_alpha = true
+            end
         end
     end
     if do_alpha then

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -424,9 +424,11 @@ function ImageWidget:paintTo(bb, x, y)
     end
     if do_alpha then
         -- NOTE: MuPDF feeds us premultiplied alpha (and we don't care w/ GifLib, as alpha is all or nothing),
-        --       while NanoSVG feeds us straight alpha
+        --       while NanoSVG feeds us straight alpha.
+        --       SVG icons are currently flattened at caching time, so we'll only go through the straight alpha
+        --       codepath for non-icons PNGs.
         if self._is_straight_alpha then
-            -- NOTE: Our icons are already preprocessed properly, either at encoding time, or at caching time.
+            -- NOTE: Our icons are already dithered properly, either at encoding time, or at caching time.
             if Screen.sw_dithering and not self.is_icon then
                 bb:ditheralphablitFrom(self._bb, x, y, self._offset_x, self._offset_y, size.w, size.h)
             else

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -419,10 +419,7 @@ function ImageWidget:paintTo(bb, x, y)
         -- Only actually try to alpha-blend if the image really has an alpha channel...
         local bbtype = self._bb:getType()
         if bbtype == Blitbuffer.TYPE_BB8A or bbtype == Blitbuffer.TYPE_BBRGB32 then
-            -- NOTE: Icons are flattened at caching time!
-            if not self.is_icon then
-                do_alpha = true
-            end
+            do_alpha = true
         end
     end
     if do_alpha then

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -424,9 +424,9 @@ function ImageWidget:paintTo(bb, x, y)
     end
     if do_alpha then
         --- @note: MuPDF feeds us premultiplied alpha (and we don't care w/ GifLib, as alpha is all or nothing),
-        ---       while NanoSVG feeds us straight alpha.
-        ---       SVG icons are currently flattened at caching time, so we'll only go through the straight alpha
-        ---       codepath for non-icons SVGs.
+        ---        while NanoSVG feeds us straight alpha.
+        ---        SVG icons are currently flattened at caching time, so we'll only go through the straight alpha
+        ---        codepath for non-icons SVGs.
         if self._is_straight_alpha then
             --- @note: Our icons are already dithered properly, either at encoding time, or at caching time.
             if Screen.sw_dithering and not self.is_icon then

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -423,12 +423,12 @@ function ImageWidget:paintTo(bb, x, y)
         end
     end
     if do_alpha then
-        -- NOTE: MuPDF feeds us premultiplied alpha (and we don't care w/ GifLib, as alpha is all or nothing),
-        --       while NanoSVG feeds us straight alpha.
-        --       SVG icons are currently flattened at caching time, so we'll only go through the straight alpha
-        --       codepath for non-icons SVGs.
+        --- @note: MuPDF feeds us premultiplied alpha (and we don't care w/ GifLib, as alpha is all or nothing),
+        ---       while NanoSVG feeds us straight alpha.
+        ---       SVG icons are currently flattened at caching time, so we'll only go through the straight alpha
+        ---       codepath for non-icons SVGs.
         if self._is_straight_alpha then
-            -- NOTE: Our icons are already dithered properly, either at encoding time, or at caching time.
+            --- @note: Our icons are already dithered properly, either at encoding time, or at caching time.
             if Screen.sw_dithering and not self.is_icon then
                 bb:ditheralphablitFrom(self._bb, x, y, self._offset_x, self._offset_y, size.w, size.h)
             else


### PR DESCRIPTION
Also, instead of doing that every time, cache a pre-composited version
that matches the screen's BB type.
This is faster, and also has the advantage of making icon highlights
behave.

Jot down a few notes about corner-cases or future improvements, e.g.,
dimming icons on non-white backgrounds, and nightmode with color icons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7011)
<!-- Reviewable:end -->
