### PR TITLE
bump crengine, various dual-page and other tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -209,10 +209,10 @@ function ReaderBookmark:onPosUpdate(pos)
     self:setDogearVisibility(self.ui.document:getXPointer())
 end
 
-function ReaderBookmark:gotoBookmark(pn_or_xp)
+function ReaderBookmark:gotoBookmark(pn_or_xp, marker_xp)
     if pn_or_xp then
         local event = self.ui.document.info.has_pages and "GotoPage" or "GotoXPointer"
-        self.ui:handleEvent(Event:new(event, pn_or_xp))
+        self.ui:handleEvent(Event:new(event, pn_or_xp, marker_xp))
     end
 end
 
@@ -304,7 +304,7 @@ function ReaderBookmark:onShowBookmark()
     local bookmark = self
     function bm_menu:onMenuChoice(item)
         bookmark.ui.link:addCurrentLocationToStack()
-        bookmark:gotoBookmark(item.page)
+        bookmark:gotoBookmark(item.page, item.pos0)
     end
 
     function bm_menu:onMenuHold(item)

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -10,16 +10,14 @@ local ReaderCoptListener = EventListener:new{}
 
 function ReaderCoptListener:onReadSettings(config)
     local view_mode = config:readSetting("copt_view_mode") or
-           G_reader_settings:readSetting("copt_view_mode")
-    if view_mode == 0 then
-        self.ui:registerPostReadyCallback(function()
-            self.view:onSetViewMode("page")
-        end)
-    elseif view_mode == 1 then
-        self.ui:registerPostReadyCallback(function()
-            self.view:onSetViewMode("scroll")
-        end)
-    end
+           G_reader_settings:readSetting("copt_view_mode") or 0 -- default to "page" mode
+    local view_mode_name = view_mode == 0 and "page" or "scroll"
+    -- Let crengine know of the view mode before rendering, as it can
+    -- cause a rendering change (2-pages would become 1-page in
+    -- scroll mode).
+    self.ui.document:setViewMode(view_mode_name)
+    -- ReaderView is the holder of the view_mode state
+    self.view.view_mode = view_mode_name
 
     -- crengine top status bar can only show author and title together
     self.title = G_reader_settings:readSetting("cre_header_title") or 1

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -40,12 +40,18 @@ function ReaderCoptListener:onReadSettings(config)
     self.ui.document._document:setIntProperty("window.status.battery.percent", self.battery_percent)
     self.ui.document._document:setIntProperty("window.status.pos.percent", self.reading_percent)
 
+    self:onTimeFormatChanged()
+
     local status_line = config:readSetting("copt_status_line") or G_reader_settings:readSetting("copt_status_line") or 1
     self.ui:handleEvent(Event:new("SetStatusLine", status_line, true))
 end
 
 function ReaderCoptListener:onSetFontSize(font_size)
     self.document.configurable.font_size = font_size
+end
+
+function ReaderCoptListener:onTimeFormatChanged()
+    self.ui.document._document:setIntProperty("window.status.clock.12hours", G_reader_settings:isTrue("twelve_hour_clock") and 1 or 0)
 end
 
 function ReaderCoptListener:setAndSave(setting, property, value)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -873,16 +873,20 @@ function ReaderHighlight:onHoldPan(_, ges)
                 elseif self.hold_pos.x <= screen_half_width and is_in_next_page_corner then
                     return true
                 end
-                local cur_page = self.ui.document:getCurrentPage()
+                -- To be able to browse half-page when 2 visible pages as 1 page number,
+                -- we must work with internal page numbers
+                local cur_page = self.ui.document:getCurrentPage(true)
                 local restore_page_mode_xpointer = self.ui.document:getXPointer() -- top of current page
+                self.ui.document.no_page_sync = true -- avoid CreDocument:drawCurrentViewByPage() to resync page
                 self.restore_page_mode_func = function()
+                    self.ui.document.no_page_sync = nil
                     self.ui.rolling:onGotoXPointer(restore_page_mode_xpointer, self.selected_text_start_xpointer)
                 end
                 if is_in_next_page_corner then -- bottom right corner in LTR UI
-                    self.ui.rolling:_gotoPage(cur_page + 1, true) -- no odd left page enforcement
+                    self.ui.rolling:_gotoPage(cur_page + 1, true, true) -- no odd left page enforcement
                     self.hold_pos.x = self.hold_pos.x - screen_half_width
                 else -- top left corner in RTL UI
-                    self.ui.rolling:_gotoPage(cur_page - 1, true) -- no odd left page enforcement
+                    self.ui.rolling:_gotoPage(cur_page - 1, true, true) -- no odd left page enforcement
                     self.hold_pos.x = self.hold_pos.x + screen_half_width
                 end
                 UIManager:setDirty(self.dialog, "ui")

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -243,7 +243,13 @@ function ReaderToc:getTocIndexByPage(pn_or_xp)
     end
     local pre_index = 1
     for _k,_v in ipairs(self.toc) do
+        if _v.page == pageno then
+            -- Return the first chapter seen on the current page
+            pre_index = _k
+            break
+        end
         if _v.page > pageno then
+            -- Return last chapter seen on a previous page
             break
         end
         pre_index = _k

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -654,7 +654,11 @@ function ReaderToc:onShowToc()
         else
             toc_menu:close_callback()
             self.ui.link:addCurrentLocationToStack()
-            self.ui:handleEvent(Event:new("GotoPage", item.page))
+            if item.xpointer then
+                self.ui:handleEvent(Event:new("GotoXPointer", item.xpointer, item.xpointer))
+            else
+                self.ui:handleEvent(Event:new("GotoPage", item.page))
+            end
         end
     end
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -42,8 +42,12 @@ function ReaderToc:init()
     self.ui.menu:registerToMainMenu(self)
 end
 
-function ReaderToc:cleanUpTocTitle(title)
-    return (title:gsub("\13", ""))
+function ReaderToc:cleanUpTocTitle(title, replace_empty)
+    title = title:gsub("\13", "")
+    if replace_empty and title:match("^%s*$") then
+        title = "\xE2\x80\x93" -- U+2013 En-Dash
+    end
+    return title
 end
 
 function ReaderToc:onSetDimensions(dimen)
@@ -523,7 +527,7 @@ function ReaderToc:onShowToc()
     -- build menu items
     if #self.toc > 0 and not self.toc[1].text then
         for _,v in ipairs(self.toc) do
-            v.text = self.toc_indent:rep(v.depth-1)..self:cleanUpTocTitle(v.title)
+            v.text = self.toc_indent:rep(v.depth-1)..self:cleanUpTocTitle(v.title, true)
             v.mandatory = v.page
             if self.ui.document:hasHiddenFlows() then
                 local flow = self.ui.document:getPageFlow(v.page)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -270,6 +270,13 @@ function CreDocument:render()
     logger.dbg("CreDocument: rendering done.")
 end
 
+function CreDocument:getDocumentRenderingHash()
+    if self.been_rendered then
+        return self._document:getDocumentRenderingHash()
+    end
+    return 0
+end
+
 function CreDocument:_readMetadata()
     Document._readMetadata(self) -- will grab/update self.info.number_of_pages
     if self.been_rendered then

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -200,6 +200,16 @@ function CreDocument:setupDefaultView()
     self._document:readDefaults()
     logger.dbg("CreDocument: applied cr3.ini default settings.")
 
+    -- Disable crengine image scaling options (we prefer scaling them via crengine.render.dpi)
+    self._document:setIntProperty("crengine.image.scaling.zoomin.block.mode", 0)
+    self._document:setIntProperty("crengine.image.scaling.zoomin.block.scale", 1)
+    self._document:setIntProperty("crengine.image.scaling.zoomin.inline.mode", 0)
+    self._document:setIntProperty("crengine.image.scaling.zoomin.inline.scale", 1)
+    self._document:setIntProperty("crengine.image.scaling.zoomout.block.mode", 0)
+    self._document:setIntProperty("crengine.image.scaling.zoomout.block.scale", 1)
+    self._document:setIntProperty("crengine.image.scaling.zoomout.inline.mode", 0)
+    self._document:setIntProperty("crengine.image.scaling.zoomout.inline.scale", 1)
+
     -- set fallback font faces (this was formerly done in :init(), but it
     -- affects crengine calcGlobalSettingsHash() and would invalidate the
     -- cache from the main currently being read document when we just

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -33,7 +33,7 @@ local CreOptions = {
             },
             {
                 name = "visible_pages",
-                name_text = _("Dual Pages"),
+                name_text = _("Two Columns"),
                 toggle = {_("off"), _("on")},
                 values = {1, 2},
                 default_value = 1,
@@ -55,8 +55,8 @@ local CreOptions = {
                         -- and Device.screen:getScreenMode() == "landscape"
                 end,
                 name_text_hold_callback = optionsutil.showValues,
-                help_text = _([[In landscape mode, you can choose to display one or two pages of the book on the screen.
-Note that this may not be ensured under some conditions: in scroll mode, when a very big font size is used, or on devices with a very low aspect ratio.]]),
+                help_text = _([[Render the document on half the screen width and display two pages at once with a single page number. This makes it look like two columns.
+This is disabled in scroll mode. Switching from page mode with two columns to scroll mode will cause the document to be re-rendered.]]),
             },
         }
     },

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -81,6 +81,7 @@ common_settings.time = {
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("twelve_hour_clock")
+            UIManager:broadcastEvent(Event:new("TimeFormatChanged"))
         end,
         }
     }


### PR DESCRIPTION
#### CRe TOC, Bookmarks: show marker when jumping

Like we do when following links. Helps a bit on pages crowded with multiple chapters or highlights.

#### TOC: show en-dash on empty titles
Closes #5961.
<kbd>![image](https://user-images.githubusercontent.com/24273478/105974134-df6c3d00-608d-11eb-8dd0-af56207f8dea.png)</kbd>

#### Footer current chapter: use first chapter on page instead of last
Fixes issue B from https://github.com/koreader/koreader/issues/7129#issuecomment-763602579

#### bump crengine: support min/max-width/height, 2-pages tweaks
https://github.com/koreader/koreader-base/pull/1295

Includes:
- EPUB ncx TOC: allow items with an empty title https://github.com/koreader/crengine/pull/409
- resizeImage(): restore original scaling options code
- CSS: parse and store min/max-width/height
- Add getStyledImageSize() ensuring min/max-width/height
- renderBlockElementEnhanced(): ensure min/max-width/height
- 2-pages mode: add option twoVisiblePagesAsOnePageNumber https://github.com/koreader/crengine/pull/410
- TOC, PageMap: save the visible pages number they were build for
- 2-pages mode: tweak header drawing
- Header: add option to display time as 12-hours clock
- 2-pages mode: decrease min middle margin from 1.2 to 0.8em
- Add LVDocView::getDocumentRenderingHash()
- (Upstream) Text: don't remove trailing space on last word if pre https://github.com/koreader/crengine/pull/410
- (Upstream) Font: replace notfound glyphs only on last fallback font
- (Upstream) Add a few lString8 methods

#### CreDocument: disable crengine image scaling options

Since their handling in crengine has been re-enabled in https://github.com/koreader/crengine/pull/409.
We prefer zooming images via `Zoom/Render DPI`.

#### CRe top status bar: ensure 12-hours clock setting

Closes #7171.

#### CRe: use getDocumentRenderingHash() to detect rendering changes

Instead of just relying on document full height and number of pages.

#### Dual pages: shown as 2 columns on a single page

Rework Dual pages code so that the view is considered a single page number, so it looks more like 2-columns on a single page.
This solves a few issues like:
- Page number and count are consistent between top and bottom status bars
- SkimTo -1/+1 doing nothing every other tap
- Statistics being wrong (like "Pages read" never going over half of the book page count)

Discussed in #7129 and in https://github.com/koreader/crengine/pull/408

<kbd>![image](https://user-images.githubusercontent.com/24273478/105976426-72a67200-6090-11eb-9bb2-b5e99305a3d6.png)</kbd>

Haven't yet decided if/how to rename the toggle:
<kbd>![image](https://user-images.githubusercontent.com/24273478/105976561-9a95d580-6090-11eb-8df3-805bf687ecb3.png)</kbd>

<kbd>Two Columns</kbd> feels accurate in portrait mode, but a bit strange in landscape mode.
Thought a singular <kbd>Dual Page</kbd> could be better (as it's now a single page, but somehow "dual", whatever a person might think it means :)
Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7204)
<!-- Reviewable:end -->
