### PR TITLE
Regex search menu

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -148,7 +148,19 @@ function ReaderSearch:onShowFulltextSearchInput()
         },
     }
 
-   -- checkboxes
+    -- checkboxes
+    self.check_button_case = CheckButton:new{
+        text = _("Case sensitive"),
+        checked = not self.case_insensitive,
+        parent = self.input_dialog,
+        callback = function()
+            if not self.check_button_case.checked then
+                self.check_button_case:check()
+            else
+                self.check_button_case:unCheck()
+            end
+        end,
+    }
     self.check_button_regex = CheckButton:new{
         text = _("Regular expression (hold for help)"),
         checked = self.use_regex,
@@ -162,18 +174,6 @@ function ReaderSearch:onShowFulltextSearchInput()
         end,
         hold_callback = function()
             UIManager:show(InfoMessage:new{ text = help_text })
-        end,
-    }
-    self.check_button_case = CheckButton:new{
-        text = _("Case sensitive"),
-        checked = not self.case_insensitive,
-        parent = self.input_dialog,
-        callback = function()
-            if not self.check_button_case.checked then
-                self.check_button_case:check()
-            else
-                self.check_button_case:unCheck()
-            end
         end,
     }
 
@@ -395,7 +395,7 @@ function ReaderSearch:search(pattern, origin, regex, case_insensitive)
         end
         UIManager:show(Notification:new{
             text = error_message,
-            timeout = 4,
+            timeout = false,
         })
     elseif words_found and words_found > self.max_hits then
         UIManager:show(Notification:new{

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -28,12 +28,14 @@ function ReaderSearch:addToMainMenu(menu_items)
             self:onShowFulltextSearchInput()
         end,
     }
-    menu_items.regex_search = {
-        text = _("Regular expression search"),
-        callback = function()
-            self:onShowRegexSearchInput()
-        end,
-    }
+    if self.ui.document.provider == "crengine" then
+        menu_items.regex_search = {
+            text = _("Regular expression search"),
+            callback = function()
+                self:onShowRegexSearchInput()
+            end,
+        }
+    end
 end
 
 function ReaderSearch:onShowFulltextSearchInput()
@@ -128,7 +130,7 @@ end
 function ReaderSearch:onShowSearchDialog(text, direction, regex)
     local neglect_current_location = false
     local current_page
-    local do_search = function(search_func, _text, param, regex)
+    local do_search = function(search_func, _text, param)
         return function()
             local no_results = true -- for notification
             local res = search_func(self, _text, param, regex)

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -28,14 +28,6 @@ function ReaderSearch:addToMainMenu(menu_items)
             self:onShowFulltextSearchInput()
         end,
     }
-    if self.ui.document.provider == "crengine" then
-        menu_items.regex_search = {
-            text = _("Regular expression search"),
-            callback = function()
-                self:onShowRegexSearchInput()
-            end,
-        }
-    end
 end
 
 function ReaderSearch:onShowFulltextSearchInput()
@@ -47,7 +39,9 @@ function ReaderSearch:onShowFulltextSearchInput()
 
     self.input_dialog = InputDialog:new{
         title = _("Enter text to search for"),
-        input = self.last_fulltext,
+        input = self.last_search_text,
+        check_button_text = self.ui.rolling and _("Use regular expression"),
+        check_button_checked = self.use_regex,
         buttons = {
             {
                 {
@@ -60,9 +54,10 @@ function ReaderSearch:onShowFulltextSearchInput()
                     text = backward_text,
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
-                        self.last_fulltext = self.input_dialog:getInputText()
+                        self.last_search_text = self.input_dialog:getInputText()
+                        self.use_regex = self.input_dialog.check_button and self.input_dialog.check_button.checked
                         UIManager:close(self.input_dialog)
-                        self:onShowSearchDialog(self.input_dialog:getInputText(), 1)
+                        self:onShowSearchDialog(self.input_dialog:getInputText(), 1, self.use_regex)
                     end,
                 },
                 {
@@ -70,54 +65,10 @@ function ReaderSearch:onShowFulltextSearchInput()
                     is_enter_default = true,
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
-                        self.last_fulltext = self.input_dialog:getInputText()
+                        self.last_search_text = self.input_dialog:getInputText()
+                        self.use_regex = self.input_dialog.check_button and self.input_dialog.check_button.checked
                         UIManager:close(self.input_dialog)
-                        self:onShowSearchDialog(self.input_dialog:getInputText(), 0)
-                    end,
-                },
-            },
-        },
-    }
-    UIManager:show(self.input_dialog)
-    self.input_dialog:onShowKeyboard()
-end
-
-function ReaderSearch:onShowRegexSearchInput()
-    local backward_text = "◁"
-    local forward_text = "▷"
-    if BD.mirroredUILayout() then
-        backward_text, forward_text = forward_text, backward_text
-    end
-
-    self.input_dialog = InputDialog:new{
-        title = _("Enter regular expression to search for"),
-        description = _("Don't forget: If your search includes punctuation marks, escape them with '\\'."),
-        input = self.last_regex,
-        buttons = {
-            {
-                {
-                    text = _("Cancel"),
-                    callback = function()
-                        UIManager:close(self.input_dialog)
-                    end,
-                },
-                {
-                    text = backward_text,
-                    callback = function()
-                        if self.input_dialog:getInputText() == "" then return end
-                        self.last_regex = self.input_dialog:getInputText()
-                        UIManager:close(self.input_dialog)
-                        self:onShowSearchDialog(self.input_dialog:getInputText(), 1, 1)
-                    end,
-                },
-                {
-                    text = forward_text,
-                    is_enter_default = true,
-                    callback = function()
-                        if self.input_dialog:getInputText() == "" then return end
-                        self.last_regex = self.input_dialog:getInputText()
-                        UIManager:close(self.input_dialog)
-                        self:onShowSearchDialog(self.input_dialog:getInputText(), 0, 1)
+                        self:onShowSearchDialog(self.input_dialog:getInputText(), 0, self.use_regex)
                     end,
                 },
             },

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
+local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local Notification = require("ui/widget/notification")
@@ -56,8 +57,12 @@ function ReaderSearch:onShowFulltextSearchInput()
                         if self.input_dialog:getInputText() == "" then return end
                         self.last_search_text = self.input_dialog:getInputText()
                         self.use_regex = self.input_dialog.check_button and self.input_dialog.check_button.checked
-                        UIManager:close(self.input_dialog)
-                        self:onShowSearchDialog(self.input_dialog:getInputText(), 1, self.use_regex)
+                        if self.use_regex and self.ui.document:checkRegex(self.input_dialog:getInputText()) ~= 0 then
+                            UIManager:show(InfoMessage:new{ text = _("Error in regular expression!") })
+                        else
+                            UIManager:close(self.input_dialog)
+                            self:onShowSearchDialog(self.input_dialog:getInputText(), 1, self.use_regex)
+                        end
                     end,
                 },
                 {
@@ -67,8 +72,12 @@ function ReaderSearch:onShowFulltextSearchInput()
                         if self.input_dialog:getInputText() == "" then return end
                         self.last_search_text = self.input_dialog:getInputText()
                         self.use_regex = self.input_dialog.check_button and self.input_dialog.check_button.checked
-                        UIManager:close(self.input_dialog)
-                        self:onShowSearchDialog(self.input_dialog:getInputText(), 0, self.use_regex)
+                        if self.use_regex and self.ui.document:checkRegex(self.input_dialog:getInputText()) ~= 0 then
+                            UIManager:show(InfoMessage:new{ text = _("Error in regular expression!") })
+                        else
+                            UIManager:close(self.input_dialog)
+                            self:onShowSearchDialog(self.input_dialog:getInputText(), 0, self.use_regex)
+                        end
                     end,
                 },
             },

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1247,10 +1247,10 @@ function CreDocument:checkRegex(pattern)
     return self._document:checkRegex(pattern)
 end
 
-function CreDocument:findText(pattern, origin, reverse, caseInsensitive, page, regex)
-    logger.dbg("CreDocument: find text", pattern, origin, reverse, caseInsensitive, regex)
+function CreDocument:findText(pattern, origin, reverse, caseInsensitive, page, regex, max_hits)
+    logger.dbg("CreDocument: find text", pattern, origin, reverse, caseInsensitive, regex, max_hits)
     return self._document:findText(
-        pattern, origin, reverse, caseInsensitive and 1 or 0, regex and 1 or 0)
+        pattern, origin, reverse, caseInsensitive and 1 or 0, regex and 1 or 0, max_hits or 200)
 end
 
 function CreDocument:enableInternalHistory(toggle)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1244,7 +1244,6 @@ end
 
 function CreDocument:checkRegex(pattern)
     logger.dbg("CreDocument: check regex ", pattern)
-    print("xxxxxxxxx " .. tostring(pattern))
     return self._document:checkRegex(pattern)
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1242,6 +1242,12 @@ function CreDocument:setBackgroundImage(img_path) -- use nil to unset
     self._document:setBackgroundImage(img_path)
 end
 
+function CreDocument:checkRegex(pattern)
+    logger.dbg("CreDocument: check regex ", pattern)
+    print("xxxxxxxxx " .. tostring(pattern))
+    return self._document:checkRegex(pattern)
+end
+
 function CreDocument:findText(pattern, origin, reverse, caseInsensitive, page, regex)
     logger.dbg("CreDocument: find text", pattern, origin, reverse, caseInsensitive, regex)
     return self._document:findText(

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1247,6 +1247,12 @@ function CreDocument:checkRegex(pattern)
     return self._document:checkRegex(pattern)
 end
 
+function CreDocument:getAndClearRegexSearchError()
+    retval = self._document:getAndClearRegexSearchError()
+    logger.dbg("CreDocument: getAndClearRegexSearchError", retval)
+    return retval
+end
+
 function CreDocument:findText(pattern, origin, reverse, caseInsensitive, page, regex, max_hits)
     logger.dbg("CreDocument: find text", pattern, origin, reverse, caseInsensitive, regex, max_hits)
     return self._document:findText(

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1242,10 +1242,10 @@ function CreDocument:setBackgroundImage(img_path) -- use nil to unset
     self._document:setBackgroundImage(img_path)
 end
 
-function CreDocument:findText(pattern, origin, reverse, caseInsensitive)
-    logger.dbg("CreDocument: find text", pattern, origin, reverse, caseInsensitive)
+function CreDocument:findText(pattern, origin, reverse, caseInsensitive, page, regex)
+    logger.dbg("CreDocument: find text", pattern, origin, reverse, caseInsensitive, regex)
     return self._document:findText(
-        pattern, origin, reverse, caseInsensitive and 1 or 0)
+        pattern, origin, reverse, caseInsensitive and 1 or 0, regex and 1 or 0)
 end
 
 function CreDocument:enableInternalHistory(toggle)

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -183,7 +183,6 @@ local order = {
         "----------------------------",
         "find_book_in_calibre_catalog",
         "fulltext_search",
-        "regex_search",
     },
     filemanager = {},
     main = {

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -183,6 +183,7 @@ local order = {
         "----------------------------",
         "find_book_in_calibre_catalog",
         "fulltext_search",
+        "regex_search",
     },
     filemanager = {},
     main = {

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -446,7 +446,7 @@ function InputDialog:init()
         bordersize = self.border_size,
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
-            align = "center",
+            align = "left",
             self.title_widget,
             self.title_bar,
             self.description_widget,
@@ -465,9 +465,14 @@ function InputDialog:init()
 
     -- insert check button before the regular buttons
     if self.check_button then
-        local nr_elements = #self.dialog_frame[1]
-        table.insert(self.dialog_frame[1], nr_elements-1, vspan_before_input_text)
-        table.insert(self.dialog_frame[1], nr_elements-1, self.check_button)
+        local nb_elements = #self.dialog_frame[1]
+        table.insert(self.dialog_frame[1], nb_elements-1, CenterContainer:new{
+                dimen = Geom:new{
+                    w = self.width,
+                    h = self._input_widget:getSize().h,
+                },
+                self.check_button,
+            })
     end
 
     local frame = self.dialog_frame

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -96,7 +96,6 @@ longer than three words it should just read "OK".
 
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
-local CheckButton = require("ui/widget/checkbutton")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
 local Font = require("ui/font")
@@ -439,10 +438,9 @@ function InputDialog:init()
                 self._input_widget,
             },
             vspan_after_input_text,
-            buttons_container
+            buttons_container,
         }
     }
-
     local frame = self.dialog_frame
     if self.is_movable then
         self.movable = MovableContainer:new{ -- (UIManager expects this as 'self.movable')

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -418,26 +418,6 @@ function InputDialog:init()
         end
     end
 
-    -- checkbox
-    if self.check_button_text then
-        self.check_button = self.check_button or CheckButton:new{
-            text = self.check_button_text,
-            face = Font:getFace("smallinfofont"),
-            checked = self.check_button_checked,
-            callback = function()
-                if not self.check_button.checked then
-                    self.check_button:check()
-                else
-                    self.check_button:unCheck()
-                end
-                self:onShow()
-            end,
-            padding = self.padding,
-            margin = self.margin,
-            bordersize = self.bordersize,
-        }
-    end
-
     -- Final widget
     self.dialog_frame = FrameContainer:new{
         radius = self.fullscreen and 0 or Size.radius.window,
@@ -462,18 +442,6 @@ function InputDialog:init()
             buttons_container
         }
     }
-
-    -- insert check button before the regular buttons
-    if self.check_button then
-        local nb_elements = #self.dialog_frame[1]
-        table.insert(self.dialog_frame[1], nb_elements-1, CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.width,
-                    h = self._input_widget:getSize().h,
-                },
-                self.check_button,
-            })
-    end
 
     local frame = self.dialog_frame
     if self.is_movable then

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -439,56 +439,35 @@ function InputDialog:init()
     end
 
     -- Final widget
-    if not self.check_button then -- without checkbutton
-        self.dialog_frame = FrameContainer:new{
-            radius = self.fullscreen and 0 or Size.radius.window,
-            padding = 0,
-            margin = 0,
-            bordersize = self.border_size,
-            background = Blitbuffer.COLOR_WHITE,
-            VerticalGroup:new{
-                align = "center",
-                self.title_widget,
-                self.title_bar,
-                self.description_widget,
-                vspan_before_input_text,
-                CenterContainer:new{
-                    dimen = Geom:new{
-                        w = self.width,
-                        h = self._input_widget:getSize().h,
-                    },
-                    self._input_widget,
+    self.dialog_frame = FrameContainer:new{
+        radius = self.fullscreen and 0 or Size.radius.window,
+        padding = 0,
+        margin = 0,
+        bordersize = self.border_size,
+        background = Blitbuffer.COLOR_WHITE,
+        VerticalGroup:new{
+            align = "center",
+            self.title_widget,
+            self.title_bar,
+            self.description_widget,
+            vspan_before_input_text,
+            CenterContainer:new{
+                dimen = Geom:new{
+                    w = self.width,
+                    h = self._input_widget:getSize().h,
                 },
-                vspan_after_input_text,
-                buttons_container,
-            }
+                self._input_widget,
+            },
+            vspan_after_input_text,
+            buttons_container
         }
-    else -- with checkbutton
-        self.dialog_frame = FrameContainer:new{
-            radius = self.fullscreen and 0 or Size.radius.window,
-            padding = 0,
-            margin = 0,
-            bordersize = self.border_size,
-            background = Blitbuffer.COLOR_WHITE,
-            VerticalGroup:new{
-                align = "center",
-                self.title_widget,
-                self.title_bar,
-                self.description_widget,
-                vspan_before_input_text,
-                CenterContainer:new{
-                    dimen = Geom:new{
-                        w = self.width,
-                        h = self._input_widget:getSize().h,
-                    },
-                    self._input_widget,
-                },
-                vspan_before_input_text,
-                self.check_button,
-                vspan_after_input_text,
-                buttons_container,
-            }
-        }
+    }
+
+    -- insert check button before the regular buttons
+    if self.check_button then
+        local nr_elements = #self.dialog_frame[1]
+        table.insert(self.dialog_frame[1], nr_elements-1, vspan_before_input_text)
+        table.insert(self.dialog_frame[1], nr_elements-1, self.check_button)
     end
 
     local frame = self.dialog_frame

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -96,6 +96,7 @@ longer than three words it should just read "OK".
 
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
+local CheckButton = require("ui/widget/checkbutton")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
 local Font = require("ui/font")
@@ -417,30 +418,79 @@ function InputDialog:init()
         end
     end
 
-    -- Final widget
-    self.dialog_frame = FrameContainer:new{
-        radius = self.fullscreen and 0 or Size.radius.window,
-        padding = 0,
-        margin = 0,
-        bordersize = self.border_size,
-        background = Blitbuffer.COLOR_WHITE,
-        VerticalGroup:new{
-            align = "left",
-            self.title_widget,
-            self.title_bar,
-            self.description_widget,
-            vspan_before_input_text,
-            CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.width,
-                    h = self._input_widget:getSize().h,
-                },
-                self._input_widget,
-            },
-            vspan_after_input_text,
-            buttons_container,
+    -- checkbox
+    if self.check_button_text then
+        self.check_button = self.check_button or CheckButton:new{
+            text = self.check_button_text,
+            face = Font:getFace("smallinfofont"),
+            checked = self.check_button_checked,
+            callback = function()
+                if not self.check_button.checked then
+                    self.check_button:check()
+                else
+                    self.check_button:unCheck()
+                end
+                self:onShow()
+            end,
+            padding = self.padding,
+            margin = self.margin,
+            bordersize = self.bordersize,
         }
-    }
+    end
+
+    -- Final widget
+    if not self.check_button then -- without checkbutton
+        self.dialog_frame = FrameContainer:new{
+            radius = self.fullscreen and 0 or Size.radius.window,
+            padding = 0,
+            margin = 0,
+            bordersize = self.border_size,
+            background = Blitbuffer.COLOR_WHITE,
+            VerticalGroup:new{
+                align = "center",
+                self.title_widget,
+                self.title_bar,
+                self.description_widget,
+                vspan_before_input_text,
+                CenterContainer:new{
+                    dimen = Geom:new{
+                        w = self.width,
+                        h = self._input_widget:getSize().h,
+                    },
+                    self._input_widget,
+                },
+                vspan_after_input_text,
+                buttons_container,
+            }
+        }
+    else -- with checkbutton
+        self.dialog_frame = FrameContainer:new{
+            radius = self.fullscreen and 0 or Size.radius.window,
+            padding = 0,
+            margin = 0,
+            bordersize = self.border_size,
+            background = Blitbuffer.COLOR_WHITE,
+            VerticalGroup:new{
+                align = "center",
+                self.title_widget,
+                self.title_bar,
+                self.description_widget,
+                vspan_before_input_text,
+                CenterContainer:new{
+                    dimen = Geom:new{
+                        w = self.width,
+                        h = self._input_widget:getSize().h,
+                    },
+                    self._input_widget,
+                },
+                vspan_before_input_text,
+                self.check_button,
+                vspan_after_input_text,
+                buttons_container,
+            }
+        }
+    end
+
     local frame = self.dialog_frame
     if self.is_movable then
         self.movable = MovableContainer:new{ -- (UIManager expects this as 'self.movable')


### PR DESCRIPTION
For use with https://github.com/koreader/koreader-base/pull/1378
Adds a menu for regular expression searches and stores the last search string in full text as well as in regex search.

This should fix https://github.com/koreader/koreader/issues/7862

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7883)
<!-- Reviewable:end -->
