### PR TITLE
Fix y origin of the configmenu extended tapzone

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -78,7 +78,7 @@ FOLLOW_LINK_TIMEOUT = 0.5
 DTAP_ZONE_MENU = {x = 0, y = 0, w = 1, h = 1/8}
 DTAP_ZONE_MENU_EXT = {x = 1/4, y = 0, w = 2/4, h = 1/5} -- taller, narrower extension
 DTAP_ZONE_CONFIG = {x = 0, y = 7/8, w = 1, h = 1/8}
-DTAP_ZONE_CONFIG_EXT = {x = 1/4, y = 2/3, w = 2/4, h = 1/5} -- taller, narrower extension
+DTAP_ZONE_CONFIG_EXT = {x = 1/4, y = 4/5, w = 2/4, h = 1/5} -- taller, narrower extension
 DTAP_ZONE_MINIBAR = {x = 0, y = 12/13, w = 1, h = 1/13}
 DTAP_ZONE_FORWARD = {x = 1/4, y = 0, w = 3/4, h = 1}
 DTAP_ZONE_BACKWARD = {x = 0, y = 0, w = 1/4, h = 1}


### PR DESCRIPTION
Forgot to update it during the revamps in #6918, meaning it starts much
higher than expected.

(Which also leads to a weird tiny gap between the classic & extended tapzone -_-").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7015)
<!-- Reviewable:end -->
