### PR TITLE
Kindle: Enable AutoSuspend plugin

### DIFF
--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -1,6 +1,7 @@
 local Device = require("device")
 
 if not Device:isCervantes() and
+    not Device:isKindle() and
     not Device:isKobo() and
     not Device:isRemarkable() and
     not Device:isSDL() and


### PR DESCRIPTION
Kindles are not flagged canPowerOff, although that's technically not
entirely warranted, but sorta makes sense.

The Plugin already handles that sanely, and will only expose/honor the
suspend timer.

(That wasn't the case before #7400, which possibly explains the omission).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7612)
<!-- Reviewable:end -->
