### PR TITLE
 Koptoptions: add to dispatcher

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -1172,11 +1172,15 @@ function ReaderPaging:onGotoPrevChapter()
     return true
 end
 
-function ReaderPaging:onToggleReflow()
-    self.view.document.configurable.text_wrap = bit.bxor(self.view.document.configurable.text_wrap, 1)
+function ReaderPaging:onReflowUpdated()
     self.ui:handleEvent(Event:new("RedrawCurrentPage"))
     self.ui:handleEvent(Event:new("RestoreZoomMode"))
     self.ui:handleEvent(Event:new("InitScrollPageStates"))
+end
+
+function ReaderPaging:onToggleReflow()
+    self.view.document.configurable.text_wrap = bit.bxor(self.view.document.configurable.text_wrap, 1)
+    self:onReflowUpdated()
 end
 
 -- Duplicated in ReaderRolling

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -619,8 +619,16 @@ arguments are:
 function Dispatcher:execute(settings, gesture)
     for k, v in pairs(settings) do
         if settingsList[k] ~= nil and (settingsList[k].conditions == nil or settingsList[k].conditions == true) then
-            -- Be sure we don't send a document setting event if there's not yet or no longer a document
             Notification:setNotifySource(Notification.SOURCE_DISPATCHER)
+            if settingsList[k].configurable then
+                local value = v
+                if type(v) ~= "number" then
+                    for i, r in ipairs(settingsList[k].args) do
+                        if v == r then value = settingsList[k].configurable.values[i] break end
+                    end
+                end
+                UIManager:sendEvent(Event:new("ConfigChange", settingsList[k].configurable.name, value))
+            end
             if settingsList[k].category == "none" then
                 if settingsList[k].arg ~= nil then
                     UIManager:sendEvent(Event:new(settingsList[k].event, settingsList[k].arg))
@@ -642,15 +650,6 @@ function Dispatcher:execute(settings, gesture)
             if settingsList[k].category == "incrementalnumber" then
                 local arg = v ~= 0 and v or gesture or 0
                 UIManager:sendEvent(Event:new(settingsList[k].event, arg))
-            end
-            if settingsList[k].configurable then
-                local value = v
-                if type(v) ~= "number" then
-                    for i, r in ipairs(settingsList[k].args) do
-                        if v == r then value = settingsList[k].configurable.values[i] break end
-                    end
-                end
-                UIManager:sendEvent(Event:new("ConfigChange", settingsList[k].configurable.name, value))
             end
         end
         Notification:resetNotifySource()

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -60,7 +60,6 @@ local settingsList = {
     wifi_off = {category="none", event="InfoWifiOff", title=_("Turn off Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle(), separator=true},
     reading_progress = {category="none", event="ShowReaderProgress", title=_("Reading progress"), device=true},
-    stats_calendar_view = {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), device=true, separator=true},
     history = {category="none", event="ShowHist", title=_("History"), device=true},
     open_previous_document = {category="none", event="OpenLastDoc", title=_("Open previous document"), device=true},
     filemanager = {category="none", event="Home", title=_("File browser"), device=true},
@@ -115,7 +114,6 @@ local settingsList = {
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), rolling=true, paging=true, separator=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), rolling=true, paging=true},
     bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), rolling=true, paging=true},
-    book_statistics = {category="none", event="ShowBookStats", title=_("Book statistics"), rolling=true, paging=true, separator=true},
     book_status = {category="none", event="ShowBookStatus", title=_("Book status"), rolling=true, paging=true},
     book_info = {category="none", event="ShowBookInfo", title=_("Book information"), rolling=true, paging=true},
     book_description = {category="none", event="ShowBookDescription", title=_("Book description"), rolling=true, paging=true},
@@ -201,7 +199,6 @@ local dispatcher_menu_order = {
     "open_previous_document",
     "favorites",
     "filemanager",
-    "stats_calendar_view",
 
     "dictionary_lookup",
     "wikipedia_lookup",
@@ -277,7 +274,6 @@ local dispatcher_menu_order = {
 
     "toc",
     "bookmarks",
-    "book_statistics",
 
     "book_status",
     "book_info",

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -447,17 +447,7 @@ The first option ("auto") tries to automatically align reflowed text as it is in
                 toggle = {_("off"), _("on")},
                 values = {0, 1},
                 default_value = DKOPTREADER_CONFIG_TEXT_WRAP,
-                events = {
-                    {
-                        event = "RedrawCurrentPage",
-                    },
-                    {
-                        event = "RestoreZoomMode",
-                    },
-                    {
-                        event = "InitScrollPageStates",
-                    },
-                },
+                event = "ReflowUpdated",
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Reflow mode extracts text and images from the original document, possibly discarding some formatting, and reflows it on the screen for easier reading.
 Some of the other settings are only available when reflow mode is enabled.]]),

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -512,7 +512,7 @@ This can also be used to remove some gray background or to convert a grayscale o
         icon = "appbar.settings",
         options = {
             {
-                name="doc_language",
+                name = "doc_language",
                 name_text = _("Document Language"),
                 toggle = DKOPTREADER_CONFIG_DOC_LANGS_TEXT,
                 values = DKOPTREADER_CONFIG_DOC_LANGS_CODE,

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -90,7 +90,7 @@ function OptionTextItem:onTapSelect()
     Notification:setNotifySource(Notification.SOURCE_BOTTOM_MENU_ICON)
     self.config:onConfigChoose(self.values, self.name,
                     self.event, self.args,
-                    self.events, self.current_item, self.hide_on_apply)
+                    self.current_item, self.hide_on_apply)
 
     UIManager:setDirty(self.config, function()
         return "fast", self[1].dimen
@@ -169,7 +169,7 @@ function OptionIconItem:onTapSelect()
     Notification:setNotifySource(Notification.SOURCE_BOTTOM_MENU_ICON)
     self.config:onConfigChoose(self.values, self.name,
                     self.event, self.args,
-                    self.events, self.current_item, self.hide_on_apply)
+                    self.current_item, self.hide_on_apply)
 
     UIManager:setDirty(self.config, function()
         return "fast", self[1].dimen
@@ -569,7 +569,6 @@ function ConfigOption:init()
                     values = self.options[c].values,
                     args = self.options[c].args,
                     event = self.options[c].event,
-                    events = self.options[c].events,
                     hide_on_apply = self.options[c].hide_on_apply,
                     config = self.config,
                     enabled = enabled,
@@ -614,7 +613,7 @@ function ConfigOption:init()
                         if arg == "-" or arg == "+" then
                             Notification:setNotifySource(Notification.SOURCE_BOTTOM_MENU_FINE)
                             self.config:onConfigFineTuneChoose(self.options[c].values, self.options[c].name,
-                                self.options[c].event, self.options[c].args, self.options[c].events, arg, self.options[c].hide_on_apply,
+                                self.options[c].event, self.options[c].args, arg, self.options[c].hide_on_apply,
                                 self.options[c].fine_tune_param)
                         elseif arg == "⋮" then
                             Notification:setNotifySource(Notification.SOURCE_BOTTOM_MENU_MORE)
@@ -623,7 +622,7 @@ function ConfigOption:init()
                         else
                                 Notification:setNotifySource(Notification.SOURCE_BOTTOM_MENU_PROGRESS)
                             self.config:onConfigChoose(self.options[c].values, self.options[c].name,
-                                self.options[c].event, self.options[c].args, self.options[c].events, arg, self.options[c].hide_on_apply)
+                                self.options[c].event, self.options[c].args, arg, self.options[c].hide_on_apply)
                         end
 
                         UIManager:setDirty(self.config, function()
@@ -968,15 +967,7 @@ function ConfigDialog:onConfigEvent(option_event, option_arg, when_applied_callb
     return true
 end
 
-function ConfigDialog:onConfigEvents(option_events, arg_index)
-    for i=1, #option_events do
-        option_events[i].args = option_events[i].args or {}
-        self.ui:handleEvent(Event:new(option_events[i].event, option_events[i].args[arg_index]))
-    end
-    return true
-end
-
-function ConfigDialog:onConfigChoose(values, name, event, args, events, position, hide_on_apply)
+function ConfigDialog:onConfigChoose(values, name, event, args, position, hide_on_apply)
     UIManager:tickAfterNext(function()
         -- Repainting may be delayed depending on options
         local refresh_dialog_func = function()
@@ -1003,9 +994,6 @@ function ConfigDialog:onConfigChoose(values, name, event, args, events, position
             args = args or {}
             self:onConfigEvent(event, args[position], when_applied_callback)
         end
-        if events then
-            self:onConfigEvents(events, position)
-        end
         -- Even if each toggle refreshes itself when toggled, we still
         -- need to update and repaint the whole config panel, as other
         -- toggles may have their state (enabled/disabled) modified
@@ -1018,7 +1006,7 @@ function ConfigDialog:onConfigChoose(values, name, event, args, events, position
 end
 
 -- Tweaked variant used with the fine_tune variant of buttonprogress (direction can only be "-" or "+")
-function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, direction, hide_on_apply, params)
+function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, direction, hide_on_apply, params)
     UIManager:tickAfterNext(function()
         -- Repainting may be delayed depending on options
         local refresh_dialog_func = function()
@@ -1093,9 +1081,6 @@ function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, 
                 end
             end
             self:onConfigEvent(event, arg, when_applied_callback)
-        end
-        if events then
-            self:onConfigEvents(events, direction)
         end
         -- Even if each toggle refreshes itself when toggled, we still
         -- need to update and repaint the whole config panel, as other

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -210,9 +210,6 @@ function ToggleSwitch:onTapSelect(arg, gev)
         self.args = self.args or {}
         self.config:onConfigEvent(self.event, self.args[self.position])
     end
-    if self.events then
-        self.config:onConfigEvents(self.events, self.position)
-    end
     --]]
     if self.callback then
         self.callback(self.position)
@@ -224,7 +221,7 @@ function ToggleSwitch:onTapSelect(arg, gev)
             Notification:setNotifySource(Notification.SOURCE_BOTTOM_MENU_TOGGLE)
         end
         self.config:onConfigChoose(self.values, self.name,
-            self.event, self.args, self.events, self.position, self.hide_on_apply)
+            self.event, self.args, self.position, self.hide_on_apply)
 
         UIManager:setDirty(self.config, function()
             return "ui", self.dimen

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -1,5 +1,6 @@
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
+local Dispatcher = require("dispatcher")
 local KeyValuePage = require("ui/widget/keyvaluepage")
 local LuaSettings = require("luasettings")
 local PowerD = require("device"):getPowerDevice()
@@ -269,9 +270,14 @@ local BatteryStatWidget = WidgetContainer:new{
     name = "batterystat",
 }
 
+function BatteryStatWidget:onDispatcherRegisterActions()
+    Dispatcher:registerAction("battery_statistics", {category="none", event="ShowBatteryStatistics", title=_("Battery statistics"), device=true, separator=true})
+end
+
 function BatteryStatWidget:init()
     -- self.ui is nil in test cases.
     if not self.ui or not self.ui.menu then return end
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
 end
 
@@ -283,6 +289,10 @@ function BatteryStatWidget:addToMainMenu(menu_items)
             BatteryStat:showStatistics()
         end,
     }
+end
+
+function BatteryStatWidget:onShowBatteryStatistics()
+    BatteryStat:showStatistics()
 end
 
 function BatteryStatWidget:onFlushSettings()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -3,6 +3,7 @@ local BookStatusWidget = require("ui/widget/bookstatuswidget")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
+local Dispatcher = require("dispatcher")
 local DocSettings = require("docsettings")
 local FFIUtil = require("ffi/util")
 local InfoMessage = require("ui/widget/infomessage")
@@ -138,6 +139,11 @@ ReaderStatistics.default_settings = {
     calendar_browse_future_months = false,
 }
 
+function ReaderStatistics:onDispatcherRegisterActions()
+    Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), device=true, separator=true})
+    Dispatcher:registerAction("book_statistics", {category="none", event="ShowBookStats", title=_("Book statistics"), rolling=true, paging=true, separator=true})
+end
+
 function ReaderStatistics:init()
     -- Disable in PIC documents (but not the FM, as we want to be registered to the FM's menu).
     if self.ui and self.ui.document and self.ui.document.is_pic then
@@ -150,6 +156,7 @@ function ReaderStatistics:init()
     self.settings = G_reader_settings:readSetting("statistics", self.default_settings)
 
     self.ui.menu:registerToMainMenu(self)
+    self:onDispatcherRegisterActions()
     self:checkInitDatabase()
     BookStatusWidget.getStats = function()
         return self:getStatsBookStatus(self.id_curr_book, self.settings.is_enabled)

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -1,4 +1,5 @@
 local Device = require("device")
+local Dispatcher = require("dispatcher")
 local KeyValuePage = require("ui/widget/keyvaluepage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -254,7 +255,12 @@ local SystemStatWidget = WidgetContainer:new{
     name = "systemstat",
 }
 
+function SystemStatWidget:onDispatcherRegisterActions()
+    Dispatcher:registerAction("system_statistics", {category="none", event="ShowSysStatistics", title=_("System statistics"), device=true, separator=true})
+end
+
 function SystemStatWidget:init()
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
 end
 
@@ -266,6 +272,10 @@ function SystemStatWidget:addToMainMenu(menu_items)
             SystemStat:showStatistics()
         end,
     }
+end
+
+function SystemStatWidget:onShowSysStatistics()
+    SystemStat:showStatistics()
 end
 
 function SystemStatWidget:onSuspend()


### PR DESCRIPTION
Dispatcher: add Battery & System statistics
ConfigDialog: remove uneeded support for muliple events -Fixes reflow support for dispatcher
Dispatcher: update configurable before event (like configdialog)
Dispatcher: initial Kopt support
Statistics: move dispatcher items to plugin

---

Mostly done by #7827

this adds Dispatcher support for kopt options.

@zwim you should be able to add notification support in the kopt handler

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7671)
<!-- Reviewable:end -->
