### PR TITLE
Adjust wording of coverimage plugin

### DIFF
--- a/plugins/coverimage.koplugin/_meta.lua
+++ b/plugins/coverimage.koplugin/_meta.lua
@@ -1,6 +1,6 @@
 local _ = require("gettext")
 return {
     name = "coverimage",
-    fullname = _("Cover Image"),
+    fullname = _("Cover image"),
     description = _([[Stores cover image to a file.]]),
 }

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -348,7 +348,7 @@ function CoverImage:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Original size"),
+                        text = _("Original image"),
                         checked_func = function()
                             return self.cover_image_background == "none"
                         end,

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -170,7 +170,6 @@ If the fallback image isn't activated, the screensaver image will stay in place 
 
 function CoverImage:addToMainMenu(menu_items)
     menu_items.coverimage = {
---        sorting_hint = "document",
         sorting_hint = "screen",
         text = _("Cover image"),
         checked_func = function()

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -172,7 +172,7 @@ function CoverImage:addToMainMenu(menu_items)
     menu_items.coverimage = {
 --        sorting_hint = "document",
         sorting_hint = "screen",
-        text = _("Save cover image"),
+        text = _("Cover image"),
         checked_func = function()
             return self.enabled or self.fallback
         end,
@@ -190,7 +190,7 @@ function CoverImage:addToMainMenu(menu_items)
             },
             -- menu entry: filename dialog
             {
-                text = _("Set system screensaver image"),
+                text = _("Set image path"),
                 checked_func = function()
                     return self.cover_image_path ~= "" and pathOk(self.cover_image_path)
                 end,
@@ -246,7 +246,7 @@ function CoverImage:addToMainMenu(menu_items)
             },
             -- menu entry: enable
             {
-                text = _("Save book cover"),
+                text = _("Save cover image"),
                 checked_func = function()
                     return self:_enabled() and pathOk(self.cover_image_path)
                 end,
@@ -349,7 +349,7 @@ function CoverImage:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Original image"),
+                        text = _("Original size"),
                         checked_func = function()
                             return self.cover_image_background == "none"
                         end,
@@ -443,7 +443,7 @@ function CoverImage:addToMainMenu(menu_items)
             },
             -- menu entry: set fallback image
             {
-                text = _("Set fallback image"),
+                text = _("Set fallback image path"),
                 checked_func = function()
                     return lfs.attributes(self.cover_image_fallback_path, "mode") == "file"
                 end,


### PR DESCRIPTION
Standardizes case on `_meta.lua` and improves readability of the plugin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7309)
<!-- Reviewable:end -->
