### PR TITLE
Tweak footer auto refresh

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -303,6 +303,8 @@ function ReaderCoptListener:getAltStatusBarMenu()
                             -- we keep open, no need to handle this case.
                             self:setAndSave("cre_header_status_font_size", "crengine.page.header.font.size", spin.value)
                             if touchmenu_instance then touchmenu_instance:updateItems() end
+                            -- Repaint the whole page, as changing this should cause a re-rendering
+                            UIManager:setDirty(self.view.dialog, "ui")
                         end
                     }
                     UIManager:show(size_spinner)

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -420,8 +420,9 @@ describe("Readerfooter module", function()
 
         assert.are.same({}, UIManager._task_queue)
         G_reader_settings:saveSetting("footer", {
-            page_progress = true,
             auto_refresh_time = true,
+            all_at_once = true,
+            time = true,
         })
         local readerui = ReaderUI:new{
             dimen = Screen:getSize(),
@@ -430,7 +431,7 @@ describe("Readerfooter module", function()
         local footer = readerui.view.footer
         local found = 0
         for _,task in ipairs(UIManager._task_queue) do
-            if task.action == footer.autoRefreshTime then
+            if task.action == footer.autoRefreshFooter then
                 found = found + 1
             end
         end
@@ -439,7 +440,7 @@ describe("Readerfooter module", function()
         footer:onCloseDocument()
         found = 0
         for _,task in ipairs(UIManager._task_queue) do
-            if task.action == footer.autoRefreshTime then
+            if task.action == footer.autoRefreshFooter then
                 found = found + 1
             end
         end
@@ -457,8 +458,9 @@ describe("Readerfooter module", function()
         assert.are.same({}, UIManager._task_queue)
         G_reader_settings:saveSetting("footer", {
             disabled = true,
-            page_progress = true,
             auto_refresh_time = true,
+            all_at_once = true,
+            time = true,
         })
         local readerui = ReaderUI:new{
             dimen = Screen:getSize(),
@@ -467,7 +469,7 @@ describe("Readerfooter module", function()
         local footer = readerui.view.footer
         local found = 0
         for _,task in ipairs(UIManager._task_queue) do
-            if task.action == footer.autoRefreshTime then
+            if task.action == footer.autoRefreshFooter then
                 found = found + 1
             end
         end
@@ -485,8 +487,9 @@ describe("Readerfooter module", function()
         assert.are.same({}, UIManager._task_queue)
         G_reader_settings:saveSetting("footer", {
             disabled = false,
-            page_progress = true,
             auto_refresh_time = true,
+            all_at_once = true,
+            time = true,
         })
         local readerui = ReaderUI:new{
             dimen = Screen:getSize(),
@@ -498,27 +501,27 @@ describe("Readerfooter module", function()
 
         local found = 0
         for _,task in ipairs(UIManager._task_queue) do
-            if task.action == footer.autoRefreshTime then
+            if task.action == footer.autoRefreshFooter then
                 found = found + 1
             end
         end
         assert.is.same(1, found)
 
         -- disable auto refresh time
-        tapFooterMenu(fake_menu, "Auto refresh time")
+        tapFooterMenu(fake_menu, "Auto refresh")
         found = 0
         for _,task in ipairs(UIManager._task_queue) do
-            if task.action == footer.autoRefreshTime then
+            if task.action == footer.autoRefreshFooter then
                 found = found + 1
             end
         end
         assert.is.same(0, found)
 
         -- enable auto refresh time again
-        tapFooterMenu(fake_menu, "Auto refresh time")
+        tapFooterMenu(fake_menu, "Auto refresh")
         found = 0
         for _,task in ipairs(UIManager._task_queue) do
-            if task.action == footer.autoRefreshTime then
+            if task.action == footer.autoRefreshFooter then
                 found = found + 1
             end
         end
@@ -748,8 +751,16 @@ describe("Readerfooter module", function()
         local footer = readerui.view.footer
 
         assert.falsy(readerui.view.footer_visible)
-        assert.truthy(footer.onCloseDocument == nil)
         assert.truthy(footer.mode == 0)
+
+        local found = 0
+        for _,task in ipairs(UIManager._task_queue) do
+            if task.action == footer.autoRefreshFooter then
+                found = found + 1
+            end
+        end
+        assert.is.same(0, found)
+
         readerui:closeDocument()
         readerui:onClose()
     end)


### PR DESCRIPTION
Similar to how it's been done recently for CRe top status bar in #7211.
Continued from #7182. See https://github.com/koreader/koreader/pull/7211#issuecomment-770003153.

@NiLuJe : please have a look if that looks fine (at least, not worse than before)
It's a bit nightmarish with the self.mode vs self.view.footer_visible possibly getting out of sync when toggle from other modules...
So, there are probably some cases badly handled - but hopefully, it's not worse than before :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7213)
<!-- Reviewable:end -->
