### PR TITLE
IconWidget: fix user icons directory path

### DIFF
--- a/frontend/ui/widget/iconwidget.lua
+++ b/frontend/ui/widget/iconwidget.lua
@@ -8,7 +8,7 @@ local Screen = require("device").screen
 
 -- Directories to look for icons by name, with any of the accepted suffixes
 local ICONS_DIRS = {}
-local user_icons_dir = DataStorage:getSettingsDir() .. "/icons"
+local user_icons_dir = DataStorage:getDataDir() .. "/icons"
 if lfs.attributes(user_icons_dir, "mode") == "directory" then
     table.insert(ICONS_DIRS, user_icons_dir)
 end


### PR DESCRIPTION
Should be `DataStorage:getDataDir()` instead of `DataStorage:getSettingsDir()`.
(`koreader/icons/` instead of `koreader/settings/icons/`) https://github.com/koreader/koreader/pull/6977#discussion_r546375434

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7019)
<!-- Reviewable:end -->
