### PR TITLE
Fix reMarkable 2 "double-press power button required to wake up"

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -141,8 +141,20 @@ function Remarkable:setDateTime(year, month, day, hour, min, sec)
     return os.execute(command) == 0
 end
 
-function Remarkable:suspend()
+function Remarkable1:suspend()
     os.execute("systemctl suspend")
+end
+
+function Remarkable2:suspend()
+    os.execute("systemctl suspend")
+    -- While device is suspended, when the user presses the power button and wakes up the device,
+    -- a "Power" event is NOT sent.
+    -- So we schedule a manual `UIManager:resume` call just far enough in the future that it won't
+    -- trigger before the `systemctl suspend` command finishes suspending the device
+    local UIManager = require("ui/uimanager")
+    UIManager:scheduleIn(0.5, function()
+        UIManager:resume()
+    end)
 end
 
 function Remarkable:resume()


### PR DESCRIPTION
While reMarkable 2 is suspended, pressing the power button wakes up the device but does NOT send an input event. So KOReader does not know the device has exited its suspend mode. Currently, the user has to press the power button twice: once to physically wake the device, and once to send the input event to KOReader.

This PR schedules a manual `UIManager:resume` call, which will trigger after the device wakes up from suspension.

Notes:

 - I don't know if the reMarkable 1 has the same behavior quirk. If so, then it's simple enough to apply this same fix to both device types.
 - I don't know if there's a cleaner way to guarantee a post-wakeup call.
 - A zero-second wait in `scheduleIn` does *not* work; it triggers the `resume` call *before* the device actually suspends, i.e. before the `systemctl suspend` process finishes suspending the device. When that happens, things start going wonky if the device is physically suspended for longer than the `autosuspend` plugin's timeout.
 - I tried various non-zero values in `scheduleIn`. Values as low as 0.1 worked, so I left a little buffer and set it to 0.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7065)
<!-- Reviewable:end -->
