### PR TITLE
Button setIcon: keep button width

### DIFF
--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -161,10 +161,10 @@ function Button:setText(text, width)
     end
 end
 
-function Button:setIcon(icon)
+function Button:setIcon(icon, width)
     if icon ~= self.icon then
         self.icon = icon
-        self.width = nil
+        self.width = width
         self:init()
     end
 end


### PR DESCRIPTION
Allow to keep the icon centered after `setIcon`.
`setIcon` isn't used anywhere at the moment (going to be).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7546)
<!-- Reviewable:end -->
