### PR TITLE
Numberpicker: show hint with boundaries instead of the current value

### DIFF
--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -126,7 +126,7 @@ function NumberPickerWidget:init()
         callback_input = function()
             input_dialog = InputDialog:new{
                 title = _("Enter number"),
-                input = self.formatted_value,
+                input_hint = T("(%1 - %2)", self.value_min, self.value_max),
                 input_type = "number",
                 buttons = {
                     {

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -126,7 +126,7 @@ function NumberPickerWidget:init()
         callback_input = function()
             input_dialog = InputDialog:new{
                 title = _("Enter number"),
-                input_hint = T("(%1 - %2)", self.value_min, self.value_max),
+                input_hint = T("%1 (%2 - %3)", self.formatted_value, self.value_min, self.value_max),
                 input_type = "number",
                 buttons = {
                     {
@@ -140,7 +140,6 @@ function NumberPickerWidget:init()
                             text = _("OK"),
                             is_enter_default = true,
                             callback = function()
-                                input_dialog:closeInputDialog()
                                 local input_value = tonumber(input_dialog:getInputText())
                                 if input_value and input_value >= self.value_min and input_value <= self.value_max then
                                     self.value = input_value


### PR DESCRIPTION
(1) It is convenient to see the boundaries of the input value instead of the current value (which is seen in the SpinWidget).

Before
![1](https://user-images.githubusercontent.com/62179190/114295665-502cce00-9aaf-11eb-9e2d-291b31355f75.png)

After
![2](https://user-images.githubusercontent.com/62179190/114295668-54f18200-9aaf-11eb-9559-776388f47040.png)


(2) Is line 143 correct? Can it be removed (the input box is closed with 148)?
https://github.com/koreader/koreader/blob/bbe197bd4b8a1e44520a1a659d91ca1fa8e162c6/frontend/ui/widget/numberpickerwidget.lua#L142-L149


(3) Since (1), as we see the hint with the boundaries before input, do we need the detailed error infomessages?
https://github.com/koreader/koreader/blob/bbe197bd4b8a1e44520a1a659d91ca1fa8e162c6/frontend/ui/widget/numberpickerwidget.lua#L151
https://github.com/koreader/koreader/blob/bbe197bd4b8a1e44520a1a659d91ca1fa8e162c6/frontend/ui/widget/numberpickerwidget.lua#L156

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7529)
<!-- Reviewable:end -->
