### PR TITLE
DictQuickLookup: re-add "tap on title" to set as preferred dict

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -83,7 +83,10 @@ function ReaderHighlight:init()
                 text = _("Search"),
                 callback = function()
                     _self:onHighlightSearch()
-                    _self:onClose()
+                    UIManager:close(self.highlight_dialog)
+                    -- We don't call _self:onClose(), crengine will highlight
+                    -- search matches on the current page, and self:clear()
+                    -- would redraw and remove crengine native highlights
                 end,
             }
         end,

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -811,11 +811,13 @@ function UIManager:discardEvents(set_or_seconds)
         -- is really painted on screen) are discarded.
         if Device:hasEinkScreen() then
             -- A screen refresh can take a few 100ms,
-            -- sometimes > 500ms on some devices/temperatures
-            usecs = 600000
+            -- sometimes > 500ms on some devices/temperatures.
+            -- So, block for 400ms (to have it displayed) + 400ms
+            -- for user reaction to it
+            usecs = 800000
         else
-            -- On non-eInk screen, it's usually instantaneous
-            usecs = 300000
+            -- On non-eInk screen, display is usually instantaneous
+            usecs = 400000
         end
     else -- we expect a number
         usecs = set_or_seconds * MILLION

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1897,20 +1897,20 @@ end
 function ReaderStatistics:genResetBookSubItemTable()
     local sub_item_table = {}
     table.insert(sub_item_table, {
-        text = _("Reset statistics per book"),
-        keep_menu_open = true,
-        callback = function()
-            self:resetBook()
-        end,
-        separator = true,
-    })
-    table.insert(sub_item_table, {
-        text = _("Reset statistics for current book"),
+        text = _("Reset statistics for the current book"),
         keep_menu_open = true,
         callback = function()
             self:resetCurrentBook()
         end,
         enabled_func = function() return not self:isDocless() and self.is_enabled and self.id_curr_book end,
+        separator = true,
+    })
+    table.insert(sub_item_table, {
+        text = _("Reset statistics per book"),
+        keep_menu_open = true,
+        callback = function()
+            self:resetBook()
+        end,
         separator = true,
     })
     local reset_minutes = { 1, 5, 15, 30, 60 }


### PR DESCRIPTION
#### Statistics plugin: reorder Reset menu items

First Reset current book, then Reset other books by name, then Reset other books by duration - feels more logical than Reset current book sandwitched between the 2 others.

#### Search: fix matches not highlighted on current page

Regression (typo from cut and paste) from #6851. See https://github.com/koreader/koreader/pull/6851#issuecomment-754672318

#### DictQuickLookup: re-add "tap on title" to set as preferred dict

Restore feature removed in #7029: tap on title to set dict of current result as a preferred dictionary for this document.
Changes from former implementation:
- trust sdcv for ordering, instead of doing it ourselves while looking at the results (which didn't always work)
- allow setting multiple preferred dicts
- order of preference is shown with a number as a prefix to the dictionary name in the title
- taping again allows removing it from preferred dicts, and taping again allows setting it back as the first preferred dict

See discussion in #7109. Closes #7109.

![image](https://user-images.githubusercontent.com/24273478/103818945-c1508580-5069-11eb-8816-8375dcc04b45.png)

![image](https://user-images.githubusercontent.com/24273478/103818969-cdd4de00-5069-11eb-8d14-1bc1aa4f7a02.png)

![image](https://user-images.githubusercontent.com/24273478/103818980-d5948280-5069-11eb-94c0-b6c70004679c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7114)
<!-- Reviewable:end -->
