### PR TITLE
flash_ui: Workaround potential EPDC races

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1465,6 +1465,21 @@ function UIManager:waitForVSync()
 end
 
 --[[--
+Yield to the EPDC.
+
+This is a dumb workaround for potential races with the EPDC when we request a refresh on a specific region,
+and then proceed to *write* to the framebuffer, in the same region, very, very, very soon after that.
+
+We basically put ourselves to sleep for a very short amount of time, to let the kernel do its thing.
+]]
+function UIManager:yieldToEPDC()
+    if Device:hasEinkScreen() then
+        -- NOTE: Consider jumping to the jiffy resolution (100Hz/10ms) is that's not enough ;).
+        ffiUtil.usleep(1000)
+    end
+end
+
+--[[--
 Used to repaint a specific sub-widget that isn't on the `_window_stack` itself.
 
 Useful to avoid repainting a complex widget when we just want to invert an icon, for instance.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1471,11 +1471,13 @@ This is a dumb workaround for potential races with the EPDC when we request a re
 and then proceed to *write* to the framebuffer, in the same region, very, very, very soon after that.
 
 We basically put ourselves to sleep for a very short amount of time, to let the kernel do its thing.
+
+@int sleep_us Amount of time to sleep for (in µs). (Optional, defaults to 1ms).
 ]]
-function UIManager:yieldToEPDC()
+function UIManager:yieldToEPDC(sleep_us)
     if Device:hasEinkScreen() then
         -- NOTE: Consider jumping to the jiffy resolution (100Hz/10ms) is that's not enough ;).
-        ffiUtil.usleep(1000)
+        ffiUtil.usleep(sleep_us or 1000)
     end
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1470,14 +1470,14 @@ Yield to the EPDC.
 This is a dumb workaround for potential races with the EPDC when we request a refresh on a specific region,
 and then proceed to *write* to the framebuffer, in the same region, very, very, very soon after that.
 
-We basically put ourselves to sleep for a very short amount of time, to let the kernel do its thing.
+This basically just puts ourselves to sleep for a very short amount of time, to let the kernel do its thing in peace.
 
 @int sleep_us Amount of time to sleep for (in µs). (Optional, defaults to 1ms).
 ]]
 function UIManager:yieldToEPDC(sleep_us)
     if Device:hasEinkScreen() then
         -- NOTE: Early empiric evidence suggests that going as low as 1ms is enough to do the trick.
-        --       Consider jumping to the jiffy resolution (100Hz/10ms) is it turns out it isn't ;).
+        --       Consider jumping to the jiffy resolution (100Hz/10ms) if it turns out it isn't ;).
         ffiUtil.usleep(sleep_us or 1000)
     end
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1476,7 +1476,8 @@ We basically put ourselves to sleep for a very short amount of time, to let the 
 ]]
 function UIManager:yieldToEPDC(sleep_us)
     if Device:hasEinkScreen() then
-        -- NOTE: Consider jumping to the jiffy resolution (100Hz/10ms) is that's not enough ;).
+        -- NOTE: Early empiric evidence suggests that going as low as 1ms is enough to do the trick.
+        --       Consider jumping to the jiffy resolution (100Hz/10ms) is it turns out it isn't ;).
         ffiUtil.usleep(sleep_us or 1000)
     end
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -538,6 +538,7 @@ function UIManager:schedule(time, action, ...)
     table.insert(self._task_queue, p, {
         time = time,
         action = action,
+        argc = select('#', ...),
         args = {...},
     })
     self._task_queue_dirty = true
@@ -1177,7 +1178,7 @@ function UIManager:_checkTasks()
             -- task is pending to be executed right now. do it.
             -- NOTE: be careful that task.action() might modify
             -- _task_queue here. So need to avoid race condition
-            task.action(unpack(task.args or {}))
+            task.action(unpack(task.args, 1, task.argc))
         else
             -- queue is sorted in ascendant order, safe to assume all items
             -- are future tasks for now

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -27,7 +27,6 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
-local ffiUtil = require("ffi/util")
 local _ = require("gettext")
 local Screen = Device.screen
 local logger = require("logger")
@@ -308,10 +307,9 @@ function Button:onTapSelectButton()
                 --       Remember that the whole eInk refresh dance is completely asynchronous: we *request* a refresh from the kernel,
                 --       but it's up to the EPDC to schedule that however it sees fit...
                 --       Empiric evidence suggests that going as low as 1ms is enough.
-                --       The other approach would be to *ask* the EPDC to block until it's *completely* done, but that's too much (because we only care about it being done *reading* the fb),
-                --       and can take upwards of 300ms.
-                --       Consider jumping to the jiffy resolution (100Hz/10ms) is that's not enough ;).
-                ffiUtil.usleep(1000)
+                --       The other approach would be to *ask* the EPDC to block until it's *completely* done,
+                --       but that's too much (because we only care about it being done *reading* the fb), and it can take upwards of 300ms, which is also too much ;).
+                UIManager:yieldToEPDC()
             end
 
             -- Unhighlight

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -306,9 +306,9 @@ function Button:onTapSelectButton()
                 --       causing mild variants of our friend the papercut refresh glitch ;).
                 --       Remember that the whole eInk refresh dance is completely asynchronous: we *request* a refresh from the kernel,
                 --       but it's up to the EPDC to schedule that however it sees fit...
-                --       Empiric evidence suggests that going as low as 1ms is enough.
                 --       The other approach would be to *ask* the EPDC to block until it's *completely* done,
-                --       but that's too much (because we only care about it being done *reading* the fb), and it can take upwards of 300ms, which is also too much ;).
+                --       but that's too much (because we only care about it being done *reading* the fb),
+                --       and that could take upwards of 300ms, which is also way too much ;).
                 UIManager:yieldToEPDC()
             end
 

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -115,6 +115,7 @@ function CheckButton:onTapCheckButton()
             UIManager:setDirty(nil, "fast", highlight_dimen)
 
             UIManager:forceRePaint()
+            UIManager:yieldToEPDC()
 
             -- Unhighlight
             --

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -110,6 +110,7 @@ function IconButton:onTapIconButton()
         UIManager:setDirty(nil, "fast", self.dimen)
 
         UIManager:forceRePaint()
+        UIManager:yieldToEPDC()
 
         -- Unhighlight
         --

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -293,6 +293,7 @@ function KeyValueItem:onTap()
             UIManager:setDirty(nil, "fast", self[1].dimen)
 
             UIManager:forceRePaint()
+            UIManager:yieldToEPDC()
 
             -- Unhighlight
             --

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -480,6 +480,7 @@ function MenuItem:onTapSelect(arg, ges)
         UIManager:setDirty(nil, "fast", self[1].dimen)
 
         UIManager:forceRePaint()
+        UIManager:yieldToEPDC()
 
         -- Unhighlight
         --
@@ -514,6 +515,7 @@ function MenuItem:onHoldSelect(arg, ges)
         UIManager:setDirty(nil, "fast", self[1].dimen)
 
         UIManager:forceRePaint()
+        UIManager:yieldToEPDC()
 
         -- Unhighlight
         --

--- a/frontend/ui/widget/radiobutton.lua
+++ b/frontend/ui/widget/radiobutton.lua
@@ -124,6 +124,7 @@ function RadioButton:onTapCheckButton()
             UIManager:setDirty(nil, "fast", self.dimen)
 
             UIManager:forceRePaint()
+            UIManager:yieldToEPDC()
 
             -- Unhighlight
             --

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -141,8 +141,8 @@ function SkimToWidget:init()
     }
 
     -- Top row buttons
-    local chapter_next_text = "▷│"
-    local chapter_prev_text = "│◁"
+    local chapter_next_text = "▷▏"
+    local chapter_prev_text = "▕◁"
     local bookmark_next_text = "☆▷"
     local bookmark_prev_text = "◁☆"
     local bookmark_enabled_text = "★"

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -223,7 +223,6 @@ function SkimToWidget:init()
         enabled = true,
         width = button_inner_width,
         show_parent = self,
-        vsync = true,
         callback = function()
             self.ui:handleEvent(Event:new("ToggleBookmark"))
             self:update()

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -230,10 +230,8 @@ function TouchMenuItem:onHoldSelect(arg, ges)
 
         -- Callback
         --
-        print("TouchMenuItem: CB")
         self.menu:onMenuHold(self.item, self.text_truncated)
 
-        print("TouchMenuItem: Post-CB Repaint")
         UIManager:forceRePaint()
     end
     return true

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -15,11 +15,11 @@ describe("UIManager spec", function()
         local future2 = {future[1] + 5, future[2]}
         UIManager:quit()
         UIManager._task_queue = {
-            { time = {now[1] - 10, now[2] }, action = noop },
-            { time = {now[1], now[2] - 5 }, action = noop },
-            { time = now, action = noop },
-            { time = future, action = noop },
-            { time = future2, action = noop },
+            { time = {now[1] - 10, now[2] }, action = noop, args = {}, argc = 0 },
+            { time = {now[1], now[2] - 5 }, action = noop, args = {}, argc = 0 },
+            { time = now, action = noop, args = {}, argc = 0 },
+            { time = future, action = noop, args = {}, argc = 0 },
+            { time = future2, action = noop, args = {}, argc = 0 },
         }
         UIManager:_checkTasks()
         assert.are.same(2, #UIManager._task_queue, 2)
@@ -32,11 +32,11 @@ describe("UIManager spec", function()
         local future = { now[1] + 60000, now[2] }
         UIManager:quit()
         UIManager._task_queue = {
-            { time = {now[1] - 10, now[2] }, action = noop },
-            { time = {now[1], now[2] - 5 }, action = noop },
-            { time = now, action = noop },
-            { time = future, action = noop },
-            { time = {future[1] + 5, future[2]}, action = noop },
+            { time = {now[1] - 10, now[2] }, action = noop, args = {}, argc = 0 },
+            { time = {now[1], now[2] - 5 }, action = noop, args = {}, argc = 0 },
+            { time = now, action = noop, args = {}, argc = 0 },
+            { time = future, action = noop, args = {}, argc = 0 },
+            { time = {future[1] + 5, future[2]}, action = noop, args = {}, argc = 0 },
         }
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(future, wait_until)
@@ -46,9 +46,9 @@ describe("UIManager spec", function()
         now = { util.gettime() }
         UIManager:quit()
         UIManager._task_queue = {
-            { time = {now[1] - 10, now[2] }, action = noop },
-            { time = {now[1], now[2] - 5 }, action = noop },
-            { time = now, action = noop },
+            { time = {now[1] - 10, now[2] }, action = noop, args = {}, argc = 0 },
+            { time = {now[1], now[2] - 5 }, action = noop, args = {}, argc = 0 },
+            { time = now, action = noop, args = {}, argc = 0 },
         }
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(nil, wait_until)
@@ -69,7 +69,7 @@ describe("UIManager spec", function()
         local future = { now[1]+10000, now[2] }
         UIManager:quit()
         UIManager._task_queue = {
-            { time = future, action = '1' },
+            { time = future, action = '1', args = {}, argc = 0 },
         }
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'quz')
@@ -78,7 +78,7 @@ describe("UIManager spec", function()
 
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now, action = '1' },
+            { time = now, action = '1', args = {}, argc = 0 },
         }
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'foo')
@@ -93,9 +93,9 @@ describe("UIManager spec", function()
         now = { util.gettime() }
         UIManager:quit()
         UIManager._task_queue = {
-            { time = {now[1] - 10, now[2] }, action = '1' },
-            { time = {now[1], now[2] - 5 }, action = '2' },
-            { time = now, action = '3' },
+            { time = {now[1] - 10, now[2] }, action = '1', args = {}, argc = 0 },
+            { time = {now[1], now[2] - 5 }, action = '2', args = {}, argc = 0 },
+            { time = now, action = '3', args = {}, argc = 0 },
         }
         -- insert into the tail slot
         UIManager:scheduleIn(10, 'foo')
@@ -118,17 +118,17 @@ describe("UIManager spec", function()
         now = { util.gettime() }
         UIManager:quit()
         UIManager._task_queue = {
-            { time = {now[1] - 15, now[2] }, action = '3' },
-            { time = {now[1] - 10, now[2] }, action = '1' },
-            { time = {now[1], now[2] - 6 }, action = '3' },
-            { time = {now[1], now[2] - 5 }, action = '2' },
-            { time = now, action = '3' },
+            { time = {now[1] - 15, now[2] }, action = '3', args = {}, argc = 0 },
+            { time = {now[1] - 10, now[2] }, action = '1', args = {}, argc = 0 },
+            { time = {now[1], now[2] - 6 }, action = '3', args = {}, argc = 0 },
+            { time = {now[1], now[2] - 5 }, action = '2', args = {}, argc = 0 },
+            { time = now, action = '3', args = {}, argc = 0 },
         }
         -- insert into the tail slot
         UIManager:unschedule('3')
         assert.are.same({
-            { time = {now[1] - 10, now[2] }, action = '1' },
-            { time = {now[1], now[2] - 5 }, action = '2' },
+            { time = {now[1] - 10, now[2] }, action = '1', args = {}, argc = 0 },
+            { time = {now[1], now[2] - 5 }, action = '2', args = {}, argc = 0 },
         }, UIManager._task_queue)
     end)
 
@@ -140,15 +140,17 @@ describe("UIManager spec", function()
         end
         UIManager:quit()
         UIManager._task_queue = {
-            { time = { now[1], now[2]-5 }, action = task_to_remove },
+            { time = { now[1], now[2]-5 }, action = task_to_remove, args = {}, argc = 0 },
             {
                 time = { now[1]-10, now[2] },
                 action = function()
                     run_count = run_count + 1
                     UIManager:unschedule(task_to_remove)
-                end
+                end,
+                args = {},
+                argc = 0
             },
-            { time = now, action = task_to_remove },
+            { time = now, action = task_to_remove, args = {}, argc = 0 },
         }
         UIManager:_checkTasks()
         assert.are.same(2, run_count)


### PR DESCRIPTION
Followup to https://github.com/koreader/koreader/pull/7325

----

* flash_ui: Yield to the kernel between the HL and the UNHL/CB to let the EPDC do its thing in peace.
* UIManager: Handle nils in task scheduling arguments.
* SkimTo: Use the same, thicker chapter nav icons as ReaderSearch (fix #7326).
* SkimTo: The bookmark toggle button doesn't require a vsync flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7332)
<!-- Reviewable:end -->
