### PR TITLE
Fulltext search: show notification when nothing found

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -4,10 +4,9 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local Notification = require("ui/widget/notification")
 local UIManager = require("ui/uimanager")
-local T = require("ffi/util").template
 local logger = require("logger")
 local _ = require("gettext")
-
+local T = require("ffi/util").template
 local ReaderSearch = InputContainer:new{
     direction = 0, -- 0 for search forward, 1 for search backward
     case_insensitive = true, -- default to case insensitive

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -152,7 +152,7 @@ function ReaderSearch:onShowSearchDialog(text, direction)
             if no_results then
                 local notification_text
                 if self._expect_back_results then
-                    notification_text = _("No results on previous pages")
+                    notification_text = _("No results on preceding pages")
                 else
                     notification_text = _("No results on following pages")
                 end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -167,18 +167,22 @@ function ReaderSearch:onShowSearchDialog(text, direction)
             {
                 {
                     text = from_start_text,
+                    vsync = true,
                     callback = do_search(self.searchFromStart, text),
                 },
                 {
                     text = backward_text,
+                    vsync = true,
                     callback = do_search(self.searchNext, text, 1),
                 },
                 {
                     text = forward_text,
+                    vsync = true,
                     callback = do_search(self.searchNext, text, 0),
                 },
                 {
                     text = from_end_text,
+                    vsync = true,
                     callback = do_search(self.searchFromEnd, text),
                 },
             }

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -3,6 +3,8 @@ local ButtonDialog = require("ui/widget/buttondialog")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local UIManager = require("ui/uimanager")
+local InfoMessage = require("ui/widget/infomessage")
+local T = require("ffi/util").template
 local logger = require("logger")
 local _ = require("gettext")
 
@@ -144,6 +146,13 @@ function ReaderSearch:onShowSearchDialog(text, direction)
                 end
                 -- Don't add result pages to location ("Go back") stack
                 neglect_current_location = true
+            else
+                UIManager:show(
+                    InfoMessage:new{
+                        text = T(_("'%1' not found"), text),
+                        timeout = 2
+                    }
+                )
             end
         end
     end
@@ -162,22 +171,18 @@ function ReaderSearch:onShowSearchDialog(text, direction)
             {
                 {
                     text = from_start_text,
-                    vsync = true,
                     callback = do_search(self.searchFromStart, text),
                 },
                 {
                     text = backward_text,
-                    vsync = true,
                     callback = do_search(self.searchNext, text, 1),
                 },
                 {
                     text = forward_text,
-                    vsync = true,
                     callback = do_search(self.searchNext, text, 0),
                 },
                 {
                     text = from_end_text,
-                    vsync = true,
                     callback = do_search(self.searchFromEnd, text),
                 },
             }

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -6,7 +6,6 @@ local Notification = require("ui/widget/notification")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
-local T = require("ffi/util").template
 local ReaderSearch = InputContainer:new{
     direction = 0, -- 0 for search forward, 1 for search backward
     case_insensitive = true, -- default to case insensitive
@@ -148,8 +147,7 @@ function ReaderSearch:onShowSearchDialog(text, direction)
             else
                 UIManager:show(
                     Notification:new{
-                        text = T(_("'%1' not found"), text),
-                        timeout = 3,
+                        text = "Not found",
                     }
                 )
             end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -2,8 +2,8 @@ local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
+local Notification = require("ui/widget/notification")
 local UIManager = require("ui/uimanager")
-local InfoMessage = require("ui/widget/infomessage")
 local T = require("ffi/util").template
 local logger = require("logger")
 local _ = require("gettext")
@@ -148,9 +148,9 @@ function ReaderSearch:onShowSearchDialog(text, direction)
                 neglect_current_location = true
             else
                 UIManager:show(
-                    InfoMessage:new{
+                    Notification:new{
                         text = T(_("'%1' not found"), text),
-                        timeout = 2
+                        timeout = 3
                     }
                 )
             end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -147,7 +147,7 @@ function ReaderSearch:onShowSearchDialog(text, direction)
                 neglect_current_location = true
             else
                 UIManager:show(Notification:new{
-                    text = "Not found",
+                    text = _("Not found"),
                 })
             end
         end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -74,6 +74,7 @@ function ReaderSearch:onShowSearchDialog(text, direction)
     local current_page
     local do_search = function(search_func, _text, param)
         return function()
+            local valid_link
             local res = search_func(self, _text, param)
             if res then
                 if self.ui.document.info.has_pages then
@@ -88,7 +89,6 @@ function ReaderSearch:onShowSearchDialog(text, direction)
                     -- sometimes even xpointers that resolve to no page.
                     -- We need to loop thru all the results until we find one suitable,
                     -- to follow its link and go to the next/prev page with occurences.
-                    local valid_link
                     -- If backward search, results are already in a reversed order, so we'll
                     -- start from the nearest to current page one.
                     for _, r in ipairs(res) do
@@ -145,9 +145,16 @@ function ReaderSearch:onShowSearchDialog(text, direction)
                 end
                 -- Don't add result pages to location ("Go back") stack
                 neglect_current_location = true
-            else
+            end
+            if res==nil or (current_page~=nil and valid_link==nil) then
+                local notification_text
+                if self._expect_back_results then
+                    notification_text = _("No results backward")
+                else
+                    notification_text = _("No results forward")
+                end
                 UIManager:show(Notification:new{
-                    text = _("Not found"),
+                    text = notification_text,
                 })
             end
         end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -149,7 +149,7 @@ function ReaderSearch:onShowSearchDialog(text, direction)
                 UIManager:show(
                     Notification:new{
                         text = T(_("'%1' not found"), text),
-                        timeout = 3
+                        timeout = 3,
                     }
                 )
             end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -6,6 +6,7 @@ local Notification = require("ui/widget/notification")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
+
 local ReaderSearch = InputContainer:new{
     direction = 0, -- 0 for search forward, 1 for search backward
     case_insensitive = true, -- default to case insensitive
@@ -145,11 +146,9 @@ function ReaderSearch:onShowSearchDialog(text, direction)
                 -- Don't add result pages to location ("Go back") stack
                 neglect_current_location = true
             else
-                UIManager:show(
-                    Notification:new{
-                        text = "Not found",
-                    }
-                )
+                UIManager:show(Notification:new{
+                    text = "Not found",
+                })
             end
         end
     end


### PR DESCRIPTION
When nothing found now we have the `search_dialog` (arrows) displayed and need to observe the screen whether there are any search results highlighted.
I propose to show the infomessage for 2 sec.
After that we can continue search in the opposite direction with the `search_dialog` if needed.

`vsync` removed to avoid the `search_dialog` buttons showing up over the infomessage and it seems to cause no problems anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7436)
<!-- Reviewable:end -->
