### PR TITLE
Honor lang variable in virtual keyboard

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -514,6 +514,7 @@ function InputText:initKeyboard()
     self.keyboard = Keyboard:new{
         keyboard_layer = keyboard_layer,
         inputbox = self,
+        lang = self.lang,
         width = Screen:getWidth(),
     }
 end

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -720,7 +720,7 @@ function VirtualKeyboard:init()
         self.uwrap_func()
         self.uwrap_func = nil
     end
-    local lang = self:getKeyboardLayout()
+    local lang = self.lang or self:getKeyboardLayout()
     local keyboard_layout = self.lang_to_keyboard_layout[lang] or self.lang_to_keyboard_layout["en"]
     local keyboard = require("ui/data/keyboardlayouts/" .. keyboard_layout)
     self.KEYS = keyboard.keys


### PR DESCRIPTION
If creating a widget which is using the virtual keyboard, the keyboard layout is derived from `settings.reader.lua`.
This PR allows to set the keyboard language by the `lang` member. 
-> See https://github.com/koreader/koreader/blob/0b58abada58ad21761ef3c8d6a8e9ecd68e54652/frontend/apps/reader/modules/readerstyletweak.lua#L652, but the keyboard is not in English, if KOReader uses a different language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7796)
<!-- Reviewable:end -->
