### PR TITLE
Improved ramp-down of warm-light after max hour

### DIFF
--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -152,18 +152,20 @@ function CervantesPowerD:calculateAutoWarmth()
     local current_time = os.date("%H") + os.date("%M")/60
     local max_hour = self.max_warmth_hour
     local diff_time = max_hour - current_time
+    -- number of hours to stay at full warmth before decreasing
+    local warm_window = 4
     if diff_time < 0 then
         diff_time = diff_time + 24
     end
     if diff_time < 12 then
         -- We are before bedtime. Use a slower progression over 5h.
         self.fl_warmth = math.max(20 * (5 - diff_time), 0)
-    elseif diff_time > 22 then
-        -- Keep warmth at maximum for two hours after bedtime.
+    elseif diff_time > (24 - warm_window) then
+        -- Keep warmth at maximum for 'warm_window' hours after bedtime.
         self.fl_warmth = 100
     else
-        -- Between 2-4h after bedtime, return to zero.
-        self.fl_warmth = math.max(100 - 15 * (22 - diff_time), 0)
+        -- Decrease for each subsequent hour by 20% per hour
+        self.fl_warmth = math.max(100 - 20 * (24 - warm_window - diff_time), 0)
     end
     self.fl_warmth = math.floor(self.fl_warmth + 0.5)
 

--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -163,7 +163,7 @@ function CervantesPowerD:calculateAutoWarmth()
         self.fl_warmth = 100
     else
         -- Between 2-4h after bedtime, return to zero.
-        self.fl_warmth = math.max(100 - 50 * (22 - diff_time), 0)
+        self.fl_warmth = math.max(100 - 15 * (22 - diff_time), 0)
     end
     self.fl_warmth = math.floor(self.fl_warmth + 0.5)
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -278,7 +278,7 @@ function KoboPowerD:calculateAutoWarmth()
         self.fl_warmth = 100
     else
         -- Between 2-4h after bedtime, return to zero.
-        self.fl_warmth = math.max(100 - 50 * (22 - diff_time), 0)
+        self.fl_warmth = math.max(100 - 15 * (22 - diff_time), 0)
     end
     self.fl_warmth = math.floor(self.fl_warmth + 0.5)
     -- Make sure sysfs_light actually picks that new value up without an explicit setWarmth call...

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -267,18 +267,20 @@ function KoboPowerD:calculateAutoWarmth()
     local current_time = os.date("%H") + os.date("%M")/60
     local max_hour = self.max_warmth_hour
     local diff_time = max_hour - current_time
+    -- number of hours to stay at full warmth before decreasing
+    local warm_window = 4
     if diff_time < 0 then
         diff_time = diff_time + 24
     end
     if diff_time < 12 then
         -- We are before bedtime. Use a slower progression over 5h.
         self.fl_warmth = math.max(20 * (5 - diff_time), 0)
-    elseif diff_time > 22 then
-        -- Keep warmth at maximum for two hours after bedtime.
+    elseif diff_time > (24 - warm_window) then
+        -- Keep warmth at maximum for 'warm_window' hours after bedtime.
         self.fl_warmth = 100
     else
-        -- Between 2-4h after bedtime, return to zero.
-        self.fl_warmth = math.max(100 - 15 * (22 - diff_time), 0)
+        -- Decrease for each subsequent hour by 20% per hour
+        self.fl_warmth = math.max(100 - 20 * ((24 - warm_window) - diff_time), 0)
     end
     self.fl_warmth = math.floor(self.fl_warmth + 0.5)
     -- Make sure sysfs_light actually picks that new value up without an explicit setWarmth call...


### PR DESCRIPTION
This change is to improve the ramp-down of the warm-light.  Currently the warm light stays at 100% for 3 hours, and then drops to 50% and then 0%, meaning that you get a suddend and major change if you're still up reading at that hour.  If you set your max-warmth to 20:00 (8:00pm), then it'll be at max warmth at 8, 9, 10, then 50% at 11, and back to 0% at midnight.  

Ideally there would be a way to adjust these factors or to set the time at which it starts to return to 0% and calculate from there, which I might implement later if it doesn't look too hard, but for now this is still much better as it drops by 15% per hour giving you:

100,100,100,85,70,55,40,25,10,0 -- if you start at 8:00pm (as above) it'll be back to 0 at 5am.  If you start at 11:00pm, then it'll be back to the coolest setting at 8:00 am.

<img width="2454" alt="image" src="https://user-images.githubusercontent.com/399845/107468825-92707800-6b1d-11eb-9d3f-6299fcd1c428.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7272)
<!-- Reviewable:end -->
