### PR TITLE
A couple of fixes & enhancements

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -3,6 +3,7 @@ local NickelConf = require("device/kobo/nickel_conf")
 local PluginShare = require("pluginshare")
 local SysfsLight = require ("device/sysfs_light")
 local ffiUtil = require("ffi/util")
+local RTC = require("ffi/rtc")
 
 local batt_state_folder =
         "/sys/devices/platform/pmic_battery.1/power_supply/mc13892_bat/"
@@ -405,6 +406,9 @@ function KoboPowerD:afterResume()
     end
     -- Turn the frontlight back on
     self:turnOnFrontlight()
+
+    -- Set the system clock to the hardware clock's time.
+    RTC:HCToSys()
 end
 
 return KoboPowerD

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -644,6 +644,11 @@ function KeyValuePage:_populateItems()
     else
         self.page_info_text:setText(_("No items"))
         self.page_info_text:disableWithoutDimming()
+
+        self.page_info_left_chev:hide()
+        self.page_info_right_chev:hide()
+        self.page_info_first_chev:hide()
+        self.page_info_last_chev:hide()
     end
 
     UIManager:setDirty(self, function()

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -993,6 +993,12 @@ function Menu:updatePageInfo(select_number)
     else
         self.page_info_text:setText(_("No items"))
         self.page_info_text:disableWithoutDimming()
+
+        self.page_info_left_chev:hide()
+        self.page_info_right_chev:hide()
+        self.page_info_first_chev:hide()
+        self.page_info_last_chev:hide()
+        self.page_return_arrow:showHide(self.onReturn ~= nil)
     end
 end
 


### PR DESCRIPTION
* Clock shenanigans on Kobo (fix #7092, pending https://github.com/koreader/koreader-base/pull/1322).
* Menu/KeyValuePage: Make sure the buttons are hidden when no items are shown (fix #7394).
* Screensaver: Use the ReaderUI instance when we can. Because re-opening the document you're currently reading just to get its cover felt fairly stupid...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7396)
<!-- Reviewable:end -->
