### PR TITLE
UI: Button radius matches default window radius

### DIFF
--- a/frontend/ui/size.lua
+++ b/frontend/ui/size.lua
@@ -57,7 +57,7 @@ local Size = {
     radius = {
         default = Screen:scaleBySize(2),
         window = Screen:scaleBySize(7),
-        button = Screen:scaleBySize(15),
+        button = Screen:scaleBySize(7),
     },
     line = {
         thin = Screen:scaleBySize(0.5),


### PR DESCRIPTION
An utterly trivial thing but I think it looks a bit nicer if the button radius matches the windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7054)
<!-- Reviewable:end -->
