### PR TITLE
Double tap: Update default tap zones

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -88,8 +88,8 @@ DTAP_ZONE_TOP_LEFT = {x = 0, y = 0, w = 1/8, h = 1/8}
 DTAP_ZONE_TOP_RIGHT = {x = 7/8, y = 0, w = 1/8, h = 1/8}
 DTAP_ZONE_BOTTOM_LEFT = {x = 0, y = 7/8, w = 1/8, h = 1/8}
 DTAP_ZONE_BOTTOM_RIGHT = {x = 7/8, y = 7/8, w = 1/8, h = 1/8}
-DDOUBLE_TAP_ZONE_NEXT_CHAPTER = {x = 6/8, y = 0, w = 2/8, h = 2/8}
-DDOUBLE_TAP_ZONE_PREV_CHAPTER = {x = 0, y = 0, w = 2/8, h = 2/8}
+DDOUBLE_TAP_ZONE_NEXT_CHAPTER = {x = 1/4, y = 0, w = 3/4, h = 1}
+DDOUBLE_TAP_ZONE_PREV_CHAPTER = {x = 0, y = 0, w = 1/4, h = 1}
 
 -- behaviour of swipes
 DCHANGE_WEST_SWIPE_TO_EAST = false

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -800,6 +800,7 @@ function Gestures:setupGesture(ges)
         ratio_w = DTAP_ZONE_BOTTOM_RIGHT.w,
         ratio_h = DTAP_ZONE_BOTTOM_RIGHT.h,
     }
+    -- NOTE: The defaults are effectively mapped to DTAP_ZONE_BACKWARD & DTAP_ZONE_FORWARD
     local zone_left = {
         ratio_x = DDOUBLE_TAP_ZONE_PREV_CHAPTER.x,
         ratio_y = DDOUBLE_TAP_ZONE_PREV_CHAPTER.y,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -815,6 +815,7 @@ function Gestures:setupGesture(ges)
     }
 
     local overrides_tap_corner
+    local overrides_double_tap_corner
     local overrides_hold_corner
     local overrides_vertical_edge, overrides_horizontal_edge
     local overrides_pan, overrides_pan_release
@@ -837,6 +838,10 @@ function Gestures:setupGesture(ges)
             "readermenu_tap",
             "tap_forward",
             "tap_backward",
+        }
+        overrides_double_tap_corner = {
+            "double_tap_left_side",
+            "double_tap_right_side",
         }
         overrides_hold_corner = {
             -- As hold corners are "ignored" by default, and we have
@@ -905,15 +910,19 @@ function Gestures:setupGesture(ges)
     elseif ges == "double_tap_top_left_corner" then
         ges_type = "double_tap"
         zone = zone_top_left_corner
+        overrides = overrides_double_tap_corner
     elseif ges == "double_tap_top_right_corner" then
         ges_type = "double_tap"
         zone = zone_top_right_corner
+        overrides = overrides_double_tap_corner
     elseif ges == "double_tap_bottom_right_corner" then
         ges_type = "double_tap"
         zone = zone_bottom_right_corner
+        overrides = overrides_double_tap_corner
     elseif ges == "double_tap_bottom_left_corner" then
         ges_type = "double_tap"
         zone = zone_bottom_left_corner
+        overrides = overrides_double_tap_corner
     elseif ges == "hold_top_left_corner" then
         ges_type = "hold"
         zone = zone_top_left_corner

--- a/spec/unit/defaults_spec.lua
+++ b/spec/unit/defaults_spec.lua
@@ -32,7 +32,7 @@ describe("defaults module", function()
         assert.is_same(DCREREADER_CONFIG_WORD_SPACING_LARGE, { [1] = 100, [2] = 90 })
         assert.is_same(DTAP_ZONE_BACKWARD, { ["y"] = 0, ["x"] = 0, ["h"] = 1, ["w"] = 0.25 })
         assert.is_same(DCREREADER_CONFIG_H_MARGIN_SIZES_XXX_LARGE, { [1] = 50, [2] = 50 })
-        assert.is_same(DDOUBLE_TAP_ZONE_PREV_CHAPTER, { ["y"] = 0, ["x"] = 0, ["h"] = 0.25, ["w"] = 0.25 })
+        assert.is_same(DDOUBLE_TAP_ZONE_PREV_CHAPTER, { ["y"] = 0, ["x"] = 0, ["h"] = 1, ["w"] = 0.25 })
 
         -- in persistent
         Defaults:init()


### PR DESCRIPTION
Make 'em match backward & forward.
Now that we have working overrides and the gesture manager, trying to fit them in a weird superset of the top corner tapzones in a vain attempt to avoid bad interactions doesn't make much sense anymore, and just makes the Gesture Manager UI confusing.

Also make sure the corner zones override the L/R ones for double taps, like it's the case with other gestures.

Fix #7710

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7711)
<!-- Reviewable:end -->
