### PR TITLE
Wikipedia results: fix images not updated across results

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -810,7 +810,11 @@ function DictQuickLookup:update()
         self.text_widget:resetScroll()
     elseif not self.is_html and self.stw_widget then
         -- Re-use our ScrollTextWidget (self.stw_widget)
+        -- Update properties that may change across results (as done in DictQuickLookup:_instantiateScrollWidget())
         self.text_widget.text_widget.text = self.definition
+        self.text_widget.text_widget.lang = self.lang and self.lang:lower()
+        self.text_widget.text_widget.para_direction_rtl = self.rtl_lang
+        self.text_widget.text_widget.images = self.images
         -- NOTE: The recursive free via our WidgetContainer (self[1]) above already free'd us ;)
         self.text_widget.text_widget:init()
         -- Scroll back to top

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1024,6 +1024,7 @@ function Menu:updatePageInfo(select_number)
         -- update page information
         if self.page_num > 1 then
             self.page_info_text:setText(FFIUtil.template(_("Page %1 of %2"), self.page, self.page_num))
+            self.page_info_text.enabled = true
         else
             self.page_info_text:setText("");
         end
@@ -1040,6 +1041,7 @@ function Menu:updatePageInfo(select_number)
         self.page_return_arrow:enableDisable(#self.paths > 0)
     else
         self.page_info_text:setText(_("No choices available"))
+        self.page_info_text.enabled = false
     end
 end
 

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -244,6 +244,7 @@ end
 -- Split the text into logical lines to fit into the text box.
 function TextBoxWidget:_splitToLines()
     self.vertical_string_list = {}
+    self.line_num_to_image = nil
 
     local idx = 1
     local size = #self.charlist


### PR DESCRIPTION
Some results fields were forgotten by the "smarter update" from #7212.
See https://github.com/koreader/koreader/pull/7166#issuecomment-779654246.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7300)
<!-- Reviewable:end -->
