### PR TITLE
NumberPicker: correct max day in input dialog

### DIFF
--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -124,6 +124,9 @@ function NumberPickerWidget:init()
     local callback_input = nil
     if self.value_table == nil then
         callback_input = function()
+            if self.date_month and self.date_year then
+                self.value_max = self:getDaysInMonth(self.date_month:getValue(), self.date_year:getValue())
+            end
             input_dialog = InputDialog:new{
                 title = _("Enter number"),
                 input_hint = T("%1 (%2 - %3)", self.formatted_value, self.value_min, self.value_max),


### PR DESCRIPTION
Set date: number of days in direct input was 31 for all months.

![1](https://user-images.githubusercontent.com/62179190/120882303-75394b00-c5df-11eb-81c9-c1e98c612202.png)
--
![2](https://user-images.githubusercontent.com/62179190/120882307-78343b80-c5df-11eb-99c2-1fc6b37a6316.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7803)
<!-- Reviewable:end -->
