### PR TITLE
Pass dict_path to dictionary fix_html_func

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -577,7 +577,8 @@ local function tidyMarkup(results)
             result.is_html = ifo.is_html
             result.css = ifo.css
             if ifo.fix_html_func then
-                local ok, fixed_definition = pcall(ifo.fix_html_func, result.definition)
+                local dict_path = util.splitFilePathName(ifo.file)
+                local ok, fixed_definition = pcall(ifo.fix_html_func, result.definition, dict_path)
                 if ok then
                     result.definition = fixed_definition
                 else


### PR DESCRIPTION
That way images can be made to work in a more generic, portable manner, such as:

```lua
return function(html, dict_path)
    html = html:gsub('<rref[^>]*>([^<]*%.jpg)</rref>', '<img src="'..dict_path..'res/%1">')
    return html
end
```

Cf. <https://github.com/koreader/koreader/issues/6056>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7057)
<!-- Reviewable:end -->
