### PR TITLE
android: avoid downloading the APK again if there's one download in p…

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -85,6 +85,7 @@ local Device = Generic:new{
     isHapticFeedbackEnabled = yes,
     hasClipboard = yes,
     hasOTAUpdates = android.ota.isEnabled,
+    hasOTARunning = function() return android.ota.isRunning end,
     hasFastWifiStatusQuery = yes,
     hasSystemFonts = yes,
     canOpenLink = yes,
@@ -216,6 +217,7 @@ function Device:init()
                 local Event = require("ui/event")
                 UIManager:broadcastEvent(Event:new("NotCharging"))
             elseif ev.code == C.AEVENT_DOWNLOAD_COMPLETE then
+                android.ota.isRunning = false
                 if android.isResumed() then
                     self:install()
                 else

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -107,6 +107,10 @@ local Device = {
     -- (c.f., https://github.com/koreader/koreader/pull/5211#issuecomment-521304139)
     hasFastWifiStatusQuery = no,
 
+
+    -- For devices that have non-blocking OTA updates, this function will return if the download is currently running.
+    hasOTARunning = no,
+
     -- set to yes on devices with system fonts
     hasSystemFonts = no,
 

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -208,6 +208,13 @@ function OTAManager:checkUpdate()
 end
 
 function OTAManager:fetchAndProcessUpdate()
+    if Device:hasOTARunning() then
+        UIManager:show(InfoMessage:new{
+            text = _("Download already scheduled. You'll be notified when it is complete"),
+        })
+        return
+    end
+
     local ota_version, local_version, link, ota_package = OTAManager:checkUpdate()
 
     if ota_version == 0 then
@@ -247,6 +254,7 @@ function OTAManager:fetchAndProcessUpdate()
                         if ok == C.ADOWNLOAD_EXISTS then
                             Device:install()
                         elseif ok == C.ADOWNLOAD_OK then
+                            android.ota.isRunning = true
                             UIManager:show(InfoMessage:new{
                                 text = wait_for_download,
                                 timeout = 3,


### PR DESCRIPTION
…rogress

Since download process is non blocking in android and users might think something went wrong and try to update again and again.

Show a little message instead of scheduling a new download:

![device-2021-05-09-171620](https://user-images.githubusercontent.com/975883/117577658-fbe72f00-b0ea-11eb-97ab-b970b3ec3775.png)

Help with the message text is very welcome