### PR TITLE
Input: Process input events in batches

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -48,8 +48,6 @@ local Screen = Device.screen
 local T = BaseUtil.template
 
 local FileManager = InputContainer:extend{
-    registered_modules = {},
-
     title = _("KOReader"),
     root_path = lfs.currentdir(),
     onExit = function() end,
@@ -520,8 +518,6 @@ function FileManager:init()
                 local name = plugin_module.name
                 if name then self[name] = plugin_or_err end
                 table.insert(self, plugin_or_err)
-                -- Keep track of 'em in an easy to iterate place, for deregistration purposes...
-                table.insert(self.registered_modules, plugin_or_err)
                 logger.info("FM loaded plugin", name,
                             "at", plugin_module.path)
             end
@@ -764,13 +760,6 @@ function FileManager:onClose()
     UIManager:close(self)
     if self.onExit then
         self:onExit()
-    end
-    -- Tear down registered modules.
-    -- This is useful for modules that aren't proper Widgets, yet register event hooks...
-    for i, module in ipairs(self.registered_modules) do
-        if module.onCloseWidget then
-            module:onCloseWidget()
-        end
     end
     return true
 end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -64,6 +64,7 @@ local T = ffiUtil.template
 local ReaderUI = InputContainer:new{
     name = "ReaderUI",
     active_widgets = {},
+    registered_modules = {},
 
     -- if we have a parent container, it must be referenced for now
     dialog = nil,
@@ -86,6 +87,8 @@ function ReaderUI:registerModule(name, ui_module, always_active)
         -- to get events even when hidden
         table.insert(self.active_widgets, ui_module)
     end
+    -- Keep track of 'em in an easy to iterate place, for deregistration purposes...
+    table.insert(self.registered_modules, ui_module)
 end
 
 function ReaderUI:registerPostInitCallback(callback)
@@ -717,6 +720,13 @@ function ReaderUI:onClose(full_refresh)
     Cache:serialize()
     if _running_instance == self then
         _running_instance = nil
+    end
+
+    -- Tear down registered modules
+    for i, module in ipairs(self.registered_modules) do
+        if module.fini then
+            module:fini()
+        end
     end
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -722,10 +722,11 @@ function ReaderUI:onClose(full_refresh)
         _running_instance = nil
     end
 
-    -- Tear down registered modules
+    -- Tear down registered modules.
+    -- This is useful for modules that aren't proper Widgets, yet register event hooks...
     for i, module in ipairs(self.registered_modules) do
-        if module.fini then
-            module:fini()
+        if module.onCloseWidget then
+            module:onCloseWidget()
         end
     end
 end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -64,7 +64,6 @@ local T = ffiUtil.template
 local ReaderUI = InputContainer:new{
     name = "ReaderUI",
     active_widgets = {},
-    registered_modules = {},
 
     -- if we have a parent container, it must be referenced for now
     dialog = nil,
@@ -87,8 +86,6 @@ function ReaderUI:registerModule(name, ui_module, always_active)
         -- to get events even when hidden
         table.insert(self.active_widgets, ui_module)
     end
-    -- Keep track of 'em in an easy to iterate place, for deregistration purposes...
-    table.insert(self.registered_modules, ui_module)
 end
 
 function ReaderUI:registerPostInitCallback(callback)
@@ -720,14 +717,6 @@ function ReaderUI:onClose(full_refresh)
     Cache:serialize()
     if _running_instance == self then
         _running_instance = nil
-    end
-
-    -- Tear down registered modules.
-    -- This is useful for modules that aren't proper Widgets, yet register event hooks...
-    for i, module in ipairs(self.registered_modules) do
-        if module.onCloseWidget then
-            module:onCloseWidget()
-        end
     end
 end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1155,7 +1155,7 @@ function Input:waitEvent(now, deadline)
         end
         return handled
     elseif ok == false and ev then
-        return { Event:new("InputError", ev) }
+        return { Event:new("InputError", string.format("%d: %s", ev, ffi.string(C.strerror(ev)))) }
     elseif ok == nil then
         -- No ok and no ev? Hu oh...
         return { Event:new("InputError", "Catastrophic") }

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1029,9 +1029,7 @@ function Input:waitEvent(now, deadline)
                             -- This is why we clear the full list of timers on the first match ;).
                             self:clearTimeouts()
                             self:gestureAdjustHook(touch_ges)
-                            return {
-                                Event:new("Gesture", self.gesture_detector:adjustGesCoordinate(touch_ges))
-                            }
+                            return { Event:new("Gesture", self.gesture_detector:adjustGesCoordinate(touch_ges)) }
                         end -- if touch_ges
                     end -- if poll_deadline reached
                 else

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1028,9 +1028,9 @@ function Input:waitEvent(now, deadline)
                             -- This is why we clear the full list of timers on the first match ;).
                             self:clearTimeouts()
                             self:gestureAdjustHook(touch_ges)
-                            return Event:new("Gesture",
+                            return { Event:new("Gesture",
                                 self.gesture_detector:adjustGesCoordinate(touch_ges)
-                            )
+                            ) }
                         end -- if touch_ges
                     end -- if poll_deadline reached
                 end -- if poll returned ETIME
@@ -1086,8 +1086,8 @@ function Input:waitEvent(now, deadline)
         now = nil
     end
 
-    local handled = {}
     if ok and ev then
+        local handled = {}
         for i, event in ipairs(ev) do
             logger.dbg(i, event)
             if DEBUG.is_on then
@@ -1155,13 +1155,13 @@ function Input:waitEvent(now, deadline)
                 table.insert(handled, Event:new("GenericInput", event))
             end
         end
+        return handled
     elseif ok == false and ev then
-        table.insert(handled, Event:new("InputError", ev))
+        return { Event:new("InputError", ev) }
     elseif ok == nil then
         -- No ok and no ev? Hu oh...
-        table.insert(handled, Event:new("InputError", "Catastrophic"))
+        return { Event:new("InputError", "Catastrophic") }
     end
-    return handled
 end
 
 return Input

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -934,9 +934,9 @@ end
 function Input:waitEvent(now, deadline)
     -- On the first iteration of the loop, we don't need to update now, we're following closely (a couple ms at most) behind UIManager.
     local ok, ev
-    -- Wrapper around the platform-specific input.waitForEvent (which itself is generally poll-like).
+    -- Wrapper around the platform-specific input.waitForEvent (which itself is generally poll-like, and supposed to poll *once*).
     -- Speaking of input.waitForEvent, it can return:
-    -- * true, ev: When an input event was read. ev is a table mapped after the input_event <linux/input.h> struct.
+    -- * true, ev: When a batch of input events was read. ev is an array of tables themselves mapped after the input_event <linux/input.h> struct.
     -- * false, errno, timerfd: When no input event was read, possibly for benign reasons.
     --                        One such common case is after a polling timeout, in which case errno is C.ETIME.
     --                        If the timerfd backend is in use, and the early return was caused by a timerfd expiring,
@@ -1135,6 +1135,7 @@ function Input:waitEvent(now, deadline)
             elseif event.type == C.EV_ABS or event.type == C.EV_SYN then
                 local handled_ev = self:handleTouchEv(event)
                 print(handled_ev)
+                -- We don't gnerate an Event for *every* input event, so, make sure we don't push nil values to the array
                 if handled_ev then
                     table.insert(handled, handled_ev)
                 end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1121,17 +1121,35 @@ function Input:waitEvent(now, deadline)
             end
             self:eventAdjustHook(event)
             if event.type == C.EV_KEY then
-                table.insert(handled, self:handleKeyBoardEv(event))
+                local handled_ev = self:handleKeyBoardEv(event)
+                print(handled_ev)
+                if handled_ev then
+                    table.insert(handled, handled_ev)
+                end
             elseif event.type == C.EV_ABS and event.code == ABS_OASIS_ORIENTATION then
-                table.insert(handled, self:handleOasisOrientationEv(event))
+                local handled_ev = self:handleOasisOrientationEv(event)
+                print(handled_ev)
+                if handled_ev then
+                    table.insert(handled, handled_ev)
+                end
             elseif event.type == C.EV_ABS or event.type == C.EV_SYN then
-                local parsed = self:handleTouchEv(event)
-                print(parsed)
-                table.insert(handled, parsed)
+                local handled_ev = self:handleTouchEv(event)
+                print(handled_ev)
+                if handled_ev then
+                    table.insert(handled, handled_ev)
+                end
             elseif event.type == C.EV_MSC then
-                table.insert(handled, self:handleMiscEv(event))
+                local handled_ev = self:handleMiscEv(event)
+                print(handled_ev)
+                if handled_ev then
+                    table.insert(handled, handled_ev)
+                end
             elseif event.type == C.EV_SDL then
-                table.insert(handled, self:handleSdlEv(event))
+                local handled_ev = self:handleSdlEv(event)
+                print(handled_ev)
+                if handled_ev then
+                    table.insert(handled, handled_ev)
+                end
             else
                 -- Received some other kind of event that we do not know how to specifically handle yet
                 table.insert(handled, Event:new("GenericInput", event))

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1033,10 +1033,10 @@ function Input:waitEvent(now, deadline)
                             ) }
                         end -- if touch_ges
                     end -- if poll_deadline reached
+                else
+                    -- Something went wrong, jump to error handling
+                    break
                 end -- if poll returned ETIME
-
-                -- Something went wrong
-                if ok == nil then break end
 
                 -- Refresh now on the next iteration (e.g., when we have multiple timers to check)
                 now = nil

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1029,7 +1029,9 @@ function Input:waitEvent(now, deadline)
                             -- This is why we clear the full list of timers on the first match ;).
                             self:clearTimeouts()
                             self:gestureAdjustHook(touch_ges)
-                            return { Event:new("Gesture", self.gesture_detector:adjustGesCoordinate(touch_ges)) }
+                            return {
+                                Event:new("Gesture", self.gesture_detector:adjustGesCoordinate(touch_ges))
+                            }
                         end -- if touch_ges
                     end -- if poll_deadline reached
                 else
@@ -1155,10 +1157,14 @@ function Input:waitEvent(now, deadline)
         end
         return handled
     elseif ok == false and ev then
-        return { Event:new("InputError", string.format("%d: %s", ev, ffi.string(C.strerror(ev)))) }
+        return {
+            Event:new("InputError", string.format("%d: %s", ev, ffi.string(C.strerror(ev))))
+        }
     elseif ok == nil then
         -- No ok and no ev? Hu oh...
-        return { Event:new("InputError", "Catastrophic") }
+        return {
+            Event:new("InputError", "Catastrophic")
+        }
     end
 end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -936,13 +936,14 @@ function Input:waitEvent(now, deadline)
     local ok, ev
     -- Wrapper around the platform-specific input.waitForEvent (which itself is generally poll-like, and supposed to poll *once*).
     -- Speaking of input.waitForEvent, it can return:
-    -- * true, ev: When a batch of input events was read. ev is an array of tables themselves mapped after the input_event <linux/input.h> struct.
+    -- * true, ev: When a batch of input events was read.
+    --             ev is an array of event tables, themselves mapped after the input_event <linux/input.h> struct.
     -- * false, errno, timerfd: When no input event was read, possibly for benign reasons.
-    --                        One such common case is after a polling timeout, in which case errno is C.ETIME.
-    --                        If the timerfd backend is in use, and the early return was caused by a timerfd expiring,
-    --                        it returns false, C.ETIME, timerfd; where timerfd is a C pointer (i.e., light userdata)
-    --                        to the timerfd node that expired (so as to be able to free it later, c.f., input/timerfd-callbacks.h).
-    --                        Otherwise, errno is the actual error code from the backend (e.g., select's errno for the C backend).
+    --                          One such common case is after a polling timeout, in which case errno is C.ETIME.
+    --                          If the timerfd backend is in use, and the early return was caused by a timerfd expiring,
+    --                          it returns false, C.ETIME, timerfd; where timerfd is a C pointer (i.e., light userdata)
+    --                          to the timerfd node that expired (so as to be able to free it later, c.f., input/timerfd-callbacks.h).
+    --                          Otherwise, errno is the actual error code from the backend (e.g., select's errno for the C backend).
     -- * nil: When something terrible happened (e.g., fatal poll/read failure). We abort in such cases.
     while true do
         if #self.timer_callbacks > 0 then

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -361,6 +361,7 @@ function Input:setTimeout(slot, ges, cb, origin, delay)
         -- If GestureDetector's clock source probing was inconclusive, do this on the UI timescale instead.
         if clock_id == -1 then
             deadline = TimeVal:now() + delay
+            clock_id = C.CLOCK_MONOTONIC
         else
             deadline = origin + delay
         end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1075,7 +1075,7 @@ function Input:waitEvent(now, deadline)
                 -- Retry on EINTR
             else
                 -- Warn, report, and go back to UIManager
-                logger.warn("Polling for input events returned an error:", ev)
+                logger.warn("Polling for input events returned an error:", ev, "->", ffi.string(C.strerror(ev)))
                 break
             end
         elseif ok == nil then
@@ -1158,7 +1158,7 @@ function Input:waitEvent(now, deadline)
         return handled
     elseif ok == false and ev then
         return {
-            Event:new("InputError", string.format("%d: %s", ev, ffi.string(C.strerror(ev))))
+            Event:new("InputError", ev)
         }
     elseif ok == nil then
         -- No ok and no ev? Hu oh...

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1034,11 +1034,11 @@ function Input:waitEvent(now, deadline)
                         end -- if touch_ges
                     end -- if poll_deadline reached
                 else
-                    -- Something went wrong, jump to error handling
+                    -- Something went wrong, jump to error handling *now*
                     break
                 end -- if poll returned ETIME
 
-                -- Refresh now on the next iteration (e.g., when we have multiple timers to check)
+                -- Refresh now on the next iteration (e.g., when we have multiple timers to check, and we just timed out)
                 now = nil
             end -- while #timer_callbacks > 0
         else

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1029,9 +1029,9 @@ function Input:waitEvent(now, deadline)
                             -- This is why we clear the full list of timers on the first match ;).
                             self:clearTimeouts()
                             self:gestureAdjustHook(touch_ges)
-                            return { Event:new("Gesture",
-                                self.gesture_detector:adjustGesCoordinate(touch_ges)
-                            ) }
+                            return {
+                                Event:new("Gesture", self.gesture_detector:adjustGesCoordinate(touch_ges))
+                            }
                         end -- if touch_ges
                     end -- if poll_deadline reached
                 else

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1035,6 +1035,9 @@ function Input:waitEvent(now, deadline)
                     end -- if poll_deadline reached
                 end -- if poll returned ETIME
 
+                -- Something went wrong
+                if ok == nil then break end
+
                 -- Refresh now on the next iteration (e.g., when we have multiple timers to check)
                 now = nil
             end -- while #timer_callbacks > 0

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1039,7 +1039,7 @@ function Input:waitEvent(now, deadline)
                     break
                 end -- if poll returned ETIME
 
-                -- Refresh now on the next iteration (e.g., when we have multiple timers to check, and we just timed out)
+                -- Refresh now on the next iteration (e.g., when we have multiple timers to check, and we've just timed out)
                 now = nil
             end -- while #timer_callbacks > 0
         else

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1091,8 +1091,8 @@ function Input:waitEvent(now, deadline)
 
     if ok and ev then
         local handled = {}
+        -- We're guaranteed that ev is an array of event tables. Might be an array of *one* event, but an array nontheless ;).
         for i, event in ipairs(ev) do
-            logger.dbg(i, event)
             if DEBUG.is_on then
                 DEBUG:logEv(event)
                 if event.type == C.EV_KEY then
@@ -1125,32 +1125,27 @@ function Input:waitEvent(now, deadline)
             self:eventAdjustHook(event)
             if event.type == C.EV_KEY then
                 local handled_ev = self:handleKeyBoardEv(event)
-                print(handled_ev)
                 if handled_ev then
                     table.insert(handled, handled_ev)
                 end
             elseif event.type == C.EV_ABS and event.code == ABS_OASIS_ORIENTATION then
                 local handled_ev = self:handleOasisOrientationEv(event)
-                print(handled_ev)
                 if handled_ev then
                     table.insert(handled, handled_ev)
                 end
             elseif event.type == C.EV_ABS or event.type == C.EV_SYN then
                 local handled_ev = self:handleTouchEv(event)
-                print(handled_ev)
                 -- We don't gnerate an Event for *every* input event, so, make sure we don't push nil values to the array
                 if handled_ev then
                     table.insert(handled, handled_ev)
                 end
             elseif event.type == C.EV_MSC then
                 local handled_ev = self:handleMiscEv(event)
-                print(handled_ev)
                 if handled_ev then
                     table.insert(handled, handled_ev)
                 end
             elseif event.type == C.EV_SDL then
                 local handled_ev = self:handleSdlEv(event)
-                print(handled_ev)
                 if handled_ev then
                     table.insert(handled, handled_ev)
                 end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1091,8 +1091,8 @@ function Input:waitEvent(now, deadline)
 
     if ok and ev then
         local handled = {}
-        -- We're guaranteed that ev is an array of event tables. Might be an array of *one* event, but an array nontheless ;).
-        for i, event in ipairs(ev) do
+        -- We're guaranteed that ev is an array of event tables. Might be an array of *one* event, but an array nonetheless ;).
+        for __, event in ipairs(ev) do
             if DEBUG.is_on then
                 DEBUG:logEv(event)
                 if event.type == C.EV_KEY then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -94,7 +94,8 @@ local KoboDahlia = Kobo:new{
     model = "Kobo_dahlia",
     hasFrontlight = yes,
     touch_phoenix_protocol = true,
-    -- There's no slot 0, the first finger gets assigned slot 1, and the second slot 2
+    -- There's no slot 0, the first finger gets assigned slot 1, and the second slot 2.
+    -- NOTE: Could be queried at runtime via EVIOCGABS on ABS_MT_TRACKING_ID (minimum field).
     main_finger_slot = 1,
     display_dpi = 265,
     -- the bezel covers the top 11 pixels:

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -84,8 +84,8 @@ function PluginLoader:loadPlugins()
     for element in pairs(OBSOLETE_PLUGINS) do
         plugins_disabled[element] = true
     end
-    for _,lookup_path in ipairs(lookup_path_list) do
-        logger.info('Loading plugins from directory:', lookup_path)
+    for _, lookup_path in ipairs(lookup_path_list) do
+        logger.info("Loading plugins from directory:", lookup_path)
         for entry in lfs.dir(lookup_path) do
             local plugin_root = lookup_path.."/"..entry
             local mode = lfs.attributes(plugin_root, "mode")
@@ -124,7 +124,7 @@ function PluginLoader:loadPlugins()
     end
 
     -- set package path for all loaded plugins
-    for _,plugin in ipairs(self.enabled_plugins) do
+    for _, plugin in ipairs(self.enabled_plugins) do
         package.path = string.format("%s;%s/?.lua", package.path, plugin.path)
         package.cpath = string.format("%s;%s/lib/?.so", package.cpath, plugin.path)
     end
@@ -193,7 +193,7 @@ function PluginLoader:createPluginInstance(plugin, attr)
     if ok then  -- re is a plugin instance
         return ok, re
     else  -- re is the error message
-        logger.err('Failed to initialize', plugin.name, 'plugin: ', re)
+        logger.err("Failed to initialize", plugin.name, "plugin: ", re)
         return nil, re
     end
 end

--- a/frontend/ui/hook_container.lua
+++ b/frontend/ui/hook_container.lua
@@ -75,18 +75,13 @@ function HookContainer:unregister(name, func)
         return false
     end
 
-    local popped = false
-    for i = #self[name], 1, -1 do
-        local f = self[name][i]
+    for i, f in ipairs(self[name]) do
         if f == func then
             table.remove(self[name], i)
-            popped = true
+            return true
         end
     end
-    if #self[name] == 0 then
-        self[name] = nil
-    end
-    return popped
+    return false
 end
 
 --- Execute all registered functions of name. Must be called with self.

--- a/frontend/ui/hook_container.lua
+++ b/frontend/ui/hook_container.lua
@@ -51,18 +51,19 @@ function HookContainer:registerWidget(name, widget)
     print("HookContainer:registerWidget", name, widget)
     self:_assertIsValidName(name)
     assert(type(widget) == "table")
-    -- Store *that* in a ref, and unregister *that*, duh''
-    self:register(name, function(args)
+    -- *That* is the function we actually register and need to unregister later, so keep a ref to it...
+    local hook_func = function(args)
         local f = widget["on" .. name]
         self:_assertIsValidFunction(f)
         f(widget, args)
-    end)
+    end
+    self:register(name, hook_func)
     local original_close_widget = widget.onCloseWidget
     self:_assertIsValidFunctionOrNil(original_close_widget)
     widget.onCloseWidget = function()
         if original_close_widget then original_close_widget(widget) end
-        print("Asking to unregister", widget["on" .. name]) -- Spoiler alert: wrong ref.
-        self:unregister(name, widget["on" .. name])
+        print("Asking to unregister", hook_func)
+        self:unregister(name, hook_func)
     end
 end
 

--- a/frontend/ui/hook_container.lua
+++ b/frontend/ui/hook_container.lua
@@ -35,7 +35,6 @@ end
 -- @tparam string name The name of the hook. Can only be an non-empty string.
 -- @tparam function func The function to handle the hook. Can only be a function.
 function HookContainer:register(name, func)
-    print("HookContainer:register", name, func)
     self:_assertIsValidName(name)
     self:_assertIsValidFunction(func)
     if self[name] == nil then
@@ -48,7 +47,6 @@ end
 -- @tparam string name The name of the hook. Can only be an non-empty string.
 -- @tparam table widget The widget to handle the hook. Can only be a table with required functions.
 function HookContainer:registerWidget(name, widget)
-    print("HookContainer:registerWidget", name, widget)
     self:_assertIsValidName(name)
     assert(type(widget) == "table")
     -- *That* is the function we actually register and need to unregister later, so keep a ref to it...
@@ -62,7 +60,6 @@ function HookContainer:registerWidget(name, widget)
     self:_assertIsValidFunctionOrNil(original_close_widget)
     widget.onCloseWidget = function()
         if original_close_widget then original_close_widget(widget) end
-        print("Asking to unregister", hook_func)
         self:unregister(name, hook_func)
     end
 end
@@ -72,7 +69,6 @@ end
 -- @tparam function func The function to handle the hook. Can only be a function.
 -- @treturn boolean Return true if the function is found and removed, otherwise false.
 function HookContainer:unregister(name, func)
-    print("HookContainer:unregister", name, func)
     self:_assertIsValidName(name)
     self:_assertIsValidFunction(func)
     if self[name] == nil then
@@ -82,7 +78,6 @@ function HookContainer:unregister(name, func)
     local popped = false
     for i = #self[name], 1, -1 do
         local f = self[name][i]
-        print("found f", f)
         if f == func then
             table.remove(self[name], i)
             popped = true
@@ -91,7 +86,6 @@ function HookContainer:unregister(name, func)
     if #self[name] == 0 then
         self[name] = nil
     end
-    print("popped?", popped)
     return popped
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1549,7 +1549,7 @@ end
 -- Process all pending events on all registered ZMQs.
 function UIManager:processZMQs()
     for _, zeromq in ipairs(self._zeromqs) do
-        for input_event in zeromq.waitEvent,zeromq do
+        for input_event in zeromq.waitEvent, zeromq do
             self:handleInputEvent(input_event)
         end
     end
@@ -1616,7 +1616,9 @@ function UIManager:handleInput()
 
     -- delegate input_event to handler
     if input_event then
-        self:handleInputEvent(input_event)
+        for i, ev in ipairs(input_event) do
+            self:handleInputEvent(ev)
+        end
     end
 
     if self.looper then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1611,13 +1611,13 @@ function UIManager:handleInput()
     -- Anywhere else breaks preventStandby/allowStandby invariants used by background jobs while UI is left running.
     self:_standbyTransition()
 
-    -- wait for next event
-    local input_event = Input:waitEvent(now, deadline)
+    -- wait for next batch of events
+    local input_events = Input:waitEvent(now, deadline)
 
-    -- delegate input_event to handler
-    if input_event then
+    -- delegate each input event to handler
+    if input_events then
         -- Handle the full batch of events
-        for __, ev in ipairs(input_event) do
+        for __, ev in ipairs(input_events) do
             self:handleInputEvent(ev)
         end
     end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1616,7 +1616,8 @@ function UIManager:handleInput()
 
     -- delegate input_event to handler
     if input_event then
-        for i, ev in ipairs(input_event) do
+        -- Handle the full batch of events
+        for __, ev in ipairs(input_event) do
             self:handleInputEvent(ev)
         end
     end
@@ -1639,7 +1640,7 @@ end
 
 
 function UIManager:onRotation()
-    self:setDirty('all', 'full')
+    self:setDirty("all", "full")
     self:forceRePaint()
 end
 

--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -44,6 +44,11 @@ function AutoStandby:init()
     self.ui.menu:registerToMainMenu(self)
 end
 
+function AutoStandby:onCloseWidget()
+    logger.dbg("AutoStandby:onCloseWidget() instance=", tostring(self))
+    UIManager:unschedule(AutoStandby.allow)
+end
+
 function AutoStandby:addToMainMenu(menu_items)
     menu_items.autostandby = {
         sorting_hint = "device",

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -100,6 +100,8 @@ function AutoSuspend:_restart()
 end
 
 function AutoSuspend:init()
+    print("AutoSuspend:init")
+    print(debug.traceback())
     if Device:isPocketBook() and not Device:canSuspend() then return end
     UIManager.event_hook:registerWidget("InputEvent", self)
     self:_unschedule()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -100,8 +100,7 @@ function AutoSuspend:_restart()
 end
 
 function AutoSuspend:init()
-    logger.dbg("AutoSuspend: init", tostring(self))
-    print(debug.traceback())
+    logger.dbg("AutoSuspend: init")
     if Device:isPocketBook() and not Device:canSuspend() then return end
     UIManager.event_hook:registerWidget("InputEvent", self)
     self:_unschedule()
@@ -111,15 +110,15 @@ function AutoSuspend:init()
     self.ui.menu:registerToMainMenu(self)
 end
 
--- For even_hook deregistration purposes
+-- For event_hook automagic deregistration purposes
 function AutoSuspend:onCloseWidget()
-    logger.dbg("AutoSuspend: onCloseWidget", tostring(self))
+    logger.dbg("AutoSuspend: onCloseWidget")
     if Device:isPocketBook() and not Device:canSuspend() then return end
     self:_unschedule()
 end
 
 function AutoSuspend:onInputEvent()
-    logger.dbg("AutoSuspend: onInputEvent", tostring(self))
+    logger.dbg("AutoSuspend: onInputEvent")
     self.last_action_tv = UIManager:getTime()
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -100,7 +100,7 @@ function AutoSuspend:_restart()
 end
 
 function AutoSuspend:init()
-    print("AutoSuspend:init")
+    logger.dbg("AutoSuspend: init", tostring(self))
     print(debug.traceback())
     if Device:isPocketBook() and not Device:canSuspend() then return end
     UIManager.event_hook:registerWidget("InputEvent", self)
@@ -111,8 +111,16 @@ function AutoSuspend:init()
     self.ui.menu:registerToMainMenu(self)
 end
 
+function AutoSuspend:fini()
+    logger.dbg("AutoSuspend: fini", tostring(self))
+    if Device:isPocketBook() and not Device:canSuspend() then return end
+    -- We're not a real Widget, we don't have an onCloseWidget, so the hook cannot be unregistered automatically...
+    self:_unschedule()
+    UIManager.event_hook:unregister("InputEvent", self.onInputEvent)
+end
+
 function AutoSuspend:onInputEvent()
-    logger.dbg("AutoSuspend: onInputEvent")
+    logger.dbg("AutoSuspend: onInputEvent", tostring(self))
     self.last_action_tv = UIManager:getTime()
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -111,12 +111,11 @@ function AutoSuspend:init()
     self.ui.menu:registerToMainMenu(self)
 end
 
-function AutoSuspend:fini()
-    logger.dbg("AutoSuspend: fini", tostring(self))
+-- For even_hook deregistration purposes
+function AutoSuspend:onCloseWidget()
+    logger.dbg("AutoSuspend: onCloseWidget", tostring(self))
     if Device:isPocketBook() and not Device:canSuspend() then return end
-    -- We're not a real Widget, we don't have an onCloseWidget, so the hook cannot be unregistered automatically...
     self:_unschedule()
-    UIManager.event_hook:unregister("InputEvent", self.onInputEvent)
 end
 
 function AutoSuspend:onInputEvent()

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -94,6 +94,11 @@ function AutoTurn:init()
     self:_start()
 end
 
+function AutoTurn:onCloseWidget()
+    logger.dbg("AutoTurn: onCloseWidget")
+    self:_deprecateLastTask()
+end
+
 function AutoTurn:onCloseDocument()
     logger.dbg("AutoTurn: onCloseDocument")
     self:_deprecateLastTask()

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -273,15 +273,17 @@ describe("device module", function()
 
             mock_ffi_input = require('ffi/input')
             stub(mock_ffi_input, "waitForEvent")
-            mock_ffi_input.waitForEvent.returns(true, { {
-                type = 3,
-                time = {
-                    usec = 450565,
-                    sec = 1471081881
-                },
-                code = 24,
-                value = 16
-            } })
+            mock_ffi_input.waitForEvent.returns(true, {
+                {
+                    type = 3,
+                    time = {
+                        usec = 450565,
+                        sec = 1471081881
+                    },
+                    code = 24,
+                    value = 16
+                }
+            })
 
             local UIManager = require("ui/uimanager")
             stub(UIManager, "onRotation")

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -273,7 +273,7 @@ describe("device module", function()
 
             mock_ffi_input = require('ffi/input')
             stub(mock_ffi_input, "waitForEvent")
-            mock_ffi_input.waitForEvent.returns(true, {
+            mock_ffi_input.waitForEvent.returns(true, { {
                 type = 3,
                 time = {
                     usec = 450565,
@@ -281,7 +281,7 @@ describe("device module", function()
                 },
                 code = 24,
                 value = 16
-            })
+            } })
 
             local UIManager = require("ui/uimanager")
             stub(UIManager, "onRotation")


### PR DESCRIPTION
Requires https://github.com/koreader/koreader-base/pull/1344 & https://github.com/koreader/koreader-base/pull/1346 (fix #7485)

Assorted input fixes:

* Actually handle errors in the "there's a callback timer" input polling loop.
* Don't break timerfd when the clock probe was inconclusive.

Not directly related, but noticed because of duplicate onInputEvent handlers:

* HookContainer: Fix deregistration to actually deregister properly. "Regression" extant since its inception in #2933 (!).
* Made sure the three plugins (basically the trio of AutoThingies ;p) that were using HookContainer actually unschedule their task on teardown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7483)
<!-- Reviewable:end -->
