### PR TITLE
PB: Unconditionally disable HW rotation on B288 SoC

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -549,6 +549,26 @@ To:
             end,
         })
     end
+    --- @note: Intended to debug/investigate B288 quirks on PocketBook devices
+    if Device:hasEinkScreen() and Device:isPocketBook() then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            -- @translators B288 is the codename of the CPU/chipset (SoC stands for 'System on Chip').
+            text = _("Ignore feature bans on B288 SoCs"),
+            enabled_func = function()
+                return Device:isB288SoC()
+            end,
+            checked_func = function()
+                return G_reader_settings:isTrue("pb_ignore_b288_quirks")
+            end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("pb_ignore_b288_quirks")
+                local InfoMessage = require("ui/widget/infomessage")
+                UIManager:show(InfoMessage:new{
+                    text = _("This will take effect on next restart."),
+                })
+            end,
+        })
+    end
     if Device:isAndroid() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
             text = _("Start E-ink test"),

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -54,7 +54,11 @@ local PocketBook = Generic:new{
         keymap = { [scan] = event },
     }]]
     -- Runtime state: whether raw input is actually used
+    --- @fixme: Never actually set anywhere?
     is_using_raw_input = nil,
+
+    -- Will be set appropriately at init
+    isB288SoC = no,
 
     -- Private per-model kludges
     _fb_init = function() end,
@@ -108,11 +112,16 @@ function PocketBook:init()
             fb.forced_rotation = self.usingForcedRotation()
             -- Tweak combination of alwaysPortrait/hwRot/hwInvert flags depending on probed HW and wf settings.
             if fb:isB288() then
-                logger.dbg("mxcfb: Disabling hwinvert on B288 chipset")
-                self.canHWInvert = no
-                -- GL16 glitches with hwrot. And apparently with more stuff on newer FW (#7663)
-                logger.dbg("mxcfb: Disabling hwrot on B288 chipset")
-                fb.forced_rotation = nil
+                self.isB288SoC = yes
+
+                -- Allow bypassing the bans for debugging purposes...
+                if G_reader_settings:nilOrFalse("pb_ignore_b288_quirks") then
+                    logger.dbg("mxcfb: Disabling hwinvert on B288 chipset")
+                    self.canHWInvert = no
+                    -- GL16 glitches with hwrot. And apparently with more stuff on newer FW (#7663)
+                    logger.dbg("mxcfb: Disabling hwrot on B288 chipset")
+                    fb.forced_rotation = nil
+                end
             end
             -- If hwrot is still on, nuke swrot
             if fb.forced_rotation then

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -110,11 +110,9 @@ function PocketBook:init()
             if fb:isB288() then
                 logger.dbg("mxcfb: Disabling hwinvert on B288 chipset")
                 self.canHWInvert = no
-                -- GL16 glitches with hwrot
-                if fb.wf_level == 3 then
-                    logger.dbg("mxcfb: Disabling hwrot on fast waveforms (B288 glitch)")
-                    fb.forced_rotation = nil
-                end
+                -- GL16 glitches with hwrot. And apparently with more stuff on newer FW (#7663)
+                logger.dbg("mxcfb: Disabling hwrot on B288 chipset")
+                fb.forced_rotation = nil
             end
             -- If hwrot is still on, nuke swrot
             if fb.forced_rotation then


### PR DESCRIPTION
Apparently, it's even more broken on some devices/FW combos.

Fix #7663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7684)
<!-- Reviewable:end -->
