### PR TITLE
 save rotation across restarts.

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -70,13 +70,10 @@ function FileManager:onSetRotationMode(rotation)
     return true
 end
 
--- init should be set to True when starting the FM for the first time
--- (not coming from the reader). This allows the default to be properly set.
-function FileManager:setRotationMode(init)
+function FileManager:setRotationMode()
     local locked = G_reader_settings:isTrue("lock_rotation")
-    local rotation_mode = G_reader_settings:readSetting("fm_rotation_mode") or Screen.ORIENTATION_PORTRAIT
-    -- Only enforce the default rotation on first FM open, or when switching to the FM when sticky rota is disabled.
-    if init or not locked then
+    if not locked then
+        local rotation_mode = G_reader_settings:readSetting("fm_rotation_mode") or Screen.ORIENTATION_PORTRAIT
         self:onSetRotationMode(rotation_mode)
     end
 end

--- a/reader.lua
+++ b/reader.lua
@@ -151,6 +151,13 @@ end
 if G_reader_settings:isTrue("night_mode") then
     Device.screen:toggleNightMode()
 end
+-- Ensure the proper rotation on startup.
+-- We default to the rotation KOReader closed with.
+-- If the rotation is not locked it will be overridden by a book or the FM when opened.
+local rotation_mode = G_reader_settings:readSetting("closed_rotation_mode")
+if rotation_mode and rotation_mode ~= Device.screen:getRotationMode() then
+    Device.screen:setRotationMode(rotation_mode)
+end
 -- Dithering
 if Device:hasEinkScreen() then
     Device.screen:setupDithering()
@@ -262,7 +269,6 @@ if file then
 elseif directory then
     local FileManager = require("apps/filemanager/filemanager")
     UIManager:nextTick(function()
-        FileManager:setRotationMode(true)
         FileManager:showFiles(directory)
     end)
     exit_code = UIManager:run()
@@ -289,7 +295,6 @@ else
         local home_dir =
             G_reader_settings:readSetting("home_dir") or Device.home_dir or lfs.currentdir()
         UIManager:nextTick(function()
-            FileManager:setRotationMode(true)
             FileManager:showFiles(home_dir)
         end)
         -- Always open history on top of filemanager so closing history
@@ -333,6 +338,9 @@ local function exitReader()
 
     -- Save any device settings before closing G_reader_settings
     Device:saveSettings()
+
+    --  Save current rotation to have it for next startup
+    G_reader_settings:saveSetting("closed_rotation_mode", Device.screen:getRotationMode())
 
     G_reader_settings:close()
 


### PR DESCRIPTION
Fixes: #7093 

~~Based on #7053 as they change the same file.~~

~~only the last commit is related.~~

we now do not have to reset the FM rotation at start when rotation is locked.

This only affects locked rotation (never change rotation), we will ignore defaults and use the way we left off last time.
If rotation is not locked the FM or book will override.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7096)
<!-- Reviewable:end -->
