### PR TITLE
Don't need to keep attempting WiFi connection after success

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -594,7 +594,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback)
         table.sort(network_list,
            function(l, r) return l.signal_quality > r.signal_quality end)
         local success = false
-        for idx, network in pairs(network_list) do
+        for idx, network in ipairs(network_list) do
             if network.password then
                 success = NetworkMgr:authenticateNetwork(network)
                 if success then

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -594,23 +594,22 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback)
         table.sort(network_list,
            function(l, r) return l.signal_quality > r.signal_quality end)
         local success = false
-        table.foreach(network_list,
-           function(idx, network)
-               if network.password then
-                   success = NetworkMgr:authenticateNetwork(network)
-                   if success then
-                       NetworkMgr:obtainIP()
-                       if complete_callback then
-                           complete_callback()
-                       end
-                       UIManager:show(InfoMessage:new{
-                           text = T(_("Connected to network %1"), BD.wrap(network.ssid)),
-                           timeout = 3,
-                       })
-                       return
-                   end
-               end
-           end)
+        for idx, network in pairs(network_list) do
+            if network.password then
+                success = NetworkMgr:authenticateNetwork(network)
+                if success then
+                    NetworkMgr:obtainIP()
+                    if complete_callback then
+                        complete_callback()
+                    end
+                    UIManager:show(InfoMessage:new{
+                        text = T(_("Connected to network %1"), BD.wrap(network.ssid)),
+                        timeout = 3,
+                    })
+                    break
+                end
+            end
+        end
         if not success then
             UIManager:show(require("ui/widget/networksetting"):new{
                 network_list = network_list,

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -594,7 +594,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback)
         table.sort(network_list,
            function(l, r) return l.signal_quality > r.signal_quality end)
         local success = false
-        for idx, network in ipairs(network_list) do
+        for dummy, network in ipairs(network_list) do
             if network.password then
                 success = NetworkMgr:authenticateNetwork(network)
                 if success then


### PR DESCRIPTION
If we're in range of multiple known WiFi Access Points (including multiple instances of the same SSID), we don't need to keep trying to connect after the first successful connection.

Minimal change would have been replacing the `return` inside the `foreach` function with `return [a non-nil value]`.
But foreach is deprecated, and since I was touching the code anyhow, I figured I'd do that tiny update as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7121)
<!-- Reviewable:end -->
