### PR TITLE
Account for result pagination when fetching notes or notebooks from Joplin API

### DIFF
--- a/plugins/evernote.koplugin/JoplinClient.lua
+++ b/plugins/evernote.koplugin/JoplinClient.lua
@@ -71,7 +71,7 @@ function JoplinClient:findNoteByTitle(title, notebook_id)
         url = url_base..page
         local notes = self:_makeRequest(url, "GET")
         has_more = notes.has_more
-        for _, note in pairs(notes.items) do
+        for _, note in ipairs(notes.items) do
             if note.title == title then
                 if notebook_id == nil or note.parent_id == notebook_id then
                     return note.id
@@ -97,7 +97,7 @@ function JoplinClient:findNotebookByTitle(title)
         url = url_base..page
         local folders = self:_makeRequest(url, "GET")
         has_more = folders.has_more
-        for _, folder in pairs(folders.items) do
+        for _, folder in ipairs(folders.items) do
             if folder.title== title then
                 return folder.id
             end

--- a/plugins/evernote.koplugin/JoplinClient.lua
+++ b/plugins/evernote.koplugin/JoplinClient.lua
@@ -79,7 +79,7 @@ function JoplinClient:findNoteByTitle(title, notebook_id)
             end
         end
         page = page + 1
-    until(not(has_more))
+    until not has_more
     return false
 
 end
@@ -98,12 +98,12 @@ function JoplinClient:findNotebookByTitle(title)
         local folders = self:_makeRequest(url, "GET")
         has_more = folders.has_more
         for _, folder in ipairs(folders.items) do
-            if folder.title== title then
+            if folder.title == title then
                 return folder.id
             end
         end
         page = page + 1
-    until(not(has_more))
+    until not has_more
     return false
 end
 


### PR DESCRIPTION
The Joplin API endpoints for fetching notes or notebooks are paginated now

Resolves #7148

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7162)
<!-- Reviewable:end -->
