### PR TITLE
A bunch of fixes

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -110,7 +110,7 @@ function ReaderDictionary:init()
     -- Allow quick interruption or dismiss of search result window
     -- with tap if done before this delay. After this delay, the
     -- result window is shown and dismiss prevented for a few 100ms
-    self.quick_dismiss_before_delay = TimeVal:new{ sec = 3 }
+    self.quick_dismiss_before_delay = TimeVal:new{ sec = 3, usec = 0 }
 
     -- Gather info about available dictionaries
     if not available_ifos then

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1156,7 +1156,7 @@ function ReaderHighlight:onHoldRelease()
     local long_final_hold = false
     if self.hold_last_tv then
         local hold_duration = UIManager:getTime() - self.hold_last_tv
-        if hold_duration > TimeVal:new{ sec = 3 } then
+        if hold_duration > TimeVal:new{ sec = 3, usec = 0 } then
             -- We stayed 3 seconds before release without updating selection
             long_final_hold = true
         end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1101,8 +1101,8 @@ function ReaderRolling:handleEngineCallback(ev, ...)
     -- ignore other events
 end
 
-local ENGINE_PROGRESS_INITIAL_DELAY = TimeVal:new{ sec = 2 }
-local ENGINE_PROGRESS_UPDATE_DELAY = TimeVal:new{ usec = 500000 }
+local ENGINE_PROGRESS_INITIAL_DELAY = TimeVal:new{ sec = 2, usec = 0 }
+local ENGINE_PROGRESS_UPDATE_DELAY = TimeVal:new{ sec = 0, usec = 500000 }
 
 function ReaderRolling:showEngineProgress(percent)
     if G_reader_settings and G_reader_settings:isFalse("cre_show_progress") then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -975,7 +975,7 @@ function ReaderView:checkAutoSaveSettings()
     end
 
     local interval = G_reader_settings:readSetting("auto_save_settings_interval_minutes")
-    interval = TimeVal:new{ sec = interval*60 }
+    interval = TimeVal:new{ sec = interval*60, usec = 0 }
     local now_tv = UIManager:getTime()
     if now_tv - self.settings_last_save_tv >= interval then
         self.settings_last_save_tv = now_tv

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -607,8 +607,10 @@ function Input:handleTouchEv(ev)
         end
     elseif ev.type == C.EV_SYN then
         if ev.code == C.SYN_REPORT then
+            -- Promote our event's time table to a real TimeVal
+            setmetatable(ev.time, TimeVal)
             for _, MTSlot in pairs(self.MTSlots) do
-                self:setMtSlot(MTSlot.slot, "timev", TimeVal:new(ev.time))
+                self:setMtSlot(MTSlot.slot, "timev", ev.time)
                 if self.snow_protocol then
                     -- if a slot appears in the current touch event, set "used"
                     self:setMtSlot(MTSlot.slot, "used", true)
@@ -622,7 +624,7 @@ function Input:handleTouchEv(ev)
                     table.insert(self.MTSlots, slot)
                     if not slot.used then
                         slot.id = -1
-                        slot.timev = TimeVal:new(ev.time)
+                        slot.timev = ev.time
                     end
                 end
             end
@@ -691,8 +693,9 @@ function Input:handleTouchEvPhoenix(ev)
         end
     elseif ev.type == C.EV_SYN then
         if ev.code == C.SYN_REPORT then
+            setmetatable(ev.time, TimeVal)
             for _, MTSlot in pairs(self.MTSlots) do
-                self:setMtSlot(MTSlot.slot, "timev", TimeVal:new(ev.time))
+                self:setMtSlot(MTSlot.slot, "timev", ev.time)
             end
             -- feed ev in all slots to state machine
             local touch_ges = self.gesture_detector:feedEvent(self.MTSlots)
@@ -726,8 +729,9 @@ function Input:handleTouchEvLegacy(ev)
         end
     elseif ev.type == C.EV_SYN then
         if ev.code == C.SYN_REPORT then
+            setmetatable(ev.time, TimeVal)
             for _, MTSlot in pairs(self.MTSlots) do
-                self:setMtSlot(MTSlot.slot, "timev", TimeVal:new(ev.time))
+                self:setMtSlot(MTSlot.slot, "timev", ev.time)
             end
 
             -- feed ev in all slots to state machine
@@ -986,7 +990,7 @@ function Input:waitEvent(now, deadline)
                         poll_timeout = poll_deadline - now
                     else
                         -- We've already blown the deadline: make select return immediately (most likely straight to timeout)
-                        poll_timeout = TimeVal:new{ sec = 0 }
+                        poll_timeout = TimeVal.zero
                     end
                 end
 
@@ -1057,7 +1061,7 @@ function Input:waitEvent(now, deadline)
                     poll_timeout = deadline - now
                 else
                     -- Deadline has been blown: make select return immediately.
-                    poll_timeout = TimeVal:new{ sec = 0 }
+                    poll_timeout = TimeVal.zero
                 end
             end
 

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -190,7 +190,7 @@ function Device:init()
                     w = 0, h = 0,
                 }
 
-                local timev = TimeVal:new(ev.time)
+                setmetatable(ev.time, TimeVal)
 
                 local fake_ges = {
                     ges = "pan",
@@ -205,7 +205,7 @@ function Device:init()
                         y = 100*scrolled_y,
                     },
                     pos = pos,
-                    time = timev,
+                    time = ev.time,
                     mousewheel_direction = scrolled_y,
                 }
                 local fake_ges_release = {
@@ -215,7 +215,7 @@ function Device:init()
                     relative = fake_ges.relative,
                     relative_delayed = fake_ges.relative_delayed,
                     pos = pos,
-                    time = timev,
+                    time = ev.time,
                 }
                 local fake_pan_ev = Event:new("Pan", nil, fake_ges)
                 local fake_release_ev = Event:new("Gesture", fake_ges_release)

--- a/frontend/ui/gesturerange.lua
+++ b/frontend/ui/gesturerange.lua
@@ -43,8 +43,8 @@ function GestureRange:match(gs)
         -- This field sets up rate-limiting (in matches per second).
         -- It's mostly useful for e-Ink devices with less powerful CPUs
         -- and screens that cannot handle the amount of gesture events that would otherwise be generated.
-        local last_time = self.last_time or TimeVal:new{}
-        if gs.time - last_time > TimeVal:new{usec = 1000000 / self.rate} then
+        local last_time = self.last_time or TimeVal.zero
+        if gs.time - last_time > TimeVal:new{ usec = 1000000 / self.rate } then
             self.last_time = gs.time
         else
             return false

--- a/frontend/ui/timeval.lua
+++ b/frontend/ui/timeval.lua
@@ -112,7 +112,7 @@ end
 
 -- If sec is negative, time went backwards!
 function TimeVal:__sub(time_b)
-    local diff = TimeVal:new{}
+    local diff = TimeVal:new{ sec = 0, usec = 0 }
 
     diff.sec = self.sec - time_b.sec
     diff.usec = self.usec - time_b.usec
@@ -126,7 +126,7 @@ function TimeVal:__sub(time_b)
 end
 
 function TimeVal:__add(time_b)
-    local sum = TimeVal:new{}
+    local sum = TimeVal:new{ sec = 0, usec = 0 }
 
     sum.sec = self.sec + time_b.sec
     sum.usec = self.usec + time_b.usec
@@ -158,7 +158,7 @@ Which means that, yes, this is a fancier POSIX Epoch ;).
 ]]
 function TimeVal:realtime()
     local sec, usec = util.gettime()
-    return TimeVal:new{sec = sec, usec = usec}
+    return TimeVal:new{ sec = sec, usec = usec }
 end
 
 --[[--
@@ -175,7 +175,7 @@ function TimeVal:monotonic()
     C.clock_gettime(C.CLOCK_MONOTONIC, timespec)
 
     -- TIMESPEC_TO_TIMEVAL
-    return TimeVal:new{sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000))}
+    return TimeVal:new{ sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000)) }
 end
 
 --- Ditto, but w/ CLOCK_MONOTONIC_COARSE if it's available and has a 1ms resolution or better (uses CLOCK_MONOTONIC otherwise).
@@ -184,7 +184,7 @@ function TimeVal:monotonic_coarse()
     C.clock_gettime(PREFERRED_MONOTONIC_CLOCKID, timespec)
 
     -- TIMESPEC_TO_TIMEVAL
-    return TimeVal:new{sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000))}
+    return TimeVal:new{ sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000)) }
 end
 
 --- Ditto, but w/ CLOCK_REALTIME_COARSE if it's available and has a 1ms resolution or better (uses CLOCK_REALTIME otherwise).
@@ -193,7 +193,7 @@ function TimeVal:realtime_coarse()
     C.clock_gettime(PREFERRED_REALTIME_CLOCKID, timespec)
 
     -- TIMESPEC_TO_TIMEVAL
-    return TimeVal:new{sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000))}
+    return TimeVal:new{ sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000)) }
 end
 
 --- Ditto, but w/ CLOCK_BOOTTIME (will return a TimeVal set to 0, 0 if the clock source is unsupported, as it's 2.6.39+)
@@ -202,7 +202,7 @@ function TimeVal:boottime()
     C.clock_gettime(C.CLOCK_BOOTTIME, timespec)
 
     -- TIMESPEC_TO_TIMEVAL
-    return TimeVal:new{sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000))}
+    return TimeVal:new{ sec = tonumber(timespec.tv_sec), usec = math.floor(tonumber(timespec.tv_nsec / 1000)) }
 end
 
 --[[-- Alias for `monotonic_coarse`.
@@ -235,7 +235,7 @@ end
 function TimeVal:fromnumber(seconds)
     local sec = math.floor(seconds)
     local usec = math.floor((seconds - sec) * 1000000 + 0.5)
-    return TimeVal:new{sec = sec, usec = usec}
+    return TimeVal:new{ sec = sec, usec = usec }
 end
 
 --- Checks if a TimeVal object is positive
@@ -247,5 +247,12 @@ end
 function TimeVal:isZero()
     return self.sec == 0 and self.usec == 0
 end
+
+--- We often need a const TimeVal set to zero...
+--- LuaJIT doesn't actually support const values (Lua 5.4+): Do *NOT* modify it.
+TimeVal.zero = TimeVal:new{ sec = 0, usec = 0 }
+
+--- Ditto for one set to math.huge
+TimeVal.huge = TimeVal:new{ sec = math.huge, usec = 0 }
 
 return TimeVal

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1052,13 +1052,13 @@ function UIManager:discardEvents(set_or_seconds)
             -- sometimes > 500ms on some devices/temperatures.
             -- So, block for 400ms (to have it displayed) + 400ms
             -- for user reaction to it
-            delay = TimeVal:new{ usec = 800000 }
+            delay = TimeVal:new{ sec = 0, usec = 800000 }
         else
             -- On non-eInk screen, display is usually instantaneous
-            delay = TimeVal:new{ usec = 400000 }
+            delay = TimeVal:new{ sec = 0, usec = 400000 }
         end
     else -- we expect a number
-        delay = TimeVal:new{ sec = set_or_seconds }
+        delay = TimeVal:new{ sec = set_or_seconds, usec = 0 }
     end
     self._discard_events_till = self._now + delay
 end
@@ -1160,7 +1160,7 @@ function UIManager:_checkTasks()
             break
         end
         local task = self._task_queue[1]
-        local task_tv = task.time or TimeVal:new{}
+        local task_tv = task.time or TimeVal.zero
         if task_tv <= self._now then
             -- remove from table
             table.remove(self._task_queue, 1)

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -155,7 +155,7 @@ function DictQuickLookup:init()
                 -- callback function when HoldReleaseText is handled as args
                 args = function(text, hold_duration)
                     local lookup_target
-                    if hold_duration < TimeVal:new{ sec = 3 } then
+                    if hold_duration < TimeVal:new{ sec = 3, usec = 0 } then
                         -- do this lookup in the same domain (dict/wikipedia)
                         lookup_target = self.is_wiki and "LookupWikipedia" or "LookupWord"
                     else

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -195,7 +195,7 @@ function FootnoteWidget:init()
                 -- callback function when HoldReleaseText is handled as args
                 args = function(text, hold_duration)
                     if self.dialog then
-                        local lookup_target = hold_duration < TimeVal:new{ sec = 3 } and "LookupWord" or "LookupWikipedia"
+                        local lookup_target = hold_duration < TimeVal:new{ sec = 3, usec = 0 } and "LookupWord" or "LookupWikipedia"
                         self.dialog:handleEvent(
                             Event:new(lookup_target, text)
                         )

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -280,8 +280,7 @@ function FrontLightWidget:setProgress(num, step, num_warmth)
     return true
 end
 
--- Currently, we are assuming the 'warmth' has the same min/max limits
--- as 'brightness'.
+-- Currently, we are assuming the 'warmth' has the same min/max limits as 'brightness'.
 function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
     local button_group_down = HorizontalGroup:new{ align = "center" }
     local button_group_up = HorizontalGroup:new{ align = "center" }
@@ -323,7 +322,7 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
 
         for i = math.floor(num_warmth / step) + 1, self.steps - 1 do
             table.insert(warmth_group, self.fl_prog_button:new{
-                             text="",
+                             text = "",
                              enabled = not self.powerd.auto_warmth,
                              callback = function()
                                  self:setProgress(self.fl_cur, step, i * step)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -627,6 +627,12 @@ function FrontLightWidget:naturalLightConfigClose()
 end
 
 function FrontLightWidget:onTapProgress(arg, ges_ev)
+    -- The throttling has a tendency to wreak a bit of a havoc,
+    -- so, if the widget hasn't been repainted yet, go away.
+    if not self.fl_group.dimen or not self.light_frame.dimen then
+        return true
+    end
+
     if ges_ev.pos:intersectWith(self.fl_group.dimen) then
         -- Unschedule any pending updates.
         UIManager:unschedule(self.update)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -34,7 +34,7 @@ local FrontLightWidget = InputContainer:new{
     -- This should stay active during natural light configuration
     is_always_active = true,
     rate = Screen.low_pan_rate and 3 or 30,     -- Widget update rate.
-    last_time = TimeVal:new{},                  -- Tracks last update time to prevent update spamming.
+    last_time = TimeVal.zero,                   -- Tracks last update time to prevent update spamming.
 }
 
 function FrontLightWidget:init()
@@ -643,8 +643,8 @@ function FrontLightWidget:onTapProgress(arg, ges_ev)
         -- But limit the widget update frequency on E Ink.
         if Screen.low_pan_rate then
             local current_time = TimeVal:now()
-            local last_time = self.last_time or TimeVal:new{}
-            if current_time - last_time > TimeVal:new{usec = 1000000 / self.rate} then
+            local last_time = self.last_time or TimeVal.zero
+            if current_time - last_time > TimeVal:new{ usec = 1000000 / self.rate } then
                 self.last_time = current_time
             else
                 -- Schedule a final update after we stop panning.

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -308,19 +308,20 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
     end
 
     if self.natural_light and num_warmth then
-        for i = 0, math.floor(num_warmth / step) do
+        local curr_warmth_step = math.floor(num_warmth / step)
+        for i = 0, curr_warmth_step do
             table.insert(warmth_group, self.fl_prog_button:new{
                              text = "",
-                             preselect = true,
+                             preselect = curr_warmth_step > 0 and true or false,
                              enabled = not self.powerd.auto_warmth,
-                             background = button_color,
+                             background = curr_warmth_step > 0 and button_color or nil,
                              callback = function()
                                  self:setProgress(self.fl_cur, step, i * step)
                              end
             })
         end
 
-        for i = math.floor(num_warmth / step) + 1, self.steps - 1 do
+        for i = curr_warmth_step + 1, self.steps - 1 do
             table.insert(warmth_group, self.fl_prog_button:new{
                              text = "",
                              enabled = not self.powerd.auto_warmth,

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -61,6 +61,8 @@ local InfoMessage = InputContainer:new{
     icon = "notice-info",
     alpha = nil, -- if image or icon have an alpha channel (default to true for icons, false for images
     dismiss_callback = nil,
+    -- Passed to  TextBoxWidget
+    alignment = "left",
     -- In case we'd like to use it to display some text we know a few more things about:
     lang = nil,
     para_direction_rtl = nil,
@@ -132,6 +134,7 @@ function InfoMessage:init()
             face = self.face,
             width = text_width,
             height = self.height,
+            alignment = self.alignment,
             dialog = self,
             lang = self.lang,
             para_direction_rtl = self.para_direction_rtl,
@@ -142,6 +145,7 @@ function InfoMessage:init()
             text = self.text,
             face = self.face,
             width = text_width,
+            alignment = self.alignment,
             lang = self.lang,
             para_direction_rtl = self.para_direction_rtl,
             auto_para_direction = self.auto_para_direction,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -88,7 +88,7 @@ local MenuCloseButton = InputContainer:new{
     overlap_align = "right",
     padding_right = 0,
     menu = nil,
-    dimen = Geom:new{},
+    dimen = nil,
 }
 
 function MenuCloseButton:init()
@@ -544,8 +544,8 @@ local Menu = FocusManager:new{
     -- height will be calculated according to item number if not given
     height = nil,
     header_padding = Size.padding.large,
-    dimen = Geom:new{},
-    item_table = {},
+    dimen = nil,
+    item_table = nil, -- NOT mandatory (will be empty)
     item_shortcuts = {
         "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P",
         "A", "S", "D", "F", "G", "H", "J", "K", "L", "Del",
@@ -605,9 +605,9 @@ end
 
 function Menu:init()
     self.show_parent = self.show_parent or self
+    self.item_table = self.item_table or {}
     self.item_table_stack = {}
-    self.dimen.w = self.width
-    self.dimen.h = self.height or Screen:getHeight()
+    self.dimen = Geom:new{ w = self.width, h = self.height or Screen:getHeight() }
     if self.dimen.h > Screen:getHeight() or self.dimen.h == nil then
         self.dimen.h = Screen:getHeight()
     end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -407,7 +407,7 @@ function MenuItem:init()
     }
     local hgroup = HorizontalGroup:new{
         align = "center",
-        HorizontalSpan:new{ width = Size.padding.fullscreen },
+        HorizontalSpan:new{ width = self.items_padding or Size.padding.fullscreen },
     }
     if self.shortcut then
         table.insert(hgroup, ItemShortCutIcon:new{
@@ -873,6 +873,7 @@ function Menu:init()
         radius = self.is_popout and math.floor(self.dimen.w / 20) or 0,
         content
     }
+
     ------------------------------------------
     -- start to set up input event callback --
     ------------------------------------------
@@ -1066,6 +1067,7 @@ function Menu:updateItems(select_number)
                 multilines_show_more_text = multilines_show_more_text,
                 align_baselines = self.align_baselines,
                 line_color = self.line_color,
+                items_padding = self.items_padding,
             }
             table.insert(self.item_group, item_tmp)
             -- this is for focus manager

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -105,7 +105,7 @@ function Notification:_cleanShownStack(num)
     -- to follow what is happening).
     -- As a sanity check, we also forget those shown for
     -- more than 30s in case no close event was received.
-    local expire_tv = UIManager:getTime() - TimeVal:new{ sec = 30 }
+    local expire_tv = UIManager:getTime() - TimeVal:new{ sec = 30, usec = 0 }
     for i=#Notification._nums_shown, 1, -1 do
         if Notification._nums_shown[i] and Notification._nums_shown[i] > expire_tv then
             break -- still shown (or not yet expired)

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -149,7 +149,7 @@ local SortWidget = InputContainer:new{
     -- index for the first item to show
     show_page = 1,
     -- table of items to sort
-    item_table = {},
+    item_table = nil, -- mandatory
     callback = nil,
 }
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -417,7 +417,7 @@ end
 TouchMenu widget for hierarchical menus
 --]]
 local TouchMenu = FocusManager:new{
-    tab_item_table = {},
+    tab_item_table = nil, -- mandatory
     -- for returning in multi-level menus
     item_table_stack = nil,
     item_table = nil,

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -50,9 +50,9 @@ function AutoSuspend:_schedule(shutdown_only)
         delay_shutdown = self.autoshutdown_timeout_seconds
     else
         local now_tv = UIManager:getTime()
-        delay_suspend = self.last_action_tv + TimeVal:new{ sec = self.auto_suspend_timeout_seconds } - now_tv
+        delay_suspend = self.last_action_tv + TimeVal:new{ sec = self.auto_suspend_timeout_seconds, usec = 0 } - now_tv
         delay_suspend = delay_suspend:tonumber()
-        delay_shutdown = self.last_action_tv + TimeVal:new{ sec = self.autoshutdown_timeout_seconds } - now_tv
+        delay_shutdown = self.last_action_tv + TimeVal:new{ sec = self.autoshutdown_timeout_seconds, usec = 0 } - now_tv
         delay_shutdown = delay_shutdown:tonumber()
     end
 

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -35,7 +35,7 @@ function AutoTurn:_schedule(settings_id)
         return
     end
 
-    local delay = self.last_action_tv + TimeVal:new{ sec = self.autoturn_sec } - UIManager:getTime()
+    local delay = self.last_action_tv + TimeVal:new{ sec = self.autoturn_sec, usec = 0 } - UIManager:getTime()
     delay = delay:tonumber()
 
     if delay <= 0 then

--- a/plugins/backgroundrunner.koplugin/main.lua
+++ b/plugins/backgroundrunner.koplugin/main.lua
@@ -118,7 +118,7 @@ function BackgroundRunner:_finishJob(job)
     assert(self ~= nil)
     if type(job.executable) == "function" then
         local tv_diff = job.end_tv - job.start_tv
-        local threshold = TimeVal:new{ sec = 1 }
+        local threshold = TimeVal:new{ sec = 1, usec = 0 }
         job.timeout = (tv_diff > threshold)
     end
     job.blocked = job.timeout

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -331,7 +331,7 @@ function CalibreSearch:find(option)
         local result = self:bookCatalog(books)
         self:showresults(result)
     else
-        self:browse(option,1)
+        self:browse(option, 1)
     end
     logger.info(string.format("search done in %.3f milliseconds (%s, %s, %s, %s, %s)",
         (TimeVal:now() - start):tomsecs(),


### PR DESCRIPTION
* Input: Don't create a new TimeVal object for input frame timestamps, just promote our existing table by assigning it the `TimeVal` metatable.
* TimeVal: Export (const) `zero` & `huge` TimeVal objects, because they're common enough in our codebase. (NOTE: not actually const, that's a Lua 5.4 feature ;p).
* GestureDetector: Explain the behavior of the `last_tevs` & `first_tevs` tables, and why one needs a new object and not the other.
* Speaking of, simplify the copy method for `first_tevs`, because it doesn't to create a new TimeVal object, we can just reference the original, it's unique and re-assigned for each frame.
* Menu: Don't share the `dimen` object across instances. Because we can have a few different instances of it at one time. This fixes, probably among other things, the Calibre metadata search enforcing its smaller width on the FM.
* Android: Fix #7552 by simply ensuring we drain the input/cmd queue first, simply by scheduling the task to the next tick, instead of locally re-implementing part of the event loop ;). (Requires https://github.com/koreader/koreader-base/pull/1356 for extra safety).
* Android: Clear input state when the window loses focus. (Related to the above fix).
* ReaderToc: Tweak padding around items to be a tad more balanced for multi-level ToCs, and perfectly balanced for flat ToCs. (Re #7548)
* ReaderToc: Make the onHold popup's width match said padding. (Re #7548)
* FrontLight: Ensure the warmth bar appears empty at 0. (Fix #7548)
* FrontLight: Avoid crashes when swiping the frontlight bar in some cases.

----

~~History's a bit of a mess because I started to work on multiple things at a time, and then needed to test all of them, hence the completely random mix of stuff in this PR :s.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7553)
<!-- Reviewable:end -->
