### PR TITLE
Table persistence

### DIFF
--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -1,0 +1,150 @@
+local bitser = require("ffi/bitser")
+local dump = require("dump")
+local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
+
+local function readFile(file, bytes)
+    local f, str, err
+    f, err = io.open(file, "rb")
+    if not f then
+        return nil, err
+    end
+    str, err = f:read(bytes or "*a")
+    f:close()
+    if not str then
+        return nil, err
+    end
+    return str
+end
+
+local codecs = {
+    -- bitser: binary form, fast encode/decode, low size. Not human readable.
+    bitser = {
+        id = "bitser",
+        reads_from_file = false,
+
+        serialize = function(t)
+            local ok, str = pcall(bitser.dumps, t)
+            if not ok then
+                return nil, "cannot serialize " .. tostring(t)
+            end
+            return str
+        end,
+
+        deserialize = function(str)
+            local ok, t = pcall(bitser.loads, str)
+            if not ok then
+                return nil, "malformed serialized data"
+            end
+            return t
+        end,
+    },
+    -- dump: human readable, pretty printed, fast enough for most user cases.
+    dump = {
+        id = "dump",
+        reads_from_file = true,
+
+        serialize = function(t, as_bytecode)
+            local content
+            if as_bytecode then
+                local bytecode, err = load("return " .. dump(t))
+                if not bytecode then
+                    logger.warn("cannot convert table to bytecode", err, "fallback to text")
+                else
+                    content = string.dump(bytecode, true)
+                end
+            end
+            if not content then
+                content = "return " .. dump(t)
+            end
+            return content
+        end,
+
+        deserialize = function(str)
+            local t, err = loadfile(str)
+            if not t then
+                t, err = loadstring(str)
+            end
+            if not t then
+                return nil, err
+            end
+            return t()
+        end,
+    }
+}
+
+local Persist = {}
+
+function Persist:new(o)
+    o = o or {}
+    assert(type(o.path) == "string", "path is required")
+    o.codec = o.codec or "dump"
+    setmetatable(o, self)
+    self.__index = self
+    return o
+end
+
+function Persist:exists()
+    local mode = lfs.attributes(self.path, "mode")
+    if mode then
+        return mode == "file"
+    end
+end
+
+function Persist:timestamp()
+    return lfs.attributes(self.path, "modification")
+end
+
+function Persist:size()
+    return lfs.attributes(self.path, "size")
+end
+
+function Persist:load()
+    local t, err
+    if codecs[self.codec].reads_from_file then
+        t, err = codecs[self.codec].deserialize(self.path)
+    else
+        local str
+        str, err = readFile(self.path)
+        if not str then
+            return nil, err
+        end
+        t, err = codecs[self.codec].deserialize(str)
+    end
+    if not t then
+        return nil, err
+    end
+    return t
+end
+
+function Persist:save(t, as_bytecode)
+    local str, file, err
+    str, err = codecs[self.codec].serialize(t, as_bytecode)
+    if not str then
+        return nil, err
+    end
+    file, err = io.open(self.path, "wb")
+    if not file then
+        return nil, err
+    end
+    file:write(str)
+    file:close()
+    return true
+end
+
+function Persist:delete()
+    if not self:exists() then return end
+    return os.remove(self.path)
+end
+
+function Persist.getCodec(name)
+    local fallback = codecs["dump"]
+    for key, codec in pairs(codecs) do
+        if type(key) == "string" and key == name then
+            return codec
+        end
+    end
+    return fallback
+end
+
+return Persist

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -1160,23 +1160,6 @@ function util.clearTable(t)
     for i = 0, c do t[i] = nil end
 end
 
---- Dumps a table into a file.
---- @table t the table to be dumped
---- @string file the file to store the table
---- @treturn bool true on success, false otherwise
-function util.dumpTable(t, file)
-    if not t or not file or file == "" then return end
-    local dump = require("dump")
-    local f = io.open(file, "w")
-    if f then
-        f:write("return "..dump(t))
-        f:close()
-        return true
-    end
-    return false
-end
-
-
 --- Encode URL also known as percent-encoding see https://en.wikipedia.org/wiki/Percent-encoding
 --- @string text the string to encode
 --- @treturn encode string

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -127,7 +127,7 @@ function Calibre:getSearchMenuTable()
             sub_item_table_func = function()
                 local result = {}
                 -- append previous scanned dirs to the list.
-                local cache = LuaSettings:open(CalibreSearch.user_libraries)
+                local cache = LuaSettings:open(CalibreSearch.cache_libs.path)
                 for path, _ in pairs(cache.data) do
                     table.insert(result, {
                         text = path,

--- a/spec/unit/persist_spec.lua
+++ b/spec/unit/persist_spec.lua
@@ -1,0 +1,89 @@
+describe("Persist module", function()
+    local Persist
+    local sample
+    local bitserInstance, dumpInstance
+    local ser, deser, str, tab
+    local fail = { a = function() end, }
+
+    local function arrayOf(n)
+        assert(type(n) == "number", "wrong type (expected number)")
+        local t = {}
+        for i = 1, n do
+            table.insert(t, i, {
+                a = "sample " .. tostring(i),
+                b = true,
+                c = nil,
+                d = i,
+                e = {
+                    f = {
+                        g = nil,
+                        h = false,
+                    },
+                },
+            })
+        end
+        return t
+    end
+
+    setup(function()
+        require("commonrequire")
+        Persist = require("persist")
+        bitserInstance = Persist:new{ path = "test.dat", codec = "bitser" }
+        dumpInstance = Persist:new { path = "test.txt", codec = "dump" }
+        sample = arrayOf(1000)
+    end)
+
+    it("should save a table to file", function()
+        assert.is_true(bitserInstance:save(sample))
+        assert.is_true(dumpInstance:save(sample))
+    end)
+
+    it("should generate a valid file", function()
+        assert.is_true(bitserInstance:exists())
+        assert.is_true(bitserInstance:size() > 0)
+        assert.is_true(type(bitserInstance:timestamp()) == "number")
+    end)
+
+    it("should load a table from file", function()
+        assert.are.same(sample, bitserInstance:load())
+        assert.are.same(sample, dumpInstance:load())
+    end)
+
+    it("should delete the file", function()
+        bitserInstance:delete()
+        dumpInstance:delete()
+        assert.is_nil(bitserInstance:exists())
+        assert.is_nil(dumpInstance:exists())
+    end)
+
+    it("should return standalone serializers/deserializers", function()
+        tab = sample
+        for _, codec in ipairs({"dump", "bitser"}) do
+            assert.is_true(Persist.getCodec(codec).id == codec)
+            ser = Persist.getCodec(codec).serialize
+            deser = Persist.getCodec(codec).deserialize
+            str = ser(tab)
+            assert.are.same(deser(str), tab)
+            str, ser, deser = nil, nil, nil
+        end
+    end)
+
+    it("should work with huge tables", function()
+        tab = arrayOf(100000)
+        ser = Persist.getCodec("bitser").serialize
+        deser = Persist.getCodec("bitser").deserialize
+        str = ser(tab)
+        assert.are.same(deser(str), tab)
+    end)
+
+    it ("should fail to serialize functions", function()
+        for _, codec in ipairs({"dump", "bitser"}) do
+            assert.is_true(Persist.getCodec(codec).id == codec)
+            ser = Persist.getCodec(codec).serialize
+            deser = Persist.getCodec(codec).deserialize
+            str = ser(fail)
+            assert.are_not.same(deser(str), fail)
+        end
+    end)
+
+end)


### PR DESCRIPTION
- table dumps is what we're using now to get table persistence. It is pretty printed, uncompressed.
- binary dumps using bitser is needed for tables where human readibility doesn't matter. It is faster encoding, decoding and produces smaller cache files.

A test to show the difference in encoding/decoding speed and the result cache size

```
encoding table 1: bitser: 1161KB [84ms]| dump: 9118KB [429ms](7.85x size)
encoding table 2: bitser: 2332KB [179ms]| dump: 18259KB [975ms](7.83x size)
encoding table 3: bitser: 3524KB [291ms]| dump: 27439KB [1442ms](7.79x size)
encoding table 4: bitser: 4735KB [377ms]| dump: 36658KB [2092ms](7.74x size)
encoding table 5: bitser: 5946KB [503ms]| dump: 45876KB [2531ms](7.72x size)
encoding table 6: bitser: 7157KB [592ms]| dump: 55095KB [3163ms](7.70x size)
encoding table 7: bitser: 8368KB [696ms]| dump: 64314KB [3715ms](7.69x size)
encoding table 8: bitser: 9579KB [813ms]| dump: 73533KB [4799ms](7.68x size)
decoding table 1: bitser: [38ms]| dump: [96ms]
decoding table 2: bitser: [65ms]| dump: [221ms]
decoding table 3: bitser: [103ms]| dump: [748ms]
decoding table 4: bitser: [132ms]| dump: [488ms]
decoding table 5: bitser: [311ms]| dump: [773ms]
decoding table 6: bitser: [239ms]| dump: [894ms]
decoding table 7: bitser: [401ms]| dump: [1049ms]
decoding table 8: bitser: [373ms]| dump: [1154ms]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7120)
<!-- Reviewable:end -->
