### PR TITLE
ToC: option to show/hide entries separator

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1054,7 +1054,7 @@ Enabling this option will restrict display to the chapter titles of progress bar
         end,
     }
     menu_items.toc_items_show_separator = {
-        text = _("Show ToC entries separator"),
+        text = _("Add a separator between ToC entries"),
         keep_menu_open = true,
         checked_func = function()
             return G_reader_settings:isTrue("toc_items_show_separator")

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1,4 +1,5 @@
 local BD = require("ui/bidi")
+local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
@@ -641,6 +642,7 @@ function ReaderToc:onShowToc()
 
     local items_per_page = G_reader_settings:readSetting("toc_items_per_page") or self.toc_items_per_page_default
     local items_font_size = G_reader_settings:readSetting("toc_items_font_size") or Menu.getItemFontSize(items_per_page)
+    local items_show_separator = G_reader_settings:isTrue("toc_items_show_separator")
     -- Estimate expand/collapse icon size
     -- *2/5 to acount for Menu top title and bottom icons, and add some air between consecutive icons
     local icon_size = math.floor(Screen:getHeight() / items_per_page * 2/5)
@@ -698,7 +700,7 @@ function ReaderToc:onShowToc()
         align_baselines = true,
         items_per_page = items_per_page,
         items_font_size = items_font_size,
-        line_color = require("ffi/blitbuffer").COLOR_WHITE,
+        line_color = items_show_separator and Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_WHITE,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",
@@ -1050,6 +1052,16 @@ Enabling this option will restrict display to the chapter titles of progress bar
             }
             UIManager:show(items_font)
         end,
+    }
+    menu_items.toc_items_show_separator = {
+        text = _("Show ToC entries separator"),
+        keep_menu_open = true,
+        checked_func = function()
+            return G_reader_settings:isTrue("toc_items_show_separator")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("toc_items_show_separator")
+        end
     }
 end
 

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -33,6 +33,7 @@ local order = {
         "----------------------------",
         "toc_items_per_page",
         "toc_items_font_size",
+        "toc_items_show_separator",
         "----------------------------",
         "bookmarks_items_per_page",
         "bookmarks_items_font_size",


### PR DESCRIPTION
Sometimes ToC entries are too short and it is hard to trace page numbers.

![1](https://user-images.githubusercontent.com/62179190/114855352-8db29380-9dee-11eb-8997-bea4dffc7c92.png)
---
![2](https://user-images.githubusercontent.com/62179190/114855376-930fde00-9dee-11eb-935d-59367b8bd3b7.png)
---
![3](https://user-images.githubusercontent.com/62179190/114855397-96a36500-9dee-11eb-84f7-298e21df1a50.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7551)
<!-- Reviewable:end -->
