### PR TITLE
InputDialog: add 'Go to line' button

### DIFF
--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -266,6 +266,9 @@ function InputContainer:onGesture(ev)
             end
         end
     end
+    if self.stop_events_propagation then
+        return true
+    end
 end
 
 function InputContainer:onInput(input, ignore_first_hold_release)

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -734,6 +734,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                         title = _("Enter line number"),
                         input_hint = T("%1 (1 - %2)", cur_line_num, last_line_num),
                         input_type = "number",
+                        stop_events_propagation = true, -- avoid interactions with upper InputDialog
                         buttons = {
                             {
                                 {

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -725,22 +725,14 @@ function InputDialog:_addScrollButtons(nav_bar)
             })
         end
         -- Add a button to go to the line by its number in the file
-        if self.fullscreen and self.view_pos_callback then
+        if self.fullscreen then
             table.insert(row, {
                 text = "Go",
                 callback = function()
-                    -- calculate current line number
-                    local curr_line_num = 1
-                    for i = 1, #self._input_widget.charlist do
-                        if self._input_widget.charlist[i] == "\n" then
-                            if i >= self._input_widget.charpos then break end
-                            curr_line_num = curr_line_num + 1
-                        end
-                    end
-                    local last_line_num = select(2, string.gsub(self:getInputText(), "\n", "")) + 1
+                    local cur_line_num, last_line_num = self._input_widget:getLineNums()
                     input_dialog = InputDialog:new{
                         title = _("Enter line number"),
-                        input_hint = T("%1 (1 - %2)", curr_line_num, last_line_num),
+                        input_hint = T("%1 (1 - %2)", cur_line_num, last_line_num),
                         input_type = "number",
                         buttons = {
                             {
@@ -759,26 +751,9 @@ function InputDialog:_addScrollButtons(nav_bar)
                                     callback = function()
                                         local new_line_num = tonumber(input_dialog:getInputText())
                                         if new_line_num and new_line_num >= 1 and new_line_num <= last_line_num then
-                                            -- calculate charpos for the beginning of the target line
-                                            local new_char_pos = 1
-                                            if new_line_num > 1 then
-                                                local j = 1
-                                                for i = 1, #self._input_widget.charlist do
-                                                    if self._input_widget.charlist[i] == "\n" then
-                                                        j = j + 1
-                                                        if j == new_line_num then
-                                                            new_char_pos = i + 1
-                                                            break
-                                                        end
-                                                    end
-                                                end
-                                            end
-                                            -- reinit with the target line on the top, cursor at the beginning
                                             UIManager:close(input_dialog)
                                             self._input_widget:onCloseKeyboard()
-                                            self.input = self:getInputText()
-                                            self.view_pos_callback(#self._input_widget.charlist, new_char_pos)
-                                            self:init()
+                                            self._input_widget:moveCursorToCharPos(self._input_widget:getLineCharPos(new_line_num))
                                             if not self.keyboard_hidden then
                                                 self:refreshButtons()
                                                 self:onShowKeyboard ()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -727,9 +727,10 @@ function InputDialog:_addScrollButtons(nav_bar)
         -- Add a button to go to the line by its number in the file
         if self.fullscreen then
             table.insert(row, {
-                text = "Go",
+                text = _("Go"),
                 callback = function()
                     local cur_line_num, last_line_num = self._input_widget:getLineNums()
+                    local input_dialog
                     input_dialog = InputDialog:new{
                         title = _("Enter line number"),
                         input_hint = T("%1 (1 - %2)", cur_line_num, last_line_num),
@@ -741,9 +742,6 @@ function InputDialog:_addScrollButtons(nav_bar)
                                     text = _("Cancel"),
                                     callback = function()
                                         UIManager:close(input_dialog)
-                                        if not self.keyboard_hidden then
-                                            self:onShowKeyboard()
-                                        end
                                     end,
                                 },
                                 {
@@ -753,12 +751,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                                         local new_line_num = tonumber(input_dialog:getInputText())
                                         if new_line_num and new_line_num >= 1 and new_line_num <= last_line_num then
                                             UIManager:close(input_dialog)
-                                            self._input_widget:onCloseKeyboard()
                                             self._input_widget:moveCursorToCharPos(self._input_widget:getLineCharPos(new_line_num))
-                                            if not self.keyboard_hidden then
-                                                self:refreshButtons()
-                                                self:onShowKeyboard ()
-                                            end
                                         end
                                     end,
                                 },

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -115,6 +115,7 @@ local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = Device.screen
+local T = require("ffi/util").template
 local _ = require("gettext")
 
 local InputDialog = InputContainer:new{
@@ -775,7 +776,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                                             -- reinit with the target line on the top, cursor at the beginning
                                             UIManager:close(input_dialog)
                                             self._input_widget:onCloseKeyboard()
-                                            self.input=self:getInputText()
+                                            self.input = self:getInputText()
                                             self.view_pos_callback(#self._input_widget.charlist, new_char_pos)
                                             self:init()
                                             if not self.keyboard_hidden then

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -733,7 +733,8 @@ function InputDialog:_addScrollButtons(nav_bar)
                     local input_dialog
                     input_dialog = InputDialog:new{
                         title = _("Enter line number"),
-                        input_hint = T("%1 (1 - %2)", cur_line_num, last_line_num),
+                        -- @translators %1 is the current line number, %2 is the last line number
+                        input_hint = T(_("%1 (1 - %2)"), cur_line_num, last_line_num),
                         input_type = "number",
                         stop_events_propagation = true, -- avoid interactions with upper InputDialog
                         buttons = {

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -501,6 +501,38 @@ function InputText:getKeyboardDimen()
     return self.keyboard.dimen
 end
 
+-- calculate current and last (original) line numbers
+function InputText:getLineNums()
+    local cur_line_num, last_line_num = 1, 1
+    for i = 1, #self.charlist do
+        if self.text_widget.charlist[i] == "\n" then
+            if i < self.charpos then
+                cur_line_num = cur_line_num + 1
+            end
+            last_line_num = last_line_num + 1
+        end
+    end
+    return cur_line_num, last_line_num
+end
+
+-- calculate charpos for the beginning of (original) line
+function InputText:getLineCharPos(line_num)
+    local char_pos = 1
+    if line_num > 1 then
+        local j = 1
+        for i = 1, #self.charlist do
+            if self.charlist[i] == "\n" then
+                j = j + 1
+                if j == line_num then
+                    char_pos = i + 1
+                    break
+                end
+            end
+        end
+    end
+    return char_pos
+end
+
 function InputText:addChars(chars)
     if not chars then
         -- VirtualKeyboard:addChar(key) gave us 'nil' once (?!)
@@ -576,6 +608,11 @@ end
 
 function InputText:goToEnd()
     self.text_widget:moveCursorToCharPos(0)
+end
+
+function InputText:moveCursorToCharPos(char_pos)
+    self.text_widget:moveCursorToCharPos(char_pos)
+    self.charpos, self.top_line_num = self.text_widget:getCharPos()
 end
 
 function InputText:upLine()


### PR DESCRIPTION
Allows to jump to a line by its number in the file.
Shows the target line at top of the screen, cursor positioning at the beginning.
By now available in the Text editor and in the Book-specific style tweak.
Current line number is shown in the hint.

![1](https://user-images.githubusercontent.com/62179190/118107187-2127b600-b3e7-11eb-8239-08c03e495801.png)
--
![2](https://user-images.githubusercontent.com/62179190/118107201-2422a680-b3e7-11eb-9899-5e3d3837dd00.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7673)
<!-- Reviewable:end -->
