### PR TITLE
Remove flibusta from default list of OPDS catalogs

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -78,15 +78,6 @@ function OPDSBrowser:init()
              url = "https://bookserver.archive.org/",
           },
           {
-             title = "Flibusta (Russian)",
-             url = "http://www.flibusta.is/opds",
-          },
-          {
-             title = "Flibusta [Ru] [Searchable]",
-             url = "http://www.flibusta.is/opds/search?searchTerm=%s",
-             searchable = true,
-          },
-          {
              title = "textos.info (Spanish)",
              url = "https://www.textos.info/catalogo.atom",
           },


### PR DESCRIPTION
While it is large, popular and open library, its legal status is not clear, so better not add this server by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7352)
<!-- Reviewable:end -->
