### PR TITLE
cervantes4: get rid of autowarmth 'feature'

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -56,6 +56,9 @@ local Cervantes = Generic:new{
     -- all devices, except the original Cervantes Touch, have frontlight
     hasFrontlight = yes,
 
+    -- REMOVE ME: workaround until the frontlight widget is sane enough
+    hasNaturalLightApi = yes,
+
     -- currently only Cervantes 4 has coloured frontlight
     hasNaturalLight = no,
     hasNaturalLightMixer = no,


### PR DESCRIPTION
Now uses a workaround that I've added for Pocketbooks, to avoid touching the fl widget. If @NiLuJe or somebody else does the same in Kobos I would gladly remove all the junk from fl widget in a companion commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7220)
<!-- Reviewable:end -->
