### PR TITLE
ScreenSaver: Get rid of automagic settings

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -123,130 +123,140 @@ return {
                 end,
             },
             {
-                text = _("Black background behind images"),
-                enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                end,
-                checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_img_background") == "black"
-                end,
-                callback = function()
-                    G_reader_settings:saveSetting("screensaver_img_background", "black")
-                end,
-            },
-            {
-                text = _("White background behind images"),
-                enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                end,
-                checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_img_background") == "white"
-                end,
-                callback = function()
-                    G_reader_settings:saveSetting("screensaver_img_background", "white")
-                end,
-            },
-            {
-                text = _("Leave background as-is behind images"),
-                enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                end,
-                checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_img_background") == "none"
-                end,
-                callback = function()
-                    G_reader_settings:saveSetting("screensaver_img_background", "none")
-                end,
-            },
-            {
-                text = _("Stretch covers and images to fit screen"),
-                enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                end,
-                checked_func = function()
-                    return G_reader_settings:isTrue("screensaver_stretch_images")
-                end,
-                callback = function()
-                    G_reader_settings:toggle("screensaver_stretch_images")
-                end,
-                separator = true,
-            },
-            {
-                text = _("Black background behind message"),
-                enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
-                end,
-                checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_msg_background") == "black"
-                end,
-                callback = function()
-                    G_reader_settings:saveSetting("screensaver_msg_background", "black")
-                end,
-            },
-            {
-                text = _("White background behind message"),
-                enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
-                end,
-                checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_msg_background") == "white"
-                end,
-                callback = function()
-                    G_reader_settings:saveSetting("screensaver_msg_background", "white")
-                end,
-            },
-            {
-                text = _("Leave background as-is behind message"),
-                enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
-                end,
-                checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_msg_background") == "none"
-                end,
-                callback = function()
-                    G_reader_settings:saveSetting("screensaver_msg_background", "none")
-                end,
-            },
-            {
-                text = _("Screensaver message position"),
+                text = _("Covers and images settings"),
                 sub_item_table = {
                     {
-                        text = _("Top"),
+                        text = _("Black background behind covers and images"),
                         enabled_func = function()
-                            return G_reader_settings:isTrue("screensaver_show_message")
+                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
                         end,
                         checked_func = function()
-                            return G_reader_settings:readSetting("screensaver_message_position") == "top"
+                            return G_reader_settings:readSetting("screensaver_img_background") == "black"
                         end,
                         callback = function()
-                            G_reader_settings:saveSetting("screensaver_message_position", "top")
-                        end
+                            G_reader_settings:saveSetting("screensaver_img_background", "black")
+                        end,
                     },
                     {
-                        text = _("Middle"),
+                        text = _("White background behind covers and images"),
                         enabled_func = function()
-                            return G_reader_settings:isTrue("screensaver_show_message")
+                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
                         end,
                         checked_func = function()
-                            return G_reader_settings:readSetting("screensaver_message_position") == "middle"
+                            return G_reader_settings:readSetting("screensaver_img_background") == "white"
                         end,
                         callback = function()
-                            G_reader_settings:saveSetting("screensaver_message_position", "middle")
-                        end
+                            G_reader_settings:saveSetting("screensaver_img_background", "white")
+                        end,
                     },
                     {
-                        text = _("Bottom"),
+                        text = _("Leave background as-is behind covers and images"),
                         enabled_func = function()
-                            return G_reader_settings:isTrue("screensaver_show_message")
+                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
                         end,
                         checked_func = function()
-                            return G_reader_settings:readSetting("screensaver_message_position") == "bottom"
+                            return G_reader_settings:readSetting("screensaver_img_background") == "none"
                         end,
                         callback = function()
-                            G_reader_settings:saveSetting("screensaver_message_position", "bottom")
-                        end
+                            G_reader_settings:saveSetting("screensaver_img_background", "none")
+                        end,
                     },
-                }
+                    {
+                        text = _("Stretch covers and images to fit screen"),
+                        enabled_func = function()
+                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
+                        end,
+                        checked_func = function()
+                            return G_reader_settings:isTrue("screensaver_stretch_images")
+                        end,
+                        callback = function()
+                            G_reader_settings:toggle("screensaver_stretch_images")
+                        end,
+                        separator = true,
+                    },
+                },
+            },
+            {
+                text = _("Message settings"),
+                sub_item_table = {
+                    {
+                        text = _("Black background behind message"),
+                        enabled_func = function()
+                            return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
+                        end,
+                        checked_func = function()
+                            return G_reader_settings:readSetting("screensaver_msg_background") == "black"
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_msg_background", "black")
+                        end,
+                    },
+                    {
+                        text = _("White background behind message"),
+                        enabled_func = function()
+                            return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
+                        end,
+                        checked_func = function()
+                            return G_reader_settings:readSetting("screensaver_msg_background") == "white"
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_msg_background", "white")
+                        end,
+                    },
+                    {
+                        text = _("Leave background as-is behind message"),
+                        enabled_func = function()
+                            return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
+                        end,
+                        checked_func = function()
+                            return G_reader_settings:readSetting("screensaver_msg_background") == "none"
+                        end,
+                        callback = function()
+                            G_reader_settings:saveSetting("screensaver_msg_background", "none")
+                        end,
+                    },
+                    {
+                        text = _("Message position"),
+                        sub_item_table = {
+                            {
+                                text = _("Top"),
+                                enabled_func = function()
+                                    return G_reader_settings:isTrue("screensaver_show_message")
+                                end,
+                                checked_func = function()
+                                    return G_reader_settings:readSetting("screensaver_message_position") == "top"
+                                end,
+                                callback = function()
+                                    G_reader_settings:saveSetting("screensaver_message_position", "top")
+                                end
+                            },
+                            {
+                                text = _("Middle"),
+                                enabled_func = function()
+                                    return G_reader_settings:isTrue("screensaver_show_message")
+                                end,
+                                checked_func = function()
+                                    return G_reader_settings:readSetting("screensaver_message_position") == "middle"
+                                end,
+                                callback = function()
+                                    G_reader_settings:saveSetting("screensaver_message_position", "middle")
+                                end
+                            },
+                            {
+                                text = _("Bottom"),
+                                enabled_func = function()
+                                    return G_reader_settings:isTrue("screensaver_show_message")
+                                end,
+                                checked_func = function()
+                                    return G_reader_settings:readSetting("screensaver_message_position") == "bottom"
+                                end,
+                                callback = function()
+                                    G_reader_settings:saveSetting("screensaver_message_position", "bottom")
+                                end
+                            },
+                        },
+                    },
+                },
             },
             {
                 text = _("Keep the screensaver on screen after wakeup"),
@@ -296,8 +306,8 @@ return {
                             G_reader_settings:saveSetting("screensaver_delay", "tap")
                         end
                     },
-                }
-            }
-        }
-    }
+                },
+            },
+        },
+    },
 }

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -127,9 +127,6 @@ return {
                 sub_item_table = {
                     {
                         text = _("Black background behind covers and images"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_img_background") == "black"
                         end,
@@ -139,9 +136,6 @@ return {
                     },
                     {
                         text = _("White background behind covers and images"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_img_background") == "white"
                         end,
@@ -151,9 +145,6 @@ return {
                     },
                     {
                         text = _("Leave background as-is behind covers and images"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_img_background") == "none"
                         end,
@@ -163,9 +154,6 @@ return {
                     },
                     {
                         text = _("Stretch covers and images to fit screen"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") ~= "disable"
-                        end,
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_stretch_images")
                         end,
@@ -181,9 +169,6 @@ return {
                 sub_item_table = {
                     {
                         text = _("Black background behind message"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
-                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_msg_background") == "black"
                         end,
@@ -193,9 +178,6 @@ return {
                     },
                     {
                         text = _("White background behind message"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
-                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_msg_background") == "white"
                         end,
@@ -205,9 +187,6 @@ return {
                     },
                     {
                         text = _("Leave background as-is behind message"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
-                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_msg_background") == "none"
                         end,
@@ -220,9 +199,6 @@ return {
                         sub_item_table = {
                             {
                                 text = _("Top"),
-                                enabled_func = function()
-                                    return G_reader_settings:isTrue("screensaver_show_message")
-                                end,
                                 checked_func = function()
                                     return G_reader_settings:readSetting("screensaver_message_position") == "top"
                                 end,
@@ -232,9 +208,6 @@ return {
                             },
                             {
                                 text = _("Middle"),
-                                enabled_func = function()
-                                    return G_reader_settings:isTrue("screensaver_show_message")
-                                end,
                                 checked_func = function()
                                     return G_reader_settings:readSetting("screensaver_message_position") == "middle"
                                 end,
@@ -244,9 +217,6 @@ return {
                             },
                             {
                                 text = _("Bottom"),
-                                enabled_func = function()
-                                    return G_reader_settings:isTrue("screensaver_show_message")
-                                end,
                                 checked_func = function()
                                     return G_reader_settings:readSetting("screensaver_message_position") == "bottom"
                                 end,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -61,7 +61,9 @@ return {
     },
     {
         text = _("Use reading progress as screensaver"),
-        enabled_func = function() return Screensaver.getReaderProgress ~= nil and hasLastFile() end,
+        enabled_func = function()
+            return Screensaver.getReaderProgress ~= nil and hasLastFile()
+        end,
         checked_func = function()
             return G_reader_settings:readSetting("screensaver_type") == "readingprogress"
         end,
@@ -72,7 +74,7 @@ return {
     {
         text = _("Leave screen as it is"),
         checked_func = function()
-            return G_reader_settings:readSetting("screensaver_type") == "disable" or G_reader_settings:hasNot("screensaver_type")
+            return G_reader_settings:readSetting("screensaver_type") == "disable"
         end,
         callback = function()
             G_reader_settings:saveSetting("screensaver_type", "disable")
@@ -82,10 +84,9 @@ return {
     {
         text = _("Add message to screensaver"),
         checked_func = function()
-            return G_reader_settings:isTrue("screensaver_show_message") or G_reader_settings:hasNot("screensaver_type")
+            return G_reader_settings:isTrue("screensaver_show_message")
         end,
         callback = function()
-            -- NOTE: Since the default is nil, the first toggle will keep it checked (but true instead of nil).
             G_reader_settings:toggle("screensaver_show_message")
         end,
         separator = true,
@@ -123,33 +124,45 @@ return {
             },
             {
                 text = _("Black background behind images"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
+                end,
                 checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_background") == "black" or G_reader_settings:hasNot("screensaver_background")
+                    return G_reader_settings:readSetting("screensaver_img_background") == "black"
                 end,
                 callback = function()
-                    G_reader_settings:saveSetting("screensaver_background", "black")
+                    G_reader_settings:saveSetting("screensaver_img_background", "black")
                 end,
             },
             {
-                text = _("White background behind message and images"),
+                text = _("White background behind images"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
+                end,
                 checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_background") == "white"
+                    return G_reader_settings:readSetting("screensaver_img_background") == "white"
                 end,
                 callback = function()
-                    G_reader_settings:saveSetting("screensaver_background", "white")
+                    G_reader_settings:saveSetting("screensaver_img_background", "white")
                 end,
             },
             {
-                text = _("Leave background as-is behind message and images"),
+                text = _("Leave background as-is behind images"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
+                end,
                 checked_func = function()
-                    return G_reader_settings:readSetting("screensaver_background") == "none"
+                    return G_reader_settings:readSetting("screensaver_img_background") == "none"
                 end,
                 callback = function()
-                    G_reader_settings:saveSetting("screensaver_background", "none")
+                    G_reader_settings:saveSetting("screensaver_img_background", "none")
                 end,
             },
             {
                 text = _("Stretch covers and images to fit screen"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") ~= "disable"
+                end,
                 checked_func = function()
                     return G_reader_settings:isTrue("screensaver_stretch_images")
                 end,
@@ -159,10 +172,49 @@ return {
                 separator = true,
             },
             {
+                text = _("Black background behind message"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
+                end,
+                checked_func = function()
+                    return G_reader_settings:readSetting("screensaver_msg_background") == "black"
+                end,
+                callback = function()
+                    G_reader_settings:saveSetting("screensaver_msg_background", "black")
+                end,
+            },
+            {
+                text = _("White background behind message"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
+                end,
+                checked_func = function()
+                    return G_reader_settings:readSetting("screensaver_msg_background") == "white"
+                end,
+                callback = function()
+                    G_reader_settings:saveSetting("screensaver_msg_background", "white")
+                end,
+            },
+            {
+                text = _("Leave background as-is behind message"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
+                end,
+                checked_func = function()
+                    return G_reader_settings:readSetting("screensaver_msg_background") == "none"
+                end,
+                callback = function()
+                    G_reader_settings:saveSetting("screensaver_msg_background", "none")
+                end,
+            },
+            {
                 text = _("Screensaver message position"),
                 sub_item_table = {
                     {
                         text = _("Top"),
+                        enabled_func = function()
+                            return G_reader_settings:isTrue("screensaver_show_message")
+                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_message_position") == "top"
                         end,
@@ -172,8 +224,11 @@ return {
                     },
                     {
                         text = _("Middle"),
+                        enabled_func = function()
+                            return G_reader_settings:isTrue("screensaver_show_message")
+                        end,
                         checked_func = function()
-                            return G_reader_settings:readSetting("screensaver_message_position") == "middle" or G_reader_settings:hasNot("screensaver_message_position")
+                            return G_reader_settings:readSetting("screensaver_message_position") == "middle"
                         end,
                         callback = function()
                             G_reader_settings:saveSetting("screensaver_message_position", "middle")
@@ -181,6 +236,9 @@ return {
                     },
                     {
                         text = _("Bottom"),
+                        enabled_func = function()
+                            return G_reader_settings:isTrue("screensaver_show_message")
+                        end,
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_message_position") == "bottom"
                         end,
@@ -196,7 +254,7 @@ return {
                     {
                         text = _("Disable"),
                         checked_func = function()
-                            return G_reader_settings:readSetting("screensaver_delay") == "disable" or G_reader_settings:hasNot("screensaver_delay")
+                            return G_reader_settings:readSetting("screensaver_delay") == "disable"
                         end,
                         callback = function()
                             G_reader_settings:saveSetting("screensaver_delay", "disable")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -23,7 +23,7 @@ local _ = require("gettext")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
--- Migrate old settings from 2021.02 or older.
+-- Migrate settings from 2021.02 or older.
 if G_reader_settings:readSetting("screensaver_type") == "message" then
     G_reader_settings:saveSetting("screensaver_type", "disable")
     G_reader_settings:makeTrue("screensaver_show_message")
@@ -39,6 +39,32 @@ if G_reader_settings:has("screensaver_white_background") then
         G_reader_settings:saveSetting("screensaver_background", "white")
     end
     G_reader_settings:delSetting("screensaver_white_background")
+end
+-- Migrate settings from 2021.03 or older.
+if G_reader_settings:has("screensaver_background") then
+    G_reader_settings:saveSetting("screensaver_img_background", G_reader_settings:readSetting("screensaver_background"))
+    G_reader_settings:delSetting("screensaver_background")
+end
+
+-- Default settings
+if G_reader_settings:hasNot("screensaver_show_message") then
+    G_reader_settings:makeFalse("screensaver_show_message")
+end
+if G_reader_settings:hasNot("screensaver_type") then
+    G_reader_settings:saveSetting("screensaver_type", "disable")
+    G_reader_settings:makeTrue("screensaver_show_message")
+end
+if G_reader_settings:hasNot("screensaver_img_background") then
+    G_reader_settings:saveSetting("screensaver_img_background", "black")
+end
+if G_reader_settings:hasNot("screensaver_msg_background") then
+    G_reader_settings:saveSetting("screensaver_msg_background", "none")
+end
+if G_reader_settings:hasNot("screensaver_message_position") then
+    G_reader_settings:saveSetting("screensaver_message_position", "middle")
+end
+if G_reader_settings:hasNot("screensaver_delay") then
+    G_reader_settings:hasNot("screensaver_delay", "disable")
 end
 
 local Screensaver = {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -63,6 +63,9 @@ end
 if G_reader_settings:hasNot("screensaver_message_position") then
     G_reader_settings:saveSetting("screensaver_message_position", "middle")
 end
+if G_reader_settings:hasNot("screensaver_stretch_images") then
+    G_reader_settings:makeFalse("screensaver_stretch_images")
+end
 if G_reader_settings:hasNot("screensaver_delay") then
     G_reader_settings:saveSetting("screensaver_delay", "disable")
 end
@@ -529,7 +532,7 @@ function Screensaver:show()
             image_disposable = true,
             height = Screen:getHeight(),
             width = Screen:getWidth(),
-            scale_factor = G_reader_settings:nilOrFalse("screensaver_stretch_images") and 0 or nil,
+            scale_factor = G_reader_settings:isFalse("screensaver_stretch_images") and 0 or nil,
         }
     elseif self.screensaver_type == "bookstatus" then
         local ReaderUI = require("apps/reader/readerui")
@@ -551,7 +554,7 @@ function Screensaver:show()
             alpha = true,
             height = Screen:getHeight(),
             width = Screen:getWidth(),
-            scale_factor = G_reader_settings:nilOrFalse("screensaver_stretch_images") and 0 or nil,
+            scale_factor = G_reader_settings:isFalse("screensaver_stretch_images") and 0 or nil,
         }
     elseif self.screensaver_type == "readingprogress" then
         widget = Screensaver.getReaderProgress()

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -64,7 +64,7 @@ if G_reader_settings:hasNot("screensaver_message_position") then
     G_reader_settings:saveSetting("screensaver_message_position", "middle")
 end
 if G_reader_settings:hasNot("screensaver_delay") then
-    G_reader_settings:hasNot("screensaver_delay", "disable")
+    G_reader_settings:saveSetting("screensaver_delay", "disable")
 end
 
 local Screensaver = {


### PR DESCRIPTION
By which I mean, explicitly initialize default settings, making everything seven hundred billion percent less weird.

Also, split the background option between image and (solo) message, because the defaults for those are different, and trying to twist the one into the other was leading to pure madness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7496)
<!-- Reviewable:end -->
