### PR TITLE
CreDocument Cache: Minor tweaks

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -620,7 +620,7 @@ function ReaderUI:doShowReader(file, provider)
         FileManager.instance:onClose()
     end
 
-    UIManager:show(reader)
+    UIManager:show(reader, "full")
     _running_instance = reader
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1358,10 +1358,10 @@ function CreDocument:setupCallCache()
         return
     end
     logger.dbg("CreDocument: using cre call cache")
-    local do_stats = G_reader_settings:isTrue("use_cre_call_cache_log_stats")
+    local do_stats = true -- G_reader_settings:isTrue("use_cre_call_cache_log_stats")
     -- Tune these when debugging
-    local do_stats_include_not_cached = false
-    local do_log = false
+    local do_stats_include_not_cached = true
+    local do_log = true
 
     -- Beware below for luacheck warnings "shadowing upvalue argument 'self'":
     -- the 'self' we got and use here, and the one we may get implicitely
@@ -1378,7 +1378,7 @@ function CreDocument:setupCallCache()
         if self._call_cache_tags then
             self._call_cache_tags:clear()
         else
-            self._call_cache_tags = lru:new(10)
+            self._call_cache_tags = lru.new(10)
         end
         -- i.e., the only thing that follows any sort of LRU eviction logic is the *list* of tag caches.
         -- Each individual cache itself is just a simple key, value store (i.e., a hash map).
@@ -1757,12 +1757,12 @@ function CreDocument:setupCallCache()
     if do_stats then
         self.close = function(_self)
             dumpStats()
-            CreDocument._callCacheReset(_self)
+            self._callCacheReset()
             CreDocument.close(_self)
         end
     else
         self.close = function(_self)
-            CreDocument._callCacheReset(_self)
+            self._callCacheReset()
             CreDocument.close(_self)
         end
     end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1358,10 +1358,10 @@ function CreDocument:setupCallCache()
         return
     end
     logger.dbg("CreDocument: using cre call cache")
-    local do_stats = true -- G_reader_settings:isTrue("use_cre_call_cache_log_stats")
+    local do_stats =  G_reader_settings:isTrue("use_cre_call_cache_log_stats")
     -- Tune these when debugging
-    local do_stats_include_not_cached = true
-    local do_log = true
+    local do_stats_include_not_cached = false
+    local do_log = false
 
     -- Beware below for luacheck warnings "shadowing upvalue argument 'self'":
     -- the 'self' we got and use here, and the one we may get implicitely

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1,4 +1,5 @@
 local Blitbuffer = require("ffi/blitbuffer")
+local CacheItem = require("cacheitem")
 local CanvasContext = require("document/canvascontext")
 local DataStorage = require("datastorage")
 local Document = require("document/document")
@@ -11,6 +12,7 @@ local ffi = require("ffi")
 local C = ffi.C
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
+local lru = require("ffi/lru")
 
 -- engine can be initialized only once, on first document opened
 local engine_initialized = false
@@ -1370,50 +1372,53 @@ function CreDocument:setupCallCache()
 
     -- reset full cache
     self._callCacheReset = function()
-        self._call_cache = {}
-        self._call_cache_tags_lru = {}
+        -- "Global" cache, a simple key, value store for *this* document
+        self._call_cache_global = {}
+        -- "Tags" cache, an LRU cache of per-tag simple key, value stores. 10 slots.
+        if self._call_cache_tags then
+            self._call_cache_tags:clear()
+        else
+            self._call_cache_tags = lru:new(10)
+        end
+        -- i.e., the only thing that follows any sort of LRU eviction logic is the *list* of tag caches.
+        -- Each individual cache itself is just a simple key, value store (i.e., a hash map).
+        -- Points to said per-tag cache for the current tag.
+        self._call_cache_tag = nil
+        -- Stores the key for said current tag
+        self._call_cache_current_tag = nil
     end
     -- global cache
     self._callCacheGet = function(key)
-        return self._call_cache[key]
+        return self._call_cache_global[key]
     end
     self._callCacheSet = function(key, value)
-        self._call_cache[key] = value
+        self._call_cache_global[key] = value
     end
 
-    -- nb of by-tag sub-caches to keep
-    self._call_cache_keep_tags_nb = 10
     -- current tag (page, pos) sub-cache
     self._callCacheSetCurrentTag = function(tag)
-        if not self._call_cache[tag] then
-            self._call_cache[tag] = {}
+        -- If it already exists, return it and make it the MRU
+        self._call_cache_tag = self._call_cache_tags:get(tag)
+        if not self._call_cache_tag then
+            -- Otherwise, create it and insert it in the list cache, evicting the LRU tag cache if necessary.
+            -- NOTE: We need CacheItem for its NOP onFree eviction callback.
+            self._call_cache_tag = CacheItem:new{}
+            self._call_cache_tags:set(tag, self._call_cache_tag)
         end
         self._call_cache_current_tag = tag
-        -- clean up LRU tag list
-        if self._call_cache_tags_lru[1] ~= tag then
-            for i = #self._call_cache_tags_lru, 1, -1 do
-                if self._call_cache_tags_lru[i] == tag then
-                    table.remove(self._call_cache_tags_lru, i)
-                elseif i > self._call_cache_keep_tags_nb then
-                    self._call_cache[self._call_cache_tags_lru[i]] = nil
-                    table.remove(self._call_cache_tags_lru, i)
-                end
-            end
-            table.insert(self._call_cache_tags_lru, 1, tag)
-        end
     end
     self._callCacheGetCurrentTag = function(tag)
         return self._call_cache_current_tag
     end
     -- per current tag cache
     self._callCacheTagGet = function(key)
-        if self._call_cache_current_tag and self._call_cache[self._call_cache_current_tag] then
-            return self._call_cache[self._call_cache_current_tag][key]
+        if self._call_cache_tag then
+            return self._call_cache_tag[key]
         end
     end
     self._callCacheTagSet = function(key, value)
-        if self._call_cache_current_tag and self._call_cache[self._call_cache_current_tag] then
-            self._call_cache[self._call_cache_current_tag][key] = value
+        if self._call_cache_tag then
+            self._call_cache_tag[key] = value
         end
     end
     self._callCacheReset()
@@ -1480,12 +1485,12 @@ function CreDocument:setupCallCache()
             local util = require("util")
             local res = {}
             table.insert(res, "CRE call cache content:")
-            table.insert(res, string.format("     all: %d items", util.tableSize(self._call_cache)))
-            table.insert(res, string.format("  global: %d items", util.tableSize(self._call_cache) - #self._call_cache_tags_lru))
-            table.insert(res, string.format("    tags: %d items", #self._call_cache_tags_lru))
-            for i=1, #self._call_cache_tags_lru do
-                table.insert(res, string.format("          '%s': %d items", self._call_cache_tags_lru[i],
-                        util.tableSize(self._call_cache[self._call_cache_tags_lru[i]])))
+            table.insert(res, string.format("     all: %d items", util.tableSize(self._call_cache_global) + self._call_cache_tags:used_slots()))
+            table.insert(res, string.format("  global: %d items", util.tableSize(self._call_cache_global)))
+            table.insert(res, string.format("    tags: %d items", self._call_cache_tags:used_slots()))
+            for tag, tag_cache in self._call_cache_tags:pairs() do
+                table.insert(res, string.format("          '%s': %d items", tag,
+                        util.tableSize(tag_cache)))
             end
             local hit_keys = {}
             local nohit_keys = {}

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1756,8 +1756,14 @@ function CreDocument:setupCallCache()
     -- Dump statistics on close
     if do_stats then
         self.close = function(_self)
-            CreDocument.close(_self)
             dumpStats()
+            CreDocument._callCacheReset(_self)
+            CreDocument.close(_self)
+        end
+    else
+        self.close = function(_self)
+            CreDocument._callCacheReset(_self)
+            CreDocument.close(_self)
         end
     end
 end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1443,9 +1443,15 @@ function CreDocument:setupCallCache()
     local addStatMiss = no_op
     local addStatHit = no_op
     local dumpStats = no_op
+    local now = function()
+        return TimeVal.zero
+    end
     if do_stats then
         -- cache statistics
         self._call_cache_stats = {}
+        now = function()
+            return TimeVal:now()
+        end
         addStatMiss = function(name, starttime, not_cached)
             local duration = TimeVal:getDuration(starttime)
             if not self._call_cache_stats[name] then
@@ -1667,7 +1673,7 @@ function CreDocument:setupCallCache()
             elseif cache_by_tag then
                 is_cached = true
                 self[name] = function(...)
-                    local starttime = TimeVal:now()
+                    local starttime = now()
                     local cache_key = name .. asString(select(2, ...))
                     local results = self._callCacheTagGet(cache_key)
                     if results then
@@ -1688,7 +1694,7 @@ function CreDocument:setupCallCache()
             elseif cache_global then
                 is_cached = true
                 self[name] = function(...)
-                    local starttime = TimeVal:now()
+                    local starttime = now()
                     local cache_key = name .. asString(select(2, ...))
                     local results = self._callCacheGet(cache_key)
                     if results then
@@ -1708,7 +1714,7 @@ function CreDocument:setupCallCache()
             if do_stats_include_not_cached and not is_cached then
                 local func2 = self[name] -- might already be wrapped
                 self[name] = function(...)
-                    local starttime = TimeVal:now()
+                    local starttime = now()
                     local results = { func2(...) }
                     addStatMiss(name, starttime, true) -- not_cached = true
                     return unpack(results)
@@ -1730,7 +1736,7 @@ function CreDocument:setupCallCache()
         elseif current_buffer_tag ~= current_tag then
             do_draw = true
         end
-        local starttime = TimeVal:now()
+        local starttime = now()
         if do_draw then
             if do_log then logger.dbg("callCache: ########## drawCurrentView: full draw") end
             CreDocument.drawCurrentView(_self, target, x, y, rect, pos)


### PR DESCRIPTION
* Move the LRU logic to ffi/lru (that was easier than I thought, not much of it actually requires LRU eviction logic).
* Neuter timekeeping when stats are disabled
* Clear the cache on close

----

And a minor regression since #7624:

* ReaderUI: Ensure we flash when opening a document