### PR TITLE
Enable bomb crash screen on Cervantes

### DIFF
--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export LC_ALL="en_US.UTF-8"
 
@@ -91,7 +91,10 @@ ENTER_QBOOKAPP=87
 RETURN_VALUE="${RESTART_KOREADER}"
 
 # Loop forever until KOReader requests a normal exit.
-while [ "${RETURN_VALUE}" -ge "${RESTART_KOREADER}" ]; do
+while [ \
+    "${RETURN_VALUE}" -eq "${ENTER_USBMS}" -o \
+    "${RETURN_VALUE}" -eq "${ENTER_QBOOKAPP}" -o \
+    "${RETURN_VALUE}" -eq "${RESTART_KOREADER}" ]; do
 
     # move dictionaries from external storage to koreader private partition.
     find /mnt/public/dict -type f -exec mv -v \{\} /mnt/private/koreader/data/dict \; 2>/dev/null
@@ -126,6 +129,35 @@ while [ "${RETURN_VALUE}" -ge "${RESTART_KOREADER}" ]; do
         done
     fi
 done
+
+if [ "${RETURN_VALUE}" -ne 0 ]; then
+
+        # Show a fancy bomb on screen
+        viewWidth=600
+        viewHeight=800
+        FONTH=16
+        eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
+        # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
+        # Height @ ~56.7%, w/ a margin worth 1.5 lines
+        bombHeight=$((viewHeight / 2 + viewHeight / 15))
+        bombMargin=$((FONTH + FONTH / 2))
+        # With a little notice at the top of the screen, on a big gray screen of death ;).
+        ./fbink -q -b -c -m -y 1 "Don't Panic! (Return value: ${RETURN_VALUE})"
+        # Warn that we're waiting on a tap to continue...
+        ./fbink -q -b -O -m -y 2 "Tap the screen to continue."
+        # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
+        # shellcheck disable=SC2039,SC3003
+        ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -- $'\xf0\x9f\x92\xa3'
+        # And then print the tail end of the log on the bottom of the screen...
+        crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
+        # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64)) -- "${crashLog}"
+        # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
+        ./fbink -q -f -s
+        # Cue a lemming's faceplant sound effect!
+
+        read -r -t 15 </dev/input/event1
+fi
 
 if [ "${STANDALONE}" != "true" ]; then
     ./release-ip.sh

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -156,7 +156,7 @@ if [ "${RETURN_VALUE}" -ne 0 ]; then
         ./fbink -q -f -s
         # Cue a lemming's faceplant sound effect!
 
-        read -r -t 15 </dev/input/event1
+        timeout 15 head -c 24 /dev/input/event1 > /dev/null
 fi
 
 if [ "${STANDALONE}" != "true" ]; then

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -154,7 +154,7 @@ while [ "${RETURN_VALUE}" -ne 0 ]; do
         {
             echo "!!!!"
             echo "Uh oh, something went awry... (Crash n°${CRASH_COUNT}: $(date +'%x @ %X'))"
-            echo "Running FW $(xargs </.version) on Linux $(uname -r) ($(uname -v))"
+            echo "Running on Linux $(uname -r) ($(uname -v))"
         } >>crash.log 2>&1
         if [ ${CRASH_COUNT} -lt 5 ] && [ "${ALWAYS_ABORT}" = "false" ]; then
             echo "Attempting to restart KOReader . . ." >>crash.log 2>&1

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -91,10 +91,9 @@ ENTER_QBOOKAPP=87
 RETURN_VALUE="${RESTART_KOREADER}"
 
 # Loop forever until KOReader requests a normal exit.
-while [ \
-    "${RETURN_VALUE}" -eq "${ENTER_USBMS}" -o \
-    "${RETURN_VALUE}" -eq "${ENTER_QBOOKAPP}" -o \
-    "${RETURN_VALUE}" -eq "${RESTART_KOREADER}" ]; do
+while [ "${RETURN_VALUE}" -eq "${ENTER_USBMS}" ] ||
+    [ "${RETURN_VALUE}" -eq "${ENTER_QBOOKAPP}" ] ||
+    [ "${RETURN_VALUE}" -eq "${RESTART_KOREADER}" ]; do
 
     # move dictionaries from external storage to koreader private partition.
     find /mnt/public/dict -type f -exec mv -v \{\} /mnt/private/koreader/data/dict \; 2>/dev/null
@@ -146,7 +145,6 @@ if [ "${RETURN_VALUE}" -ne 0 ]; then
     # Warn that we're waiting on a tap to continue...
     ./fbink -q -b -O -m -y 2 "Tap the screen to continue."
     # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
-    # shellcheck disable=SC2039,SC3003
     ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -- $'\xf0\x9f\x92\xa3'
     # And then print the tail end of the log on the bottom of the screen...
     crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
@@ -156,7 +154,7 @@ if [ "${RETURN_VALUE}" -ne 0 ]; then
     ./fbink -q -f -s
     # Cue a lemming's faceplant sound effect!
 
-    timeout 15 head -c 24 /dev/input/event1 > /dev/null
+    timeout 15 head -c 24 /dev/input/event1 >/dev/null
 fi
 
 if [ "${STANDALONE}" != "true" ]; then

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -211,9 +211,7 @@ while [ "${RETURN_VALUE}" -ne 0 ]; do
             sleep 10
         done
     fi
-
 done
-
 
 if [ "${STANDALONE}" != "true" ]; then
     ./release-ip.sh

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -132,31 +132,31 @@ done
 
 if [ "${RETURN_VALUE}" -ne 0 ]; then
 
-        # Show a fancy bomb on screen
-        viewWidth=600
-        viewHeight=800
-        FONTH=16
-        eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
-        # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
-        # Height @ ~56.7%, w/ a margin worth 1.5 lines
-        bombHeight=$((viewHeight / 2 + viewHeight / 15))
-        bombMargin=$((FONTH + FONTH / 2))
-        # With a little notice at the top of the screen, on a big gray screen of death ;).
-        ./fbink -q -b -c -m -y 1 "Don't Panic! (Return value: ${RETURN_VALUE})"
-        # Warn that we're waiting on a tap to continue...
-        ./fbink -q -b -O -m -y 2 "Tap the screen to continue."
-        # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
-        # shellcheck disable=SC2039,SC3003
-        ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -- $'\xf0\x9f\x92\xa3'
-        # And then print the tail end of the log on the bottom of the screen...
-        crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
-        # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
-        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64)) -- "${crashLog}"
-        # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
-        ./fbink -q -f -s
-        # Cue a lemming's faceplant sound effect!
+    # Show a fancy bomb on screen
+    viewWidth=600
+    viewHeight=800
+    FONTH=16
+    eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
+    # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
+    # Height @ ~56.7%, w/ a margin worth 1.5 lines
+    bombHeight=$((viewHeight / 2 + viewHeight / 15))
+    bombMargin=$((FONTH + FONTH / 2))
+    # With a little notice at the top of the screen, on a big gray screen of death ;).
+    ./fbink -q -b -c -m -y 1 "Don't Panic! (Return value: ${RETURN_VALUE})"
+    # Warn that we're waiting on a tap to continue...
+    ./fbink -q -b -O -m -y 2 "Tap the screen to continue."
+    # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
+    # shellcheck disable=SC2039,SC3003
+    ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -- $'\xf0\x9f\x92\xa3'
+    # And then print the tail end of the log on the bottom of the screen...
+    crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
+    # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
+    ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64)) -- "${crashLog}"
+    # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
+    ./fbink -q -f -s
+    # Cue a lemming's faceplant sound effect!
 
-        timeout 15 head -c 24 /dev/input/event1 > /dev/null
+    timeout 15 head -c 24 /dev/input/event1 > /dev/null
 fi
 
 if [ "${STANDALONE}" != "true" ]; then

--- a/platform/cervantes/koreader.sh
+++ b/platform/cervantes/koreader.sh
@@ -83,6 +83,9 @@ if [ "${STANDALONE}" != "true" ]; then
     [ -x /etc/init.d/connman ] && /etc/init.d/connman stop
 fi
 
+CRASH_COUNT=0
+CRASH_TS=0
+CRASH_PREV_TS=0
 # **magic** values to request shell stuff. It starts at 85,
 # any number lower than that will exit this script.
 RESTART_KOREADER=85
@@ -91,19 +94,100 @@ ENTER_QBOOKAPP=87
 RETURN_VALUE="${RESTART_KOREADER}"
 
 # Loop forever until KOReader requests a normal exit.
-while [ "${RETURN_VALUE}" -eq "${ENTER_USBMS}" ] ||
-    [ "${RETURN_VALUE}" -eq "${ENTER_QBOOKAPP}" ] ||
-    [ "${RETURN_VALUE}" -eq "${RESTART_KOREADER}" ]; do
+while [ "${RETURN_VALUE}" -ne 0 ]; do
 
     # move dictionaries from external storage to koreader private partition.
     find /mnt/public/dict -type f -exec mv -v \{\} /mnt/private/koreader/data/dict \; 2>/dev/null
 
-    # Do an update check now, so we can actually update KOReader via the "Restart KOReader" menu entry ;).
-    ko_update_check
+    if [ ${RETURN_VALUE} -eq ${RESTART_KOREADER} ]; then
+        # Do an update check now, so we can actually update KOReader via the "Restart KOReader" menu entry ;).
+        ko_update_check
+    fi
 
     # run KOReader
     ./reader.lua "$@" >>crash.log 2>&1
     RETURN_VALUE=$?
+
+    if [ ${RETURN_VALUE} -ne 0 ] && [ "${RETURN_VALUE}" -ne "${ENTER_USBMS}" ] && [ "${RETURN_VALUE}" -ne "${ENTER_QBOOKAPP}" ] && [ "${RETURN_VALUE}" -ne "${RESTART_KOREADER}" ]; then
+        # Increment the crash counter
+        CRASH_COUNT=$((CRASH_COUNT + 1))
+        CRASH_TS=$(date +'%s')
+        # Reset it to a first crash if it's been a while since our last crash...
+        if [ $((CRASH_TS - CRASH_PREV_TS)) -ge 20 ]; then
+            CRASH_COUNT=1
+        fi
+
+        # Check if the user requested to always abort on crash
+        if grep -q '\["dev_abort_on_crash"\] = true' 'settings.reader.lua' 2>/dev/null; then
+            ALWAYS_ABORT="true"
+            # In which case, make sure we pause on *every* crash
+            CRASH_COUNT=1
+        else
+            ALWAYS_ABORT="false"
+        fi
+
+        # Show a fancy bomb on screen
+        viewWidth=600
+        viewHeight=800
+        FONTH=16
+        eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
+        # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
+        # Height @ ~56.7%, w/ a margin worth 1.5 lines
+        bombHeight=$((viewHeight / 2 + viewHeight / 15))
+        bombMargin=$((FONTH + FONTH / 2))
+        # With a little notice at the top of the screen, on a big gray screen of death ;).
+        ./fbink -q -b -c -B GRAY9 -m -y 1 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
+        if [ ${CRASH_COUNT} -eq 1 ]; then
+            # Warn that we're waiting on a tap to continue...
+            ./fbink -q -b -O -m -y 2 "Tap the screen to continue."
+        fi
+        # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
+        ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -- $'\xf0\x9f\x92\xa3'
+        # And then print the tail end of the log on the bottom of the screen...
+        crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
+        # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64)) -- "${crashLog}"
+        # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
+        ./fbink -q -f -s
+        # Cue a lemming's faceplant sound effect!
+
+        {
+            echo "!!!!"
+            echo "Uh oh, something went awry... (Crash n°${CRASH_COUNT}: $(date +'%x @ %X'))"
+            echo "Running FW $(xargs </.version) on Linux $(uname -r) ($(uname -v))"
+        } >>crash.log 2>&1
+        if [ ${CRASH_COUNT} -lt 5 ] && [ "${ALWAYS_ABORT}" = "false" ]; then
+            echo "Attempting to restart KOReader . . ." >>crash.log 2>&1
+            echo "!!!!" >>crash.log 2>&1
+        fi
+
+        # Pause a bit if it's the first crash in a while, so that it actually has a chance of getting noticed ;).
+        if [ ${CRASH_COUNT} -eq 1 ]; then
+            # NOTE: We don't actually care about what head reads, we're just using it as a fancy sleep ;).
+            #       i.e., we pause either until the 15s timeout, or until the user touches the screen.
+            timeout 15 head -c 24 /dev/input/event1 >/dev/null
+        fi
+        # Cycle the last crash timestamp
+        CRASH_PREV_TS=${CRASH_TS}
+
+        # But if we've crashed more than 5 consecutive times, exit, because we wouldn't want to be stuck in a loop...
+        # NOTE: No need to check for ALWAYS_ABORT, CRASH_COUNT will always be 1 when it's true ;).
+        if [ ${CRASH_COUNT} -ge 5 ]; then
+            echo "Too many consecutive crashes, aborting . . ." >>crash.log 2>&1
+            echo "!!!! ! !!!!" >>crash.log 2>&1
+            break
+        fi
+
+        # If the user requested to always abort on crash, do so.
+        if [ "${ALWAYS_ABORT}" = "true" ]; then
+            echo "Aborting . . ." >>crash.log 2>&1
+            echo "!!!! ! !!!!" >>crash.log 2>&1
+            break
+        fi
+    else
+        # Reset the crash counter if that was a sane exit/restart
+        CRASH_COUNT=0
+    fi
 
     # check if KOReader requested to enter in mass storage mode.
     if [ "${RETURN_VALUE}" -eq "${ENTER_USBMS}" ]; then
@@ -127,35 +211,9 @@ while [ "${RETURN_VALUE}" -eq "${ENTER_USBMS}" ] ||
             sleep 10
         done
     fi
+
 done
 
-if [ "${RETURN_VALUE}" -ne 0 ]; then
-
-    # Show a fancy bomb on screen
-    viewWidth=600
-    viewHeight=800
-    FONTH=16
-    eval "$(./fbink -e | tr ';' '\n' | grep -e viewWidth -e viewHeight -e FONTH | tr '\n' ';')"
-    # Compute margins & sizes relative to the screen's resolution, so we end up with a similar layout, no matter the device.
-    # Height @ ~56.7%, w/ a margin worth 1.5 lines
-    bombHeight=$((viewHeight / 2 + viewHeight / 15))
-    bombMargin=$((FONTH + FONTH / 2))
-    # With a little notice at the top of the screen, on a big gray screen of death ;).
-    ./fbink -q -b -c -m -y 1 "Don't Panic! (Return value: ${RETURN_VALUE})"
-    # Warn that we're waiting on a tap to continue...
-    ./fbink -q -b -O -m -y 2 "Tap the screen to continue."
-    # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
-    ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -- $'\xf0\x9f\x92\xa3'
-    # And then print the tail end of the log on the bottom of the screen...
-    crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
-    # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
-    ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64)) -- "${crashLog}"
-    # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
-    ./fbink -q -f -s
-    # Cue a lemming's faceplant sound effect!
-
-    timeout 15 head -c 24 /dev/input/event1 >/dev/null
-fi
 
 if [ "${STANDALONE}" != "true" ]; then
     ./release-ip.sh


### PR DESCRIPTION
I have made the minimal modifications to enable the bomb crash screen on Cervantes while preserving as much of the current behavior as possible, but the current behavior is inconsistent: it leaves the restart loop for return values between 1 and 84 but treats any return value greater than 87 as a request to restart koreader.

I decided to maintain the spirit of the original script and only restart koreader for the special return values (85, 86 and 87), and exit for any other return value, showing the crash screen if the return value is not zero.

If it is deemed better that koreader.sh loops forever restarting koreader until the return value is zero I can change the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7731)
<!-- Reviewable:end -->
