### PR TITLE
TOC: expand to show all chapter on current page

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -757,7 +757,17 @@ function ReaderToc:onShowToc()
 
     self:updateCurrentNode()
     -- auto expand the parent node of current page
-    self:expandParentNode(self:getTocIndexByPage(self.pageno))
+    local idx = self:getTocIndexByPage(self.pageno)
+    if idx then
+        self:expandParentNode(idx)
+        -- Also do it for other toc items on current page
+        idx = idx + 1
+        while self.toc[idx] and self.toc[idx].page == self.pageno do
+            self:expandParentNode(idx)
+            idx = idx + 1
+        end
+    end
+
     -- auto goto page of the current toc entry
     self.toc_menu:switchItemTable(nil, self.collapsed_toc, self.collapsed_toc.current or -1)
 


### PR DESCRIPTION
When showing TOC, expand/show TOC entries for all items on current page.

I.e.: when on this page:
<kbd>![image](https://user-images.githubusercontent.com/24273478/108775535-7a5b1880-7561-11eb-8676-04a8488b2bd2.png)</kbd>

ToC currently opens like this (possibly more accentuated since a482baac5 #7204, but a similar situation could have happened before):
<kbd>![image](https://user-images.githubusercontent.com/24273478/108775642-aaa2b700-7561-11eb-82ff-baaa36dc3716.png)</kbd>

It will now show:
<kbd>![image](https://user-images.githubusercontent.com/24273478/108775582-8d6de880-7561-11eb-8688-c43e9da4adcf.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7339)
<!-- Reviewable:end -->
