### PR TITLE
NetworkManager: Slightly more accurate wifi strength icons

### DIFF
--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -121,22 +121,20 @@ function NetworkItem:init()
     else
         wifi_icon = "wifi.open.%d"
     end
-    -- NOTE: Load the dice a bit to get slightly more useful icons... (c.f., https://github.com/koreader/lj-wpaclient/pull/6)
-    local weighted_rssi = self.info.signal_quality
-    if weighted_rssi < 9 then
-        wifi_icon = string.format(wifi_icon, 0)
-    elseif weighted_rssi > 85 then
+    -- Based on NetworkManager's nmc_wifi_strength_bars
+    -- c.f., https://github.com/NetworkManager/NetworkManager/blob/2fa8ef9fb9c7fe0cc2d9523eed6c5a3749b05175/clients/common/nm-client-utils.c#L585-L612
+    if self.info.signal_quality > 80 then
         wifi_icon = string.format(wifi_icon, 100)
+    elseif self.info.signal_quality > 55 then
+        wifi_icon = string.format(wifi_icon, 75)
+    elseif self.info.signal_quality > 30 then
+        wifi_icon = string.format(wifi_icon, 50)
+    elseif self.info.signal_quality > 5 then
+        wifi_icon = string.format(wifi_icon, 25)
     else
-        -- Fudge the realistic range of values by 15, because we're unlikely to see anything better than -15dBm
-        if weighted_rssi > 25 then
-            weighted_rssi = self.info.signal_quality + 15
-        end
-        -- Round up to the next multiple of 25
-        wifi_icon = string.format(
-            wifi_icon,
-            weighted_rssi + 25 - weighted_rssi % 25)
+        wifi_icon = string.format(wifi_icon, 0)
     end
+
     local horizontal_space = HorizontalSpan:new{width = Size.span.horizontal_default}
     self.content_container = OverlapGroup:new{
         dimen = self.dimen:copy(),

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -121,12 +121,19 @@ function NetworkItem:init()
     else
         wifi_icon = "wifi.open.%d"
     end
-    if self.info.signal_quality == 0 or self.info.signal_quality == 100 then
-        wifi_icon = string.format(wifi_icon, self.info.signal_quality)
+    -- NOTE: Load the dice a bit to get slightly more useful icons... (c.f., https://github.com/koreader/lj-wpaclient/pull/6)
+    local weighted_rssi = self.info.signal_quality
+    if weighted_rssi < 15 then
+        wifi_icon = string.format(wifi_icon, 0)
+    elseif weighted_rssi > 85 then
+        wifi_icon = string.format(wifi_icon, 100)
     else
+        -- Fudge the realistic range of values by 15, because we're unlikely to see anything better than -15dBm
+        weighted_rssi = self.info.signal_quality + 15
+        -- Round up to the next multiple of 25
         wifi_icon = string.format(
             wifi_icon,
-            self.info.signal_quality + 25 - self.info.signal_quality % 25)
+            weighted_rssi + 25 - weighted_rssi % 25)
     end
     local horizontal_space = HorizontalSpan:new{width = Size.span.horizontal_default}
     self.content_container = OverlapGroup:new{

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -123,13 +123,15 @@ function NetworkItem:init()
     end
     -- NOTE: Load the dice a bit to get slightly more useful icons... (c.f., https://github.com/koreader/lj-wpaclient/pull/6)
     local weighted_rssi = self.info.signal_quality
-    if weighted_rssi < 15 then
+    if weighted_rssi < 9 then
         wifi_icon = string.format(wifi_icon, 0)
     elseif weighted_rssi > 85 then
         wifi_icon = string.format(wifi_icon, 100)
     else
         -- Fudge the realistic range of values by 15, because we're unlikely to see anything better than -15dBm
-        weighted_rssi = self.info.signal_quality + 15
+        if weighted_rssi > 25 then
+            weighted_rssi = self.info.signal_quality + 15
+        end
         -- Round up to the next multiple of 25
         wifi_icon = string.format(
             wifi_icon,


### PR DESCRIPTION
Depends on https://github.com/koreader/lj-wpaclient/pull/6

Fix #7008

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7020)
<!-- Reviewable:end -->
