### PR TITLE
Style tweaks: add links italic font style

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -539,6 +539,17 @@ table, tcaption, tr, th, td { border: black solid 1px; border-collapse: collapse
             separator = true,
         },
         {
+            id = "a_italic";
+            title = _("Links always italic"),
+            css = [[a, a * { font-style: italic !important; }]],
+        },
+        {
+            id = "a_not_italic";
+            title = _("Links never italic"),
+            css = [[a, a * { font-style: normal !important; }]],
+            separator = true,
+        },
+        {
             id = "a_underline";
             title = _("Links always underlined"),
             css = [[a[href], a[href] * { text-decoration: underline !important; }]],


### PR DESCRIPTION
A small addition to the beautiful set of style tweaks.
Before: footnote numbers follow the style of the text element, e.g. epigraph+author makes them italic+bold.
After: footnote numbers are normal throughout the text of the book.

![1](https://user-images.githubusercontent.com/62179190/115135400-dbaedd80-a020-11eb-918d-737b40746ff8.png)
---
![2](https://user-images.githubusercontent.com/62179190/115135404-dfdafb00-a020-11eb-80dd-34f8e37225c3.png)
---
![3](https://user-images.githubusercontent.com/62179190/115135405-e49faf00-a020-11eb-9bff-3bb0bd517262.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7567)
<!-- Reviewable:end -->
