### PR TITLE
Fix for PR #7415 breaking reMarkable touch input

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -79,6 +79,7 @@ local Remarkable2 = Remarkable:new{
 }
 
 function Remarkable2:adjustTouchEvent(ev, by)
+    ev.time = nil -- stylus input and touchscreen input have conflicting event clocks, so just toss them all out
     if ev.type == EV_ABS then
         -- Mirror Y and scale up both X & Y as touch input is different res from
         -- display


### PR DESCRIPTION
Note from @NiLuJe 's PR https://github.com/koreader/koreader/pull/7415#issuecomment-807855785
"reMarkable: Stopped enforcing synthetic timestamps on input events, as it should no longer be necessary."

It's definitely still necessary, at least on rm2
The basic problem is that *stylus* input is synced with the realtime clock, but *touch* input is not.

After KOReader starts, if the very first input is from the stylus, then the log says
```
GestureDetector:probeClockSource: Touch event timestamps appear to use CLOCK_REALTIME
```

But if the very first input is from my finger, then the log says
```
GestureDetector:probeClockSource: Touch event clock source detection was inconclusive
```

So if the stylus is the very first input, then all subsequent finger inputs are always misinterpreted as long holds.
But if my finger is the very first input, then everything works fine (since KOReader has decided the device's event timestamps cannot be used)

Since the two input types are inconsistent, I think the simplest solution is to always ignore the time data provided by the device. The existing Gesture/Input code knows how to handle devices with invalid input timestamps.

I do not know if this same input vs. touch inconsistency exists on the reMarkable 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7536)
<!-- Reviewable:end -->
