### PR TITLE
remarkable: poweroff.png ghosting fix

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -149,6 +149,8 @@ function Remarkable:resume()
 end
 
 function Remarkable:powerOff()
+    self.screen:clear()
+    self.screen:refreshFull()
     os.execute("systemctl poweroff")
 end
 


### PR DESCRIPTION
Preserves the ghosting fix without the suspend crash from https://github.com/koreader/koreader/pull/7043

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7051)
<!-- Reviewable:end -->
