### PR TITLE
ReaderFooter settings menu: keep upper menu page

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1774,8 +1774,8 @@ function ReaderFooter:addToMainMenu(menu_items)
     table.insert(sub_items, getMinibarOption("book_chapter"))
 
     -- Settings menu: keep the same parent page for going up from submenu
-    for i = 1, #sub_items[1].sub_item_table do
-        sub_items[1].sub_item_table[i].menu_item_id = i
+    for i = 1, #sub_items[settings_submenu_num].sub_item_table do
+        sub_items[settings_submenu_num].sub_item_table[i].menu_item_id = i
     end
 
     -- If using crengine, add Alt status bar items at top

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1423,9 +1423,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
         }
     })
-    for i = 1, #sub_items[1].sub_item_table do
-        sub_items[1].sub_item_table[i].menu_item_id = i
-    end
     table.insert(sub_items, {
         text = _("Progress bar"),
         separator = true,
@@ -1775,6 +1772,11 @@ function ReaderFooter:addToMainMenu(menu_items)
     end
     table.insert(sub_items, getMinibarOption("book_title"))
     table.insert(sub_items, getMinibarOption("book_chapter"))
+
+    -- Settings menu: keep the same parent page for going up from submenu
+    for i = 1, #sub_items[1].sub_item_table do
+        sub_items[1].sub_item_table[i].menu_item_id = i
+    end
 
     -- If using crengine, add Alt status bar items at top
     if self.ui.crelistener then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1159,7 +1159,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Maximum width of items"),
-                menu_item_id = 11, -- from submenu go up to the 2nd upper menu page
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1217,7 +1216,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Alignment"),
-                menu_item_id = 11,
                 separator = true,
                 enabled_func = function()
                     return self.settings.disable_progress_bar or self.settings.progress_bar_position ~= "alongside"
@@ -1257,7 +1255,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Prefix"),
-                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1311,7 +1308,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Item separator"),
-                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text = _("Vertical line (|)"),
@@ -1347,7 +1343,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Progress percentage format"),
-                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1389,7 +1384,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Duration format"),
-                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1429,6 +1423,9 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
         }
     })
+    for i = 1, #sub_items[1].sub_item_table do
+        sub_items[1].sub_item_table[i].menu_item_id = i
+    end
     table.insert(sub_items, {
         text = _("Progress bar"),
         separator = true,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1159,6 +1159,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Maximum width of items"),
+                menu_item_id = 11, -- from submenu go up to the 2nd upper menu page
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1216,6 +1217,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Alignment"),
+                menu_item_id = 11,
                 separator = true,
                 enabled_func = function()
                     return self.settings.disable_progress_bar or self.settings.progress_bar_position ~= "alongside"
@@ -1255,6 +1257,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Prefix"),
+                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1308,6 +1311,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Item separator"),
+                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text = _("Vertical line (|)"),
@@ -1343,6 +1347,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Progress percentage format"),
+                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1384,6 +1389,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Duration format"),
+                menu_item_id = 11,
                 sub_item_table = {
                     {
                         text_func = function()


### PR DESCRIPTION
On the 2nd page of ReaderFooter settings menu will go up from the submenus to the same 2nd page.
Require and thanks to https://github.com/koreader/koreader/commit/0577f57617943d86ee33633804e36e027f54c008

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7835)
<!-- Reviewable:end -->
