### PR TITLE
HW rotation causing PB632 inversion state issues

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -453,8 +453,8 @@ local PocketBook632 = PocketBook:new{
     model = "PBTouchHDPlus",
     display_dpi = 300,
     isAlwaysPortrait = yes,
-    usingForcedRotation = landscape_ccw,
     hasNaturalLight = yes,
+    -- Buggy kernel, no usingForcedRotation, fb reinits done by the HW rotation shenanigans forget about inversion, c.f. #7017
 }
 
 -- PocketBook Color (633)


### PR DESCRIPTION
More details here:
https://github.com/koreader/koreader/issues/7017

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7022)
<!-- Reviewable:end -->
