### PR TITLE
VirtualKeyboard: move cursor with holding left/right arrows

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -755,13 +755,13 @@ function InputText:rightChar()
     self.charpos, self.top_line_num = self.text_widget:getCharPos()
 end
 
-function InputText:startLine()
+function InputText:goToStartOfLine()
     local new_pos = select(1, self:getStringPos({"\n", "\r"}, {"\n", "\r"}))
     self.text_widget:moveCursorToCharPos(new_pos)
     self.charpos, self.top_line_num = self.text_widget:getCharPos()
 end
 
-function InputText:endLine()
+function InputText:goToEndOfLine()
     local new_pos = select(2, self:getStringPos({"\n", "\r"}, {"\n", "\r"})) + 1
     self.text_widget:moveCursorToCharPos(new_pos)
     self.charpos, self.top_line_num = self.text_widget:getCharPos()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -755,6 +755,18 @@ function InputText:rightChar()
     self.charpos, self.top_line_num = self.text_widget:getCharPos()
 end
 
+function InputText:startLine()
+    local new_pos = select(1, self:getStringPos({"\n", "\r"}, {"\n", "\r"}))
+    self.text_widget:moveCursorToCharPos(new_pos)
+    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+end
+
+function InputText:endLine()
+    local new_pos = select(2, self:getStringPos({"\n", "\r"}, {"\n", "\r"})) + 1
+    self.text_widget:moveCursorToCharPos(new_pos)
+    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+end
+
 function InputText:goToHome()
     self.text_widget:moveCursorToCharPos(1)
 end

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -115,13 +115,13 @@ function VirtualKey:init()
         self.callback = function() self.keyboard:leftChar() end
         self.hold_callback = function()
             self.ignore_key_release = true
-            self.keyboard:startLine()
+            self.keyboard:goToStartOfLine()
         end
     elseif self.label == "→" then
         self.callback = function() self.keyboard:rightChar() end
         self.hold_callback = function()
             self.ignore_key_release = true
-            self.keyboard:endLine()
+            self.keyboard:goToEndOfLine()
         end
     elseif self.label == "↑" then
         self.callback = function() self.keyboard:upLine() end
@@ -907,12 +907,12 @@ function VirtualKeyboard:rightChar()
     self.inputbox:rightChar()
 end
 
-function VirtualKeyboard:startLine()
-    self.inputbox:startLine()
+function VirtualKeyboard:goToStartOfLine()
+    self.inputbox:goToStartOfLine()
 end
 
-function VirtualKeyboard:endLine()
-    self.inputbox:endLine()
+function VirtualKeyboard:goToEndOfLine()
+    self.inputbox:goToEndOfLine()
 end
 
 function VirtualKeyboard:upLine()

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -113,8 +113,16 @@ function VirtualKey:init()
         --self.skiphold = true
     elseif self.label =="←" then
         self.callback = function() self.keyboard:leftChar() end
+        self.hold_callback = function()
+            self.ignore_key_release = true
+            self.keyboard:startLine()
+        end
     elseif self.label == "→" then
         self.callback = function() self.keyboard:rightChar() end
+        self.hold_callback = function()
+            self.ignore_key_release = true
+            self.keyboard:endLine()
+        end
     elseif self.label == "↑" then
         self.callback = function() self.keyboard:upLine() end
     elseif self.label == "↓" then
@@ -897,6 +905,14 @@ end
 
 function VirtualKeyboard:rightChar()
     self.inputbox:rightChar()
+end
+
+function VirtualKeyboard:startLine()
+    self.inputbox:startLine()
+end
+
+function VirtualKeyboard:endLine()
+    self.inputbox:endLine()
 end
 
 function VirtualKeyboard:upLine()


### PR DESCRIPTION
Holding `left arrow` will move cursor to the beginning of the line.
Holding `right arrow` will move cursor to the end of the line.
Available in all input boxes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7730)
<!-- Reviewable:end -->
