### PR TITLE
PluginLoader should update lookup_path_list if data_dir is not ".".

### DIFF
--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -66,8 +66,9 @@ function PluginLoader:loadPlugins()
     else
         local data_dir = require("datastorage"):getDataDir()
         if data_dir ~= "." then
-            extra_paths = { data_dir .. "/plugins/" }
-            G_reader_settings:saveSetting("extra_plugin_paths", extra_paths)
+            local extra_path = data_dir .. "/plugins/"
+            G_reader_settings:saveSetting("extra_plugin_paths", { extra_path })
+            table.insert(lookup_path_list, extra_path)
         end
     end
 

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -66,7 +66,8 @@ function PluginLoader:loadPlugins()
     else
         local data_dir = require("datastorage"):getDataDir()
         if data_dir ~= "." then
-            G_reader_settings:saveSetting("extra_plugin_paths", { data_dir .. "/plugins/" })
+            extra_paths = { data_dir .. "/plugins/" }
+            G_reader_settings:saveSetting("extra_plugin_paths", extra_paths)
         end
     end
 


### PR DESCRIPTION
It looks like a problem introduced by https://github.com/koreader/koreader/commit/dee72a431c1ef4d59569ffc80b876e2e91765bbf#diff-b3b0e0e90ea7b43a9d97a1c7572acef3f1dc7d1d2f75fe634345a1b841c624fa. Or did I misunderstand it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7447)
<!-- Reviewable:end -->
