### PR TITLE
move SDL check to the end of Device's probe function

### DIFF
--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -36,7 +36,6 @@ local function probeDevice()
     if cervantes_test_stat then
         return require("device/cervantes/device")
     end
-    
     if util.isSDL() then
         return require("device/sdl/device")
     end

--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -2,10 +2,6 @@ local isAndroid, _ = pcall(require, "android")
 local util = require("ffi/util")
 
 local function probeDevice()
-    if util.isSDL() then
-        return require("device/sdl/device")
-    end
-
     if isAndroid then
         return require("device/android/device")
     end
@@ -39,6 +35,10 @@ local function probeDevice()
     local cervantes_test_stat = lfs.attributes("/usr/bin/ntxinfo")
     if cervantes_test_stat then
         return require("device/cervantes/device")
+    end
+    
+    if util.isSDL() then
+        return require("device/sdl/device")
     end
 
     -- add new ports here:


### PR DESCRIPTION
To avoid a few log lines on all platforms:

```
ffi.load: SDL2
ffi.load (warning): libSDL2.so: cannot open shared object file: No such file or directory
ffi.load: libSDL2-2.0.so
ffi.load (warning): libSDL2-2.0.so: cannot open shared object file: No such file or directory
ffi.load: libSDL2-2.0.so.0
ffi.load (warning): libSDL2-2.0.so.0: cannot open shared object file: No such file or directory
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7682)
<!-- Reviewable:end -->
