### PR TITLE
Legacy Kindle: Unbreak screensavers

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -58,6 +58,7 @@ end
 
 --[[
 Test if a kindle device has Special Offers
+FIXME: Find a way to probe for SO status on FX < 5.x
 --]]
 local function isSpecialOffers()
     -- Look at the current blanket modules to see if the SO screensavers are enabled...
@@ -125,6 +126,11 @@ function Kindle:initNetworkManager(NetworkMgr)
 end
 
 function Kindle:supportsScreensaver()
+    -- NOTE: The first ad-supported device was the K3
+    if self.model == "Kindle2" or self.model == "KindleDXG" then
+        return true
+    end
+
     if self.isSpecialOffers then
         return false
     else

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -126,11 +126,6 @@ function Kindle:initNetworkManager(NetworkMgr)
 end
 
 function Kindle:supportsScreensaver()
-    -- NOTE: The first ad-supported device was the K3
-    if self.model == "Kindle2" or self.model == "KindleDXG" then
-        return true
-    end
-
     if self.isSpecialOffers then
         return false
     else
@@ -276,6 +271,7 @@ local Kindle2 = Kindle:new{
     canHWInvert = no,
     canUseCBB = no, -- 4bpp
     canUseWAL = no, -- Kernel too old to support mmap'ed I/O on /mnt/us
+    supportsScreensaver = yes, -- The first ad-supported device was the K3
 }
 
 local KindleDXG = Kindle:new{
@@ -286,6 +282,7 @@ local KindleDXG = Kindle:new{
     canHWInvert = no,
     canUseCBB = no, -- 4bpp
     canUseWAL = no, -- Kernel too old to support mmap'ed I/O on /mnt/us
+    supportsScreensaver = yes, -- The first ad-supported device was the K3
 }
 
 local Kindle3 = Kindle:new{
@@ -295,6 +292,7 @@ local Kindle3 = Kindle:new{
     hasDPad = yes,
     canHWInvert = no,
     canUseCBB = no, -- 4bpp
+    supportsScreensaver = no, -- Can't probe for SO status on FW < 5.x
 }
 
 local Kindle4 = Kindle:new{
@@ -304,6 +302,7 @@ local Kindle4 = Kindle:new{
     canHWInvert = no,
     -- NOTE: It could *technically* use the C BB, as it's running @ 8bpp, but it's expecting an inverted palette...
     canUseCBB = no,
+    supportsScreensaver = no, -- Can't probe for SO status on FW < 5.x
 }
 
 local KindleTouch = Kindle:new{

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -207,7 +207,9 @@ function Kindle:intoScreenSaver()
         else
             -- Let the native system handle screensavers on SO devices...
             if os.getenv("AWESOME_STOPPED") == "yes" then
-                os.execute("killall -cont awesome")
+                os.execute("killall -CONT awesome")
+            elseif os.getenv("CVM_STOPPED") == "yes" then
+                os.execute("killall -CONT cvm")
             end
         end
     end
@@ -230,7 +232,9 @@ function Kindle:outofScreenSaver()
         else
             -- Stop awesome again if need be...
             if os.getenv("AWESOME_STOPPED") == "yes" then
-                os.execute("killall -stop awesome")
+                os.execute("killall -STOP awesome")
+            elseif os.getenv("CVM_STOPPED") == "yes" then
+                os.execute("killall -STOP cvm")
             end
             local UIManager = require("ui/uimanager")
             -- NOTE: We redraw after a slightly longer delay to take care of the potentially dynamic ad screen...
@@ -808,7 +812,7 @@ function KindleTouch:exit()
     if self.isSpecialOffers then
         -- Wakey wakey...
         if os.getenv("AWESOME_STOPPED") == "yes" then
-            os.execute("killall -cont awesome")
+            os.execute("killall -CONT awesome")
         end
         -- fake a touch event
         if self.touch_dev then

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -58,7 +58,7 @@ end
 
 --[[
 Test if a kindle device has Special Offers
-FIXME: Find a way to probe for SO status on FX < 5.x
+FIXME: Find a way to probe for SO status on FW < 5.x
 --]]
 local function isSpecialOffers()
     -- Look at the current blanket modules to see if the SO screensavers are enabled...

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -57,6 +57,7 @@ fi
 
 # Keep track of what we do with pillow...
 export AWESOME_STOPPED="no"
+export CVM_STOPPED="no"
 export VOLUMD_STOPPED="no"
 PILLOW_HARD_DISABLED="no"
 PILLOW_SOFT_DISABLED="no"
@@ -282,6 +283,7 @@ fi
 if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "sysv" ]; then
     logmsg "Stopping cvm . . ."
     killall -STOP cvm
+    CVM_STOPPED="yes"
 fi
 
 # SIGSTOP volumd, to inhibit USBMS (sysv & upstart)


### PR DESCRIPTION
* Flag the K2/K2i & DX/DXg as `supportsScreensaver`, since these cannot be SO.
* On the K3 & the K4, where we can't detect SO properly, which means they are forcibly flagged as NOT `supportsScreensaver`, unbreak native screensaver handling by doing the SIGSTOP/SIGCONT dance with cvm. I'm fairly sure this used to be implemented, and/or I thought it was and never actually checked. In any case, it's probably been broken for ages.

Fix #7108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7112)
<!-- Reviewable:end -->
