### PR TITLE
[RFC] ReaderFooter: Make pages_left_book use an actual prefix icon

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -47,6 +47,7 @@ local MODE = {
 local symbol_prefix = {
     letters = {
         time = nil,
+        pages_left_book = "->",
         pages_left = "=>",
         -- @translators This is the footer letter prefix for battery % remaining.
         battery = C_("FooterLetterPrefix", "B:"),
@@ -67,6 +68,7 @@ local symbol_prefix = {
     },
     icons = {
         time = "⌚",
+        pages_left_book = BD.mirroredUILayout() and "↢" or "↣",
         pages_left = BD.mirroredUILayout() and "⇐" or "⇒",
         battery = "",
         bookmark_count = "☆",
@@ -80,13 +82,14 @@ local symbol_prefix = {
     },
     compact_items = {
         time = nil,
-        pages_left = "›",
+        pages_left_book = BD.mirroredUILayout() and "<" or ">",
+        pages_left = BD.mirroredUILayout() and "‹" or "›",
         battery = "",
         -- @translators This is the footer compact item prefix for the number of bookmarks (bookmark count).
         bookmark_count = C_("FooterCompactItemsPrefix", "BM"),
         percentage = nil,
         book_time_to_read = nil,
-        chapter_time_to_read = "»",
+        chapter_time_to_read = BD.mirroredUILayout() and "«" or "»",
         frontlight = "*",
         -- @translators This is the footer compact item prefix for memory usage.
         mem_usage = C_("FooterCompactItemsPrefix", "M"),
@@ -227,10 +230,13 @@ local footerTextGeneratorMap = {
         end
     end,
     pages_left_book = function(footer)
+        local symbol_type = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_type].pages_left_book
         if footer.pageno then
             if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
                 -- (Page labels might not be numbers)
-                return ("%s / %s"):format(footer.ui.pagemap:getCurrentPageLabel(true),
+                return ("%s %s / %s"):format(prefix,
+                                          footer.ui.pagemap:getCurrentPageLabel(true),
                                           footer.ui.pagemap:getLastPageLabel(true))
             end
             if footer.ui.document:hasHiddenFlows() then
@@ -240,16 +246,16 @@ local footerTextGeneratorMap = {
                 local pages = footer.ui.document:getTotalPagesInFlow(flow)
                 local remaining = pages - page;
                 if flow == 0 then
-                    return ("-%d // %d"):format(remaining, pages)
+                    return ("%s %d // %d"):format(prefix, remaining, pages)
                 else
-                    return ("[-%d / %d]%d"):format(remaining, pages, flow)
+                    return ("%s [%d / %d]%d"):format(prefix, remaining, pages, flow)
                 end
             else
                 local remaining = footer.pages - footer.pageno
-                return ("-%d / %d"):format(remaining, footer.pages)
+                return ("%s %d / %d"):format(prefix, remaining, footer.pages)
             end
         elseif footer.position then
-            return ("-%d / %d"):format(footer.doc_height - footer.position, footer.doc_height)
+            return ("%s %d / %d"):format(prefix, footer.doc_height - footer.position, footer.doc_height)
         end
     end,
     pages_left = function(footer)
@@ -825,7 +831,7 @@ function ReaderFooter:textOptionTitles(option)
         reclaim_height = _("Reclaim bar height from bottom margin"),
         bookmark_count = T(_("Bookmark count (%1)"), symbol_prefix[symbol].bookmark_count),
         page_progress = T(_("Current page (%1)"), "/"),
-        pages_left_book = T(_("Pages left in book (%1)"), "-"),
+        pages_left_book = T(_("Pages left in book (%1)"), symbol_prefix[symbol].pages_left_book),
         time = symbol_prefix[symbol].time
             and T(_("Current time (%1)"), symbol_prefix[symbol].time) or _("Current time"),
         pages_left = T(_("Pages left in chapter (%1)"), symbol_prefix[symbol].pages_left),

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -520,6 +520,38 @@ function ReaderToc:isChapterEnd(cur_pageno)
     return _end
 end
 
+function ReaderToc:getChapterPageCount(pageno)
+    if self.ui.document:hasHiddenFlows() then
+        -- Count pages until new chapter, starting by going backwards to the beginning of the current chapter if necessary
+        local page_count = 1
+        if not self:isChapterStart(pageno) then
+            local test_page = self.ui.document:getPrevPage(pageno)
+            while test_page > 0 do
+                page_count = page_count + 1
+                if self:isChapterStart(test_page) then
+                    break
+                end
+                test_page = self.ui.document:getPrevPage(test_page)
+            end
+        end
+
+        -- Then forward
+        local test_page = self.ui.document:getNextPage(pageno)
+        while test_page > 0 do
+            page_count = page_count + 1
+            if self:isChapterStart(test_page) then
+                return page_count - 1
+            end
+            test_page = self.ui.document:getNextPage(test_page)
+        end
+    else
+        local next_chapter = self:getNextChapter(pageno) or self.ui.document:getPageCount() + 1
+        local previous_chapter = self:isChapterStart(pageno) and pageno or self:getPreviousChapter(pageno) or 1
+        local page_count = next_chapter - previous_chapter
+        return page_count
+    end
+end
+
 function ReaderToc:getChapterPagesLeft(pageno)
     if self.ui.document:hasHiddenFlows() then
         -- Count pages until new chapter


### PR DESCRIPTION
Instead of baking in a hyphen, so as to avoid signed zeroes, or confusion with page progress if page maps are enabled.

Also, made compact items RTL friendly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7807)
<!-- Reviewable:end -->
