### PR TITLE
Persist: Add the new native LuaJIT serializer to the list of supported codecs

### DIFF
--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -40,7 +40,7 @@ local codecs = {
             return t
         end,
     },
-    -- luajit: binary form, optimized for speed, not size (combine w/ zstd if necessary).  Not human readable.
+    -- luajit: binary form, optimized for speed, not size (combine w/ zstd if necessary). Not human readable.
     --         Slightly larger data format than bitser, *much* faster to decode, slightly faster to encode.
     luajit = {
         id = "luajit",

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -1,4 +1,5 @@
 local bitser = require("ffi/bitser")
+local buffer = require("string.buffer")
 local dump = require("dump")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
@@ -26,7 +27,7 @@ local codecs = {
         serialize = function(t)
             local ok, str = pcall(bitser.dumps, t)
             if not ok then
-                return nil, "cannot serialize " .. tostring(t)
+                return nil, "cannot serialize " .. tostring(t) .. " (" .. str .. ")"
             end
             return str
         end,
@@ -34,7 +35,29 @@ local codecs = {
         deserialize = function(str)
             local ok, t = pcall(bitser.loads, str)
             if not ok then
-                return nil, "malformed serialized data"
+                return nil, "malformed serialized data: " .. t
+            end
+            return t
+        end,
+    },
+    -- luajit: binary form, optimized for speed, not size (combine w/ zstd if necessary).  Not human readable.
+    --         Slightly larger data format than bitser, *much* faster to decode, slightly faster to encode.
+    luajit = {
+        id = "luajit",
+        reads_from_file = false,
+
+        serialize = function(t)
+            local ok, str = pcall(buffer.encode, t)
+            if not ok then
+                return nil, "cannot serialize " .. tostring(t) .. " (" .. str .. ")"
+            end
+            return str
+        end,
+
+        deserialize = function(str)
+            local ok, t = pcall(buffer.decode, str)
+            if not ok then
+                return nil, "malformed serialized data (" .. t .. ")"
             end
             return t
         end,

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -19,7 +19,7 @@ local function readFile(file, bytes)
 end
 
 local codecs = {
-    -- bitser: binary form, fast encode/decode, low size. Not human readable.
+    -- bitser: binary format, fast encode/decode, low size. Not human readable.
     bitser = {
         id = "bitser",
         reads_from_file = false,
@@ -40,8 +40,8 @@ local codecs = {
             return t
         end,
     },
-    -- luajit: binary form, optimized for speed, not size (combine w/ zstd if necessary). Not human readable.
-    --         Slightly larger data format than bitser, *much* faster to decode, slightly faster to encode.
+    -- luajit: binary format, optimized for speed, not size (combine w/ zstd if necessary). Not human readable.
+    --         Slightly larger on-disk representation than bitser, *much* faster to decode, slightly faster to encode.
     luajit = {
         id = "luajit",
         reads_from_file = false,

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210413
+local CURRENT_MIGRATION_DATE = 20210414
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -196,6 +196,17 @@ if last_migration_date < 20210412 then
     -- Make sure Cache gets the memo
     local Cache = require("cache")
     Cache:refreshSnapshot()
+end
+
+-- Calibre, cache encoding format change, https://github.com/koreader/koreader/pull/7543
+if last_migration_date < 20210414 then
+    logger.info("Performing one-time migration for 20210414")
+
+    local cache_path = DataStorage:getDataDir() .. "/cache/calibre"
+    ok, err = os.remove(cache_path .. "/books.dat")
+    if not ok then
+       logger.warn("os.remove:", err)
+    end
 end
 
 -- We're done, store the current migration date

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -590,6 +590,7 @@ function CalibreSearch:getMetadata()
         local cache, err = self.cache_books:load()
         if not cache then
             logger.warn("invalid cache:", err)
+            self:invalidateCache()
         else
             local is_newer = true
             for path, enabled in pairs(self.libraries) do

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -176,7 +176,7 @@ local CalibreSearch = InputContainer:new{
     },
     cache_books = Persist:new{
         path = DataStorage:getDataDir() .. "/cache/calibre/books.dat",
-        codec = "bitser",
+        codec = "luajit",
     },
 }
 


### PR DESCRIPTION
And swap the Calibre metadata cache to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7543)
<!-- Reviewable:end -->
