### PR TITLE
Better image fit in Cover-Image plugin

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -303,6 +303,8 @@ function ReaderCoptListener:getAltStatusBarMenu()
                             -- we keep open, no need to handle this case.
                             self:setAndSave("cre_header_status_font_size", "crengine.page.header.font.size", spin.value)
                             if touchmenu_instance then touchmenu_instance:updateItems() end
+                            -- Repaint the whole page, as changing this should cause a re-rendering
+                            UIManager:setDirty(self.view.dialog, "ui")
                         end
                     }
                     UIManager:show(size_spinner)

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -48,6 +48,7 @@ function CoverImage:init()
     self.cover_image_format = G_reader_settings:readSetting("cover_image_format") or "auto"
     self.cover_image_extension = getExtension(self.cover_image_path)
     self.cover_image_quality = G_reader_settings:readSetting("cover_image_quality") or 75
+    self.cover_image_stretch_limit = G_reader_settings:readSetting("cover_image_stretch_limit") or 10
     self.cover_image_background = G_reader_settings:readSetting("cover_image_background") or "black"
     self.cover_image_fallback_path = G_reader_settings:readSetting("cover_image_fallback_path") or "cover_fallback.png"
     self.enabled = G_reader_settings:isTrue("cover_image_enabled")
@@ -99,23 +100,35 @@ function CoverImage:createCoverImage(doc_settings)
                 return
             end
 
-            local scaled_w, scaled_h = math.floor(i_w * scale_factor), math.floor(i_h * scale_factor)
-            cover_image = RenderImage:scaleBlitBuffer(cover_image, scaled_w, scaled_h)
+            local screen_ratio = s_w / s_h
+            local image_ratio = i_w / i_h
+            local ratio_factor = image_ratio < screen_ratio and image_ratio/screen_ratio or screen_ratio/image_ratio
+            logger.dbg("CoverImage: geometries screen=" .. screen_ratio .. ", image=" .. image_ratio .. "; ratio=" .. ratio_factor)
 
-            -- new buffer with screen dimensions,
-            local image = Blitbuffer.new(s_w, s_h, cover_image:getType()) -- new buffer, filled with black
-            if self.cover_image_background == "white" then
-                image:fill(Blitbuffer.COLOR_WHITE)
-            elseif self.cover_image_background == "gray" then
-                image:fill(Blitbuffer.COLOR_GRAY)
+            local image
+            if 100 - ratio_factor * 100 < self.cover_image_stretch_limit then -- stretch
+                logger.dbg("CoverImage: stretch to fullscreen")
+                image = RenderImage:scaleBlitBuffer(cover_image, s_w, s_h)
+            else -- scale
+                local scaled_w, scaled_h = math.floor(i_w * scale_factor), math.floor(i_h * scale_factor)
+                logger.dbg("CoverImage: scale to fullscreen, fill background")
+
+                cover_image = RenderImage:scaleBlitBuffer(cover_image, scaled_w, scaled_h)
+                -- new buffer with screen dimensions,
+                image = Blitbuffer.new(s_w, s_h, cover_image:getType()) -- new buffer, filled with black
+                if self.cover_image_background == "white" then
+                    image:fill(Blitbuffer.COLOR_WHITE)
+                elseif self.cover_image_background == "gray" then
+                    image:fill(Blitbuffer.COLOR_GRAY)
+                end
+                -- copy scaled image to buffer
+                if s_w > scaled_w then -- move right
+                    image:blitFrom(cover_image, math.floor((s_w - scaled_w) / 2), 0, 0, 0, scaled_w, scaled_h)
+                else -- move down
+                    image:blitFrom(cover_image, 0, math.floor((s_h - scaled_h) / 2), 0, 0, scaled_w, scaled_h)
+                end
             end
 
-            -- copy scaled image to buffer
-            if s_w > scaled_w then -- move right
-                image:blitFrom(cover_image, math.floor((s_w - scaled_w) / 2), 0, 0, 0, scaled_w, scaled_h)
-            else -- move down
-                image:blitFrom(cover_image, 0, math.floor((s_h - scaled_h) / 2), 0, 0, scaled_w, scaled_h)
-            end
             cover_image:free()
 
             local act_format = self.cover_image_format == "auto" and self.cover_image_extension or self.cover_image_format
@@ -259,7 +272,41 @@ function CoverImage:addToMainMenu(menu_items)
                 end,
                 sub_item_table = {
                     {
-                        text = _("Scale, black background"),
+                        text_func = function()
+                            return T(_("Elastic stretch limit (%1%)"), self.cover_image_stretch_limit )
+                        end,
+                        help_text_func = function()
+                            return T(_("If the aspect ratios of the image and the screen differ less than the selected limit (%1%), the image gets stretched (instead of scaled) to fullscreen."), self.cover_image_stretch_limit )
+                        end,
+                        keep_menu_open = true,
+                        callback = function(touchmenu_instance)
+                            local old_stretch_limit = self.cover_image_stretch_limit
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            local size_spinner = SpinWidget:new{
+                                width = math.floor(Device.screen:getWidth() * 0.6),
+                                value = old_stretch_limit,
+                                value_min = 0,
+                                value_max = 25,
+                                default_value = 95,
+                                title_text =  _("Set the stretch limit"),
+                                ok_text = _("Set"),
+                                callback = function(spin)
+                                    if self.enabled and spin.value ~= old_stretch_limit then
+                                        self.cover_image_stretch_limit = spin.value
+                                        G_reader_settings:saveSetting("cover_image_stretch_limit", self.cover_image_stretch_limit)
+                                        self:createCoverImage(self.ui.doc_settings)
+                                    end
+                                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                                end
+                            }
+                            UIManager:show(size_spinner)
+                            if self.enabled and old_stretch_limit ~= self.cover_image_stretch_limit then
+                                self:createCoverImage(self.ui.doc_settings)
+                            end
+                        end,
+                    },
+                    {
+                        text = _("Fit to screen, black background"),
                         checked_func = function()
                             return self.cover_image_background == "black"
                         end,
@@ -273,7 +320,7 @@ function CoverImage:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Scale, white background"),
+                        text = _("Fit to screen, white background"),
                         checked_func = function()
                             return self.cover_image_background == "white"
                         end,
@@ -287,7 +334,7 @@ function CoverImage:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Scale, gray background"),
+                        text = _("Fit to screen, gray background"),
                         checked_func = function()
                             return self.cover_image_background == "gray"
                         end,
@@ -318,7 +365,7 @@ function CoverImage:addToMainMenu(menu_items)
                     -- menu entries: File format
                     {
                         text = _("File format derived from filename"),
-                        help_text = _("If the file format is not supported, then PNG will be used."),
+                        help_text = _("If the file format is not supported, then JPG will be used."),
                         checked_func = function()
                             return self.cover_image_format == "auto"
                         end,


### PR DESCRIPTION
If the aspect ratios of the cover image and the screen are similar, the image should get stretched (instead of being scaled) to fill the screen. Stretching looks better than scaling, if the background is only a small stripe. 

See
![Untitled](https://user-images.githubusercontent.com/36999612/106384427-0f3b7d80-63cb-11eb-8253-00edaacbc17f.jpg)

The menu has to be change also to reflect the new functionality:
![grafik](https://user-images.githubusercontent.com/36999612/106384657-4c543f80-63cc-11eb-88a3-5bc09e8df784.png)


As usual, improvements in the wording are appreciated.
How can I get rid of https://github.com/koreader/koreader/commit/c31278cee1c249ccb29aa372defc3004b2ec4f5e? Does a simple `git revert` will do the job?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7214)
<!-- Reviewable:end -->
