### PR TITLE
CRE: allow both Top/Bottom margins fine tuning

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -94,6 +94,7 @@ Note that this may not be ensured under some conditions: in scroll mode, when a 
                 name_text_hold_callback = optionsutil.showValuesHMargins,
                 more_options = true,
                 more_options_param = {
+                    name_text = _("Left/Right Margins"),
                     left_min = 0,
                     left_max = 140,
                     left_step = 1,
@@ -154,10 +155,23 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                 name_text_hold_callback = optionsutil.showValues,
                 more_options = true,
                 more_options_param = {
-                  value_min = 0,
-                  value_max = 140,
-                  value_step = 1,
-                  value_hold_step = 5,
+                    -- Allow this to tune both top and bottom margins,
+                    -- handling 2 setting names and sending 2 events
+                    -- (we'll get the exact same DoubleSpinWidget in
+                    -- the b_page_margin setting just below)
+                    name_text = _("Top/Bottom Margins"),
+                    names = { "t_page_margin", "b_page_margin" },
+                    events = { "SetPageTopMargin", "SetPageBottomMargin" },
+                    left_text = _("Top"),
+                    left_min = 0,
+                    left_max = 140,
+                    left_step = 1,
+                    left_hold_step = 5,
+                    right_text = _("Bottom"),
+                    right_min = 0,
+                    right_max = 140,
+                    right_step = 1,
+                    right_hold_step = 5,
                 },
             },
             {
@@ -194,10 +208,20 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                 help_text = _([[In the top menu → Settings → Status bar, you can choose whether the bottom margin applies from the bottom of the screen, or from above the status bar.]]),
                 more_options = true,
                 more_options_param = {
-                  value_min = 0,
-                  value_max = 140,
-                  value_step = 1,
-                  value_hold_step = 5,
+                    -- Similar as for t_page_margin above
+                    name_text = _("Top/Bottom Margins"),
+                    names = { "t_page_margin", "b_page_margin" },
+                    events = { "SetPageTopMargin", "SetPageBottomMargin" },
+                    left_text = _("Top"),
+                    left_min = 0,
+                    left_max = 140,
+                    left_step = 1,
+                    left_hold_step = 5,
+                    right_text = _("Bottom"),
+                    right_min = 0,
+                    right_max = 140,
+                    right_step = 1,
+                    right_hold_step = 5,
                 },
             },
         }

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -167,16 +167,21 @@ function DoubleSpinWidget:update()
         widget_title,
         CloseButton:new{ window = self, padding_top = Size.margin.title, },
     }
-    local widget_info = FrameContainer:new{
-        padding = Size.padding.default,
-        margin = Size.margin.small,
-        bordersize = 0,
-        TextBoxWidget:new{
-            text = self.info_text or "",
-            face = Font:getFace("x_smallinfofont"),
-            width = math.floor(self.width * 0.9),
+    local widget_info
+    if self.info_text then
+        widget_info = FrameContainer:new{
+            padding = Size.padding.default,
+            margin = Size.margin.small,
+            bordersize = 0,
+            TextBoxWidget:new{
+                text = self.info_text,
+                face = Font:getFace("x_smallinfofont"),
+                width = math.floor(self.width * 0.9),
+            }
         }
-    }
+    else
+        widget_info = VerticalSpan:new{ width = 0 }
+    end
     local buttons = {
         {
             {


### PR DESCRIPTION
By having the same DoubleSpinWidget launched when hitting <kbd>...</kbd> on any of Top margin or Bottom margin progress bars.
DoubleSpinWidget: remove blank space when no info_text.

Follow up to @yparitcher #7021, solving https://github.com/koreader/koreader/pull/7021#issuecomment-749389043:
>> We already have a 2-values picker for L/R Margin.
As when tweaking top or bottom, we may want to adjust the other, could it be the same 2-values picker allowing tweaking both top and bottom margin, when launched from either ... ?
(Probably less simple as the current tweaks so far :)

> not easy,
L/R are done with one event hence one picker with 2 values, T/B are 2 separate events and configdialog does not provide a way to tie them together.
so out of scope for now.

![image](https://user-images.githubusercontent.com/24273478/103456715-1ce0e300-4cf9-11eb-923c-6874da2d664f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7104)
<!-- Reviewable:end -->
