### PR TITLE
bump crengine: add support for MathML

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -934,7 +934,7 @@ function CreDocument:setupFallbackFontFaces()
     -- names than ',' or ';', without the need to have to use quotes.
     local s_fallbacks = table.concat(fallbacks, "|")
     logger.dbg("CreDocument: set fallback font faces:", s_fallbacks)
-    self._document:setStringProperty("crengine.font.fallback.face", s_fallbacks)
+    self._document:setStringProperty("crengine.font.fallback.faces", s_fallbacks)
 end
 
 -- To use the new crengine language typography facilities (hyphenation, line breaking,


### PR DESCRIPTION
Includes (among others):
- LVImg: Tweak JPEG decoding some more https://github.com/koreader/crengine/pull/427
- toStringV2(): fix (again) when target node is a boxing node https://github.com/koreader/crengine/pull/428
- LVFontCache::find(): give more weight to first fonts in list
- Page splitting: more accurate rendering progress
- getRenderedWidths(): fix nowrap around image/inlineBoxes
- Tables rendering: tweak column widths algorithm
- CSS: parse/handle "currentcolor", default for border-color
- CSS: add units 'ch' (just like 'ex')
- SVG images: proper alpha blending
- MathML: add parsing and rendering support files https://github.com/koreader/crengine/pull/429
- MathML: plug MathML code into crengine core
- MathML: <epub:switch/case/default>: accept MathML
- (Upstream) Make crengine.font.fallback.faces plural https://github.com/koreader/crengine/pull/430
- (Upstream) Option to not limit font size to a set
- Text: dont adjust space after consecutive initial marks/dashes - Closes #7366
- Update German hyphenation patterns https://github.com/koreader/crengine/pull/431

Closes #981. Closes #1367. Closes #6678. (MathML issues).

About Math fonts: the code will try to use a OpenType Math font (with specific info about math spacings and thickness, etc...). We do ship one math font: FreeSerif which is quite ok (but with integral signs a bit too thick, and the math axis a bit off).
The code will look for the following other known math fonts in that order - and will use the first one found. So, if you find a nice one among these, just drop this one in your koreader/font/ directory. (You can drop more, and select one from the font menu, but it will then apply also to the non-math text. or you can make user style tweaks with `math { font-family: "XITS Math" !important }` to force one so the code does not have to find another one.
```
"Latin Modern Math"
"STIX Two Math"
"XITS Math"
"Libertinus Math"
"TeX Gyre Termes Math"
"TeX Gyre Bonum Math"
"TeX Gyre Schola Math" (naming typo of mine for this one in the code, will be fixed later)
"TeX Gyre Pagella Math"
"DejaVu Math TeX Gyre"
"Asana Math"
"Cambria Math"
"Lucida Bright Math"
"Minion Math"
"FreeSerif"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7465)
<!-- Reviewable:end -->
