### PR TITLE
NetworkManager: Just warn if the gateway is unreachable after a successful authentication.

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -372,24 +372,18 @@ function NetworkMgr:getWifiToggleMenuTable()
                     if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
                         UIManager:broadcastEvent(Event:new("NetworkConnected"))
                     elseif NetworkMgr:isWifiOn() and not NetworkMgr:isConnected() then
-                        -- Don't leave Wi-Fi in an inconsistent state if the connection failed.
+                        -- If we can't ping the gateway, despite a successful authentication w/ the AP, display a warning,
+                        -- because this means that Wi-Fi is technically still enabled (e.g., modules are loaded).
+                        -- We can't really enforce a turnOffWifi right now, because the user might want to try another AP or something.
+                        -- (c.f., #5912, #4616).
                         -- NOTE: Keep in mind that NetworkSetting only runs this callback on *successful* connections!
                         --       (It's called connect_callback there).
                         --       This makes this branch somewhat hard to reach, which is why it gets a dedicated prompt below...
-                        self.wifi_was_on = false
-                        G_reader_settings:makeFalse("wifi_was_on")
-                        -- NOTE: We're limiting this to only a few platforms, as it might be actually harmful on some devices.
-                        --       The intent being to unload kernel modules, and make a subsequent turnOnWifi behave sanely.
-                        --       PB: Relies on netagent, no idea what it does, but it's not using this codepath anyway (!hasWifiToggle)
-                        --       Android: Definitely shouldn't do it.
-                        --       Sony: Doesn't play with modules, don't do it.
-                        --       Kobo: Yes, please.
-                        --       Cervantes: Loads/unloads module, probably could use it like Kobo.
-                        --       Kindle: Probably could use it, if only because leaving Wireless on is generally a terrible idea on Kindle,
-                        --               except that we defer to lipc, which makes Wi-Fi handling asynchronous, and the callback is simply delayed by 1s,
-                        --               so we can't be sure the system will actually have finished bringing Wi-Fi up by then...
-                        NetworkMgr:turnOffWifi()
-                        touchmenu_instance:updateItems()
+                        UIManager:show(InfoMessage:new{
+                            icon = "notice-warning",
+                            text = _("Gateway is unreachable, but Wi-Fi is still on!"),
+                            timeout = 3,
+                        })
                     end
                 else
                     -- Assume success on other platforms

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -482,7 +482,7 @@ function NetworkSetting:init()
         if connected_item ~= nil then
             obtainIP()
             if G_reader_settings:nilOrTrue("auto_dismiss_wifi_scan") then
-                UIManager:close(self, 'ui', self.dimen)
+                UIManager:close(self, "ui", self.dimen)
             end
             UIManager:show(InfoMessage:new{
                 text = T(_("Connected to network %1"), BD.wrap(connected_item.info.ssid)),


### PR DESCRIPTION
Fully tearing down Wi-Fi was a bit optimistic, as the AP list can
technically still be up, so the user might want to try again and/or
connect to another AP.

Fix #5912, regression since #4616.

The reasoning behind #4616 doesn't really apply anymore anyway, as the
Wi-Fi prompt now handles this inconsistent state properly (#7368).

The whole codepath should be *extremely* rare anyway (and/or require
super-broken network conditions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7570)
<!-- Reviewable:end -->
