### PR TITLE
ReaderStatus: Don't crash in EndOfDocument actions that *immediately*…

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -144,8 +144,11 @@ function ReaderStatus:onEndOfBook()
             }
             UIManager:show(info)
             UIManager:forceRePaint()
-            self:openNextFile(self.document.file)
             UIManager:close(info)
+            -- Delay until the next tick, as this will destroy the Document instance, but we may not be the final Event caught by said Document...
+            UIManager:nextTick(function()
+                self:openNextFile(self.document.file)
+            end)
         else
             UIManager:show(InfoMessage:new{
                 text = _("Could not open next file. Sort by last read date does not support this feature."),
@@ -154,7 +157,10 @@ function ReaderStatus:onEndOfBook()
     elseif settings == "goto_beginning" then
         self.ui:handleEvent(Event:new("GoToBeginning"))
     elseif settings == "file_browser" then
-        self:openFileBrowser()
+        -- Ditto
+        UIManager:nextTick(function()
+            self:openFileBrowser()
+        end)
     elseif settings == "mark_read" then
         self:onMarkBook(true)
         UIManager:show(InfoMessage:new{
@@ -162,10 +168,16 @@ function ReaderStatus:onEndOfBook()
             timeout = 3
         })
     elseif settings == "book_status_file_browser" then
-        local before_show_callback = function() self:openFileBrowser() end
-        self:onShowBookStatus(before_show_callback)
+        -- Ditto
+        UIManager:nextTick(function()
+            local before_show_callback = function() self:openFileBrowser() end
+            self:onShowBookStatus(before_show_callback)
+        end)
     elseif settings == "delete_file" then
-        self:deleteFile(self.document.file, true)
+        -- Ditto
+        UIManager:nextTick(function()
+            self:deleteFile(self.document.file, true)
+        end)
     end
 end
 
@@ -175,7 +187,6 @@ function ReaderStatus:openFileBrowser()
     if not FileManager.instance then
         self.ui:showFileManager()
     end
-    self.document = nil
 end
 
 function ReaderStatus:openNextFile(next_file)


### PR DESCRIPTION
… destroy the

ReaderUI instance.

This is handled in an Event handler, but we have zero guarantee that
we're actually the *final* Event sent to the Document, and other Events
usually kinda need the Document instance to still be alive ;).

Delay action until the next tick to avoid potential crashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7733)
<!-- Reviewable:end -->
