### PR TITLE
TOC settings: fix possible crash

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -961,7 +961,9 @@ See Style tweaks → Miscellaneous → Alternative ToC hints.]]),
                     break
                 end
             end
-            toc_ticks_levels[#toc_ticks_levels].separator = true
+            if #toc_ticks_levels > 0 then
+                toc_ticks_levels[#toc_ticks_levels].separator = true
+            end
             table.insert(toc_ticks_levels, {
                 text = _("Bind chapter navigation to ticks"),
                 help_text = _([[Entries from ToC levels that are ignored in the progress bars will still be used for chapter navigation and 'page/time left until next chapter' in the footer.


### PR DESCRIPTION
Fix for https://github.com/koreader/koreader/issues/7428#issuecomment-802959731 , although I can't reproduce it, and this part being run and this crash happening should have been prevented by the enabled_func not allowing it to be run...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7434)
<!-- Reviewable:end -->
