### PR TITLE
TOC settings: add bind chapter navigation/titles to ticks

### DIFF
--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -39,6 +39,9 @@ local function buildEntry(input_time, input_file)
             end
             return util.secondsToDate(last_read_ts, G_reader_settings:isTrue("twelve_hour_clock"))
         end,
+        select_enabled_func = function()
+            return lfs.attributes(file_path, "mode") == "file"
+        end,
         callback = function()
             local ReaderUI = require("apps/reader/readerui")
             ReaderUI:showReader(input_file)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1228,6 +1228,14 @@ override this function to process the item selected in a different manner
 ]]--
 function Menu:onMenuSelect(item)
     if item.sub_item_table == nil then
+        if item.select_enabled == false then
+            return true
+        end
+        if item.select_enabled_func then
+            if not item.select_enabled_func() then
+                return true
+            end
+        end
         if self.close_callback then
             self.close_callback()
         end


### PR DESCRIPTION
#### TOC settings: add bind chapter navigation/titles to ticks

Add 2 convenience settings, allowing ToC ignored depths settings to apply further than just the progress bars.
See https://github.com/koreader/koreader/pull/7238#issuecomment-774729725 and followups.

<kbd>![image](https://user-images.githubusercontent.com/24273478/107854503-82f27700-6e1c-11eb-8f5c-c03145a5373e.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/107854495-73732e00-6e1c-11eb-9b3a-eff6a8894c43.png)</kbd>


Also includes:

~~#### Button: don't handle long-press when not enabled~~

~~It was only not handled when hold_callback. Do that also when hold_input/hold_input_func.
Menu: prevent long-press on "No choice available", as there's then no page to navigate to.
Closes #7276.~~
^ Updated commit included in hotfix #7300.

#### History: avoid opening non-existent files

Mostly just so we don't get the History closed when erroneously tapping on a deleted file.
See https://github.com/koreader/koreader/issues/7271#issuecomment-778280742. Closes #7271.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7280)
<!-- Reviewable:end -->
