### PR TITLE
Bump android backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,7 @@ androidupdate: all
 	cp -pR $(INSTALL_DIR)/koreader/libs $(ANDROID_LAUNCHER_DIR)/assets
 
 	# binaries are stored as shared libraries to prevent W^X exception on Android 10+
+	# https://developer.android.com/about/versions/10/behavior-changes-10#execute-permission
 	cp -pR $(INSTALL_DIR)/koreader/sdcv $(ANDROID_LIBS_ABI)/libsdcv.so
 	echo "sdcv libsdcv.so" > $(ANDROID_ASSETS)/map.txt
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ IS_RELEASE := $(if $(or $(EMULATE_READER),$(WIN32)),,1)
 IS_RELEASE := $(if $(or $(IS_RELEASE),$(APPIMAGE),$(DEBIAN),$(MACOS)),1,)
 
 ANDROID_ARCH?=arm
+ifeq ($(ANDROID_ARCH), x86)
+	ANDROID_ABI:=$(ANDROID_ARCH)
+endif
+ANDROID_ABI?=armeabi-v7a
+
 # Use the git commit count as the (integer) Android version code
 ANDROID_VERSION?=$(shell git rev-list --count HEAD)
 ANDROID_NAME?=$(VERSION)
@@ -46,6 +51,8 @@ COMMON_DIR=$(PLATFORM_DIR)/common
 ANDROID_DIR=$(PLATFORM_DIR)/android
 ANDROID_LAUNCHER_DIR:=$(ANDROID_DIR)/luajit-launcher
 ANDROID_ASSETS:=$(ANDROID_LAUNCHER_DIR)/assets/module
+ANDROID_LIBS_ROOT:=$(ANDROID_LAUNCHER_DIR)/libs
+ANDROID_LIBS_ABI:=$(ANDROID_LIBS_ROOT)/$(ANDROID_ABI)
 APPIMAGE_DIR=$(PLATFORM_DIR)/appimage
 CERVANTES_DIR=$(PLATFORM_DIR)/cervantes
 DEBIAN_DIR=$(PLATFORM_DIR)/debian
@@ -355,14 +362,18 @@ androidupdate: all
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
 
         # fresh APK assets
-	rm -rfv $(ANDROID_ASSETS)
-	mkdir -p $(ANDROID_ASSETS)
+	rm -rfv $(ANDROID_ASSETS) $(ANDROID_LIBS_ROOT)
+	mkdir -p $(ANDROID_ASSETS) $(ANDROID_LIBS_ABI)
 
 	# APK version
 	echo $(VERSION) > $(ANDROID_ASSETS)/version.txt
 
 	# shared libraries are stored as raw assets
 	cp -pR $(INSTALL_DIR)/koreader/libs $(ANDROID_LAUNCHER_DIR)/assets
+
+	# binaries are stored as shared libraries to prevent W^X exception on Android 10+
+	cp -pR $(INSTALL_DIR)/koreader/sdcv $(ANDROID_LIBS_ABI)/libsdcv.so
+	echo "sdcv libsdcv.so" > $(ANDROID_ASSETS)/map.txt
 
 	# assets are compressed manually and stored inside the APK.
 	cd $(INSTALL_DIR)/koreader && 7z a -l -m0=lzma2 -mx=9 \
@@ -388,6 +399,7 @@ androidupdate: all
 		-xr!*NOTES.txt$ \
 		-xr!*NOTICE$ \
 		-xr!*README.md$ \
+		-xr!*sdcv \
 		-xr'!.*'
 
 	# make the android APK

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -91,7 +91,7 @@ local Device = Generic:new{
     canOpenLink = yes,
     openLink = function(self, link)
         if not link or type(link) ~= "string" then return end
-        return android.openLink(link) == 0
+        return android.openLink(link)
     end,
     canImportFiles = function() return android.app.activity.sdkVersion >= 19 end,
     hasExternalSD = function() return android.getExternalSdPath() end,

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -62,7 +62,7 @@ common_info.report_bug = {
 
         if Device:isAndroid() then
             local android = require("android")
-            android.dumpLogs(log_path)
+            android.dumpLogs()
         end
 
         local msg

--- a/kodev
+++ b/kodev
@@ -1128,10 +1128,18 @@ TARGET:
 
     case "${1}" in
         android)
-            if [ -n "${KODEBUG}" ]; then
-                adb logcat 'KOReader:* ActivityManager:* AndroidRuntime:* DEBUG:* *:F dlopen:* LuaJIT:*'
+            if command -v pidcat >/dev/null; then
+                if [ -n "${KODEBUG}" ]; then
+                    pidcat "org.koreader.launcher"
+                else
+                    pidcat org.koreader.launcher --min-level=I
+                fi
             else
-                adb logcat 'KOReader:I ActivityManager:* AndroidRuntime:* DEBUG:* *:F'
+                if [ -n "${KODEBUG}" ]; then
+                    adb logcat 'KOReader:V ApkUpdater:V Assets:V Device:V dlopen:V EPD:V EventReceiver:V Lights:V LuaJIT:V MainActivity:V NativeGlue:V NativeThread:V Timeout:V ActivityManager:V AndroidRuntime:V DEBUG:* *:F'
+                else
+                    adb logcat 'KOReader:I MainActivity:V NativeGlue:V NativeThread:V ActivityManager:W AndroidRuntime:E DEBUG:* *:F'
+                fi
             fi
             ;;
         *)

--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -64,11 +64,6 @@ if android.prop.runtimeChanges then
     pcall(dofile, path.."/koreader/patch.lua")
 end
 
--- Set proper permission for binaries.
---- @todo Take care of this on extraction instead.
--- Cf. <https://github.com/koreader/koreader/issues/5347#issuecomment-529476693>.
-android.execute("chmod", "755", "./sdcv")
-
 -- set TESSDATA_PREFIX env var
 C.setenv("TESSDATA_PREFIX", path.."/koreader/data", 1)
 


### PR DESCRIPTION
Requires https://github.com/koreader/android-luajit-launcher/pull/276

- Bumps the target Sdk to Android 11 (API30)
- `kodev-log` uses `pidcat` if available
- Add a crash handler
![Sin nombre](https://user-images.githubusercontent.com/975883/120943960-60210100-c732-11eb-9158-c14a7473430a.png)


The crash handler is raised on errors, like in other platforms, but the UI differs a bit:

-  App isn't restarted. The user needs to launch it again from the app launcher.
- Shows the entire log in a scrollable view
- Provides a share/send button

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7813)
<!-- Reviewable:end -->
