### PR TITLE
WakeupMgr: Minor usage tweak

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -540,7 +540,8 @@ local function check_unexpected_wakeup()
     -- just in case other events like SleepCoverClosed also scheduled a suspend
     UIManager:unschedule(Kobo.suspend)
 
-    if WakeupMgr:isWakeupAlarmScheduled() then
+    -- Do an initial validation to discriminate unscheduled wakeups happening *outside* of the alarm proximity window.
+    if WakeupMgr:isWakeupAlarmScheduled() and WakeupMgr:validateWakeupAlarmByProximity() then
         logger.info("Kobo suspend: scheduled wakeup.")
         local res = WakeupMgr:wakeupAction()
         if not res then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -540,7 +540,7 @@ local function check_unexpected_wakeup()
     -- just in case other events like SleepCoverClosed also scheduled a suspend
     UIManager:unschedule(Kobo.suspend)
 
-    if WakeupMgr:isWakeupAlarmScheduled() and WakeupMgr:validateWakeupAlarmByProximity() then
+    if WakeupMgr:isWakeupAlarmScheduled() then
         logger.info("Kobo suspend: scheduled wakeup.")
         local res = WakeupMgr:wakeupAction()
         if not res then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -558,6 +558,9 @@ local function check_unexpected_wakeup()
             -- Don't put device back to sleep under the following two cases:
             --   1. a resume event triggered Kobo:resume() function
             --   2. trying to put device back to sleep more than 20 times after unexpected wakeup
+            -- Broadcast a specific event, so that AutoSuspend can pick up the baton...
+            local Event = require("ui/event")
+            UIManager:broadcastEvent(Event:new("UnexpectedWakeupLimit"))
             return
         end
 

--- a/frontend/device/wakeupmgr.lua
+++ b/frontend/device/wakeupmgr.lua
@@ -55,7 +55,7 @@ function WakeupMgr:addTask(seconds_from_now, callback)
     if not type(seconds_from_now) == "number" and not type(callback) == "function" then return end
 
     local epoch = RTC:secondsFromNowToEpoch(seconds_from_now)
-    logger.info("WakeupMgr: scheduling wakeup for:", seconds_from_now, epoch)
+    logger.info("WakeupMgr: scheduling wakeup in", seconds_from_now)
 
     local old_upcoming_task = (self._task_queue[1] or {}).epoch
 

--- a/frontend/device/wakeupmgr.lua
+++ b/frontend/device/wakeupmgr.lua
@@ -182,6 +182,7 @@ Simple wrapper for @{ffi.rtc.isWakeupAlarmScheduled}.
 function WakeupMgr:isWakeupAlarmScheduled()
     local wakeup_scheduled = RTC:isWakeupAlarmScheduled()
     if wakeup_scheduled then
+        -- NOTE: This can't return nil given that we're behind an isWakeupAlarmScheduled check.
         local alarm = RTC:getWakeupAlarmEpoch()
         logger.dbg("WakeupMgr:isWakeupAlarmScheduled: An alarm is scheduled for " .. alarm .. os.date(" (%F %T %z)", alarm))
     else

--- a/frontend/device/wakeupmgr.lua
+++ b/frontend/device/wakeupmgr.lua
@@ -181,7 +181,12 @@ Simple wrapper for @{ffi.rtc.isWakeupAlarmScheduled}.
 --]]
 function WakeupMgr:isWakeupAlarmScheduled()
     local wakeup_scheduled = RTC:isWakeupAlarmScheduled()
-    logger.dbg("isWakeupAlarmScheduled", wakeup_scheduled)
+    if wakeup_scheduled then
+        local alarm = RTC:getWakeupAlarmEpoch()
+        logger.dbg("WakeupMgr:isWakeupAlarmScheduled: An alarm is scheduled for " .. alarm .. os.date(" (%F %T %z)", alarm))
+    else
+        logger.dbg("WakeupMgr:isWakeupAlarmScheduled: No alarm is currently scheduled.")
+    end
     return wakeup_scheduled
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -62,11 +62,11 @@ function AutoSuspend:_schedule()
         UIManager:suspend()
     else
         if self:_enabled() then
-            logger.dbg("AutoSuspend: schedule next suspend check in", delay_suspend)
+            logger.dbg("AutoSuspend: scheduling next suspend check in", delay_suspend)
             UIManager:scheduleIn(delay_suspend, self._schedule, self)
         end
         if self:_enabledShutdown() then
-            logger.dbg("AutoSuspend: schedule next shutdown check in", delay_shutdown)
+            logger.dbg("AutoSuspend: scheduling next shutdown check in", delay_shutdown)
             UIManager:scheduleIn(delay_shutdown, self._schedule, self)
         end
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -37,7 +37,7 @@ function AutoSuspend:_enabledShutdown()
 end
 
 function AutoSuspend:_schedule()
-    if not self:_enabled() then
+    if not self:_enabled() and (Device:canPowerOff() and not self:_enabledShutdown()) then
         logger.dbg("AutoSuspend:_schedule is disabled")
         return
     end
@@ -117,6 +117,10 @@ function AutoSuspend:onResume()
         Device.wakeup_mgr:removeTask(nil, nil, UIManager.poweroff_action)
     end
     self:_start()
+end
+
+function AutoSuspend:onUnexpectedWakeupLimit()
+    logger.dbg("AutoSuspend: onUnexpectedWakeupLimit")
 end
 
 function AutoSuspend:onAllowStandby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -62,11 +62,11 @@ function AutoSuspend:_schedule()
         UIManager:suspend()
     else
         if self:_enabled() then
-            logger.dbg("AutoSuspend: schedule suspend in", delay_suspend)
+            logger.dbg("AutoSuspend: schedule next suspend check in", delay_suspend)
             UIManager:scheduleIn(delay_suspend, self._schedule, self)
         end
         if self:_enabledShutdown() then
-            logger.dbg("AutoSuspend: schedule shutdown in", delay_shutdown)
+            logger.dbg("AutoSuspend: schedule next shutdown check in", delay_shutdown)
             UIManager:scheduleIn(delay_shutdown, self._schedule, self)
         end
     end


### PR DESCRIPTION
* Unify logging with AutoSuspend (e.g., keep ourselves to showing the delay in seconds, not the raw timestamp, as that's way harder to interpret, and the RTC module and/or logger will do that for us when the time comes).
* Speaking of, minor revamp of RTC related logging to make it more human-readable.
* On Kobo, if we hit the unexpected wakeup limit, re-engage AutoSuspend's *suspend* check, so that the device has a chance to poweroff instead of being kept awake.

Depends on https://github.com/koreader/koreader-base/pull/1323

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7400)
<!-- Reviewable:end -->
