### PR TITLE
ReaderToc: option to show a dotted line

### DIFF
--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -212,6 +212,7 @@ function ReaderPageMap:onShowPageList()
     -- We use the per-page and font-size settings set for the ToC
     local items_per_page = G_reader_settings:readSetting("toc_items_per_page") or 14
     local items_font_size = G_reader_settings:readSetting("toc_items_font_size") or Menu.getItemFontSize(items_per_page)
+    local items_with_dotted_lines = G_reader_settings:nilOrTrue("toc_items_with_dotted_lines")
 
     local pl_menu = Menu:new{
         title = _("Reference page numbers list"),
@@ -225,6 +226,8 @@ function ReaderPageMap:onShowPageList()
         items_font_size = items_font_size,
         line_color = require("ffi/blitbuffer").COLOR_WHITE,
         single_line = true,
+        align_baselines = true,
+        with_dotted_lines = items_with_dotted_lines,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",

--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -212,7 +212,7 @@ function ReaderPageMap:onShowPageList()
     -- We use the per-page and font-size settings set for the ToC
     local items_per_page = G_reader_settings:readSetting("toc_items_per_page") or 14
     local items_font_size = G_reader_settings:readSetting("toc_items_font_size") or Menu.getItemFontSize(items_per_page)
-    local items_with_dotted_lines = G_reader_settings:nilOrTrue("toc_items_with_dotted_lines")
+    local items_with_dots = G_reader_settings:nilOrTrue("toc_items_with_dots")
 
     local pl_menu = Menu:new{
         title = _("Reference page numbers list"),
@@ -227,7 +227,7 @@ function ReaderPageMap:onShowPageList()
         line_color = require("ffi/blitbuffer").COLOR_WHITE,
         single_line = true,
         align_baselines = true,
-        with_dotted_lines = items_with_dotted_lines,
+        with_dots = items_with_dots,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -643,7 +643,7 @@ function ReaderToc:onShowToc()
 
     local items_per_page = G_reader_settings:readSetting("toc_items_per_page") or self.toc_items_per_page_default
     local items_font_size = G_reader_settings:readSetting("toc_items_font_size") or Menu.getItemFontSize(items_per_page)
-    local items_with_dotted_lines = G_reader_settings:nilOrTrue("toc_items_with_dotted_lines")
+    local items_with_dots = G_reader_settings:nilOrTrue("toc_items_with_dots")
     -- Estimate expand/collapse icon size
     -- *2/5 to acount for Menu top title and bottom icons, and add some space between consecutive icons
     local icon_size = math.floor(Screen:getHeight() / items_per_page * 2/5)
@@ -703,7 +703,7 @@ function ReaderToc:onShowToc()
         cface = Font:getFace("x_smallinfofont"),
         single_line = true,
         align_baselines = true,
-        with_dotted_lines = items_with_dotted_lines,
+        with_dots = items_with_dots,
         items_per_page = items_per_page,
         items_font_size = items_font_size,
         items_padding = can_collapse and math.floor(Size.padding.fullscreen / 2) or nil, -- c.f., note above. Menu's default is twice that.
@@ -1063,14 +1063,14 @@ Enabling this option will restrict display to the chapter titles of progress bar
             UIManager:show(items_font)
         end,
     }
-    menu_items.toc_items_with_dotted_lines = {
-        text = _("With dotted lines"),
+    menu_items.toc_items_with_dots = {
+        text = _("With dots"),
         keep_menu_open = true,
         checked_func = function()
-            return G_reader_settings:nilOrTrue("toc_items_with_dotted_lines")
+            return G_reader_settings:nilOrTrue("toc_items_with_dots")
         end,
         callback = function()
-            G_reader_settings:flipNilOrTrue("toc_items_with_dotted_lines")
+            G_reader_settings:flipNilOrTrue("toc_items_with_dots")
         end
     }
 end

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -643,7 +643,7 @@ function ReaderToc:onShowToc()
 
     local items_per_page = G_reader_settings:readSetting("toc_items_per_page") or self.toc_items_per_page_default
     local items_font_size = G_reader_settings:readSetting("toc_items_font_size") or Menu.getItemFontSize(items_per_page)
-    local items_show_separator = G_reader_settings:isTrue("toc_items_show_separator")
+    local items_with_dotted_lines = G_reader_settings:nilOrTrue("toc_items_with_dotted_lines")
     -- Estimate expand/collapse icon size
     -- *2/5 to acount for Menu top title and bottom icons, and add some space between consecutive icons
     local icon_size = math.floor(Screen:getHeight() / items_per_page * 2/5)
@@ -703,10 +703,11 @@ function ReaderToc:onShowToc()
         cface = Font:getFace("x_smallinfofont"),
         single_line = true,
         align_baselines = true,
+        with_dotted_lines = items_with_dotted_lines,
         items_per_page = items_per_page,
         items_font_size = items_font_size,
         items_padding = can_collapse and math.floor(Size.padding.fullscreen / 2) or nil, -- c.f., note above. Menu's default is twice that.
-        line_color = items_show_separator and Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_WHITE,
+        line_color = Blitbuffer.COLOR_WHITE,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",
@@ -1062,14 +1063,14 @@ Enabling this option will restrict display to the chapter titles of progress bar
             UIManager:show(items_font)
         end,
     }
-    menu_items.toc_items_show_separator = {
-        text = _("Add a separator between ToC entries"),
+    menu_items.toc_items_with_dotted_lines = {
+        text = _("With dotted lines"),
         keep_menu_open = true,
         checked_func = function()
-            return G_reader_settings:isTrue("toc_items_show_separator")
+            return G_reader_settings:nilOrTrue("toc_items_with_dotted_lines")
         end,
         callback = function()
-            G_reader_settings:flipNilOrFalse("toc_items_show_separator")
+            G_reader_settings:flipNilOrTrue("toc_items_with_dotted_lines")
         end
     }
 end

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -33,7 +33,7 @@ local order = {
         "----------------------------",
         "toc_items_per_page",
         "toc_items_font_size",
-        "toc_items_with_dotted_lines",
+        "toc_items_with_dots",
         "----------------------------",
         "bookmarks_items_per_page",
         "bookmarks_items_font_size",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -33,7 +33,7 @@ local order = {
         "----------------------------",
         "toc_items_per_page",
         "toc_items_font_size",
-        "toc_items_show_separator",
+        "toc_items_with_dotted_lines",
         "----------------------------",
         "bookmarks_items_per_page",
         "bookmarks_items_font_size",


### PR DESCRIPTION
A dotted line joining the ToC entry text to the page number may make it easier to use.
This replaces the menu item separator from #7551. See https://github.com/koreader/koreader/pull/7551#issuecomment-835384193
Also fix baseline aligment, which could be a bit off.

Should this be enabled by default (currently is) to advertize it, or not ?
(I think most people really don't care about page numbers, so no line would keep them appart and you would not be distracted.)

<kbd>![image](https://user-images.githubusercontent.com/24273478/118017232-a911af80-b356-11eb-8968-605f43dcdb57.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/118017304-be86d980-b356-11eb-82ec-161cddec6759.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7669)
<!-- Reviewable:end -->
