### PR TITLE
ScreenSaver: Unbreak "disable" mode

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -399,7 +399,7 @@ function Screensaver:show(event, fallback_message)
     if show_message == true then
         local screensaver_message = G_reader_settings:readSetting(prefix.."screensaver_message")
         local message_pos = G_reader_settings:readSetting(prefix.."screensaver_message_position")
-        if self:noBackground() and not widget then
+        if background == nil and not widget then
             covers_fullscreen = false
         end
         if screensaver_message == nil and prefix ~= "" then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -399,7 +399,7 @@ function Screensaver:show(event, fallback_message)
     if show_message == true then
         local screensaver_message = G_reader_settings:readSetting(prefix.."screensaver_message")
         local message_pos = G_reader_settings:readSetting(prefix.."screensaver_message_position")
-        if background == nil and not widget then
+        if self:noBackground() and not widget then
             covers_fullscreen = false
         end
         if screensaver_message == nil and prefix ~= "" then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -265,11 +265,13 @@ function Screensaver:show(event, fallback_message)
     end
 
     local widget = nil
+    local no_background = false
     local background = Blitbuffer.COLOR_BLACK
     if self:whiteBackground() then
         background = Blitbuffer.COLOR_WHITE
     elseif self:noBackground() then
         background = nil
+        no_background = true
     end
 
     -- "as-is" mode obviously requires not mangling the background ;).
@@ -281,6 +283,7 @@ function Screensaver:show(event, fallback_message)
         --       (Which means that you can have no background, a white background, but *NOT* a black background in this mode :/).
         if not self:whiteBackground() then
             background = nil
+            no_background = true
         end
     end
 
@@ -399,7 +402,7 @@ function Screensaver:show(event, fallback_message)
     if show_message == true then
         local screensaver_message = G_reader_settings:readSetting(prefix.."screensaver_message")
         local message_pos = G_reader_settings:readSetting(prefix.."screensaver_message_position")
-        if self:noBackground() and not widget then
+        if no_background and widget == nil then
             covers_fullscreen = false
         end
         if screensaver_message == nil and prefix ~= "" then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -272,6 +272,16 @@ function Screensaver:show(event, fallback_message)
         background = nil
     end
 
+    -- "as-is" mode obviously requires not mangling the background ;).
+    if screensaver_type == "disable" then
+        -- NOTE: Ideally, "disable" mode should *honor* the "background" options.
+        --       Unfortunately, the no background option is much more recent than the "disable" mode,
+        --       and as such, the default assumes that in "disable" mode, the default background is nil instead of black.
+        --       We previously honored the *white* option, but it doesn't make much sense to allow white but not black,
+        --       so just enforce nil, no matter what.
+        background = nil
+    end
+
     local lastfile = G_reader_settings:readSetting("lastfile")
     if screensaver_type == "document_cover" then
         -- Set lastfile to the document of which we want to show the cover.

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -274,12 +274,14 @@ function Screensaver:show(event, fallback_message)
 
     -- "as-is" mode obviously requires not mangling the background ;).
     if screensaver_type == "disable" then
-        -- NOTE: Ideally, "disable" mode should *honor* the "background" options.
+        -- NOTE: Ideally, "disable" mode should *honor* all the "background" options.
         --       Unfortunately, the no background option is much more recent than the "disable" mode,
         --       and as such, the default assumes that in "disable" mode, the default background is nil instead of black.
-        --       We previously honored the *white* option, but it doesn't make much sense to allow white but not black,
-        --       so just enforce nil, no matter what.
-        background = nil
+        --       This implies that, for the same legacy reasons, we have to honor the *white* background setting here...
+        --       (Which means that you can have no background, a white background, but *NOT* a black background in this mode :/).
+        if not self:whiteBackground() then
+            background = nil
+        end
     end
 
     local lastfile = G_reader_settings:readSetting("lastfile")


### PR DESCRIPTION
Regression since f67296942f9c28e76c9c45b27c3b8ad0c1dc7860

That's a bit of legacy/backward compat mess, because we now have an explicit "no background" setting, but the "disable" mode predates it (*and* the white bg option, for that matter), and as such, just assumes the the default magically morphs from black to nil in this mode.

I mistakenly reverted that bit of the hack in f67296942f9c28e76c9c45b27c3b8ad0c1dc7860 by "fixing" the check to actually honor settings ^^.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7124)
<!-- Reviewable:end -->
