### PR TITLE
ReaderHighlight: clearer symbols on selection start/end buttons

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1155,7 +1155,7 @@ end
 function ReaderHighlight:onHoldRelease()
     local long_final_hold = false
     if self.hold_last_tv then
-        local hold_duration = UIManager:getTime() - self.hold_last_tv
+        local hold_duration = TimeVal:now() - self.hold_last_tv
         if hold_duration > TimeVal:new{ sec = 3, usec = 0 } then
             -- We stayed 3 seconds before release without updating selection
             long_final_hold = true

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -617,15 +617,14 @@ function ReaderHighlight:onShowHighlightDialog(page, index)
     }
 
     if not self.ui.document.info.has_pages then
-        local start_prev = "◁⇱"
-        local start_next = "⇱▷"
-        local end_prev = "◁⇲"
-        local end_next = "⇲▷"
+        local start_prev = "◁▒▒"
+        local start_next = "▷▒▒"
+        local end_prev = "▒▒◁"
+        local end_next = "▒▒▷"
         if BD.mirroredUILayout() then
-            -- Sadly, there's only north west & south east arrow to corner,
-            -- north east and south west do not exist in Unicode.
-            start_prev, start_next = BD.ltr(start_next), BD.ltr(start_prev)
-            end_prev, end_next = BD.ltr(end_next), BD.ltr(end_prev)
+            -- BiDi will mirror the arrows, and this just works
+            start_prev, start_next = start_next, start_prev
+            end_prev, end_next = end_next, end_prev
         end
         table.insert(buttons, {
             {


### PR DESCRIPTION
See #7713. Closes #7713.

<kbd>![image](https://user-images.githubusercontent.com/24273478/119050563-55403f80-b9c2-11eb-8f65-0a9c5de4a181.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/119050707-7f91fd00-b9c2-11eb-9776-4974a18b441e.png)</kbd>

(Just realising with these screenshots these buttons ended up looking the same in LTR and RTL - although doing different things :)


Also fix long-long-press on single word (to bring the highlight dialog instead of doing a lookup) which was broken since a few weeks. See https://github.com/koreader/koreader/issues/7722#issuecomment-845365207

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7725)
<!-- Reviewable:end -->
