### PR TITLE
InputText: add clipboard dialog

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -142,12 +142,12 @@ if Device:isTouchDevice() or Device:hasDPad() then
                     if self.selection_start_pos then -- select end
                         local selection_end_pos = self.charpos - 1
                         if self.selection_start_pos > selection_end_pos then
-                            self.selection_start_pos, selection_end_pos = selection_end_pos, self.selection_start_pos
+                            self.selection_start_pos, selection_end_pos = selection_end_pos + 1, self.selection_start_pos - 1
                         end
                         local txt = table.concat(self.charlist, "", self.selection_start_pos, selection_end_pos)
                         Device.input.setClipboardText(txt)
                         UIManager:show(Notification:new{
-                            text = _("Text copied to clipboard"),
+                            text = _("Selection copied to clipboard."),
                         })
                         self.selection_start_pos = nil
                         self.do_select = false
@@ -155,7 +155,7 @@ if Device:isTouchDevice() or Device:hasDPad() then
                     else -- select start
                         self.selection_start_pos = self.charpos
                         UIManager:show(Notification:new{
-                            text = _("Hold the end of selection"),
+                            text = _("Set cursor to end of selection, then hold."),
                         })
                         return true
                     end
@@ -173,6 +173,9 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                 callback = function()
                                     UIManager:close(input_dialog)
                                     Device.input.setClipboardText(table.concat(self.charlist))
+                                    UIManager:show(Notification:new{
+                                        text = _("All text copied to clipboard."),
+                                    })
                                 end,
                             },
                             {
@@ -181,6 +184,9 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                     UIManager:close(input_dialog)
                                     local txt = table.concat(self.charlist, "", self:getStringPos({"\n"}, {"\n"}))
                                     Device.input.setClipboardText(txt)
+                                    UIManager:show(Notification:new{
+                                        text = _("Line copied to clipboard."),
+                                    })
                                 end,
                             },
                             {
@@ -189,6 +195,9 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                     UIManager:close(input_dialog)
                                     local txt = table.concat(self.charlist, "", self:getStringPos({"\n", " "}, {"\n", " "}))
                                     Device.input.setClipboardText(txt)
+                                    UIManager:show(Notification:new{
+                                        text = _("Word copied to clipboard."),
+                                    })
                                 end,
                             },
                         },
@@ -204,7 +213,7 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                 callback = function()
                                     UIManager:close(input_dialog)
                                     UIManager:show(Notification:new{
-                                        text = _("Hold the start of selection"),
+                                        text = _("Set cursor to start of selection, then hold."),
                                     })
                                     self.do_select = true
                                 end,

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -182,7 +182,7 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                 text = _("Line"),
                                 callback = function()
                                     UIManager:close(input_dialog)
-                                    local txt = table.concat(self.charlist, "", self:getStringPos({"\n"}, {"\n"}))
+                                    local txt = table.concat(self.charlist, "", self:getStringPos({"\n", "\r"}, {"\n", "\r"}))
                                     Device.input.setClipboardText(txt)
                                     UIManager:show(Notification:new{
                                         text = _("Line copied to clipboard."),
@@ -193,7 +193,7 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                 text = _("Word"),
                                 callback = function()
                                     UIManager:close(input_dialog)
-                                    local txt = table.concat(self.charlist, "", self:getStringPos({"\n", " "}, {"\n", " "}))
+                                    local txt = table.concat(self.charlist, "", self:getStringPos({"\n", "\r", " "}, {"\n", "\r", " "}))
                                     Device.input.setClipboardText(txt)
                                     UIManager:show(Notification:new{
                                         text = _("Word copied to clipboard."),

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -147,7 +147,12 @@ if Device:isTouchDevice() or Device:hasDPad() then
             if Device:hasClipboard() then
                 if self.do_select then -- select mode on
                     if self.selection_start_pos then -- select end
-                        Device.input.setClipboardText(table.concat(self.charlist, "", self.selection_start_pos, self.charpos-1))
+                        local selection_end_pos = self.charpos - 1
+                        if self.selection_start_pos > selection_end_pos then
+                            self.selection_start_pos, selection_end_pos = selection_end_pos, self.selection_start_pos
+                        end
+                        local txt = table.concat(self.charlist, "", self.selection_start_pos, selection_end_pos)
+                        Device.input.setClipboardText(txt)
                         UIManager:show(Notification:new{
                             text = _("Text copied to clipboard"),
                         })
@@ -181,16 +186,17 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                 text = _("Line"),
                                 callback = function()
                                     UIManager:close(input_dialog)
-                                    Device.input.setClipboardText(table.concat(self.charlist, "", self:getStringPos({"\n"}, {"\n"})))
+                                    local txt = table.concat(self.charlist, "", self:getStringPos({"\n"}, {"\n"}))
+                                    Device.input.setClipboardText(txt)
                                 end,
                             },
                             {
                                 text = _("Word"),
                                 callback = function()
                                     UIManager:close(input_dialog)
-                                    Device.input.setClipboardText(table.concat(self.charlist, "", self:getStringPos({"\n", " "}, {"\n", " "})))
+                                    local txt = table.concat(self.charlist, "", self:getStringPos({"\n", " "}, {"\n", " "}))
+                                    Device.input.setClipboardText(txt)
                                 end,
-                               
                             },
                         },
                         {
@@ -624,7 +630,7 @@ end
 -- delimited with the delimiters and containing char_pos.
 -- If char_pos not set, current charpos assumed.
 function InputText:getStringPos(left_delimiter, right_delimiter, char_pos)
-    local char_pos = char_pos and char_pos or self.charpos
+    char_pos = char_pos and char_pos or self.charpos
     local start_pos, end_pos = 1, #self.charlist
     local done = false
     if char_pos > 1 then

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -136,13 +136,6 @@ if Device:isTouchDevice() or Device:hasDPad() then
             if self.parent.onSwitchFocus then
                 self.parent:onSwitchFocus(self)
             end
-            if #self.charlist > 0 then -- Avoid cursor moving within a hint.
-                local textwidget_offset = self.margin + self.bordersize + self.padding
-                local x = ges.pos.x - self._frame_textwidget.dimen.x - textwidget_offset
-                local y = ges.pos.y - self._frame_textwidget.dimen.y - textwidget_offset
-                self.text_widget:moveCursorToXY(x, y, true) -- restrict_to_view=true
-                self.charpos, self.top_line_num = self.text_widget:getCharPos()
-            end
             -- clipboard dialog
             if Device:hasClipboard() then
                 if self.do_select then -- select mode on


### PR DESCRIPTION
Add some clipboard management to the Text editor and other text input boxes.
Screenshots here: https://github.com/koreader/koreader/issues/7715
Closes #7715.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7719)
<!-- Reviewable:end -->
