### PR TITLE
ReaderDogEar: Enforce a minimum size, too

### DIFF
--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -17,8 +17,8 @@ function ReaderDogear:init()
     -- to not overwrite the book text.
     -- For other documents, there is no easy way to know if valuable content
     -- may be hidden by the icon (kopt's page_margin is quite obscure).
-    self.dogear_min_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 32)
-    self.dogear_max_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 24)
+    self.dogear_min_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 40)
+    self.dogear_max_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 32)
     self.dogear_size = nil
     self.dogear_y_offset = 0
     self.top_pad = nil
@@ -28,7 +28,7 @@ end
 
 function ReaderDogear:setupDogear(new_dogear_size)
     if not new_dogear_size then
-        new_dogear_size = self.dogear_min_size
+        new_dogear_size = self.dogear_max_size
     end
     if new_dogear_size ~= self.dogear_size then
         self.dogear_size = new_dogear_size

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -82,6 +82,7 @@ function ReaderDogear:onSetPageMargins(margins)
     -- (the provided margins are not scaled, so do as ReaderTypeset)
     local margin = Screen:scaleBySize(math.max(margin_top, margin_right))
     local new_dogear_size = math.max(self.dogear_min_size, math.min(self.dogear_max_size, margin))
+    print("Dogear clamped", margin, "between", self.dogear_min_size, "and", self.dogear_max_size, "to", new_dogear_size)
     self:setupDogear(new_dogear_size)
 end
 

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -38,10 +38,11 @@ function ReaderDogear:setupDogear(new_dogear_size)
         self.vgroup = VerticalGroup:new{
             self.top_pad,
             IconWidget:new{
-                icon = "dogear.opaque",
+                icon = "dogear.alpha",
                 rotation_angle = BD.mirroredUILayout() and 90 or 0,
                 width = self.dogear_size,
                 height = self.dogear_size,
+                alpha = true, -- Keep the alpha layer intact
             }
         }
         self[1] = RightContainer:new{

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -17,7 +17,8 @@ function ReaderDogear:init()
     -- to not overwrite the book text.
     -- For other documents, there is no easy way to know if valuable content
     -- may be hidden by the icon (kopt's page_margin is quite obscure).
-    self.dogear_max_size = math.ceil( math.min(Screen:getWidth(), Screen:getHeight()) / 32)
+    self.dogear_min_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 32)
+    self.dogear_max_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 24)
     self.dogear_size = nil
     self.dogear_y_offset = 0
     self.top_pad = nil
@@ -27,7 +28,7 @@ end
 
 function ReaderDogear:setupDogear(new_dogear_size)
     if not new_dogear_size then
-        new_dogear_size = self.dogear_max_size
+        new_dogear_size = self.dogear_min_size
     end
     if new_dogear_size ~= self.dogear_size then
         self.dogear_size = new_dogear_size
@@ -80,7 +81,7 @@ function ReaderDogear:onSetPageMargins(margins)
     -- top & right margins and be sure no text is hidden by the icon
     -- (the provided margins are not scaled, so do as ReaderTypeset)
     local margin = Screen:scaleBySize(math.max(margin_top, margin_right))
-    local new_dogear_size = math.min(self.dogear_max_size, margin)
+    local new_dogear_size = math.max(self.dogear_min_size, math.min(self.dogear_max_size, margin))
     self:setupDogear(new_dogear_size)
 end
 

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -81,7 +81,7 @@ function ReaderDogear:onSetPageMargins(margins)
     -- top & right margins and be sure no text is hidden by the icon
     -- (the provided margins are not scaled, so do as ReaderTypeset)
     local margin = Screen:scaleBySize(math.max(margin_top, margin_right))
-    local new_dogear_size = math.max(self.dogear_min_size, math.min(self.dogear_max_size, margin))
+    local new_dogear_size = math.min(self.dogear_max_size, math.max(self.dogear_min_size, margin))
     print("Dogear clamped", margin, "between", self.dogear_min_size, "and", self.dogear_max_size, "to", new_dogear_size)
     self:setupDogear(new_dogear_size)
 end

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -82,7 +82,6 @@ function ReaderDogear:onSetPageMargins(margins)
     -- (the provided margins are not scaled, so do as ReaderTypeset)
     local margin = Screen:scaleBySize(math.max(margin_top, margin_right))
     local new_dogear_size = math.min(self.dogear_max_size, math.max(self.dogear_min_size, margin))
-    print("Dogear clamped", margin, "between", self.dogear_min_size, "and", self.dogear_max_size, "to", new_dogear_size)
     self:setupDogear(new_dogear_size)
 end
 

--- a/resources/icons/mdlight/dogear.alpha.svg
+++ b/resources/icons/mdlight/dogear.alpha.svg
@@ -70,13 +70,9 @@
    style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.12;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.999901"
    d="M 48,46 V 0 H 2 Z"
    sodipodi:nodetypes="cccc" /><path
-   style="fill:#ffffff;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;opacity:1;fill-opacity:0"
-   d="M 1.9999949,1.9994296 V 45.999919 H 46.00078"
+   style="opacity:1;fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.75"
+   d="M 1.9999949,2 V 45.999919 H 46 Z"
    id="path1127"
-   sodipodi:nodetypes="ccc"
+   sodipodi:nodetypes="cccc"
    inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96" /><path
-   style="fill:none;stroke:#000000;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-   d="m 2.25,1.75 44,44"
-   id="path14686"
-   sodipodi:nodetypes="cc" /></svg>
+   inkscape:export-ydpi="96" /></svg>

--- a/resources/icons/mdlight/dogear.alpha.svg
+++ b/resources/icons/mdlight/dogear.alpha.svg
@@ -70,7 +70,7 @@
    style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.12;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.999901"
    d="M 48,46 V 0 H 2 Z"
    sodipodi:nodetypes="cccc" /><path
-   style="opacity:1;fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.75"
+   style="opacity:1;fill:#ffffff;fill-opacity:0.75;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.75"
    d="M 1.9999949,2 V 45.999919 H 46 Z"
    id="path1127"
    sodipodi:nodetypes="cccc"

--- a/resources/icons/mdlight/dogear.alpha.svg
+++ b/resources/icons/mdlight/dogear.alpha.svg
@@ -43,27 +43,7 @@
      id="grid856" /></sodipodi:namedview><metadata
    id="metadata10"><rdf:RDF><cc:Work
        rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
-   id="defs8">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-	
-
-		
-	</defs>
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs id="defs8"></defs>
 
 <path
    id="path871"

--- a/resources/icons/mdlight/dogear.alpha.svg
+++ b/resources/icons/mdlight/dogear.alpha.svg
@@ -70,7 +70,7 @@
    style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.12;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.999901"
    d="M 48,46 V 0 H 2 Z"
    sodipodi:nodetypes="cccc" /><path
-   style="opacity:1;fill:#ffffff;fill-opacity:0.75;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.75"
+   style="opacity:1;fill:#ffffff;fill-opacity:0.5;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
    d="M 1.9999949,2 V 45.999919 H 46 Z"
    id="path1127"
    sodipodi:nodetypes="cccc"

--- a/resources/icons/mdlight/dogear.alpha.svg
+++ b/resources/icons/mdlight/dogear.alpha.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   enable-background="new 0 0 24.00 24.00"
+   xml:space="preserve"
+   id="svg4"
+   sodipodi:docname="dogear.alpha.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:export-filename="/home/niluje/MPLAYER/koreader/resources/icons/mdlight/dogear.opaque.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="2560"
+   inkscape:window-height="1381"
+   id="namedview6"
+   showgrid="true"
+   inkscape:zoom="16.610526"
+   inkscape:cx="23.798479"
+   inkscape:cy="21.341888"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg4"
+   inkscape:document-rotation="0"><inkscape:grid
+     type="xygrid"
+     id="grid856" /></sodipodi:namedview><metadata
+   id="metadata10"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+   id="defs8">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+		
+	</defs>
+
+<path
+   id="path871"
+   style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.12;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.999901"
+   d="M 48,46 V 0 H 2 Z"
+   sodipodi:nodetypes="cccc" /><path
+   style="fill:#ffffff;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;opacity:1;fill-opacity:0"
+   d="M 1.9999949,1.9994296 V 45.999919 H 46.00078"
+   id="path1127"
+   sodipodi:nodetypes="ccc"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96" /><path
+   style="fill:none;stroke:#000000;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+   d="m 2.25,1.75 44,44"
+   id="path14686"
+   sodipodi:nodetypes="cc" /></svg>


### PR DESCRIPTION
Also, update the actual ReaderDogEar variant of the icon to use a semi-transparent fill for the bottom-left corner.

Fix #7364

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7369)
<!-- Reviewable:end -->
