### PR TITLE
[fix] Debian package: ensure failure is caught

### DIFF
--- a/platform/debian/do_debian_package.sh
+++ b/platform/debian/do_debian_package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script to generate debian packages for KOReader
-# shellcheck disable=SC2164
+set -e
 
 if [ -z "${1}" ]; then
     echo "${0}: can't find KOReader build, please specify a path"
@@ -120,5 +120,3 @@ else
     echo "${COMMAND} not found, unable to build Debian package"
     exit 1
 fi
-
-exit 0


### PR DESCRIPTION
fakeroot was missing from the Docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7804)
<!-- Reviewable:end -->
