### PR TITLE
ToC: harmonize font sizes

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -706,7 +706,6 @@ function ReaderToc:onShowToc()
         with_dots = items_with_dots,
         items_per_page = items_per_page,
         items_font_size = items_font_size,
-        items_mandatory_font_size = items_font_size - 3,
         items_padding = can_collapse and math.floor(Size.padding.fullscreen / 2) or nil, -- c.f., note above. Menu's default is twice that.
         line_color = Blitbuffer.COLOR_WHITE,
         on_close_ges = {

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -706,7 +706,6 @@ function ReaderToc:onShowToc()
         with_dots = items_with_dots,
         items_per_page = items_per_page,
         items_font_size = items_font_size,
-        items_mandatory_font_size = items_font_size,
         items_padding = can_collapse and math.floor(Size.padding.fullscreen / 2) or nil, -- c.f., note above. Menu's default is twice that.
         line_color = Blitbuffer.COLOR_WHITE,
         on_close_ges = {

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -706,6 +706,7 @@ function ReaderToc:onShowToc()
         with_dots = items_with_dots,
         items_per_page = items_per_page,
         items_font_size = items_font_size,
+        items_mandatory_font_size = items_font_size - 3,
         items_padding = can_collapse and math.floor(Size.padding.fullscreen / 2) or nil, -- c.f., note above. Menu's default is twice that.
         line_color = Blitbuffer.COLOR_WHITE,
         on_close_ges = {

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -706,6 +706,7 @@ function ReaderToc:onShowToc()
         with_dots = items_with_dots,
         items_per_page = items_per_page,
         items_font_size = items_font_size,
+        items_mandatory_font_size = items_font_size,
         items_padding = can_collapse and math.floor(Size.padding.fullscreen / 2) or nil, -- c.f., note above. Menu's default is twice that.
         line_color = Blitbuffer.COLOR_WHITE,
         on_close_ges = {
@@ -760,6 +761,7 @@ function ReaderToc:onShowToc()
             alignment = "center",
             show_icon = false,
             text = trimmed_text,
+            face = Font:getFace("infofont", self.items_font_size),
         }
         UIManager:show(infomessage)
         return true

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1110,7 +1110,7 @@ function Menu:updateItems(select_number)
 
     local font_size = self.items_font_size or G_reader_settings:readSetting("items_font_size")
                                      or Menu.getItemFontSize(self.perpage)
-    local infont_size = self.items_mandatory_font_size or Menu.getItemMandatoryFontSize(self.perpage)
+    local infont_size = self.items_mandatory_font_size or (font_size - 4)
     local multilines_show_more_text = self.multilines_show_more_text
     if multilines_show_more_text == nil then
         multilines_show_more_text = G_reader_settings:isTrue("items_multilines_show_more_text")


### PR DESCRIPTION
Currently the ToC is shown with **three** font sizes:
- entry names
- page numbers
- entry names in popups

I propose to use one and only font size as set in the `ToC entry font size` setting.
Let persons with poor eyes increase interface elements if they need to.

Before
![1](https://user-images.githubusercontent.com/62179190/120431446-2bebc000-c381-11eb-9265-c5b7a0da841c.png)

After
![2](https://user-images.githubusercontent.com/62179190/120431459-30b07400-c381-11eb-8126-7aaf43e00a8c.png)
--

**ToC with dots**
Additionally, may I propose @poire-z to enhance nice dots https://github.com/koreader/koreader/pull/7669 in accordance with the typography rules recommendations:
![3](https://user-images.githubusercontent.com/62179190/120431770-a0266380-c381-11eb-85c3-1f4cec4fbaf6.png)

I mean a large padding:
https://github.com/koreader/koreader/blob/0b58abada58ad21761ef3c8d6a8e9ecd68e54652/frontend/ui/widget/menu.lua#L273

and aligned right margin of the dots:
https://github.com/koreader/koreader/blob/0b58abada58ad21761ef3c8d6a8e9ecd68e54652/frontend/ui/widget/menu.lua#L290
The width of dots for the current entry to be calculated based on the last entry biggest page number.

I believe it corresponds with the example from https://github.com/koreader/koreader/pull/7551#issuecomment-820484139.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7795)
<!-- Reviewable:end -->
