### PR TITLE
Kobo: Allow toggling the WAIT_FOR_UPDATE_COMPLETE hack

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -542,11 +542,8 @@ To:
                 else
                     mxcfb_bypass_wait_for = not Device:hasReliableMxcWaitFor()
                 end
-                G_reader_settings:saveSetting("mxcfb_bypass_wait_for", not mxcfb_bypass_wait_for)
-                local InfoMessage = require("ui/widget/infomessage")
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                Screen:toggleMxcWaitForBypass(not mxcfb_bypass_wait_for)
+                G_reader_settings:saveSetting("mxcfb_bypass_wait_for", Screen:getMxcWaitForBypass())
             end,
         })
     end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -527,10 +527,22 @@ To:
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Bypass the MXCFB_WAIT_FOR_* ioctls"),
             checked_func = function()
-                return (G_reader_settings:has("mxcfb_bypass_wait_for") and G_reader_settings:isTrue("mxcfb_bypass_wait_for")) or not Device:hasReliableMxcWaitFor()
+                local mxcfb_bypass_wait_for
+                if G_reader_settings:has("mxcfb_bypass_wait_for") then
+                    mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
+                else
+                    mxcfb_bypass_wait_for = not Device:hasReliableMxcWaitFor()
+                end
+                return mxcfb_bypass_wait_for
             end,
             callback = function()
-                G_reader_settings:toggle("mxcfb_bypass_wait_for")
+                local mxcfb_bypass_wait_for
+                if G_reader_settings:has("mxcfb_bypass_wait_for") then
+                    mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
+                else
+                    mxcfb_bypass_wait_for = not Device:hasReliableMxcWaitFor()
+                end
+                G_reader_settings:saveSetting("mxcfb_bypass_wait_for", not mxcfb_bypass_wait_for)
                 local InfoMessage = require("ui/widget/infomessage")
                 UIManager:show(InfoMessage:new{
                     text = _("This will take effect on next restart."),

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -542,8 +542,11 @@ To:
                 else
                     mxcfb_bypass_wait_for = not Device:hasReliableMxcWaitFor()
                 end
-                Screen:toggleMxcWaitForBypass(not mxcfb_bypass_wait_for)
-                G_reader_settings:saveSetting("mxcfb_bypass_wait_for", Screen:getMxcWaitForBypass())
+                G_reader_settings:saveSetting("mxcfb_bypass_wait_for", not mxcfb_bypass_wait_for)
+                local InfoMessage = require("ui/widget/infomessage")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
             end,
         })
     end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -451,8 +451,8 @@ To:
             end,
         })
     end
-    --- @note Currently, only Kobo has a fancy crash display (#5328)
-    if Device:isKobo() then
+    --- @note Currently, only Kobo, rM & PB have a fancy crash display (#5328)
+    if Device:isKobo() or Device:isRemarkable() or Device:isPocketBook() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Always abort on crash"),
             checked_func = function()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -525,7 +525,7 @@ To:
     --- @note: Currently, only Kobo implements this quirk
     if Device:hasEinkScreen() and Device:isKobo() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
-            text = _("Bypass the MXCFB_WAIT_FOR ioctl"),
+            text = _("Bypass the MXCFB_WAIT_FOR_* ioctls"),
             checked_func = function()
                 return (G_reader_settings:has("mxcfb_bypass_wait_for") and G_reader_settings:isTrue("mxcfb_bypass_wait_for")) or not Device:hasReliableMxcWaitFor()
             end,

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -522,6 +522,22 @@ To:
             end,
         })
     end
+    --- @note: Currently, only Kobo implements this quirk
+    if Device:hasEinkScreen() and Device:isKobo() then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            text = _("Bypass the MXCFB_WAIT_FOR ioctl"),
+            checked_func = function()
+                return (G_reader_settings:has("mxcfb_bypass_wait_for") and G_reader_settings:isTrue("mxcfb_bypass_wait_for")) or not Device:hasReliableMxcWaitFor()
+            end,
+            callback = function()
+                G_reader_settings:toggle("mxcfb_bypass_wait_for")
+                local InfoMessage = require("ui/widget/infomessage")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
+            end,
+        })
+    end
     if Device:isAndroid() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Start E-ink test"),

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -525,6 +525,7 @@ To:
     --- @note: Currently, only Kobo implements this quirk
     if Device:hasEinkScreen() and Device:isKobo() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
+            -- @translators Highly technical (ioctl is a Linux API call, the uppercase stuff is a constant). What's translatable is essentially only the action ("bypass") and the article.
             text = _("Bypass the MXCFB_WAIT_FOR_* ioctls"),
             checked_func = function()
                 local mxcfb_bypass_wait_for

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -281,7 +281,12 @@ local KoboLuna = Kobo:new{
 
 function Kobo:init()
     -- Check if we need to disable MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls...
-    local mxcfb_bypass_wait_for = (G_reader_settings:has("mxcfb_bypass_wait_for") and G_reader_settings:isTrue("mxcfb_bypass_wait_for")) or not self:hasReliableMxcWaitFor()
+    local mxcfb_bypass_wait_for
+    if G_reader_settings:has("mxcfb_bypass_wait_for") then
+        mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
+    else
+        mxcfb_bypass_wait_for = not self:hasReliableMxcWaitFor()
+    end
 
     self.screen = require("ffi/framebuffer_mxcfb"):new{
         device = self,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -49,6 +49,8 @@ local Kobo = Generic:new{
     canHWInvert = yes,
     home_dir = "/mnt/onboard",
     canToggleMassStorage = yes,
+    -- MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls are generally reliable
+    hasReliableMxcWaitFor = yes,
 }
 
 --- @todo hasKeys for some devices?
@@ -259,6 +261,12 @@ local KoboStorm = Kobo:new{
         nl_max = 10,
         nl_inverted = true,
     },
+    -- NOTE: The Libra apparently suffers from a mysterious issue where completely innocuous WAIT_FOR_UPDATE_COMPLETE ioctls
+    --       will mysteriously fail with a timeout (5s)...
+    --       This obviously leads to *terrible* user experience, so, until more is understood avout the issue,
+    --       bypass this ioctl on this device.
+    --       c.f., https://github.com/koreader/koreader/issues/7340
+    hasReliableMxcWaitFor = no,
 }
 
 -- Kobo Nia:
@@ -272,7 +280,15 @@ local KoboLuna = Kobo:new{
 }
 
 function Kobo:init()
-    self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg, is_always_portrait = self.isAlwaysPortrait()}
+    -- Check if we need to disable MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls...
+    local mxcfb_bypass_wait_for = (G_reader_settings:has("mxcfb_bypass_wait_for") and G_reader_settings:isTrue("mxcfb_bypass_wait_for")) or not self:hasReliableMxcWaitFor()
+
+    self.screen = require("ffi/framebuffer_mxcfb"):new{
+        device = self,
+        debug = logger.dbg,
+        is_always_portrait = self.isAlwaysPortrait(),
+        mxcfb_bypass_wait_for = mxcfb_bypass_wait_for,
+    }
     if self.screen.fb_bpp == 32 then
         -- Ensure we decode images properly, as our framebuffer is BGRA...
         logger.info("Enabling Kobo @ 32bpp BGR tweaks")


### PR DESCRIPTION
And enable it by default on the Libra (which already happened in base previously, since https://github.com/koreader/koreader-base/pull/1329).

This is hidden away inside the dev menu, because duh'.

Requires https://github.com/koreader/koreader-base/pull/1334

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7431)
<!-- Reviewable:end -->
