### PR TITLE
OPDS catalog: add book info button

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -674,7 +674,7 @@ function OPDSBrowser:showDownloads(item)
             callback = function()
                 local TextViewer = require("ui/widget/textviewer")
                 UIManager:show(TextViewer:new{
-                    title = item.title,
+                    title = item.author .. " - " .. item.title,
                     text = util.htmlToPlainTextIfHtml(item.content),
                 })
             end,

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -670,7 +670,7 @@ function OPDSBrowser:showDownloads(item)
         },
         {
             text = _("Book info"),
-            enabled = item.content ~= nil,
+            enabled = item.content ~= nil and type(item.content) == "string",
             callback = function()
                 local TextViewer = require("ui/widget/textviewer")
                 UIManager:show(TextViewer:new{

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -670,7 +670,7 @@ function OPDSBrowser:showDownloads(item)
             end,
         },
         {
-            text = _("Book info"),
+            text = _("Book information"),
             enabled = type(item.content) == "string",
             callback = function()
                 local TextViewer = require("ui/widget/textviewer")

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -536,7 +536,10 @@ function OPDSBrowser:downloadFile(item, filetype, remote_url)
     -- Download to user selected folder or last opened folder.
     local download_dir = self.getCurrentDownloadDir()
 
-    local filename = item.text .. "." .. filetype
+    local filename = item.title .. "." .. filetype
+    if item.author then
+        filename = item.author .. " - " .. filename
+    end
 
     filename = util.getSafeFilename(filename, download_dir)
     local local_path = download_dir .. "/" .. filename
@@ -667,7 +670,7 @@ function OPDSBrowser:showDownloads(item)
         },
         {
             text = _("Book info"),
-            enabled = item.content ~= nil and type(item.content) == "string",
+            enabled = type(item.content) == "string",
             callback = function()
                 local TextViewer = require("ui/widget/textviewer")
                 UIManager:show(TextViewer:new{

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -612,6 +612,7 @@ end
 function OPDSBrowser:createNewDownloadDialog(path, buttons)
     self.download_dialog = ButtonDialogTitle:new{
         title = T(_("Download folder:\n%1\n\nDownload file type:"), BD.dirpath(path)),
+        use_info_style = true,
         buttons = buttons
     }
 end

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -650,10 +650,10 @@ function OPDSBrowser:showDownloads(item)
         table.insert(buttons, line)
     end
     table.insert(buttons, {})
-    -- Set download folder button.
+    -- Set download folder and book info buttons.
     table.insert(buttons, {
         {
-            text = _("Select another folder"),
+            text = _("Select folder"),
             callback = function()
                 require("ui/downloadmgr"):new{
                     onConfirm = function(path)
@@ -667,7 +667,18 @@ function OPDSBrowser:showDownloads(item)
                     end,
                 }:chooseDir()
             end,
-        }
+        },
+        {
+            text = _("Book info"),
+            enabled = item.content ~= nil,
+            callback = function()
+                local TextViewer = require("ui/widget/textviewer")
+                UIManager:show(TextViewer:new{
+                    title = _("Book description:"),
+                    text = util.htmlToPlainTextIfHtml(item.content),
+                })
+            end,
+        },
     })
 
     self:createNewDownloadDialog(self.getCurrentDownloadDir(), buttons)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -674,7 +674,7 @@ function OPDSBrowser:showDownloads(item)
             callback = function()
                 local TextViewer = require("ui/widget/textviewer")
                 UIManager:show(TextViewer:new{
-                    title = _("Book description:"),
+                    title = item.title,
                     text = util.htmlToPlainTextIfHtml(item.content),
                 })
             end,

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -536,10 +536,7 @@ function OPDSBrowser:downloadFile(item, filetype, remote_url)
     -- Download to user selected folder or last opened folder.
     local download_dir = self.getCurrentDownloadDir()
 
-    local filename = item.title .. "." .. filetype
-    if item.author then
-        filename = item.author .. " - " .. filename
-    end
+    local filename = item.text .. "." .. filetype
 
     filename = util.getSafeFilename(filename, download_dir)
     local local_path = download_dir .. "/" .. filename
@@ -674,7 +671,7 @@ function OPDSBrowser:showDownloads(item)
             callback = function()
                 local TextViewer = require("ui/widget/textviewer")
                 UIManager:show(TextViewer:new{
-                    title = item.author .. " - " .. item.title,
+                    title = item.text,
                     text = util.htmlToPlainTextIfHtml(item.content),
                 })
             end,


### PR DESCRIPTION
In accordance with
https://specs.opds.io/opds-1.2.html#513-summary-and-content
the `content` OPDS catalog entry is shown with this new button.

Useful before download.
Screenshots from flibusta.

![1](https://user-images.githubusercontent.com/62179190/119858069-caf55f80-bf1c-11eb-80a3-7a0d1b41b8ef.png)
--
![2](https://user-images.githubusercontent.com/62179190/119858089-ce88e680-bf1c-11eb-84fb-061dc3fd3c0b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7767)
<!-- Reviewable:end -->