### PR TITLE
Update readerdictionary.lua

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -718,8 +718,6 @@ end
 function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     local final_results = {}
     local seen_results = {}
-    -- Add an escape character to a dash to prevent sdcv from looking at it as an option.
-    word = word:gsub('^-', '/-')
     -- Allow for two sdcv calls : one in the classic data/dict, and
     -- another one in data/dict_ext if it exists
     -- We could put in data/dict_ext dictionaries with a great number of words

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -754,7 +754,7 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
             for _, opt in pairs(dict_names) do
                 table.insert(args, "-u")
                 table.insert(args, opt)
-                end
+            end
         end
         table.insert(args, "--")
         table.insert(args, word)
@@ -780,10 +780,8 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
         -- let stdout empty) by appending an "echo":
 
         cmd = cmd .. "; echo"
-        logger.warn(cmd)
         local completed, results_str = Trapper:dismissablePopen(cmd, self.lookup_progress_msg or false)
         lookup_cancelled = not completed
-        logger.warn(results_str)
         if results_str and results_str ~= "\n" then -- \n is when lookup was cancelled
             local ok, results = pcall(JSON.decode, results_str)
             if ok and results then

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -756,7 +756,7 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
                 table.insert(args, opt)
             end
         end
-        table.insert(args, "--")
+        table.insert(args, "--") -- prevent word starting with a "-" to be interpreted as a sdcv option
         table.insert(args, word)
 
         local cmd = util.shell_escape(args)

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -746,7 +746,7 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
             break -- don't do any more lookup on additional dict_dirs
         end
 
-        local args = {"./sdcv", "--utf8-input", "--utf8-output", "--json-output", "--non-interactive", "--data-dir", dict_dir, word}
+        local args = {"./sdcv", "--utf8-input", "--utf8-output", "--json-output", "--non-interactive", "--data-dir", dict_dir}
         if not fuzzy_search then
             table.insert(args, "--exact-search")
         end
@@ -754,8 +754,10 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
             for _, opt in pairs(dict_names) do
                 table.insert(args, "-u")
                 table.insert(args, opt)
-            end
+                end
         end
+        table.insert(args, "--")
+        table.insert(args, word)
 
         local cmd = util.shell_escape(args)
         -- cmd = "sleep 7 ; " .. cmd     -- uncomment to simulate long lookup time
@@ -776,10 +778,12 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
         -- We must ensure we will have some output to be readable (if no
         -- definition found, sdcv will output some message on stderr, and
         -- let stdout empty) by appending an "echo":
+
         cmd = cmd .. "; echo"
+        logger.warn(cmd)
         local completed, results_str = Trapper:dismissablePopen(cmd, self.lookup_progress_msg or false)
         lookup_cancelled = not completed
-
+        logger.warn(results_str)
         if results_str and results_str ~= "\n" then -- \n is when lookup was cancelled
             local ok, results = pcall(JSON.decode, results_str)
             if ok and results then

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -778,10 +778,10 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
         -- We must ensure we will have some output to be readable (if no
         -- definition found, sdcv will output some message on stderr, and
         -- let stdout empty) by appending an "echo":
-
         cmd = cmd .. "; echo"
         local completed, results_str = Trapper:dismissablePopen(cmd, self.lookup_progress_msg or false)
         lookup_cancelled = not completed
+        
         if results_str and results_str ~= "\n" then -- \n is when lookup was cancelled
             local ok, results = pcall(JSON.decode, results_str)
             if ok and results then

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -781,7 +781,7 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
         cmd = cmd .. "; echo"
         local completed, results_str = Trapper:dismissablePopen(cmd, self.lookup_progress_msg or false)
         lookup_cancelled = not completed
-        
+
         if results_str and results_str ~= "\n" then -- \n is when lookup was cancelled
             local ok, results = pcall(JSON.decode, results_str)
             if ok and results then


### PR DESCRIPTION
In the function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search):
Add an escape character to a dash to prevent sdcv from looking at it as an option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7134)
<!-- Reviewable:end -->
