### PR TITLE
Dispatcher: nil guard against access to a document instance

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -519,6 +519,7 @@ function FileManager:init()
     end
 
     self:initGesListener()
+    self:handleEvent(Event:new("SetDimensions", self.dimen))
 end
 
 function FileChooser:onBack()

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -101,7 +101,7 @@ end
 function FileManager:onSetDimensions(dimen)
     -- update listening according to new screen dimen
     if Device:isTouchDevice() then
-        self:initGesListener()
+        self:updateTouchZonesOnScreenResize(dimen)
     end
 end
 
@@ -518,7 +518,7 @@ function FileManager:init()
         table.insert(self, NetworkListener:new{ ui = self })
     end
 
-    self:handleEvent(Event:new("SetDimensions", self.dimen))
+    self:initGesListener()
 end
 
 function FileChooser:onBack()

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -599,7 +599,6 @@ arguments are:
     3) optionally a `gestures`object
 --]]--
 function Dispatcher:execute(ui, settings, gesture)
-    print("Dispatcher:execute", ui, settings, gesture)
     for k, v in pairs(settings) do
         if settingsList[k] ~= nil and (settingsList[k].conditions == nil or settingsList[k].conditions == true) then
             if settingsList[k].category == "none" then
@@ -631,8 +630,6 @@ function Dispatcher:execute(ui, settings, gesture)
                         if v == r then value = settingsList[k].configurable.values[i] break end
                     end
                 end
-                print("Have a configurable:", settingsList[k].configurable.name, value)
-                print("Document?", ui.document)
                 -- CreOptions / KoptOptions settings are exposed in the FM's Gesture Manager!
                 if ui.document then
                     ui.document.configurable[settingsList[k].configurable.name] = value

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -599,6 +599,7 @@ arguments are:
     3) optionally a `gestures`object
 --]]--
 function Dispatcher:execute(ui, settings, gesture)
+    print("Dispatcher:execute", ui, settings, gesture)
     for k, v in pairs(settings) do
         if settingsList[k] ~= nil and (settingsList[k].conditions == nil or settingsList[k].conditions == true) then
             if settingsList[k].category == "none" then
@@ -624,13 +625,15 @@ function Dispatcher:execute(ui, settings, gesture)
                 ui:handleEvent(Event:new(settingsList[k].event, arg))
             end
             if settingsList[k].configurable ~= nil then
-                 local value = v
-                 if type(v) ~= "number" then
-                     for i, r in ipairs(settingsList[k].args) do
+                local value = v
+                if type(v) ~= "number" then
+                    for i, r in ipairs(settingsList[k].args) do
                         if v == r then value = settingsList[k].configurable.values[i] break end
-                     end
-                 end
-                 ui.document.configurable[settingsList[k].configurable.name] = value
+                    end
+                end
+                print("Have a configurable:", settingsList[k].configurable.name, value)
+                print("Document?", ui.document)
+                ui.document.configurable[settingsList[k].configurable.name] = value
             end
         end
     end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -623,7 +623,7 @@ function Dispatcher:execute(ui, settings, gesture)
                 local arg = v ~= 0 and v or gesture or 0
                 ui:handleEvent(Event:new(settingsList[k].event, arg))
             end
-            if settingsList[k].configurable ~= nil and ui.document then
+            if ui.document and settingsList[k].configurable then
                 local value = v
                 if type(v) ~= "number" then
                     for i, r in ipairs(settingsList[k].args) do

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -633,7 +633,10 @@ function Dispatcher:execute(ui, settings, gesture)
                 end
                 print("Have a configurable:", settingsList[k].configurable.name, value)
                 print("Document?", ui.document)
-                ui.document.configurable[settingsList[k].configurable.name] = value
+                -- CreOptions / KoptOptions settings are exposed in the FM's Gesture Manager!
+                if ui.document then
+                    ui.document.configurable[settingsList[k].configurable.name] = value
+                end
             end
         end
     end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -623,17 +623,14 @@ function Dispatcher:execute(ui, settings, gesture)
                 local arg = v ~= 0 and v or gesture or 0
                 ui:handleEvent(Event:new(settingsList[k].event, arg))
             end
-            if settingsList[k].configurable ~= nil then
+            if settingsList[k].configurable ~= nil and ui.document then
                 local value = v
                 if type(v) ~= "number" then
                     for i, r in ipairs(settingsList[k].args) do
                         if v == r then value = settingsList[k].configurable.values[i] break end
                     end
                 end
-                -- CreOptions / KoptOptions settings are exposed in the FM's Gesture Manager!
-                if ui.document then
-                    ui.document.configurable[settingsList[k].configurable.name] = value
-                end
+                ui.document.configurable[settingsList[k].configurable.name] = value
             end
         end
     end

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -2,6 +2,7 @@ local Device = require("device")
 local Screen = Device.screen
 local optionsutil = require("ui/data/optionsutil")
 local _ = require("gettext")
+local C_ = _.pgettext
 
 -- Get font size numbers as a table of strings
 local tableOfNumbersToTableOfStrings = function(numbers)
@@ -27,6 +28,8 @@ local CreOptions = {
                     "rotation.90CW",
                     "rotation.180UD",
                 },
+                -- For Dispatcher's sake
+                labels = {C_("Rotation", "⤹ 90°"), C_("Rotation", "↑ 0°"), C_("Rotation", "⤸ 90°"), C_("Rotation", "↓ 180°")},
                 alternate = false,
                 values = {Screen.ORIENTATION_LANDSCAPE_ROTATED, Screen.ORIENTATION_PORTRAIT, Screen.ORIENTATION_LANDSCAPE, Screen.ORIENTATION_PORTRAIT_ROTATED},
                 args = {Screen.ORIENTATION_LANDSCAPE_ROTATED, Screen.ORIENTATION_PORTRAIT, Screen.ORIENTATION_LANDSCAPE, Screen.ORIENTATION_PORTRAIT_ROTATED},

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -35,6 +35,8 @@ local KoptOptions = {
                     "rotation.90CW",
                     "rotation.180UD",
                 },
+                -- For Dispatcher's sake
+                labels = {C_("Rotation", "⤹ 90°"), C_("Rotation", "↑ 0°"), C_("Rotation", "⤸ 90°"), C_("Rotation", "↓ 180°")},
                 alternate = false,
                 values = {Screen.ORIENTATION_LANDSCAPE_ROTATED, Screen.ORIENTATION_PORTRAIT, Screen.ORIENTATION_LANDSCAPE, Screen.ORIENTATION_PORTRAIT_ROTATED},
                 args = {Screen.ORIENTATION_LANDSCAPE_ROTATED, Screen.ORIENTATION_PORTRAIT, Screen.ORIENTATION_LANDSCAPE, Screen.ORIENTATION_PORTRAIT_ROTATED},


### PR DESCRIPTION
Fix #7388

Related fixes:

* Unbreak the Rotation submenu entries since #7306
* Actually update the touchzones properly when the FM is rotated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7389)
<!-- Reviewable:end -->
