### PR TITLE
[Android] Refresh header and footer on Resume, unschedule refresh

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -142,8 +142,7 @@ function ReaderCoptListener:onOutOfScreenSaver()
         return
     end
 
-    self._delayed_screensaver = nil
-    ReaderCoptListener:rescheduleHeaderRefreshIfNeeded()
+    self:headerRefresh()
 end
 
 -- Unschedule on these events

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -142,6 +142,7 @@ function ReaderCoptListener:onOutOfScreenSaver()
         return
     end
 
+    self._delayed_screensaver = nil
     self:headerRefresh()
 end
 

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -134,7 +134,7 @@ function ReaderCoptListener:onResume()
         return
     end
 
-    ReaderCoptListener:rescheduleHeaderRefreshIfNeeded()
+    self:headerRefresh()
 end
 
 function ReaderCoptListener:onOutOfScreenSaver()

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -168,6 +168,9 @@ function Device:init()
                     end
                 end
                 -- to-do: keyboard connected, disconnected
+            elseif ev.code == C.APP_CMD_START then
+                local Event = require("ui/event")
+                UIManager:broadcastEvent(Event:new("Resume"))
             elseif ev.code == C.APP_CMD_RESUME then
                 if external.when_back_callback then
                     external.when_back_callback()
@@ -201,6 +204,9 @@ function Device:init()
                         end)
                     end
                 end
+            elseif ev.code == C.APP_CMD_STOP then
+                local Event = require("ui/event")
+                UIManager:broadcastEvent(Event:new("Suspend"))
             elseif ev.code == C.AEVENT_POWER_CONNECTED then
                 local Event = require("ui/event")
                 UIManager:broadcastEvent(Event:new("Charging"))


### PR DESCRIPTION
Update the time on header and footer, when device resumes. Otherwise if you put the device to sleep and resume it the next day, an old time is displayed until the autorefresh happens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7630)
<!-- Reviewable:end -->
