### PR TITLE
Status bar: do not hide alone empty indicators

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -135,7 +135,7 @@ local footerTextGeneratorMap = {
                 return (prefix .. " %d"):format(powerd:frontlightIntensity())
             end
         else
-            if footer.settings.hide_empty_generators then
+            if footer.settings.all_at_once and footer.settings.hide_empty_generators then
                 return ""
             else
                 return T(_("%1 Off"), prefix)
@@ -189,7 +189,7 @@ local footerTextGeneratorMap = {
         local symbol_type = footer.settings.item_prefix or "icons"
         local prefix = symbol_prefix[symbol_type].bookmark_count
         local bookmark_count = footer.ui.bookmark:getNumberOfBookmarks()
-        if footer.settings.hide_empty_generators and bookmark_count == 0 then
+        if footer.settings.all_at_once and footer.settings.hide_empty_generators and bookmark_count == 0 then
             return ""
         end
         return prefix .. " " .. tostring(bookmark_count)
@@ -310,7 +310,7 @@ local footerTextGeneratorMap = {
             if NetworkMgr:isWifiOn() then
                 return symbol_prefix.icons.wifi_status
             else
-                if footer.settings.hide_empty_generators then
+                if footer.settings.all_at_once and footer.settings.hide_empty_generators then
                     return ""
                 else
                     return symbol_prefix.icons.wifi_status_off
@@ -321,7 +321,7 @@ local footerTextGeneratorMap = {
             if NetworkMgr:isWifiOn() then
                 return T(_("%1 On"), prefix)
             else
-                if footer.settings.hide_empty_generators then
+                if footer.settings.all_at_once and footer.settings.hide_empty_generators then
                     return ""
                 else
                     return T(_("%1 Off"), prefix)
@@ -984,6 +984,20 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             getMinibarOption("all_at_once", self.updateFooterTextGenerator),
+            {
+                text = _("Hide empty items"),
+                help_text = _([[This will hide values like 0 or off.]]),
+                enabled_func = function()
+                    return self.settings.all_at_once
+                end,
+                checked_func = function()
+                    return self.settings.hide_empty_generators
+                end,
+                callback = function()
+                    self.settings.hide_empty_generators = not self.settings.hide_empty_generators
+                    self:refreshFooter(true, true)
+                end,
+            },
             getMinibarOption("reclaim_height"),
             {
                 text = _("Auto refresh"),
@@ -1002,17 +1016,6 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
                 callback = function()
                     self.settings.bottom_horizontal_separator = not self.settings.bottom_horizontal_separator
-                    self:refreshFooter(true, true)
-                end,
-            },
-            {
-                text = _("Hide empty items"),
-                help_text = _([[This will hide values like 0 or off.]]),
-                checked_func = function()
-                    return self.settings.hide_empty_generators
-                end,
-                callback = function()
-                    self.settings.hide_empty_generators = not self.settings.hide_empty_generators
                     self:refreshFooter(true, true)
                 end,
             },


### PR DESCRIPTION
Ignore `Hide empty items` if not `Show all at once`.
c.f. https://github.com/koreader/koreader/issues/7488#issuecomment-826340576

Small tuning of the settings:
- `Hide empty items` is disabled if not `Show all at once`
- `Hide empty items` located next to `Show all at once` for better visibility

![1](https://user-images.githubusercontent.com/62179190/116070579-78aeed80-a695-11eb-8b59-1b3220e88894.png)

![2](https://user-images.githubusercontent.com/62179190/116070590-7ba9de00-a695-11eb-982b-1bd20385cc65.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7602)
<!-- Reviewable:end -->
