### PR TITLE
Close Lua state on all os.exit() calls

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -823,7 +823,7 @@ function Input:waitEvent(timeout_us)
             break
         elseif ev == "application forced to quit" then
             --- @todo return an event that can be handled
-            os.exit(0)
+            os.exit(0, true)
         end
         logger.warn("got error waiting for events:", ev)
         if ev ~= "Waiting for input failed: 4\n" then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1278,7 +1278,7 @@ function UIManager:handleInput()
                 io.stderr:write(debug.traceback() .. "\n")
                 io.stderr:flush()
                 self.looper:close()
-                os.exit(1)
+                os.exit(1, true)
             end)
         end)
     end


### PR DESCRIPTION
Cf. <https://github.com/koreader/koreader/pull/7044>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7050)
<!-- Reviewable:end -->
