### PR TITLE
Font menu: open on page with currently selected font, and other tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -96,8 +96,12 @@ function ReaderFont:init()
             end,
             checked_func = function()
                 return v == self.font_face
-            end
+            end,
+            menu_item_id = v,
         })
+    end
+    self.face_table.open_on_menu_item_id_func = function()
+        return self.font_face
     end
     self.ui.menu:registerToMainMenu(self)
 end
@@ -332,7 +336,9 @@ function ReaderFont:addToMainMenu(menu_items)
     self.face_table.max_per_page = 5
     -- insert table to main reader menu
     menu_items.change_font = {
-        text = self.font_menu_title,
+        text_func = function()
+            return T(_("Font: %1"), BD.wrap(self.font_face))
+        end,
         sub_item_table = self.face_table,
     }
 end

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -564,8 +564,14 @@ end
 function ReaderToc:updateCurrentNode()
     if #self.collapsed_toc > 0 and self.pageno then
         for i, v in ipairs(self.collapsed_toc) do
-            if v.page > self.pageno then
-                self.collapsed_toc.current = i > 1 and i - 1 or 1
+            if v.page >= self.pageno then
+                if v.page == self.pageno then
+                    -- Use first TOC item on current page (which may have others)
+                    self.collapsed_toc.current = i
+                else
+                    -- Use previous TOC item (if any), which is on a previous page
+                    self.collapsed_toc.current = i > 1 and i - 1 or 1
+                end
                 return
             end
         end

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -824,20 +824,6 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
             },
         },
         {
-            id = "epub_switch_show_case";
-            title = _("Toggle alternative EPUB content"),
-            description = _([[
-The EPUB3 format allows a
-<epub:switch> <epub:case> <epub:default>
-construct to provide alternative content to engines that support optional features.
-KOReader currently falls back to hiding all <epub:case> content and shows the <epub:default> content (usually an image).
-This tweak toggles this behavior, and may show the <epub:case> content as plain text.]]),
-            css = [[
-switch > case    { display: inline; }
-switch > default { display: none; }
-            ]],
-        },
-        {
             id = "no_pseudo_element_before_after";
             title = _("Disable before/after pseudo elements"),
             description = _([[Disable generated text from ::before and ::after pseudo elements, usually used to add cosmetic text around some content.]]),

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -84,7 +84,10 @@ function Notification:init()
             -- have this VerticalGroup full width, to ensure centering
             width = Screen:getWidth(),
             -- push this frame at its y=self.num position
-            height = notif_height * (self.num - 1),
+            height = notif_height * (self.num - 1) + self.margin,
+                -- (let's add a leading self.margin to get the same distance
+                -- from top of screen to first notification top border as
+                -- between borders of next notifications)
         },
         self.frame,
     }

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -499,12 +499,14 @@ function TouchMenu:init()
     self.page_info_left_chev = Button:new{
         icon = chevron_left,
         callback = function() self:onPrevPage() end,
+        hold_callback = function() self:onFirstPage() end,
         bordersize = 0,
         show_parent = self.show_parent,
     }
     self.page_info_right_chev = Button:new{
         icon = chevron_right,
         callback = function() self:onNextPage() end,
+        hold_callback = function() self:onLastPage() end,
         bordersize = 0,
         show_parent = self.show_parent,
     }
@@ -787,6 +789,18 @@ function TouchMenu:onPrevPage()
     return true
 end
 
+function TouchMenu:onFirstPage()
+    self.page = 1
+    self:updateItems()
+    return true
+end
+
+function TouchMenu:onLastPage()
+    self.page = self.page_num
+    self:updateItems()
+    return true
+end
+
 function TouchMenu:onSwipe(arg, ges_ev)
     local direction = BD.flipDirectionIfMirroredUILayout(ges_ev.direction)
     if direction == "west" then
@@ -838,6 +852,16 @@ function TouchMenu:onMenuSelect(item)
             table.insert(self.item_table_stack, self.item_table)
             self.item_table = sub_item_table
             self.page = 1
+            if self.item_table.open_on_menu_item_id_func then
+                self:_recalculatePageLayout() -- we need an accurate self.perpage
+                local open_id = self.item_table.open_on_menu_item_id_func()
+                for i = 1, #self.item_table do
+                    if self.item_table[i].menu_item_id == open_id then
+                        self.page = math.floor( (i - 1) / self.perpage ) + 1
+                        break
+                    end
+                end
+            end
             self:updateItems()
         end
     end


### PR DESCRIPTION
#### Font menu: open on page with currently selected font

Generic feature added to TouchMenu: an optional callback 'open_on_menu_item_id_func()' set on an items table can tell which menu item should be shown when opening a menu.
TouchMenu: allows jumping to first or last page with long-press on the chevrons.
Proposals and discussion at at https://github.com/koreader/koreader/issues/3620#issuecomment-801421408 and https://github.com/koreader/koreader/issues/3620#issuecomment-801516104.
I haven't added it for the other menu suggested there (Languages, Dispatcher actions...) because these are less bothering _to me_ :) Tell me if I should.

I also included something that I proposed previously (can't find where) - because I've been happy having it in my own patch: showing the current font name in the `Font>` menu name itself:
<kbd>![image](https://user-images.githubusercontent.com/24273478/113434235-1d5c4900-93d0-11eb-9681-49823787e6f7.png)</kbd>
It's now less needed, with the above feature that allows seeing what font is selected by just opening the menu.
Also, it might not be the font currently shown (if the book used embedded fonts), so it might not be needed to really show it that top level.
But it fits nicely with its neighour `Typography language>` - although this one shows rightly some real information about the book (typography from metadata lang= tag) so a user better see it if it's wrong - while Font> will show what the user has selected.
Well, I'm fine with removing it, just tell me :)

#### Notifications: add some top margin

#7226 / 68a5fcdb moved them a bit too near the top than before (but the  before computation was crap: centered in a Screen:getHeight()/10), and it can overlap with CRE rendering progress bar.
Also makes it nicer when multiple notications are stacked.
<kbd>![image](https://user-images.githubusercontent.com/24273478/113434689-f3575680-93d0-11eb-9e03-368bf5ebb569.png)</kbd>


#### TOC: highlight first chapter on page instead of last

So its in sync with the chapter shown in the footer, which was previously fixed with #7204 / a482baac.

#### Style tweaks: remove "Toggle alternative EPUB content"

With MathML support, this is no longer all or nothing.  As it's quite rare and technical, let this be handled via user style tweak when needed. https://github.com/koreader/koreader/pull/7465#issuecomment-810230767

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7490)
<!-- Reviewable:end -->
