### PR TITLE
Android: Avoid the Lua blitter

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -209,6 +209,24 @@ function Device:init()
         setClipboardText = function(text)
             return android.setClipboardText(text)
         end,
+
+        -- Make sure we won't ever fallback to the Lua BB...
+        local bb = require("ffi/blitbuffer")
+        bb.BB_mt.__index:canUseCbbTogether = bb.getUseCBB
+        bb.BB4_mt.__index.canUseCbbTogether = bb.getUseCBB
+        bb.BB8_mt.__index.canUseCbbTogether = bb.getUseCBB
+        bb.BB8A_mt.__index.canUseCbbTogether = bb.getUseCBB
+        bb.BBRGB16_mt.__index.canUseCbbTogether = bb.getUseCBB
+        bb.BBRGB24_mt.__index.canUseCbbTogether = bb.getUseCBB
+        bb.BBRGB32_mt.__index.canUseCbbTogether = bb.getUseCBB
+
+        bb.BB_mt.__index:canUseCbb = bb.getUseCBB
+        bb.BB4_mt.__index.canUseCbb = bb.getUseCBB
+        bb.BB8_mt.__index.canUseCbb = bb.getUseCBB
+        bb.BB8A_mt.__index.canUseCbb = bb.getUseCBB
+        bb.BBRGB16_mt.__index.canUseCbb = bb.getUseCBB
+        bb.BBRGB24_mt.__index.canUseCbb = bb.getUseCBB
+        bb.BBRGB32_mt.__index.canUseCbb = bb.getUseCBB
     }
 
     -- check if we have a keyboard

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -209,24 +209,6 @@ function Device:init()
         setClipboardText = function(text)
             return android.setClipboardText(text)
         end,
-
-        -- Make sure we won't ever fallback to the Lua BB...
-        local bb = require("ffi/blitbuffer")
-        bb.BB_mt.__index:canUseCbbTogether = bb.getUseCBB
-        bb.BB4_mt.__index.canUseCbbTogether = bb.getUseCBB
-        bb.BB8_mt.__index.canUseCbbTogether = bb.getUseCBB
-        bb.BB8A_mt.__index.canUseCbbTogether = bb.getUseCBB
-        bb.BBRGB16_mt.__index.canUseCbbTogether = bb.getUseCBB
-        bb.BBRGB24_mt.__index.canUseCbbTogether = bb.getUseCBB
-        bb.BBRGB32_mt.__index.canUseCbbTogether = bb.getUseCBB
-
-        bb.BB_mt.__index:canUseCbb = bb.getUseCBB
-        bb.BB4_mt.__index.canUseCbb = bb.getUseCBB
-        bb.BB8_mt.__index.canUseCbb = bb.getUseCBB
-        bb.BB8A_mt.__index.canUseCbb = bb.getUseCBB
-        bb.BBRGB16_mt.__index.canUseCbb = bb.getUseCBB
-        bb.BBRGB24_mt.__index.canUseCbb = bb.getUseCBB
-        bb.BBRGB32_mt.__index.canUseCbb = bb.getUseCBB
     }
 
     -- check if we have a keyboard
@@ -276,6 +258,24 @@ function Device:init()
     if G_reader_settings:isTrue("android_ignore_back_button") then
         android.setBackButtonIgnored(true)
     end
+
+    -- Make sure we won't ever fallback to the Lua BB...
+    local bb = require("ffi/blitbuffer")
+    bb.BB_mt.__index:canUseCbbTogether = bb.getUseCBB
+    bb.BB4_mt.__index.canUseCbbTogether = bb.getUseCBB
+    bb.BB8_mt.__index.canUseCbbTogether = bb.getUseCBB
+    bb.BB8A_mt.__index.canUseCbbTogether = bb.getUseCBB
+    bb.BBRGB16_mt.__index.canUseCbbTogether = bb.getUseCBB
+    bb.BBRGB24_mt.__index.canUseCbbTogether = bb.getUseCBB
+    bb.BBRGB32_mt.__index.canUseCbbTogether = bb.getUseCBB
+
+    bb.BB_mt.__index:canUseCbb = bb.getUseCBB
+    bb.BB4_mt.__index.canUseCbb = bb.getUseCBB
+    bb.BB8_mt.__index.canUseCbb = bb.getUseCBB
+    bb.BB8A_mt.__index.canUseCbb = bb.getUseCBB
+    bb.BBRGB16_mt.__index.canUseCbb = bb.getUseCBB
+    bb.BBRGB24_mt.__index.canUseCbb = bb.getUseCBB
+    bb.BBRGB32_mt.__index.canUseCbb = bb.getUseCBB
 
     Generic.init(self)
 end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -259,24 +259,6 @@ function Device:init()
         android.setBackButtonIgnored(true)
     end
 
-    -- Make sure we won't ever fallback to the Lua BB...
-    local bb = require("ffi/blitbuffer")
-    bb.BB_mt.__index.canUseCbbTogether = bb.getUseCBB
-    bb.BB4_mt.__index.canUseCbbTogether = bb.getUseCBB
-    bb.BB8_mt.__index.canUseCbbTogether = bb.getUseCBB
-    bb.BB8A_mt.__index.canUseCbbTogether = bb.getUseCBB
-    bb.BBRGB16_mt.__index.canUseCbbTogether = bb.getUseCBB
-    bb.BBRGB24_mt.__index.canUseCbbTogether = bb.getUseCBB
-    bb.BBRGB32_mt.__index.canUseCbbTogether = bb.getUseCBB
-
-    bb.BB_mt.__index.canUseCbb = bb.getUseCBB
-    bb.BB4_mt.__index.canUseCbb = bb.getUseCBB
-    bb.BB8_mt.__index.canUseCbb = bb.getUseCBB
-    bb.BB8A_mt.__index.canUseCbb = bb.getUseCBB
-    bb.BBRGB16_mt.__index.canUseCbb = bb.getUseCBB
-    bb.BBRGB24_mt.__index.canUseCbb = bb.getUseCBB
-    bb.BBRGB32_mt.__index.canUseCbb = bb.getUseCBB
-
     Generic.init(self)
 end
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -261,7 +261,7 @@ function Device:init()
 
     -- Make sure we won't ever fallback to the Lua BB...
     local bb = require("ffi/blitbuffer")
-    bb.BB_mt.__index:canUseCbbTogether = bb.getUseCBB
+    bb.BB_mt.__index.canUseCbbTogether = bb.getUseCBB
     bb.BB4_mt.__index.canUseCbbTogether = bb.getUseCBB
     bb.BB8_mt.__index.canUseCbbTogether = bb.getUseCBB
     bb.BB8A_mt.__index.canUseCbbTogether = bb.getUseCBB
@@ -269,7 +269,7 @@ function Device:init()
     bb.BBRGB24_mt.__index.canUseCbbTogether = bb.getUseCBB
     bb.BBRGB32_mt.__index.canUseCbbTogether = bb.getUseCBB
 
-    bb.BB_mt.__index:canUseCbb = bb.getUseCBB
+    bb.BB_mt.__index.canUseCbb = bb.getUseCBB
     bb.BB4_mt.__index.canUseCbb = bb.getUseCBB
     bb.BB8_mt.__index.canUseCbb = bb.getUseCBB
     bb.BB8A_mt.__index.canUseCbb = bb.getUseCBB


### PR DESCRIPTION
Depends on https://github.com/koreader/koreader-base/pull/1268

(The magic happens in base & android-luajit-launcher)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7042)
<!-- Reviewable:end -->
