### PR TITLE
ReaderActivityIndicator: fix isStub()

### DIFF
--- a/frontend/apps/reader/modules/readeractivityindicator.lua
+++ b/frontend/apps/reader/modules/readeractivityindicator.lua
@@ -31,9 +31,9 @@ local EventListener = require("ui/widget/eventlistener")
 local util = require("ffi/util")
 -- lipc
 
-function ReaderActivityIndicator:isStub() return false end
-
 ReaderActivityIndicator = EventListener:new{}
+
+function ReaderActivityIndicator:isStub() return false end
 
 function ReaderActivityIndicator:init()
     if (pcall(require, "liblipclua")) then


### PR DESCRIPTION
it was being overridden by the EventListener:new

caused by #7002

c.f. https://www.mobileread.com/forums/showthread.php?t=335886

@NiLuJe 
I didn't test this (don't have a KPV device) but it makes sense to me, please test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7041)
<!-- Reviewable:end -->
