### PR TITLE
refesh footer only if there is a change, rename menu item accordingly

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -970,11 +970,10 @@ function ReaderFooter:addToMainMenu(menu_items)
                     return self.settings.auto_refresh == true
                 end,
                 -- only enable auto refresh when time, battery, memory or wifi is shown
-                -- maybe the enabled_func should be dropped, for simplicity
-                --  enabled_func = function()
-                --    return self.settings.time or self.settings.battery or self.settings.wifi_status
-                --        or self.settings.mem_usage
-                -- end,
+                enabled_func = function()
+                    return self.settings.time or self.settings.battery or self.settings.wifi_status
+                        or self.settings.mem_usage
+                end,
                 callback = function()
                     self.settings.auto_refresh = not self.settings.auto_refresh
                     G_reader_settings:saveSetting("footer", self.settings)


### PR DESCRIPTION
There are some quirks with the refresh of the bottom bar.
*) The menu entry "Auto refresh time" is misleading. If it is activated the bottom bar is refreshed every full minute (no matter if "Current time" is set or not) -> So I renamed it to "Auto refresh".
*) You cannot change the "Auto refresh time", when "Current time" is disabled, so you cannot change the refresh of the status bar (battery, WiFi change) -> So I have deleted the enabled_func as you can always switch the refresh behavior of the bottom bar.
*) The auto refresh function is updated, so it just refreshes the footer if time, battery, WiFi of memory changes. -> So a lot of  refreshes can be saved when "Current time" is disabled.
*) Renamed the ***refresh*time to ***refresh[footer] to reflect the actual behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7182)
<!-- Reviewable:end -->
