### PR TITLE
Fix changeFontSize whith the new granulary gestures

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -196,7 +196,7 @@ end
     UpdatePos event is used to tell ReaderRolling to update pos.
 --]]
 function ReaderFont:onChangeSize(direction, font_delta)
-    local delta = direction == "decrease" and -0.5 or 0.5
+    local delta = direction == "decrease" and -1 or 1
     if font_delta then
         self.font_size = self.font_size + font_delta * delta
     else


### PR DESCRIPTION
Whith the new font size step of 0.5 the gesture for increasing or decreasing font size would change the size by only half of the given value. 
This fix would also be in #7623. But I expect it is better to apply this sooner as #7623 will come :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7689)
<!-- Reviewable:end -->
