### PR TITLE
Tune pogress indicator

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1113,8 +1113,8 @@ function ReaderRolling:handleEngineCallback(ev, ...)
     -- ignore other events
 end
 
-local ENGINE_PROGRESS_INITIAL_DELAY = TimeVal:new{ sec = 2, usec = 0 }
-local ENGINE_PROGRESS_UPDATE_DELAY = TimeVal:new{ sec = 0, usec = 500000 }
+local ENGINE_PROGRESS_INITIAL_DELAY = TimeVal:new{ sec = 0, usec = 0 }
+local ENGINE_PROGRESS_UPDATE_DELAY = TimeVal:new{ sec = 0, usec = 50000 }
 
 function ReaderRolling:showEngineProgress(percent)
     if G_reader_settings and G_reader_settings:isFalse("cre_show_progress") then
@@ -1154,6 +1154,7 @@ function ReaderRolling:showEngineProgress(percent)
         local h = Size.line.progress
         if self.engine_progress_widget then
             self.engine_progress_widget:setPercentage(percent)
+            y = self.engine_progress_widget._engine_progress_widget_orig_y
         else
             self.engine_progress_widget = ProgressWidget:new{
                 width = w,
@@ -1166,7 +1167,9 @@ function ReaderRolling:showEngineProgress(percent)
                 tick_width = Screen:scaleBySize(1),
                 ticks = {1,2},
                 last = 2,
-            }
+                -- Be sure we keep showing it at its start position
+                _engine_progress_widget_orig_y = y,
+        }
         end
         -- Paint directly to the screen and force a regional refresh
         -- as UIManager won't get a change to run until loading/rendering
@@ -1182,6 +1185,10 @@ function ReaderRolling:showEngineProgress(percent)
         -- some progress callback for will generate a full
         -- screen refresh.
      self.progress_last_y_shift = self.ui.document:getHeaderHeight()
+    end
+
+    local st = TimeVal:now() + TimeVal:new{sec=0, usec=100000}
+    while st > TimeVal:now() do
     end
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1124,6 +1124,7 @@ function ReaderRolling:showEngineProgress(percent)
         -- so allow disabling it.
         return
     end
+
     if percent then
         local now = TimeVal:now()
         if self.engine_progress_update_not_before and now < self.engine_progress_update_not_before then
@@ -1135,10 +1136,11 @@ function ReaderRolling:showEngineProgress(percent)
             self.engine_progress_update_not_before = now + ENGINE_PROGRESS_INITIAL_DELAY
             return
         end
+
         -- Widget size and position: best to anchor it at top left,
         -- so it does not override the footer or a bookmark dogear
         local x = 0
-        local y = Size.margin.small
+        local y = Size.margin.small + (self.ui.document.been_rendered and self.ui.document:getHeaderHeight() or 0)
         local w = math.floor(Screen:getWidth() / 3)
         local h = Size.line.progress
         if self.engine_progress_widget then

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1113,8 +1113,8 @@ function ReaderRolling:handleEngineCallback(ev, ...)
     -- ignore other events
 end
 
-local ENGINE_PROGRESS_INITIAL_DELAY = TimeVal:new{ sec = 0, usec = 0 }
-local ENGINE_PROGRESS_UPDATE_DELAY = TimeVal:new{ sec = 0, usec = 50000 }
+local ENGINE_PROGRESS_INITIAL_DELAY = TimeVal:new{ sec = 2, usec = 0 }
+local ENGINE_PROGRESS_UPDATE_DELAY = TimeVal:new{ sec = 0, usec = 500000 }
 
 function ReaderRolling:showEngineProgress(percent)
     if G_reader_settings and G_reader_settings:isFalse("cre_show_progress") then
@@ -1184,11 +1184,7 @@ function ReaderRolling:showEngineProgress(percent)
         -- No need for any paint/refresh: any action we got
         -- some progress callback for will generate a full
         -- screen refresh.
-     self.progress_last_y_shift = self.ui.document:getHeaderHeight()
-    end
-
-    local st = TimeVal:now() + TimeVal:new{sec=0, usec=100000}
-    while st > TimeVal:now() do
+        self.progress_last_y_shift = self.ui.document:getHeaderHeight()
     end
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1146,11 +1146,9 @@ function ReaderRolling:showEngineProgress(percent)
         --    or if the top status bar is enabled, just below that.
         -- On toggling the top status bar, the location of the progress indicator
         --    should be on the location it would be expected in respect of the (old) drawn text.
-        if self.ui.document.been_rendered and self.progress_last_top_bar then
+        if self.ui.document.been_rendered then
             y = y + (self.progress_last_y_shift or 0)
         end
-        self.progress_last_y_shift = self.ui.document:getHeaderHeight()
-        self.progress_last_top_bar = self.cre_top_bar_enabled
 
         local w = math.floor(Screen:getWidth() / 3)
         local h = Size.line.progress
@@ -1183,6 +1181,7 @@ function ReaderRolling:showEngineProgress(percent)
         -- No need for any paint/refresh: any action we got
         -- some progress callback for will generate a full
         -- screen refresh.
+     self.progress_last_y_shift = self.ui.document:getHeaderHeight()
     end
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1149,7 +1149,7 @@ function ReaderRolling:showEngineProgress(percent)
         if self.ui.document.been_rendered and self.progress_last_top_bar then
             y = y + (self.progress_last_y_shift or 0)
         end
-        self.progress_last_y_shift = self.ui.document:getHeaderHeight() or 0
+        self.progress_last_y_shift = self.ui.document:getHeaderHeight()
         self.progress_last_top_bar = self.cre_top_bar_enabled
 
         local w = math.floor(Screen:getWidth() / 3)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -878,6 +878,7 @@ function ReaderRolling:updatePos()
     end
     self:onUpdateTopStatusBarMarkers()
     UIManager:setDirty(self.view.dialog, "partial")
+    self.current_header_height = self.ui.document:getHeaderHeight()
     -- Allow for the new rendering to be shown before possibly showing
     -- the "Styles have changed..." ConfirmBox so the user can decide
     -- if it is really needed
@@ -892,6 +893,7 @@ end
 function ReaderRolling:onChangeViewMode()
     self.rendering_hash = self.ui.document:getDocumentRenderingHash()
     self.ui.document:_readMetadata()
+    self.current_header_height = self.ui.document:getHeaderHeight()
     self.ui:handleEvent(Event:new("UpdateToc"))
     if self.xpointer then
         self:_gotoXPointer(self.xpointer)
@@ -1146,15 +1148,14 @@ function ReaderRolling:showEngineProgress(percent)
         --    or if the top status bar is enabled, just below that.
         -- On toggling the top status bar, the location of the progress indicator
         --    should be on the location it would be expected in respect of the (old) drawn text.
-        if self.ui.document.been_rendered then
-            y = y + (self.progress_last_y_shift or 0)
+        if self.ui.document.been_rendered and self.current_header_height then
+            y = y + self.current_header_height
         end
 
         local w = math.floor(Screen:getWidth() / 3)
         local h = Size.line.progress
         if self.engine_progress_widget then
             self.engine_progress_widget:setPercentage(percent)
-            y = self.engine_progress_widget._engine_progress_widget_orig_y
         else
             self.engine_progress_widget = ProgressWidget:new{
                 width = w,
@@ -1168,7 +1169,6 @@ function ReaderRolling:showEngineProgress(percent)
                 ticks = {1,2},
                 last = 2,
                 -- Be sure we keep showing it at its start position
-                _engine_progress_widget_orig_y = y,
         }
         end
         -- Paint directly to the screen and force a regional refresh
@@ -1184,7 +1184,6 @@ function ReaderRolling:showEngineProgress(percent)
         -- No need for any paint/refresh: any action we got
         -- some progress callback for will generate a full
         -- screen refresh.
-        self.progress_last_y_shift = self.ui.document:getHeaderHeight()
     end
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -255,6 +255,7 @@ end
 -- in scroll mode percent_finished must be save before close document
 -- we cannot do it in onSaveSettings() because getLastPercent() uses self.ui.document
 function ReaderRolling:onCloseDocument()
+    self.current_header_height = nil -- show unload progress bar at top
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
     local cache_file_path = self.ui.document:getCacheFilePath() -- nil if no cache file
     self.ui.doc_settings:saveSetting("cache_file_path", cache_file_path)
@@ -1168,8 +1169,7 @@ function ReaderRolling:showEngineProgress(percent)
                 tick_width = Screen:scaleBySize(1),
                 ticks = {1,2},
                 last = 2,
-                -- Be sure we keep showing it at its start position
-        }
+            }
         end
         -- Paint directly to the screen and force a regional refresh
         -- as UIManager won't get a change to run until loading/rendering

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1140,7 +1140,18 @@ function ReaderRolling:showEngineProgress(percent)
         -- Widget size and position: best to anchor it at top left,
         -- so it does not override the footer or a bookmark dogear
         local x = 0
-        local y = Size.margin.small + (self.ui.document.been_rendered and self.ui.document:getHeaderHeight() or 0)
+        local y = Size.margin.small
+        -- On the first rendering the progress indicator should be on top.
+        -- On further renderings the progress indicator should be on top,
+        --    or if the top status bar is enabled, just below that.
+        -- On toggling the top status bar, the location of the progress indicator
+        --    should be on the location it would be expected in respect of the (old) drawn text.
+        if self.ui.document.been_rendered and self.progress_last_top_bar then
+            y = y + (self.progress_last_y_shift or 0)
+        end
+        self.progress_last_y_shift = self.ui.document:getHeaderHeight() or 0
+        self.progress_last_top_bar = self.cre_top_bar_enabled
+
         local w = math.floor(Screen:getWidth() / 3)
         local h = Size.line.progress
         if self.engine_progress_widget then

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -310,7 +310,6 @@ function CreDocument:close()
         self.buffer = nil
     end
 
-    self.been_rendered = false
     Document.close(self)
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -310,6 +310,7 @@ function CreDocument:close()
         self.buffer = nil
     end
 
+    self.been_rendered = false
     Document.close(self)
 end
 


### PR DESCRIPTION
If the top status bar is enabled and the document has already been rendered, then the progress indicator is shown just below the status line.
On book opening or if there is no top status bar, no changes.

see #7666. Closes #7666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7667)
<!-- Reviewable:end -->
