### PR TITLE
File browser settings: reorganize into Settings submenu

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -142,19 +142,20 @@ function FileManagerMenu:setUpdateItemTable()
     end
 
     -- setting tab
-    self.menu_items.show_hidden_files = {
-        text = _("Show hidden files"),
-        checked_func = function() return self.ui.file_chooser.show_hidden end,
-        callback = function() self.ui:toggleHiddenFiles() end
-    }
-    self.menu_items.show_unsupported_files = {
-        text = _("Show unsupported files"),
-        checked_func = function() return self.ui.file_chooser.show_unsupported end,
-        callback = function() self.ui:toggleUnsupportedFiles() end
-    }
-    self.menu_items.items = {
-        text = _("Items"),
+    self.menu_items.filebrowser_settings = {
+        text = _("Settings"),
         sub_item_table = {
+            {
+                text = _("Show hidden files"),
+                checked_func = function() return self.ui.file_chooser.show_hidden end,
+                callback = function() self.ui:toggleHiddenFiles() end,
+            },
+            {
+                text = _("Show unsupported files"),
+                checked_func = function() return self.ui.file_chooser.show_unsupported end,
+                callback = function() self.ui:toggleUnsupportedFiles() end,
+                separator = true,
+            },
             {
                 text = _("Items per page"),
                 help_text = _([[This sets the number of items per page in:
@@ -182,10 +183,10 @@ function FileManagerMenu:setUpdateItemTable()
                         end
                     }
                     UIManager:show(items)
-                end
+                end,
             },
             {
-                text = _("Font size"),
+                text = _("Item font size"),
                 keep_menu_open = true,
                 callback = function()
                     local Menu = require("ui/widget/menu")
@@ -200,7 +201,7 @@ function FileManagerMenu:setUpdateItemTable()
                         value_max = 72,
                         default_value = default_font_size,
                         keep_shown_on_apply = true,
-                        title_text =  _("Maximum font size for item"),
+                        title_text =  _("Item font size"),
                         callback = function(spin)
                             if spin.value == default_font_size then
                                 -- We can't know if the user has set a size or hit "Use default", but
@@ -214,10 +215,10 @@ function FileManagerMenu:setUpdateItemTable()
                         end
                     }
                     UIManager:show(items_font)
-                end
+                end,
             },
             {
-                text = _("Reduce font size to show more text"),
+                text = _("Shrink item font size to fit more text"),
                 keep_menu_open = true,
                 checked_func = function()
                     return G_reader_settings:isTrue("items_multilines_show_more_text")
@@ -225,8 +226,72 @@ function FileManagerMenu:setUpdateItemTable()
                 callback = function()
                     G_reader_settings:flipNilOrFalse("items_multilines_show_more_text")
                     self.ui:onRefresh()
-                end
-            }
+                end,
+            },
+            {
+                text_func = function()
+                    local current_state = _("Show new files in bold")
+                    if G_reader_settings:readSetting("show_file_in_bold") == "opened" then
+                        current_state = _("Show opened files in bold")
+                    elseif G_reader_settings:readSetting("show_file_in_bold") == false then
+                        current_state = _("Show files in bold") -- with checkmark unchecked
+                    end
+                    -- Inform that this settings applies only to classic file chooser
+                    current_state = T(_("(Classic file browser) %1"), current_state)
+                    return current_state
+                end,
+                checked_func = function() return G_reader_settings:readSetting("show_file_in_bold") ~= false end,
+                sub_item_table = {
+                    {
+                        text = _("Don't show files in bold"),
+                        checked_func = function() return G_reader_settings:readSetting("show_file_in_bold") == false end,
+                        callback = function()
+                            G_reader_settings:saveSetting("show_file_in_bold", false)
+                            self.ui:onRefresh()
+                        end,
+                    },
+                    {
+                        text = _("Show opened files in bold"),
+                        checked_func = function() return G_reader_settings:readSetting("show_file_in_bold") == "opened" end,
+                        callback = function()
+                            G_reader_settings:saveSetting("show_file_in_bold", "opened")
+                            self.ui:onRefresh()
+                        end,
+                    },
+                    {
+                        text = _("Show new (not yet opened) files in bold"),
+                        checked_func = function()
+                            return G_reader_settings:readSetting("show_file_in_bold") ~= false and G_reader_settings:readSetting("show_file_in_bold") ~= "opened"
+                        end,
+                        callback = function()
+                            G_reader_settings:delSetting("show_file_in_bold")
+                            self.ui:onRefresh()
+                        end,
+                    },
+                },
+                separator = true,
+            },
+            {
+                text = _("Shorten home directory"),
+                checked_func = function()
+                    return G_reader_settings:nilOrTrue("shorten_home_dir")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrTrue("shorten_home_dir")
+                    local FileManager = require("apps/filemanager/filemanager")
+                    if FileManager.instance then FileManager.instance:reinit() end
+                end,
+            },
+            {
+                text = _("Show filename in Open last/previous menu items"),
+                checked_func = function() return G_reader_settings:readSetting("open_last_menu_show_filename") end,
+                callback = function() G_reader_settings:flipNilOrFalse("open_last_menu_show_filename") end,
+            },
+            {
+                text = _("Auto-remove deleted or purged items from history"),
+                checked_func = function() return G_reader_settings:readSetting("autoremove_deleted_items_from_history") end,
+                callback = function() G_reader_settings:flipNilOrFalse("autoremove_deleted_items_from_history") end,
+            },
         }
     }
     self.menu_items.sort_by = self.ui:getSortingMenuTable()

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -11,9 +11,7 @@ local order = {
     },
     filemanager_settings = {
         "filemanager_display_mode",
-        "show_hidden_files",
-        "show_unsupported_files",
-        "items",
+        "filebrowser_settings",
         "----------------------------",
         "sort_by",
         "reverse_sorting",


### PR DESCRIPTION
Move classic file browser settings from CoverBrowser plugin into FileManagerMenu, so they are available when this plugin is disabled (as they also apply to everything based on Menu).
Disccused at https://github.com/koreader/koreader/issues/7141#issuecomment-774727373.

Updated screenshots:

<kbd>![image](https://user-images.githubusercontent.com/24273478/107204568-1a129580-69fd-11eb-8aac-83b03f34027a.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/107204582-20a10d00-69fd-11eb-98d0-910725c53cae.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/107204654-36aecd80-69fd-11eb-845d-5b4dad0c1fa4.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/107204463-fcddc700-69fc-11eb-80c9-25bae63e943c.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/107204505-05360200-69fd-11eb-8301-4375f1564f51.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7259)
<!-- Reviewable:end -->
