### PR TITLE
OPDS: Do not include author in download filename if nil or empty

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -535,7 +535,13 @@ end
 function OPDSBrowser:downloadFile(item, filetype, remote_url)
     -- download to user selected directory or last opened dir
     local download_dir = self.getCurrentDownloadDir()
-    local filename = util.getSafeFilename(item.author .. " - " .. item.title .. "." .. filetype, download_dir)
+
+    local filename = item.title .. "." .. filetype
+    if item.author then
+        filename = item.author .. " - " .. filename
+    end
+
+    filename = util.getSafeFilename(filename, download_dir)
     local local_path = download_dir .. "/" .. filename
     local_path = util.fixUtf8(local_path, "_")
 


### PR DESCRIPTION
Some OPDS servers do not provide authors for all items. In this case, fall back to the item name only.
Resolves crash in #6418, option for downloading by Content-Disposition should still be considered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7384)
<!-- Reviewable:end -->
