### PR TITLE
Minor followup to #7335

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -585,19 +585,6 @@ local Menu = FocusManager:new{
 function Menu:_recalculateDimen()
     self.perpage = self.items_per_page or G_reader_settings:readSetting("items_per_page") or self.items_per_page_default
     self.span_width = 0
-    self.dimen.w = self.width
-    self.dimen.h = self.height or Screen:getHeight()
-    if self.dimen.h > Screen:getHeight() or self.dimen.h == nil then
-        self.dimen.h = Screen:getHeight()
-    end
-    self.inner_dimen = Geom:new{
-        w = self.dimen.w - 2 * self.border_size,
-        h = self.dimen.h - 2 * self.border_size,
-    }
-    self.item_dimen = Geom:new{
-        w = self.inner_dimen.w,
-        h = Screen:scaleBySize(46),
-    }
     local height_dim
     local bottom_height = 0
     local top_height = 0
@@ -629,6 +616,11 @@ function Menu:init()
     self.inner_dimen = Geom:new{
         w = self.dimen.w - 2 * self.border_size,
         h = self.dimen.h - 2 * self.border_size,
+    }
+
+    self.item_dimen = Geom:new{
+        w = self.inner_dimen.w,
+        h = Screen:scaleBySize(46),
     }
 
     self.page = 1

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -296,7 +296,7 @@ function SortWidget:init()
 
     self.footer_page = Button:new{
         text = "",
-        tap_input = {
+        hold_input = {
             title = _("Enter page number"),
             type = "number",
             hint_func = function()
@@ -308,7 +308,9 @@ function SortWidget:init()
                     self:goToPage(page)
                 end
             end,
+            ok_text = "Go to page",
         },
+        call_hold_input_on_tap = true,
         bordersize = 0,
         margin = 0,
         text_font_face = "pgfont",

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -49,8 +49,10 @@ function CoverMenu:updateItems(select_number)
     -- self.layout must be updated for focusmanager
     self.layout = {}
     self.item_group:clear()
-    -- strange, best here if resetLayout() are done after _recalculateDimen(),
-    -- unlike what is done in menu.lua
+    -- NOTE: Our various _recalculateDimen overloads appear to have a stronger dependency
+    --       on the rest of the wiget elements being properly laid-out,
+    --       so we have to run it *first*, unlike in Menu.
+    --       Otherwise, various layout issues arise (e.g., MosaicMenu's page_info is misaligned).
     self:_recalculateDimen()
     self.page_info:resetLayout()
     self.return_button:resetLayout()

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -50,7 +50,7 @@ function CoverMenu:updateItems(select_number)
     self.layout = {}
     self.item_group:clear()
     -- NOTE: Our various _recalculateDimen overloads appear to have a stronger dependency
-    --       on the rest of the wiget elements being properly laid-out,
+    --       on the rest of the widget elements being properly laid-out,
     --       so we have to run it *first*, unlike in Menu.
     --       Otherwise, various layout issues arise (e.g., MosaicMenu's page_info is misaligned).
     self:_recalculateDimen()

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -881,14 +881,6 @@ end
 local ListMenu = {}
 
 function ListMenu:_recalculateDimen()
-    self.dimen.w = self.width
-    self.dimen.h = self.height or Screen:getHeight()
-    -- NOTE: inner_dimen should match dimen because we're generally (always?) borderless
-    self.inner_dimen = Geom:new{
-        w = self.dimen.w - 2 * self.border_size,
-        h = self.dimen.h - 2 * self.border_size,
-    }
-
     -- Find out available height from other UI elements made in Menu
     self.others_height = 0
     if self.title_bar then -- Menu:init() has been done

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -797,10 +797,7 @@ end
 local MosaicMenu = {}
 
 function MosaicMenu:_recalculateDimen()
-    local portrait_mode = true
-    if Screen:getWidth() > Screen:getHeight() then
-        portrait_mode = false
-    end
+    local portrait_mode = Screen:getWidth() <= Screen:getHeight()
     -- 3 x 3 grid by default if not initially provided (4 x 2 in landscape mode)
     if portrait_mode then
         self.nb_cols = self.nb_cols_portrait or 3

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -797,14 +797,6 @@ end
 local MosaicMenu = {}
 
 function MosaicMenu:_recalculateDimen()
-    self.dimen.w = self.width
-    self.dimen.h = self.height or Screen:getHeight()
-    -- NOTE: inner_dimen should match dimen because we're generally (always?) borderless
-    self.inner_dimen = Geom:new{
-        w = self.dimen.w - 2 * self.border_size,
-        h = self.dimen.h - 2 * self.border_size,
-    }
-
     local portrait_mode = true
     if Screen:getWidth() > Screen:getHeight() then
         portrait_mode = false


### PR DESCRIPTION
* Unify SortWidget's pagination button (it was using a tap_input, which is why I'd missed it ;)). (https://github.com/koreader/koreader/pull/7335#issuecomment-785628495)
* Menu*: Remove redundant screen-layout updates from `_recalculateDimen`, as it should only be concerned with item layout (https://github.com/koreader/koreader/pull/7335#discussion_r582072032)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7347)
<!-- Reviewable:end -->
