### PR TITLE
CloudStorage: Log download failures

### DIFF
--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -84,7 +84,7 @@ end
 function DropBoxApi:downloadFile(path, token, local_path)
     local data1 = "{\"path\": \"" .. path .. "\"}"
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
-    local code_return = socket.skip(1, http.request{
+    local code, _, status = socket.skip(1, http.request{
         url     = API_DOWNLOAD_FILE,
         method  = "GET",
         headers = {
@@ -94,7 +94,10 @@ function DropBoxApi:downloadFile(path, token, local_path)
         sink    = ltn12.sink.file(io.open(local_path, "w")),
     })
     socketutil:reset_timeout()
-    return code_return
+    if code ~= 200 then
+        logger.warn("DropBoxApi: Download failure:", status or code or "network unreachable")
+    end
+    return code
 end
 
 -- folder_mode - set to true when we want to see only folder.

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -158,7 +158,7 @@ end
 
 function WebDavApi:downloadFile(file_url, user, pass, local_path)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
-    local code_return = socket.skip(1, http.request{
+    local code, _, status = socket.skip(1, http.request{
         url      = file_url,
         method   = "GET",
         sink     = ltn12.sink.file(io.open(local_path, "w")),
@@ -166,7 +166,10 @@ function WebDavApi:downloadFile(file_url, user, pass, local_path)
         password = pass,
     })
     socketutil:reset_timeout()
-    return code_return
+    if code ~= 200 then
+        logger.warn("WebDavApi: Download failure:", status or code or "network unreachable")
+    end
+    return code
 end
 
 return WebDavApi


### PR DESCRIPTION
Re #7354

(Except w/ FTP, because LuaSocket's FTP module is a special snowflake, and the whole protocol is just plain terrible).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7834)
<!-- Reviewable:end -->
