### PR TITLE
Add OPDS catalog for Library Genesis

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -102,6 +102,10 @@ function OPDSBrowser:init()
           {
              title = "Беларуская палічка",
              url = "https://knihi.com/opds.xml",
+          },
+          {
+             title = "Library Genesis",
+             url = "https://libgen.avsej.download/opds.xml",
           }
         }
         G_reader_settings:saveSetting("opds_servers", servers)


### PR DESCRIPTION
Library Genesis (libgen) is pretty popular library. Unfortunately it does not have its own OPDS server, but I generated static XML files and hosted them on S3 behind CDN, so they can be accessed pretty fast. I have script to regenerate and update tree from the official SQL dumps of libgen. Right now my tree covers fiction and main libraries of libgen.

I hope koreader users will find it useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7349)
<!-- Reviewable:end -->
