### PR TITLE
Add DBNL footnotes styletweak

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -796,7 +796,8 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
                 css = [[
 .footnote, .footnotes, .fn,
 .note, .note1, .note2, .note3,
-.ntb, .ntb-txt, .ntb-txt-j
+.ntb, .ntb-txt, .ntb-txt-j,
+.voetnoten
 {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
@@ -812,7 +813,8 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
                 css = [[
 .footnote, .footnotes, .fn,
 .note, .note1, .note2, .note3,
-.ntb, .ntb-txt, .ntb-txt-j
+.ntb, .ntb-txt, .ntb-txt-j,
+.voetnoten
 {
     -cr-hint: footnote-inpage;
     margin: 0 !important;


### PR DESCRIPTION
`.voetnoten` is standard in DBNL ebooks.

A good test book can be found at <https://www.dbnl.org/tekst/veld028jnot01_01/>.

![Screenshot_2021-03-30_19-02-18](https://user-images.githubusercontent.com/202757/113027683-a84c0200-918a-11eb-9ab3-99a4329ce3cd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7467)
<!-- Reviewable:end -->
