### PR TITLE
add hasSystemFonts device property

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -89,6 +89,7 @@ local Device = Generic:new{
     hasClipboard = yes,
     hasOTAUpdates = canUpdateApk,
     hasFastWifiStatusQuery = yes,
+    hasSystemFonts = yes,
     canOpenLink = yes,
     openLink = function(self, link)
         if not link or type(link) ~= "string" then return end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -106,6 +106,9 @@ local Device = {
     -- (c.f., https://github.com/koreader/koreader/pull/5211#issuecomment-521304139)
     hasFastWifiStatusQuery = no,
 
+    -- set to yes on devices with system fonts
+    hasSystemFonts = no,
+
     canOpenLink = no,
     openLink = no,
     canExternalDictLookup = no,

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -28,6 +28,7 @@ local PocketBook = Generic:new{
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
+    hasSystemFonts = yes,
     canSuspend = no,
     canReboot = yes,
     canPowerOff = yes,

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -39,6 +39,7 @@ local Remarkable = Generic:new{
     canPowerOff = yes,
     isTouchDevice = yes,
     hasFrontlight = no,
+    hasSystemFonts = yes,
     display_dpi = 226,
     -- Despite the SoC supporting it, it's finicky in practice (#6772)
     canHWInvert = no,

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -64,6 +64,7 @@ local Device = Generic:new{
     needsScreenRefreshAfterResume = no,
     hasColorScreen = yes,
     hasEinkScreen = no,
+    hasSystemFonts = yes,
     canSuspend = no,
     startTextInput = SDL.startTextInput,
     stopTextInput = SDL.stopTextInput,

--- a/frontend/document/canvascontext.lua
+++ b/frontend/document/canvascontext.lua
@@ -42,6 +42,7 @@ function CanvasContext:init(device)
     self.isKindle = device.isKindle
     self.isPocketBook = device.isPocketBook
     self.should_restrict_JIT = device.should_restrict_JIT
+    self.hasSystemFonts = device.hasSystemFonts
     self:setColorRenderingEnabled(device.screen.isColorEnabled())
 
     -- NOTE: Kobo's fb is BGR, not RGB. Handle the conversion in MuPDF if needed.

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -94,11 +94,7 @@ local function isInFontsBlacklist(f)
 end
 
 local function getExternalFontDir()
-    if CanvasContext.isAndroid() or
-        CanvasContext.isDesktop() or
-        CanvasContext.isEmulator() or
-        CanvasContext.isPocketBook()
-    then
+    if CanvasContext.hasSystemFonts() then
         return require("frontend/ui/elements/font_settings"):getPath()
     else
         return os.getenv("EXT_FONT_DIR")

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -3,7 +3,10 @@ local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
 
---[[ Font settings for desktop linux, mac and android ]]--
+--[[ Font settings for systems with multiple font dirs ]]--
+
+local LINUX_FONT_PATH = "share/fonts"
+local MACOS_FONT_PATH = "Library/fonts"
 
 local function getDir(isUser)
     local home = Device.home_dir
@@ -20,11 +23,16 @@ local function getDir(isUser)
         else
             return "/ebrmain/adobefonts;/ebrmain/fonts"
         end
+    elseif Device:isRemarkable() then
+        return isUser and string.format("%s/.local/%s", home, LINUX_FONT_PATH)
+            or string.format("/usr/%s", LINUX_FONT_PATH)
     elseif Device:isDesktop() or Device:isEmulator() then
         if jit.os == "OSX" then
-            return isUser and home .. "/Library/fonts" or "/Library/fonts"
+            return isUser and string.format("%s/%s", home, MACOS_FONT_PATH)
+                or string.format("/%s", MACOS_FONT_PATH)
         else
-            return isUser and home .. "/.local/share/fonts" or "/usr/share/fonts"
+            return isUser and string.format("%s/.local/%s", home, LINUX_FONT_PATH)
+                or string.format("/usr/%s", LINUX_FONT_PATH)
         end
     end
 end

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -75,9 +75,6 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# export external font directory
-export EXT_FONT_DIR="/usr/share/fonts/ttf;/usr/share/fonts/opentype"
-
 # We'll want to ensure Portrait rotation to allow us to use faster blitting codepaths @ 8bpp,
 # so remember the current one before fbdepth does its thing.
 ORIG_FB_ROTA="$(./fbdepth -o)"


### PR DESCRIPTION
Add system + user paths to the ReMarkable (it has "normal" linux paths)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7535)
<!-- Reviewable:end -->
