### PR TITLE
File manager: disable forbidden or dangerous actions for parent folder

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -895,7 +895,7 @@ function FileManager:pasteHere(file)
             if mode == "file" then
                 text = T(_("The file %1 already exists. Do you want to overwrite it?"), BD.filename(basename))
             else
-                text = T(_("The directory %1 already exists. Do you want to overwrite it?"), BD.directory(basename))
+                text = T(_("The folder %1 already exists. Do you want to overwrite it?"), BD.directory(basename))
             end
 
             UIManager:show(ConfirmBox:new {

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -227,10 +227,14 @@ function FileManager:setupLayout()
     local fileManager = self
 
     function file_chooser:onFileHold(file)  -- luacheck: ignore
+        local is_file = lfs.attributes(file, "mode") == "file"
+        local is_folder = lfs.attributes(file, "mode") == "directory"
+        local is_not_parent_folder = BaseUtil.basename(file) ~= ".."
         local buttons = {
             {
                 {
                     text = C_("File", "Copy"),
+                    enabled = is_not_parent_folder,
                     callback = function()
                         copyFile(file)
                         UIManager:close(self.file_dialog)
@@ -264,6 +268,7 @@ function FileManager:setupLayout()
             {
                 {
                     text = _("Cut"),
+                    enabled = is_not_parent_folder,
                     callback = function()
                         cutFile(file)
                         UIManager:close(self.file_dialog)
@@ -271,6 +276,7 @@ function FileManager:setupLayout()
                 },
                 {
                     text = _("Delete"),
+                    enabled = is_not_parent_folder,
                     callback = function()
                         UIManager:show(ConfirmBox:new{
                             text = _("Are you sure that you want to delete this file?\n") .. BD.filepath(file) .. ("\n") .. _("If you delete a file, it is permanently lost."),
@@ -286,6 +292,7 @@ function FileManager:setupLayout()
                 },
                 {
                     text = _("Rename"),
+                    enabled = is_not_parent_folder,
                     callback = function()
                         UIManager:close(self.file_dialog)
                         fileManager.rename_dialog = InputDialog:new{
@@ -320,7 +327,7 @@ function FileManager:setupLayout()
             },
         }
 
-        if lfs.attributes(file, "mode") == "file" and Device:canExecuteScript(file) then
+        if is_file and Device:canExecuteScript(file) then
             -- NOTE: We populate the empty separator, in order not to mess with the button reordering code in CoverMenu
             table.insert(buttons[3],
                 {
@@ -361,7 +368,7 @@ function FileManager:setupLayout()
             )
         end
 
-        if lfs.attributes(file, "mode") == "file" then
+        if is_file then
             table.insert(buttons, {
                 {
                     text = _("Open with…"),
@@ -422,7 +429,7 @@ function FileManager:setupLayout()
                 })
             end
         end
-        if lfs.attributes(file, "mode") == "directory" then
+        if is_folder then
             local realpath = BaseUtil.realpath(file)
             table.insert(buttons, {
                 {
@@ -436,8 +443,8 @@ function FileManager:setupLayout()
         end
 
         local title
-        if lfs.attributes(file, "mode") == "directory" then
-            title = BD.directory(file:match("([^/]+)$"))
+        if is_folder then
+            title = BD.directory(file:match("([^/]+)$")).."/"
         else
             title = BD.filename(file:match("([^/]+)$"))
         end

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -895,7 +895,7 @@ function FileManager:pasteHere(file)
             if mode == "file" then
                 text = T(_("The file %1 already exists. Do you want to overwrite it?"), BD.filename(basename))
             else
-                text = T(_("The folder %1 already exists. Do you want to overwrite it?"), BD.directory(basename))
+                text = T(_("The folder %1 already exists. Overwrite folder?"), BD.directory(basename))
             end
 
             UIManager:show(ConfirmBox:new {

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -444,7 +444,7 @@ function FileManager:setupLayout()
 
         local title
         if is_folder then
-            title = BD.directory(file:match("([^/]+)$")).."/"
+            title = BD.directory(file:match("([^/]+)$"))
         else
             title = BD.filename(file:match("([^/]+)$"))
         end


### PR DESCRIPTION
For parent folder (..):
disabled `Copy`, `Cut`, `Delete`, `Rename`.
enabled `Paste`, `Set as HOME folder`.

Added `/` to the dialog title for folders (same as in the files list) to distinguish folders and files (in addition to different sets of the bottom buttons).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7475)
<!-- Reviewable:end -->
