### PR TITLE
Text editor: option to show/hide keyboard on start

### DIFF
--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -478,7 +478,7 @@ function TextEditor:editFile(file_path, readonly)
     local buttons_first_row = {}  -- First button on first row, that will be filled with Reset|Save|Close
     if is_lua then
         table.insert(buttons_first_row, {
-            text = _("Check Lua"),
+            text = _("Lua check"),
             callback = function()
                 local parse_error = util.checkLuaSyntax(input:getInputText())
                 if parse_error then

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -67,7 +67,7 @@ function TextEditor:loadSettings()
     self.auto_para_direction = self.settings:nilOrTrue("auto_para_direction")
     self.force_ltr_para_direction = self.settings:isTrue("force_ltr_para_direction")
     self.qr_code_export = self.settings:nilOrTrue("qr_code_export")
-    self.show_kbd_on_start = self.settings:nilOrTrue("show_kbd_on_start")
+    self.show_keyboard_on_start = self.settings:nilOrTrue("show_keyboard_on_start")
 end
 
 function TextEditor:onFlushSettings()
@@ -80,7 +80,7 @@ function TextEditor:onFlushSettings()
         self.settings:saveSetting("auto_para_direction", self.auto_para_direction)
         self.settings:saveSetting("force_ltr_para_direction", self.force_ltr_para_direction)
         self.settings:saveSetting("qr_code_export", self.qr_code_export)
-        self.settings:saveSetting("show_kbd_on_start", self.show_kbd_on_start)
+        self.settings:saveSetting("show_keyboard_on_start", self.show_keyboard_on_start)
         self.settings:flush()
     end
 end
@@ -173,10 +173,10 @@ Export text to QR code, that can be scanned, for example, by a phone.]]),
                 {
                     text = _("Show keyboard on start"),
                     checked_func = function()
-                        return self.show_kbd_on_start
+                        return self.show_keyboard_on_start
                     end,
                     callback = function()
-                        self.show_kbd_on_start = not self.show_kbd_on_start
+                        self.show_keyboard_on_start = not self.show_keyboard_on_start
                     end,
                 },
             },
@@ -516,7 +516,7 @@ function TextEditor:editFile(file_path, readonly)
         cursor_at_end = false,
         readonly = readonly,
         add_nav_bar = true,
-        keyboard_hidden = not self.show_kbd_on_start,
+        keyboard_hidden = not self.show_keyboard_on_start,
         scroll_by_pan = true,
         buttons = {buttons_first_row},
         -- Set/save view and cursor position callback

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -158,6 +158,16 @@ Enable this if you are mostly editing code, HTML, CSS…]]),
                     callback = function()
                         self.force_ltr_para_direction = not self.force_ltr_para_direction
                     end,
+                    separator = true,
+                },
+                {
+                    text = _("Show keyboard on start"),
+                    checked_func = function()
+                        return self.show_keyboard_on_start
+                    end,
+                    callback = function()
+                        self.show_keyboard_on_start = not self.show_keyboard_on_start
+                    end,
                 },
                 {
                     text = _("Enable QR code export"),
@@ -168,15 +178,6 @@ Export text to QR code, that can be scanned, for example, by a phone.]]),
                     end,
                     callback = function()
                         self.qr_code_export = not self.qr_code_export
-                    end,
-                },
-                {
-                    text = _("Show keyboard on start"),
-                    checked_func = function()
-                        return self.show_keyboard_on_start
-                    end,
-                    callback = function()
-                        self.show_keyboard_on_start = not self.show_keyboard_on_start
                     end,
                 },
             },

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -28,6 +28,7 @@ local TextEditor = WidgetContainer:new{
     history_keep_size = 60, -- hom many to keep in settings
     normal_font = "x_smallinfofont",
     monospace_font = "infont",
+    default_font_size = 20, -- x_smallinfofont default size
     min_file_size_warn = 200000, -- warn/ask when opening files bigger than this
 }
 
@@ -50,7 +51,7 @@ function TextEditor:loadSettings()
     self.last_view_pos = self.settings:readSetting("last_view_pos") or {}
     self.last_path = self.settings:readSetting("last_path") or ffiutil.realpath(DataStorage:getDataDir())
     self.font_face = self.settings:readSetting("font_face") or self.normal_font
-    self.font_size = self.settings:readSetting("font_size") or 20 -- x_smallinfofont default size
+    self.font_size = self.settings:readSetting("font_size") or self.default_font_size
     -- The font settings could be saved in G_reader_setting if we want them
     -- to be re-used by default by InputDialog (on certain conditaions,
     -- when fullscreen or condensed or add_nav_bar...)
@@ -66,6 +67,7 @@ function TextEditor:loadSettings()
     self.auto_para_direction = self.settings:nilOrTrue("auto_para_direction")
     self.force_ltr_para_direction = self.settings:isTrue("force_ltr_para_direction")
     self.qr_code_export = self.settings:nilOrTrue("qr_code_export")
+    self.show_kbd_on_start = self.settings:nilOrTrue("show_kbd_on_start")
 end
 
 function TextEditor:onFlushSettings()
@@ -78,6 +80,7 @@ function TextEditor:onFlushSettings()
         self.settings:saveSetting("auto_para_direction", self.auto_para_direction)
         self.settings:saveSetting("force_ltr_para_direction", self.force_ltr_para_direction)
         self.settings:saveSetting("qr_code_export", self.qr_code_export)
+        self.settings:saveSetting("show_kbd_on_start", self.show_kbd_on_start)
         self.settings:flush()
     end
 end
@@ -96,10 +99,10 @@ function TextEditor:getSubMenuItems()
     self.whenDoneFunc = nil -- discard reference to previous TouchMenu instance
     local sub_item_table = {
         {
-            text = _("Text editor settings"),
+            text = _("Settings"),
             sub_item_table = {
                 {
-                    text = _("Set text font size"),
+                    text = _("Text font size"),
                     keep_menu_open = true,
                     callback = function()
                         local SpinWidget = require("ui/widget/spinwidget")
@@ -109,8 +112,8 @@ function TextEditor:getSubMenuItems()
                             value = font_size,
                             value_min = 8,
                             value_max = 26,
-                            ok_text = _("Set font size"),
-                            title_text =  _("Select font size"),
+                            default_value = self.default_font_size,
+                            title_text =  _("Text font size"),
                             callback = function(spin)
                                 self.font_size = spin.value
                             end,
@@ -167,23 +170,32 @@ Export text to QR code, that can be scanned, for example, by a phone.]]),
                         self.qr_code_export = not self.qr_code_export
                     end,
                 },
+                {
+                    text = _("Show keyboard on start"),
+                    checked_func = function()
+                        return self.show_kbd_on_start
+                    end,
+                    callback = function()
+                        self.show_kbd_on_start = not self.show_kbd_on_start
+                    end,
+                },
             },
             separator = true,
         },
         {
-            text = _("Select a file to open"),
-            keep_menu_open = true,
-            callback = function(touchmenu_instance)
-                self:setupWhenDoneFunc(touchmenu_instance)
-                self:chooseFile()
-            end,
-        },
-        {
-            text = _("Edit a new empty file"),
+            text = _("New file"),
             keep_menu_open = true,
             callback = function(touchmenu_instance)
                 self:setupWhenDoneFunc(touchmenu_instance)
                 self:newFile()
+            end,
+        },
+        {
+            text = _("Open file"),
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                self:setupWhenDoneFunc(touchmenu_instance)
+                self:chooseFile()
             end,
             separator = true,
         },
@@ -504,6 +516,7 @@ function TextEditor:editFile(file_path, readonly)
         cursor_at_end = false,
         readonly = readonly,
         add_nav_bar = true,
+        keyboard_hidden = not self.show_kbd_on_start,
         scroll_by_pan = true,
         buttons = {buttons_first_row},
         -- Set/save view and cursor position callback


### PR DESCRIPTION
Allows to hide keyboard on start to see more text.
Default is to show keyboard.

Some wordings unification.
`Open file` goes down, closer to the list of opened files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7460)
<!-- Reviewable:end -->
