### PR TITLE
Move to archive on end

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -120,6 +120,13 @@ function ReaderStatus:onEndOfBook()
             },
             {
                 {
+                    text = _("Move to archive"),
+                    callback = function()
+                        local MoveToArchive = require("plugins/movetoarchive.koplugin/main")
+                        MoveToArchive:moveFileToArchive(self.document.file)
+                    end,
+                },
+                {
                     text = _("Cancel"),
                     callback = function()
                         UIManager:close(choose_action)

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -76,21 +76,25 @@ function MoveToArchive:addToMainMenu(menu_items)
 end
 
 function MoveToArchive:moveToArchive()
+    self:moveFileToArchive(self.ui.document.file)
+end
+
+function MoveToArchive:moveFileToArchive(file)
     local move_done_text = _("Book moved.\nDo you want to open it from the archive folder?")
-    self:commonProcess(true, move_done_text)
+    self:commonProcess(file, is_move_process, moved_done_text)
 end
 
 function MoveToArchive:copyToArchive()
     local copy_done_text = _("Book copied.\nDo you want to open it from the archive folder?")
-    self:commonProcess(false, copy_done_text)
+    self:commonProcess(self.ui.document.file, false, copy_done_text)
 end
 
-function MoveToArchive:commonProcess(is_move_process, moved_done_text)
+function MoveToArchive:commonProcess(file, is_move_process, moved_done_text)
     if not self.archive_dir_path then
         self:showNoArchiveConfirmBox()
         return
     end
-    local document_full_path = self.ui.document.file
+    local document_full_path = file
     local filename
     self.last_copied_from_dir, filename = util.splitFilePathName(document_full_path)
 

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -22,6 +22,13 @@ function MoveToArchive:init()
     self.settings = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), "move_to_archive_settings.lua"))
     self.archive_dir_path = self.settings:readSetting("archive_dir")
     self.last_copied_from_dir = self.settings:readSetting("last_copied_from_dir")
+    table.insert(self.ui.status.additional_actions, {
+        text = _("Move to archive"),
+        callback = function()
+            print('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+            self:moveFileToArchive(self.document.file)
+        end,
+    })
 end
 
 function MoveToArchive:addToMainMenu(menu_items)


### PR DESCRIPTION
Followup to #6164 

This Pull Request introduces:

* A way to add new action to the popup that opens after a document end is reached
* The "move to archive" plugin using that way to provide a quick way to move files to the archive
* Fixed a bug where a old state of the movetoarchive settings was held in memory
* A setting to "move to archive" that allows you to skip the popup after a move
* A setting for the default action when movetoarchive shows no popup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7598)
<!-- Reviewable:end -->
