### PR TITLE
KeyValuePage: configurable items per page

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -64,8 +64,7 @@ function BookInfo:show(file, book_props)
     table.insert(kv_pairs, { _("Format:"), filetype:upper() })
     table.insert(kv_pairs, { _("Size:"), size })
     table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", file_modification) })
-    table.insert(kv_pairs, { _("Directory:"), BD.dirpath(filemanagerutil.abbreviate(directory)) })
-    table.insert(kv_pairs, "----")
+    table.insert(kv_pairs, { _("Directory:"), BD.dirpath(filemanagerutil.abbreviate(directory)), separator = true })
 
     -- book_props may be provided if caller already has them available
     -- but it may lack 'pages', that we may get from sidecar file

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -165,8 +165,8 @@ function FileManagerMenu:setUpdateItemTable()
 - Calibre and OPDS browsers/search results]]),
                 keep_menu_open = true,
                 callback = function()
-                    local Menu = require("ui/widget/menu")
                     local SpinWidget = require("ui/widget/spinwidget")
+                    local Menu = require("ui/widget/menu")
                     local default_perpage = Menu.items_per_page_default
                     local curr_perpage = G_reader_settings:readSetting("items_per_page") or default_perpage
                     local items = SpinWidget:new{
@@ -189,8 +189,8 @@ function FileManagerMenu:setUpdateItemTable()
                 text = _("Item font size"),
                 keep_menu_open = true,
                 callback = function()
-                    local Menu = require("ui/widget/menu")
                     local SpinWidget = require("ui/widget/spinwidget")
+                    local Menu = require("ui/widget/menu")
                     local curr_perpage = G_reader_settings:readSetting("items_per_page") or Menu.items_per_page_default
                     local default_font_size = Menu.getItemFontSize(curr_perpage)
                     local curr_font_size = G_reader_settings:readSetting("items_font_size") or default_font_size
@@ -206,7 +206,7 @@ function FileManagerMenu:setUpdateItemTable()
                             if spin.value == default_font_size then
                                 -- We can't know if the user has set a size or hit "Use default", but
                                 -- assume that if it is the default font size, he will prefer to have
-                                -- our default font size if he later update per-page
+                                -- our default font size if he later updates per-page
                                 G_reader_settings:delSetting("items_font_size")
                             else
                                 G_reader_settings:saveSetting("items_font_size", spin.value)
@@ -291,6 +291,41 @@ function FileManagerMenu:setUpdateItemTable()
                 text = _("Auto-remove deleted or purged items from history"),
                 checked_func = function() return G_reader_settings:readSetting("autoremove_deleted_items_from_history") end,
                 callback = function() G_reader_settings:flipNilOrFalse("autoremove_deleted_items_from_history") end,
+                separator = true,
+            },
+            {
+                text = _("Info lists items per page"),
+                help_text = _([[This sets the number of items per page in:
+- Book information
+- Dictionary and Wikipedia lookup history
+- Reading statistics details
+- A few other plugins]]),
+                keep_menu_open = true,
+                callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local KeyValuePage = require("ui/widget/keyvaluepage")
+                    local default_perpage = KeyValuePage:getDefaultKeyValuesPerPage()
+                    local curr_perpage = G_reader_settings:readSetting("keyvalues_per_page") or default_perpage
+                    local items = SpinWidget:new{
+                        width = math.floor(Screen:getWidth() * 0.6),
+                        value = curr_perpage,
+                        value_min = 10,
+                        value_max = 24,
+                        default_value = default_perpage,
+                        title_text =  _("Info lists items per page"),
+                        callback = function(spin)
+                            if spin.value == default_perpage then
+                                -- We can't know if the user has set a value or hit "Use default", but
+                                -- assume that if it is the default, he will prefer to stay with our
+                                -- default if he later changes screen DPI
+                                G_reader_settings:delSetting("keyvalues_per_page")
+                            else
+                                G_reader_settings:saveSetting("keyvalues_per_page", spin.value)
+                            end
+                        end
+                    }
+                    UIManager:show(items)
+                end,
             },
         }
     }
@@ -498,7 +533,7 @@ function FileManagerMenu:setUpdateItemTable()
         end,
     })
     table.insert(self.menu_items.developer_options.sub_item_table, {
-        text = "UI layout mirroring and text direction",
+        text = _("UI layout mirroring and text direction"),
         sub_item_table = {
             {
                 text = _("Reverse UI layout mirroring"),

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -241,6 +241,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
             end
             UIManager:show(KeyValuePage:new{
                 title = _("Dictionary lookup history"),
+                value_overflow_align = "right",
                 kv_pairs = kv_pairs,
             })
         end,
@@ -944,8 +945,7 @@ function ReaderDictionary:showDownload(downloadable_dicts)
         end
         table.insert(kv_pairs, {lang, ""})
         table.insert(kv_pairs, {"    ".._("License"), dict.license})
-        table.insert(kv_pairs, {"    ".._("Entries"), dict.entries})
-        table.insert(kv_pairs, "----------------------------")
+        table.insert(kv_pairs, {"    ".._("Entries"), dict.entries, separator = true})
     end
     self.download_window = KeyValuePage:new{
         title = _("Tap dictionary name to download"),

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -807,7 +807,7 @@ function ReaderTypography:onPreRenderDocument(config)
     -- Add a menu item to language sub-menu, whether the lang is known or not, so the
     -- user can see it and switch from and back to it easily
     table.insert(self.language_submenu, 1, {
-        text = T(_("Book language: %1"), self.book_lang_tag or _("n/a")),
+        text = T(_("Book language: %1"), self.book_lang_tag or _("N/A")),
         callback = function()
             UIManager:show(InfoMessage:new{
                 text = T(_("Changed language for typography rules to book language: %1."), BD.wrap(self.book_lang_tag)),

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -106,6 +106,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
             end
             UIManager:show(KeyValuePage:new{
                 title = _("Wikipedia history"),
+                value_overflow_align = "right",
                 kv_pairs = kv_pairs,
             })
         end,

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -63,19 +63,19 @@ function Usage:percentagePerHour()
 end
 
 function Usage:remainingHours()
-    if self:percentagePerHour() == 0 then return "n/a" end
+    if self:percentagePerHour() == 0 then return "N/A" end
     local curr = State:new()
     return curr.percentage / self:percentagePerHour()
 end
 
 function Usage:chargingHours()
-    if self:percentagePerHour() == 0 then return "n/a" end
+    if self:percentagePerHour() == 0 then return "N/A" end
     local curr = State:new()
     return math.abs(curr.percentage - 100) / self:percentagePerHour()
 end
 
 local function shorten(number)
-    if number == "n/a" then return _("n/a") end
+    if number == "N/A" then return _("N/A") end
     return string.format("%.2f", number);
 end
 
@@ -199,7 +199,7 @@ function BatteryStat:showStatistics()
 
     self:accumulate()
     local kv_pairs = self:dump()
-    table.insert(kv_pairs, "----------")
+    kv_pairs[#kv_pairs].separator = true
     table.insert(kv_pairs, {_("If you would like to reset the data,"), "",
                             callback = function()
                                 UIManager:setDirty(self.kv_page, "fast")

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1099,8 +1099,8 @@ function ReaderStatistics:statMenu()
                     }
                     UIManager:show(self.kv)
                 end,
+                separator = true,
             },
-            "----",
             { _("Last week"),"",
                 callback = function()
                     local kv = self.kv
@@ -1303,8 +1303,7 @@ function ReaderStatistics:getCurrentStat(id_book)
         { _("Pages read this session"), tonumber(current_pages) },
         -- today
         { _("Time spent reading today"), util.secondsToClock(today_duration, false) },
-        { _("Pages read today"), tonumber(today_pages) },
-        "----",
+        { _("Pages read today"), tonumber(today_pages), separator = true },
         -- Current book statistics
         -- Includes re-reads
         { _("Total time spent on this book"), util.secondsToClock(total_time_book, false) },
@@ -1324,7 +1323,7 @@ function ReaderStatistics:getCurrentStat(id_book)
         { _("Estimated reading finished"),
             T(N_("%1 (1 day)", "%1 (%2 days)", estimate_days_to_read), estimate_end_of_read_date, estimate_days_to_read) },
 
-        { _("Highlights"), tonumber(highlights) },
+        { _("Highlights"), tonumber(highlights), separator = true },
         -- { _("Total notes"), tonumber(notes) }, -- not accurate, don't show it
     }
 end
@@ -1404,9 +1403,8 @@ function ReaderStatistics:getBookStat(id_book)
         -- These 2 ones are about page actually read (not the current page and % into book)
         { _("Read pages/Total pages"), total_read_pages .. "/" .. pages },
         { _("Percentage read"), Math.round(total_read_pages / pages * 100) .. "%" },
-        { _("Highlights"), highlights },
+        { _("Highlights"), highlights, separator = true },
         -- { _("Total notes"), notes }, -- not accurate, don't show it
-        "----",
         { _("Show days"), _("Tap to display"),
             callback = function()
                 local kv = self.kv

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -31,6 +31,10 @@ function SystemStat:put(p)
     table.insert(self.kv_pairs, p)
 end
 
+function SystemStat:putSeparator()
+    self.kv_pairs[#self.kv_pairs].separator = true
+end
+
 function SystemStat:appendCounters()
     self:put({_("KOReader started at"), os.date("%c", self.start_sec)})
     if self.suspend_sec then
@@ -232,8 +236,11 @@ end
 function SystemStat:showStatistics()
     self.kv_pairs = {}
     self:appendCounters()
+    self:putSeparator()
     self:appendProcessInfo()
+    self:putSeparator()
     self:appendStorageInfo()
+    self:putSeparator()
     self:appendSystemInfo()
     UIManager:show(KeyValuePage:new{
         title = _("System statistics"),


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/3620#issuecomment-777775675. Closes #3620.

#### KeyValuePage: configurable items per page

Tweak building to start from items per page instead of a fixed item height.
Guess the best font size that fit.
Update separator specification from using a `"----"` to the now generic `separator=true` (this allows not wasting a slot for each separator in the page and not have only 12 items and 2 small lines in a 14 items page).

<kbd>![image](https://user-images.githubusercontent.com/24273478/107848564-a86b8a80-6df4-11eb-8468-64b0343ddea2.png)</kbd>

Before | After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/107854793-a9191680-6e1e-11eb-8ee8-eafc98e37171.png)</kbd>

And when switched from the default of 12 (on my emulator with Screen DPI: small) to a custom value of 16:
<kbd>![image](https://user-images.githubusercontent.com/24273478/107854834-ed0c1b80-6e1e-11eb-8059-b20091aa2abf.png)</kbd>


#### Reading statistics: tweak book stats views

Make "Current statistics" and previsouly opened book statistics display missing info that the other view
has, mostly:
- Pages read: `nb (pct%)`
- Current page/Total pages: `num/total (pct%)`

Stats for the same book as above, but invoked from Calendar or Time range when book is closed:
<kbd>![image](https://user-images.githubusercontent.com/24273478/107854847-057c3600-6e1f-11eb-80a0-44f4d6c500da.png)</kbd>

(The difference between current page 22 and last read page 21 is because I didn't stay long enough on that page 22, and the not-opened book use the last page_stat saved, to avoid opening the docsetting - and because past books may no longer be there so no docsettings to look at.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7282)
<!-- Reviewable:end -->
