### PR TITLE
Remove leftover in CoverImage after  #7239

### DIFF
--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -170,8 +170,6 @@ If the fallback image isn't activated, the screensaver image will stay in place 
 
 function CoverImage:addToMainMenu(menu_items)
     menu_items.coverimage = {
---        sorting_hint = "document",
-        sorting_hint = "screen",
         text = _("Save cover image"),
         checked_func = function()
             return self.enabled or self.fallback


### PR DESCRIPTION
`sorting_hint` is not necessary after #7239 anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7245)
<!-- Reviewable:end -->
