### PR TITLE
Use smaller symbols for pages_left_book in compact_items

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -83,7 +83,7 @@ local symbol_prefix = {
     },
     compact_items = {
         time = nil,
-        pages_left_book = BD.mirroredUILayout() and "<" or ">",
+        pages_left_book = BD.mirroredUILayout() and "‹" or "›",
         pages_left = BD.mirroredUILayout() and "‹" or "›",
         battery = "",
         -- @translators This is the footer compact item prefix for the number of bookmarks (bookmark count).


### PR DESCRIPTION
Use the (smaller) "‹" or "›" symbols in pages_left_book, to match pages_left, in compact_items

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7828)
<!-- Reviewable:end -->
