### PR TITLE
Screensaver: Unbreak screensaver_stretch_images

### DIFF
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -111,7 +111,7 @@ function ReaderTypeset:onReadSettings(config)
         self.smooth_scaling = config:isTrue("smooth_scaling")
     else
         local global = G_reader_settings:readSetting("copt_smooth_scaling")
-        self.smooth_scaling = (global == nil or global == 0) and false or true
+        self.smooth_scaling = global == 1 and true or false
     end
     self:toggleImageScaling(self.smooth_scaling)
 

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -518,7 +518,7 @@ function Screensaver:show()
             image_disposable = true,
             height = Screen:getHeight(),
             width = Screen:getWidth(),
-            scale_factor = G_reader_settings:isTrue("screensaver_stretch_images") and nil or 0,
+            scale_factor = G_reader_settings:nilOrFalse("screensaver_stretch_images") and 0 or nil,
         }
     elseif self.screensaver_type == "bookstatus" then
         local ReaderUI = require("apps/reader/readerui")
@@ -540,7 +540,7 @@ function Screensaver:show()
             alpha = true,
             height = Screen:getHeight(),
             width = Screen:getWidth(),
-            scale_factor = G_reader_settings:isTrue("screensaver_stretch_images") and nil or 0,
+            scale_factor = G_reader_settings:nilOrFalse("screensaver_stretch_images") and 0 or nil,
         }
     elseif self.screensaver_type == "readingprogress" then
         widget = Screensaver.getReaderProgress()

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -694,13 +694,13 @@ function KOSync:saveSettings()
         auto_sync = self.kosync_auto_sync,
         pages_before_update = self.kosync_pages_before_update,
         whisper_forward =
-              (self.kosync_whisper_forward == SYNC_STRATEGY.DEFAULT_FORWARD
-               and nil
-               or self.kosync_whisper_forward),
+              (self.kosync_whisper_forward ~= SYNC_STRATEGY.DEFAULT_FORWARD
+               and self.kosync_whisper_forward
+               or nil),
         whisper_backward =
-              (self.kosync_whisper_backward == SYNC_STRATEGY.DEFAULT_BACKWARD
-               and nil
-               or self.kosync_whisper_backward),
+              (self.kosync_whisper_backward ~= SYNC_STRATEGY.DEFAULT_BACKWARD
+               and self.kosync_whisper_backward
+               or nil),
     }
     G_reader_settings:saveSetting("kosync", settings)
 end


### PR DESCRIPTION
We don't have real ternary operators in Lua, if the second argument
evaluates to false, it doesn't work.
Invert the test to avoid this pitfall.
(c.f., http://lua-users.org/wiki/TernaryOperator).

Fix #7402, regression since #7371

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7403)
<!-- Reviewable:end -->
