### PR TITLE
WIP: Use rapidjson for all sizes of calibre metadata files

### DIFF
--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -121,11 +121,7 @@ function CalibreMetadata:loadBookList()
         return {}
     end
     local books, err
-    if attr.size > MAX_JSON_FILESIZE then
-        books, err = parser.parseFile(self.metadata)
-    else
-        books, err = rapidjson.load(self.metadata)
-    end
+    books, err = rapidjson.load(self.metadata)
     if not books then
         logger.warn(string.format("Unable to load library from json file %s: \n%s",
             self.metadata, err))


### PR DESCRIPTION
It seems that rapidjson can handle massive json files
(tested up to 125MB), so there's no need to try using
a different method for parsing larger files.

In any case, the other method was parsing improperly,
and also causing crashes for large metadata.calibre files.

Discussion at:
https://github.com/koreader/koreader/issues/7790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7800)
<!-- Reviewable:end -->
