### PR TITLE
Reversing commit 2348cd, changes to warmth values

### DIFF
--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -152,20 +152,18 @@ function CervantesPowerD:calculateAutoWarmth()
     local current_time = os.date("%H") + os.date("%M")/60
     local max_hour = self.max_warmth_hour
     local diff_time = max_hour - current_time
-    -- number of hours to stay at full warmth before decreasing
-    local warm_window = 4
     if diff_time < 0 then
         diff_time = diff_time + 24
     end
     if diff_time < 12 then
         -- We are before bedtime. Use a slower progression over 5h.
         self.fl_warmth = math.max(20 * (5 - diff_time), 0)
-    elseif diff_time > (24 - warm_window) then
-        -- Keep warmth at maximum for 'warm_window' hours after bedtime.
+    elseif diff_time > 22 then
+        -- Keep warmth at maximum for two hours after bedtime.
         self.fl_warmth = 100
     else
-        -- Decrease for each subsequent hour by 20% per hour
-        self.fl_warmth = math.max(100 - 20 * (24 - warm_window - diff_time), 0)
+        -- Between 2-4h after bedtime, return to zero.
+        self.fl_warmth = math.max(100 - 50 * (22 - diff_time), 0)
     end
     self.fl_warmth = math.floor(self.fl_warmth + 0.5)
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -267,20 +267,18 @@ function KoboPowerD:calculateAutoWarmth()
     local current_time = os.date("%H") + os.date("%M")/60
     local max_hour = self.max_warmth_hour
     local diff_time = max_hour - current_time
-    -- number of hours to stay at full warmth before decreasing
-    local warm_window = 4
     if diff_time < 0 then
         diff_time = diff_time + 24
     end
     if diff_time < 12 then
         -- We are before bedtime. Use a slower progression over 5h.
         self.fl_warmth = math.max(20 * (5 - diff_time), 0)
-    elseif diff_time > (24 - warm_window) then
-        -- Keep warmth at maximum for 'warm_window' hours after bedtime.
+    elseif diff_time > 22 then
+        -- Keep warmth at maximum for two hours after bedtime.
         self.fl_warmth = 100
     else
-        -- Decrease for each subsequent hour by 20% per hour
-        self.fl_warmth = math.max(100 - 20 * ((24 - warm_window) - diff_time), 0)
+        -- Between 2-4h after bedtime, return to zero.
+        self.fl_warmth = math.max(100 - 50 * (22 - diff_time), 0)
     end
     self.fl_warmth = math.floor(self.fl_warmth + 0.5)
     -- Make sure sysfs_light actually picks that new value up without an explicit setWarmth call...


### PR DESCRIPTION
Somewhat urgent PR, please merge before the next stable build -- the changes I made somehow made the warm light hours even worse, so I'm reverting them.

Even though I've plotted the output of the algorithm multiple times in both a spreadsheet, and copied the algorithm into Python and made the minimal changes necessary to make it work in Python and plotted the output using numpy and the algorithm is absolutely correct -- there's something VERY weird about the warm-light code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7296)
<!-- Reviewable:end -->
