### PR TITLE
More dictionary tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -889,6 +889,12 @@ function ReaderDictionary:showDict(word, results, box, link)
     self:dismissLookupInfo()
     if results and results[1] then
         UIManager:show(self.dict_window)
+        if not results[1].lookup_cancelled then
+            -- Discard queued and coming up events to avoid accidental
+            -- dismissal (but not if lookup interrupted, so 2 quick
+            -- taps can discard everything)
+            UIManager:discardEvents(true)
+        end
     end
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -937,14 +937,14 @@ function ReaderHighlight:lookup(selected_word, selected_link)
     -- if we extracted text directly
     if selected_word.word then
         local word_box = self.view:pageToScreenTransform(self.hold_pos.page, selected_word.sbox)
-        self.ui:handleEvent(Event:new("LookupWord", selected_word.word, word_box, self, selected_link))
+        self.ui:handleEvent(Event:new("LookupWord", selected_word.word, false, word_box, self, selected_link))
     -- or we will do OCR
     elseif selected_word.sbox and self.hold_pos then
         local word = self.ui.document:getOCRWord(self.hold_pos.page, selected_word)
         logger.dbg("OCRed word:", word)
         if word and word ~= "" then
             local word_box = self.view:pageToScreenTransform(self.hold_pos.page, selected_word.sbox)
-            self.ui:handleEvent(Event:new("LookupWord", word, word_box, self, selected_link))
+            self.ui:handleEvent(Event:new("LookupWord", word, false, word_box, self, selected_link))
         else
             UIManager:show(InfoMessage:new{
                 text = info_message_ocr_text,

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -711,7 +711,7 @@ function ReaderLink:onGoToExternalLink(link_url)
             callback = function()
                 UIManager:nextTick(function()
                     UIManager:close(dialog)
-                    self.ui:handleEvent(Event:new("LookupWikipedia", wiki_page, false, true, wiki_lang))
+                    self.ui:handleEvent(Event:new("LookupWikipedia", wiki_page, true, false, true, wiki_lang))
                 end)
             end,
         })

--- a/frontend/ui/trapper.lua
+++ b/frontend/ui/trapper.lua
@@ -165,6 +165,9 @@ function Trapper:info(text, fast_refresh)
                 ok_callback = function()
                     coroutine.resume(_coroutine, false)
                 end,
+                -- flush any pending tap, so past events won't be considered
+                -- action on the yet to be displayed widget
+                flush_events_on_show = true,
             }
             UIManager:show(abort_box)
             -- no need to forceRePaint, UIManager will do it when we yield()
@@ -185,10 +188,6 @@ function Trapper:info(text, fast_refresh)
         -- go_on_func returned result = true, or abort_box did not abort:
         -- continue processing
     end
-
-    --- @todo We should try to flush any pending tap, so past
-    -- events won't be considered action on the yet to be displayed
-    -- widget
 
     -- If fast_refresh option, avoid UIManager refresh overhead
     if fast_refresh and self.current_widget and self.current_widget.is_infomessage then
@@ -214,7 +213,10 @@ function Trapper:info(text, fast_refresh)
             dismiss_callback = function()
                 coroutine.resume(_coroutine, false)
             end,
-            is_infomessage = true -- flag on our InfoMessages
+            is_infomessage = true, -- flag on our InfoMessages
+            -- flush any pending tap, so past events won't be considered
+            -- action on the yet to be displayed widget
+            flush_events_on_show = true,
         }
         logger.dbg("Showing InfoMessage:", text)
         UIManager:show(self.current_widget)
@@ -268,10 +270,6 @@ function Trapper:confirm(text, cancel_text, ok_text)
         return true -- always select "OK" in ConfirmBox if no UI
     end
 
-    --- @todo We should try to flush any pending tap, so past
-    -- events won't be considered action on the yet to be displayed
-    -- widget
-
     -- Close any previous widget
     if self.current_widget then
         UIManager:close(self.current_widget)
@@ -289,6 +287,9 @@ function Trapper:confirm(text, cancel_text, ok_text)
         ok_callback = function()
             coroutine.resume(_coroutine, true)
         end,
+        -- flush any pending tap, so past events won't be considered
+        -- action on the yet to be displayed widget
+        flush_events_on_show = true,
     }
     logger.dbg("Showing ConfirmBox and waiting for answer:", text)
     UIManager:show(self.current_widget)

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -51,6 +51,8 @@ local ConfirmBox = InputContainer:new{
     margin = Size.margin.default,
     padding = Size.padding.default,
     dismissable = true, -- set to false if any button callback is required
+    flush_events_on_show = false, -- set to true when it might be displayed after
+                                  -- some processing, to avoid accidental dismissal
 }
 
 function ConfirmBox:init()
@@ -182,6 +184,10 @@ function ConfirmBox:onShow()
     UIManager:setDirty(self, function()
         return "ui", self[1][1].dimen
     end)
+    if self.flush_events_on_show then
+        -- Discard queued and coming up events to avoid accidental dismissal
+        UIManager:discardEvents(true)
+    end
 end
 
 function ConfirmBox:onCloseWidget()

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -461,6 +461,9 @@ function DictQuickLookup:update()
                     callback = function()
                         self:changeToPrevDict()
                     end,
+                    hold_callback = function()
+                        self:changeToFirstDict()
+                    end,
                 },
                 {
                     text = self:getHighlightText(),
@@ -479,6 +482,9 @@ function DictQuickLookup:update()
                     enabled = self:isNextDictAvaiable(),
                     callback = function()
                         self:changeToNextDict()
+                    end,
+                    hold_callback = function()
+                        self:changeToLastDict()
                     end,
                 },
             },
@@ -843,6 +849,18 @@ function DictQuickLookup:changeToNextDict()
         self:changeDictionary(self.dict_index + 1)
     elseif #self.results > 1 then -- restart at first if end reached
         self:changeDictionary(1)
+    end
+end
+
+function DictQuickLookup:changeToFirstDict()
+    if self:isPrevDictAvaiable() then
+        self:changeDictionary(1)
+    end
+end
+
+function DictQuickLookup:changeToLastDict()
+    if self:isNextDictAvaiable() then
+        self:changeDictionary(#self.results)
     end
 end
 

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1102,7 +1102,8 @@ function DictQuickLookup:inputLookup()
         else
             event = "LookupWord"
         end
-        self.ui:handleEvent(Event:new(event, word))
+        -- Trust that input text does not need any cleaning (allows querying for "-suffix")
+        self.ui:handleEvent(Event:new(event, word, true))
     end
 end
 
@@ -1131,18 +1132,21 @@ end
 
 function DictQuickLookup:lookupWikipedia(get_fullpage)
     local word
+    local is_sane
     if get_fullpage then
         -- we use the word of the displayed result's definition, which
         -- is the exact title of the full wikipedia page
         word = self.lookupword
+        is_sane = true
     else
         -- we use the original word that was querried
         word = self.word
+        is_sane = false
     end
     self:resyncWikiLanguages()
-    -- strange : we need to pass false instead of nil if word_box is nil,
-    -- otherwise get_fullpage is not passed
-    self.ui:handleEvent(Event:new("LookupWikipedia", word, self.word_box and self.word_box or false, get_fullpage))
+    -- (With Event, we need to pass false instead of nil if word_box is nil,
+    -- otherwise next arguments are discarded)
+    self.ui:handleEvent(Event:new("LookupWikipedia", word, is_sane, self.word_box and self.word_box or false, get_fullpage))
 end
 
 return DictQuickLookup

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -69,6 +69,8 @@ local InfoMessage = InputContainer:new{
     no_refresh_on_close = nil,
     -- Only have it painted after this delay (dismissing still works before it's shown)
     show_delay = nil,
+    -- Set to true when it might be displayed after some processing, to avoid accidental dismissal
+    flush_events_on_show = false,
 }
 
 function InfoMessage:init()
@@ -224,6 +226,10 @@ function InfoMessage:onShow()
     UIManager:setDirty(self, function()
         return "ui", self[1][1].dimen
     end)
+    if self.flush_events_on_show then
+        -- Discard queued and coming up events to avoid accidental dismissal
+        UIManager:discardEvents(true)
+    end
     -- schedule us to close ourself if timeout provided
     if self.timeout then
         UIManager:scheduleIn(self.timeout, function() UIManager:close(self) end)


### PR DESCRIPTION
More dictionary tweaks, following #7029: 

#### Dict/Wiki lookup: less text cleanup on manual input
Don't cleanup input text as much when entered manually (or when it's sane) than when coming from book text selection.
This may allow looking up words like "-suffix", or do more precise Wikipedia queries.
I haven't have much need for this, but it was thought of as a possible solution to https://github.com/koreader/koreader/issues/6877#issuecomment-727192483 . Possible caveats: people who cut & paste crappy input may need to clean that input manually in the InputText widget.
Closes #6877.

#### DictQuickLookup: hold prev/next buttons go to first/last result
Because sometimes I hit <kbd>></kbd> a few times to see what kind of results I got, and then want to quickly get back to the first result to start reading them.

#### Dict, Trapper: prevent dismissal by past events

Add `UIManager:discardEvents()`, to allow dropping events for a period of time.
Default duration of 600ms on eInk, 300ms otherwise.
Used when showing the dict result window, so that a tap happening just when it's being shown won't discard it. See https://github.com/koreader/koreader/pull/7029#issuecomment-752732528
Used with Trapper:confirm()/:info(), to avoid taps made in a previous processing to dismiss (and so, select the cancel action) a ConfirmBox not yet painted/visible (I'm not sure I didn't add too many, for the info() and the confirmbox happening when interrupting info()s - we'll see.)
(Mentionned previously at https://github.com/koreader/koreader/pull/5138#issuecomment-707384339, been using 500ms with all ConfirmBox and 1000ms with dict for years.)

This is mostly useful for these 2 cases - all other cases of bounces/accidental dismissal may be taken care of by the Tap interval setting from #6798.
And it shouldn't cause much discussion (I hope :) as when a dict lookup result is shown, nobody would ever go at wanting to dismiss it - or find another button to tap - in less thans 1s :)
And for Trapper, it's mostly only used in the Wikipedia Save as EPUB and FM plus button to refresh cached book info for a whole directory, where you'd have to answer a few questions at start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7099)
<!-- Reviewable:end -->
