### PR TITLE
OPDS catalog invoked from reader: fix crash KOReader on close

### DIFF
--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -23,7 +23,12 @@ function OPDS:showCatalog()
     local OPDSCatalog = require("opdscatalog")
     local filemanagerRefresh = function() self.ui:onRefresh() end
     function OPDSCatalog:onClose()
-        filemanagerRefresh()
+        local FileManager = require("apps/filemanager/filemanager")
+        if FileManager.instance then
+            filemanagerRefresh()
+        else
+            FileManager:showFiles(G_reader_settings:readSetting("download_dir"))
+        end
         UIManager:close(self)
     end
     OPDSCatalog:showCatalog()

--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -23,13 +23,13 @@ function OPDS:showCatalog()
     local OPDSCatalog = require("opdscatalog")
     local filemanagerRefresh = function() self.ui:onRefresh() end
     function OPDSCatalog:onClose()
+        UIManager:close(self)
         local FileManager = require("apps/filemanager/filemanager")
         if FileManager.instance then
             filemanagerRefresh()
         else
             FileManager:showFiles(G_reader_settings:readSetting("download_dir"))
         end
-        UIManager:close(self)
     end
     OPDSCatalog:showCatalog()
 end


### PR DESCRIPTION
OPDS catalog can be invoked from reader with gesture.
Then on closing OPDS catalog, KOReader crashes.
Let's jump to the download folder instead.
Closes https://github.com/koreader/koreader/issues/7784.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7825)
<!-- Reviewable:end -->
