### PR TITLE
Initial KOA3 support

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -795,7 +795,8 @@ function KindleOasis2:init()
     self.input.open("fake_events")
 end
 
--- For now, assume that the KOA3 doesn't do anything differently than the KOA2
+-- For now, assume that the KOA3 doesn't do anything differently than the KOA2.
+--- @fixme: That means, possibly among other things, that frontlight warmth needs to be implemented.
 KindleOasis3.init = KindleOasis2.init
 
 function KindleBasic2:init()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -109,6 +109,15 @@ local Kindle = Generic:new{
     -- NOTE: Newer devices will turn the frontlight off at 0
     canTurnFrontlightOff = yes,
     home_dir = "/mnt/us",
+    -- New devices are REAGL-aware, default to REAGL
+    isREAGL = yes,
+    -- Rex & Zelda devices sport an updated driver.
+    isZelda = no,
+    isRex = no,
+    -- But of course, some devices don't actually support all the features the kernel exposes...
+    isNightModeChallenged = no,
+    -- NOTE: While this ought to behave on Zelda/Rex, turns out, nope, it really doesn't work on *any* of 'em :/ (c.f., ko#5884).
+    canHWDither = no,
 }
 
 function Kindle:initNetworkManager(NetworkMgr)
@@ -274,6 +283,7 @@ end
 
 local Kindle2 = Kindle:new{
     model = "Kindle2",
+    isREAGL = no,
     hasKeyboard = yes,
     hasKeys = yes,
     hasDPad = yes,
@@ -285,6 +295,7 @@ local Kindle2 = Kindle:new{
 
 local KindleDXG = Kindle:new{
     model = "KindleDXG",
+    isREAGL = no,
     hasKeyboard = yes,
     hasKeys = yes,
     hasDPad = yes,
@@ -296,6 +307,7 @@ local KindleDXG = Kindle:new{
 
 local Kindle3 = Kindle:new{
     model = "Kindle3",
+    isREAGL = no,
     hasKeyboard = yes,
     hasKeys = yes,
     hasDPad = yes,
@@ -306,6 +318,7 @@ local Kindle3 = Kindle:new{
 
 local Kindle4 = Kindle:new{
     model = "Kindle4",
+    isREAGL = no,
     hasKeys = yes,
     hasDPad = yes,
     canHWInvert = no,
@@ -316,6 +329,7 @@ local Kindle4 = Kindle:new{
 
 local KindleTouch = Kindle:new{
     model = "KindleTouch",
+    isREAGL = no,
     isTouchDevice = yes,
     hasKeys = yes,
     touch_dev = "/dev/input/event3",
@@ -323,6 +337,7 @@ local KindleTouch = Kindle:new{
 
 local KindlePaperWhite = Kindle:new{
     model = "KindlePaperWhite",
+    isREAGL = no,
     isTouchDevice = yes,
     hasFrontlight = yes,
     canTurnFrontlightOff = no,
@@ -382,6 +397,7 @@ local KindleOasis = Kindle:new{
 
 local KindleOasis2 = Kindle:new{
     model = "KindleOasis2",
+    isZelda = yes,
     isTouchDevice = yes,
     hasFrontlight = yes,
     hasKeys = yes,
@@ -398,6 +414,7 @@ local KindleBasic2 = Kindle:new{
 
 local KindlePaperWhite4 = Kindle:new{
     model = "KindlePaperWhite4",
+    isRex = yes,
     isTouchDevice = yes,
     hasFrontlight = yes,
     display_dpi = 300,
@@ -409,6 +426,10 @@ local KindlePaperWhite4 = Kindle:new{
 
 local KindleBasic3 = Kindle:new{
     model = "KindleBasic3",
+    isRex = yes,
+    -- NOTE: Apparently, the KT4 doesn't actually support the fancy nightmode waveforms, c.f., ko/#5076
+    --       It also doesn't handle HW dithering, c.f., base/#1039
+    isNightModeChallenged = yes,
     isTouchDevice = yes,
     hasFrontlight = yes,
     touch_dev = "/dev/input/event2",

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -406,6 +406,17 @@ local KindleOasis2 = Kindle:new{
     touch_dev = "/dev/input/by-path/platform-30a30000.i2c-event",
 }
 
+local KindleOasis3 = Kindle:new{
+    model = "KindleOasis3",
+    isZelda = yes,
+    isTouchDevice = yes,
+    hasFrontlight = yes,
+    hasKeys = yes,
+    hasGSensor = yes,
+    display_dpi = 300,
+    touch_dev = "/dev/input/by-path/platform-30a30000.i2c-event",
+}
+
 local KindleBasic2 = Kindle:new{
     model = "KindleBasic2",
     isTouchDevice = yes,
@@ -784,6 +795,9 @@ function KindleOasis2:init()
     self.input.open("fake_events")
 end
 
+-- For now, assume that the KOA3 doesn't do anything differently than the KOA2
+KindleOasis3.init = KindleOasis2.init
+
 function KindleBasic2:init()
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
@@ -866,6 +880,7 @@ KindleOasis2.exit = KindleTouch.exit
 KindleBasic2.exit = KindleTouch.exit
 KindlePaperWhite4.exit = KindleTouch.exit
 KindleBasic3.exit = KindleTouch.exit
+KindleOasis3.exit = KindleTouch.exit
 
 function Kindle3:exit()
     -- send double menu key press events to trigger screen refresh
@@ -918,6 +933,7 @@ local pw4_set = Set { "0PP", "0T1", "0T2", "0T3", "0T4", "0T5", "0T6",
                   "0T7", "0TJ", "0TK", "0TL", "0TM", "0TN", "102", "103",
                   "16Q", "16R", "16S", "16T", "16U", "16V" }
 local kt4_set = Set { "10L", "0WF", "0WG", "0WH", "0WJ", "0VB" }
+local koa3_set = Set { "11L", "0WQ", "0WP", "0WN", "0WM", "0WL" }
 
 if kindle_sn_lead == "B" or kindle_sn_lead == "9" then
     local kindle_devcode = string.sub(kindle_sn,3,4)
@@ -958,6 +974,8 @@ else
         return KindlePaperWhite4
     elseif kt4_set[kindle_devcode_v2] then
         return KindleBasic3
+    elseif koa3_set[kindle_devcode_v2] then
+        return KindleOasis3
     end
 end
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -49,6 +49,10 @@ local Kobo = Generic:new{
     canHWInvert = yes,
     home_dir = "/mnt/onboard",
     canToggleMassStorage = yes,
+    -- New devices *may* be REAGL-aware, but generally don't expect explicit REAGL requests, default to not.
+    isREAGL = no,
+    -- Mark 7 devices sport an updated driver.
+    isMk7 = no,
     -- MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls are generally reliable
     hasReliableMxcWaitFor = yes,
 }
@@ -125,6 +129,8 @@ local KoboPhoenix = Kobo:new{
     display_dpi = 212,
     -- The bezel covers 10 pixels at the bottom:
     viewport = Geom:new{x=0, y=0, w=758, h=1014},
+    -- NOTE: AFAICT, the Aura was the only one explicitly requiring REAGL requests...
+    isREAGL = yes,
     -- NOTE: May have a buggy kernel, according to the nightmode hack...
     canHWInvert = no,
 }
@@ -148,6 +154,7 @@ local KoboSnow = Kobo:new{
 --- @fixme Check if the Clara fix actually helps here... (#4015)
 local KoboSnowRev2 = Kobo:new{
     model = "Kobo_snow_r2",
+    isMk7 = yes,
     hasFrontlight = yes,
     touch_snow_protocol = true,
     display_dpi = 265,
@@ -167,9 +174,9 @@ local KoboStar = Kobo:new{
 }
 
 -- Kobo Aura second edition, Rev 2:
---- @fixme Confirm that this is accurate? If it is, and matches the Rev1, ditch the special casing.
 local KoboStarRev2 = Kobo:new{
     model = "Kobo_star_r2",
+    isMk7 = yes,
     hasFrontlight = yes,
     touch_phoenix_protocol = true,
     display_dpi = 212,
@@ -194,6 +201,7 @@ local KoboPika = Kobo:new{
 -- Kobo Clara HD:
 local KoboNova = Kobo:new{
     model = "Kobo_nova",
+    isMk7 = yes,
     canToggleChargingLED = yes,
     hasFrontlight = yes,
     touch_snow_protocol = true,
@@ -219,6 +227,7 @@ local KoboNova = Kobo:new{
 --       There's also a CM_ROTARY_ENABLE command, but which seems to do as much nothing as the STATUS one...
 local KoboFrost = Kobo:new{
     model = "Kobo_frost",
+    isMk7 = yes,
     canToggleChargingLED = yes,
     hasFrontlight = yes,
     hasKeys = yes,
@@ -243,6 +252,7 @@ local KoboFrost = Kobo:new{
 -- NOTE: Assume the same quirks as the Forma apply.
 local KoboStorm = Kobo:new{
     model = "Kobo_storm",
+    isMk7 = yes,
     canToggleChargingLED = yes,
     hasFrontlight = yes,
     hasKeys = yes,
@@ -273,6 +283,7 @@ local KoboStorm = Kobo:new{
 --- @fixme: Untested, assume it's Clara-ish for now.
 local KoboLuna = Kobo:new{
     model = "Kobo_luna",
+    isMk7 = yes,
     canToggleChargingLED = yes,
     hasFrontlight = yes,
     touch_snow_protocol = true,
@@ -303,6 +314,10 @@ function Kobo:init()
     -- Automagically set this so we never have to remember to do it manually ;p
     if self:hasNaturalLight() and self.frontlight_settings and self.frontlight_settings.frontlight_mixer then
         self.hasNaturalLightMixer = yes
+    end
+    -- Ditto
+    if self:isMk7() then
+        self.canHWDither = yes
     end
 
     self.powerd = require("device/kobo/powerd"):new{device = self}

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -40,8 +40,6 @@ local Kobo = Generic:new{
     isAlwaysPortrait = yes,
     -- we don't need an extra refreshFull on resume, thank you very much.
     needsScreenRefreshAfterResume = no,
-    -- the internal storage mount point users can write to
-    internal_storage_mount_point = "/mnt/onboard/",
     -- currently only the Aura One and Forma have coloured frontlights
     hasNaturalLight = no,
     hasNaturalLightMixer = no,


### PR DESCRIPTION
* Also, move MXCFB cap checks to Device.
* Requires https://github.com/koreader/koreader-base/pull/1339

Fix #7433 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7446)
<!-- Reviewable:end -->
