### PR TITLE
Always show open with dialog

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -381,7 +381,7 @@ function FileManager:setupLayout()
             table.insert(buttons, {
                 {
                     text = _("Open with…"),
-                    enabled = DocumentRegistry:getProviders(file) == nil or #(DocumentRegistry:getProviders(file)) > 1 or fileManager.texteditor,
+                    enabled = true,
                     callback = function()
                         UIManager:close(self.file_dialog)
                         local one_time_providers = {}


### PR DESCRIPTION
`DocumentRegistry:getProviders(file) == nil or #(DocumentRegistry:getProviders(file)) > 1` is just a very verbose way of saying "always".

References <https://github.com/koreader/koreader/issues/7577>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7578)
<!-- Reviewable:end -->
