### PR TITLE
Show only 1 End Document Dialog at a time

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -60,7 +60,7 @@ function ReaderStatus:onEndOfBook()
         self:onMarkBook(true)
     end
 
-    if settings == "pop-up" or settings == nil then
+    if (settings == "pop-up" or settings == nil) and UIManager:getTopWidget() ~= "end_document" then
         local buttons = {
             {
                 {
@@ -128,6 +128,7 @@ function ReaderStatus:onEndOfBook()
             },
         }
         choose_action = ButtonDialogTitle:new{
+            name = "end_document",
             title = _("You've reached the end of the document.\nWhat would you like to do?"),
             title_align = "center",
             buttons = buttons,


### PR DESCRIPTION
if scrolling past the end of a document the EndOfBook event get fired once per scroll (a lot).

This can cause humorous results, ie. if the end action is set to `next book` a long enough scroll will go through a few books.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7035)
<!-- Reviewable:end -->
