### PR TITLE
KeyValuePage: propagate items font size to the child TextViewer

### DIFF
--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -316,6 +316,7 @@ function KeyValueItem:onHold()
     local textviewer = TextViewer:new{
         title = self.key,
         text = self.value,
+        text_face = Font:getFace("x_smallinfofont", self.font_size),
         lang = self.value_lang,
         width = self.textviewer_width,
         height = self.textviewer_height,


### PR DESCRIPTION
Allows to show an item's value with the same font size as the KVP table itself (which is based on the `Info lists items per page` setting).
Currently affects Book information (Book Description etc. will be shown with the same font size as the Book information table) and Reading statistics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7782)
<!-- Reviewable:end -->
