### PR TITLE
Time-adjust all reMarkable 2 events, not just EV_ABS

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -70,8 +70,8 @@ local Remarkable2 = Remarkable:new{
 }
 
 function Remarkable2:adjustTouchEvent(ev, by)
+    ev.time = TimeVal:now()
     if ev.type == EV_ABS then
-        ev.time = TimeVal:now()
         -- Mirror Y and scale up both X & Y as touch input is different res from
         -- display
         if ev.code == ABS_MT_POSITION_X then


### PR DESCRIPTION
Long explanation for a one-line change :)
Still a n00b, so my analysis might be off, but the end result works on my reMarkable 2.

High-level problem is that *sometimes* after starting koreader, "touchscreen" events (i.e. finger inputs, not stylus) are always interpreted as long-hold presses, no matter how brief the tap.

I think it comes down to the `_has_real_clock_time_ev_time` flag that only gets set *once* in `frontend/device/gesturedetector.lua`.
The timestamps on raw event data for the reMarkable 2 are definitely NOT real clock time.
If I got the log message "event times are real clock time: no adjustment needed" then touchscreen taps all got misinterpreted as holds.
If I got the log message "event times are not real clock time: some adjustments will be made" then everything worked fine.

I figured out that the touchscreen generates `EV_ABS` *and* `EV_SYN` events, and both of those types get sent to `handleTouch` in `frontend/device/input.lua`.
Since the current code currently only time-corrects `EV_ABS` events, I thiiiiink that depending on whether the `EV_ABS` or `EV_SYN` events happen to get into the `handleTouch` function first, the `_has_real_clock_time_ev_time` flag may be set to true or false.
I did not dig any deeper to figure out why the stylus ("wacom") events still work fine, no matter the value of that flag.

It might work to more explicitly check for `EV_SYN` and `EV_ABS`, and do the time adjustment for both types.
But I figured it doesn't hurt to take the more simple approach of fixing the time for all events, regardless of type. Makes the PR simpler, too :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7066)
<!-- Reviewable:end -->
