### PR TITLE
Refresh AltStatusBar once a minute (continued)

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -40,8 +40,9 @@ function ReaderCoptListener:onReadSettings(config)
 
     self:onTimeFormatChanged()
 
+    -- Enable or disable crengine header status line (note that for crengine, 0=header enabled, 1=header disabled)
     local status_line = config:readSetting("copt_status_line") or G_reader_settings:readSetting("copt_status_line") or 1
-    self.ui:handleEvent(Event:new("SetStatusLine", status_line, true))
+    self.ui:handleEvent(Event:new("SetStatusLine", status_line))
 end
 
 function ReaderCoptListener:onSetFontSize(font_size)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -757,7 +757,6 @@ function ReaderFooter:disableFooter()
     self.updateFooterPage = function() end
     self.updateFooterPos = function() end
     self.onUpdatePos = function() end
-    self.onSetStatusLine = function() end
     self.mode = self.mode_list.off
     self.view.footer_visible = false
 end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1031,17 +1031,14 @@ function ReaderRolling:onSetVisiblePages(visible_pages)
     end
 end
 
-function ReaderRolling:onSetStatusLine(status_line, on_read_settings)
-    -- status_line values:
-    -- in crengine: 0=header enabled, 1=disabled
-    -- in koreader: 0=top status bar, 1=bottom mini bar
+function ReaderRolling:onSetStatusLine(status_line)
+    -- Enable or disable crengine header status line
+    -- Note that for crengine, 0=header enabled, 1=header disabled
     self.ui.document:setStatusLineProp(status_line)
     self.cre_top_bar_enabled = status_line == 0
-    if not on_read_settings then
-        -- Ignore this event when it is first sent by ReaderCoptListener
-        -- on book loading, so we stay with the saved footer settings
-        self.view.footer:setVisible(status_line == 1)
-    end
+    -- (We used to toggle the footer when toggling the top status bar,
+    -- but people seem to like having them both, and it feels more
+    -- practicable to have the independant.)
     self.ui:handleEvent(Event:new("UpdatePos"))
 end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -864,7 +864,6 @@ function ReaderView:onSetViewMode(new_mode)
         self.ui.document:setViewMode(new_mode)
         self.ui:handleEvent(Event:new("ChangeViewMode"))
     end
-    return true
 end
 
 --Refresh after changing a variable done by koptoptions.lua since all of them

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1331,6 +1331,9 @@ end
 -- no-op that will be wrapped by setupCallCache
 function CreDocument:resetCallCache() end
 
+-- no-op that will be wrapped by setupCallCache
+function CreDocument:resetBufferCache() end
+
 -- Optimise usage of some of the above methods by caching their results,
 -- either globally, or per page/pos for those whose result may depend on
 -- current page number or y-position.
@@ -1562,6 +1565,7 @@ function CreDocument:setupCallCache()
             elseif name == "getWordFromPosition" then add_buffer_trash = true
             elseif name == "getTextFromPositions" then add_buffer_trash = true
             elseif name == "findText" then add_buffer_trash = true
+            elseif name == "resetBufferCache" then add_buffer_trash = true
 
             -- These may change page/pos
             elseif name == "gotoPage" then set_tag = "page" ; set_arg = 2 ; set_arg2 = 3

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -533,15 +533,15 @@ Note that your selected font size is not affected by this setting.]]),
                 name = "status_line",
                 name_text = _("Alt Status Bar"),
                 toggle = {_("off"), _("on")},
-                values = {1, 0},
-                default_value = 1, -- Note that 1 means KOReader (bottom) status bar only
+                values = {1, 0}, -- Note that 0 means crengine header status line enabled, and 1 means disabled
+                default_value = 1,
                 args = {1, 0},
                 default_arg = 1,
                 event = "SetStatusLine",
                 name_text_hold_callback = optionsutil.showValues,
-                help_text = _([[Enable or disable the rendering engine alternative status bar at the top of the screen (this status bar can't be customized).
+                help_text = _([[Enable or disable the rendering engine alternative status bar at the top of the screen. The items displayed can be customized via the main menu.
 
-Whether enabled or disabled, KOReader's own status bar at the bottom of the screen can be toggled by tapping. The items displayed can be customized via the main menu.]]),
+Whether enabled or disabled, KOReader's own status bar at the bottom of the screen can be toggled by tapping.]]),
             },
             {
                 name = "embedded_css",

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -579,11 +579,14 @@ UIManager:scheduleIn(10, self.anonymousFunction)
 UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
+    local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then
             table.remove(self._task_queue, i)
+            removed = true
         end
     end
+    return removed
 end
 dbg:guard(UIManager, 'unschedule',
     function(self, action) assert(action ~= nil) end)

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -50,6 +50,7 @@ local TextWidget = Widget:new{
     _height = 0,
     _baseline_h = 0,
     _maxlength = 1200,
+    _is_truncated = nil,
 
     -- Additional properties only used when using xtext
     use_xtext = G_reader_settings:nilOrTrue("use_xtext"),
@@ -122,6 +123,7 @@ function TextWidget:updateSize()
         self._length = 0
         return
     end
+    self._is_truncated = false
 
     -- Compute width:
     if self.use_xtext then
@@ -170,6 +172,7 @@ function TextWidget:updateSize()
         -- smaller than max_width when dropping the truncated glyph).
         tsize = RenderText:sizeUtf8Text(0, self.max_width, self.face, self._text_to_draw, true, self.bold)
         self._length = math.floor(tsize.x)
+        self._is_truncated = true
     end
 end
 dbg:guard(TextWidget, "updateSize",
@@ -227,6 +230,7 @@ function TextWidget:_measureWithXText()
                 self._shape_idx_to_substitute_with_ellipsis = self._shape_end
             end
         end
+        self._is_truncated = true
     end
 end
 
@@ -292,6 +296,11 @@ end
 function TextWidget:getWidth()
     self:updateSize()
     return self._length
+end
+
+function TextWidget:isTruncated()
+    self:updateSize()
+    return self._is_truncated
 end
 
 function TextWidget:getBaseline()

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -56,6 +56,13 @@ describe("Readerfooter module", function()
         end
     end)
 
+    teardown(function()
+        -- Clean up global settings we played with
+        G_reader_settings:delSetting("reader_footer_mode")
+        G_reader_settings:delSetting("footer")
+        G_reader_settings:flush()
+    end)
+
     before_each(function()
         G_reader_settings:saveSetting("footer", {
             disabled = false,
@@ -747,6 +754,7 @@ describe("Readerfooter module", function()
         readerui:onClose()
     end)
 
+    --[[ This toggling behaviour has been removed:
     it("should toggle between full and min progress bar for cre documents", function()
         local sample_txt = "spec/front/unit/data/sample.txt"
         local readerui = ReaderUI:new{
@@ -773,4 +781,5 @@ describe("Readerfooter module", function()
         readerui:closeDocument()
         readerui:onClose()
     end)
+    ]]--
 end)


### PR DESCRIPTION
#### Top menu: long-press on truncated menu item to show full text

Close #7201 (even if that's a shitty discussion and can't be closed...)

#### Don't toggle the footer when toggling the top status bar

See #7176. Seems people prefer having both bars - and auto-removing the footer when toggling it is a bit bothering when you have footer's "Lock status bar" enabled.
People who really want only the top one can just disable the footer - so they can hide the top without havig the footer auto-shown back.
Feels more prectical to have them independant.

#### Refresh AltStatusBar once a minute, if there are changes + continue work on previous commit

I'll rebase these 2 commits: the first is @zwim latest work on #7179 - the second my continuation.
(Haven't tested resume/suspend.)
@NiLuJe : what do you think about handling auto refresh in the footer the same way: a function called from all involved menu items and events to cancel/reschedule the refresh, with everything ready for auto refresh. The current footer bits that create/nil'ify `self.onCloseDocument` are really ugly.

(I think there is no need for a `UIManager:getTopWidget() == "ReaderUI"` check - if we are reading a dict or wikipedia result, auto-refresh addicts might still want header and footer time auto-updated.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7211)
<!-- Reviewable:end -->
