### PR TITLE
Unbreak HTTP authentication

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -6,6 +6,7 @@ local socket = require("socket")
 local socketutil = require("socketutil")
 local util = require("util")
 local _ = require("gettext")
+local logger = require("logger")
 
 local WebDavApi = {
 }
@@ -94,6 +95,11 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
     local headers_request = socket.skip(1, http.request(request))
     socketutil:reset_timeout()
     if headers_request == nil then
+        return nil
+    elseif headers_request < 200 or headers_request >= 300 then
+        -- got a response, but it wasn't a success (e.g. auth failure)
+        logger.dbg(headers_request)
+        logger.dbg(table.concat(sink))
         return nil
     end
 

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -87,7 +87,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
             ["Depth"]          = "1",
             ["Content-Length"] = #data,
         },
-        username = user,
+        user     = user,
         password = pass,
         source   = ltn12.source.string(data),
         sink     = ltn12.sink.table(sink),
@@ -162,7 +162,7 @@ function WebDavApi:downloadFile(file_url, user, pass, local_path)
         url      = file_url,
         method   = "GET",
         sink     = ltn12.sink.file(io.open(local_path, "w")),
-        username = user,
+        user     = user,
         password = pass,
     })
     socketutil:reset_timeout()

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -4,6 +4,7 @@ local http = require("socket.http")
 local ltn12 = require("ltn12")
 local socket = require("socket")
 local socketutil = require("socketutil")
+local mime = require("mime")
 local util = require("util")
 local _ = require("gettext")
 local logger = require("logger")
@@ -79,16 +80,16 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
     local sink = {}
     local data = [[<?xml version="1.0"?><a:propfind xmlns:a="DAV:"><a:prop><a:resourcetype/></a:prop></a:propfind>]]
     socketutil:set_timeout()
+    local auth = string.format("%s:%s", user, pass)
     local request = {
         url      = webdav_url,
         method   = "PROPFIND",
         headers  = {
+            ["Authorization"] = "Basic " .. mime.b64( auth ),
             ["Content-Type"]   = "application/xml",
             ["Depth"]          = "1",
             ["Content-Length"] = #data,
         },
-        username = user,
-        password = pass,
         source   = ltn12.source.string(data),
         sink     = ltn12.sink.table(sink),
     }
@@ -158,12 +159,14 @@ end
 
 function WebDavApi:downloadFile(file_url, user, pass, local_path)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+    local auth = string.format("%s:%s", user, pass)
     local code_return = socket.skip(1, http.request{
         url      = file_url,
+        headers  = {
+            ["Authorization"] = "Basic " .. mime.b64( auth ),
+        },
         method   = "GET",
         sink     = ltn12.sink.file(io.open(local_path, "w")),
-        username = user,
-        password = pass,
     })
     socketutil:reset_timeout()
     return code_return

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -278,7 +278,7 @@ function OPDSBrowser:fetchFeed(item_url, username, password, method)
             ["Accept-Encoding"] = "identity",
         },
         sink     = ltn12.sink.table(sink),
-        username = username,
+        user     = username,
         password = password,
     }
     logger.info("Request:", request)


### PR DESCRIPTION
It appears that passing `username` and `password` to `http.request()` doesn't work.

http://w3.impa.br/~diego/software/luasocket/http.html#request indicates that the way to set this is with a URL like `http://user:pass@url.com/foo`. This does actually work if you set this URL in the WebDAV settings.

This patch uses the (old) alternative method of direct authentication, so as not to have to mess about with splitting the protocol, adding the `user:password@` and recombining.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7425)
<!-- Reviewable:end -->
