### PR TITLE
Use a full-width plus for buttons paired with a unicode minus

### DIFF
--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -180,7 +180,7 @@ function ButtonProgressWidget:update()
         local margin = button_margin
         local extra_border_size = 0
         local button = Button:new{
-            text = "+",
+            text = "＋",
             radius = 0,
             margin = margin,
             padding = button_padding,

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -452,7 +452,7 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
             end,
         }
         button_plus_one_hour = Button:new{
-            text = "+",
+            text = "＋",
             margin = Size.margin.small,
             radius = 0,
             enabled = self.powerd.auto_warmth,

--- a/frontend/ui/widget/naturallightwidget.lua
+++ b/frontend/ui/widget/naturallightwidget.lua
@@ -100,7 +100,7 @@ function NaturalLightWidget:adaptableNumber(initial, step)
         end,
     }
     local button_plus = Button:new{
-        text = "+",
+        text = "＋",
         margin = Size.margin.small,
         radius = 0,
         width = self.button_width,


### PR DESCRIPTION
U+FF0B vs. U+002B

Because otherwise it is not, in fact, the same width as the minus, which looks weird in buttons ;).

Re #3840 & #6939

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7018)
<!-- Reviewable:end -->
