### PR TITLE
Status bar: hide battery if level higher than threshold

### DIFF
--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210531
+local CURRENT_MIGRATION_DATE = 20210622
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -218,9 +218,9 @@ if last_migration_date < 20210508 then
     DocCache:clearDiskCache()
 end
 
--- 20210518, ReaderFooter, https://github.com/koreader/koreader/pull/7702
-if last_migration_date < 20210518 then
-    logger.info("Performing one-time migration for 20210518")
+-- 20210622, ReaderFooter, https://github.com/koreader/koreader/pull/7876
+if last_migration_date < 20210622 then
+    logger.info("Performing one-time migration for 20210622")
 
     local ReaderFooter = require("apps/reader/modules/readerfooter")
     local settings = G_reader_settings:readSetting("footer", ReaderFooter.default_settings)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -218,6 +218,7 @@ if last_migration_date < 20210508 then
     DocCache:clearDiskCache()
 end
 
+-- 20210518, ReaderFooter, https://github.com/koreader/koreader/pull/7702
 -- 20210622, ReaderFooter, https://github.com/koreader/koreader/pull/7876
 if last_migration_date < 20210622 then
     logger.info("Performing one-time migration for 20210622")


### PR DESCRIPTION
Follow up and closes (?) https://github.com/koreader/koreader/pull/7242
Hides the battery status if battery level is higher than threshold.
Default threshold 100% (do not hide).

Requires one time migration to put `battery_hide_threshold` to the footer settings.
What date should be set at the migration module?
https://github.com/koreader/koreader/blob/12ebffc669a14a7775bd688548d7b962668d7414/frontend/ui/data/onetime_migration.lua#L221-L222

![1](https://user-images.githubusercontent.com/62179190/122910073-79df5c80-d35e-11eb-9a0b-df444aaf2445.png)
--
![2](https://user-images.githubusercontent.com/62179190/122910082-7e0b7a00-d35e-11eb-9af0-5c7d6a7add89.png)
--
![3](https://user-images.githubusercontent.com/62179190/122910093-806dd400-d35e-11eb-81d3-83c923fcbadb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7876)
<!-- Reviewable:end -->
