### PR TITLE
[chore] Properly set CoverImage menu order

### DIFF
--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -100,6 +100,7 @@ local order = {
     },
     screen = {
         "screensaver",
+        "coverimage",
         "----------------------------",
         "screen_rotation",
         "----------------------------",
@@ -109,8 +110,6 @@ local order = {
         "----------------------------",
         "screen_timeout",
         "fullscreen",
-        "----------------------------",
-        "coverimage",
     },
     taps_and_gestures = {
         "gesture_manager",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -109,6 +109,8 @@ local order = {
         "----------------------------",
         "screen_timeout",
         "fullscreen",
+        "----------------------------",
+        "coverimage",
     },
     taps_and_gestures = {
         "gesture_manager",


### PR DESCRIPTION
Reported by @pazos in <https://github.com/koreader/koreader/pull/7237#discussion_r570395126>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7239)
<!-- Reviewable:end -->
