### PR TITLE
don't log thirdparty app list if they're platform defaults

### DIFF
--- a/frontend/device/thirdparty.lua
+++ b/frontend/device/thirdparty.lua
@@ -33,7 +33,9 @@ function M:new(o)
             end
         end
     end
-    logger.info(o:dump())
+    if o.is_user_list then
+        logger.info(o:dump())
+    end
     return o
 end
 
@@ -54,7 +56,7 @@ function M:checkMethod(role, method)
 end
 
 function M:dump()
-    local str = (self.is_user_list and "user" or "platform") .. " thirdparty apps\n"
+    local str = "user defined thirdparty apps\n"
     for i, role in ipairs(roles) do
         local apps = self[role.."s"]
         for index, _ in ipairs(apps or {}) do


### PR DESCRIPTION
They add noise to early logs, just to print defaults

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7760)
<!-- Reviewable:end -->
