### PR TITLE
Assorted fixes after #7118

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -47,6 +47,7 @@ function ReaderSearch:onShowFulltextSearchInput()
                 },
                 {
                     text = backward_text,
+                    vsync = true,
                     callback = function()
                         self:onShowSearchDialog(self.input_dialog:getInputText(), 1)
                         self:closeInputDialog()
@@ -54,6 +55,7 @@ function ReaderSearch:onShowFulltextSearchInput()
                 },
                 {
                     text = forward_text,
+                    vsync = true,
                     is_enter_default = true,
                     callback = function()
                         self:onShowSearchDialog(self.input_dialog:getInputText(), 0)
@@ -159,18 +161,22 @@ function ReaderSearch:onShowSearchDialog(text, direction)
             {
                 {
                     text = from_start_text,
+                    vsync = true,
                     callback = do_search(self.searchFromStart, text),
                 },
                 {
                     text = backward_text,
+                    vsync = true,
                     callback = do_search(self.searchNext, text, 1),
                 },
                 {
                     text = forward_text,
+                    vsync = true,
                     callback = do_search(self.searchNext, text, 0),
                 },
                 {
                     text = from_end_text,
+                    vsync = true,
                     callback = do_search(self.searchFromEnd, text),
                 },
             }

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -301,7 +301,10 @@ function Button:onTapSelectButton()
                     UIManager:setDirty(self.show_parent, function()
                         return "ui", self[1].dimen
                     end)
-                    return true
+
+                    if self.readonly ~= true then
+                        return true
+                    end
                 end
 
                 if self.text then

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -302,6 +302,7 @@ function Button:onTapSelectButton()
                         return "ui", self[1].dimen
                     end)
 
+                    -- It's a sane exit, handle the return the same way.
                     if self.readonly ~= true then
                         return true
                     end

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -278,6 +278,13 @@ function Button:onTapSelectButton()
                 return true
             end
 
+            -- If the button can no longer be found inside a shown widget, abort early
+            -- (this allows us to catch widgets that instanciate *new* Buttons on every updates... (e.g., ButtonTable) :()
+            if not UIManager:isSubwidgetShown(self) then
+                print("Button", self, "doesn't belong to a visible widget anymore")
+                return true
+            end
+
             self[1].invert = false
             if self.text then
                 if self[1].radius == Size.radius.button then

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -324,6 +324,7 @@ function Button:onTapSelectButton()
                 --UIManager:forceRePaint() -- Ensures the unhighlight happens now, instead of potentially waiting and having it batched with something else.
             else
                 print("Button", self, "parent", self.show_parent, "is no longer shown")
+                return true
             end
         end
     elseif self.tap_input then

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -295,7 +295,6 @@ function Button:onTapSelectButton()
 
                 -- If our parent is no longer the toplevel widget, toplevel is now a true modal, and our highlight would clash with that modal's region,
                 -- we have no other choice than repainting the full stack...
-                -- (this mainly concerns stuff that pops up the virtual keyboard (e.g., TextEditor), where said keyboard will always be top-level)
                 if top_widget ~= self.show_parent and top_widget ~= "VirtualKeyboard" and top_widget.modal and self[1].dimen:intersectWith(UIManager:getPreviousRefreshRegion()) then
                     -- Much like in TouchMenu, the fact that the two intersect means we have no choice but to repaint the full stack to avoid half-painted widgets...
                     UIManager:waitForVSync()
@@ -320,6 +319,8 @@ function Button:onTapSelectButton()
                 end)
                 --UIManager:forceRePaint() -- Ensures the unhighlight happens now, instead of potentially waiting and having it batched with something else.
             else
+                -- This branch will mainly be taken by stuff that pops up the virtual keyboard (e.g., TextEditor), where said keyboard will always be top-level,
+                -- (hence the exception in the check above).
                 return true
             end
         end

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -286,9 +286,9 @@ function Button:onTapSelectButton()
                     return true
                 end
 
-                -- If our parent is no longer the toplevel widget, toplevel is now a modal, and our highlight would clash with that modal's region, abort early
+                -- If our parent is no longer the toplevel widget, toplevel is now a true modal, and our highlight would clash with that modal's region, abort early
                 -- (this mainly concerns stuff that pops up the virtual keyboard (e.g., TextEditor), where said keyboard will always be top-level)
-                if top_widget ~= self.show_parent and top_widget.modal and self[1].dimen:intersectWith(UIManager:getPreviousRefreshRegion()) then
+                if top_widget ~= self.show_parent and top_widget ~= "VirtualKeyboard" and top_widget.modal and self[1].dimen:intersectWith(UIManager:getPreviousRefreshRegion()) then
                     print("Button", self, "unhighlight would clash with previous refresh of a modal")
                     print("Modal", top_widget:getSize())
                     print("Refresh", UIManager:getPreviousRefreshRegion())

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -243,13 +243,11 @@ function Button:onTapSelectButton()
                     self[1].invert = true
                 end
 
-                print("Highlight: Repaint text Button", self, self.enabled)
                 UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
                 -- But do make sure the invert flag is set in both cases, mainly for the early return check below
                 self[1].invert = true
             else
                 self[1].invert = true
-                print("Highlight: Invert text Button", self, self.enabled)
                 UIManager:widgetInvert(self[1], self[1].dimen.x, self[1].dimen.y)
             end
             UIManager:setDirty(nil, function()
@@ -273,7 +271,6 @@ function Button:onTapSelectButton()
             if not self[1] or not self[1].invert or not self[1].dimen then
                 -- If the frame widget no longer exists (destroyed, re-init'ed by setText(), or is no longer inverted: we have nothing to invert back
                 -- NOTE: This cannot catch orphaned Button instances, c.f., the isSubwidgetShown(self) check below for that.
-                print("Button", self, "no longer exists")
                 return true
             end
 
@@ -293,16 +290,12 @@ function Button:onTapSelectButton()
                 -- If the button can no longer be found inside a shown widget, abort early
                 -- (this allows us to catch widgets that instanciate *new* Buttons on every update... (e.g., ButtonTable) :()
                 if not UIManager:isSubwidgetShown(self) then
-                    print("Button", self, "doesn't belong to a visible widget anymore")
                     return true
                 end
 
                 -- If our parent is no longer the toplevel widget, toplevel is now a true modal, and our highlight would clash with that modal's region, abort early
                 -- (this mainly concerns stuff that pops up the virtual keyboard (e.g., TextEditor), where said keyboard will always be top-level)
                 if top_widget ~= self.show_parent and top_widget ~= "VirtualKeyboard" and top_widget.modal and self[1].dimen:intersectWith(UIManager:getPreviousRefreshRegion()) then
-                    print("Button", self, "unhighlight would clash with previous refresh of a modal")
-                    print("Modal", top_widget:getSize())
-                    print("Refresh", UIManager:getPreviousRefreshRegion())
                     -- Much like in TouchMenu, the fact that the two intersect means we have no choice but to repaint the full stack to avoid half-painted widgets...
                     UIManager:waitForVSync()
                     UIManager:setDirty(self.show_parent, function()
@@ -312,10 +305,8 @@ function Button:onTapSelectButton()
                 end
 
                 if self.text then
-                    print("Unhighlight: Repaint text Button", self, self.enabled)
                     UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
                 else
-                    print("Unhighlight: Invert text Button", self, self.enabled)
                     UIManager:widgetInvert(self[1], self[1].dimen.x, self[1].dimen.y)
                 end
                 -- If the button was disabled, switch to UI to make sure the gray comes through unharmed ;).
@@ -324,7 +315,6 @@ function Button:onTapSelectButton()
                 end)
                 --UIManager:forceRePaint() -- Ensures the unhighlight happens now, instead of potentially waiting and having it batched with something else.
             else
-                print("Button", self, "parent", self.show_parent, "is no longer shown")
                 return true
             end
         end

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -277,7 +277,8 @@ function Button:onTapSelectButton()
             end
 
             -- If the callback closed our parent (which may not always be the top-level widget, or even *a* window-level widget), we're done
-            if UIManager:getTopWidget() == self.show_parent or UIManager:isSubwidgetShown(self.show_parent) then
+            local top_widget = UIManager:getTopWidget()
+            if top_widget == self.show_parent or UIManager:isSubwidgetShown(self.show_parent) then
                 -- If the button can no longer be found inside a shown widget, abort early
                 -- (this allows us to catch widgets that instanciate *new* Buttons on every update... (e.g., ButtonTable) :()
                 if not UIManager:isSubwidgetShown(self) then
@@ -285,8 +286,14 @@ function Button:onTapSelectButton()
                     return true
                 end
 
-                -- If our parent is no longer the toplevel widget, and our highlight would clash with the last refresh, abort early
+                -- If our parent is no longer the toplevel widget, toplevel is now a modal, and our highlight would clash with that modal's region, abort early
                 -- (this mainly concerns stuff that pops up the virtual keyboard (e.g., TextEditor), where said keyboard will always be top-level)
+                if top_widget ~= self.show_parent and top_widget.modal and self[1].dimen:intersectWith(UIManager:getPreviousRefreshRegion()) then
+                    print("Button", self, "unhighlight would clash with previous refresh of a modal")
+                    print("Modal", top_widget:getSize())
+                    print("Refresh", UIManager:getPreviousRefreshRegion())
+                    return true
+                end
 
                 self[1].invert = false
                 if self.text then

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -293,7 +293,8 @@ function Button:onTapSelectButton()
                     return true
                 end
 
-                -- If our parent is no longer the toplevel widget, toplevel is now a true modal, and our highlight would clash with that modal's region, abort early
+                -- If our parent is no longer the toplevel widget, toplevel is now a true modal, and our highlight would clash with that modal's region,
+                -- we have no other choice than repainting the full stack...
                 -- (this mainly concerns stuff that pops up the virtual keyboard (e.g., TextEditor), where said keyboard will always be top-level)
                 if top_widget ~= self.show_parent and top_widget ~= "VirtualKeyboard" and top_widget.modal and self[1].dimen:intersectWith(UIManager:getPreviousRefreshRegion()) then
                     -- Much like in TouchMenu, the fact that the two intersect means we have no choice but to repaint the full stack to avoid half-painted widgets...

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -271,7 +271,8 @@ function Button:onTapSelectButton()
             end
 
             if not self[1] or not self[1].invert or not self[1].dimen then
-                -- If the widget no longer exists (destroyed, re-init'ed by setText(), or not inverted: nothing to invert back
+                -- If the frame widget no longer exists (destroyed, re-init'ed by setText(), or is no longer inverted: we have nothing to invert back
+                -- NOTE: This cannot catch orphaned Button instances, c.f., the isSubwidgetShown(self) check below for that.
                 print("Button", self, "no longer exists")
                 return true
             end

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -55,6 +55,7 @@ function ButtonTable:init()
                 enabled = btn_entry.enabled,
                 callback = btn_entry.callback,
                 hold_callback = btn_entry.hold_callback,
+                vsync = btn_entry.vsync,
                 width = (self.width - sizer_space)/column_cnt,
                 max_width = (self.width - sizer_space)/column_cnt - 2*self.sep_width - 2*self.padding,
                 bordersize = 0,

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -460,6 +460,7 @@ function DictQuickLookup:update()
             {
                 {
                     text = prev_dict_text,
+                    vsync = true,
                     enabled = self:isPrevDictAvaiable(),
                     callback = function()
                         self:changeToPrevDict()
@@ -482,6 +483,7 @@ function DictQuickLookup:update()
                 },
                 {
                     text = next_dict_text,
+                    vsync = true,
                     enabled = self:isNextDictAvaiable(),
                     callback = function()
                         self:changeToNextDict()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -725,6 +725,7 @@ function InputDialog:_addScrollButtons(nav_bar)
         table.insert(row, {
             text = "⇱",
             id = "top",
+            vsync = true,
             callback = function()
                 self._input_widget:scrollToTop()
             end,
@@ -732,6 +733,7 @@ function InputDialog:_addScrollButtons(nav_bar)
         table.insert(row, {
             text = "⇲",
             id = "bottom",
+            vsync = true,
             callback = function()
                 self._input_widget:scrollToBottom()
             end,

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -181,25 +181,19 @@ function TouchMenuItem:onTapSelect(arg, ges)
         --       and because "fast" can have some weird side-effects on some devices in this specific instance...
         if self.item.hold_keep_menu_open or self.item.keep_menu_open then
             local top_widget = UIManager:getTopWidget()
-            print("Keep menu open, and top_widget is", top_widget)
             -- If the callback opened a full-screen widget, we're done
             if top_widget.covers_fullscreen then
-                print("Top widget covers the full screen")
                 return true
             end
 
             -- If the callback opened the Virtual Keyboard, we're done
-            -- (this is for TextEditor, terminal & friends)
+            -- (this is for TextEditor, Terminal & co)
             if top_widget == "VirtualKeyboard" then
-                print("Top widget is VK")
                 return true
             end
 
             -- If we're still on top, or if a modal was opened outside of our highlight region, we can unhighlight safely
             if top_widget == self.menu or highlight_dimen:notIntersectWith(UIManager:getPreviousRefreshRegion()) then
-                print("Top widget is still menu, or our highlight doesn't clash with the last refresh")
-                print("HL", highlight_dimen)
-                print("refresh:", UIManager:getPreviousRefreshRegion())
                 UIManager:widgetInvert(self.item_frame, highlight_dimen.x, highlight_dimen.y, highlight_dimen.w)
                 UIManager:setDirty(nil, function()
                     return "ui", highlight_dimen
@@ -208,7 +202,6 @@ function TouchMenuItem:onTapSelect(arg, ges)
                 -- That leaves modals that might have been displayed on top of the highlighted menu entry, in which case,
                 -- we can't take any shortcuts, as it would invert/paint *over* the popop.
                 -- Instead, fence the callback to avoid races, and repaint the *full* widget stack properly.
-                print("Repainting the full stack")
                 UIManager:waitForVSync()
                 UIManager:setDirty(self.show_parent, function()
                     return "ui", highlight_dimen
@@ -255,9 +248,6 @@ function TouchMenuItem:onHoldSelect(arg, ges)
         local top_widget = UIManager:getTopWidget()
         -- If we're still on top, or if a modal was opened outside of our highlight region, we can unhighlight safely
         if top_widget == self.menu or highlight_dimen:notIntersectWith(UIManager:getPreviousRefreshRegion()) then
-            print("Top widget is still menu, or our highlight doesn't clash with the last refresh")
-            print("HL", highlight_dimen)
-            print("refresh:", UIManager:getPreviousRefreshRegion())
             UIManager:widgetInvert(self.item_frame, highlight_dimen.x, highlight_dimen.y, highlight_dimen.w)
             UIManager:setDirty(nil, function()
                 return "ui", highlight_dimen
@@ -266,7 +256,6 @@ function TouchMenuItem:onHoldSelect(arg, ges)
             -- That leaves modals that might have been displayed on top of the highlighted menu entry, in which case,
             -- we can't take any shortcuts, as it would invert/paint *over* the popop.
             -- Instead, fence the callback to avoid races, and repaint the *full* widget stack properly.
-            print("Repainting the full stack")
             UIManager:waitForVSync()
             UIManager:setDirty(self.show_parent, function()
                 return "ui", highlight_dimen

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -181,13 +181,25 @@ function TouchMenuItem:onTapSelect(arg, ges)
         --       and because "fast" can have some weird side-effects on some devices in this specific instance...
         if self.item.hold_keep_menu_open or self.item.keep_menu_open then
             local top_widget = UIManager:getTopWidget()
+            print("Keep menu open, and top_widget is", top_widget)
             -- If the callback opened a full-screen widget, we're done
             if top_widget.covers_fullscreen then
+                print("Top widget covers the full screen")
+                return true
+            end
+
+            -- If the callback opened the Virtual Keyboard, we're done
+            -- (this is for TextEditor, terminal & friends)
+            if top_widget == "VirtualKeyboard" then
+                print("Top widget is VK")
                 return true
             end
 
             -- If we're still on top, or if a modal was opened outside of our highlight region, we can unhighlight safely
             if top_widget == self.menu or highlight_dimen:notIntersectWith(UIManager:getPreviousRefreshRegion()) then
+                print("Top widget is still menu, or our highlight doesn't clash with the last refresh")
+                print("HL", highlight_dimen)
+                print("refresh:", UIManager:getPreviousRefreshRegion())
                 UIManager:widgetInvert(self.item_frame, highlight_dimen.x, highlight_dimen.y, highlight_dimen.w)
                 UIManager:setDirty(nil, function()
                     return "ui", highlight_dimen
@@ -196,6 +208,7 @@ function TouchMenuItem:onTapSelect(arg, ges)
                 -- That leaves modals that might have been displayed on top of the highlighted menu entry, in which case,
                 -- we can't take any shortcuts, as it would invert/paint *over* the popop.
                 -- Instead, fence the callback to avoid races, and repaint the *full* widget stack properly.
+                print("Repainting the full stack")
                 UIManager:waitForVSync()
                 UIManager:setDirty(self.show_parent, function()
                     return "ui", highlight_dimen

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -639,6 +639,7 @@ function VirtualKeyPopup:init()
 end
 
 local VirtualKeyboard = FocusManager:new{
+    name = "VirtualKeyboard",
     modal = true,
     disable_double_tap = true,
     inputbox = nil,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -29,7 +29,6 @@ local TextEditor = WidgetContainer:new{
     normal_font = "x_smallinfofont",
     monospace_font = "infont",
     min_file_size_warn = 200000, -- warn/ask when opening files bigger than this
-    covers_fullscreen = true, -- Asking for a fullscreen InputDialog also flags InputDialog itself that way, but it's not enough.
 }
 
 function TextEditor:onDispatcherRegisterActions()

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -29,6 +29,7 @@ local TextEditor = WidgetContainer:new{
     normal_font = "x_smallinfofont",
     monospace_font = "infont",
     min_file_size_warn = 200000, -- warn/ask when opening files bigger than this
+    covers_fullscreen = true, -- Asking for a fullscreen InputDialog also flags InputDialog itself that way, but it's not enough.
 }
 
 function TextEditor:onDispatcherRegisterActions()


### PR DESCRIPTION
* I'd failed to notice that ButtonTable *also* instantiates seven billion Buttons on each update. Unfortunately, that one is way trickier to fix properly, so, work around its behavior in Button. (This fixes multiple issues with stuff using ButtonTable, which is basically anything with a persistent set of buttons. A good and easy test-case is the dictionary popup, e.g., the Highlight button changes text, and the next/prev dic buttons change state. All that, and more, was broken ;p).

* Handle corner-cases related to VirtualKeyboard (e.g., Terminal & Text Editor), which screwed with both TouchMenu & Button heuristics because it's weird.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7161)
<!-- Reviewable:end -->
