### PR TITLE
WiFi: Handle inconsistent states a tad better.

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -600,6 +600,8 @@ function NetworkMgr:showNetworkMenu(complete_callback)
                 return
             end
         end
+        -- NOTE: Also supports a disconnect_callback, should we use it for something?
+        --       Tearing down Wi-Fi completely when tapping "disconnect" would feel a bit harsh, though...
         UIManager:show(require("ui/widget/networksetting"):new{
             network_list = network_list,
             connect_callback = complete_callback,

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -372,6 +372,9 @@ function NetworkMgr:getWifiToggleMenuTable()
                             UIManager:broadcastEvent(Event:new("NetworkConnected"))
                         elseif NetworkMgr:isWifiOn() and not NetworkMgr:isConnected() then
                             -- Don't leave Wi-Fi in an inconsistent state if the connection failed.
+                            -- NOTE: Keep in mind that NetworkSetting only runs this callback on *successful* connections!
+                            --       (It's called connect_callback there).
+                            --       This makes this branch somewhat hard to reach, which is why it gets a dedicated prompt below...
                             self.wifi_was_on = false
                             G_reader_settings:saveSetting("wifi_was_on", false)
                             -- NOTE: We're limiting this to only a few platforms, as it might be actually harmful on some devices.

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -237,6 +237,7 @@ function NetworkItem:connect()
     end
 
     -- Do what it says on the tin, and only trigger the connect_callback on a *successful* connect.
+    -- NOTE: This callback comes from NetworkManager, where it's named complete_callback.
     if success and self.setting_ui.connect_callback then
         self.setting_ui.connect_callback()
     end


### PR DESCRIPTION
Namely, if Wi-Fi is enabled, but the connection is down.

Fix #7358

(Note that we have a Kobo-specific workaround to tear-down Wi-Fi in these cases, that was probably subtly inhibited in most cases by #6424 ^^).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7368)
<!-- Reviewable:end -->
