### PR TITLE
Dict/Wiki lookup results window: improve the 'pencil' button

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1223,11 +1223,11 @@ function DictQuickLookup:lookupInputWord(hint)
                     end,
                 },
                 {
-                    text = _("Search dictionary"),
-                    is_enter_default = not self.is_wiki,
+                    text = _("Search Wikipedia"),
+                    is_enter_default = self.is_wiki,
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
-                        self.is_wiki = false
+                        self.is_wiki = true
                         self:closeInputDialog()
                         self:inputLookup()
                     end,
@@ -1241,11 +1241,11 @@ function DictQuickLookup:lookupInputWord(hint)
                     end,
                 },
                 {
-                    text = _("Search Wikipedia"),
-                    is_enter_default = self.is_wiki,
+                    text = _("Search dictionary"),
+                    is_enter_default = not self.is_wiki,
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
-                        self.is_wiki = true
+                        self.is_wiki = false
                         self:closeInputDialog()
                         self:inputLookup()
                     end,

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1227,7 +1227,7 @@ function DictQuickLookup:lookupInputWord(hint)
                     is_enter_default = not self.is_wiki,
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
-                        self.is_wiki=false
+                        self.is_wiki = false
                         self:closeInputDialog()
                         self:inputLookup()
                     end,
@@ -1245,7 +1245,7 @@ function DictQuickLookup:lookupInputWord(hint)
                     is_enter_default = self.is_wiki,
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
-                        self.is_wiki=true
+                        self.is_wiki = true
                         self:closeInputDialog()
                         self:inputLookup()
                     end,

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -21,6 +21,7 @@ local ScrollTextWidget = require("ui/widget/scrolltextwidget")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local TimeVal = require("ui/timeval")
+local Translator = require("ui/translator")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
@@ -1213,22 +1214,43 @@ function DictQuickLookup:lookupInputWord(hint)
         buttons = {
             {
                 {
+                    text = _("Translate"),
+                    is_enter_default = false,
+                    callback = function()
+                        if self.input_dialog:getInputText() == "" then return end
+                        self:closeInputDialog()
+                        Translator:showTranslation(self.input_dialog:getInputText())
+                    end,
+                },
+                {
+                    text = _("Search dictionary"),
+                    is_enter_default = not self.is_wiki,
+                    callback = function()
+                        if self.input_dialog:getInputText() == "" then return end
+                        self.is_wiki=false
+                        self:closeInputDialog()
+                        self:inputLookup()
+                    end,
+                },
+            },
+            {
+                {
                     text = _("Cancel"),
                     callback = function()
                         self:closeInputDialog()
                     end,
                 },
                 {
-                    text = self.is_wiki and _("Search Wikipedia") or _("Search dictionary"),
-                    is_enter_default = true,
+                    text = _("Search Wikipedia"),
+                    is_enter_default = self.is_wiki,
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
+                        self.is_wiki=true
                         self:closeInputDialog()
-                        self:onClose()
                         self:inputLookup()
                     end,
                 },
-            }
+            },
         },
     }
     UIManager:show(self.input_dialog)


### PR DESCRIPTION
Discussed in https://github.com/koreader/koreader/issues/7511.
Allow continue search in Dict, Wiki or Translate.
New window will stack over the window with the previous lookup results (same as with the long press in the article).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7523)
<!-- Reviewable:end -->
