### PR TITLE
ReaderZooming: Deal with some more zoom_mode shenanigans

### DIFF
--- a/frontend/apps/reader/modules/readerkoptlistener.lua
+++ b/frontend/apps/reader/modules/readerkoptlistener.lua
@@ -17,11 +17,10 @@ end
 function ReaderKoptListener:onReadSettings(config)
     -- normal zoom mode is zoom mode used in non-reflow mode.
     local normal_zoom_mode = config:readSetting("normal_zoom_mode")
-                          or G_reader_settings:readSetting("zoom_mode")
-                          or "page"
+                          or ReaderZooming:combo_to_mode(G_reader_settings:readSetting("kopt_zoom_mode_genus"), G_reader_settings:readSetting("kopt_zoom_mode_type"))
     normal_zoom_mode = util.arrayContains(ReaderZooming.available_zoom_modes, normal_zoom_mode)
                    and normal_zoom_mode
-                    or "page"
+                    or ReaderZooming.DEFAULT_ZOOM_MODE
     self.normal_zoom_mode = normal_zoom_mode
     self:setZoomMode(normal_zoom_mode)
     self.document.configurable.contrast = config:readSetting("kopt_contrast")

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -1,4 +1,3 @@
-local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local DocCache = require("document/doccache")
 local Event = require("ui/event")

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -217,12 +217,7 @@ function ReaderZooming:onReadSettings(config)
         local zoom_mode_type = config:readSetting("kopt_zoom_mode_type")
                             or G_reader_settings:readSetting("kopt_zoom_mode_type")
         if zoom_mode_genus or zoom_mode_type then
-            -- Handle defaults
-            zoom_mode_genus = zoom_mode_genus or 4 -- "page"
-            zoom_mode_type = zoom_mode_type or 1 -- "width"
-            zoom_mode_genus = self.zoom_genus_to_mode[zoom_mode_genus]
-            zoom_mode_type = self.zoom_type_to_mode[zoom_mode_type]
-            zoom_mode = zoom_mode_genus .. zoom_mode_type
+            zoom_mode = self:combo_to_mode(zoom_mode_genus, zoom_mode_type)
         end
 
         -- Validate it

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210521
+local CURRENT_MIGRATION_DATE = 20210531
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -244,6 +244,21 @@ if last_migration_date < 20210521 then
         G_reader_settings:delSetting("zoom_factor")
     elseif G_reader_settings:has("zoom_factor") and G_reader_settings:has("kopt_zoom_factor") then
         G_reader_settings:delSetting("zoom_factor")
+    end
+end
+
+-- 20210531, ReaderZooming, deprecate zoom_mode in global settings
+if last_migration_date < 20210531 then
+    logger.info("Performing one-time migration for 20210531")
+
+    if G_reader_settings:has("zoom_mode") then
+        local ReaderZooming = require("apps/reader/modules/readerzooming")
+        -- NOTE: For simplicity's sake, this will overwrite potentially existing mode/genus globals,
+        --       as they were ignored in this specific case anyway...
+        local zoom_mode_genus, zoom_mode_type = ReaderZooming:mode_to_combo(G_reader_settings:readSetting("zoom_mode"))
+        G_reader_settings:saveSetting("kopt_zoom_mode_genus", zoom_mode_genus)
+        G_reader_settings:saveSetting("kopt_zoom_mode_type", zoom_mode_type)
+        G_reader_settings:delSetting("zoom_mode")
     end
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -247,7 +247,7 @@ if last_migration_date < 20210521 then
     end
 end
 
--- 20210531, ReaderZooming, deprecate zoom_mode in global settings
+-- 20210531, ReaderZooming, deprecate zoom_mode in global settings, https://github.com/koreader/koreader/pull/7780
 if last_migration_date < 20210531 then
     logger.info("Performing one-time migration for 20210531")
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -253,7 +253,7 @@ if last_migration_date < 20210531 then
 
     if G_reader_settings:has("zoom_mode") then
         local ReaderZooming = require("apps/reader/modules/readerzooming")
-        -- NOTE: For simplicity's sake, this will overwrite potentially existing mode/genus globals,
+        -- NOTE: For simplicity's sake, this will overwrite potentially existing genus/type globals,
         --       as they were ignored in this specific case anyway...
         local zoom_mode_genus, zoom_mode_type = ReaderZooming:mode_to_combo(G_reader_settings:readSetting("zoom_mode"))
         G_reader_settings:saveSetting("kopt_zoom_mode_genus", zoom_mode_genus)


### PR DESCRIPTION
Namely, in case the user had a global legacy `zoom_mode` set.

Nothing can actually set this as a global anymore, but we were still honoring it... because we still use it for *local* DocSettings...(because everything is terrible and the internal API relies mostly on zoom_mode instead of the genus/type combos).

So, add some more public conversion methods, and get rid of the global.

Fix #7778

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7780)
<!-- Reviewable:end -->
