### PR TITLE
Inputtext: don't allow the cursor to move within a hint

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -120,6 +120,7 @@ if Device:isTouchDevice() or Device:hasDPad() then
             if self.parent.onSwitchFocus then
                 self.parent:onSwitchFocus(self)
             end
+            if #self.charlist == 0 then return end
             local textwidget_offset = self.margin + self.bordersize + self.padding
             local x = ges.pos.x - self._frame_textwidget.dimen.x - textwidget_offset
             local y = ges.pos.y - self._frame_textwidget.dimen.y - textwidget_offset

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -120,7 +120,7 @@ if Device:isTouchDevice() or Device:hasDPad() then
             if self.parent.onSwitchFocus then
                 self.parent:onSwitchFocus(self)
             end
-            if #self.charlist == 0 then return end
+            if #self.charlist == 0 then return end -- Avoid cursor moving within a hint.
             local textwidget_offset = self.margin + self.bordersize + self.padding
             local x = ges.pos.x - self._frame_textwidget.dimen.x - textwidget_offset
             local y = ges.pos.y - self._frame_textwidget.dimen.y - textwidget_offset


### PR DESCRIPTION
Before: you can tap a hint and cursor jumps to that position. Not nice, as we haven't started to input yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7507)
<!-- Reviewable:end -->
