### PR TITLE
File manager: make "Refresh content" action customizable

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -131,13 +131,6 @@ function FileManager:setupLayout()
         padding_right = Size.padding.large,
         padding_bottom = 0,
         callback = function() self:onShowPlusMenu() end,
-        hold_callback = function()
-            self:onRefresh()
-            UIManager:show(InfoMessage:new{
-                text = _("Content refreshed."),
-                timeout = 2,
-            })
-        end,
     }
 
     self.path_text = TextWidget:new{
@@ -1153,6 +1146,14 @@ end
 
 function FileManager:onHome()
     return self:goHome()
+end
+
+function FileManager:onRefreshContent()
+    self:onRefresh()
+    UIManager:show(InfoMessage:new{
+        text = _("Content refreshed."),
+        timeout = 2,
+    })
 end
 
 return FileManager

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -90,6 +90,7 @@ local settingsList = {
     -- filemanager settings
     folder_up = { category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
     show_plus_menu = { category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true},
+    refresh_content = { category="none", event="RefreshContent", title=_("Refresh content"), filemanager=true},
     folder_shortcuts = { category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, separator=true,},
 
     -- reader settings
@@ -216,6 +217,7 @@ local dispatcher_menu_order = {
     -- filemanager
     "folder_up",
     "show_plus_menu",
+    "refresh_content",
     "folder_shortcuts",
 
     -- reader

--- a/plugins/gestures.koplugin/defaults.lua
+++ b/plugins/gestures.koplugin/defaults.lua
@@ -8,7 +8,7 @@ return {
         tap_right_bottom_corner = nil,
         tap_left_bottom_corner = Device:hasFrontlight() and {toggle_frontlight = true,} or nil,
         hold_top_left_corner = nil,
-        hold_top_right_corner = nil,
+        hold_top_right_corner = {refresh_content = true,},
         hold_bottom_left_corner = nil,
         hold_bottom_right_corner = nil,
         one_finger_swipe_left_edge_down = Device:hasFrontlight() and {decrease_frontlight = 0,} or nil,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -232,7 +232,7 @@ end
 
 function Gestures:genSubItem(ges, separator, hold_callback)
     local reader_only = {tap_top_left_corner=true, hold_top_left_corner=true,
-                         tap_top_right_corner=true, hold_top_right_corner=true,}
+                         tap_top_right_corner=true,}
     local enabled_func
     if reader_only[ges] then
        enabled_func = function() return self.ges_mode == "gesture_reader" end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -232,7 +232,7 @@ end
 
 function Gestures:genSubItem(ges, separator, hold_callback)
     local reader_only = {tap_top_left_corner=true, hold_top_left_corner=true,
-                         tap_top_right_corner=true,}
+                         tap_top_right_corner=true, hold_top_right_corner=true,}
     local enabled_func
     if reader_only[ges] then
        enabled_func = function() return self.ges_mode == "gesture_reader" end


### PR DESCRIPTION
Holding the "Plus" button is reserved for content refresh in https://github.com/koreader/koreader/pull/7559.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7592)
<!-- Reviewable:end -->
