### PR TITLE
bump crengine: more granular font weights

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -127,10 +127,10 @@ function ReaderFont:onReadSettings(config)
                   or 22
     self.ui.document:setFontSize(Screen:scaleBySize(self.font_size))
 
-    self.font_embolden = config:readSetting("font_embolden")
-                      or G_reader_settings:readSetting("copt_font_weight")
+    self.font_base_weight = config:readSetting("font_base_weight")
+                      or G_reader_settings:readSetting("copt_font_base_weight")
                       or 0
-    self.ui.document:toggleFontBolder(self.font_embolden)
+    self.ui.document:setFontBaseWeight(self.font_base_weight)
 
     self.font_hinting = config:readSetting("font_hinting")
                      or G_reader_settings:readSetting("copt_font_hinting")
@@ -238,9 +238,9 @@ function ReaderFont:onSetLineSpace(space)
     return true
 end
 
-function ReaderFont:onToggleFontBolder(toggle)
-    self.font_embolden = toggle
-    self.ui.document:toggleFontBolder(toggle)
+function ReaderFont:onSetFontBaseWeight(weight)
+    self.font_base_weight = weight
+    self.ui.document:setFontBaseWeight(weight)
     self.ui:handleEvent(Event:new("UpdatePos"))
     return true
 end
@@ -288,7 +288,7 @@ function ReaderFont:onSaveSettings()
     self.ui.doc_settings:saveSetting("font_face", self.font_face)
     self.ui.doc_settings:saveSetting("header_font_face", self.header_font_face)
     self.ui.doc_settings:saveSetting("font_size", self.font_size)
-    self.ui.doc_settings:saveSetting("font_embolden", self.font_embolden)
+    self.ui.doc_settings:saveSetting("font_base_weight", self.font_base_weight)
     self.ui.doc_settings:saveSetting("font_hinting", self.font_hinting)
     self.ui.doc_settings:saveSetting("font_kerning", self.font_kerning)
     self.ui.doc_settings:saveSetting("word_spacing", self.word_spacing)

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -146,7 +146,7 @@ local settingsList = {
     render_dpi = {category="string", rolling=true},
     line_spacing = {category="absolutenumber", rolling=true, separator=true,},
     font_size = {category="absolutenumber", title=_("Set font size to %1"), rolling=true},
-    font_weight = {category="string", rolling=true},
+    font_base_weight = {category="string", rolling=true},
     font_gamma = {category="string", rolling=true},
     font_hinting = {category="string", rolling=true},
     font_kerning = {category="string", rolling=true, separator=true,},
@@ -251,7 +251,7 @@ local dispatcher_menu_order = {
     "decrease_font",
     "font_size",
     "font_gamma",
-    "font_weight",
+    "font_base_weight",
     "font_hinting",
     "font_kerning",
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -118,6 +118,14 @@ function CreDocument:engineInit()
                 end
             end
         end
+        -- Make sure registered fonts have a proper entry at weight 400 and 700 when
+        -- possible, to avoid having synthesized fonts for these normal and bold weights.
+        -- This allows restoring a bit of the previous behaviour of crengine when it
+        -- wasn't handling font styles, and associated for each typeface one single
+        -- font to regular (400) and one to bold (700).
+        -- It should ensure we use real fonts (and not synthesized ones) for normal text
+        -- and bold text with the font_base_weight setting set to its default value of 0 (=400).
+        cre.regularizeRegisteredFontsWeights(true) -- true to print what modifications were made
 
         engine_initialized = true
     end
@@ -1067,9 +1075,12 @@ function CreDocument:setInterlineSpacePercent(percent)
     self._document:setDefaultInterlineSpace(percent)
 end
 
-function CreDocument:toggleFontBolder(toggle)
-    logger.dbg("CreDocument: toggle font bolder", toggle)
-    self._document:setIntProperty("font.face.weight.embolden", toggle)
+function CreDocument:setFontBaseWeight(weight)
+    -- In frontend, we use: 0, 1, -0.5, a delta from the regular weight of 400.
+    -- crengine expects for these: 400, 500, 350
+    local cre_weight = math.floor(400 + weight*100)
+    logger.dbg("CreDocument: set font base weight", weight, "=", cre_weight)
+    self._document:setIntProperty("font.face.base.weight", cre_weight)
 end
 
 function CreDocument:getGammaLevel()

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -3,6 +3,7 @@ local Screen = Device.screen
 local optionsutil = require("ui/data/optionsutil")
 local _ = require("gettext")
 local C_ = _.pgettext
+local T = require("ffi/util").template
 
 -- Get font size numbers as a table of strings
 local tableOfNumbersToTableOfStrings = function(numbers)
@@ -493,16 +494,6 @@ Note that your selected font size is not affected by this setting.]]),
         icon = "appbar.contrast",
         options = {
             {
-                name = "font_weight",
-                name_text = _("Font Weight"),
-                toggle = {_("regular"), _("bold")},
-                values = {0, 1},
-                default_value = 0,
-                args = {0, 1},
-                event = "ToggleFontBolder",
-                name_text_hold_callback = optionsutil.showValues,
-            },
-            {
                 name = "font_gamma",
                 name_text = _("Contrast"),
                 buttonprogress = true,
@@ -527,6 +518,39 @@ Note that your selected font size is not affected by this setting.]]),
                                    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56 };
                     value_step = 1,
                 },
+            },
+            {
+                name = "font_base_weight",
+                name_text = _("Font Weight"),
+                toggle = { "-1", "-½", "0", "+½", "+1", "+1½", "+3" },
+                values = { -1, -0.5, 0, 0.5, 1, 1.5, 3 },
+                args = { -1, -0.5, 0, 0.5, 1, 1.5, 3 },
+                default_value = 0,
+                event = "SetFontBaseWeight",
+                more_options = true,
+                more_options_param = {
+                    value_min = -3,
+                    value_max = 5.5,
+                    value_step = 0.25,
+                    precision = "%+.2f",
+                    value_hold_step = 1,
+                },
+                help_text = _([[Set the font weight delta from "regular" to apply to all fonts.
+
+- 0 will use the "regular (400)" variation of a font.
+- +1 will use the "medium (500)" variation of a font if available
+- +3 will use the "bold (700)" variation of a font if available
+If a font variation is not available, as well as for fractional adjustments, a font variation will be synthesized from the nearest available weight of the font.]]),
+                help_text_func = function(configurable, document)
+                    local font_face = document:getFontFace()
+                    local available_weights = cre.getFontFaceAvailableWeights(font_face)
+                    return T(_("The default font '%1' is available in %2."), font_face, table.concat(available_weights, ", "))
+                end,
+                name_text_hold_callback = optionsutil.showValues,
+                name_text_true_values = true,
+                show_true_value_func = function(val)
+                    return string.format("%d", 400+val*100)
+                end,
             },
             {
                 name = "font_hinting",

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -13,7 +13,7 @@ function optionsutil.enableIfEquals(configurable, option, value)
     return configurable[option] == value
 end
 
-function optionsutil.showValues(configurable, option, prefix)
+function optionsutil.showValues(configurable, option, prefix, document)
     local default = G_reader_settings:readSetting(prefix.."_"..option.name)
     local current = configurable[option.name]
     local value_default, value_current
@@ -97,6 +97,10 @@ function optionsutil.showValues(configurable, option, prefix)
     local help_text = ""
     if option.help_text then
         help_text = T("\n%1\n", option.help_text)
+    end
+    if option.help_text_func then
+        -- Allow for concatenating a dynamic help_text_func to a static help_text
+        help_text = T("%1\n%2\n", help_text, option.help_text_func(configurable, document))
     end
     local text
     local name_text = option.name_text_func

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -299,7 +299,7 @@ function ConfigOption:init()
                     hold_callback = function()
                         if self.options[c].name_text_hold_callback then
                             self.options[c].name_text_hold_callback(self.config.configurable, self.options[c],
-                                self.config.config_options.prefix)
+                                self.config.config_options.prefix, self.config.document)
                         end
                     end,
                 }


### PR DESCRIPTION
Includes:
- MathML: a few minor fixes https://github.com/koreader/crengine/pull/435
- (Upstream) lvtext: fix possible index out of range
- Fonts: RegisterExternalFont() should take a documentId
- Fonts: fix: letter-spacing should not be applied on diacritic
- (Upstream) Fonts: more granular synthetic weights
- Fonts: synthesized weights: tweak some comments
- Fonts: keep hinting with synthetic weight
- Fonts: fix synthesized weight inconsitencies
- Fonts: fix getFontFileNameAndFaceIndex()
- Fonts: adds LVFontMan::RegularizeRegisteredFontsWeights()
- Fonts: handle synth_weight tweaks in glyph/glyphinfo slots
- (Upstream) Fonts: fix some compiler warnings
- Fix hyphenation on Armenian and Georgian text https://github.com/koreader/crengine/pull/436 Closes #7539.

I decided to not care about the migration from the old boolean `font_embolden` to the replacement number `font_base_weight` - this will let people who had <kbd>bold</kbd> know that there is this new setting with more granular weights, as they'll probably enjoy 1.5 more than the old "bold"=3.

<kbd>![image](https://user-images.githubusercontent.com/24273478/116445180-db4ee780-a855-11eb-9cf2-d83410b2906e.png)</kbd>
(<kbd>2</kbd> in the screenshots has been corrected to <kbd>+2</kbd>, too lazy to remake the screenshot)

I got rid of <kbd>+3</kbd>, I wanted to get rid of <kbd>+2</kbd> but the toggle felt a bit naked then :)

Rewording suggestions welcome.

@yparitcher : any idea if we renaming/removing a dispatcher setting/action (font_weight) can cause issues if a user has been using it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7616)
<!-- Reviewable:end -->
