### PR TITLE
'Book description' inconsistency fix

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -269,7 +269,7 @@ function BookInfo:onShowBookDescription()
         description = util.htmlToPlainTextIfHtml(description)
         local TextViewer = require("ui/widget/textviewer")
         UIManager:show(TextViewer:new{
-            title = _("Book description:"),
+            title = _("Description:"),
             text = description,
         })
     else

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -340,12 +340,12 @@ function CoverMenu:updateItems(select_number)
                         end,
                     },
                     { -- Allow user to directly view description in TextViewer
-                        text = bookinfo.description and _("View book description") or _("No book description"),
+                        text = _("Book description"),
                         enabled = bookinfo.description and true or false,
                         callback = function()
                             local description = util.htmlToPlainTextIfHtml(bookinfo.description)
                             local textviewer = TextViewer:new{
-                                title = bookinfo.title,
+                                title = _("Description:"),
                                 text = description,
                             }
                             UIManager:close(self.file_dialog)
@@ -473,12 +473,12 @@ function CoverMenu:onHistoryMenuHold(item)
             end,
         },
         { -- Allow user to directly view description in TextViewer
-            text = bookinfo.description and _("View book description") or _("No book description"),
+            text = _("Book description"),
             enabled = bookinfo.description and true or false,
             callback = function()
                 local description = util.htmlToPlainTextIfHtml(bookinfo.description)
                 local textviewer = TextViewer:new{
-                    title = bookinfo.title,
+                    title = _("Description:"),
                     text = description,
                 }
                 UIManager:close(self.histfile_dialog)
@@ -595,12 +595,12 @@ function CoverMenu:onCollectionsMenuHold(item)
             end,
         },
         { -- Allow user to directly view description in TextViewer
-            text = bookinfo.description and _("View book description") or _("No book description"),
+            text = _("Book description"),
             enabled = bookinfo.description and true or false,
             callback = function()
                 local description = util.htmlToPlainTextIfHtml(bookinfo.description)
                 local textviewer = TextViewer:new{
-                    title = bookinfo.title,
+                    title = _("Description:"),
                     text = description,
                 }
                 UIManager:close(self.collfile_dialog)


### PR DESCRIPTION
We can call the "Book description" window in three ways and all three windows have different titles.

**1. Via "Book information" KVP window.**
https://github.com/koreader/koreader/blob/0b58abada58ad21761ef3c8d6a8e9ecd68e54652/frontend/apps/filemanager/filemanagerbookinfo.lua#L204

![1](https://user-images.githubusercontent.com/62179190/120312184-12933700-c2e1-11eb-963e-71dbf6c2ef48.png)
--
![2](https://user-images.githubusercontent.com/62179190/120312198-1626be00-c2e1-11eb-84f6-037c4f1a9abb.png)

The title is just a key name in the KVP table. The similar titles (`Key_name:`) are shown for other "Book information" fields.

**2. With a gesture in the reader.**
https://github.com/koreader/koreader/blob/0b58abada58ad21761ef3c8d6a8e9ecd68e54652/frontend/apps/filemanager/filemanagerbookinfo.lua#L272

**3. With a popup menu in the file browser detailed view mode.**
https://github.com/koreader/koreader/blob/0b58abada58ad21761ef3c8d6a8e9ecd68e54652/plugins/coverbrowser.koplugin/covermenu.lua#L348
It shows the book title (the same for File browser, History and Favorites).

I propose to standardize all of the above to `Descrption:` (as in p.1), which harmonizes with the "Book information" table.

Additionally, the button in the popup menu is standardized to `Book information` button in the filebrowser popup onhold menu.
I believe we do not need to change the button text when no Description available, disabling it is enough.

**Description font size**
Unfortunately, I have no final decision how to standardize the font size in the Book description windows.
For "Book information" kvp table font size is calculated based on the `keyvalues_per_page` setting:
https://github.com/koreader/koreader/blob/0b58abada58ad21761ef3c8d6a8e9ecd68e54652/frontend/ui/widget/keyvaluepage.lua#L507-L511
https://github.com/koreader/koreader/pull/7782 allowed to pass the font size to the "Description:" window.

We cannot get that size for the pp. 2 and 3.
Maybe we can take `items_font_size` (used for the Menu), which is stored in the settings? I think usually it is rather close to the size calculated in KVP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7789)
<!-- Reviewable:end -->
