### PR TITLE
reader.lua: open the correct item / rework args handling

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -54,7 +54,7 @@ local external = require("device/thirdparty"):new{
 local Device = Generic:new{
     model = "SDL",
     isSDL = yes,
-    home_dir = os.getenv("HOME"),
+    home_dir = os.getenv("XDG_DOCUMENTS_DIR") or os.getenv("HOME"),
     hasBattery = SDL.getPowerInfo(),
     hasKeyboard = yes,
     hasKeys = yes,
@@ -125,7 +125,6 @@ local Emulator = Device:new{
 local UbuntuTouch = Device:new{
     model = "UbuntuTouch",
     hasFrontlight = yes,
-    home_dir = nil,
 }
 
 function Device:init()

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -15,6 +15,7 @@ local SonyPRSTUX = Generic:new{
     canReboot = yes,
     canPowerOff = yes,
     usbPluggedIn = false,
+    home_dir = nil,
 }
 
 

--- a/kodev
+++ b/kodev
@@ -853,11 +853,9 @@ TARGET:
                 KOREADER_COMMAND="${valgrind} env LD_LIBRARY_PATH=${KO_LD_LIBRARY_PATH} ./luajit reader.lua ${KOREADER_ARGS}"
             fi
 
-            echo "[*] Running KOReader with arguments: $*..."
+            echo "[*] Running KOReader with arguments: $* ..."
             pushd "${EMU_DIR}" && {
-                if [ $# -lt 1 ]; then
-                    args="${CURDIR}/test"
-                else
+                if [ $# -ge 1 ]; then
                     args="$*"
                     [[ "${args}" != /* ]] && args="${CURDIR}/${args}"
                 fi

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -75,9 +75,9 @@ C.setenv("TESSDATA_PREFIX", path.."/koreader/data", 1)
 -- create fake command-line arguments
 -- luacheck: ignore 121
 if android.isDebuggable() then
-    arg = {"-d", file or path}
+    arg = {"-d", file}
 else
-    arg = {file or path}
+    arg = {file}
 end
 
 dofile(android.dir.."/reader.lua")

--- a/platform/appimage/AppRun
+++ b/platform/appimage/AppRun
@@ -12,19 +12,8 @@ export LD_LIBRARY_PATH=${KOREADER_DIR}/libs:${LD_LIBRARY_PATH}
 
 RETURN_VALUE=85
 
-if [ $# -eq 0 ]; then
-    # no arguments
-    if [ -n "${XDG_DOCUMENTS_DIR+x}" ]; then
-        start_path=${XDG_DOCUMENTS_DIR}
-    else
-        start_path=$(pwd)
-    fi
-else
-    start_path="$*"
-fi
-
 while [ ${RETURN_VALUE} -eq 85 ]; do
-    ./reader.lua "${start_path}"
+    ./reader.lua "$@"
     RETURN_VALUE=$?
 done
 

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -39,19 +39,12 @@ ko_update_check() {
     fi
 }
 
-# if no args were passed to the script, start the FM on public partition.
-if [ "$#" -eq 0 ]; then
-    args="/mnt/public"
-else
-    args="$*"
-fi
-
 # NOTE: Keep doing an initial update check, in addition to one during the restart loop, so we can pickup potential updates of this very script...
 ko_update_check
 # If an update happened, and was successful, reexec
 if [ -n "${fail}" ] && [ "${fail}" -eq 0 ]; then
     # By now, we know we're in the right directory, and our script name is pretty much set in stone, so we can forgo using $0
-    exec ./koreader.sh "${args}"
+    exec ./koreader.sh "$@"
 fi
 
 # load our own shared libraries if possible
@@ -101,7 +94,7 @@ while [ "${RETURN_VALUE}" -ge "${RESTART_KOREADER}" ]; do
     ko_update_check
 
     # run KOReader
-    ./reader.lua "${args}" >>crash.log 2>&1
+    ./reader.lua "$@" >>crash.log 2>&1
     RETURN_VALUE=$?
 
     # check if KOReader requested to enter in mass storage mode.

--- a/platform/debian/koreader.sh
+++ b/platform/debian/koreader.sh
@@ -4,14 +4,10 @@ export LC_ALL="en_US.UTF-8"
 # writable storage: ${HOME}/.config/koreader.
 export KO_MULTIUSER=1
 
-if [ -z "${1}" ]; then
-    ARGS="${HOME}"
+if [ $# -eq 1 ] && [ -e "$(pwd)/${1}" ]; then
+    ARGS="$(pwd)/${1}"
 else
-    if [ $# -eq 1 ] && [ -e "$(pwd)/${1}" ]; then
-        ARGS="$(pwd)/${1}"
-    else
-        ARGS="${*}"
-    fi
+    ARGS="${*}"
 fi
 
 # working directory of koreader

--- a/platform/kindle/extensions/koreader/menu.json
+++ b/platform/kindle/extensions/koreader/menu.json
@@ -5,54 +5,26 @@
 		"priority": 0,
 		"items": [
 		{
-			"name": "Start the filemanager",
-			"if": "\"KindleVoyage\" -m!",
-			"priority": 1,
-			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--kual /mnt/us/documents",
-			"status": false,
-			"internal": "status Start KOReader on the File Manager"
-		},
-		{
-			"name": "Start the filemanager",
-			"if": "\"KindleVoyage\" -m",
-			"priority": 1,
-			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--kual /mnt/us/documents",
-			"exitmenu": false,
-			"status": false,
-			"internal": "status Start KOReader on the File Manager"
-		},
-		{
-			"name": "Open the last document",
+			"name": "Start KOReader",
 			"if": "\"KindleVoyage\" -m!",
 			"priority": 2,
 			"action": "/mnt/us/koreader/koreader.sh",
 			"params": "--kual",
 			"status": false,
-			"internal": "status Start KOReader on the last document"
+			"internal": "status Start KOReader"
 		},
 		{
-			"name": "Open the last document",
+			"name": "Start KOReader",
 			"if": "\"KindleVoyage\" -m",
 			"priority": 2,
 			"action": "/mnt/us/koreader/koreader.sh",
 			"params": "--kual",
 			"exitmenu": false,
 			"status": false,
-			"internal": "status Start KOReader on the last document"
+			"internal": "status Start KOReader"
 		},
 		{
-			"name": "Start the filemanager (no framework)",
-			"if": "\"Kindle2\" -m \"KindleDX\" -m \"KindleDXG\" -m \"Kindle3\" -m \"Kindle4\" -m || || || ||",
-			"priority": 3,
-			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--kual --framework_stop /mnt/us/documents",
-			"status": false,
-			"internal": "status Kill the framework and start KOReader's FM"
-		},
-		{
-			"name": "Open the last document (no framework)",
+			"name": "Start KOReader (no framework)",
 			"if": "\"Kindle2\" -m \"KindleDX\" -m \"KindleDXG\" -m \"Kindle3\" -m \"Kindle4\" -m || || || ||",
 			"priority": 4,
 			"action": "/mnt/us/koreader/koreader.sh",
@@ -61,42 +33,23 @@
 			"internal": "status Kill the framework and start KOReader"
 		},
 		{
-			"name": "Start the filemanager (ASAP)",
-			"if": "\"KindleVoyage\" -m!",
-			"priority": 5,
-			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--kual --asap /mnt/us/documents",
-			"status": false,
-			"internal": "status Start KOreader on the File Manager ASAP"
-		},
-		{
-			"name": "Start the filemanager (ASAP)",
-			"if": "\"KindleVoyage\" -m",
-			"priority": 5,
-			"action": "/mnt/us/koreader/koreader.sh",
-			"params": "--kual --asap /mnt/us/documents",
-			"exitmenu": false,
-			"status": false,
-			"internal": "status Start KOreader on the File Manager ASAP"
-		},
-		{
-			"name": "Open the last document (ASAP)",
+			"name": "Start KOReader (ASAP)",
 			"if": "\"KindleVoyage\" -m!",
 			"priority": 6,
 			"action": "/mnt/us/koreader/koreader.sh",
 			"params": "--kual --asap",
 			"status": false,
-			"internal": "status Start KOreader on the last document ASAP"
+			"internal": "status Start KOReader ASAP"
 		},
 		{
-			"name": "Open the last document (ASAP)",
+			"name": "Start KOReader (ASAP)",
 			"if": "\"KindleVoyage\" -m",
 			"priority": 6,
 			"action": "/mnt/us/koreader/koreader.sh",
 			"params": "--kual --asap",
 			"exitmenu": false,
 			"status": false,
-			"internal": "status Start KOreader on the last document ASAP"
+			"internal": "status Start KOReader ASAP"
 		},
 		{
 			"name": "Tools",
@@ -122,7 +75,7 @@
 				"checked": true,
 				"refresh": false,
 				"status": false,
-				"internal": "status Try to install KOreader from scratch . . ."
+				"internal": "status Try to install KOReader from scratch . . ."
 			}
 			]
 		}

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -198,13 +198,6 @@ if [ "${VIA_NICKEL}" = "true" ]; then
     fi
 fi
 
-# fallback for old fmon, KFMon and advboot users (-> if no args were passed to the script, start the FM)
-if [ "$#" -eq 0 ]; then
-    args="/mnt/onboard"
-else
-    args="$*"
-fi
-
 # check whether PLATFORM & PRODUCT have a value assigned by rcS
 if [ -z "${PRODUCT}" ]; then
     # shellcheck disable=SC2046
@@ -333,7 +326,7 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         ko_do_dns
     fi
 
-    ./reader.lua "${args}" >>crash.log 2>&1
+    ./reader.lua "$@" >>crash.log 2>&1
     RETURN_VALUE=$?
 
     # Did we crash?

--- a/platform/mac/do_mac_bundle.sh
+++ b/platform/mac/do_mac_bundle.sh
@@ -175,7 +175,6 @@ rm -rf cache clipboard history ota \
 
 sed '1d' reader.lua >tempfile
 sed -i.backup 's/.\/reader.lua/koreader/' tempfile
-sed -i.backup 's/the last viewed document will be opened"/" .. os.getenv("HOME") .. " will be opened"/' tempfile
 mv tempfile reader.lua
 rm -f tempfile*
 chmod -x reader.lua

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -65,13 +65,6 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# shellcheck disable=2000
-if [ "$(echo "$@" | wc -c)" -eq 1 ]; then
-    args="/mnt/ext1/"
-else
-    args="$*"
-fi
-
 # we keep at maximum 500K worth of crash log
 if [ -e crash.log ]; then
     tail -c 500000 crash.log >crash.log.new
@@ -94,7 +87,7 @@ while [ "${RETURN_VALUE}" -ne 0 ]; do
         ko_update_check
     fi
 
-    ./reader.lua "${args}" >>crash.log 2>&1
+    ./reader.lua "$@" >>crash.log 2>&1
 
     # Account for the fact a hard crash may have prevented the KO_EXIT_CODE file from being written to...
     if [ -f "${KO_EXIT_CODE}" ]; then

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -132,12 +132,6 @@ if [ -e crash.log ]; then
     mv -f crash.log.new crash.log
 fi
 
-if [ "$#" -eq 0 ]; then
-    args="/home/root"
-else
-    args="$*"
-fi
-
 CRASH_COUNT=0
 CRASH_TS=0
 CRASH_PREV_TS=0
@@ -152,7 +146,7 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         ko_do_fbdepth
     fi
 
-    ./reader.lua "${args}" >>crash.log 2>&1
+    ./reader.lua "$@" >>crash.log 2>&1
     RETURN_VALUE=$?
 
     # Did we crash?

--- a/platform/ubuntu-touch/koreader.sh
+++ b/platform/ubuntu-touch/koreader.sh
@@ -22,7 +22,7 @@ export SDL_FULLSCREEN=1
 RETURN_VALUE=85
 
 while [ ${RETURN_VALUE} -eq 85 ]; do
-    ./reader.lua -d ~/Documents
+    ./reader.lua -d
     RETURN_VALUE=$?
 done
 


### PR DESCRIPTION
it was sometimes crashing when opened with no args

Fixes: #7049

The behavior is now (in order of precedence).

1. open **file** passed on command line
2. show the Quickstart if not shown before.
3. if `start_with` is `last document` try to open the last document (confirming that it exists).
4. else if a directory was passed on the command line or `start_with` is defined with a FM based action start the correct action.
5. else show usage.

The reason I didn't prioritize a directory passed on the command line over `start_with` is that many of the launchers start koreader with the directory to start from by default so `start_with` would end up doing nothing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7053)
<!-- Reviewable:end -->
