### PR TITLE
ReaderHighlight: close popup menu on 'Copy'

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -75,6 +75,11 @@ function ReaderHighlight:init()
                 enabled = Device:hasClipboard(),
                 callback = function()
                     Device.input.setClipboardText(cleanupSelectedText(_self.selected_text.text))
+                    _self:onClose()
+                    self:clear()
+                    UIManager:show(Notification:new{ 
+                        text = _("Selection copied to clipboard."), 
+                    }) 
                 end,
             }
         end,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -77,9 +77,9 @@ function ReaderHighlight:init()
                     Device.input.setClipboardText(cleanupSelectedText(_self.selected_text.text))
                     _self:onClose()
                     self:clear()
-                    UIManager:show(Notification:new{ 
-                        text = _("Selection copied to clipboard."), 
-                    }) 
+                    UIManager:show(Notification:new{
+                        text = _("Selection copied to clipboard."),
+                    })
                 end,
             }
         end,


### PR DESCRIPTION
Pressing <kbd>Copy</kbd> in the popup highlight menu:
- copies the selection to the clipboard
- closes the popup menu
- clears the selection
- shows notification

Pressing <kbd>Copy</kbd> in the `…` HighlightDialog menu does not clear the highlighting.

Closes https://github.com/koreader/koreader/issues/7772

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7776)
<!-- Reviewable:end -->
