### PR TITLE
Dispatcher: add "Toggle status bar" action

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -221,6 +221,7 @@ local dispatcher_menu_order = {
 
     -- reader
     "toggle_status_bar",
+
     "page_jmp",
     "prev_chapter",
     "next_chapter",

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -93,6 +93,7 @@ local settingsList = {
     folder_shortcuts = { category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, separator=true,},
 
     -- reader settings
+    toggle_status_bar = { category="none", event="TapFooter", title=_("Toggle status bar"), rolling=true, paging=true, separator=true,},
     prev_chapter = { category="none", event="GotoPrevChapter", title=_("Previous chapter"), rolling=true, paging=true,},
     next_chapter = { category="none", event="GotoNextChapter", title=_("Next chapter"), rolling=true, paging=true,},
     first_page = { category="none", event="GoToBeginning", title=_("First page"), rolling=true, paging=true,},
@@ -219,6 +220,8 @@ local dispatcher_menu_order = {
     "folder_shortcuts",
 
     -- reader
+    "toggle_status_bar",
+    
     "page_jmp",
     "prev_chapter",
     "next_chapter",

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -221,7 +221,6 @@ local dispatcher_menu_order = {
 
     -- reader
     "toggle_status_bar",
-    
     "page_jmp",
     "prev_chapter",
     "next_chapter",


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/7488.
As discussed, the action is the same as tapping the footer.

![1](https://user-images.githubusercontent.com/62179190/116114398-fc7ecf00-a6c1-11eb-8793-16bad7929912.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7606)
<!-- Reviewable:end -->
