### PR TITLE
Dictionary: disable 'Clean history' when the history is empty

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -287,14 +287,18 @@ function ReaderDictionary:addToMainMenu(menu_items)
             },
             {
                 text = _("Clean dictionary lookup history"),
+                enabled_func = function()
+                    return lookup_history:has("lookup_history")
+                end,
                 keep_menu_open = true,
-                callback = function()
+                callback = function(touchmenu_instance)
                     UIManager:show(ConfirmBox:new{
                         text = _("Clean dictionary lookup history?"),
                         ok_text = _("Clean"),
                         ok_callback = function()
                             -- empty data table to replace current one
                             lookup_history:reset{}
+                            touchmenu_instance:updateItems()
                         end,
                     })
                 end,


### PR DESCRIPTION
Self explained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7636)
<!-- Reviewable:end -->
