### PR TITLE
add noop callback to cache size to prevent artifacts

### DIFF
--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -472,7 +472,8 @@ function CoverBrowser:addToMainMenu(menu_items)
                             local sstr = BookInfoManager:getDbSize()
                             return _("Current cache size: ") .. sstr
                         end,
-                        -- no callback, only for information
+                        keep_menu_open = true,
+                        callback = function() end, -- no callback, only for information
                     },
                     {
                         text = _("Prune cache of removed books"),


### PR DESCRIPTION
I was getting this:  (the lighter one is invisible on E-ink)


![FileManager_2021-01-02_211039](https://user-images.githubusercontent.com/38916402/103470364-88e63a00-4d3f-11eb-9f51-b7b139620b3c.png)


![FileManager_2021-01-02_211044](https://user-images.githubusercontent.com/38916402/103470365-8a176700-4d3f-11eb-8573-ca7a75227d15.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7106)
<!-- Reviewable:end -->
