### PR TITLE
Refresh AltStatusBar once a minute, if there are changes

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -65,12 +65,13 @@ end
 function ReaderCoptListener:updateHeader()
     if self.view.view_mode == "page" then
         require("logger").dbg("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx updateHeader")
-        self.ui.document._callCacheSet("current_buffer_tag", nil)
-        self.ui:handleEvent(Event:new("RedrawCurrentView", self.current_page))
---        self.ui.rolling:updateBatteryState()
---        UIManager:setDirty(self.view.dialog, function()
---            return "ui", Geom:new{ w = Device.screen:getWidth(), h = self.ui.document:getHeaderHeight()}
---        end)
+--        self.ui.document._callCacheSet("current_buffer_tag", nil)
+--        self.ui:handleEvent(Event:new("RedrawCurrentView", self.current_page))
+        self.ui.rolling:updateBatteryState()
+        self.ui.document:resetBufferCache()
+        UIManager:setDirty(self.view.dialog, function()
+            return "ui", Geom:new{ w = Device.screen:getWidth(), h = self.ui.document:getHeaderHeight()}
+        end)
     end
 end
 

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -64,14 +64,10 @@ end
 
 function ReaderCoptListener:updateHeader()
     if self.view.view_mode == "page" then
-        require("logger").dbg("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx updateHeader")
---        self.ui.document._callCacheSet("current_buffer_tag", nil)
---        self.ui:handleEvent(Event:new("RedrawCurrentView", self.current_page))
         self.ui.rolling:updateBatteryState()
         self.ui.document:resetBufferCache()
-        UIManager:setDirty(self.view.dialog, function()
-            return "ui", Geom:new{ w = Device.screen:getWidth(), h = self.ui.document:getHeaderHeight()}
-        end)
+        UIManager:setDirty(self.view.dialog, "ui",
+            Geom:new{ w = Device.screen:getWidth(), h = self.ui.document:getHeaderHeight()})
     end
 end
 
@@ -84,7 +80,7 @@ function ReaderCoptListener:setupHeaderRefresh()
                 if self.document.configurable.status_line == 0 then -- is top bar enabled
                     local new_battery_level = Device:getPowerDevice():getCapacity()
                     if self.clock == 1 or (self.battery == 1 and new_battery_level ~= self.old_battery_level) then
-                        self:updateHeader(true)
+                        self:updateHeader()
                         self.old_battery_level = new_battery_level
                     end
                 end
@@ -209,7 +205,7 @@ function ReaderCoptListener:getAltStatusBarMenu()
                     local status = _("off")
                     if self.battery == 1 then
                         if self.battery_percent == 1 then
-                            status = _("percent")
+                            status = _("percentage")
                         else
                             status = _("icon")
                         end

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -136,6 +136,7 @@ function ReaderCoptListener:getAltStatusBarMenu()
                 callback = function()
                     self.header_auto_refresh = self.header_auto_refresh == 0 and 1 or 0
                     G_reader_settings:saveSetting("cre_header_auto_refresh", self.header_auto_refresh)
+                    UIManager:broadcastEvent(Event:new("SetStatusLine", self.document.configurable.status_line, true))
                     self:updateHeaderRefreshSchedule()
                 end,
                 separator = true

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -89,17 +89,21 @@ function ReaderCoptListener:setupHeaderRefresh()
                 -- NOTE: We *do* keep its content up-to-date, though
                 self:updateHeader()
             end
-            UIManager:scheduleIn(61 - tonumber(os.date("%S")), self.headerRefresh)
+            self:updateHeaderRefreshSchedule()
         end
     end
     self.onCloseDocument = function()
         UIManager:unschedule(self.headerRefresh)
     end
-    UIManager:scheduleIn(61 - tonumber(os.date("%S")), self.headerRefresh)
+    self:updateHeaderRefreshSchedule()
 end
 
-function ReaderCoptListener:unsetHeaderRefresh()
+function ReaderCoptListener:updateHeaderRefreshSchedule()
     UIManager:unschedule(self.headerRefresh)
+    if self.document.configurable.status_line == 0 and self.header_auto_refresh == 1 and
+        (self.clock == 1 or self.battery == 1) then
+        UIManager:scheduleIn(61 - tonumber(os.date("%S")), self.headerRefresh)
+    end
 end
 
 local about_text = _([[
@@ -132,11 +136,7 @@ function ReaderCoptListener:getAltStatusBarMenu()
                 callback = function()
                     self.header_auto_refresh = self.header_auto_refresh == 0 and 1 or 0
                     G_reader_settings:saveSetting("cre_header_auto_refresh", self.header_auto_refresh)
-                    if self.header_auto_refresh then
-                        self:setupHeaderRefresh()
-                    else
-                        self:unsetHeaderRefresh()
-                    end
+                    self:updateHeaderRefreshSchedule()
                 end,
                 separator = true
             },
@@ -158,6 +158,7 @@ function ReaderCoptListener:getAltStatusBarMenu()
                 callback = function()
                     self.clock = self.clock == 0 and 1 or 0
                     self:setAndSave("cre_header_clock", "window.status.clock", self.clock)
+                    self:updateHeaderRefreshSchedule()
                 end,
             },
             {
@@ -229,9 +230,9 @@ function ReaderCoptListener:getAltStatusBarMenu()
                                 self.battery = 0
                                 self.battery_percent = 0
                             end
-
                             self:setAndSave("cre_header_battery", "window.status.battery", self.battery)
                             self:setAndSave("cre_header_battery_percent", "window.status.battery.percent", self.battery_percent)
+                            self:updateHeaderRefreshSchedule()
                         end,
                     },
                     {
@@ -249,10 +250,9 @@ function ReaderCoptListener:getAltStatusBarMenu()
                                 self.battery = 0
                                 self.battery_percent = 0
                             end
-
-
                             self:setAndSave("cre_header_battery", "window.status.battery", self.battery)
                             self:setAndSave("cre_header_battery_percent", "window.status.battery.percent", self.battery_percent)
+                            self:updateHeaderRefreshSchedule()
                         end,
                     },
                 },

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -47,9 +47,7 @@ function ReaderCoptListener:onReadSettings(config)
 
     self.old_battery_level = Device:getPowerDevice():getCapacity()
 
-    if self.header_auto_refresh then
-        self:setupHeaderRefresh()
-    end
+    self:setupHeaderRefresh()
 end
 
 function ReaderCoptListener:onSetFontSize(font_size)
@@ -72,30 +70,23 @@ function ReaderCoptListener:updateHeader()
 end
 
 function ReaderCoptListener:setupHeaderRefresh()
-    if not self.headerRefresh then
-        self.headerRefresh = function()
-            -- Only actually repaint the header if nothing's being shown over ReaderUI (#6616)
-            if UIManager:getTopWidget() == "ReaderUI" then
-                -- And that only if it's actually visible
-                if self.document.configurable.status_line == 0 then -- is top bar enabled
-                    local new_battery_level = Device:getPowerDevice():getCapacity()
-                    if self.clock == 1 or (self.battery == 1 and new_battery_level ~= self.old_battery_level) then
-                        self:updateHeader()
-                        self.old_battery_level = new_battery_level
-                    end
-                end
-            else
-                require("logger").dbg("Skipping Header repaint, because ReaderUI is not the top-level widget")
-                -- NOTE: We *do* keep its content up-to-date, though
+    self.headerRefresh = function()
+        -- Only actually repaint the header if nothing's being shown over ReaderUI (#6616)
+        -- And that only if it's actually visible
+        if self.document.configurable.status_line == 0 then -- is top bar enabled
+            local new_battery_level = Device:getPowerDevice():getCapacity()
+            if self.clock == 1 or (self.battery == 1 and new_battery_level ~= self.old_battery_level) then
                 self:updateHeader()
+                self.old_battery_level = new_battery_level
             end
-            self:updateHeaderRefreshSchedule()
         end
-    end
-    self.onCloseDocument = function()
-        UIManager:unschedule(self.headerRefresh)
+        self:updateHeaderRefreshSchedule()
     end
     self:updateHeaderRefreshSchedule()
+end
+
+function ReaderCoptListener:onCloseDocument()
+    UIManager:unschedule(self.headerRefresh)
 end
 
 function ReaderCoptListener:updateHeaderRefreshSchedule()

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -71,8 +71,7 @@ end
 
 function ReaderCoptListener:setupHeaderRefresh()
     self.headerRefresh = function()
-        -- Only actually repaint the header if nothing's being shown over ReaderUI (#6616)
-        -- And that only if it's actually visible
+        -- Only actually repaint the header only if it's actually visible
         if self.document.configurable.status_line == 0 then -- is top bar enabled
             local new_battery_level = Device:getPowerDevice():getCapacity()
             if self.clock == 1 or (self.battery == 1 and new_battery_level ~= self.old_battery_level) then

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1517,7 +1517,6 @@ function CreDocument:setupCallCache()
             elseif name:sub(1,6) == "enable" then add_reset = true
             elseif name == "zoomFont" then add_reset = true -- not used by koreader
             elseif name == "resetCallCache" then add_reset = true
-            elseif name == "resetBufferCache" then add_buffer_trash = true
             elseif name == "cacheFlows" then add_reset = true
 
             -- These may have crengine do native highlight or unhighlight
@@ -1528,6 +1527,7 @@ function CreDocument:setupCallCache()
             elseif name == "getWordFromPosition" then add_buffer_trash = true
             elseif name == "getTextFromPositions" then add_buffer_trash = true
             elseif name == "findText" then add_buffer_trash = true
+            elseif name == "resetBufferCache" then add_buffer_trash = true
 
             -- These may change page/pos
             elseif name == "gotoPage" then set_tag = "page" ; set_arg = 2

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1292,6 +1292,9 @@ end
 -- no-op that will be wrapped by setupCallCache
 function CreDocument:resetCallCache() end
 
+-- no-op that will be wrapped by setupCallCache
+function CreDocument:resetBufferCache() end
+
 -- Optimise usage of some of the above methods by caching their results,
 -- either globally, or per page/pos for those whose result may depend on
 -- current page number or y-position.
@@ -1305,6 +1308,8 @@ function CreDocument:setupCallCache()
     -- Tune these when debugging
     local do_stats_include_not_cached = false
     local do_log = false
+
+    do_log = true --xxx delete this
 
     -- Beware below for luacheck warnings "shadowing upvalue argument 'self'":
     -- the 'self' we got and use here, and the one we may get implicitely
@@ -1512,6 +1517,7 @@ function CreDocument:setupCallCache()
             elseif name:sub(1,6) == "enable" then add_reset = true
             elseif name == "zoomFont" then add_reset = true -- not used by koreader
             elseif name == "resetCallCache" then add_reset = true
+            elseif name == "resetBufferCache" then add_buffer_trash = true
             elseif name == "cacheFlows" then add_reset = true
 
             -- These may have crengine do native highlight or unhighlight


### PR DESCRIPTION
Make the top bar a bit smarter: Refresh the content if there are changes (time or battery).

Add a menu item to turn the refresh on/off
Reorganize battery items, so that the menu doesn't use two pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7179)
<!-- Reviewable:end -->
