### PR TITLE
InputDialog: add search

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -749,7 +749,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                                         if self.search_value ~= "" then
                                             UIManager:close(input_dialog)
                                             local msg
-                                            local char_pos = self._input_widget:searchStr(self.search_value, 1)
+                                            local char_pos = self._input_widget:searchString(self.search_value, 1)
                                             if char_pos > 0 then
                                                 self._input_widget:moveCursorToCharPos(char_pos)
                                                 msg = T(_("Found in line %1"), self._input_widget:getLineNums())
@@ -770,7 +770,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                                         if self.search_value ~= "" then
                                             UIManager:close(input_dialog)
                                             local msg
-                                            local char_pos = self._input_widget:searchStr(self.search_value)
+                                            local char_pos = self._input_widget:searchString(self.search_value)
                                             if char_pos > 0 then
                                                 self._input_widget:moveCursorToCharPos(char_pos)
                                                 msg = T(_("Found in line %1"), self._input_widget:getLineNums())

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -775,7 +775,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                                                 self._input_widget:moveCursorToCharPos(char_pos)
                                                 msg = T(_("Found in line %1"), self._input_widget:getLineNums())
                                             else
-                                                msg = _("Not found")
+                                                msg = _("Not found.")
                                             end
                                             UIManager:show(Notification:new{
                                                 text = msg,

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -724,8 +724,73 @@ function InputDialog:_addScrollButtons(nav_bar)
                 end,
             })
         end
-        -- Add a button to go to the line by its number in the file
         if self.fullscreen then
+            -- Add a button to search for a string in the edited text
+            table.insert(row, {
+                text = _("Find"),
+                callback = function()
+                    local input_dialog
+                    input_dialog = InputDialog:new{
+                        title = _("Enter text to search for"),
+                        stop_events_propagation = true, -- avoid interactions with upper InputDialog
+                        input = self.search_value,
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    callback = function()
+                                        UIManager:close(input_dialog)
+                                    end,
+                                },
+                                {
+                                    text = _("Find first"),
+                                    callback = function()
+                                        self.search_value = input_dialog:getInputText()
+                                        if self.search_value ~= "" then
+                                            UIManager:close(input_dialog)
+                                            local msg
+                                            local char_pos = self._input_widget:searchStr(self.search_value, 1)
+                                            if char_pos > 0 then
+                                                self._input_widget:moveCursorToCharPos(char_pos)
+                                                msg = T(_("Found in line %1"), self._input_widget:getLineNums())
+                                            else
+                                                msg = _("Not found")
+                                            end
+                                            UIManager:show(Notification:new{
+                                                text = msg,
+                                            })
+                                        end
+                                    end,
+                                },
+                                {
+                                    text = _("Find next"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        self.search_value = input_dialog:getInputText()
+                                        if self.search_value ~= "" then
+                                            UIManager:close(input_dialog)
+                                            local msg
+                                            local char_pos = self._input_widget:searchStr(self.search_value)
+                                            if char_pos > 0 then
+                                                self._input_widget:moveCursorToCharPos(char_pos)
+                                                msg = T(_("Found in line %1"), self._input_widget:getLineNums())
+                                            else
+                                                msg = _("Not found")
+                                            end
+                                            UIManager:show(Notification:new{
+                                                text = msg,
+                                            })
+                                        end
+                                    end,
+                                },
+                            },
+                        },
+                    }
+                    UIManager:show(input_dialog)
+                    input_dialog:onShowKeyboard()
+                end,
+            })
+            -- Add a button to go to the line by its number in the file
             table.insert(row, {
                 text = _("Go"),
                 callback = function()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -773,7 +773,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                                             local char_pos = self._input_widget:searchString(self.search_value)
                                             if char_pos > 0 then
                                                 self._input_widget:moveCursorToCharPos(char_pos)
-                                                msg = T(_("Found in line %1"), self._input_widget:getLineNums())
+                                                msg = T(_("Found in line %1."), self._input_widget:getLineNums())
                                             else
                                                 msg = _("Not found.")
                                             end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -536,7 +536,7 @@ end
 -- search for a string
 -- if start_pos not set, starts a search from the next to cursor position
 -- returns first found position or 0 if not found
-function InputText:searchStr(str, start_pos)
+function InputText:searchString(str, start_pos)
     local str_len = string.len(str)
     local char_pos, found = 0, 0
     start_pos = start_pos and (start_pos - 1) or self.charpos

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -533,6 +533,29 @@ function InputText:getLineCharPos(line_num)
     return char_pos
 end
 
+-- search for a string
+-- if start_pos not set, starts a search from the next to cursor position
+-- returns first found position or 0 if not found
+function InputText:searchStr(str, start_pos)
+    local str_len = string.len(str)
+    local char_pos, found = 0, 0
+    start_pos = start_pos and (start_pos - 1) or self.charpos
+    for i = start_pos, #self.charlist - str_len do
+        for j = 1, str_len do
+            if string.lower(self.charlist[i + j]) ~= string.lower(string.sub(str, j, j)) then
+                found = 0
+                break
+            end
+            found = found + 1
+        end
+        if found == str_len then
+            char_pos = i + 1
+            break
+        end
+    end
+    return char_pos
+end
+
 function InputText:addChars(chars)
     if not chars then
         -- VirtualKeyboard:addChar(key) gave us 'nil' once (?!)

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -533,7 +533,7 @@ function InputText:getLineCharPos(line_num)
     return char_pos
 end
 
--- search for a string
+--- Search for a string.
 -- if start_pos not set, starts a search from the next to cursor position
 -- returns first found position or 0 if not found
 function InputText:searchString(str, start_pos)


### PR DESCRIPTION
Searches for a string in the edited text.
Available in the Text editor and other input dialogs with the navigation bar enabled.

<kbd>Find first</kbd> searches from the beginning of the text.
<kbd>Find next</kbd> searches from the next to cursor position, used for continious search.
By now, the Search input window is closed after the search. You need to press the `Find` button again for continious search, the search string is kept in the input.
Is it better to keep the dialog open for the comfortable continious search? And close it with the `Cancel` only?

Case insensitive. Cursor jumps to the beginning of the found string.
Notifications are shown for better results visibility.

Unfortunately, violated our standartization to "search", couldn't invent better short wordings.

![1](https://user-images.githubusercontent.com/62179190/118473801-0c169400-b713-11eb-9b68-a40d12f56738.png)
--
![2](https://user-images.githubusercontent.com/62179190/118473819-0faa1b00-b713-11eb-9a65-97a7edfad549.png)
--
![3](https://user-images.githubusercontent.com/62179190/118473835-12a50b80-b713-11eb-946b-bd48753acc35.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7701)
<!-- Reviewable:end -->
