### PR TITLE
Button: Better handling of translucent MovableContainer

### DIFF
--- a/frontend/apps/reader/skimtowidget.lua
+++ b/frontend/apps/reader/skimtowidget.lua
@@ -316,6 +316,10 @@ function SkimToWidget:init()
             vertical_group_down,
         }
     }
+    self.movable = MovableContainer:new{
+        -- alpha = 0.8,
+        self.skimto_frame,
+    }
     self[1] = WidgetContainer:new{
         align = "center",
         dimen =Geom:new{
@@ -323,10 +327,7 @@ function SkimToWidget:init()
             w = self.screen_width,
             h = self.screen_height,
         },
-        MovableContainer:new{
-            -- alpha = 0.8,
-            self.skimto_frame,
-        }
+        self.movable,
     }
 
     if Device:hasDPad() then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -674,6 +674,10 @@ to, among other things, flag the right widget as setDirty (c.f., those pesky deb
 This is why you often see stuff doing, when instantiating a new widget, FancyWidget:new{ show_parent = self.show_parent or self };
 meaning, if I'm already a subwidget, cascade my parent, otherwise, it means I'm a window-level widget, so cascade myself as that widget's parent ;).
 
+Another convention (that a few things rely on) is naming a MovableContainer wrapping a full widget `movable`, accessible as an instance field.
+This is useful when it's used for transparency purposes, which, e.g., Button relies on to handle highlighting inside a transparent widget properly,
+by checking if self.show_parent.movable exists and is currently translucent ;).
+
 @usage
 
 UIManager:setDirty(self.widget, "partial")

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -674,7 +674,7 @@ to, among other things, flag the right widget as setDirty (c.f., those pesky deb
 This is why you often see stuff doing, when instantiating a new widget, FancyWidget:new{ show_parent = self.show_parent or self };
 meaning, if I'm already a subwidget, cascade my parent, otherwise, it means I'm a window-level widget, so cascade myself as that widget's parent ;).
 
-Another convention (that a few things rely on) is naming a MovableContainer wrapping a full widget `movable`, accessible as an instance field.
+Another convention (that a few things rely on) is naming a (persistent) MovableContainer wrapping a full widget `movable`, accessible as an instance field.
 This is useful when it's used for transparency purposes, which, e.g., Button relies on to handle highlighting inside a transparent widget properly,
 by checking if self.show_parent.movable exists and is currently translucent ;).
 

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -331,10 +331,19 @@ function Button:onTapSelectButton()
                 else
                     UIManager:widgetInvert(self[1], self[1].dimen.x, self[1].dimen.y)
                 end
-                -- If the button was disabled, switch to UI to make sure the gray comes through unharmed ;).
-                UIManager:setDirty(nil, function()
-                    return self.enabled and "fast" or "ui", self[1].dimen
-                end)
+
+                -- If our parent has a transparent movable container, repaint all the things to honor alpha
+                if self.show_parent and self.show_parent.movable and self.show_parent.movable.alpha then
+                    print("Alpha!")
+                    UIManager:setDirty("all", function()
+                        return "ui", self[1].dimen
+                    end)
+                else
+                    -- If the button was disabled, switch to UI to make sure the gray comes through unharmed ;).
+                    UIManager:setDirty(nil, function()
+                        return self.enabled and "fast" or "ui", self[1].dimen
+                    end)
+                end
                 --UIManager:forceRePaint() -- Ensures the unhighlight happens now, instead of potentially waiting and having it batched with something else.
             else
                 -- Callback closed our parent, we're done

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -279,9 +279,9 @@ function Button:onTapSelectButton()
                 UIManager:forceRePaint() -- Ensures we have a chance to see the highlight
             end
             self.callback()
-            -- We don't want to fence the callback when we're translucent, because we want a *single* refresh post-callback *and* post-unhighlight,
+            -- We don't want to fence the callback when we're *still* translucent, because we want a *single* refresh post-callback *and* post-unhighlight,
             -- in order to avoid flickering.
-            if not is_translucent then
+            if not (is_translucent and self.show_parent.movable.alpha) then
                 UIManager:forceRePaint() -- Ensures whatever the callback wanted to paint will be shown *now*...
             end
             if self.vsync then
@@ -357,7 +357,8 @@ function Button:onTapSelectButton()
     -- If our parent belongs to a translucent MovableContainer, repaint all the things to honor alpha without layering glitches,
     -- and refresh the full container, because the widget might have inhibited its own setDirty call to avoid flickering (c.f., *SpinWidget).
     if is_translucent then
-        UIManager:setDirty("all", function()
+        -- If the callback reset the transparency, we only need to repaint our parent
+        UIManager:setDirty(self.show_parent.movable.alpha and "all" or self.show_parent, function()
             return "ui", self.show_parent.movable.dimen
         end)
     end

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -279,7 +279,7 @@ function Button:onTapSelectButton()
                 UIManager:forceRePaint() -- Ensures we have a chance to see the highlight
             end
             self.callback()
-            -- We don't want to fence the callback when we're translucent, because we want a *single* refresh post-callback *and* post-unhilight,
+            -- We don't want to fence the callback when we're translucent, because we want a *single* refresh post-callback *and* post-unhighlight,
             -- in order to avoid flickering.
             if not is_translucent then
                 UIManager:forceRePaint() -- Ensures whatever the callback wanted to paint will be shown *now*...
@@ -338,7 +338,6 @@ function Button:onTapSelectButton()
                 else
                     UIManager:widgetInvert(self[1], self[1].dimen.x, self[1].dimen.y)
                 end
-
                 -- If the button was disabled, switch to UI to make sure the gray comes through unharmed ;).
                 UIManager:setDirty(nil, function()
                     return self.enabled and "fast" or "ui", self[1].dimen
@@ -355,8 +354,8 @@ function Button:onTapSelectButton()
         self:onInput(self.tap_input_func())
     end
 
-    -- If our parent belongs to a translucent MovableContainer, repaint all the things to honor alpha, and refresh the full container,
-    -- because the widget might have inhibited its own setDirty call to avoid flickering (c.f., *SpinWidget).
+    -- If our parent belongs to a translucent MovableContainer, repaint all the things to honor alpha without layering glitches,
+    -- and refresh the full container, because the widget might have inhibited its own setDirty call to avoid flickering (c.f., *SpinWidget).
     if is_translucent then
         print("alpha from", self)
         UIManager:setDirty("all", function()

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -357,7 +357,6 @@ function Button:onTapSelectButton()
     -- If our parent belongs to a translucent MovableContainer, repaint all the things to honor alpha without layering glitches,
     -- and refresh the full container, because the widget might have inhibited its own setDirty call to avoid flickering (c.f., *SpinWidget).
     if is_translucent then
-        print("alpha from", self)
         UIManager:setDirty("all", function()
             return "ui", self.show_parent.movable.dimen
         end)

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -37,9 +37,7 @@ function ButtonDialog:init()
             }
         }
     end
-    self[1] = CenterContainer:new{
-        dimen = Screen:getSize(),
-        MovableContainer:new{
+    self.movable = MovableContainer:new{
             alpha = self.alpha,
             FrameContainer:new{
                 ButtonTable:new{
@@ -56,19 +54,23 @@ function ButtonDialog:init()
                 padding_top = 0,
                 padding_bottom = 0,
             }
-        }
+    }
+
+    self[1] = CenterContainer:new{
+        dimen = Screen:getSize(),
+        self.movable,
     }
 end
 
 function ButtonDialog:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self[1][1].dimen
+        return "ui", self.movable.dimen
     end)
 end
 
 function ButtonDialog:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "flashui", self[1][1].dimen
+        return "flashui", self.movable.dimen
     end)
 end
 
@@ -87,7 +89,7 @@ end
 
 function ButtonDialog:paintTo(...)
     InputContainer.paintTo(self, ...)
-    self.dimen = self[1][1].dimen -- FrameContainer
+    self.dimen = self.movable.dimen
 end
 
 return ButtonDialog

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -828,13 +828,8 @@ function DictQuickLookup:update()
         end
     end
 
-    -- If the container is transparent, keep it that way (which requires repainting everything)
-    if self.movable.alpha then
-        -- FIXME: Buttons need to honor that somehow if flash_ui is enabled, otherwise the unhighlight is not transparent...
-        UIManager:setDirty("all", function()
-            return "partial", self.dict_frame.dimen
-        end)
-    else
+    -- If we're translucent, Button itself will handle that post-callback, in order to preserve alpha without flickering.
+    if not self.movable.alpha then
         UIManager:setDirty(self, function()
             return "partial", self.dict_frame.dimen
         end)

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -828,14 +828,17 @@ function DictQuickLookup:update()
         end
     end
 
-    -- Reset alpha to avoid stacking transparency on top of the previous content.
-    -- NOTE: This doesn't take care of the Scroll*Widget, which will preserve alpha on scroll,
-    --       leading to increasingly opaque and muddy text as half-transparent stuff gets stacked on top of each other...
-    self.movable.alpha = nil
-
-    UIManager:setDirty(self, function()
-        return "partial", self.dict_frame.dimen
-    end)
+    -- If the container is transparent, keep it that way (which requires repainting everything)
+    if self.movable.alpha then
+        -- FIXME: Buttons need to honor that somehow if flash_ui is enabled, otherwise the unhighlight is not transparent...
+        UIManager:setDirty("all", function()
+            return "partial", self.dict_frame.dimen
+        end)
+    else
+        UIManager:setDirty(self, function()
+            return "partial", self.dict_frame.dimen
+        end)
+    end
 end
 
 function DictQuickLookup:getInitialVisibleArea()

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -828,8 +828,11 @@ function DictQuickLookup:update()
         end
     end
 
-    -- If we're translucent, Button itself will handle that post-callback, in order to preserve alpha without flickering.
-    if not self.movable.alpha then
+    -- If we're translucent, reset alpha to make the new definition actually readable.
+    if self.movable.alpha then
+        self.movable.alpha = nil
+        -- And skip the setDirty, Button will handle it post-callback & post-unhighlight.
+    else
         UIManager:setDirty(self, function()
             return "partial", self.dict_frame.dimen
         end)

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -287,9 +287,13 @@ function DoubleSpinWidget:update()
         },
         self.movable,
     }
-    UIManager:setDirty(self, function()
-        return "ui", self.widget_frame.dimen
-    end)
+    -- If we're transparent, Button itself will handle that post-callback, in order to preserve alpha without flickering.
+    if not self.movable.alpha then
+        UIManager:setDirty(self, function()
+            return "ui", self.widget_frame.dimen
+        end)
+    end
+    --[[
     picker_update_callback = function()
         -- If we're actually transparent, force an alpha-aware repaint.
         if self.movable.alpha then
@@ -300,6 +304,7 @@ function DoubleSpinWidget:update()
         -- If we'd like to have the values auto-applied, uncomment this:
         -- self.callback(left_widget:getValue(), right_widget:getValue())
     end
+    --]]
 end
 
 function DoubleSpinWidget:hasMoved()

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -281,7 +281,7 @@ function DoubleSpinWidget:update()
         },
         self.movable,
     }
-    -- If we're transparent, Button itself will handle that post-callback, in order to preserve alpha without flickering.
+    -- If we're translucent, Button itself will handle that post-callback, in order to preserve alpha without flickering.
     if not self.movable.alpha then
         UIManager:setDirty(self, function()
             return "ui", self.widget_frame.dimen

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -83,10 +83,6 @@ function DoubleSpinWidget:init()
 end
 
 function DoubleSpinWidget:update()
-    -- This picker_update_callback will be redefined later.
-    -- It's a hack to restore transparency after a Button unhighlight in NumberPicker,
-    -- in case the MovableContainer was actually made transparent.
-    local picker_update_callback = function() end
     local left_widget = NumberPickerWidget:new{
         show_parent = self,
         width = self.picker_width,
@@ -96,7 +92,6 @@ function DoubleSpinWidget:update()
         value_step = self.left_step,
         value_hold_step = self.left_hold_step,
         wrap = false,
-        update_callback = function() picker_update_callback() end,
     }
     local right_widget = NumberPickerWidget:new{
         show_parent = self,
@@ -107,7 +102,6 @@ function DoubleSpinWidget:update()
         value_step = self.right_step,
         value_hold_step = self.right_hold_step,
         wrap = false,
-        update_callback = function() picker_update_callback() end,
     }
     local left_vertical_group = VerticalGroup:new{
         align = "center",
@@ -293,18 +287,6 @@ function DoubleSpinWidget:update()
             return "ui", self.widget_frame.dimen
         end)
     end
-    --[[
-    picker_update_callback = function()
-        -- If we're actually transparent, force an alpha-aware repaint.
-        if self.movable.alpha then
-            UIManager:setDirty("all", function()
-                return "ui", self.movable.dimen
-            end)
-        end
-        -- If we'd like to have the values auto-applied, uncomment this:
-        -- self.callback(left_widget:getValue(), right_widget:getValue())
-    end
-    --]]
 end
 
 function DoubleSpinWidget:hasMoved()

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -293,22 +293,9 @@ function DoubleSpinWidget:update()
     picker_update_callback = function()
         -- If we're actually transparent, force an alpha-aware repaint.
         if self.movable.alpha then
-            if G_reader_settings:nilOrTrue("flash_ui") then
-                -- It's delayed to the next tick to actually catch a Button unhighlight.
-                UIManager:nextTick(function()
-                    UIManager:setDirty("all", function()
-                        return "ui", self.movable.dimen
-                    end)
-                end)
-            else
-                -- This should only really be necessary for the up/down buttons here,
-                -- because they repaint the center value button & text, unlike said button,
-                -- which just pops up the VK.
-                -- On the upside, we shouldn't need to delay anything without flash_ui ;).
-                UIManager:setDirty("all", function()
-                    return "ui", self.movable.dimen
-                end)
-            end
+            UIManager:setDirty("all", function()
+                return "ui", self.movable.dimen
+            end)
         end
         -- If we'd like to have the values auto-applied, uncomment this:
         -- self.callback(left_widget:getValue(), right_widget:getValue())

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -12,7 +12,6 @@ Example:
         value_step = 1,
         value_hold_step = 4,
         wrap = true,
-        update_callback = function() end,
     }
 --]]
 
@@ -46,7 +45,6 @@ local NumberPickerWidget = InputContainer:new{
     value_table = nil,
     value_index = nil,
     wrap = true,
-    update_callback = function() end,
     -- in case we need calculate number of days in a given month and year
     date_month = nil,
     date_year = nil,
@@ -169,7 +167,6 @@ function NumberPickerWidget:init()
                     },
                 },
             }
-            self.update_callback()
             UIManager:show(input_dialog)
             input_dialog:onShowKeyboard()
         end
@@ -229,7 +226,6 @@ function NumberPickerWidget:update()
     UIManager:setDirty(self.show_parent, function()
         return "ui", self.dimen
     end)
-    self.update_callback()
 end
 
 --[[--

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -119,9 +119,18 @@ function ScrollHtmlWidget:scrollToRatio(ratio)
     self.htmlbox_widget:freeBb()
     self.htmlbox_widget:_render()
 
-    UIManager:setDirty(self.dialog, function()
-        return "partial", self.dimen
-    end)
+    -- If our dialog is wrapped in a movable, and that movable has been made translucent,
+    -- repaint all the things to avoid layering alpha on top of alpha,
+    -- leading to increasingly opaque and muddy text as half-transparent stuff gets stacked on top of each other...
+    if self.dialog.movable and self.dialog.movable.alpha then
+        UIManager:setDirty("all", function()
+            return "partial", self.dimen
+        end)
+    else
+        UIManager:setDirty(self.dialog, function()
+            return "partial", self.dimen
+        end)
+    end
 end
 
 function ScrollHtmlWidget:scrollText(direction)
@@ -147,9 +156,16 @@ function ScrollHtmlWidget:scrollText(direction)
     self.htmlbox_widget:freeBb()
     self.htmlbox_widget:_render()
 
-    UIManager:setDirty(self.dialog, function()
-        return "partial", self.dimen
-    end)
+    -- Handle the container's alpha as above...
+    if self.dialog.movable and self.dialog.movable.alpha then
+        UIManager:setDirty("all", function()
+            return "partial", self.dimen
+        end)
+    else
+        UIManager:setDirty(self.dialog, function()
+            return "partial", self.dimen
+        end)
+    end
 end
 
 function ScrollHtmlWidget:onScrollText(arg, ges)

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -119,9 +119,9 @@ function ScrollHtmlWidget:scrollToRatio(ratio)
     self.htmlbox_widget:freeBb()
     self.htmlbox_widget:_render()
 
-    -- If our dialog is wrapped in a movable, and that movable has been made translucent,
-    -- repaint all the things to avoid layering alpha on top of alpha,
-    -- leading to increasingly opaque and muddy text as half-transparent stuff gets stacked on top of each other...
+    -- If our dialog is wrapped in a MovableContainer and that container has been made translucent,
+    -- repaint all the things to avoid layering alpha on top of alpha, because
+    -- that would lead to increasingly opaque and muddy text as half-transparent stuff gets stacked on top of each other...
     if self.dialog.movable and self.dialog.movable.alpha then
         UIManager:setDirty("all", function()
             return "partial", self.dimen

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -119,12 +119,13 @@ function ScrollHtmlWidget:scrollToRatio(ratio)
     self.htmlbox_widget:freeBb()
     self.htmlbox_widget:_render()
 
-    -- If our dialog is wrapped in a MovableContainer and that container has been made translucent,
-    -- repaint all the things to avoid layering alpha on top of alpha, because
-    -- that would lead to increasingly opaque and muddy text as half-transparent stuff gets stacked on top of each other...
+    -- If our dialog is currently wrapped in a MovableContainer and that container has been made translucent,
+    -- reset the alpha and refresh the whole thing, because we assume that a scroll means the user actually wants to
+    -- *read* the content, which is kinda hard on a nearly transparent widget ;).
     if self.dialog.movable and self.dialog.movable.alpha then
-        UIManager:setDirty("all", function()
-            return "partial", self.dimen
+        self.dialog.movable.alpha = nil
+        UIManager:setDirty(self.dialog, function()
+            return "partial", self.dialog.movable.dimen
         end)
     else
         UIManager:setDirty(self.dialog, function()
@@ -158,8 +159,9 @@ function ScrollHtmlWidget:scrollText(direction)
 
     -- Handle the container's alpha as above...
     if self.dialog.movable and self.dialog.movable.alpha then
-        UIManager:setDirty("all", function()
-            return "partial", self.dimen
+        self.dialog.movable.alpha = nil
+        UIManager:setDirty(self.dialog, function()
+            return "partial", self.dialog.movable.dimen
         end)
     else
         UIManager:setDirty(self.dialog, function()

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -150,10 +150,11 @@ function ScrollTextWidget:updateScrollBar(is_partial)
         if is_partial then
             refreshfunc = "partial"
         end
-        -- Handle the dialog's MovableContainer potentially being translucent...
+        -- Reset transparency if the dialog's MovableContainer is currently translucent...
         if is_partial and self.dialog.movable and self.dialog.movable.alpha then
-            UIManager:setDirty("all", function()
-                return refreshfunc, self.dimen
+            self.dialog.movable.alpha = nil
+            UIManager:setDirty(self.dialog, function()
+                return refreshfunc, self.dialog.movable.dimen
             end)
         else
             UIManager:setDirty(self.dialog, function()

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -150,7 +150,7 @@ function ScrollTextWidget:updateScrollBar(is_partial)
         if is_partial then
             refreshfunc = "partial"
         end
-        -- Handle the dialog's container potentially being translucent...
+        -- Handle the dialog's MovableContainer potentially being translucent...
         if is_partial and self.dialog.movable and self.dialog.movable.alpha then
             UIManager:setDirty("all", function()
                 return refreshfunc, self.dimen

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -150,9 +150,16 @@ function ScrollTextWidget:updateScrollBar(is_partial)
         if is_partial then
             refreshfunc = "partial"
         end
-        UIManager:setDirty(self.dialog, function()
-            return refreshfunc, self.dimen
-        end)
+        -- Handle the dialog's container potentially being translucent...
+        if is_partial and self.dialog.movable and self.dialog.movable.alpha then
+            UIManager:setDirty("all", function()
+                return refreshfunc, self.dimen
+            end)
+        else
+            UIManager:setDirty(self.dialog, function()
+                return refreshfunc, self.dimen
+            end)
+        end
         if self.scroll_callback then
             self.scroll_callback(low, high)
         end

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -234,7 +234,7 @@ function SpinWidget:update()
         },
         self.movable,
     }
-    -- If we're transparent, Button itself will handle that post-callback, in order to preserve alpha without flickering.
+    -- If we're translucent, Button itself will handle that post-callback, in order to preserve alpha without flickering.
     if not self.movable.alpha then
         UIManager:setDirty(self, function()
             return "ui", self.spin_frame.dimen


### PR DESCRIPTION
* By actually being aware of that fact, and delaying a single full repaint post-callback and post-unhighlight, in order to avoid flickering glitches (especially when flash_ui is enabled).
* Scroll*Widget: handle belonging to a translucent dialog properly on scroll.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7223)
<!-- Reviewable:end -->
