### PR TITLE
calibre plugin: handle huge metadata files

### DIFF
--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -8,33 +8,41 @@ of storing it.
 @module koplugin.calibre.metadata
 --]]--
 
+local lfs = require("libs/libkoreader-lfs")
 local rapidjson = require("rapidjson")
 local logger = require("logger")
+local parser = require("parser")
 local util = require("util")
 
-local unused_metadata = {
-    "application_id",
-    "author_link_map",
-    "author_sort",
-    "author_sort_map",
-    "book_producer",
-    "comments",
-    "cover",
-    "db_id",
-    "identifiers",
-    "languages",
-    "pubdate",
-    "publication_type",
-    "publisher",
-    "rating",
-    "rights",
-    "thumbnail",
-    "timestamp",
-    "title_sort",
-    "user_categories",
-    "user_metadata",
-    "_series_sort_",
+local used_metadata = {
+    "uuid",
+    "lpath",
+    "last_modified",
+    "size",
+    "title",
+    "authors",
+    "tags",
+    "series",
+    "series_index"
 }
+
+local function slim(book)
+    local slim_book = {}
+    for k, _ in pairs(used_metadata) do
+        if k == "series" or k == "series_index" then
+            slim_book[k] = book[k] or rapidjson.null
+        elseif k == "tags" then
+            slim_book[k] = book[k] or {}
+        else
+            slim_book[k] = book[k]
+        end
+    end
+    return slim_book
+end
+
+-- this is the max file size we attempt to decode using json. For larger
+-- files we want to attempt to manually parse the file to avoid OOM errors
+local MAX_JSON_FILESIZE = 30 * 1024 * 1024
 
 --- find calibre files for a given dir
 local function findCalibreFiles(dir)
@@ -90,12 +98,28 @@ end
 
 -- loads books' metadata from JSON file
 function CalibreMetadata:loadBookList()
-    local json, err = rapidjson.load(self.metadata)
-    if not json then
-        logger.warn("Unable to load book list from JSON file:", self.metadata, err)
+    local attr = lfs.attributes(self.metadata)
+    if not attr then
+        logger.warn("Unable to get file attributes from JSON file:", self.metadata)
         return {}
     end
-    return json
+    local valid = attr.mode == "file" and attr.size > 0
+    if not valid then
+        logger.warn("File is invalid", self.metadata)
+        return {}
+    end
+    local books, err
+    if attr.size > MAX_JSON_FILESIZE then
+        books, err = parser.parseFile(self.metadata)
+    else
+        books, err = rapidjson.load(self.metadata)
+    end
+    if not books then
+        logger.warn(string.format("Unable to load library from json file %s: \n%s",
+            self.metadata, err))
+        return {}
+    end
+    return books
 end
 
 -- saves books' metadata to JSON file
@@ -114,11 +138,8 @@ function CalibreMetadata:saveBookList()
 end
 
 -- add a book to our books table
-function CalibreMetadata:addBook(metadata)
-    for _, key in pairs(unused_metadata) do
-        metadata[key] = nil
-    end
-    table.insert(self.books, #self.books + 1, metadata)
+function CalibreMetadata:addBook(book)
+    table.insert(self.books, #self.books + 1, slim(book))
 end
 
 -- remove a book from our books table
@@ -180,13 +201,9 @@ end
 
 -- removes unused metadata from books
 function CalibreMetadata:cleanUnused()
-    local slim_books = self.books
-    for index, _ in ipairs(slim_books) do
-        for _, key in pairs(unused_metadata) do
-            slim_books[index][key] = nil
-        end
+    for index, book in ipairs(self.books) do
+        self.books[index] = slim(book)
     end
-    self.books = slim_books
     self:saveBookList()
 end
 
@@ -238,14 +255,17 @@ function CalibreMetadata:init(dir, is_search)
         return false
     end
 
-    local deleted_count = self:prune()
-    local elapsed = socket.gettime() - start
-    logger.info(string.format(
-        "calibre info loaded from disk in %f milliseconds: %d books. %d pruned",
-        elapsed * 1000, #self.books, deleted_count))
-    if not is_search then
+    local msg
+    if is_search then
+        msg = string.format("(search) in %f milliseconds: %d books",
+            (socket.gettime() - start) * 1000, #self.books)
+    else
+        local deleted_count = self:prune()
         self:cleanUnused()
+        msg = string.format("in %f milliseconds: %d books. %d pruned",
+            (socket.gettime() - start) * 1000, #self.books, deleted_count)
     end
+    logger.info(string.format("calibre info loaded from disk %s", msg))
     return true
 end
 

--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -28,7 +28,7 @@ local used_metadata = {
 
 local function slim(book)
     local slim_book = {}
-    for k, _ in pairs(used_metadata) do
+    for _, k in ipairs(used_metadata) do
         if k == "series" or k == "series_index" then
             slim_book[k] = book[k] or rapidjson.null
         elseif k == "tags" then
@@ -42,7 +42,7 @@ end
 
 -- this is the max file size we attempt to decode using json. For larger
 -- files we want to attempt to manually parse the file to avoid OOM errors
-local MAX_JSON_FILESIZE = 30 * 1024 * 1024
+local MAX_JSON_FILESIZE = 30 * 1000 * 1000
 
 --- find calibre files for a given dir
 local function findCalibreFiles(dir)

--- a/plugins/calibre.koplugin/parser.lua
+++ b/plugins/calibre.koplugin/parser.lua
@@ -1,0 +1,90 @@
+-- A parser for metadata.calibre
+local util = require("util")
+
+-- removes leading and closing characters and converts hex-unicodes
+local function replaceHexChars(s, n, j)
+    local l = string.len(s)
+    if string.sub(s, l, l) == "\"" then
+        s = string.sub(s, n, string.len(s)-1)
+    else
+        s = string.sub(s, n, string.len(s)-j)
+    end
+    s = string.gsub(s, "\\u([a-f0-9][a-f0-9][a-f0-9][a-f0-9])", function(w)
+        return util.unicodeCodepointToUtf8(tonumber(w, 16))
+    end)
+    return s
+end
+
+-- a couple of string helper functions for dealing with raw json strings
+local function isEqual(str, key)
+    if str:sub(1, key:len() + 6) == string.format("    \"%s\"", key) then
+        return true
+    end
+    return false
+end
+
+local function getValue(str, key)
+    if str == string.format("    \"%s\": null, ", key) then
+        return nil
+    else
+        return replaceHexChars(str, key:len() + 10, key == "series_index" and 2 or 3)
+    end
+end
+
+local jsonStr = getmetatable("")
+jsonStr.__index["equals"] = isEqual
+jsonStr.__index["value"] = getValue
+
+
+local parser = {}
+
+-- read metadata from file, line by line, and keep just the data we need
+function parser.parseFile(file)
+    assert(type(file) == "string", "wrong type (expected a string")
+    local f, err = io.open(file, "rb")
+    if not f then
+        return nil, string.format("error parsing %s: %s", file, err)
+    end
+    f:close()
+    local add = function(t, line)
+        if type(t) ~= "table" or type(line) ~= "string" then
+            return {}
+        end
+        line = replaceHexChars(line, 8, 3)
+        table.insert(t, #t + 1, line)
+        return t
+    end
+    local books, book = {}, {}
+    local is_author, is_tag = false, false
+    for line in io.lines(file) do
+        if line == "  }, " or line == "  }" then
+            if type(book) == "table" then
+                table.insert(books, #books + 1, book)
+            end
+            book = {}
+        elseif line == "    \"authors\": [" then
+            is_author = true
+        elseif line == "    \"tags\": [" then
+            is_tag = true
+        elseif line == "    ], " or line == "    ]" then
+            is_author, is_tag = false, false
+        else
+            for _, key in ipairs({"title", "uuid", "lpath", "size",
+                "last_modified", "series", "series_index"})
+            do
+                if line:equals(key) then
+                    book[key] = line:value(key)
+                    break
+                end
+            end
+        end
+        if is_author then
+            book.authors = add(book.authors, line)
+        elseif is_tag then
+            book.tags = add(book.tags, line)
+        end
+    end
+    return books
+end
+
+return parser

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -18,6 +18,7 @@ local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local socket = require("socket")
+local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
@@ -29,20 +30,6 @@ local function getDefaultRootDir()
         return lfs.currentdir()
     else
         return Device.home_dir or lfs.currentdir()
-    end
-end
-
-local function humanReadableSize(bytes)
-    if type(bytes) ~= "number" then
-        bytes = tonumber(bytes)
-        if not bytes then return _("Unknown") end
-    end
-    if bytes < 1000 then
-        return string.format("%dB", bytes)
-    elseif bytes >= 1000 and bytes < 1000 * 1000 then
-        return string.format("%4.1fKB", bytes/1000)
-    else
-        return string.format("%4.1fMB", bytes/1000/1000)
     end
 end
 
@@ -153,7 +140,7 @@ local function getBookInfo(book)
     -- all entries can be empty, except size, which is always filled by calibre.
     local title = _("Title:") .. " " .. book.title or "-"
     local authors = _("Author(s):") .. " " .. getEntries(book.authors) or "-"
-    local size = _("Size:") .. " " .. humanReadableSize(book.size)
+    local size = _("Size:") .. " " .. util.getFriendlySize(book.size) or _("Unknown")
     local tags = getEntries(book.tags)
     if tags then
         tags = _("Tags:") .. " " .. tags


### PR DESCRIPTION
Repurposes parts of @WS64 manual parser to read huge json files.

~~Likely broken for json right now, for whatever reason I need to debug. It works fine with the manual parser.~~

rapidjson is 10x faster than manually parsing but manually parsing avoids OOM.

~~Do not review for the moment, as it is broken. Testing  is welcome but there's a 99'9% chance you'll lose faith in humanity.~~

Pinging @NiLuJe, as our chief calibre user: I hardcoded the max JSON file to 30MB. Files bigger than that are going to be parsed manually. I have no idea how many books can be fit in 30MB on calibre metadata. The two files I've tested are mine (200 books, 200kb) and @WS64 (50000 books, 186MB)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7159)
<!-- Reviewable:end -->
