### PR TITLE
remarkable FW 2.6: Set absolute path for 'sync'

### DIFF
--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -51,7 +51,7 @@ ko_update_check() {
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
         unset BLOCKS CPOINTS
         # Ensure everything is flushed to disk before we restart. This *will* stall for a while on slow storage!
-        sync
+        /bin/sync
 
         if [ ${USING_BUTTON_LISTEN} -eq 0 ]; then
             systemctl start button-listen

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -51,7 +51,7 @@ ko_update_check() {
         rm -f "${NEWUPDATE}" # always purge newupdate in all cases to prevent update loop
         unset BLOCKS CPOINTS
         # Ensure everything is flushed to disk before we restart. This *will* stall for a while on slow storage!
-        /bin/sync
+        busybox sync
 
         if [ ${USING_BUTTON_LISTEN} -eq 0 ]; then
             systemctl start button-listen


### PR DESCRIPTION
Fixes https://github.com/koreader/koreader/issues/7508

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7509)
<!-- Reviewable:end -->
