### PR TITLE
bump crengine: parsing, lists, 2-pages fixes & tweaks

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1134,7 +1134,7 @@ end
 
 function CreDocument:setVisiblePageCount(new_count)
     logger.dbg("CreDocument: set visible page count", new_count)
-    self._document:setVisiblePageCount(new_count)
+    self._document:setVisiblePageCount(new_count, false)
 end
 
 function CreDocument:setBatteryState(state)

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -40,6 +40,7 @@ local CreOptions = {
                 args = {1, 2},
                 default_arg = 1,
                 event = "SetVisiblePages",
+                --[[ Commented out, to have it also available in portrait mode
                 current_func = function()
                     -- If not in landscape mode, shows "1" as selected
                     if Device.screen:getScreenMode() ~= "landscape" then
@@ -48,9 +49,10 @@ local CreOptions = {
                     -- if we return nil, ConfigDialog will pick the one from the
                     -- configurable as if we hadn't provided this 'current_func'
                 end,
+                ]]--
                 enabled_func = function(configurable)
-                    return Device.screen:getScreenMode() == "landscape" and
-                        optionsutil.enableIfEquals(configurable, "view_mode", 0) -- "page"
+                    return optionsutil.enableIfEquals(configurable, "view_mode", 0) -- "page" mode
+                        -- and Device.screen:getScreenMode() == "landscape"
                 end,
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[In landscape mode, you can choose to display one or two pages of the book on the screen.


### PR DESCRIPTION
Includes:
- EPUB: fix truncated HEAD>STYLE stylesheet https://github.com/koreader/crengine/pull/405
- XML parsing: slightly better parsing of `<script>`
- Update German hyphenation patterns https://github.com/koreader/crengine/pull/406
- (chore) Silence some clang warnings https://github.com/koreader/crengine/pull/407
- (Upstream) CSS content: fix regression with open-quote/close-quote
- (Upstream) HTML lists: support the 'reversed' attribute
- (Upstream) Tweak list items disc/circle/square symbols
- 2-pages mode: option to skip geometry checks

CRE bottom menu: allow toggling Dual Pages in portrait mode. Closes #7129 
(I let in commented out the previous checks, just in case we need to tweak it after feedback, and because there are not many examples on how to use this current_func function.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7138)
<!-- Reviewable:end -->
