### PR TITLE
Input: Minor cleanups

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -396,7 +396,8 @@ function GestureDetector:probeClockSource(timev)
 
     -- Finally, BOOTTIME
     local boottime = TimeVal:boottime()
-    if timev >= boottime - threshold and timev <= boottime + threshold then
+    -- NOTE: It was implemented in Linux 2.6.39, so, reject 0, which would mean it's unsupported...
+    if not boottime:isZero() and timev >= boottime - threshold and timev <= boottime + threshold then
         self.clock_id = C.CLOCK_BOOTTIME
         logger.info("GestureDetector:probeClockSource: Touch event timestamps appear to use CLOCK_BOOTTIME")
         return

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -405,6 +405,11 @@ function GestureDetector:probeClockSource(timev)
     -- If we're here, the detection was inconclusive :/
     self.clock_id = -1
     logger.info("GestureDetector:probeClockSource: Touch event clock source detection was inconclusive")
+    -- Print all all the gory details in debug mode when this happens...
+    logger.dbg("Input frame    :", timev:tonumber())
+    logger.dbg("CLOCK_REALTIME :", realtime:tonumber())
+    logger.dbg("CLOCK_MONOTONIC:", monotonic:tonumber())
+    logger.dbg("CLOCK_BOOTTIME :", boottime:tonumber())
 end
 
 function GestureDetector:getClockSource()

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -94,6 +94,7 @@ local linux_evdev_abs_code_map = {
     [C.ABS_X] = "ABS_X",
     [C.ABS_Y] = "ABS_Y",
     [C.ABS_PRESSURE] = "ABS_PRESSURE",
+    [C.ABS_DISTANCE] = "ABS_DISTANCE",
     [C.ABS_MT_SLOT] = "ABS_MT_SLOT",
     [C.ABS_MT_TOUCH_MAJOR] = "ABS_MT_TOUCH_MAJOR",
     [C.ABS_MT_TOUCH_MINOR] = "ABS_MT_TOUCH_MINOR",

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -2,8 +2,13 @@ local Generic = require("device/generic/device")
 local Geom = require("ui/geometry")
 local WakeupMgr = require("device/wakeupmgr")
 local logger = require("logger")
+local ffi = require("ffi")
 local util = require("ffi/util")
 local _ = require("gettext")
+
+local C = ffi.C
+require("ffi/posix_h")
+require("ffi/linux_input_h")
 
 local function yes() return true end
 local function no() return false end
@@ -95,7 +100,7 @@ local KoboDahlia = Kobo:new{
     hasFrontlight = yes,
     touch_phoenix_protocol = true,
     -- There's no slot 0, the first finger gets assigned slot 1, and the second slot 2.
-    -- NOTE: Could be queried at runtime via EVIOCGABS on ABS_MT_TRACKING_ID (minimum field).
+    -- NOTE: Could be queried at runtime via EVIOCGABS on C.ABS_MT_TRACKING_ID (minimum field).
     main_finger_slot = 1,
     display_dpi = 265,
     -- the bezel covers the top 11 pixels:
@@ -460,10 +465,8 @@ end
 
 function Kobo:supportsScreensaver() return true end
 
-local ABS_MT_TRACKING_ID = 57
-local EV_ABS = 3
 local adjustTouchAlyssum = function(self, ev)
-    if ev.type == EV_ABS and ev.code == ABS_MT_TRACKING_ID then
+    if ev.type == C.EV_ABS and ev.code == C.ABS_MT_TRACKING_ID then
         ev.value = ev.value - 1
     end
 end

--- a/frontend/ui/timeval.lua
+++ b/frontend/ui/timeval.lua
@@ -14,6 +14,7 @@ A simple module to module to compare and do arithmetic with time values.
 
 local ffi = require("ffi")
 require("ffi/posix_h")
+local logger = require("logger")
 local util = require("ffi/util")
 
 local C = ffi.C
@@ -35,11 +36,13 @@ if ffi.os == "Linux" then
             PREFERRED_MONOTONIC_CLOCKID = C.CLOCK_MONOTONIC_COARSE
         end
     end
+    logger.dbg("TimeVal: Preferred MONOTONIC clock source is", PREFERRED_MONOTONIC_CLOCKID == C.CLOCK_MONOTONIC_COARSE and "CLOCK_MONOTONIC_COARSE" or "CLOCK_MONOTONIC")
     if C.clock_getres(C.CLOCK_REALTIME_COARSE, probe_ts) == 0 then
         if probe_ts.tv_sec == 0 and probe_ts.tv_nsec <= 1000000 then
             PREFERRED_REALTIME_CLOCKID = C.CLOCK_REALTIME_COARSE
         end
     end
+    logger.dbg("TimeVal: Preferred REALTIME clock source is", PREFERRED_REALTIME_CLOCKID == C.CLOCK_REALTIME_COARSE and "CLOCK_REALTIME_COARSE" or "CLOCK_REALTIME")
     probe_ts = nil --luacheck: ignore
 end
 

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -3,6 +3,7 @@ describe("device module", function()
     local mock_fb, mock_input
     local iopen = io.open
     local osgetenv = os.getenv
+    local ffi, C
 
     setup(function()
         mock_fb = {
@@ -20,6 +21,9 @@ describe("device module", function()
         }
         require("commonrequire")
         package.unloadAll()
+        ffi = require("ffi")
+        C = ffi.C
+        require("ffi/linux_input_h")
         require("document/canvascontext"):init(require("device"))
     end)
 
@@ -86,19 +90,16 @@ describe("device module", function()
             G_reader_settings:saveSetting("kobo_touch_switch_xy", true)
             kobo_dev:touchScreenProbe()
             local x, y = Screen:getWidth()-5, 10
-            local EV_ABS = 3
-            local ABS_X = 00
-            local ABS_Y = 01
             -- mirror x, then switch_xy
             local ev_x = {
-                type = EV_ABS,
-                code = ABS_X,
+                type = C.EV_ABS,
+                code = C.ABS_X,
                 value = y,
                 time = TimeVal:realtime(),
             }
             local ev_y = {
-                type = EV_ABS,
-                code = ABS_Y,
+                type = C.EV_ABS,
+                code = C.ABS_Y,
                 value = Screen:getWidth()-x,
                 time = TimeVal:realtime(),
             }
@@ -106,9 +107,9 @@ describe("device module", function()
             kobo_dev.input:eventAdjustHook(ev_x)
             kobo_dev.input:eventAdjustHook(ev_y)
             assert.is.same(x, ev_y.value)
-            assert.is.same(ABS_X, ev_y.code)
+            assert.is.same(C.ABS_X, ev_y.code)
             assert.is.same(y, ev_x.value)
-            assert.is.same(ABS_Y, ev_x.code)
+            assert.is.same(C.ABS_Y, ev_x.code)
 
             -- reset eventAdjustHook
             kobo_dev.input.eventAdjustHook = function() end
@@ -137,18 +138,15 @@ describe("device module", function()
             assert.truthy(kobo_dev:needsTouchScreenProbe())
             kobo_dev:touchScreenProbe()
             local x, y = Screen:getWidth()-5, 10
-            local EV_ABS = 3
-            local ABS_X = 00
-            local ABS_Y = 01
             local ev_x = {
-                type = EV_ABS,
-                code = ABS_X,
+                type = C.EV_ABS,
+                code = C.ABS_X,
                 value = y,
                 time = {sec = 1000}
             }
             local ev_y = {
-                type = EV_ABS,
-                code = ABS_Y,
+                type = C.EV_ABS,
+                code = C.ABS_Y,
                 value = Screen:getWidth()-x,
                 time = {sec = 1000}
             }
@@ -156,9 +154,9 @@ describe("device module", function()
             kobo_dev.input:eventAdjustHook(ev_x)
             kobo_dev.input:eventAdjustHook(ev_y)
             assert.is.same(x, ev_y.value)
-            assert.is.same(ABS_X, ev_y.code)
+            assert.is.same(C.ABS_X, ev_y.code)
             assert.is.same(y, ev_x.value)
-            assert.is.same(ABS_Y, ev_x.code)
+            assert.is.same(C.ABS_Y, ev_x.code)
 
             -- reset eventAdjustHook
             kobo_dev.input.eventAdjustHook = function() end
@@ -275,12 +273,12 @@ describe("device module", function()
             stub(mock_ffi_input, "waitForEvent")
             mock_ffi_input.waitForEvent.returns(true, {
                 {
-                    type = 3,
+                    type = C.EV_ABS,
                     time = {
                         usec = 450565,
                         sec = 1471081881
                     },
-                    code = 24,
+                    code = 24, -- C.ABS_PRESSURE -> ABS_OASIS_ORIENTATION
                     value = 16
                 }
             })

--- a/spec/unit/input_spec.lua
+++ b/spec/unit/input_spec.lua
@@ -1,7 +1,11 @@
 describe("input module", function()
     local Input
+    local ffi, C
     setup(function()
         require("commonrequire")
+        ffi = require("ffi")
+        C = ffi.C
+        require("ffi/linux_input_h")
         Input = require("device/input")
     end)
 
@@ -40,36 +44,36 @@ Event: time 1510346969.076908, -------------- SYN_REPORT ------------
         it("should set cur_slot correctly", function()
             local ev
             ev = {
-                type = 3,
-                code = 57,
+                type = C.EV_ABS,
+                code = C.ABS_MT_TRACKING_ID,
                 value = 1,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(1, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 48,
+                type = C.EV_ABS,
+                code = C.ABS_MT_TOUCH_MAJOR,
                 value = 1,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(1, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 50,
+                type = C.EV_ABS,
+                code = C.ABS_MT_WIDTH_MAJOR,
                 value = 1,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(1, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 53,
+                type = C.EV_ABS,
+                code = C.ABS_MT_POSITION_X,
                 value = 1012,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(1, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 54,
+                type = C.EV_ABS,
+                code = C.ABS_MT_POSITION_Y,
                 value = 914,
             }
             Input:handleTouchEvPhoenix(ev)
@@ -79,8 +83,8 @@ Event: time 1510346969.076908, -------------- SYN_REPORT ------------
             -- depends on gesture_detector
             --[[
             ev = {
-                type = 0,
-                code = 0,
+                type = C.EV_SYN,
+                code = C.SYN_REPORT,
                 value = 0,
             }
             Input:handleTouchEvPhoenix(ev)
@@ -89,36 +93,36 @@ Event: time 1510346969.076908, -------------- SYN_REPORT ------------
 
             -- this value=2 stuff doesn't happen IRL, just testing logic
             ev = {
-                type = 3,
-                code = 57,
+                type = C.EV_ABS,
+                code = C.ABS_MT_TRACKING_ID,
                 value = 2,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(2, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 48,
+                type = C.EV_ABS,
+                code = C.ABS_MT_TOUCH_MAJOR,
                 value = 2,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(2, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 50,
+                type = C.EV_ABS,
+                code = C.ABS_MT_WIDTH_MAJOR,
                 value = 2,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(2, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 53,
+                type = C.EV_ABS,
+                code = C.ABS_MT_POSITION_X,
                 value = 1012,
             }
             Input:handleTouchEvPhoenix(ev)
             assert.is_equal(2, Input.cur_slot)
             ev = {
-                type = 3,
-                code = 54,
+                type = C.EV_ABS,
+                code = C.ABS_MT_POSITION_Y,
                 value = 914,
             }
             Input:handleTouchEvPhoenix(ev)


### PR DESCRIPTION
* TimeVal: Log the results of the COARSE probes in debug logs
* GestureDetector: Print details of failed clock probes in debug logs
* GestureDetector: Skip the BOOTTIME probe when CLOCK_BOOTTIME is unsupported.
* Input: Decode ABS_DISTANCE events in debug logs
* Get rid of duplicated <linux/input.h> constants, use the FFI module everywhere (re #7536)
* Kobo: Get rid of the `touch_alyssum_protocol` quirk. Replace it by setting `main_finger_slot` to `1`, like on the H2O.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7542)
<!-- Reviewable:end -->
