### PR TITLE
Gestures menu optimization

### DIFF
--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -707,12 +707,8 @@ function Gestures:addToMainMenu(menu_items)
                 sub_item_table = self:genSubItemTable({"hold_top_left_corner", "hold_top_right_corner", "hold_bottom_left_corner", "hold_bottom_right_corner"}),
             },
             {
-                text = _("Short diagonal swipe"),
-                sub_item_table = self:genMenu("short_diagonal_swipe"),
-            },
-            {
                 text = _("One-finger swipe"),
-                sub_item_table = self:genSubItemTable({"one_finger_swipe_left_edge_down", "one_finger_swipe_left_edge_up", "one_finger_swipe_right_edge_down", "one_finger_swipe_right_edge_up", "one_finger_swipe_top_edge_right", "one_finger_swipe_top_edge_left", "one_finger_swipe_bottom_edge_right", "one_finger_swipe_bottom_edge_left"}),
+                sub_item_table = self:genSubItemTable({"short_diagonal_swipe", "one_finger_swipe_left_edge_down", "one_finger_swipe_left_edge_up", "one_finger_swipe_right_edge_down", "one_finger_swipe_right_edge_up", "one_finger_swipe_top_edge_right", "one_finger_swipe_top_edge_left", "one_finger_swipe_bottom_edge_right", "one_finger_swipe_bottom_edge_left"}),
             },
             {
                 text = _("Double tap"),


### PR DESCRIPTION
There are 11 `Gesture manager` submenu items, that creates the second page with `Spread and pinch` alone.
Propose to move `Short diagonal swipe` into `One-finger swipe` (it is the one-finger swipe actually) and get a nice one-page menu.


![1](https://user-images.githubusercontent.com/62179190/116237929-77e78b80-a769-11eb-8304-5a530e0fa304.png)
---
![2](https://user-images.githubusercontent.com/62179190/116237961-7ddd6c80-a769-11eb-9ef9-9817ab6487f4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7609)
<!-- Reviewable:end -->
