### PR TITLE
Input: Followup tweaks to #7415

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -205,18 +205,21 @@ function GestureDetector:isHold(t1, t2)
 end
 
 function GestureDetector:isTwoFingerTap()
-    if self.last_tevs[0] == nil or self.last_tevs[1] == nil then
+    local s1 = self.input.main_finger_slot
+    local s2 = self.input.main_finger_slot + 1
+
+    if self.last_tevs[s1] == nil or self.last_tevs[1] == nil then
         return false
     end
-    local x_diff0 = math.abs(self.last_tevs[0].x - self.first_tevs[0].x)
-    local x_diff1 = math.abs(self.last_tevs[1].x - self.first_tevs[1].x)
-    local y_diff0 = math.abs(self.last_tevs[0].y - self.first_tevs[0].y)
-    local y_diff1 = math.abs(self.last_tevs[1].y - self.first_tevs[1].y)
-    local tv_diff0 = self.last_tevs[0].timev - self.first_tevs[0].timev
+    local x_diff0 = math.abs(self.last_tevs[s1].x - self.first_tevs[s1].x)
+    local x_diff1 = math.abs(self.last_tevs[s2].x - self.first_tevs[s2].x)
+    local y_diff0 = math.abs(self.last_tevs[s1].y - self.first_tevs[s1].y)
+    local y_diff1 = math.abs(self.last_tevs[s2].y - self.first_tevs[s2].y)
+    local tv_diff0 = self.last_tevs[s1].timev - self.first_tevs[s1].timev
     if not tv_diff0:isPositive() then
         tv_diff0 = TimeVal:new{ sec = math.huge }
     end
-    local tv_diff1 = self.last_tevs[1].timev - self.first_tevs[1].timev
+    local tv_diff1 = self.last_tevs[s2].timev - self.first_tevs[s2].timev
     if not tv_diff1:isPositive() then
         tv_diff1 = TimeVal:new{ sec = math.huge }
     end
@@ -424,17 +427,19 @@ function GestureDetector:tapState(tev)
     logger.dbg("in tap state...")
     local slot = tev.slot
     if tev.id == -1 then
+        local s1 = self.input.main_finger_slot
+        local s2 = self.input.main_finger_slot + 1
         -- end of tap event
-        if self.detectings[0] and self.detectings[1] then
+        if self.detectings[s1] and self.detectings[s2] then
             if self:isTwoFingerTap() then
                 local pos0 = Geom:new{
-                    x = self.last_tevs[0].x,
-                    y = self.last_tevs[0].y,
+                    x = self.last_tevs[s1].x,
+                    y = self.last_tevs[s1].y,
                     w = 0, h = 0,
                 }
                 local pos1 = Geom:new{
-                    x = self.last_tevs[1].x,
-                    y = self.last_tevs[1].y,
+                    x = self.last_tevs[s2].x,
+                    y = self.last_tevs[s2].y,
                     w = 0, h = 0,
                 }
                 local tap_span = pos0:distance(pos1)
@@ -592,7 +597,9 @@ function GestureDetector:panState(tev)
     if tev.id == -1 then
         -- end of pan, signal swipe gesture if necessary
         if self:isSwipe(slot) then
-            if self.detectings[0] and self.detectings[1] then
+            local s1 = self.input.main_finger_slot
+            local s2 = self.input.main_finger_slot + 1
+            if self.detectings[s1] and self.detectings[s2] then
                 local ges_ev = self:handleTwoFingerPan(tev)
                 self:clearStates()
                 if ges_ev then
@@ -665,7 +672,9 @@ end
 
 function GestureDetector:handlePan(tev)
     local slot = tev.slot
-    if self.detectings[0] and self.detectings[1] then
+    local s1 = self.input.main_finger_slot
+    local s2 = self.input.main_finger_slot + 1
+    if self.detectings[s1] and self.detectings[s2] then
         return self:handleTwoFingerPan(tev)
     else
         local pan_direction, pan_distance = self:getPath(slot)
@@ -768,10 +777,12 @@ function GestureDetector:handlePan(tev)
 end
 
 function GestureDetector:handleTwoFingerPan(tev)
+    local s1 = self.input.main_finger_slot
+    local s2 = self.input.main_finger_slot + 1
     -- triggering slot
     local tslot = tev.slot
     -- reference slot
-    local rslot = tslot == 1 and 0 or 1
+    local rslot = tslot == s2 and s1 or s2
     local tpan_dir, tpan_dis = self:getPath(tslot)
     local tstart_pos = Geom:new{
         x = self.first_tevs[tslot].x,
@@ -839,7 +850,9 @@ function GestureDetector:handlePanRelease(tev)
         pos = release_pos,
         time = tev.timev,
     }
-    if self.detectings[0] and self.detectings[1] then
+    local s1 = self.input.main_finger_slot
+    local s2 = self.input.main_finger_slot + 1
+    if self.detectings[s1] and self.detectings[s2] then
         logger.dbg("two finger pan release detected")
         pan_ev.ges = "two_finger_pan_release"
         self:clearStates()

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -208,7 +208,7 @@ function GestureDetector:isTwoFingerTap()
     local s1 = self.input.main_finger_slot
     local s2 = self.input.main_finger_slot + 1
 
-    if self.last_tevs[s1] == nil or self.last_tevs[1] == nil then
+    if self.last_tevs[s1] == nil or self.last_tevs[s2] == nil then
         return false
     end
     local x_diff0 = math.abs(self.last_tevs[s1].x - self.first_tevs[s1].x)

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -216,6 +216,7 @@ function Input:init()
     -- Handle default finger slot
     if self.device.main_finger_slot then
         self.main_finger_slot = self.device.main_finger_slot
+        self.cur_slot = self.device.main_finger_slot
     end
     self.ev_slots = {
         [self.main_finger_slot] = {

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -82,7 +82,6 @@ local linux_evdev_syn_code_map = {
     [C.SYN_DROPPED] = "SYN_DROPPED",
 }
 
--- For debug logging of ev.code
 local linux_evdev_key_code_map = {
     [C.BTN_TOOL_PEN] = "BTN_TOOL_PEN",
     [C.BTN_TOOL_FINGER] = "BTN_TOOL_FINGER",

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -122,6 +122,8 @@ local linux_evdev_msc_code_map = {
 local _internal_clipboard_text = nil -- holds the last copied text
 
 local Input = {
+    -- must point to the device implementation when instantiating
+    device = nil,
     -- this depends on keyboard layout and should be overridden:
     event_map = {},
     -- adapters are post processing functions that transform a given event to another event
@@ -184,13 +186,10 @@ local Input = {
     repeat_count = 0,
 
     -- touch state:
+    main_finger_slot = 0,
     cur_slot = 0,
     MTSlots = {},
-    ev_slots = {
-        [0] = {
-            slot = 0,
-        }
-    },
+    ev_slots = {},
     gesture_detector = nil,
 
     -- simple internal clipboard implementation, can be overidden to use system clipboard
@@ -214,6 +213,16 @@ function Input:new(o)
 end
 
 function Input:init()
+    -- Handle default finger slot
+    if self.device.main_finger_slot then
+        self.main_finger_slot = self.device.main_finger_slot
+    end
+    self.ev_slots = {
+        [self.main_finger_slot] = {
+            slot = self.main_finger_slot,
+        },
+    }
+
     self.gesture_detector = GestureDetector:new{
         screen = self.device.screen,
         input = self,

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -82,6 +82,15 @@ local linux_evdev_syn_code_map = {
     [C.SYN_DROPPED] = "SYN_DROPPED",
 }
 
+-- For debug logging of ev.code
+local linux_evdev_key_code_map = {
+    [C.BTN_TOOL_PEN] = "BTN_TOOL_PEN",
+    [C.BTN_TOOL_FINGER] = "BTN_TOOL_FINGER",
+    [C.BTN_TOOL_RUBBER] = "BTN_TOOL_RUBBER",
+    [C.BTN_TOUCH] = "BTN_TOUCH",
+    [C.BTN_STYLUS] = "BTN_STYLUS",
+}
+
 local linux_evdev_abs_code_map = {
     [C.ABS_X] = "ABS_X",
     [C.ABS_Y] = "ABS_Y",
@@ -98,6 +107,8 @@ local linux_evdev_abs_code_map = {
     [C.ABS_MT_BLOB_ID] = "ABS_MT_BLOB_ID",
     [C.ABS_MT_TRACKING_ID] = "ABS_MT_TRACKING_ID",
     [C.ABS_MT_PRESSURE] = "ABS_MT_PRESSURE",
+    [C.ABS_TILT_X] = "ABS_TILT_X",
+    [C.ABS_TILT_Y] = "ABS_TILT_Y",
     [C.ABS_MT_DISTANCE] = "ABS_MT_DISTANCE",
     [C.ABS_MT_TOOL_X] = "ABS_MT_TOOL_X",
     [C.ABS_MT_TOOL_Y] = "ABS_MT_TOOL_Y",
@@ -1055,7 +1066,7 @@ function Input:waitEvent(now, deadline)
             if ev.type == C.EV_KEY then
                 logger.dbg(string.format(
                     "key event => code: %d (%s), value: %s, time: %d.%d",
-                    ev.code, self.event_map[ev.code], ev.value,
+                    ev.code, self.event_map[ev.code] or linux_evdev_key_code_map[ev.code], ev.value,
                     ev.time.sec, ev.time.usec))
             elseif ev.type == C.EV_SYN then
                 logger.dbg(string.format(

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1002,10 +1002,10 @@ function Input:waitEvent(now, deadline)
                         -- and it also means that we're guaranteed to have reached its deadline.
                         consume_callback = true
                     elseif not with_timerfd then
-                        -- On systems without timerfd, we have a few more cases to handle...
+                        -- On systems where the timerfd backend is *NOT* in use, we have a few more cases to handle...
                         if deadline_is_timer then
-                            -- When the timerfd backend is *NOT* in use,
-                            -- that's only a guarantee when our actual select deadline was the timer itself!
+                            -- We're only guaranteed to have blown the timer's deadline
+                            -- when our actual select deadline *was* the timer's!
                             consume_callback = true
                         elseif TimeVal:now() >= self.timer_callbacks[1].deadline then
                             -- But if it was a task deadline instead, we to have to check the timer's against the current time,

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -932,7 +932,6 @@ end
 -- it's either nil (meaning block forever waiting for input), or the earliest UIManager deadline (in most cases, that's the next scheduled task,
 -- in much less common cases, that's the earliest of UIManager.INPUT_TIMEOUT (currently, only KOSync ever sets it) or UIManager.ZMQ_TIMEOUT if there are pending ZMQs).
 function Input:waitEvent(now, deadline)
-    print("Input:waitEvent", now:tonumber(), deadline:tonumber())
     -- On the first iteration of the loop, we don't need to update now, we're following closely (a couple ms at most) behind UIManager.
     local ok, ev
     -- Wrapper around the platform-specific input.waitForEvent (which itself is generally poll-like).
@@ -958,21 +957,17 @@ function Input:waitEvent(now, deadline)
                     -- We use the ultimate deadline, as the kernel will just signal us when the timer expires during polling.
                     poll_deadline = deadline
                     with_timerfd = true
-                    print("timerfd, use input deadline", poll_deadline:tonumber())
                 else
                     if not deadline then
                         -- If we don't actually have a full timeout deadline, just honor the timer's.
                         poll_deadline = self.timer_callbacks[1].deadline
                         deadline_is_timer = true
-                        print("no input deadline, use timer deadline", poll_deadline:tonumber())
                     else
                         if self.timer_callbacks[1].deadline < deadline then
                             poll_deadline = self.timer_callbacks[1].deadline
                             deadline_is_timer = true
-                            print("timer < input; use timer deadline", poll_deadline:tonumber())
                         else
                             poll_deadline = deadline
-                            print("timer > input; use input deadline", poll_deadline:tonumber())
                         end
                     end
                 end
@@ -991,7 +986,6 @@ function Input:waitEvent(now, deadline)
                         poll_timeout = TimeVal:new{ sec = 0 }
                     end
                 end
-                print("w/ timer: effective deadline", poll_timeout:tonumber())
 
                 local timerfd
                 ok, ev, timerfd = input.waitForEvent(poll_timeout and poll_timeout.sec, poll_timeout and poll_timeout.usec)
@@ -1000,26 +994,22 @@ function Input:waitEvent(now, deadline)
 
                 -- If we've drained all pending input events, causing waitForEvent to time out, check our timers
                 if ok == false and ev == C.ETIME then
-                    print("ETIME")
                     -- Check whether the earliest timer to finalize a Gesture detection is up.
                     local consume_callback = false
                     if timerfd then
                         -- If we were woken up by a timerfd, that means the timerfd backend is in use, of course,
                         -- and it also means that we're guaranteed to have reached its deadline.
                         consume_callback = true
-                        print("timerfd, consume callback")
                     elseif not with_timerfd then
                         -- On systems where the timerfd backend is *NOT* in use, we have a few more cases to handle...
                         if deadline_is_timer then
                             -- We're only guaranteed to have blown the timer's deadline
                             -- when our actual select deadline *was* the timer's!
                             consume_callback = true
-                            print("deadline timer, consume callback")
                         elseif TimeVal:now() >= self.timer_callbacks[1].deadline then
                             -- But if it was a task deadline instead, we to have to check the timer's against the current time,
                             -- to double-check whether we blew it or not.
                             consume_callback = true
-                            print("deadline blown, consume callback")
                         end
                     end
 
@@ -1064,7 +1054,6 @@ function Input:waitEvent(now, deadline)
                     poll_timeout = TimeVal:new{ sec = 0 }
                 end
             end
-            print("w/o timer: effective deadline", poll_timeout:tonumber())
 
             ok, ev = input.waitForEvent(poll_timeout and poll_timeout.sec, poll_timeout and poll_timeout.usec)
         end -- if #timer_callbacks > 0

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -93,8 +93,6 @@ local KoboDaylight = Kobo:new{
 local KoboDahlia = Kobo:new{
     model = "Kobo_dahlia",
     hasFrontlight = yes,
-    -- NOTE: The hardware can technically track 2 different fingers, but we don't seem to be able to figure it out...
-    hasMultitouch = no,
     touch_phoenix_protocol = true,
     -- There's no slot 0, the first finger gets assigned slot 1, and the second slot 2
     main_finger_slot = 1,
@@ -346,16 +344,6 @@ function Kobo:init()
         }
     }
     self.wakeup_mgr = WakeupMgr:new()
-
-    -- Tweak initial slot, if necessary
-    if self.main_finger_slot then
-        self.input.cur_slot = self.main_finger_slot
-        self.input.ev_slots = {
-            [self.main_finger_slot] = {
-                slot = self.main_finger_slot,
-            }
-        }
-    end
 
     Generic.init(self)
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1588,27 +1588,22 @@ function UIManager:handleInput()
     local deadline
     -- Default to INPUT_TIMEOUT (which may be nil, i.e. block until an event happens).
     local wait_us = self.INPUT_TIMEOUT
-    print("UIManager: INPUT", wait_us)
 
     -- If we have any ZMQs registered, ZMQ_TIMEOUT is another upper bound.
     if #self._zeromqs > 0 then
         wait_us = math.min(wait_us or math.huge, self.ZMQ_TIMEOUT)
-        print("UIManager: ZMQ", wait_us)
     end
 
     -- We pass that on as an absolute deadline, not a relative wait time.
     if wait_us then
         deadline = now + TimeVal:new{ usec = wait_us }
-        print("UIManager: INPUT+ZMQ", deadline:tonumber())
     end
 
-    print("UIManager: wait_until, deadline", wait_until and wait_until:tonumber(), deadline and deadline:tonumber())
     -- If there's a scheduled task pending, that puts an upper bound on how long to wait.
     if wait_until and (not deadline or wait_until < deadline) then
         --             ^ We don't have a TIMEOUT induced deadline, making the choice easy.
         --                             ^ We have a task scheduled for *before* our TIMEOUT induced deadline.
         deadline = wait_until
-        print("UIManager: TASK", deadline:tonumber())
     end
 
     -- If allowed, entering standby (from which we can wake by input) must trigger in response to event

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1588,22 +1588,27 @@ function UIManager:handleInput()
     local deadline
     -- Default to INPUT_TIMEOUT (which may be nil, i.e. block until an event happens).
     local wait_us = self.INPUT_TIMEOUT
+    print("UIManager: INPUT", wait_us)
 
     -- If we have any ZMQs registered, ZMQ_TIMEOUT is another upper bound.
     if #self._zeromqs > 0 then
         wait_us = math.min(wait_us or math.huge, self.ZMQ_TIMEOUT)
+        print("UIManager: ZMQ", wait_us)
     end
 
     -- We pass that on as an absolute deadline, not a relative wait time.
     if wait_us then
         deadline = now + TimeVal:new{ usec = wait_us }
+        print("UIManager: INPUT+ZMQ", deadline:tonumber())
     end
 
+    print("UIManager: wait_until, deadline", wait_until and wait_until:tonumber(), deadline and deadline:tonumber())
     -- If there's a scheduled task pending, that puts an upper bound on how long to wait.
     if wait_until and (not deadline or wait_until < deadline) then
         --             ^ We don't have a TIMEOUT induced deadline, making the choice easy.
         --                             ^ We have a task scheduled for *before* our TIMEOUT induced deadline.
         deadline = wait_until
+        print("UIManager: TASK", deadline:tonumber())
     end
 
     -- If allowed, entering standby (from which we can wake by input) must trigger in response to event


### PR DESCRIPTION
* Actually load librt properly on old Linux systems (fix #7472)
* Made sure SDL & Android honored timeouts properly in some edgy (or not so edgy, in SDL's case) cases (c.f., https://github.com/koreader/koreader-base/pull/1343).
* Try harder not to consume a timer callback when the timerfd backend is in use and `select` timed out *not* because of a timerfd expiring. This would take some particularly heinous timing to reproduce (e.g., a timerfd set, but a task deadline expiring *before* it). May or may not help with #7473.
* Decode `BTN_` KEY codes in verbose debug logs.
* Fix MultiTouch on the H2O (GestureDetector was hard-coding the two slots as 0 & 1, but the H2O kernel is a special snowflake that doesn't use slot 0, instead switching to slot 1 & 2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7478)
<!-- Reviewable:end -->
