### PR TITLE
DictQuickLookup: allow continuous reading with key - and other fixes

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -914,7 +914,7 @@ function ReaderDictionary:showDict(word, results, box, link)
     self:dismissLookupInfo()
     if results and results[1] then
         UIManager:show(self.dict_window)
-        if not results.lookup_cancelled and ffiUtil.getDuration(self._lookup_start_ts) > self.quick_dismiss_before_delay then
+        if not results.lookup_cancelled and self._lookup_start_ts and ffiUtil.getDuration(self._lookup_start_ts) > self.quick_dismiss_before_delay then
             -- If the search took more than a few seconds to be done, discard
             -- queued and coming up events to avoid a voluntary dismissal
             -- (because the user felt the result would not come) to kill the

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -762,11 +762,13 @@ function ReaderHighlight:onHold(arg, ges)
             local boxes = {}
             table.insert(boxes, self.selected_word.sbox)
             self.view.highlight.temp[self.hold_pos.page] = boxes
+            -- Unfortunately, getWordFromPosition() may not return good coordinates,
+            -- so refresh the whole page
+            UIManager:setDirty(self.dialog, "ui")
+        else
+            -- With crengine, getWordFromPosition() does return good coordinates
+            UIManager:setDirty(self.dialog, "ui", self.selected_word.sbox)
         end
-        -- Unfortunately, CREngine does not return good coordinates
-        -- UIManager:setDirty(self.dialog, "ui")
-        -- But now it does:
-        UIManager:setDirty(self.dialog, "ui", self.selected_word.sbox)
         self:_resetHoldTimer()
         if word.pos0 then
             -- Remember original highlight start position, so we can show

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -497,12 +497,13 @@ function ReaderTypeset:onSetPageMargins(margins, refresh_callback)
             text = T(_([[
 Margins set to:
 
-  horizontal: %1 (%2px)
-  top: %3 (%4px)
-  bottom: %5 (%6px)
+  left: %1 (%2px)
+  right: %3 (%4px)
+  top: %5 (%6px)
+  bottom: %7 (%8px)
 
 Tap to dismiss.]]),
-            margins[1], left, margins[2], top, margins[4], bottom),
+            margins[1], left, margins[3], right, margins[2], top, margins[4], bottom),
             dismiss_callback = refresh_callback,
         })
     end

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -502,7 +502,7 @@ function ReaderWikipedia:lookupWikipedia(word, is_sane, box, get_fullpage, force
         -- dummy results
         local definition
         if lookup_cancelled then
-            definition = _("Wikipedia request canceled.")
+            definition = _("Wikipedia request interrupted.")
         elseif ok then
             definition = no_result_text
         else

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -430,7 +430,7 @@ function DictQuickLookup:update()
                                             })
                                         else
                                             UIManager:show(InfoMessage:new{
-                                                text = _("Saving Wikipedia article failed or canceled."),
+                                                text = _("Saving Wikipedia article failed or interrupted."),
                                             })
                                         end
                                     end)

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -150,28 +150,28 @@ end
 
 function ScrollHtmlWidget:onTapScrollText(arg, ges)
     if BD.flipIfMirroredUILayout(ges.pos.x < Screen:getWidth()/2) then
-        if self.htmlbox_widget.page_number > 1 then
-            self:scrollText(-1)
-            return true
-        end
+        return self:onScrollUp()
     else
-        if self.htmlbox_widget.page_number < self.htmlbox_widget.page_count then
-            self:scrollText(1)
-            return true
-        end
+        return self:onScrollDown()
+    end
+end
+
+function ScrollHtmlWidget:onScrollUp()
+    if self.htmlbox_widget.page_number > 1 then
+        self:scrollText(-1)
+        return true
     end
     -- if we couldn't scroll (because we're already at top or bottom),
     -- let it propagate up (e.g. for quickdictlookup to go to next/prev result)
 end
 
 function ScrollHtmlWidget:onScrollDown()
-    self:scrollText(1)
-    return true
-end
-
-function ScrollHtmlWidget:onScrollUp()
-    self:scrollText(-1)
-    return true
+    if self.htmlbox_widget.page_number < self.htmlbox_widget.page_count then
+        self:scrollText(1)
+        return true
+    end
+    -- if we couldn't scroll (because we're already at top or bottom),
+    -- let it propagate up (e.g. for quickdictlookup to go to next/prev result)
 end
 
 return ScrollHtmlWidget

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -252,28 +252,28 @@ function ScrollTextWidget:onTapScrollText(arg, ges)
     end
     -- same tests as done in TextBoxWidget:scrollUp/Down
     if BD.flipIfMirroredUILayout(ges.pos.x < Screen:getWidth()/2) then
-        if self.text_widget.virtual_line_num > 1 then
-            self:scrollText(-1)
-            return true
-        end
+        return self:onScrollUp()
     else
-        if self.text_widget.virtual_line_num + self.text_widget:getVisLineCount() <= #self.text_widget.vertical_string_list then
-            self:scrollText(1)
-            return true
-        end
+        return self:onScrollDown()
+    end
+end
+
+function ScrollTextWidget:onScrollUp()
+    if self.text_widget.virtual_line_num > 1 then
+        self:scrollText(-1)
+        return true
     end
     -- if we couldn't scroll (because we're already at top or bottom),
     -- let it propagate up (e.g. for quickdictlookup to go to next/prev result)
 end
 
 function ScrollTextWidget:onScrollDown()
-    self:scrollText(1)
-    return true
-end
-
-function ScrollTextWidget:onScrollUp()
-    self:scrollText(-1)
-    return true
+    if self.text_widget.virtual_line_num + self.text_widget:getVisLineCount() <= #self.text_widget.vertical_string_list then
+        self:scrollText(1)
+        return true
+    end
+    -- if we couldn't scroll (because we're already at top or bottom),
+    -- let it propagate up (e.g. for quickdictlookup to go to next/prev result)
 end
 
 function ScrollTextWidget:onPanText(arg, ges)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -207,7 +207,7 @@ function ReaderStatistics:initData()
     else
         -- NOTE: Possibly less weird-looking than initializing this to 0?
         self.avg_time = math.floor(0.50 * self.page_max_read_sec)
-        logger.info("ReaderStatistics: Initializing average time per page at 50% of the max value, i.e.,", self.avg_time)
+        logger.dbg("ReaderStatistics: Initializing average time per page at 50% of the max value, i.e.,", self.avg_time)
     end
 end
 
@@ -216,7 +216,7 @@ function ReaderStatistics:onUpdateToc()
     local new_pagecount = self.view.document:getPageCount()
 
     if new_pagecount ~= self.data.pages then
-        logger.info("ReaderStatistics: Pagecount change, flushing volatile book statistics")
+        logger.dbg("ReaderStatistics: Pagecount change, flushing volatile book statistics")
         -- Flush volatile stats to DB for current book, and update pagecount and average time per page stats
         self:insertDB(self.id_curr_book, new_pagecount)
     end
@@ -2033,7 +2033,7 @@ function ReaderStatistics:resetCurrentBook()
             self.book_read_pages = 0
             self.book_read_time = 0
             self.avg_time = math.floor(0.50 * self.page_max_read_sec)
-            logger.info("ReaderStatistics: Initializing average time per page at 50% of the max value, i.e.,", self.avg_time)
+            logger.dbg("ReaderStatistics: Initializing average time per page at 50% of the max value, i.e.,", self.avg_time)
 
             -- And the current volatile stats
             self:resetVolatileStats(os.time())


### PR DESCRIPTION
#### DictQuickLookup: allow continuous reading with keys

We could scroll a definition with keys. Now, when reaching top or bottom, switch to prev/next result - like it happens when tap on left/right of definition. Requested in #7126.

Also includes a few fixes:
####  ReaderDictionary: fix possible crash with Wikipedia

Closes #7123 
Also reword some "...canceled" to "...interrupted" for consistency, like done previously for dictionary lookup.

####  Fix selected word non-highlighted on PDF

Optimisation for CRE from #7029 dd74194 made it not work with KOpt-based documents. Closes #7126.

#### Statistics plugin: change some logger.info() to dbg()

See https://github.com/koreader/koreader/pull/6778#discussion_r553957794

####  Margins info msg: show left/right margin values

As we can now tweak them independantly. See https://github.com/koreader/koreader/pull/7104#issuecomment-757338930

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7128)
<!-- Reviewable:end -->
