### PR TITLE
[dispatcher] Komma after the last elements in settingsList

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -88,8 +88,8 @@ local settingsList = {
     screenshot = { category="none", event="Screenshot", title=_("Screenshot"), device=true, separator=true,},
 
     -- filemanager settings
-    folder_up = { category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
-    show_plus_menu = { category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true},
+    folder_up = { category="none", event="FolderUp", title=_("Folder up"), filemanager=true,},
+    show_plus_menu = { category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true,},
     folder_shortcuts = { category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, separator=true,},
 
     -- reader settings
@@ -117,7 +117,7 @@ local settingsList = {
     book_cover = { category="none", event="ShowBookCover", title=_("Book cover"), rolling=true, paging=true, separator=true,},
     show_config_menu = { category="none", event="ShowConfigMenu", title=_("Show bottom menu"), rolling=true, paging=true,},
     toggle_bookmark = { category="none", event="ToggleBookmark", title=_("Toggle bookmark"), rolling=true, paging=true,},
-    toggle_inverse_reading_order = { category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), rolling=true, paging=true, separator=true},
+    toggle_inverse_reading_order = { category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), rolling=true, paging=true, separator=true,},
     cycle_highlight_action = { category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), rolling=true, paging=true,},
     cycle_highlight_style = { category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), rolling=true, paging=true,},
     page_jmp = { category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true,},
@@ -131,30 +131,30 @@ local settingsList = {
     toggle_page_flipping = { category="none", event="TogglePageFlipping", title=_("Toggle page flipping"), paging=true,},
     toggle_reflow = { category="none", event="ToggleReflow", title=_("Toggle reflow"), paging=true,},
     zoom = { category="string", event="SetZoomMode", title=_("Zoom mode"), args=ReaderZooming.available_zoom_modes, toggle=ReaderZooming.available_zoom_modes, paging=true,},
-    zoom_factor_change = {category="none", event="ZoomFactorChange", title=_("Change zoom factor"), paging=true, separator=true},
+    zoom_factor_change = {category="none", event="ZoomFactorChange", title=_("Change zoom factor"), paging=true, separator=true,},
 
     -- parsed from CreOptions
     -- the rest of the table elements are built from their counterparts in CreOptions
     rotation_mode = {category="string", device=true, separator=true,},
     visible_pages = {category="string", rolling=true, separator=true,},
-    h_page_margins = {category="string", rolling=true},
-    sync_t_b_page_margins = {category="string", rolling=true},
-    t_page_margin = {category="absolutenumber", rolling=true},
+    h_page_margins = {category="string", rolling=true,},
+    sync_t_b_page_margins = {category="string", rolling=true,},
+    t_page_margin = {category="absolutenumber", rolling=true,},
     b_page_margin = {category="absolutenumber", rolling=true, separator=true,},
-    view_mode = {category="string", rolling=true},
-    block_rendering_mode = {category="string", rolling=true},
-    render_dpi = {category="string", rolling=true},
+    view_mode = {category="string", rolling=true,},
+    block_rendering_mode = {category="string", rolling=true,},
+    render_dpi = {category="string", rolling=true,},
     line_spacing = {category="absolutenumber", rolling=true, separator=true,},
-    font_size = {category="absolutenumber", title=_("Set font size to %1"), rolling=true},
-    font_base_weight = {category="string", rolling=true},
-    font_gamma = {category="string", rolling=true},
-    font_hinting = {category="string", rolling=true},
+    font_size = {category="absolutenumber", title=_("Set font size to %1"), rolling=true,},
+    font_base_weight = {category="string", rolling=true,},
+    font_gamma = {category="string", rolling=true,},
+    font_hinting = {category="string", rolling=true,},
     font_kerning = {category="string", rolling=true, separator=true,},
-    status_line = {category="string", rolling=true},
-    embedded_css = {category="string", rolling=true},
-    embedded_fonts = {category="string", rolling=true},
-    smooth_scaling = {category="string", rolling=true},
-    nightmode_images = {category="string", rolling=true},
+    status_line = {category="string", rolling=true,},
+    embedded_css = {category="string", rolling=true,},
+    embedded_fonts = {category="string", rolling=true,},
+    smooth_scaling = {category="string", rolling=true,},
+    nightmode_images = {category="string", rolling=true,},
 }
 
 -- array for item order in menu


### PR DESCRIPTION
The initializations of the elements of `settingsList` does not follow the same styling guides. Some end with a Komma others don't. 
I have changed all to end with `,},`

I have made an own PR on this, so that the changes are easier to follow. Maybe #7626 has to rebased after this.