### PR TITLE
Centralize one time migration code after updates

### DIFF
--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -17,6 +17,8 @@ local ReaderTypography = InputContainer:new{}
 -- This is used to migrate old hyph settings, and to show the currently
 -- used hyph dict language in the hyphenation menu.
 -- It will be completed with info from the LANGUAGES table below.
+-- NOTE: Actual migration is handled in ui/data/onetime_migration,
+--       which is why this hash is public.
 ReaderTypography.HYPH_DICT_NAME_TO_LANG_NAME_TAG = {
     ["@none"]                = { "@none",           "en" },
     ["@softhyphens"]         = { "@softhyphens",    "en" },

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -12,10 +12,12 @@ local C_ = _.pgettext
 local T = require("ffi/util").template
 local Screen = Device.screen
 
+local ReaderTypography = InputContainer:new{}
+
 -- This is used to migrate old hyph settings, and to show the currently
 -- used hyph dict language in the hyphenation menu.
 -- It will be completed with info from the LANGUAGES table below.
-local HYPH_DICT_NAME_TO_LANG_NAME_TAG = {
+ReaderTypography.HYPH_DICT_NAME_TO_LANG_NAME_TAG = {
     ["@none"]                = { "@none",           "en" },
     ["@softhyphens"]         = { "@softhyphens",    "en" },
     ["@algorithm"]           = { "@algorithm",      "en" },
@@ -93,7 +95,7 @@ local LANGUAGES = {
     { "zu",               {"zul"},   "H   ",   _("Zulu"),                   "Zulu.pattern" },
 }
 
-local DEFAULT_LANG_TAG = "en-US" -- English_US.pattern is loaded by default in crengine
+ReaderTypography.DEFAULT_LANG_TAG = "en-US" -- English_US.pattern is loaded by default in crengine
 
 local LANG_TAG_TO_LANG_NAME = {}
 local LANG_ALIAS_TO_LANG_TAG = {}
@@ -106,11 +108,9 @@ for __, v in ipairs(LANGUAGES) do
         end
     end
     if hyph_filename then
-        HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_filename] = { lang_name, lang_tag }
+        ReaderTypography.HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_filename] = { lang_name, lang_tag }
     end
 end
-
-local ReaderTypography = InputContainer:new{}
 
 function ReaderTypography:init()
     self.menu_table = {}
@@ -123,44 +123,6 @@ function ReaderTypography:init()
     self.hyph_soft_hyphens_only = false
     self.hyph_force_algorithmic = false
     self.floating_punctuation = 0
-
-    -- Migrate old readerhyphenation settings (but keep them in case one
-    -- go back to a previous version)
-    if G_reader_settings:hasNot("text_lang_default") and G_reader_settings:hasNot("text_lang_fallback") then
-        local g_text_lang_set = false
-        local hyph_alg_default = G_reader_settings:readSetting("hyph_alg_default")
-        if hyph_alg_default then
-            local dict_info = HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_alg_default]
-            if dict_info then
-                G_reader_settings:saveSetting("text_lang_default", dict_info[2])
-                g_text_lang_set = true
-                -- Tweak the other settings if the default hyph algo happens
-                -- to be one of these:
-                if hyph_alg_default == "@none" then
-                    G_reader_settings:makeFalse("hyphenation")
-                elseif hyph_alg_default == "@softhyphens" then
-                    G_reader_settings:makeTrue("hyph_soft_hyphens_only")
-                elseif hyph_alg_default == "@algorithm" then
-                    G_reader_settings:makeTrue("hyph_force_algorithmic")
-                end
-            end
-        end
-        local hyph_alg_fallback = G_reader_settings:readSetting("hyph_alg_fallback")
-        if not g_text_lang_set and hyph_alg_fallback then
-            local dict_info = HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_alg_fallback]
-            if dict_info then
-                G_reader_settings:saveSetting("text_lang_fallback", dict_info[2])
-                g_text_lang_set = true
-                -- We can't really tweak other settings if the hyph algo fallback
-                -- happens to be @none, @softhyphens, @algortihm...
-            end
-        end
-        if not g_text_lang_set then
-            -- If nothing migrated, set the fallback to DEFAULT_LANG_TAG,
-            -- as we'll always have one of text_lang_default/_fallback set.
-            G_reader_settings:saveSetting("text_lang_fallback", DEFAULT_LANG_TAG)
-        end
-    end
 
     local info_text = _([[
 Some languages have specific typographic rules: these include hyphenation, line breaking rules, and language specific glyph variants.
@@ -639,7 +601,7 @@ end
 
 function ReaderTypography:getCurrentDefaultHyphDictLanguage()
     local hyph_dict_name = self.ui.document:getTextMainLangDefaultHyphDictionary()
-    local dict_info = HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_dict_name]
+    local dict_info = self.HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_dict_name]
     if dict_info then
         hyph_dict_name = dict_info[1]
     else -- shouldn't happen
@@ -703,7 +665,7 @@ function ReaderTypography:onReadSettings(config)
     -- Migrate old readerhyphenation setting, if one was set
     if config:hasNot("text_lang") and config:has("hyph_alg") then
         local hyph_alg = config:readSetting("hyph_alg")
-        local dict_info = HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_alg]
+        local dict_info = self.HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_alg]
         if dict_info then
             config:saveSetting("text_lang", dict_info[2])
             -- Set the other settings if the default hyph algo happens
@@ -792,7 +754,7 @@ function ReaderTypography:onReadSettings(config)
     else
         self.allow_doc_lang_tag_override = true
         -- None decided, use default (shouldn't be reached)
-        self.text_lang_tag = DEFAULT_LANG_TAG
+        self.text_lang_tag = self.DEFAULT_LANG_TAG
         logger.dbg("Typography lang: no lang set, using", self.text_lang_tag)
     end
     self.ui.document:setTextMainLang(self.text_lang_tag)

--- a/frontend/cache.lua
+++ b/frontend/cache.lua
@@ -154,7 +154,7 @@ function Cache:serialize()
     -- calculate disk cache size
     local cached_size = 0
     local sorted_caches = {}
-    for _,file in pairs(self.cached) do
+    for _, file in pairs(self.cached) do
         table.insert(sorted_caches, {file=file, time=lfs.attributes(file, "access")})
         cached_size = cached_size + (lfs.attributes(file, "size") or 0)
     end
@@ -195,6 +195,11 @@ function Cache:clear()
     self.cache = {}
     self.cache_order = {}
     self.current_memsize = 0
+end
+
+-- Refresh the disk snapshot (mainly used by ui/data/onetime_migration)
+function Cache:refreshSnapshot()
+    self.cached = getDiskCache()
 end
 
 return Cache

--- a/frontend/cache.lua
+++ b/frontend/cache.lua
@@ -39,12 +39,6 @@ end
 
 local cache_path = DataStorage:getDataDir() .. "/cache/"
 
--- NOTE: Before 2021.04, fontlist used to squat our folder, needlessly polluting our state tracking.
-os.remove(cache_path .. "/fontinfo.dat")
--- Ditto for Calibre
-os.remove(cache_path .. "/calibre-libraries.lua")
-os.remove(cache_path .. "/calibre-books.dat")
-
 --[[
 -- return a snapshot of disk cached items for subsequent check
 --]]

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -26,6 +26,12 @@ if from_version < Version:getNormalizedVersion("v2019.12") then
     SettingsMigration:migrateSettings(G_reader_settings)
 end
 
+-- NOTE: ReaderTypography handles a few things @ init that could perhaps be moved here with minor refactoring...
+--       https://github.com/koreader/koreader/pull/6072
+-- NOTE: ReaderRolling, on the other hand, does some lower-level things @ onReadSettings tied to CRe that would be much harder to factor out.
+--       https://github.com/koreader/koreader/pull/1930
+-- NOTE: The Gestures plugin also handles this on its own, but deals with it sanely.
+
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7371
 if from_version < Version:getNormalizedVersion("v2021.03") then
     logger.info("Running one-time migration for v2021.03")

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -55,5 +55,23 @@ if from_version < Version:getNormalizedVersion("v2021.03-35") then
     end
 end
 
+-- Fontlist, cache migration, https://github.com/koreader/koreader/pull/7524
+if from_version < Version:getNormalizedVersion("v2021.03-43") then
+    logger.info("Running one-time migration for v2021.03-43")
+
+    local cache_path = DataStorage:getDataDir() .. "/cache/"
+    -- NOTE: Before 2021.04, fontlist used to squat our folder, needlessly polluting our state tracking.
+    os.remove(cache_path .. "/fontinfo.dat")
+end
+
+-- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
+if from_version < Version:getNormalizedVersion("v2021.03-47") then
+    logger.info("Running one-time migration for v2021.03-47")
+
+    -- Ditto for Calibre
+    os.remove(cache_path .. "/calibre-libraries.lua")
+    os.remove(cache_path .. "/calibre-books.dat")
+end
+
 -- We're done, store the current migration version
 G_reader_settings:saveSetting("last_migration_version", Version:getNormalizedCurrentVersion())

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -1,0 +1,50 @@
+--[[
+Centralizes any and all one time migration concerns.
+--]]
+
+local DataStorage = require("datastorage")
+local Version = require("version")
+local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
+
+-- Retrieve the last migration version
+local from_version = G_reader_settings:readSetting("last_migration_version", 0)
+
+-- Keep this in rough chronological order, with a reference to the PR that implemented the change.
+
+-- ScreenSaver, https://github.com/koreader/koreader/pull/7371
+if from_version < Version:getNormalizedVersion("v2021.03") then
+    logger.info("Running one-time migration for v2021.03")
+
+    -- Migrate settings from 2021.02 or older.
+    if G_reader_settings:readSetting("screensaver_type") == "message" then
+        G_reader_settings:saveSetting("screensaver_type", "disable")
+        G_reader_settings:makeTrue("screensaver_show_message")
+    end
+    if G_reader_settings:has("screensaver_no_background") then
+        if G_reader_settings:isTrue("screensaver_no_background") then
+            G_reader_settings:saveSetting("screensaver_background", "none")
+        end
+        G_reader_settings:delSetting("screensaver_no_background")
+    end
+    if G_reader_settings:has("screensaver_white_background") then
+        if G_reader_settings:isTrue("screensaver_white_background") then
+            G_reader_settings:saveSetting("screensaver_background", "white")
+        end
+        G_reader_settings:delSetting("screensaver_white_background")
+    end
+end
+
+-- ScreenSaver, https://github.com/koreader/koreader/pull/7496
+if from_version < Version:getNormalizedVersion("v2021.03-35") then
+    logger.info("Running one-time migration for v2021.03-35")
+
+    -- Migrate settings from 2021.03 or older.
+    if G_reader_settings:has("screensaver_background") then
+        G_reader_settings:saveSetting("screensaver_img_background", G_reader_settings:readSetting("screensaver_background"))
+        G_reader_settings:delSetting("screensaver_background")
+    end
+end
+
+-- We're done, store the current migration version
+G_reader_settings:saveSetting("last_migration_version", Version:getNormalizedCurrentVersion())

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -128,7 +128,7 @@ end
 if from_version < Version:getNormalizedVersion("v2021.03-12") then
     logger.info("Running one-time migration for v2021.03-12")
 
-    local ReaderStatistics = require("plugins/statistics.koplugin/main.lua")
+    local ReaderStatistics = require("plugins/statistics.koplugin/main")
     local settings = G_reader_settings:readSetting("statistics", ReaderStatistics.default_settings)
     -- Handle a snafu in 2021.03 that could lead to an empty settings table on fresh installs.
     for k, v in pairs(ReaderStatistics.default_settings) do

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -73,7 +73,7 @@ end
 
 -- NOTE: ReaderRolling, on the other hand, does some lower-level things @ onReadSettings tied to CRe that would be much harder to factor out.
 --       https://github.com/koreader/koreader/pull/1930
--- NOTE: The Gestures plugin also handles its settings migration its own, but deals with it sanely.
+-- NOTE: The Gestures plugin also handles its settings migration on its own, but deals with it sanely.
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7371
 if last_migration_date < 20210306 then

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -9,8 +9,6 @@ local logger = require("logger")
 
 -- Retrieve the last migration version
 local from_version = G_reader_settings:readSetting("last_migration_version", 0)
-print("from_version:", from_version)
-print("Version:getCurrentDate():", Version:getCurrentDate())
 
 -- If we haven't actually changed version since the last launch, we're done.
 if from_version == Version:getCurrentDate() then
@@ -22,7 +20,7 @@ end
 -- Global settings, https://github.com/koreader/koreader/pull/4945 & https://github.com/koreader/koreader/pull/5655
 -- Limit the check to the most recent update. ReaderUI calls this one unconditionally to update docsettings, too.
 if from_version < 20191129 then
-    logger.info("Running one-time migration for 20191129")
+    logger.info("Performing one-time migration for 20191129")
 
     local SettingsMigration = require("ui/data/settings_migration")
     SettingsMigration:migrateSettings(G_reader_settings)
@@ -30,7 +28,7 @@ end
 
 -- ReaderTypography, https://github.com/koreader/koreader/pull/6072
 if from_version < 20200421 then
-    logger.info("Running one-time migration for 20200421")
+    logger.info("Performing one-time migration for 20200421")
 
     local ReaderTypography = require("apps/reader/modules/readertypography")
     -- Migrate old readerhyphenation settings
@@ -77,7 +75,7 @@ end
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7371
 if from_version < 20210306 then
-    logger.info("Running one-time migration for 20210306 (1/2)")
+    logger.info("Performing one-time migration for 20210306 (1/2)")
 
     -- Migrate settings from 2021.02 or older.
     if G_reader_settings:readSetting("screensaver_type") == "message" then
@@ -100,7 +98,7 @@ end
 
 -- OPDS, same as above
 if from_version < 20210306 then
-    logger.info("Running one-time migration for 20210306 (2/2)")
+    logger.info("Performing one-time migration for 20210306 (2/2)")
 
     local opds_servers = G_reader_settings:readSetting("opds_servers")
     if opds_servers then
@@ -126,7 +124,7 @@ end
 
 -- Statistics, https://github.com/koreader/koreader/pull/7471
 if from_version < 20210330 then
-    logger.info("Running one-time migration for 20210330")
+    logger.info("Performing one-time migration for 20210330")
 
     local package_path = package.path
     package.path = string.format("%s/?.lua;%s", "plugins/statistics.koplugin", package_path)
@@ -145,7 +143,7 @@ end
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7496
 if from_version < 20210404 then
-    logger.info("Running one-time migration for 20210404")
+    logger.info("Performing one-time migration for 20210404")
 
     -- Migrate settings from 2021.03 or older.
     if G_reader_settings:has("screensaver_background") then
@@ -156,7 +154,7 @@ end
 
 -- Fontlist, cache migration, https://github.com/koreader/koreader/pull/7524
 if from_version < 20210409 then
-    logger.info("Running one-time migration for 20210409")
+    logger.info("Performing one-time migration for 20210409")
 
     -- NOTE: Before 2021.04, fontlist used to squat our folder, needlessly polluting our state tracking.
     local cache_path = DataStorage:getDataDir() .. "/cache"
@@ -170,7 +168,7 @@ end
 
 -- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
 if from_version < 20210412 then
-    logger.info("Running one-time migration for 20210412")
+    logger.info("Performing one-time migration for 20210412")
 
     -- Ditto for Calibre
     local cache_path = DataStorage:getDataDir() .. "/cache"

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -100,16 +100,15 @@ end
 if from_version < Version:getNormalizedVersion("v2021.03-12") then
     logger.info("Running one-time migration for v2021.03-12")
 
-    local statistics = G_reader_settings:readSetting("statistics", {})
-    local count = 0
-    for _, _ in pairs(statistics) do
-        count = count + 1
+    local ReaderStatistics = require("plugins/statistics.koplugin/main.lua")
+    local settings = G_reader_settings:readSetting("statistics", ReaderStatistics.default_settings)
+    -- Handle a snafu in 2021.03 that could lead to an empty settings table on fresh installs.
+    for k, v in pairs(ReaderStatistics.default_settings) do
+        if settings[k] == nil then
+            settings[k] = v
+        end
     end
-
-    -- If we don't have the full set of keys, wipe the table to let the plugin re-initialize it correctly.
-    if count < 8 then
-        G_reader_settings:delSetting("statistics")
-    end
+    G_reader_settings:saveSetting("statistics", settings)
 end
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7496

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -3,15 +3,17 @@ Centralizes any and all one time migration concerns.
 --]]
 
 local DataStorage = require("datastorage")
-local Version = require("version")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
--- Retrieve the last migration version
-local from_version = G_reader_settings:readSetting("last_migration_version", 0)
+-- Date at which the last migration snippet was added
+local CURRENT_MIGRATION_DATE = 20210413
 
--- If we haven't actually changed version since the last launch, we're done.
-if from_version == Version:getCurrentDate() then
+-- Retrieve the last migration version
+local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
+
+-- If there's nothing new to migrate since the last time, we're done.
+if last_migration_date == CURRENT_MIGRATION_DATE then
     return
 end
 
@@ -19,7 +21,7 @@ end
 
 -- Global settings, https://github.com/koreader/koreader/pull/4945 & https://github.com/koreader/koreader/pull/5655
 -- Limit the check to the most recent update. ReaderUI calls this one unconditionally to update docsettings, too.
-if from_version < 20191129 then
+if last_migration_date < 20191129 then
     logger.info("Performing one-time migration for 20191129")
 
     local SettingsMigration = require("ui/data/settings_migration")
@@ -27,7 +29,7 @@ if from_version < 20191129 then
 end
 
 -- ReaderTypography, https://github.com/koreader/koreader/pull/6072
-if from_version < 20200421 then
+if last_migration_date < 20200421 then
     logger.info("Performing one-time migration for 20200421")
 
     local ReaderTypography = require("apps/reader/modules/readertypography")
@@ -74,7 +76,7 @@ end
 -- NOTE: The Gestures plugin also handles its settings migration its own, but deals with it sanely.
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7371
-if from_version < 20210306 then
+if last_migration_date < 20210306 then
     logger.info("Performing one-time migration for 20210306 (1/2)")
 
     -- Migrate settings from 2021.02 or older.
@@ -97,7 +99,7 @@ if from_version < 20210306 then
 end
 
 -- OPDS, same as above
-if from_version < 20210306 then
+if last_migration_date < 20210306 then
     logger.info("Performing one-time migration for 20210306 (2/2)")
 
     local opds_servers = G_reader_settings:readSetting("opds_servers")
@@ -123,7 +125,7 @@ if from_version < 20210306 then
 end
 
 -- Statistics, https://github.com/koreader/koreader/pull/7471
-if from_version < 20210330 then
+if last_migration_date < 20210330 then
     logger.info("Performing one-time migration for 20210330")
 
     local package_path = package.path
@@ -142,7 +144,7 @@ if from_version < 20210330 then
 end
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7496
-if from_version < 20210404 then
+if last_migration_date < 20210404 then
     logger.info("Performing one-time migration for 20210404")
 
     -- Migrate settings from 2021.03 or older.
@@ -153,7 +155,7 @@ if from_version < 20210404 then
 end
 
 -- Fontlist, cache migration, https://github.com/koreader/koreader/pull/7524
-if from_version < 20210409 then
+if last_migration_date < 20210409 then
     logger.info("Performing one-time migration for 20210409")
 
     -- NOTE: Before 2021.04, fontlist used to squat our folder, needlessly polluting our state tracking.
@@ -171,7 +173,7 @@ if from_version < 20210409 then
 end
 
 -- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
-if from_version < 20210412 then
+if last_migration_date < 20210412 then
     logger.info("Performing one-time migration for 20210412")
 
     -- Ditto for Calibre
@@ -192,5 +194,5 @@ if from_version < 20210412 then
     Cache:refreshSnapshot()
 end
 
--- We're done, store the current migration version
-G_reader_settings:saveSetting("last_migration_version", Version:getCurrentDate())
+-- We're done, store the current migration date
+G_reader_settings:saveSetting("last_migration_date", CURRENT_MIGRATION_DATE)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -96,6 +96,29 @@ if from_version < Version:getNormalizedVersion("v2021.03") then
     end
 end
 
+-- OPDS, same as above
+if from_version < Version:getNormalizedVersion("v2021.03") then
+    logger.info("Running one-time migration for v2021.03")
+
+    local opds_servers = G_reader_settings:readSetting("opds_servers")
+    if not opds_servers then
+        return
+    end
+
+    -- Update deprecated URLs
+    for _, server in ipairs(opds_servers) do
+        if server.url == "http://bookserver.archive.org/catalog/" then
+            server.url = "https://bookserver.archive.org"
+        elseif server.url = "http://m.gutenberg.org/ebooks.opds/?format=opds" then
+            server.url = "https://m.gutenberg.org/ebooks.opds/?format=opds"
+        elseif server.url = "http://www.feedbooks.com/publicdomain/catalog.atom" then
+            server.url = "https://catalog.feedbooks.com/catalog/public_domain.atom"
+        end
+        -- TODO: Punt "Gallica [Fr] [Searchable]" & "Project Gutenberg [Searchable]"
+    end
+    G_reader_settings:saveSetting("opds_servers", opds_servers)
+end
+
 -- Statistics, https://github.com/koreader/koreader/pull/7471
 if from_version < Version:getNormalizedVersion("v2021.03-12") then
     logger.info("Running one-time migration for v2021.03-12")

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -44,6 +44,22 @@ if from_version < Version:getNormalizedVersion("v2021.03") then
     end
 end
 
+-- Statistics, https://github.com/koreader/koreader/pull/7471
+if from_version < Version:getNormalizedVersion("v2021.03-12") then
+    logger.info("Running one-time migration for v2021.03-12")
+
+    local statistics = G_reader_settings:readSetting("statistics", {})
+    count = 0
+    for _, _ in pairs(statistics) do
+        count = count + 1
+    end
+
+    -- If we don't have the full set of keys, wipe the table to let the plugin re-initialize it correctly.
+    if count < 8 then
+        G_reader_settings:delSetting("statistics")
+    end
+end
+
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7496
 if from_version < Version:getNormalizedVersion("v2021.03-35") then
     logger.info("Running one-time migration for v2021.03-35")

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -128,7 +128,11 @@ end
 if from_version < Version:getNormalizedVersion("v2021.03-12") then
     logger.info("Running one-time migration for v2021.03-12")
 
-    local ReaderStatistics = require("plugins/statistics.koplugin/main")
+    local package_path = package.path
+    package.path = string.format("%s/?.lua;%s", "plugins/statistics.koplugin", package_path)
+    local ReaderStatistics = dofile("plugins/statistics.koplugin/main.lua")
+    package.path = package_path
+
     local settings = G_reader_settings:readSetting("statistics", ReaderStatistics.default_settings)
     -- Handle a snafu in 2021.03 that could lead to an empty settings table on fresh installs.
     for k, v in pairs(ReaderStatistics.default_settings) do

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -105,16 +105,21 @@ if from_version < Version:getNormalizedVersion("v2021.03") then
         return
     end
 
-    -- Update deprecated URLs
-    for _, server in ipairs(opds_servers) do
+    -- Update deprecated URLs & remove deprecated entries
+    for i = #opds_servers, 1, -1 do
+        local server = opds_servers[i]
+
         if server.url == "http://bookserver.archive.org/catalog/" then
             server.url = "https://bookserver.archive.org"
-        elseif server.url = "http://m.gutenberg.org/ebooks.opds/?format=opds" then
+        elseif server.url == "http://m.gutenberg.org/ebooks.opds/?format=opds" then
             server.url = "https://m.gutenberg.org/ebooks.opds/?format=opds"
-        elseif server.url = "http://www.feedbooks.com/publicdomain/catalog.atom" then
+        elseif server.url == "http://www.feedbooks.com/publicdomain/catalog.atom" then
             server.url = "https://catalog.feedbooks.com/catalog/public_domain.atom"
         end
-        -- TODO: Punt "Gallica [Fr] [Searchable]" & "Project Gutenberg [Searchable]"
+
+        if server.title == "Gallica [Fr] [Searchable]" or server.title == "Project Gutenberg [Searchable]" then
+            table.remove(opds_servers, i)
+        end
     end
     G_reader_settings:saveSetting("opds_servers", opds_servers)
 end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -164,6 +164,10 @@ if from_version < 20210409 then
     if not ok then
        logger.warn("os.rename:", err)
     end
+
+    -- Make sure Cache gets the memo
+    local Cache = require("cache")
+    Cache:refreshSnapshot()
 end
 
 -- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
@@ -182,6 +186,10 @@ if from_version < 20210412 then
     if not ok then
        logger.warn("os.rename:", err)
     end
+
+    -- Make sure Cache gets the memo
+    local Cache = require("cache")
+    Cache:refreshSnapshot()
 end
 
 -- We're done, store the current migration version

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,6 +12,15 @@ local from_version = G_reader_settings:readSetting("last_migration_version", 0)
 
 -- Keep this in rough chronological order, with a reference to the PR that implemented the change.
 
+-- Global settings, https://github.com/koreader/koreader/pull/4945 & https://github.com/koreader/koreader/pull/5655
+-- Limit the check to the most recent update. ReaderUI calls this one unconditionally to update docsettings, too.
+if from_version < Version:getNormalizedVersion("v2019.12") then
+    logger.info("Running one-time migration for v2019.12")
+
+    local SettingsMigration = require("ui/data/settings_migration")
+    SettingsMigration:migrateSettings(G_reader_settings)
+end
+
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7371
 if from_version < Version:getNormalizedVersion("v2021.03") then
     logger.info("Running one-time migration for v2021.03")

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -59,9 +59,11 @@ end
 if from_version < Version:getNormalizedVersion("v2021.03-43") then
     logger.info("Running one-time migration for v2021.03-43")
 
-    local cache_path = DataStorage:getDataDir() .. "/cache/"
     -- NOTE: Before 2021.04, fontlist used to squat our folder, needlessly polluting our state tracking.
-    os.remove(cache_path .. "/fontinfo.dat")
+    local cache_path = DataStorage:getDataDir() .. "/cache"
+    local new_path = cache .. "/fontlist"
+    lfs.mkdir(new_path)
+    os.rename(cache_path .. "/fontinfo.dat", new_path .. "/fontinfo.dat")
 end
 
 -- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
@@ -69,8 +71,11 @@ if from_version < Version:getNormalizedVersion("v2021.03-47") then
     logger.info("Running one-time migration for v2021.03-47")
 
     -- Ditto for Calibre
-    os.remove(cache_path .. "/calibre-libraries.lua")
-    os.remove(cache_path .. "/calibre-books.dat")
+    local cache_path = DataStorage:getDataDir() .. "/cache"
+    local new_path = cache .. "/calibre"
+    lfs.mkdir(new_path)
+    os.rename(cache_path .. "/calibre-libraries.lua", new_path .. "/libraries.lua")
+    os.rename(cache_path .. "/calibre-books.dat", new_path .. "/books.dat")
 end
 
 -- We're done, store the current migration version

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -9,7 +9,7 @@ local logger = require("logger")
 -- Date at which the last migration snippet was added
 local CURRENT_MIGRATION_DATE = 20210413
 
--- Retrieve the last migration version
+-- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
 
 -- If there's nothing new to migrate since the last time, we're done.

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -11,7 +11,7 @@ local logger = require("logger")
 local from_version = G_reader_settings:readSetting("last_migration_version", 0)
 
 -- If we haven't actually changed version since the last launch, we're done.
-if from_version == Version:getNormalizedCurrentVersion() then
+if from_version == Version:getCurrentDate() then
     return
 end
 
@@ -19,16 +19,16 @@ end
 
 -- Global settings, https://github.com/koreader/koreader/pull/4945 & https://github.com/koreader/koreader/pull/5655
 -- Limit the check to the most recent update. ReaderUI calls this one unconditionally to update docsettings, too.
-if from_version < Version:getNormalizedVersion("v2019.12") then
-    logger.info("Running one-time migration for v2019.12")
+if from_version < 20191129 then
+    logger.info("Running one-time migration for 20191129")
 
     local SettingsMigration = require("ui/data/settings_migration")
     SettingsMigration:migrateSettings(G_reader_settings)
 end
 
 -- ReaderTypography, https://github.com/koreader/koreader/pull/6072
-if from_version < Version:getNormalizedVersion("v2020.05") then
-    logger.info("Running one-time migration for v2020.05")
+if from_version < 20200421 then
+    logger.info("Running one-time migration for 20200421")
 
     local ReaderTypography = require("apps/reader/modules/readertypography")
     -- Migrate old readerhyphenation settings
@@ -71,11 +71,11 @@ end
 
 -- NOTE: ReaderRolling, on the other hand, does some lower-level things @ onReadSettings tied to CRe that would be much harder to factor out.
 --       https://github.com/koreader/koreader/pull/1930
--- NOTE: The Gestures plugin also handles this on its own, but deals with it sanely.
+-- NOTE: The Gestures plugin also handles its settings migration its own, but deals with it sanely.
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7371
-if from_version < Version:getNormalizedVersion("v2021.03") then
-    logger.info("Running one-time migration for v2021.03")
+if from_version < 20210306 then
+    logger.info("Running one-time migration for 20210306 (1/2)")
 
     -- Migrate settings from 2021.02 or older.
     if G_reader_settings:readSetting("screensaver_type") == "message" then
@@ -97,8 +97,8 @@ if from_version < Version:getNormalizedVersion("v2021.03") then
 end
 
 -- OPDS, same as above
-if from_version < Version:getNormalizedVersion("v2021.03") then
-    logger.info("Running one-time migration for v2021.03")
+if from_version < 20210306 then
+    logger.info("Running one-time migration for 20210306 (2/2)")
 
     local opds_servers = G_reader_settings:readSetting("opds_servers")
     if not opds_servers then
@@ -125,8 +125,8 @@ if from_version < Version:getNormalizedVersion("v2021.03") then
 end
 
 -- Statistics, https://github.com/koreader/koreader/pull/7471
-if from_version < Version:getNormalizedVersion("v2021.03-12") then
-    logger.info("Running one-time migration for v2021.03-12")
+if from_version < 20210330 then
+    logger.info("Running one-time migration for 20210330")
 
     local package_path = package.path
     package.path = string.format("%s/?.lua;%s", "plugins/statistics.koplugin", package_path)
@@ -144,8 +144,8 @@ if from_version < Version:getNormalizedVersion("v2021.03-12") then
 end
 
 -- ScreenSaver, https://github.com/koreader/koreader/pull/7496
-if from_version < Version:getNormalizedVersion("v2021.03-35") then
-    logger.info("Running one-time migration for v2021.03-35")
+if from_version < 20210404 then
+    logger.info("Running one-time migration for 20210404")
 
     -- Migrate settings from 2021.03 or older.
     if G_reader_settings:has("screensaver_background") then
@@ -155,8 +155,8 @@ if from_version < Version:getNormalizedVersion("v2021.03-35") then
 end
 
 -- Fontlist, cache migration, https://github.com/koreader/koreader/pull/7524
-if from_version < Version:getNormalizedVersion("v2021.03-43") then
-    logger.info("Running one-time migration for v2021.03-43")
+if from_version < 20210409 then
+    logger.info("Running one-time migration for 20210409")
 
     -- NOTE: Before 2021.04, fontlist used to squat our folder, needlessly polluting our state tracking.
     local cache_path = DataStorage:getDataDir() .. "/cache"
@@ -169,8 +169,8 @@ if from_version < Version:getNormalizedVersion("v2021.03-43") then
 end
 
 -- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
-if from_version < Version:getNormalizedVersion("v2021.03-47") then
-    logger.info("Running one-time migration for v2021.03-47")
+if from_version < 20210412 then
+    logger.info("Running one-time migration for 20210412")
 
     -- Ditto for Calibre
     local cache_path = DataStorage:getDataDir() .. "/cache"
@@ -187,4 +187,4 @@ if from_version < Version:getNormalizedVersion("v2021.03-47") then
 end
 
 -- We're done, store the current migration version
-G_reader_settings:saveSetting("last_migration_version", Version:getNormalizedCurrentVersion())
+G_reader_settings:saveSetting("last_migration_version", Version:getCurrentDate())

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -49,7 +49,7 @@ if from_version < Version:getNormalizedVersion("v2021.03-12") then
     logger.info("Running one-time migration for v2021.03-12")
 
     local statistics = G_reader_settings:readSetting("statistics", {})
-    count = 0
+    local count = 0
     for _, _ in pairs(statistics) do
         count = count + 1
     end
@@ -77,7 +77,7 @@ if from_version < Version:getNormalizedVersion("v2021.03-43") then
 
     -- NOTE: Before 2021.04, fontlist used to squat our folder, needlessly polluting our state tracking.
     local cache_path = DataStorage:getDataDir() .. "/cache"
-    local new_path = cache .. "/fontlist"
+    local new_path = cache_path .. "/fontlist"
     lfs.mkdir(new_path)
     os.rename(cache_path .. "/fontinfo.dat", new_path .. "/fontinfo.dat")
 end
@@ -88,7 +88,7 @@ if from_version < Version:getNormalizedVersion("v2021.03-47") then
 
     -- Ditto for Calibre
     local cache_path = DataStorage:getDataDir() .. "/cache"
-    local new_path = cache .. "/calibre"
+    local new_path = cache_path .. "/calibre"
     lfs.mkdir(new_path)
     os.rename(cache_path .. "/calibre-libraries.lua", new_path .. "/libraries.lua")
     os.rename(cache_path .. "/calibre-books.dat", new_path .. "/books.dat")

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,6 +10,11 @@ local logger = require("logger")
 -- Retrieve the last migration version
 local from_version = G_reader_settings:readSetting("last_migration_version", 0)
 
+-- If we haven't actually changed version since the last launch, we're done.
+if from_version == Version:getNormalizedCurrentVersion() then
+    return
+end
+
 -- Keep this in rough chronological order, with a reference to the PR that implemented the change.
 
 -- Global settings, https://github.com/koreader/koreader/pull/4945 & https://github.com/koreader/koreader/pull/5655

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -162,7 +162,10 @@ if from_version < Version:getNormalizedVersion("v2021.03-43") then
     local cache_path = DataStorage:getDataDir() .. "/cache"
     local new_path = cache_path .. "/fontlist"
     lfs.mkdir(new_path)
-    os.rename(cache_path .. "/fontinfo.dat", new_path .. "/fontinfo.dat")
+    local ok, err = os.rename(cache_path .. "/fontinfo.dat", new_path .. "/fontinfo.dat")
+    if not ok then
+       logger.warn("os.rename:", err)
+    end
 end
 
 -- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
@@ -173,8 +176,14 @@ if from_version < Version:getNormalizedVersion("v2021.03-47") then
     local cache_path = DataStorage:getDataDir() .. "/cache"
     local new_path = cache_path .. "/calibre"
     lfs.mkdir(new_path)
-    os.rename(cache_path .. "/calibre-libraries.lua", new_path .. "/libraries.lua")
-    os.rename(cache_path .. "/calibre-books.dat", new_path .. "/books.dat")
+    local ok, err = os.rename(cache_path .. "/calibre-libraries.lua", new_path .. "/libraries.lua")
+    if not ok then
+       logger.warn("os.rename:", err)
+    end
+    ok, err = os.rename(cache_path .. "/calibre-books.dat", new_path .. "/books.dat")
+    if not ok then
+       logger.warn("os.rename:", err)
+    end
 end
 
 -- We're done, store the current migration version

--- a/frontend/ui/data/settings_migration.lua
+++ b/frontend/ui/data/settings_migration.lua
@@ -24,7 +24,7 @@ function SettingsMigration:migrateSettings(config)
         return
     end
 
-    -- Fine-grained CRe margins (#4945)
+    -- Fine-grained CRe margins (https://github.com/koreader/koreader/pull/4945)
     if config:has("copt_page_margins") then
         local old_margins = config:readSetting("copt_page_margins")
         logger.info("Migrating old", cfg_class, "CRe margin settings: L", old_margins[1], "T", old_margins[2], "R", old_margins[3], "B", old_margins[4])
@@ -36,7 +36,7 @@ function SettingsMigration:migrateSettings(config)
         config:delSetting("copt_page_margins")
     end
 
-    -- Space condensing to Word spacing
+    -- Space condensing to Word spacing (https://github.com/koreader/koreader/pull/5655)
     -- From a single number (space condensing) to a table of 2 numbers ({space width scale, space condensing}).
     -- Be conservative and don't change space width scale: use 100%
     if config:hasNot("copt_word_spacing") and config:has("copt_space_condensing") then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -23,29 +23,6 @@ local _ = require("gettext")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
--- Migrate settings from 2021.02 or older.
-if G_reader_settings:readSetting("screensaver_type") == "message" then
-    G_reader_settings:saveSetting("screensaver_type", "disable")
-    G_reader_settings:makeTrue("screensaver_show_message")
-end
-if G_reader_settings:has("screensaver_no_background") then
-    if G_reader_settings:isTrue("screensaver_no_background") then
-        G_reader_settings:saveSetting("screensaver_background", "none")
-    end
-    G_reader_settings:delSetting("screensaver_no_background")
-end
-if G_reader_settings:has("screensaver_white_background") then
-    if G_reader_settings:isTrue("screensaver_white_background") then
-        G_reader_settings:saveSetting("screensaver_background", "white")
-    end
-    G_reader_settings:delSetting("screensaver_white_background")
-end
--- Migrate settings from 2021.03 or older.
-if G_reader_settings:has("screensaver_background") then
-    G_reader_settings:saveSetting("screensaver_img_background", G_reader_settings:readSetting("screensaver_background"))
-    G_reader_settings:delSetting("screensaver_background")
-end
-
 -- Default settings
 if G_reader_settings:hasNot("screensaver_show_message") then
     G_reader_settings:makeFalse("screensaver_show_message")

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -68,9 +68,9 @@ function Version:getShortVersion()
 end
 
 --- Returns the release date of the current version of KOReader, YYYYmmdd, in UTC.
---- Technically closer to the build date, but good enough for our purposes ;).
+--- Technically closer to the build date, but close enough where official builds are concerned ;).
 -- @treturn int date
-function Version:getCurrentDate()
+function Version:getBuildDate()
     if not self.date then
         local lfs = require("libs/libkoreader-lfs")
         local mtime = lfs.attributes("git-rev", "modification")

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -67,4 +67,22 @@ function Version:getShortVersion()
     return self.short
 end
 
+--- Returns the release date of the current version of KOReader, YYYYmmdd, in UTC.
+--- Technically closer to the build date, but good enough for our purposes ;).
+-- @treturn int date
+function Version:getCurrentDate()
+    if not self.date then
+        local lfs = require("libs/libkoreader-lfs")
+        local mtime = lfs.attributes("git-rev", "modification")
+        if mtime then
+            local ts = os.date("!%Y%m%d", mtime)
+            self.date = tonumber(ts) or 0
+        else
+            -- No git-rev file?
+            self.date = 0
+        end
+    end
+    return self.date
+end
+
 return Version

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -80,13 +80,6 @@ local OPDSBrowser = Menu:extend{
 }
 
 function OPDSBrowser:init()
-    -- Update deprecated URLs
-    for _, server in ipairs(self.opds_servers) do
-        if server.url == "http://bookserver.archive.org/catalog/" then
-            server.url = "https://bookserver.archive.org"
-        end
-    end
-
     self.item_table = self:genItemTableFromRoot()
     self.catalog_title = nil
     Menu.init(self) -- call parent's init()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -143,12 +143,6 @@ function ReaderStatistics:init()
         calendar_browse_future_months = false,
     }
     self.settings = G_reader_settings:readSetting("statistics", default_settings)
-    -- Handle a snafu in 2021.03 that could lead to an empty settings table on fresh installs.
-    for k, v in pairs(default_settings) do
-        if self.settings[k] == nil then
-            self.settings[k] = v
-        end
-    end
 
     self.ui.menu:registerToMainMenu(self)
     self:checkInitDatabase()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -125,6 +125,17 @@ function ReaderStatistics:isDocless()
     return self.ui == nil or self.ui.document == nil
 end
 
+ReaderStatistics.default_settings = {
+    min_sec = DEFAULT_MIN_READ_SEC,
+    max_sec = DEFAULT_MAX_READ_SEC,
+    is_enabled = true,
+    convert_to_db = nil,
+    calendar_start_day_of_week = DEFAULT_CALENDAR_START_DAY_OF_WEEK,
+    calendar_nb_book_spans = DEFAULT_CALENDAR_NB_BOOK_SPANS,
+    calendar_show_histogram = true,
+    calendar_browse_future_months = false,
+}
+
 function ReaderStatistics:init()
     if not self:isDocless() and self.ui.document.is_pic then
         return
@@ -132,17 +143,7 @@ function ReaderStatistics:init()
     self.start_current_period = os.time()
     self:resetVolatileStats()
 
-    local default_settings = {
-        min_sec = DEFAULT_MIN_READ_SEC,
-        max_sec = DEFAULT_MAX_READ_SEC,
-        is_enabled = true,
-        convert_to_db = nil,
-        calendar_start_day_of_week = DEFAULT_CALENDAR_START_DAY_OF_WEEK,
-        calendar_nb_book_spans = DEFAULT_CALENDAR_NB_BOOK_SPANS,
-        calendar_show_histogram = true,
-        calendar_browse_future_months = false,
-    }
-    self.settings = G_reader_settings:readSetting("statistics", default_settings)
+    self.settings = G_reader_settings:readSetting("statistics", self.default_settings)
 
     self.ui.menu:registerToMainMenu(self)
     self:checkInitDatabase()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -125,6 +125,8 @@ function ReaderStatistics:isDocless()
     return self.ui == nil or self.ui.document == nil
 end
 
+-- NOTE: This is used in a migration script by ui/data/onetime_migration,
+--       which is why it's public.
 ReaderStatistics.default_settings = {
     min_sec = DEFAULT_MIN_READ_SEC,
     max_sec = DEFAULT_MAX_READ_SEC,

--- a/reader.lua
+++ b/reader.lua
@@ -172,12 +172,12 @@ if Device:hasEinkScreen() then
     end
 end
 
--- Handle one time migration stuff (settings, deprecation, ...) in case of an upgrade...
-require("ui/data/onetime_migration")
-
 -- Document renderers canvas
 local CanvasContext = require("document/canvascontext")
 CanvasContext:init(Device)
+
+-- Handle one time migration stuff (settings, deprecation, ...) in case of an upgrade...
+require("ui/data/onetime_migration")
 
 -- Touch screen (this may display some widget, on first install on Kobo Touch,
 -- so have it done after CanvasContext:init() but before Bidi.setup() to not

--- a/reader.lua
+++ b/reader.lua
@@ -172,12 +172,8 @@ if Device:hasEinkScreen() then
     end
 end
 
--- Handle one time migration in case of an upgrade...
+-- Handle one time migration stuff (settings, deprecation, ...) in case of an upgrade...
 require("ui/data/onetime_migration")
-
--- Handle global settings migration
-local SettingsMigration = require("ui/data/settings_migration")
-SettingsMigration:migrateSettings(G_reader_settings)
 
 -- Document renderers canvas
 local CanvasContext = require("document/canvascontext")

--- a/reader.lua
+++ b/reader.lua
@@ -172,6 +172,9 @@ if Device:hasEinkScreen() then
     end
 end
 
+-- Handle one time migration in case of an upgrade...
+require("ui/data/onetime_migration")
+
 -- Handle global settings migration
 local SettingsMigration = require("ui/data/settings_migration")
 SettingsMigration:migrateSettings(G_reader_settings)


### PR DESCRIPTION
There have been a couple of these this month, and keeping stuff that should only ever run once piling up in their respective module was getting ugly, especially when it's usually simple stuff (settings, files).

So, move everything to a dedicated module, run by reader.lua on startup, and that will actually only do things once, when necessary.

~~(Draft because on top of #7528; starts after 7305f8f)~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7531)
<!-- Reviewable:end -->
