### PR TITLE
Style tweaks: add page break after <body>

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -134,6 +134,11 @@ h1 + h6, h2 + h6, h3 + h6, h4 + h6, h5 + h6 { page-break-before: avoid !importan
                     ]],
                 },
             },
+            {
+                id = "page-break-after-body";
+                title = _("New page after <body>"),
+                css = [[body { page-break-after: always !important; }]],
+            },
         },
     },
     {

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -136,7 +136,7 @@ h1 + h6, h2 + h6, h3 + h6, h4 + h6, h5 + h6 { page-break-before: avoid !importan
             },
             {
                 id = "page-break-after-body";
-                title = _("New page after <body>"),
+                title = _("New page on next <body>"),
                 css = [[body { page-break-after: always !important; }]],
             },
         },


### PR DESCRIPTION
When the next [body] (notes, comments) has no [title] or [title] is inside [section], the notes stick to the main text.

Before

![1](https://user-images.githubusercontent.com/62179190/116774760-6e12a080-aa67-11eb-90c3-69a85331c8a9.png)
---
![2](https://user-images.githubusercontent.com/62179190/116774763-72d75480-aa67-11eb-9dc1-8e6adcfb7d71.png)

After

![3](https://user-images.githubusercontent.com/62179190/116774768-78349f00-aa67-11eb-94ab-c1cf067724f2.png)
---
![4](https://user-images.githubusercontent.com/62179190/116774771-7bc82600-aa67-11eb-9363-ff7b2b8859af.png)
---
![5](https://user-images.githubusercontent.com/62179190/116774777-7ec31680-aa67-11eb-83e7-b589eb0e2b39.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7625)
<!-- Reviewable:end -->
