### PR TITLE
CReDocument: Don't break it when a cached ref is closed

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -502,7 +502,8 @@ function ReaderUI:onShowingReader()
     self.tearing_down = true
     self.dithered = nil
 
-    self:onClose()
+    -- Don't enforce a "full" refresh, leave that decision to the next widget we'll *show*.
+    self:onClose(false)
 end
 
 -- Same as above, except we don't close it yet. Useful for plugins that need to close custom Menus before calling showReader.

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -214,6 +214,7 @@ function DocumentRegistry:openDocument(file, provider)
         end
     else
         self.registry[file].refs = self.registry[file].refs + 1
+        logger.dbg("DocumentRegistry: Increased refcount to", self.registry[file].refs, "for", file)
     end
     if self.registry[file] then
         return self.registry[file].doc
@@ -232,7 +233,16 @@ function DocumentRegistry:closeDocument(file)
             return self.registry[file].refs
         end
     else
-        error("Try to close unregistered file.")
+        error("Tried to close an unregistered file.")
+    end
+end
+
+--- Queries the current refcount for a given file
+function DocumentRegistry:getReferenceCount(file)
+    if self.registry[file] then
+        return self.registry[file].refs
+    else
+        return nil
     end
 end
 

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -261,9 +261,16 @@ function PdfDocument:writeDocument()
 end
 
 function PdfDocument:close()
-    if self.is_edited then
-        self:writeDocument()
+    -- NOTE: We can't just rely on Document:close's return code for that, as we need self._document
+    --       in :writeDocument, and it would have been destroyed.
+    local DocumentRegistry = require("document/documentregistry")
+    if DocumentRegistry:getReferenceCount(self.file) == 1 then
+        -- We're the final reference to this Document instance.
+        if self.is_edited then
+            self:writeDocument()
+        end
     end
+
     Document.close(self)
 end
 

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -22,6 +22,7 @@ function PicDocument:init()
         error("Failed to open image:" .. self._document)
     end
 
+    self.is_open = true
     self.info.has_pages = true
     self.info.configurable = false
 

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -122,7 +122,7 @@ local monthTranslation = {
 }
 
 function ReaderStatistics:isDocless()
-    return self.ui == nil or self.ui.document == nil
+    return self.ui == nil or self.ui.document == nil or self.ui.document.is_pic == true
 end
 
 -- NOTE: This is used in a migration script by ui/data/onetime_migration,
@@ -139,9 +139,10 @@ ReaderStatistics.default_settings = {
 }
 
 function ReaderStatistics:init()
-    if not self:isDocless() and self.ui.document.is_pic then
+    if self:isDocless() then
         return
     end
+
     self.start_current_period = os.time()
     self:resetVolatileStats()
 


### PR DESCRIPTION
There was a nasty interaction whereas CReDocument would assume *all* :close calls were "final". That isn't actually the case, as DocumentRegistry will keep a cache of currently open documents with refcounting.

Tweak Document:close & DocumentRegistry to make the refcounting state more explicit, allowing CreDocument (& PdfDocument) to only do "final" stuff on actually final :close calls (i.e., closing the last ref, a.k.a., tearing down the actual instance).

Regression since #7702, c.f., https://github.com/koreader/koreader/pull/7702#issuecomment-845042727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7723)
<!-- Reviewable:end -->
