### PR TITLE
Wikipedia: disable 'Clean history' when the history is empty

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -299,14 +299,18 @@ Where do you want them saved?]])
             },
             {
                 text = _("Clean Wikipedia history"),
+                enabled_func = function()
+                    return wikipedia_history:has("wikipedia_history")
+                end,
                 keep_menu_open = true,
-                callback = function()
+                callback = function(touchmenu_instance)
                     UIManager:show(ConfirmBox:new{
                         text = _("Clean Wikipedia history?"),
                         ok_text = _("Clean"),
                         ok_callback = function()
                             -- empty data table to replace current one
                             wikipedia_history:reset{}
+                            touchmenu_instance:updateItems()
                         end,
                     })
                 end,


### PR DESCRIPTION
Self explained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7637)
<!-- Reviewable:end -->
