### PR TITLE
Calibre: More QoL tweaks

### DIFF
--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -103,6 +103,9 @@ local codecs = {
                 return nil, "fopen: " .. ffi.string(C.strerror(ffi.errno()))
             end
             local size = lfs.attributes(path, "size")
+            -- NOTE: In a perfect world, we'd just mmap the file.
+            --       But that's problematic on a portability level: while mmap is POSIX, implementations differ,
+            --       and some old platforms don't support mmap-on-vfat (Legacy Kindle) :'(.
             local data = C.malloc(size)
             if data == nil then
                 C.fclose(f)

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -100,8 +100,8 @@ local codecs = {
             if f == nil then
                 return nil, "fopen: " .. ffi.string(C.strerror(ffi.errno()))
             end
-            local size = lfs.attribute(path, "size")
-            local data = C.malloc(size, 1)
+            local size = lfs.attributes(path, "size")
+            local data = C.malloc(size)
             if data == nil then
                 C.fclose(f)
                 return nil, "failed to allocate read buffer"

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -68,7 +68,7 @@ local codecs = {
             return t
         end,
     },
-    -- zstd: luajit, but compressed w/ zstd ;).
+    -- zstd: luajit, but compressed w/ zstd ;). Much smaller, at a very small performance cost (decompressing is *fast*).
     zstd = {
         id = "zstd",
         reads_from_file = true,
@@ -127,7 +127,7 @@ local codecs = {
             return t
         end,
     },
-    -- dump: human readable, pretty printed, fast enough for most user cases.
+    -- dump: human readable, pretty printed, fast enough for most use cases.
     dump = {
         id = "dump",
         reads_from_file = true,

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -208,17 +208,17 @@ function Persist:load()
 end
 
 function Persist:save(t, as_bytecode)
-    local str, file, err
     if codecs[self.codec].writes_to_file then
-        str, err = codecs[self.codec].serialize(t, as_bytecode, self.path)
-        if not str then
+        local ok, err = codecs[self.codec].serialize(t, as_bytecode, self.path)
+        if not ok then
             return nil, err
         end
     else
-        str, err = codecs[self.codec].serialize(t, as_bytecode)
+        local str, err = codecs[self.codec].serialize(t, as_bytecode)
         if not str then
             return nil, err
         end
+        local file
         file, err = io.open(self.path, "wb")
         if not file then
             return nil, err

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -82,7 +82,7 @@ local codecs = {
 
             local cbuff, clen = zstd.zstd_compress(str, #str)
 
-            local f = C.fopen(path, "w+b")
+            local f = C.fopen(path, "wb")
             if f == nil then
                 return nil, "fopen: " .. ffi.string(C.strerror(ffi.errno()))
             end

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -91,6 +91,7 @@ local codecs = {
                 return nil, "failed to write file"
             end
             C.fclose(f)
+            C.free(cbuff)
 
             return true
         end,
@@ -117,6 +118,8 @@ local codecs = {
             C.free(data)
 
             local str = ffi.string(buff, ulen)
+            C.free(buff)
+
             local ok, t = pcall(buffer.decode, str)
             if not ok then
                 return nil, "malformed serialized data (" .. t .. ")"

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -88,6 +88,7 @@ local codecs = {
             end
             if C.fwrite(cbuff, 1, clen, f) < clen then
                 C.fclose(f)
+                C.free(cbuff)
                 return nil, "failed to write file"
             end
             C.fclose(f)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -203,7 +203,7 @@ if last_migration_date < 20210414 then
     logger.info("Performing one-time migration for 20210414")
 
     local cache_path = DataStorage:getDataDir() .. "/cache/calibre"
-    ok, err = os.remove(cache_path .. "/books.dat")
+    local ok, err = os.remove(cache_path .. "/books.dat")
     if not ok then
        logger.warn("os.remove:", err)
     end

--- a/frontend/ui/message/streammessagequeue.lua
+++ b/frontend/ui/message/streammessagequeue.lua
@@ -56,7 +56,6 @@ function StreamMessageQueue:handleZframe(frame)
 end
 
 function StreamMessageQueue:waitEvent()
-    local data = ""
     -- Successive zframes may come in batches of tens or hundreds in some cases.
     -- Since we buffer each frame's data in a Lua string,
     -- and then let the caller concatenate those,

--- a/frontend/ui/message/streammessagequeue.lua
+++ b/frontend/ui/message/streammessagequeue.lua
@@ -60,9 +60,9 @@ function StreamMessageQueue:waitEvent()
     -- Successive zframes may come in batches of tens or hundreds in some cases.
     -- If they are concatenated in a single loop, it may consume a significant amount
     -- of memory. And it's fairly easy to trigger when receiving file data from Calibre.
-    -- So, throttle reception to 24 packages at most in one waitEvent loop,
+    -- So, throttle reception to 256 packages at most in one waitEvent loop,
     -- after which we immediately call receiveCallback.
-    local wait_packages = 24
+    local wait_packages = 256
     -- In a similar spirit, much like LuaSocket,
     -- we store the data as ropes of strings in an array,
     -- to be concatenated by the caller.

--- a/frontend/ui/message/streammessagequeue.lua
+++ b/frontend/ui/message/streammessagequeue.lua
@@ -58,8 +58,10 @@ end
 function StreamMessageQueue:waitEvent()
     local data = ""
     -- Successive zframes may come in batches of tens or hundreds in some cases.
-    -- If they are concatenated in a single loop, it may consume a significant amount
-    -- of memory. And it's fairly easy to trigger when receiving file data from Calibre.
+    -- Since we buffer each frame's data in a Lua string,
+    -- and then let the caller concatenate those,
+    -- it may consume a significant amount of memory.
+    -- And it's fairly easy to trigger when receiving file data from Calibre.
     -- So, throttle reception to 256 packages at most in one waitEvent loop,
     -- after which we immediately call receiveCallback.
     local wait_packages = 256

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -176,7 +176,7 @@ local CalibreSearch = InputContainer:new{
     },
     cache_books = Persist:new{
         path = DataStorage:getDataDir() .. "/cache/calibre/books.dat",
-        codec = "luajit",
+        codec = "zstd",
     },
 }
 

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -132,7 +132,8 @@ function CalibreWireless:JSONReceiveCallback(host, port)
     -- NOTE: Closure trickery because we need a reference to *this* self *inside* the callback,
     --       which will be called as a function from another object (namely, StreamMessageQueue).
     local this = self
-    return function(data)
+    return function(t)
+        local data = table.concat(t)
         this:onReceiveJSON(data)
         if not this.connect_message then
             this.password_check_callback = function()
@@ -546,9 +547,10 @@ function CalibreWireless:sendBook(arg)
         end
     end
     -- switching to raw data receiving mode
-    self.calibre_socket.receiveCallback = function(data)
-        --logger.info("receive file data", #data)
-        --logger.info("Memory usage KB:", collectgarbage("count"))
+    self.calibre_socket.receiveCallback = function(t)
+        local data = table.concat(t)
+        logger.info("receive file data", #data)
+        logger.info("Memory usage KB:", collectgarbage("count"))
         local to_write_data = data:sub(1, to_write_bytes)
         if fits then
             outfile:write(to_write_data)

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -549,8 +549,8 @@ function CalibreWireless:sendBook(arg)
     -- switching to raw data receiving mode
     self.calibre_socket.receiveCallback = function(t)
         local data = table.concat(t)
-        logger.info("receive file data", #data)
-        logger.info("Memory usage KB:", collectgarbage("count"))
+        --logger.info("receive file data", #data)
+        --logger.info("Memory usage KB:", collectgarbage("count"))
         local to_write_data = data:sub(1, to_write_bytes)
         if fits then
             outfile:write(to_write_data)


### PR DESCRIPTION
* Wireless: Optimize memory usage in StreamMessageQueue (use an array of string ropes, that we only concatenate once). Allowed to relax the throttling, making transfers that much faster.
* Persist: Add a "zstd" codec, that uses the "luajit" codec, but compressed via zstd. Since both of those are very fast, it pretty much trounces everything in terms of speed and size ;).
* Persist: Implemented a "writes_to_file" framework, much like the existing "reads_from_file" one. And use it in the zstd codec to avoid useless temporary string interning.
* Metadata: Switch to the zstd codec.

Requires https://github.com/koreader/koreader-base/pull/1355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7545)
<!-- Reviewable:end -->
