### PR TITLE
Update PDF annotations when changing bookmark text

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -597,9 +597,11 @@ end
 function ReaderBookmark:renameBookmark(item, from_highlight)
     if from_highlight then
         -- Called by ReaderHighlight:editHighlight, we need to find the bookmark
+        local pboxes = item.pboxes
         for i=1, #self.bookmarks do
             if item.datetime == self.bookmarks[i].datetime and item.page == self.bookmarks[i].page then
                 item = self.bookmarks[i]
+                item.pboxes = pboxes
                 if item.text == nil or item.text == "" then
                     -- Make up bookmark text as done in onShowBookmark
                     local page = item.page
@@ -647,6 +649,10 @@ function ReaderBookmark:renameBookmark(item, from_highlight)
                                 if item.text == self.bookmarks[i].text and  item.pos0 == self.bookmarks[i].pos0 and
                                     item.pos1 == self.bookmarks[i].pos1 and item.page == self.bookmarks[i].page then
                                     self.bookmarks[i].text = value
+                                    local setting = G_reader_settings:readSetting("save_document")
+                                    if setting ~= "disable" then
+                                        self.ui.document:updateHighlightContents(item.page, item, value)
+                                    end
                                     UIManager:close(self.input)
                                     if not from_highlight then
                                         self.refresh()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1441,6 +1441,7 @@ function ReaderHighlight:editHighlight(page, i)
     self.ui.bookmark:renameBookmark({
         page = self.ui.document.info.has_pages and page or item.pos0,
         datetime = item.datetime,
+        pboxes = item.pboxes
     }, true)
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1434,6 +1434,11 @@ function ReaderHighlight:deleteHighlight(page, i, bookmark_item)
             datetime = removed.datetime,
         })
     end
+    local setting = G_reader_settings:readSetting("save_document")
+    if setting ~= "disable" then
+        logger.dbg("delete highlight from document", removed)
+        self.ui.document:deleteHighlight(page, removed)
+    end
 end
 
 function ReaderHighlight:editHighlight(page, i)

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -483,6 +483,10 @@ function Document:saveHighlight(pageno, item)
     return nil
 end
 
+function Document:deleteHighlight(pageno, item)
+    return nil
+end
+
 function Document:updateHighlightContents(pageno, item, contents)
     return nil
 end

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -483,6 +483,10 @@ function Document:saveHighlight(pageno, item)
     return nil
 end
 
+function Document:updateHighlightContents(pageno, item, contents)
+    return nil
+end
+
 --[[
 helper functions
 --]]

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -194,6 +194,20 @@ function PdfDocument:saveHighlight(pageno, item)
     page:close()
 end
 
+function Document:deleteHighlight(pageno, item)
+    local can_write = self:_checkIfWritable()
+    if can_write ~= true then return can_write end
+
+    self.is_edited = true
+    local quadpoints, n = self:_quadpointsFromPboxes(item.pboxes)
+    local page = self._document:openPage(pageno)
+    local annot = page:getMarkupAnnotation(quadpoints, n)
+    if annot ~= nil then
+        page:deleteMarkupAnnotation(annot)
+    end
+    return nil
+end
+
 function PdfDocument:updateHighlightContents(pageno, item, contents)
     local can_write = self:_checkIfWritable()
     if can_write ~= true then return can_write end

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -205,7 +205,7 @@ function Document:deleteHighlight(pageno, item)
     if annot ~= nil then
         page:deleteMarkupAnnotation(annot)
     end
-    return nil
+    page:close()
 end
 
 function PdfDocument:updateHighlightContents(pageno, item, contents)


### PR DESCRIPTION
This changes the PDF annotation contents each time the corresponding bookmark text is edited. When the annotations are written to the PDF file, the annotation contents are saved as well into the PDF.

In my initial tests it works - I can see the bookmark texts in the PDF viewer Okular. However, there are still some rough edges (partly due to my inexperience with the code base and with Lua):
- To touch as little existing code as possible, I duplicated some code. Once verified that everything works, some refactoring should be done.
- More error checking/reporting should be added.
- Tests should be added for the feature.

Depends on some [low-level additions to koreader-base](https://github.com/koreader/koreader-base/pull/1327).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7411)
<!-- Reviewable:end -->
