### PR TITLE
FM/RD lifecycle cleanup; Cache revamp; unbreak AutoSuspend

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,3 +29,12 @@ Android won't have a crash.log file because Google restricts what apps can log, 
 Please try to include the relevant sections in your issue description.
 You can upload the whole `crash.log` file on GitHub by dragging and
 dropping it onto this textbox.
+
+If you instead opt to inline it, please do so behind a spoiler tag:
+<details>
+  <summary>crash.log</summary>
+  
+```
+<Paste crash.log content here>
+```
+</details>

--- a/defaults.lua
+++ b/defaults.lua
@@ -27,13 +27,13 @@ DHINTCOUNT = 1
 DRENDER_MODE = 0 -- 0 is COLOUR
 
 -- minimum cache size
-DGLOBAL_CACHE_SIZE_MINIMUM = 1024*1024*10
+DGLOBAL_CACHE_SIZE_MINIMUM = 1024*1024*16
 
 -- proportion of system free memory used as global cache
 DGLOBAL_CACHE_FREE_PROPORTION = 0.4
 
 -- maximum cache size
-DGLOBAL_CACHE_SIZE_MAXIMUM = 1024*1024*60
+DGLOBAL_CACHE_SIZE_MAXIMUM = 1024*1024*64
 
 -- background colour in non scroll mode: 8 = gray, 0 = white, 15 = black
 DBACKGROUND_COLOR = 0

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -21,7 +21,7 @@ function DropBox:showFiles(url, password)
     return DropBoxApi:showFiles(url, password)
 end
 
-function DropBox:downloadFile(item, password, path, close)
+function DropBox:downloadFile(item, password, path, callback_close)
     local code_response = DropBoxApi:downloadFile(item.url, password, path)
     if code_response == 200 then
         local __, filename = util.splitFilePathName(path)
@@ -34,7 +34,13 @@ function DropBox:downloadFile(item, password, path, close)
                 text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
                     BD.filepath(path)),
                 ok_callback = function()
-                    close()
+                    local Event = require("ui/event")
+                    UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
+                    if callback_close then
+                        callback_close()
+                    end
+
                     ReaderUI:showReader(path)
                 end
             })

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -20,7 +20,7 @@ function Ftp:run(address, user, pass, path)
     return FtpApi:listFolder(url, path)
 end
 
-function Ftp:downloadFile(item, address, user, pass, path, close)
+function Ftp:downloadFile(item, address, user, pass, path, callback_close)
     local url = FtpApi:generateUrl(address, util.urlEncode(user), util.urlEncode(pass)) .. item.url
     logger.dbg("downloadFile url", url)
     path = util.fixUtf8(path, "_")
@@ -43,7 +43,13 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
                 text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
                     BD.filepath(path)),
                 ok_callback = function()
-                    close()
+                    local Event = require("ui/event")
+                    UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
+                    if callback_close then
+                        callback_close()
+                    end
+
                     ReaderUI:showReader(path)
                 end
             })

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -17,7 +17,7 @@ function WebDav:run(address, user, pass, path)
     return WebDavApi:listFolder(address, user, pass, path)
 end
 
-function WebDav:downloadFile(item, address, username, password, local_path, close)
+function WebDav:downloadFile(item, address, username, password, local_path, callback_close)
     local code_response = WebDavApi:downloadFile(address .. WebDavApi:urlEncode( item.url ), username, password, local_path)
     if code_response == 200 then
         local __, filename = util.splitFilePathName(local_path)
@@ -30,7 +30,13 @@ function WebDav:downloadFile(item, address, username, password, local_path, clos
                 text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"),
                     BD.filepath(local_path)),
                 ok_callback = function()
-                    close()
+                    local Event = require("ui/event")
+                    UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
+                    if callback_close then
+                        callback_close()
+                    end
+
                     ReaderUI:showReader(local_path)
                 end
             })

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -166,12 +166,7 @@ function FileManagerCollection:onShowColl(collection)
 
     self:updateItemTable()
     self.coll_menu.close_callback = function()
-        -- Close it at next tick so it stays displayed
-        -- while a book is opening (avoids a transient
-        -- display of the underlying File Browser)
-        UIManager:nextTick(function()
-            UIManager:close(self.coll_menu)
-        end)
+        UIManager:close(self.coll_menu)
     end
     UIManager:show(self.coll_menu)
     return true

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -42,10 +42,24 @@ function FileSearcher:readDir()
                 -- Don't traverse hidden folders if we're not showing them
                 if attributes.mode == "directory" and f ~= "." and f ~= ".." and (G_reader_settings:isTrue("show_hidden") or not util.stringStartsWith(f, ".")) then
                     table.insert(new_dirs, fullpath)
-                    table.insert(self.files, {name = f, text = f.."/", attr = attributes, callback = function() FileManager:showFiles(fullpath) end})
+                    table.insert(self.files, {
+                        name = f,
+                        text = f.."/",
+                        attr = attributes,
+                        callback = function()
+                            FileManager:showFiles(fullpath)
+                        end,
+                    })
                 -- Always ignore macOS resource forks, too.
                 elseif attributes.mode == "file" and not util.stringStartsWith(f, "._") and (show_unsupported or DocumentRegistry:hasProvider(fullpath)) then
-                    table.insert(self.files, {name = f, text = f, attr = attributes, callback = function() ReaderUI:showReader(fullpath) end})
+                    table.insert(self.files, {
+                        name = f,
+                        text = f,
+                        attr = attributes,
+                        callback = function()
+                            ReaderUI:showReader(fullpath)
+                        end,
+                    })
                 end
             end
         end

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -155,12 +155,7 @@ function FileManagerHistory:onShowHist()
 
     self:updateItemTable()
     self.hist_menu.close_callback = function()
-        -- Close it at next tick so it stays displayed
-        -- while a book is opening (avoids a transient
-        -- display of the underlying File Browser)
-        UIManager:nextTick(function()
-            UIManager:close(self.hist_menu)
-        end)
+        UIManager:close(self.hist_menu)
     end
     UIManager:show(self.hist_menu)
     return true

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -122,13 +122,17 @@ function FileManagerMenu:onOpenLastDoc()
         })
         return
     end
-    local ReaderUI = require("apps/reader/readerui")
-    ReaderUI:showReader(last_file)
 
-    -- only close menu if we were called from the menu
+    -- Only close menu if we were called from the menu
     if self.menu_container then
+        -- Mimic's FileManager's onShowingReader refresh optimizations
+        self.ui.tearing_down = true
+        self.ui.dithered = nil
         self:onCloseFileManagerMenu()
     end
+
+    local ReaderUI = require("apps/reader/readerui")
+    ReaderUI:showReader(last_file)
 end
 
 function FileManagerMenu:setUpdateItemTable()
@@ -784,7 +788,7 @@ function FileManagerMenu:onShowMenu(tab_index)
         }
     end
 
-    main_menu.close_callback = function ()
+    main_menu.close_callback = function()
         self:onCloseFileManagerMenu()
     end
 

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -188,7 +188,7 @@ function ReaderFont:onShowFontMenu()
         dimen = Screen:getSize(),
         main_menu,
     }
-    main_menu.close_callback = function ()
+    main_menu.close_callback = function()
         UIManager:close(menu_container)
     end
     -- show menu

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -376,7 +376,7 @@ function ReaderMenu:onShowMenu(tab_index)
         }
     end
 
-    main_menu.close_callback = function ()
+    main_menu.close_callback = function()
         self.ui:handleEvent(Event:new("CloseReaderMenu"))
     end
 

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -1,6 +1,6 @@
-local Cache = require("cache")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
+local DocCache = require("document/doccache")
 local Event = require("ui/event")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
@@ -458,9 +458,9 @@ function ReaderZooming:getZoom(pageno)
                          or self.zoom_factor
         zoom = zoom_w * zoom_factor
     end
-    if zoom and zoom > 10 and not Cache:willAccept(zoom * (self.dimen.w * self.dimen.h + 512)) then
+    if zoom and zoom > 10 and not DocCache:willAccept(zoom * (self.dimen.w * self.dimen.h + 512)) then
         logger.dbg("zoom too large, adjusting")
-        while not Cache:willAccept(zoom * (self.dimen.w * self.dimen.h + 512)) do
+        while not DocCache:willAccept(zoom * (self.dimen.w * self.dimen.h + 512)) do
             if zoom > 100 then
                 zoom = zoom - 50
             elseif zoom > 10 then

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -458,9 +458,9 @@ function ReaderZooming:getZoom(pageno)
                          or self.zoom_factor
         zoom = zoom_w * zoom_factor
     end
-    if zoom and zoom > 10 and not Cache:willAccept(zoom * (self.dimen.w * self.dimen.h + 64)) then
+    if zoom and zoom > 10 and not Cache:willAccept(zoom * (self.dimen.w * self.dimen.h + 512)) then
         logger.dbg("zoom too large, adjusting")
-        while not Cache:willAccept(zoom * (self.dimen.w * self.dimen.h + 64)) do
+        while not Cache:willAccept(zoom * (self.dimen.w * self.dimen.h + 512)) do
             if zoom > 100 then
                 zoom = zoom - 50
             elseif zoom > 10 then

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -733,13 +733,13 @@ function ReaderUI:onClose(full_refresh)
     if self.dialog ~= self then
         self:saveSettings()
     end
+    -- serialize last used items for later launch
+    Cache:serialize()
     if self.document ~= nil then
         logger.dbg("closing document")
         self:notifyCloseDocument()
     end
     UIManager:close(self.dialog, full_refresh and "full")
-    -- serialize last used items for later launch
-    Cache:serialize()
     if _running_instance == self then
         _running_instance = nil
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -5,10 +5,10 @@ It works using data gathered from a document interface.
 ]]--
 
 local BD = require("ui/bidi")
-local Cache = require("cache")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local DeviceListener = require("device/devicelistener")
+local DocCache = require("document/doccache")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
 local Event = require("ui/event")
@@ -733,8 +733,8 @@ function ReaderUI:onClose(full_refresh)
     if self.dialog ~= self then
         self:saveSettings()
     end
-    -- serialize last used items for later launch
-    Cache:serialize()
+    -- Serialize the most recently displayed page for later launch
+    DocCache:serialize()
     if self.document ~= nil then
         logger.dbg("closing document")
         self:notifyCloseDocument()

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -52,6 +52,7 @@ local ReaderWikipedia = require("apps/reader/modules/readerwikipedia")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
 local Screenshoter = require("ui/widget/screenshoter")
 local SettingsMigration = require("ui/data/settings_migration")
+local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
 local ffiUtil  = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
@@ -277,19 +278,19 @@ function ReaderUI:init()
         end
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
-            local start_ts = ffiUtil.getTimestamp()
+            local start_tv = TimeVal:now()
             if not self.document:loadDocument() then
                 self:dealWithLoadDocumentFailure()
             end
-            logger.dbg(string.format("  loading took %.3f seconds", ffiUtil.getDuration(start_ts)))
+            logger.dbg(string.format("  loading took %.3f seconds", TimeVal:getDuration(start_tv)))
 
             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)
             self:handleEvent(Event:new("PreRenderDocument", self.doc_settings))
 
-            start_ts = ffiUtil.getTimestamp()
+            start_tv = TimeVal:now()
             self.document:render()
-            logger.dbg(string.format("  rendering took %.3f seconds", ffiUtil.getDuration(start_ts)))
+            logger.dbg(string.format("  rendering took %.3f seconds", TimeVal:getDuration(start_tv)))
 
             -- Uncomment to output the built DOM (for debugging)
             -- logger.dbg(self.document:getHTMLFromXPointer(".0", 0x6830))

--- a/frontend/cache.lua
+++ b/frontend/cache.lua
@@ -12,28 +12,99 @@ if CanvasContext.should_restrict_JIT then
     jit.off(true, true)
 end
 
+-- For documentation purposes, here's a battle-tested shell version of calcFreeMem
+--[[
+    if grep -q 'MemAvailable' /proc/meminfo ; then
+        # We'll settle for 85% of available memory to leave a bit of breathing room
+        tmpfs_size="$(awk '/MemAvailable/ {printf "%d", $2 * 0.85}' /proc/meminfo)"
+    elif grep -q 'Inactive(file)' /proc/meminfo ; then
+        # Basically try to emulate the kernel's computation, c.f., https://unix.stackexchange.com/q/261247
+        # Again, 85% of available memory
+        tmpfs_size="$(awk -v low=$(grep low /proc/zoneinfo | awk '{k+=$2}END{printf "%d", k}') \
+            '{a[$1]=$2}
+            END{
+                printf "%d", (a["MemFree:"]+a["Active(file):"]+a["Inactive(file):"]+a["SReclaimable:"]-(12*low))*0.85;
+            }' /proc/meminfo)"
+    else
+        # Ye olde crap workaround of Free + Buffers + Cache...
+        # Take it with a grain of salt, and settle for 80% of that...
+        tmpfs_size="$(awk \
+            '{a[$1]=$2}
+            END{
+                printf "%d", (a["MemFree:"]+a["Buffers:"]+a["Cached:"])*0.80;
+            }' /proc/meminfo)"
+    fi
+--]]
+
+-- And here's our simplified Lua version...
 local function calcFreeMem()
+    local memtotal, memfree, memavailable, buffers, cached
+
     local meminfo = io.open("/proc/meminfo", "r")
-    local freemem = 0
     if meminfo then
         for line in meminfo:lines() do
-            local free, buffer, cached, n
-            free, n = line:gsub("^MemFree:%s-(%d+) kB", "%1")
-            if n ~= 0 then freemem = freemem + tonumber(free)*1024 end
-            buffer, n = line:gsub("^Buffers:%s-(%d+) kB", "%1")
-            if n ~= 0 then freemem = freemem + tonumber(buffer)*1024 end
-            cached, n = line:gsub("^Cached:%s-(%d+) kB", "%1")
-            if n ~= 0 then freemem = freemem + tonumber(cached)*1024 end
+            if not memtotal then
+                memtotal = line:match("^MemTotal:%s-(%d+) kB")
+                if memtotal then
+                    -- Next!
+                    goto continue
+                end
+            end
+
+            if not memfree then
+                memfree = line:match("^MemFree:%s-(%d+) kB")
+                if memfree then
+                    -- Next!
+                    goto continue
+                end
+            end
+
+            if not memavailable then
+                memavailable = line:match("^MemAvailable:%s-(%d+) kB")
+                if memavailable then
+                    -- Best case scenario, we're done :)
+                    break
+                end
+            end
+
+            if not buffers then
+                buffers = line:match("^Buffers:%s-(%d+) kB")
+                if buffers then
+                    -- Next!
+                    goto continue
+                end
+            end
+
+            if not cached then
+                cached = line:match("^Cached:%s-(%d+) kB")
+                if cached then
+                    -- Ought to be the last entry we care about, we're done
+                    break
+                end
+            end
+
+            ::continue::
         end
         meminfo:close()
+    else
+        -- Not on Linux?
+        return 0, 0
     end
-    return freemem
+
+    if memavailable then
+        -- Leave a bit of margin, and report 85% of that...
+        return math.floor(memavailable * 0.85) * 1024, memtotal * 1024
+    else
+        -- Crappy Free + Buffers + Cache version, because the zoneinfo approach is a tad hairy...
+        -- So, leave an even larger margin, and only report 75% of that...
+        return math.floor((memfree + buffers + cached) * 0.75) * 1024, memtotal * 1024
+    end
 end
 
 local function calcCacheMemSize()
     local min = DGLOBAL_CACHE_SIZE_MINIMUM
     local max = DGLOBAL_CACHE_SIZE_MAXIMUM
-    local calc = calcFreeMem()*(DGLOBAL_CACHE_FREE_PROPORTION or 0)
+    local calc = calcFreeMem() * (DGLOBAL_CACHE_FREE_PROPORTION or 0)
     return math.min(max, math.max(min, calc))
 end
 
@@ -45,7 +116,7 @@ local cache_path = DataStorage:getDataDir() .. "/cache/"
 local function getDiskCache()
     local cached = {}
     for key_md5 in lfs.dir(cache_path) do
-        local file = cache_path..key_md5
+        local file = cache_path .. key_md5
         if lfs.attributes(file, "mode") == "file" then
             cached[key_md5] = file
         end
@@ -78,13 +149,13 @@ function Cache:_unref(key)
     for i = #self.cache_order, 1, -1 do
         if self.cache_order[i] == key then
             table.remove(self.cache_order, i)
+            break
         end
     end
 end
 
 -- internal: free cache item
 function Cache:_free(key)
-    if not self.cache[key] then return end
     self.current_memsize = self.current_memsize - self.cache[key].size
     self.cache[key]:onFree()
     self.cache[key] = nil
@@ -92,6 +163,8 @@ end
 
 -- drop an item named via key from the cache
 function Cache:drop(key)
+    if not self.cache[key] then return end
+
     self:_unref(key)
     self:_free(key)
 end
@@ -99,31 +172,37 @@ end
 function Cache:insert(key, object)
     -- make sure that one key only exists once: delete existing
     self:drop(key)
-    -- guarantee that we have enough memory in cache
-    if (object.size > self.max_memsize) then
-        logger.warn("too much memory claimed for", key)
+    -- If this object is single-handledly too large for the cache, we're done
+    if object.size > self.max_memsize then
+        logger.warn("Too much memory would be claimed by caching", key)
         return
     end
-    -- delete objects that least recently used
+    -- If inserting this obect would blow the cache's watermark,
+    -- start dropping least recently used items first.
     -- (they are at the end of the cache_order array)
     while self.current_memsize + object.size > self.max_memsize do
         local removed_key = table.remove(self.cache_order)
-        self:_free(removed_key)
+        if removed_key then
+            self:_free(removed_key)
+        else
+            logger.warn("Cache accounting is broken")
+            break
+        end
     end
-    -- insert new object in front of the LRU order
+    -- Insert new object in front of the LRU order
     table.insert(self.cache_order, 1, key)
     self.cache[key] = object
     self.current_memsize = self.current_memsize + object.size
 end
 
 --[[
---  check for cache item for key
+--  check for cache item by key
 --  if ItemClass is given, disk cache is also checked.
 --]]
 function Cache:check(key, ItemClass)
     if self.cache[key] then
         if self.cache_order[1] ~= key then
-            -- put key in front of the LRU list
+            -- Move key in front of the LRU list (i.e., MRU)
             self:_unref(key)
             table.insert(self.cache_order, 1, key)
         end
@@ -137,57 +216,77 @@ function Cache:check(key, ItemClass)
                 self:insert(key, item)
                 return item
             else
-                logger.warn("discard cache", msg)
+                logger.warn("Failed to load on-disk cache:", msg)
+                --- It's apparently unusable, purge it and refresh the snapshot.
+                os.remove(cached)
+                self:refreshSnapshot()
             end
         end
     end
 end
 
 function Cache:willAccept(size)
-    -- we only allow single objects to fill 75% of the cache
-    if size*4 < self.max_memsize*3 then
-        return true
-    end
+    -- We only allow single objects to fill 75% of the cache
+    return size*4 < self.max_memsize*3
 end
 
 function Cache:serialize()
-    -- calculate disk cache size
+    -- Calculate the current disk cache size
     local cached_size = 0
     local sorted_caches = {}
     for _, file in pairs(self.cached) do
         table.insert(sorted_caches, {file=file, time=lfs.attributes(file, "access")})
         cached_size = cached_size + (lfs.attributes(file, "size") or 0)
     end
-    table.sort(sorted_caches, function(v1,v2) return v1.time > v2.time end)
-    -- only serialize the most recently used cache
-    local cache_size = 0
+    table.sort(sorted_caches, function(v1, v2) return v1.time > v2.time end)
+
+    -- Only serialize the second most recently used cache item (as the MRU would be the *hinted* page).
+    local mru_key
+    local mru_found = 0
     for _, key in ipairs(self.cache_order) do
         local cache_item = self.cache[key]
 
-        -- only dump cache item that requests serialization explicitly
+        -- Only dump cache items that actually request persistence
         if cache_item.persistent and cache_item.dump then
-            local cache_full_path = cache_path..md5(key)
-            local cache_file_exists = lfs.attributes(cache_full_path)
-
-            if cache_file_exists then break end
-
-            logger.dbg("dump cache item", key)
-            cache_size = cache_item:dump(cache_full_path) or 0
-            if cache_size > 0 then break end
+            mru_key = key
+            mru_found = mru_found + 1
+            if mru_found >= 2 then
+                -- We found the second MRU item, i.e., the *displayed* page
+                break
+            end
         end
     end
-    -- set disk cache the same limit as memory cache
-    while cached_size + cache_size - self.max_memsize > 0 do
+    if mru_key then
+        local cache_full_path = cache_path .. md5(mru_key)
+        local cache_file_exists = lfs.attributes(cache_full_path)
+
+        if not cache_file_exists then
+            logger.dbg("Dumping cache item", mru_key)
+            local cache_item = self.cache[mru_key]
+            local cache_size = cache_item:dump(cache_full_path)
+            if cache_size then
+                cached_size = cached_size + cache_size
+            end
+        end
+    end
+
+    -- Allocate the same amount of storage to the disk cache than the memory cache
+    while cached_size > self.max_memsize do
         -- discard the least recently used cache
         local discarded = table.remove(sorted_caches)
-        cached_size = cached_size - lfs.attributes(discarded.file, "size")
-        os.remove(discarded.file)
+        if discarded then
+            cached_size = cached_size - lfs.attributes(discarded.file, "size")
+            os.remove(discarded.file)
+        else
+            logger.warn("Cache accounting is broken")
+            break
+        end
     end
-    -- disk cache may have changes so need to refresh disk cache snapshot
-    self.cached = getDiskCache()
+    -- We may have updated the disk cache's content, so refresh its state
+    self:refreshSnapshot()
 end
 
--- blank the cache
+-- Blank the cache
 function Cache:clear()
     for k, _ in pairs(self.cache) do
         self.cache[k]:onFree()
@@ -197,9 +296,41 @@ function Cache:clear()
     self.current_memsize = 0
 end
 
+-- Terribly crappy workaround: evict half the cache if we appear to be redlining on free RAM...
+function Cache:memoryPressureCheck()
+    local memfree, memtotal = calcFreeMem()
+
+    -- Nonsensical values? (!Linux), skip this.
+    if memtotal == 0 then
+        return
+    end
+
+    -- If less that 20% of the total RAM is free, drop half the Cache...
+    if memfree / memtotal < 0.20 then
+        logger.warn("Running low on memory, evicting half of the cache...")
+        for i = #self.cache_order / 2, 1, -1 do
+            local removed_key = table.remove(self.cache_order)
+            self:_free(removed_key)
+        end
+
+        -- And finish by forcing a GC sweep now...
+        collectgarbage()
+        collectgarbage()
+    end
+end
+
 -- Refresh the disk snapshot (mainly used by ui/data/onetime_migration)
 function Cache:refreshSnapshot()
     self.cached = getDiskCache()
+end
+
+-- Evict the disk cache (ditto)
+function Cache:clearDiskCache()
+    for _, file in pairs(self.cached) do
+        os.remove(file)
+    end
+
+    self:refreshSnapshot()
 end
 
 return Cache

--- a/frontend/cacheitem.lua
+++ b/frontend/cacheitem.lua
@@ -3,8 +3,11 @@ Inheritable abstraction for cache items
 --]]
 
 local CacheItem = {
-    size = 64, -- some reasonable default for simple Lua values / small tables
+    size = 128, -- some reasonable default for a small table.
 }
+--- NOTE: As far as size estimations go, the assumption is that a key, value pair should roughly take two words,
+---       and the most common items we cache are Geom-like tables (i.e., 4 key-value pairs).
+---       That's generally a low estimation, especially for larger tables, where memory allocation trickery may be happening.
 
 function CacheItem:new(o)
     o = o or {}

--- a/frontend/cacheitem.lua
+++ b/frontend/cacheitem.lua
@@ -16,6 +16,9 @@ function CacheItem:new(o)
     return o
 end
 
+-- Called on eviction.
+-- We generally use it to free C/FFI ressources *immediately* (as opposed to relying on our Userdata/FFI finalizers to do it "later" on GC).
+-- c.f., TileCacheItem, GlyphCacheItem & ImageCacheItem
 function CacheItem:onFree()
 end
 

--- a/frontend/configurable.lua
+++ b/frontend/configurable.lua
@@ -1,3 +1,5 @@
+local ffiUtil = require("ffi/util")
+
 local Configurable = {}
 
 function Configurable:new(o)
@@ -8,7 +10,7 @@ function Configurable:new(o)
 end
 
 function Configurable:reset()
-    for key,value in pairs(self) do
+    for key, value in pairs(self) do
         local value_type = type(value)
         if value_type == "number" or value_type == "string" then
             self[key] = nil
@@ -18,7 +20,7 @@ end
 
 function Configurable:hash(sep)
     local hash = ""
-    for key,value in pairs(self) do
+    for key, value in ffiUtil.orderedPairs(self) do
         local value_type = type(value)
         if value_type == "number" or value_type == "string" then
             hash = hash..sep..value
@@ -31,7 +33,7 @@ function Configurable:loadDefaults(config_options)
     -- reset configurable before loading new options
     self:reset()
     local prefix = config_options.prefix.."_"
-    for i=1,#config_options do
+    for i=1, #config_options do
         local options = config_options[i].options
         for j=1,#options do
             local key = options[j].name
@@ -46,7 +48,7 @@ function Configurable:loadDefaults(config_options)
 end
 
 function Configurable:loadSettings(settings, prefix)
-    for key,value in pairs(self) do
+    for key, value in pairs(self) do
         local value_type = type(value)
         if value_type == "number" or value_type == "string"
             or value_type == "table" then
@@ -59,7 +61,7 @@ function Configurable:loadSettings(settings, prefix)
 end
 
 function Configurable:saveSettings(settings, prefix)
-    for key,value in pairs(self) do
+    for key, value in pairs(self) do
         local value_type = type(value)
         if value_type == "number" or value_type == "string"
             or value_type == "table" then

--- a/frontend/document/doccache.lua
+++ b/frontend/document/doccache.lua
@@ -1,0 +1,24 @@
+--[[
+"Global" LRU cache used by Document & friends.
+--]]
+
+local Cache = require("cache")
+local CanvasContext = require("document/canvascontext")
+local DataStorage = require("datastorage")
+
+local function calcCacheMemSize()
+    local min = DGLOBAL_CACHE_SIZE_MINIMUM
+    local max = DGLOBAL_CACHE_SIZE_MAXIMUM
+    local calc = Cache:_calcFreeMem() * (DGLOBAL_CACHE_FREE_PROPORTION or 0)
+    return math.min(max, math.max(min, calc))
+end
+
+local DocCache = Cache:new{
+    size = calcCacheMemSize(),
+    -- Average item size is a screen's worth of bitmap, mixed with a few much smaller tables (pgdim, pglinks, etc.), hence the / 3
+    avg_itemsize = math.floor(CanvasContext:getWidth() * CanvasContext:getHeight() * (CanvasContext.is_color_rendering_enabled and 4 or 1) / 3),
+    disk_cache = true,
+    cache_path = DataStorage:getDataDir() .. "/cache/",
+}
+
+return DocCache

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -1,7 +1,7 @@
 local Blitbuffer = require("ffi/blitbuffer")
-local Cache = require("cache")
 local CacheItem = require("cacheitem")
 local Configurable = require("configurable")
+local DocCache = require("document/doccache")
 local DrawContext = require("ffi/drawcontext")
 local CanvasContext = require("document/canvascontext")
 local Geom = require("ui/geometry")
@@ -172,14 +172,14 @@ end
 -- this might be overridden by a document implementation
 function Document:getNativePageDimensions(pageno)
     local hash = "pgdim|"..self.file.."|"..pageno
-    local cached = Cache:check(hash)
+    local cached = DocCache:check(hash)
     if cached then
         return cached[1]
     end
     local page = self._document:openPage(pageno)
     local page_size_w, page_size_h = page:getSize(self.dc_null)
     local page_size = Geom:new{ w = page_size_w, h = page_size_h }
-    Cache:insert(hash, CacheItem:new{ page_size })
+    DocCache:insert(hash, CacheItem:new{ page_size })
     page:close()
     return page_size
 end
@@ -372,10 +372,10 @@ end
 function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode)
     local hash_excerpt
     local hash = self:getFullPageHash(pageno, zoom, rotation, gamma, render_mode, self.render_color)
-    local tile = Cache:check(hash, TileCacheItem)
+    local tile = DocCache:check(hash, TileCacheItem)
     if not tile then
         hash_excerpt = hash.."|"..tostring(rect)
-        tile = Cache:check(hash_excerpt)
+        tile = DocCache:check(hash_excerpt)
     end
     if tile then return tile end
 
@@ -385,7 +385,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode)
     -- this will be the size we actually render
     local size = page_size
     -- we prefer to render the full page, if it fits into cache
-    if not Cache:willAccept(size.w * size.h * (self.render_color and 4 or 1) + 512) then
+    if not DocCache:willAccept(size.w * size.h * (self.render_color and 4 or 1) + 512) then
         -- whole page won't fit into cache
         logger.dbg("rendering only part of the page")
         --- @todo figure out how to better segment the page
@@ -430,7 +430,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode)
     local page = self._document:openPage(pageno)
     page:draw(dc, tile.bb, size.x, size.y, render_mode)
     page:close()
-    Cache:insert(hash, tile)
+    DocCache:insert(hash, tile)
 
     self:postRenderPage()
     return tile
@@ -440,7 +440,7 @@ end
 --- @todo this should trigger a background operation
 function Document:hintPage(pageno, zoom, rotation, gamma, render_mode)
     --- @note: Crappy safeguard around memory issues like in #7627: if we're eating too much RAM, drop half the cache...
-    Cache:memoryPressureCheck()
+    DocCache:memoryPressureCheck()
 
     logger.dbg("hinting page", pageno)
     self:renderPage(pageno, nil, zoom, rotation, gamma, render_mode)

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -10,9 +10,9 @@ local DEBUG = require("dbg")
 local Document = require("document/document")
 local Geom = require("ui/geometry")
 local KOPTContext = require("ffi/koptcontext")
+local Persist = require("persist")
 local TileCacheItem = require("document/tilecacheitem")
 local logger = require("logger")
-local serial = require("serialize")
 local util = require("ffi/util")
 
 local KoptInterface = {
@@ -36,16 +36,41 @@ end
 
 function ContextCacheItem:dump(filename)
     if self.kctx:isPreCache() == 0 then
-        logger.dbg("dumping koptcontext to", filename)
-        return serial.dump(self.size, KOPTContext.totable(self.kctx), filename)
+        logger.dbg("Dumping KOPTContext to", filename)
+
+        local cache_file = Persist:new{
+            path = filename,
+            codec = "zstd",
+        }
+
+        local t = KOPTContext.totable(self.kctx)
+        t.cache_size = self.size
+
+        local ok, size = cache_file:save(t)
+        if ok then
+            return size
+        else
+            logger.warn("Failed to dump KOPTContext")
+            return nil
+        end
     end
 end
 
 function ContextCacheItem:load(filename)
-    logger.dbg("loading koptcontext from", filename)
-    local size, kc_table = serial.load(filename)
-    self.size = size
-    self.kctx = KOPTContext.fromtable(kc_table)
+    logger.dbg("Loading KOPTContext from", filename)
+
+    local cache_file = Persist:new{
+        path = filename,
+        codec = "zstd",
+    }
+
+    local t = cache_file:load(filename)
+    if t then
+        self.size = t.cache_size
+        self.kctx = KOPTContext.fromtable(t)
+    else
+        logger.warn("Failed to load KOPTContext")
+    end
 end
 
 local OCREngine = CacheItem:new{}
@@ -154,7 +179,8 @@ Auto detect bbox.
 function KoptInterface:getAutoBBox(doc, pageno)
     local native_size = Document.getNativePageDimensions(doc, pageno)
     local bbox = {
-        x0 = 0, y0 = 0,
+        x0 = 0,
+        y0 = 0,
         x1 = native_size.w,
         y1 = native_size.h,
     }
@@ -172,7 +198,7 @@ function KoptInterface:getAutoBBox(doc, pageno)
         else
             bbox = Document.getPageBBox(doc, pageno)
         end
-        Cache:insert(hash, CacheItem:new{ autobbox = bbox })
+        Cache:insert(hash, CacheItem:new{ autobbox = bbox, size = 160 })
         page:close()
         kc:free()
         return bbox
@@ -207,7 +233,7 @@ function KoptInterface:getSemiAutoBBox(doc, pageno)
             auto_bbox = bbox
         end
         page:close()
-        Cache:insert(hash, CacheItem:new{ semiautobbox = auto_bbox })
+        Cache:insert(hash, CacheItem:new{ semiautobbox = auto_bbox, size = 160 })
         kc:free()
         return auto_bbox
     else
@@ -240,7 +266,7 @@ function KoptInterface:getCachedContext(doc, pageno)
         --self:logReflowDuration(pageno, dur)
         local fullwidth, fullheight = kc:getPageDim()
         logger.dbg("reflowed page", pageno, "fullwidth:", fullwidth, "fullheight:", fullheight)
-        self.last_context_size = fullwidth * fullheight + 128 -- estimation
+        self.last_context_size = fullwidth * fullheight + 3072 -- estimation
         Cache:insert(kctx_hash, ContextCacheItem:new{
             persistent = true,
             size = self.last_context_size,
@@ -251,7 +277,7 @@ function KoptInterface:getCachedContext(doc, pageno)
         -- wait for background thread
         local kc = self:waitForContext(cached.kctx)
         local fullwidth, fullheight = kc:getPageDim()
-        self.last_context_size = fullwidth * fullheight + 128 -- estimation
+        self.last_context_size = fullwidth * fullheight + 3072 -- estimation
         return kc
     end
 end
@@ -312,20 +338,20 @@ function KoptInterface:renderReflowedPage(doc, pageno, rect, zoom, rotation, ren
 
     local cached = Cache:check(renderpg_hash)
     if not cached then
-        -- do the real reflowing if kctx is not been cached yet
+        -- do the real reflowing if kctx has not been cached yet
         local kc = self:getCachedContext(doc, pageno)
         local fullwidth, fullheight = kc:getPageDim()
-        if not Cache:willAccept(fullwidth * fullheight / 2) then
+        if not Cache:willAccept(fullwidth * fullheight) then
             -- whole page won't fit into cache
             error("aborting, since we don't have enough cache for this page")
         end
         -- prepare cache item with contained blitbuffer
         local tile = TileCacheItem:new{
-            size = fullwidth * fullheight + 64, -- estimation
             excerpt = Geom:new{ w = fullwidth, h = fullheight },
             pageno = pageno,
         }
         tile.bb = kc:dstToBlitBuffer()
+        tile.size = tonumber(tile.bb.stride) * tile.bb.h + 512 -- estimation
         Cache:insert(renderpg_hash, tile)
         return tile
     else
@@ -363,7 +389,6 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, re
         -- prepare cache item with contained blitbuffer
         local tile = TileCacheItem:new{
             persistent = true,
-            size = fullwidth * fullheight + 64, -- estimation
             excerpt = Geom:new{
                 x = 0, y = 0,
                 w = fullwidth,
@@ -372,6 +397,7 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, re
             pageno = pageno,
         }
         tile.bb = kc:dstToBlitBuffer()
+        tile.size = tonumber(tile.bb.stride) * tile.bb.h + 512 -- estimation
         kc:free()
         Cache:insert(renderpg_hash, tile)
         return tile
@@ -478,8 +504,8 @@ function KoptInterface:getReflowedTextBoxes(doc, pageno)
             local kc = self:waitForContext(cached.kctx)
             --kc:setDebug()
             local fullwidth, fullheight = kc:getPageDim()
-            local boxes = kc:getReflowedWordBoxes("dst", 0, 0, fullwidth, fullheight)
-            Cache:insert(hash, CacheItem:new{ rfpgboxes = boxes })
+            local boxes, nr_word = kc:getReflowedWordBoxes("dst", 0, 0, fullwidth, fullheight)
+            Cache:insert(hash, CacheItem:new{ rfpgboxes = boxes, size = 192 * nr_word }) -- estimation
             return boxes
         end
     else
@@ -502,8 +528,8 @@ function KoptInterface:getNativeTextBoxes(doc, pageno)
             local kc = self:waitForContext(cached.kctx)
             --kc:setDebug()
             local fullwidth, fullheight = kc:getPageDim()
-            local boxes = kc:getNativeWordBoxes("dst", 0, 0, fullwidth, fullheight)
-            Cache:insert(hash, CacheItem:new{ nativepgboxes = boxes })
+            local boxes, nr_word = kc:getNativeWordBoxes("dst", 0, 0, fullwidth, fullheight)
+            Cache:insert(hash, CacheItem:new{ nativepgboxes = boxes, size = 192 * nr_word }) -- estimation
             return boxes
         end
     else
@@ -529,8 +555,8 @@ function KoptInterface:getReflowedTextBoxesFromScratch(doc, pageno)
             local fullwidth, fullheight = reflowed_kc:getPageDim()
             local kc = self:createContext(doc, pageno)
             kc:copyDestBMP(reflowed_kc)
-            local boxes = kc:getNativeWordBoxes("dst", 0, 0, fullwidth, fullheight)
-            Cache:insert(hash, CacheItem:new{ scratchrfpgboxes = boxes })
+            local boxes, nr_word = kc:getNativeWordBoxes("dst", 0, 0, fullwidth, fullheight)
+            Cache:insert(hash, CacheItem:new{ scratchrfpgboxes = boxes, size = 192 * nr_word }) -- estimation
             kc:free()
             return boxes
         end
@@ -575,8 +601,8 @@ function KoptInterface:getNativeTextBoxesFromScratch(doc, pageno)
         kc:setZoom(1.0)
         local page = doc._document:openPage(pageno)
         page:getPagePix(kc)
-        local boxes = kc:getNativeWordBoxes("src", 0, 0, page_size.w, page_size.h)
-        Cache:insert(hash, CacheItem:new{ scratchnativepgboxes = boxes })
+        local boxes, nr_word = kc:getNativeWordBoxes("src", 0, 0, page_size.w, page_size.h)
+        Cache:insert(hash, CacheItem:new{ scratchnativepgboxes = boxes, size = 192 * nr_word }) -- estimation
         page:close()
         kc:free()
         return boxes
@@ -607,7 +633,7 @@ function KoptInterface:getPageBlock(doc, pageno, x, y)
         local page = doc._document:openPage(pageno)
         page:getPagePix(kc)
         kc:findPageBlocks()
-        Cache:insert(hash, CacheItem:new{ kctx = kc })
+        Cache:insert(hash, CacheItem:new{ kctx = kc, size = 3072 }) -- estimation
         page:close()
         kctx = kc
     else
@@ -621,7 +647,7 @@ Get word from OCR providing selected word box.
 --]]
 function KoptInterface:getOCRWord(doc, pageno, wbox)
     if not Cache:check(self.ocrengine) then
-        Cache:insert(self.ocrengine, OCREngine:new{ ocrengine = KOPTContext.new() })
+        Cache:insert(self.ocrengine, OCREngine:new{ ocrengine = KOPTContext.new(), size = 3072 }) -- estimation
     end
     if doc.configurable.text_wrap == 1 then
         return self:getReflewOCRWord(doc, pageno, wbox.sbox)
@@ -648,7 +674,7 @@ function KoptInterface:getReflewOCRWord(doc, pageno, rect)
                 kc.getTOCRWord, kc, "dst",
                 rect.x, rect.y, rect.w, rect.h,
                 self.tessocr_data, self.ocr_lang, self.ocr_type, 0, 1)
-            Cache:insert(hash, CacheItem:new{ rfocrword = word })
+            Cache:insert(hash, CacheItem:new{ rfocrword = word, size = #word + 64 }) -- estimation
             return word
         end
     else
@@ -681,7 +707,7 @@ function KoptInterface:getNativeOCRWord(doc, pageno, rect)
             kc.getTOCRWord, kc, "src",
             0, 0, word_w, word_h,
             self.tessocr_data, self.ocr_lang, self.ocr_type, 0, 1)
-        Cache:insert(hash, CacheItem:new{ ocrword = word })
+        Cache:insert(hash, CacheItem:new{ ocrword = word, size = #word + 64 }) -- estimation
         logger.dbg("word", word)
         page:close()
         kc:free()
@@ -696,7 +722,7 @@ Get text from OCR providing selected text boxes.
 --]]
 function KoptInterface:getOCRText(doc, pageno, tboxes)
     if not Cache:check(self.ocrengine) then
-        Cache:insert(self.ocrengine, OCREngine:new{ ocrengine = KOPTContext.new() })
+        Cache:insert(self.ocrengine, OCREngine:new{ ocrengine = KOPTContext.new(), size = 3072 }) -- estimation
     end
     logger.info("Not implemented yet")
 end

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -152,9 +152,9 @@ function PdfDocument:getUsedBBox(pageno)
     if used.x1 > pwidth then used.x1 = pwidth end
     if used.y0 < 0 then used.y0 = 0 end
     if used.y1 > pheight then used.y1 = pheight end
-    --- @todo Give size for cacheitem?  02.12 2012 (houqp)
     Cache:insert(hash, CacheItem:new{
         ubbox = used,
+        size = 256, -- might be closer to 160
     })
     page:close()
     return used
@@ -170,6 +170,7 @@ function PdfDocument:getPageLinks(pageno)
     local links = page:getPageLinks()
     Cache:insert(hash, CacheItem:new{
         links = links,
+        size = 64 + (8 * 32 * #links),
     })
     page:close()
     return links

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -1,6 +1,6 @@
-local Cache = require("cache")
 local CacheItem = require("cacheitem")
 local CanvasContext = require("document/canvascontext")
+local DocCache = require("document/doccache")
 local DocSettings = require("docsettings")
 local Document = require("document/document")
 local DrawContext = require("ffi/drawcontext")
@@ -139,7 +139,7 @@ end
 
 function PdfDocument:getUsedBBox(pageno)
     local hash = "pgubbox|"..self.file.."|"..self.reflowable_font_size.."|"..pageno
-    local cached = Cache:check(hash)
+    local cached = DocCache:check(hash)
     if cached then
         return cached.ubbox
     end
@@ -152,7 +152,7 @@ function PdfDocument:getUsedBBox(pageno)
     if used.x1 > pwidth then used.x1 = pwidth end
     if used.y0 < 0 then used.y0 = 0 end
     if used.y1 > pheight then used.y1 = pheight end
-    Cache:insert(hash, CacheItem:new{
+    DocCache:insert(hash, CacheItem:new{
         ubbox = used,
         size = 256, -- might be closer to 160
     })
@@ -162,13 +162,13 @@ end
 
 function PdfDocument:getPageLinks(pageno)
     local hash = "pglinks|"..self.file.."|"..self.reflowable_font_size.."|"..pageno
-    local cached = Cache:check(hash)
+    local cached = DocCache:check(hash)
     if cached then
         return cached.links
     end
     local page = self._document:openPage(pageno)
     local links = page:getPageLinks()
-    Cache:insert(hash, CacheItem:new{
+    DocCache:insert(hash, CacheItem:new{
         links = links,
         size = 64 + (8 * 32 * #links),
     })

--- a/frontend/document/tilecacheitem.lua
+++ b/frontend/document/tilecacheitem.lua
@@ -6,10 +6,8 @@ local logger = require("logger")
 local TileCacheItem = CacheItem:new{}
 
 function TileCacheItem:onFree()
-    if self.bb.free then
-        logger.dbg("free blitbuffer", self.bb)
-        self.bb:free()
-    end
+    logger.dbg("TileCacheItem: free blitbuffer", self.bb)
+    self.bb:free()
 end
 
 --- @note: Perhaps one day we'll be able to teach bitser or string.buffer about custom structs with pointers to buffers,

--- a/frontend/document/tilecacheitem.lua
+++ b/frontend/document/tilecacheitem.lua
@@ -1,6 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local CacheItem = require("cacheitem")
-local serial = require("serialize")
+local Persist = require("persist")
 local logger = require("logger")
 
 local TileCacheItem = CacheItem:new{}
@@ -12,19 +12,65 @@ function TileCacheItem:onFree()
     end
 end
 
+--- @note: Perhaps one day we'll be able to teach bitser or string.buffer about custom structs with pointers to buffers,
+---        so we won't have to do the BB tostring/fromstring dance anymore...
+function TileCacheItem:totable()
+    local t = {
+        size = self.size,
+        pageno = self.pageno,
+        excerpt = self.excerpt,
+        persistent = self.persistent,
+        bb = {
+            w = self.bb.w,
+            h = self.bb.h,
+            stride = tonumber(self.bb.stride),
+            fmt = self.bb:getType(),
+            data = Blitbuffer.tostring(self.bb),
+        },
+    }
+
+    return t
+end
+
 function TileCacheItem:dump(filename)
-    logger.dbg("dumping tile cache to", filename, self.excerpt)
-    return serial.dump(self.size, self.excerpt, self.pageno,
-            self.bb.w, self.bb.h, tonumber(self.bb.stride), self.bb:getType(),
-            Blitbuffer.tostring(self.bb), filename)
+    logger.dbg("Dumping tile cache to", filename, self.excerpt)
+
+    local cache_file = Persist:new{
+        path = filename,
+        codec = "zstd",
+    }
+
+    local ok, size = cache_file:save(self:totable())
+    if ok then
+        return size
+    else
+        logger.warn("Failed to dump tile cache")
+        return nil
+    end
+end
+
+function TileCacheItem:fromtable(t)
+    self.size = t.size
+    self.pageno = t.pageno
+    self.excerpt = t.excerpt
+    self.persistent = t.persistent
+    self.bb = Blitbuffer.fromstring(t.bb.w, t.bb.h, t.bb.fmt, t.bb.data, t.bb.stride)
 end
 
 function TileCacheItem:load(filename)
-    local w, h, stride, bb_type, bb_data
-    self.size, self.excerpt, self.pageno,
-            w, h, stride, bb_type, bb_data = serial.load(filename)
-    self.bb = Blitbuffer.fromstring(w, h, bb_type, bb_data, stride)
-    logger.dbg("loading tile cache from", filename, self)
+    local cache_file = Persist:new{
+        path = filename,
+        codec = "zstd",
+    }
+
+    local t = cache_file:load(filename)
+    if t then
+        self:fromtable(t)
+
+        logger.dbg("Loaded tile cache from", filename, self)
+    else
+        logger.warn("Failed to load tile cache from", filename)
+    end
 end
 
 return TileCacheItem

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -94,7 +94,8 @@ local codecs = {
             C.fclose(f)
             C.free(cbuff)
 
-            return true
+            --- @note: Slight API extension for TileCacheItem, which needs to know the on-disk size, and saves us a :size() call
+            return true, clen
         end,
 
         deserialize = function(path)
@@ -216,6 +217,9 @@ function Persist:save(t, as_bytecode)
         if not ok then
             return nil, err
         end
+
+        -- c.f., note above, err is the on-disk size
+        return true, err
     else
         local str, err = codecs[self.codec].serialize(t, as_bytecode)
         if not str then

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -14,6 +14,11 @@ local ReadHistory = {
     last_read_time = 0,
 }
 
+local function selectCallback(path)
+    local ReaderUI = require("apps/reader/readerui")
+    ReaderUI:showReader(path)
+end
+
 local function buildEntry(input_time, input_file)
     local file_path = realpath(input_file) or input_file -- keep orig file path of deleted files
     local file_exists = lfs.attributes(file_path, "mode") == "file"
@@ -43,8 +48,7 @@ local function buildEntry(input_time, input_file)
             return lfs.attributes(file_path, "mode") == "file"
         end,
         callback = function()
-            local ReaderUI = require("apps/reader/readerui")
-            ReaderUI:showReader(input_file)
+            selectCallback(input_file)
         end
     }
 end
@@ -245,8 +249,7 @@ function ReadHistory:updateItemByPath(old_path, new_path)
             self.hist[i].text = new_path:gsub(".*/", "")
             self:_flush()
             self.hist[i].callback = function()
-                local ReaderUI = require("apps/reader/readerui")
-                ReaderUI:showReader(new_path)
+                selectCallback(new_path)
             end
             break
         end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -171,9 +171,9 @@ if last_migration_date < 20210409 then
        logger.warn("os.rename:", err)
     end
 
-    -- Make sure Cache gets the memo
-    local Cache = require("cache")
-    Cache:refreshSnapshot()
+    -- Make sure DocCache gets the memo
+    local DocCache = require("document/doccache")
+    DocCache:refreshSnapshot()
 end
 
 -- Calibre, cache migration, https://github.com/koreader/koreader/pull/7528
@@ -193,9 +193,9 @@ if last_migration_date < 20210412 then
        logger.warn("os.rename:", err)
     end
 
-    -- Make sure Cache gets the memo
-    local Cache = require("cache")
-    Cache:refreshSnapshot()
+    -- Make sure DocCache gets the memo
+    local DocCache = require("document/doccache")
+    DocCache:refreshSnapshot()
 end
 
 -- Calibre, cache encoding format change, https://github.com/koreader/koreader/pull/7543
@@ -209,12 +209,12 @@ if last_migration_date < 20210414 then
     end
 end
 
--- Cache, migration to Persist, https://github.com/koreader/koreader/pull/7624
+-- DocCache, migration to Persist, https://github.com/koreader/koreader/pull/7624
 if last_migration_date < 20210503 then
     logger.info("Performing one-time migration for 20210503")
 
-    local Cache = require("cache")
-    Cache:clearDiskCache()
+    local DocCache = require("document/doccache")
+    DocCache:clearDiskCache()
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210414
+local CURRENT_MIGRATION_DATE = 20210503
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -207,6 +207,14 @@ if last_migration_date < 20210414 then
     if not ok then
        logger.warn("os.remove:", err)
     end
+end
+
+-- Cache, migration to Persist, https://github.com/koreader/koreader/pull/7624
+if last_migration_date < 20210503 then
+    logger.info("Performing one-time migration for 20210503")
+
+    local Cache = require("cache")
+    Cache:clearDiskCache()
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -113,7 +113,7 @@ function RenderText:getGlyph(face, charcode, bold)
         return
     end
     glyph = CacheItem:new{rendered_glyph}
-    glyph.size = glyph[1].bb:getWidth() * glyph[1].bb:getHeight() / 2 + 32
+    glyph.size = tonumber(glyph[1].bb.stride) * glyph[1].bb.h + 320
     GlyphCache:insert(hash, glyph)
     return rendered_glyph
 end
@@ -314,7 +314,7 @@ function RenderText:getGlyphByIndex(face, glyphindex, bold)
         return
     end
     glyph = CacheItem:new{rendered_glyph}
-    glyph.size = glyph[1].bb:getWidth() * glyph[1].bb:getHeight() / 2 + 32
+    glyph.size = tonumber(glyph[1].bb.stride) * glyph[1].bb.h + 320
     GlyphCache:insert(hash, glyph)
     return rendered_glyph
 end

--- a/frontend/ui/rendertext.lua
+++ b/frontend/ui/rendertext.lua
@@ -24,12 +24,17 @@ end
 local RenderText = {}
 
 local GlyphCache = Cache:new{
-    max_memsize = 512*1024,
-    current_memsize = 0,
-    cache = {},
-    -- this will hold the LRU order of the cache
-    cache_order = {}
+    -- 1 MiB of glyph cache, with 1024 slots
+    size = 1 * 1024 * 1024,
+    avg_itemsize = 1024,
 }
+
+local GlyphCacheItem = CacheItem:new{}
+
+function GlyphCacheItem:onFree()
+    logger.dbg("GlyphCacheItem: free blitbuffer", self.bb)
+    self.bb:free()
+end
 
 -- iterator over UTF8 encoded characters in a string
 local function utf8Chars(input_text)
@@ -92,7 +97,7 @@ function RenderText:getGlyph(face, charcode, bold)
     local glyph = GlyphCache:check(hash)
     if glyph then
         -- cache hit
-        return glyph[1]
+        return glyph
     end
     local rendered_glyph = face.ftface:renderGlyph(charcode, bold)
     if face.ftface:checkGlyph(charcode) == 0 then
@@ -112,8 +117,15 @@ function RenderText:getGlyph(face, charcode, bold)
         logger.warn("error rendering glyph (charcode=", charcode, ") for face", face)
         return
     end
-    glyph = CacheItem:new{rendered_glyph}
-    glyph.size = tonumber(glyph[1].bb.stride) * glyph[1].bb.h + 320
+    glyph = GlyphCacheItem:new{
+        bb = rendered_glyph.bb,
+        l  = rendered_glyph.l,
+        t  = rendered_glyph.t,
+        r  = rendered_glyph.r,
+        ax = rendered_glyph.ax,
+        ay = rendered_glyph.ay,
+    }
+    glyph.size = tonumber(glyph.bb.stride) * glyph.bb.h + 320
     GlyphCache:insert(hash, glyph)
     return rendered_glyph
 end
@@ -306,15 +318,22 @@ function RenderText:getGlyphByIndex(face, glyphindex, bold)
     local glyph = GlyphCache:check(hash)
     if glyph then
         -- cache hit
-        return glyph[1]
+        return glyph
     end
     local rendered_glyph = face.ftface:renderGlyphByIndex(glyphindex, bold and face.embolden_half_strength)
     if not rendered_glyph then
         logger.warn("error rendering glyph (glyphindex=", glyphindex, ") for face", face)
         return
     end
-    glyph = CacheItem:new{rendered_glyph}
-    glyph.size = tonumber(glyph[1].bb.stride) * glyph[1].bb.h + 320
+    glyph = GlyphCacheItem:new{
+        bb = rendered_glyph.bb,
+        l  = rendered_glyph.l,
+        t  = rendered_glyph.t,
+        r  = rendered_glyph.r,
+        ax = rendered_glyph.ax,
+        ay = rendered_glyph.ay,
+    }
+    glyph.size = tonumber(glyph.bb.stride) * glyph.bb.h + 320
     GlyphCache:insert(hash, glyph)
     return rendered_glyph
 end

--- a/frontend/ui/timeval.lua
+++ b/frontend/ui/timeval.lua
@@ -238,6 +238,30 @@ function TimeVal:fromnumber(seconds)
     return TimeVal:new{ sec = sec, usec = usec }
 end
 
+--[[-- Compare a past *MONOTONIC* TimeVal object to *now*, returning the elapsed time between the two. (sec.usecs variant)
+
+Returns a Lua (decimal) number (sec.usecs) (accurate to the ms, rounded to 4 decimal places) (i.e., :tonumber())
+]]
+function TimeVal:getDuration(start_tv)
+   return (TimeVal:now() - start_tv):tonumber()
+end
+
+--[[-- Compare a past *MONOTONIC* TimeVal object to *now*, returning the elapsed time between the two. (µs variant)
+
+Returns a Lua (int) number (resolution: 1µs) (i.e., :tousecs())
+]]
+function TimeVal:getDurationUs(start_tv)
+   return (TimeVal:now() - start_tv):tousecs()
+end
+
+--[[-- Compare a past *MONOTONIC* TimeVal object to *now*, returning the elapsed time between the two. (ms variant)
+
+Returns a Lua (int) number (resolution: 1ms) (i.e., :tomsecs())
+]]
+function TimeVal:getDurationMs(start_tv)
+   return (TimeVal:now() - start_tv):tomsecs()
+end
+
 --- Checks if a TimeVal object is positive
 function TimeVal:isPositive()
     return self.sec >= 0

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -392,6 +392,8 @@ function DictQuickLookup:init()
                                                     self:onHoldClose(true)
                                                     -- close current ReaderUI in 1 sec, and create a new one
                                                     UIManager:scheduleIn(1.0, function()
+                                                        UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
                                                         if self.ui then
                                                             -- close Highlight menu if any still shown
                                                             if self.ui.highlight and self.ui.highlight.highlight_dialog then
@@ -399,6 +401,7 @@ function DictQuickLookup:init()
                                                             end
                                                             self.ui:onClose()
                                                         end
+
                                                         self.ui:showReader(epub_path)
                                                     end)
                                                 end,

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -540,7 +540,6 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
                         ok_callback = function()
                             DocumentRegistry:setProvider(file, provider, false)
 
-                            filemanager_instance:onClose()
                             reader_ui:showReader(file, provider)
                             UIManager:close(self.set_provider_dialog)
                         end,
@@ -554,14 +553,12 @@ function FileChooser:showSetProviderButtons(file, filemanager_instance, reader_u
                         ok_callback = function()
                             DocumentRegistry:setProvider(file, provider, true)
 
-                            filemanager_instance:onClose()
                             reader_ui:showReader(file, provider)
                             UIManager:close(self.set_provider_dialog)
                         end,
                     })
                 else
                     -- just once
-                    filemanager_instance:onClose()
                     reader_ui:showReader(file, provider)
                     UIManager:close(self.set_provider_dialog)
                 end

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -39,7 +39,7 @@ end
 local DPI_SCALE = get_dpi_scale()
 
 local ImageCache = Cache:new{
-    max_memsize = 5*1024*1024, -- 5M of image cache
+    max_memsize = 8*1024*1024, -- 8M of image cache
     current_memsize = 0,
     cache = {},
     -- this will hold the LRU order of the cache

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -39,20 +39,19 @@ end
 local DPI_SCALE = get_dpi_scale()
 
 local ImageCache = Cache:new{
-    max_memsize = 8*1024*1024, -- 8M of image cache
-    current_memsize = 0,
-    cache = {},
-    -- this will hold the LRU order of the cache
-    cache_order = {}
+    -- 8 MiB of image cache, with 128 slots
+    -- Overwhelmingly used for our icons, which are tiny in size, and not very numerous (< 100),
+    -- but also by ImageViewer (on files, which we never do), and ScreenSaver (again, on image files, but not covers),
+    -- hence the leeway.
+    size = 8 * 1024 * 1024,
+    avg_itemsize = 64 * 1024,
 }
 
 local ImageCacheItem = CacheItem:new{}
 
 function ImageCacheItem:onFree()
-    if self.bb.free then
-        logger.dbg("free image blitbuffer", self.bb)
-        self.bb:free()
-    end
+    logger.dbg("ImageCacheItem: free blitbuffer", self.bb)
+    self.bb:free()
 end
 
 local ImageWidget = Widget:new{

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -592,8 +592,15 @@ function TouchMenu:init()
 end
 
 function TouchMenu:onCloseWidget()
-    -- NOTE: We don't pass a region in order to ensure a full-screen flash to avoid ghosting
-    UIManager:setDirty(nil, "flashui")
+    -- NOTE: We don't pass a region in order to ensure a full-screen flash to avoid ghosting,
+    --       but we only need to do that if we actually have a FM or RD below us.
+    -- Don't do anything when we're switching between the two, or if we don't actually have a live instance of 'em...
+    local FileManager = require("apps/filemanager/filemanager")
+    local ReaderUI = require("apps/reader/readerui")
+    local reader_ui = ReaderUI:_getRunningInstance()
+    if (FileManager.instance and not FileManager.instance.tearing_down) or (reader_ui and not reader_ui.tearing_down) then
+        UIManager:setDirty(nil, "flashui")
+    end
 end
 
 function TouchMenu:_recalculatePageLayout()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -110,8 +110,8 @@ function AutoSuspend:init()
     self.auto_suspend_timeout_seconds = G_reader_settings:readSetting("auto_suspend_timeout_seconds") or default_auto_suspend_timeout_seconds
 
     UIManager.event_hook:registerWidget("InputEvent", self)
-    -- We need an instance-specific function reference to schedule, because when going from FM to RD,
-    -- we instantiate the RD instance *before* tearing down the old FM instance.
+    -- We need an instance-specific function reference to schedule, because in some rare cases,
+    -- we may instantiate a new plugin instance *before* tearing down the old one.
     self.task = function(shutdown_only)
         self:_schedule(shutdown_only)
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -24,10 +24,11 @@ local default_auto_suspend_timeout_seconds = 60*60
 local AutoSuspend = WidgetContainer:new{
     name = "autosuspend",
     is_doc_only = false,
-    autoshutdown_timeout_seconds = G_reader_settings:readSetting("autoshutdown_timeout_seconds") or default_autoshutdown_timeout_seconds,
-    auto_suspend_timeout_seconds = G_reader_settings:readSetting("auto_suspend_timeout_seconds") or default_auto_suspend_timeout_seconds,
-    last_action_tv = TimeVal:now(),
+    autoshutdown_timeout_seconds = default_autoshutdown_timeout_seconds,
+    auto_suspend_timeout_seconds = default_auto_suspend_timeout_seconds,
+    last_action_tv = TimeVal.zero,
     standby_prevented = false,
+    task = nil,
 }
 
 function AutoSuspend:_enabled()
@@ -67,18 +68,20 @@ function AutoSuspend:_schedule(shutdown_only)
     else
         if self:_enabled() and not shutdown_only then
             logger.dbg("AutoSuspend: scheduling next suspend check in", delay_suspend)
-            UIManager:scheduleIn(delay_suspend, self._schedule, self, shutdown_only)
+            UIManager:scheduleIn(delay_suspend, self.task)
         end
         if self:_enabledShutdown() then
             logger.dbg("AutoSuspend: scheduling next shutdown check in", delay_shutdown)
-            UIManager:scheduleIn(delay_shutdown, self._schedule, self, shutdown_only)
+            UIManager:scheduleIn(delay_shutdown, self.task)
         end
     end
 end
 
 function AutoSuspend:_unschedule()
-    logger.dbg("AutoSuspend: unschedule")
-    UIManager:unschedule(self._schedule)
+    if self.task then
+        logger.dbg("AutoSuspend: unschedule")
+        UIManager:unschedule(self.task)
+    end
 end
 
 function AutoSuspend:_start()
@@ -103,8 +106,15 @@ end
 function AutoSuspend:init()
     logger.dbg("AutoSuspend: init")
     if Device:isPocketBook() and not Device:canSuspend() then return end
+    self.autoshutdown_timeout_seconds = G_reader_settings:readSetting("autoshutdown_timeout_seconds") or default_autoshutdown_timeout_seconds
+    self.auto_suspend_timeout_seconds = G_reader_settings:readSetting("auto_suspend_timeout_seconds") or default_auto_suspend_timeout_seconds
+
     UIManager.event_hook:registerWidget("InputEvent", self)
-    self:_unschedule()
+    -- We need an instance-specific function reference to schedule, because when going from FM to RD,
+    -- we instantiate the RD instance *before* tearing down the old FM instance.
+    self.task = function(shutdown_only)
+        self:_schedule(shutdown_only)
+    end
     self:_start()
     -- self.ui is nil in the testsuite
     if not self.ui or not self.ui.menu then return end
@@ -116,6 +126,7 @@ function AutoSuspend:onCloseWidget()
     logger.dbg("AutoSuspend: onCloseWidget")
     if Device:isPocketBook() and not Device:canSuspend() then return end
     self:_unschedule()
+    self.task = nil
 end
 
 function AutoSuspend:onInputEvent()

--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -261,12 +261,12 @@ function CalibreMetadata:init(dir, is_search)
     if is_search then
         self:cleanUnused(is_search)
         msg = string.format("(search) in %.3f milliseconds: %d books",
-            (TimeVal:now() - start):tomsecs(), #self.books)
+            TimeVal:getDurationMs(start), #self.books)
     else
         local deleted_count = self:prune()
         self:cleanUnused()
         msg = string.format("in %.3f milliseconds: %d books. %d pruned",
-            (TimeVal:now() - start):tomsecs(), #self.books, deleted_count)
+            TimeVal:getDurationMs(start), #self.books, deleted_count)
     end
     logger.info(string.format("calibre info loaded from disk %s", msg))
     return true

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -338,7 +338,7 @@ function CalibreSearch:find(option)
         self:browse(option, 1)
     end
     logger.info(string.format("search done in %.3f milliseconds (%s, %s, %s, %s, %s)",
-        (TimeVal:now() - start):tomsecs(),
+        TimeVal:getDurationMs(start),
         option == "find" and "books" or option,
         "case sensitive: " .. tostring(not self.case_insensitive),
         "title: " .. tostring(self.find_by_title),
@@ -604,7 +604,7 @@ function CalibreSearch:getMetadata()
                 end
             end
             if is_newer then
-                logger.info(string.format(template, #cache, "cache", (TimeVal:now() - start):tomsecs()))
+                logger.info(string.format(template, #cache, "cache", TimeVal:getDurationMs(start)))
                 return cache
             else
                 logger.warn("cache is older than metadata, ignoring it")
@@ -633,7 +633,7 @@ function CalibreSearch:getMetadata()
             logger.info("Failed to serialize calibre metadata cache:", err)
         end
     end
-    logger.info(string.format(template, #books, "calibre", (TimeVal:now() - start):tomsecs()))
+    logger.info(string.format(template, #books, "calibre", TimeVal:getDurationMs(start)))
     return books
 end
 

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -283,9 +283,13 @@ function CalibreSearch:bookCatalog(t, option)
             entry.text = string.format("%s - %s", book.title, book.authors[1])
         end
         entry.callback = function()
+            local Event = require("ui/event")
+            UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
+            self.search_menu:onClose()
+
             local ReaderUI = require("apps/reader/readerui")
             ReaderUI:showReader(book.rootpath .. "/" .. book.lpath)
-            self.search_menu:onClose()
         end
         table.insert(catalog, entry)
     end

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -5,6 +5,7 @@
 
 local BD = require("ui/bidi")
 local CalibreMetadata = require("metadata")
+local CalibreSearch = require("search")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local FFIUtil = require("ffi/util")
@@ -278,6 +279,9 @@ function CalibreWireless:disconnect()
         self.calibre_messagequeue = nil
     end
     CalibreMetadata:clean()
+
+    -- Assume the library content was modified, as such, invalidate our Search metadata cache.
+    CalibreSearch:invalidateCache()
 end
 
 function CalibreWireless:reconnect()

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -97,6 +97,9 @@ function MoveToArchive:commonProcess(is_move_process, moved_done_text)
     self.settings:saveSetting("last_copied_from_dir", self.last_copied_from_dir)
     self.settings:flush()
 
+    local Event = require("ui/event")
+    UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
     self.ui:onClose()
     if is_move_process then
         FileManager:moveFile(document_full_path, self.archive_dir_path)
@@ -110,10 +113,10 @@ function MoveToArchive:commonProcess(is_move_process, moved_done_text)
     ReadCollection:updateItemByPath(document_full_path, dest_file)
     UIManager:show(ConfirmBox:new{
         text = moved_done_text,
-        ok_callback = function ()
+        ok_callback = function()
             ReaderUI:showReader(dest_file)
         end,
-        cancel_callback = function ()
+        cancel_callback = function()
             self:openFileBrowser(self.last_copied_from_dir)
         end,
     })

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -30,7 +30,7 @@ local CatalogCacheItem = CacheItem:new{
 
 -- cache catalog parsed from feed xml
 local CatalogCache = Cache:new{
-    max_memsize = 20*1024, -- keep only 20 cache items
+    max_memsize = 20*1024, -- keep only 20 items
     current_memsize = 0,
     cache = {},
     cache_order = {},

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -25,15 +25,14 @@ local _ = require("gettext")
 local T = require("ffi/util").template
 
 local CatalogCacheItem = CacheItem:new{
-    size = 1024,  -- fixed size for catalog item
+    size = 1024,  -- fixed size for catalog items
 }
 
 -- cache catalog parsed from feed xml
 local CatalogCache = Cache:new{
-    max_memsize = 20*1024, -- keep only 20 items
-    current_memsize = 0,
-    cache = {},
-    cache_order = {},
+    -- Make it 20 slots
+    size = 20 * CatalogCacheItem.size,
+    avg_itemsize = CatalogCacheItem.size,
 }
 
 local OPDSBrowser = Menu:extend{

--- a/plugins/opds.koplugin/opdscatalog.lua
+++ b/plugins/opds.koplugin/opdscatalog.lua
@@ -31,7 +31,11 @@ function OPDSCatalog:init()
                 ok_text = _("Read now"),
                 cancel_text = _("Read later"),
                 ok_callback = function()
+                    local Event = require("ui/event")
+                    UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
                     self:onClose()
+
                     ReaderUI:showReader(downloaded_file)
                 end
             })

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -22,7 +22,7 @@ local Terminal = WidgetContainer:new{
     name = "terminal",
     command = "",
     dump_file = util.realpath(DataStorage:getDataDir()) .. "/terminal_output.txt",
-    items_per_page = G_reader_settings:readSetting("items_per_page") or 16,
+    items_per_page = 16,
     settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/terminal_shortcuts.lua"),
     shortcuts_dialog = nil,
     shortcuts_menu = nil,
@@ -38,6 +38,7 @@ end
 function Terminal:init()
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
+    self.items_per_page = G_reader_settings:readSetting("items_per_page") or 16
     self.shortcuts = self.settings:readSetting("shortcuts", {})
 end
 

--- a/reader.lua
+++ b/reader.lua
@@ -284,6 +284,7 @@ else
     if start_with == "last" and last_file then
         local ReaderUI = require("apps/reader/readerui")
         UIManager:nextTick(function()
+            -- Instantiate RD
             ReaderUI:showReader(last_file)
         end)
         exit_code = UIManager:run()
@@ -292,10 +293,11 @@ else
         local home_dir =
             G_reader_settings:readSetting("home_dir") or Device.home_dir or lfs.currentdir()
         UIManager:nextTick(function()
+            -- Instantiate FM
             FileManager:showFiles(home_dir)
         end)
-        -- Always open history on top of filemanager so closing history
-        -- doesn't result in exit.
+        -- Always open FM modules on top of filemanager, so closing 'em doesn't result in an exit
+        -- because of an empty widget stack, and so they can interact with the FM instance as expected.
         if start_with == "history" then
             local FileManagerHistory = require("apps/filemanager/filemanagerhistory")
             UIManager:nextTick(function()

--- a/spec/unit/cache_spec.lua
+++ b/spec/unit/cache_spec.lua
@@ -1,11 +1,11 @@
 describe("Cache module", function()
-    local DocumentRegistry, Cache
+    local DocumentRegistry, DocCache
     local doc
     local max_page = 1
     setup(function()
         require("commonrequire")
         DocumentRegistry = require("document/documentregistry")
-        Cache = require("cache")
+        DocCache = require("document/doccache")
 
         local sample_pdf = "spec/front/unit/data/sample.pdf"
         doc = DocumentRegistry:openDocument(sample_pdf)
@@ -15,22 +15,22 @@ describe("Cache module", function()
     end)
 
     it("should clear cache", function()
-        Cache:clear()
+        DocCache:clear()
     end)
 
     it("should serialize blitbuffer", function()
         for pageno = 1, math.min(max_page, doc.info.number_of_pages) do
             doc:renderPage(pageno, nil, 1, 0, 1.0, 0)
-            Cache:serialize()
+            DocCache:serialize()
         end
-        Cache:clear()
+        DocCache:clear()
     end)
 
     it("should deserialize blitbuffer", function()
         for pageno = 1, math.min(max_page, doc.info.number_of_pages) do
             doc:hintPage(pageno, 1, 0, 1.0, 0)
         end
-        Cache:clear()
+        DocCache:clear()
     end)
 
     it("should serialize koptcontext", function()
@@ -38,9 +38,9 @@ describe("Cache module", function()
         for pageno = 1, math.min(max_page, doc.info.number_of_pages) do
             doc:renderPage(pageno, nil, 1, 0, 1.0, 0)
             doc:getPageDimensions(pageno)
-            Cache:serialize()
+            DocCache:serialize()
         end
-        Cache:clear()
+        DocCache:clear()
         doc.configurable.text_wrap = 0
     end)
 
@@ -48,6 +48,6 @@ describe("Cache module", function()
         for pageno = 1, math.min(max_page, doc.info.number_of_pages) do
             doc:renderPage(pageno, nil, 1, 0, 1.0, 0)
         end
-        Cache:clear()
+        DocCache:clear()
     end)
 end)

--- a/spec/unit/koptinterface_spec.lua
+++ b/spec/unit/koptinterface_spec.lua
@@ -1,10 +1,10 @@
 describe("Koptinterface module", function()
-    local DocumentRegistry, Koptinterface, Cache
+    local DocCache, DocumentRegistry, Koptinterface
     setup(function()
         require("commonrequire")
+        DocCache = require("document/doccache")
         DocumentRegistry = require("document/documentregistry")
         Koptinterface = require("document/koptinterface")
-        Cache = require("cache")
     end)
 
     local tall_pdf = "spec/front/unit/data/tall.pdf"
@@ -19,7 +19,7 @@ describe("Koptinterface module", function()
         doc.configurable.text_wrap = 0
         complex_doc.configurable.text_wrap = 0
         paper_doc.configurable.text_wrap = 0
-        Cache:clear()
+        DocCache:clear()
     end)
 
     after_each(function()

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -326,33 +326,76 @@ describe("UIManager spec", function()
         UIManager:broadcastEvent("foo")
         assert.is.same(#UIManager._window_stack, 0)
 
+        -- Remember that the stack is processed top to bottom!
+        -- Test making a hole in the middle of the stack.
         UIManager._window_stack = {
             {
                 widget = {
                     handleEvent = function()
-                        UIManager._window_stack[1] = nil
-                        UIManager._window_stack[2] = nil
-                        UIManager._window_stack[3] = nil
+                        assert.truthy(true)
                     end
                 }
             },
             {
                 widget = {
                     handleEvent = function()
-                        assert.falsy(true);
+                        assert.falsy(true)
                     end
                 }
             },
             {
                 widget = {
                     handleEvent = function()
-                        assert.falsy(true);
+                        assert.falsy(true)
+                    end
+                }
+            },
+            {
+                widget = {
+                    handleEvent = function()
+                        table.remove(UIManager._window_stack, #UIManager._window_stack - 2)
+                        table.remove(UIManager._window_stack, #UIManager._window_stack - 2)
+                        table.remove(UIManager._window_stack, #UIManager._window_stack - 1)
+                    end
+                }
+            },
+            {
+                widget = {
+                    handleEvent = function()
+                        assert.truthy(true)
                     end
                 }
             },
         }
         UIManager:broadcastEvent("foo")
-        assert.is.same(0, #UIManager._window_stack)
+        assert.is.same(2, #UIManager._window_stack)
+
+        -- Test inserting a new widget in the stack
+        local new_widget = {
+            widget = {
+                handleEvent = function()
+                    assert.truthy(true)
+                end
+            }
+        }
+        UIManager._window_stack = {
+            {
+                widget = {
+                    handleEvent = function()
+                        table.insert(UIManager._window_stack, new_widget)
+                    end
+                }
+            },
+            {
+                widget = {
+                    handleEvent = function()
+                        assert.truthy(true)
+                    end
+                }
+            },
+        }
+        UIManager:broadcastEvent("foo")
+        assert.is.same(3, #UIManager._window_stack)
     end)
 
     it("should handle stack change when closing widgets", function()


### PR DESCRIPTION
Plugins are loaded *once*, but instantiated *multiple* times. Moreover, when going from FM to RD, we instantiate the new RD plugin *before* tearing down the old FM one.

As such, reading settings at loading time only doesn't quite work¹, and scheduling/unscheduling functions that are public class members either.

----

1. Unless it's a table and the reference to it is never broken. c.f., OPDS & Statistics Plugins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7624)
<!-- Reviewable:end -->
