### PR TITLE
hidden setting: highlight lighten factor

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -37,7 +37,7 @@ local ReaderView = OverlapGroup:extend{
     outer_page_color = Blitbuffer.gray(DOUTER_PAGE_COLOR / 15),
     -- highlight with "lighten" or "underscore" or "invert"
     highlight = {
-        lighten_factor = 0.2,
+        lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor") or 0.2,
         temp_drawer = "invert",
         temp = {},
         saved_drawer = "lighten",

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -37,7 +37,7 @@ local ReaderView = OverlapGroup:extend{
     outer_page_color = Blitbuffer.gray(DOUTER_PAGE_COLOR / 15),
     -- highlight with "lighten" or "underscore" or "invert"
     highlight = {
-        lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor") or 0.2,
+        lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor", 0.2),
         temp_drawer = "invert",
         temp = {},
         saved_drawer = "lighten",


### PR DESCRIPTION
Adds a new hidden setting to address https://github.com/koreader/koreader/issues/7476

The setting takes values from 0 (brightest) to 1 (darkest). For example, to lighten the highlight, users can manually add the line below to their `settings.reader.lua`

```
"highlight_lighten_factor" = 0.1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7497)
<!-- Reviewable:end -->
