### PR TITLE
[wip] android: Bump to API30, binaries and libraries packaged in compliance…

### DIFF
--- a/platform/android/copy_libs.sh
+++ b/platform/android/copy_libs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+INSTALL_DIR="$1"
+JNILIBS_DIR="$2"
+SYMBOLIC_MAP="$3"
+
+# avoid duplicates
+function checkAndCopy() {
+    if [ ! -f "${JNILIBS_DIR}/${2}" ]; then
+        src="${INSTALL_DIR}/${1}"
+        dest="${JNILIBS_DIR}/${2}"
+        cp -pv "${src}" "${dest}"
+        echo "${1} ${2}" >> "${SYMBOLIC_MAP}"
+    fi
+}
+
+mapfile -t array < <(cd "${INSTALL_DIR}" && find libs/ plugins/ -type f -name '*.so')
+for i in "${array[@]}"; do
+    file="${i##*/}"
+    checkAndCopy "${i}" "${file}"
+done
+

--- a/platform/android/copy_libs.sh
+++ b/platform/android/copy_libs.sh
@@ -10,7 +10,7 @@ function checkAndCopy() {
         src="${INSTALL_DIR}/${1}"
         dest="${JNILIBS_DIR}/${2}"
         cp -pv "${src}" "${dest}"
-        echo "${1} ${2}" >> "${SYMBOLIC_MAP}"
+        echo "${1} ${2}" >>"${SYMBOLIC_MAP}"
     fi
 }
 
@@ -19,4 +19,3 @@ for i in "${array[@]}"; do
     file="${i##*/}"
     checkAndCopy "${i}" "${file}"
 done
-

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -64,11 +64,6 @@ if android.prop.flavor ~= "fdroid" then
     pcall(dofile, path.."/koreader/patch.lua")
 end
 
--- Set proper permission for binaries.
---- @todo Take care of this on extraction instead.
--- Cf. <https://github.com/koreader/koreader/issues/5347#issuecomment-529476693>.
-android.execute("chmod", "755", "./sdcv")
-
 -- set TESSDATA_PREFIX env var
 C.setenv("TESSDATA_PREFIX", path.."/koreader/data", 1)
 


### PR DESCRIPTION
… with the platform.

The bulk of native libraries are extracted at installation and linked at runtime (after each update)

Requires https://github.com/koreader/koreader-base/pull/1266
Requires https://github.com/koreader/android-luajit-launcher/pull/276

Here be dragons

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7040)
<!-- Reviewable:end -->
