### PR TITLE
Input dialogs: do not allow blank input cont'd

### DIFF
--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -287,10 +287,9 @@ function InputContainer:onInput(input, ignore_first_hold_release)
                     text = input.ok_text or _("OK"),
                     is_enter_default = true,
                     callback = function()
-                        if input.allow_blank_input or self.input_dialog:getInputText() ~= "" then
-                            input.callback(self.input_dialog:getInputText())
-                            self:closeInputDialog()
-                        end
+                        if input.deny_blank_input and self.input_dialog:getInputText() == "" then return end
+                        input.callback(self.input_dialog:getInputText())
+                        self:closeInputDialog()
                     end,
                 },
             },

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -287,8 +287,10 @@ function InputContainer:onInput(input, ignore_first_hold_release)
                     text = input.ok_text or _("OK"),
                     is_enter_default = true,
                     callback = function()
-                        input.callback(self.input_dialog:getInputText())
-                        self:closeInputDialog()
+                        if allow_blank_input or self.input_dialog:getInputText() ~= "" then
+                            input.callback(self.input_dialog:getInputText())
+                            self:closeInputDialog()
+                        end
                     end,
                 },
             },

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -287,7 +287,7 @@ function InputContainer:onInput(input, ignore_first_hold_release)
                     text = input.ok_text or _("OK"),
                     is_enter_default = true,
                     callback = function()
-                        if allow_blank_input or self.input_dialog:getInputText() ~= "" then
+                        if input.allow_blank_input or self.input_dialog:getInputText() ~= "" then
                             input.callback(self.input_dialog:getInputText())
                             self:closeInputDialog()
                         end

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -433,6 +433,7 @@ function KeyValuePage:init()
             hint_func = function()
                 return "(" .. "1 - " .. self.pages .. ")"
             end,
+            deny_blank_input = true
             callback = function(input)
                 local page = tonumber(input)
                 if page and page >= 1 and page <= self.pages then

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -433,7 +433,7 @@ function KeyValuePage:init()
             hint_func = function()
                 return "(" .. "1 - " .. self.pages .. ")"
             end,
-            deny_blank_input = true
+            deny_blank_input = true,
             callback = function(input)
                 local page = tonumber(input)
                 if page and page >= 1 and page <= self.pages then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -754,7 +754,7 @@ function Menu:init()
                     --- @todo Support utf8 lowercase.
                     local filename = FFIUtil.basename(v.path):lower()
                     local search_string = self.page_info_text.input_dialog:getInputText():lower()
-                    if search_string = "" then return end
+                    if search_string == "" then return end
                     local i, _ = filename:find(search_string)
                     if i == 1 and not v.is_go_up then
                         self:onGotoPage(math.ceil(k / self.perpage))

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -733,8 +733,8 @@ function Menu:init()
                     local page = tonumber(self.page_info_text.input_dialog:getInputText())
                     if page and page >= 1 and page <= self.page_num then
                         self:onGotoPage(page)
+                        self.page_info_text:closeInputDialog()
                     end
-                    self.page_info_text:closeInputDialog()
                 end,
             },
         },
@@ -754,6 +754,7 @@ function Menu:init()
                     --- @todo Support utf8 lowercase.
                     local filename = FFIUtil.basename(v.path):lower()
                     local search_string = self.page_info_text.input_dialog:getInputText():lower()
+                    if search_string = "" then return end
                     local i, _ = filename:find(search_string)
                     if i == 1 and not v.is_go_up then
                         self:onGotoPage(math.ceil(k / self.perpage))


### PR DESCRIPTION
Continue to implement default behaviour in input dialogs: do not accept empty input field.
Folow up to https://github.com/koreader/koreader/pull/7501.

InputContainer will not allow blank input by deafult.
If needed to allow, set `allow_blank_input = true` before calling.

Affects page selector in the KeyValuePage widget.
Does not affect Wikipedia languages settings (https://github.com/koreader/koreader/pull/7501#discussion_r606771433).

Menu.lua: do not allow blank input in page selector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7516)
<!-- Reviewable:end -->
