### PR TITLE
Add low battery status bar item which is hidden when above the low battery threshold

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -42,6 +42,7 @@ local MODE = {
     book_title = 12,
     book_chapter = 13,
     bookmark_count = 14,
+    low_battery = 15,
 }
 
 local symbol_prefix = {
@@ -147,6 +148,53 @@ local footerTextGeneratorMap = {
         local prefix = symbol_prefix[symbol_type].battery
         local powerd = Device:getPowerDevice()
         local batt_lvl = powerd:getCapacity()
+        -- If we're using icons, use fancy variable icons
+        if symbol_type == "icons" or symbol_type == "compact_items" then
+            if powerd:isCharging() then
+                prefix = ""
+            else
+                if batt_lvl >= 100 then
+                    prefix = ""
+                elseif batt_lvl >= 90 then
+                    prefix = ""
+                elseif batt_lvl >= 80 then
+                    prefix = ""
+                elseif batt_lvl >= 70 then
+                    prefix = ""
+                elseif batt_lvl >= 60 then
+                    prefix = ""
+                elseif batt_lvl >= 50 then
+                    prefix = ""
+                elseif batt_lvl >= 40 then
+                    prefix = ""
+                elseif batt_lvl >= 30 then
+                    prefix = ""
+                elseif batt_lvl >= 20 then
+                    prefix = ""
+                elseif batt_lvl >= 10 then
+                    prefix = ""
+                else
+                    prefix = ""
+                end
+            end
+            if symbol_type == "compact_items" then
+                return BD.wrap(prefix)
+            else
+                return BD.wrap(prefix) .. batt_lvl .. "%"
+            end
+        else
+            return BD.wrap(prefix) .. " " .. (powerd:isCharging() and "+" or "") .. batt_lvl .. "%"
+        end
+    end,
+    low_battery = function(footer)
+        local symbol_type = footer.settings.item_prefix or "icons"
+        local prefix = symbol_prefix[symbol_type].battery
+        local powerd = Device:getPowerDevice()
+        local batt_lvl = powerd:getCapacity()
+        local threshold = G_reader_settings:readSetting("low_battery_threshold") or 20
+        if footer.settings.hide_empty_generators and batt_lvl > threshold then
+            return ""
+        end
         -- If we're using icons, use fancy variable icons
         if symbol_type == "icons" or symbol_type == "compact_items" then
             if powerd:isCharging() then
@@ -843,6 +891,7 @@ function ReaderFooter:textOptionTitles(option)
             and T(_("Current time (%1)"), symbol_prefix[symbol].time) or _("Current time"),
         pages_left = T(_("Pages left in chapter (%1)"), symbol_prefix[symbol].pages_left),
         battery = T(_("Battery status (%1)"), symbol_prefix[symbol].battery),
+        low_battery = T(_("Battery status when low (%1)"), symbol_prefix[symbol].battery),
         percentage = symbol_prefix[symbol].percentage
             and T(_("Progress percentage (%1)"), symbol_prefix[symbol].percentage) or _("Progress percentage"),
         book_time_to_read = symbol_prefix[symbol].book_time_to_read
@@ -1747,6 +1796,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     table.insert(sub_items, getMinibarOption("pages_left"))
     if Device:hasBattery() then
         table.insert(sub_items, getMinibarOption("battery"))
+        table.insert(sub_items, getMinibarOption("low_battery"))
     end
     table.insert(sub_items, getMinibarOption("bookmark_count"))
     table.insert(sub_items, getMinibarOption("percentage"))


### PR DESCRIPTION
Most of the time I'm not interested in the battery level. However, when the battery's running low it's nice to keep half an eye on how much is left. I've implemented a new status item, "Battery status when low", which is hidden when "Hide empty items" is on, and the battery level is above the threshold configured in Device > Low battery alarm > Low battery threshold, but otherwise identical to the normal battery status.

I've implemented it as a new status on the assumption that the existing battery status should be kept as is.

Tested and works as intended, although ideally I'd like to avoid duplicating the regular battery status code, but I figured I'd get some feedback, see if people think this is useful, etc.

I wanted to do something like this:
```
    battery = function(footer)
         ...
    end,
    low_battery = function(footer)
        local powerd = Device:getPowerDevice()
        local batt_lvl = powerd:getCapacity()
        local threshold = G_reader_settings:readSetting("low_battery_threshold") or 20
        if footer.settings.hide_empty_generators and batt_lvl > threshold then
            return ""
        else
            -- delegate to normal battery status function
            return battery(footer)
        end
    end,
```
but I couldn't work out how to call the normal battery function (or if it's even possible in this scope). Guess I could factor it out into a separate function which they both call?

The other flaw with this implementation is that if you uncheck Device > Low battery alarm > Enable, this low battery status still works, and still uses the configured threshold, but it won't let you change the threshold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7242)
<!-- Reviewable:end -->
