### PR TITLE
FileSearcher: Do not crash on space, show unsupported files if enabled.

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -60,7 +60,7 @@ end
 function FileSearcher:setSearchResults()
     local keywords = self.search_value
     self.results = {}
-    if keywords == " " then -- one space to show all files
+    if keywords == "*" then -- one * to show all files
         self.results = self.files
     else
         for __,f in pairs(self.files) do


### PR DESCRIPTION
Fixes: #7361

Space is overloaded to show all results. Is this the desired behavior?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7362)
<!-- Reviewable:end -->
