### PR TITLE
bump crengine: CSS line-break/word-break, various fixes

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -318,8 +318,7 @@ ruby { display: inline !important; }
                 id = "font_family_all_inherit";
                 title = _("Ignore publisher font families"),
                 description = _("Disable font-family specified in embedded styles."),
-                -- we have to use this trick, font-family handling by crengine is a bit complex
-                css = [[* { font-family: "NoSuchFont" !important; }]],
+                css = [[* { font-family: inherit !important; }]],
             },
             {
                 id = "font_size_all_inherit";


### PR DESCRIPTION
Includes:
- LVString: Fix a c/p issue in lString8::atoi64 https://github.com/koreader/crengine/pull/421
- LVTextFm: Simplify and fix resizeImage logic
- LVXMLParser::ReadText(): fix parsing at buffer boundaries https://github.com/koreader/crengine/pull/423
- TextLang: fix lang_tag first part comparison
- CSS font-family: fix parsing of 'inherit' and '!important' - Closes #6886.
- CSS: support a few -epub-* and -webkit-* properties
- Text fragment flags: add LTEXT_HAS_EXTRA
- CSS: add support for 'line-break' and 'word-break'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7342)
<!-- Reviewable:end -->
