### PR TITLE
remarkable: remove extra refresh before poweroff

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -190,8 +190,6 @@ function Remarkable:suspend()
 end
 
 function Remarkable:powerOff()
-    self.screen:clear()
-    self.screen:refreshFull()
     os.execute("systemctl poweroff")
 end
 


### PR DESCRIPTION
"we did move rM to the same power event handler [as] Kobo, so it should already be doing a white flash before [ScreenSaver]" https://github.com/koreader/koreader/issues/7519#issuecomment-819649806

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7563)
<!-- Reviewable:end -->
