### PR TITLE
Fix stupid typo

### DIFF
--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -1,5 +1,5 @@
 --[[--
-@module koplugin.wallabag
+@module koplugin.coverimage
 
 Plugin for saving a cover image to a file and scaling it to fit the screen.
 ]]


### PR DESCRIPTION
I was still thinking about 341d6ac660e590a129ae3e8681167aa1dae0075a I suppose.

Hat tip to @yparitcher.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7678)
<!-- Reviewable:end -->
