### PR TITLE
InputDialog, InputText: a bunch of updates

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -101,6 +101,7 @@ local Device = require("device")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputText = require("ui/widget/inputtext")
@@ -388,6 +389,7 @@ function InputDialog:init()
         scroll_callback = self._buttons_scroll_callback, -- nil if no Nav or Scroll buttons
         scroll = true,
         scroll_by_pan = self.scroll_by_pan,
+        is_fullscreen = self.fullscreen,
         has_nav_bar = self.add_nav_bar,
         cursor_at_end = self.cursor_at_end,
         readonly = self.readonly,
@@ -454,7 +456,6 @@ function InputDialog:init()
         frame
     }
     if Device:isTouchDevice() then -- is used to hide the keyboard with a tap outside of inputbox
-        local GestureRange = require("ui/gesturerange")
         self.ges_events = {
             Tap = {
                 GestureRange:new{

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -389,8 +389,6 @@ function InputDialog:init()
         scroll_callback = self._buttons_scroll_callback, -- nil if no Nav or Scroll buttons
         scroll = true,
         scroll_by_pan = self.scroll_by_pan,
-        is_fullscreen = self.fullscreen,
-        has_nav_bar = self.add_nav_bar,
         cursor_at_end = self.cursor_at_end,
         readonly = self.readonly,
         parent = self,
@@ -468,7 +466,10 @@ function InputDialog:init()
 end
 
 function InputDialog:onTap()
-    self._input_widget:onHideKeyboard()
+    if self.fullscreen or self.add_nav_bar then
+        return
+    end
+    self._input_widget:onCloseKeyboard()
 end
 
 function InputDialog:getInputText()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -573,16 +573,10 @@ function InputText:onShowKeyboard(ignore_first_hold_release)
     return true
 end
 
-function InputText:onHideKeyboard()
-    if self.is_fullscreen or self.has_nav_bar then return end
-    UIManager:close(self.keyboard)
-    Device:stopTextInput()
-    self.is_keyboard_hidden = true
-end
-
 function InputText:onCloseKeyboard()
     UIManager:close(self.keyboard)
     Device:stopTextInput()
+    self.is_keyboard_hidden = true
 end
 
 function InputText:onCloseWidget()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -73,19 +73,19 @@ if Device:isTouchDevice() or Device:hasDPad() then
                 TapTextBox = {
                     GestureRange:new{
                         ges = "tap",
-                        range = self.dimen
+                        range = function() return self.dimen end
                     }
                 },
                 HoldTextBox = {
                     GestureRange:new{
                         ges = "hold",
-                        range = self.dimen
+                        range = function() return self.dimen end
                     }
                 },
                 SwipeTextBox = {
                     GestureRange:new{
                         ges = "swipe",
-                        range = self.dimen
+                        range = function() return self.dimen end
                     }
                 },
                 -- These are just to stop propagation of the event to
@@ -166,18 +166,21 @@ if Device:isTouchDevice() or Device:hasDPad() then
                         return true
                     end
                 end
-                local input_dialog
-                input_dialog = require("ui/widget/inputdialog"):new{
-                    title = _("Clipboard"),
+                local clipboard_value = Device.input.getClipboardText()
+                local clipboard_dialog
+                clipboard_dialog = require("ui/widget/textviewer"):new{
+                    title = (clipboard_value == nil or clipboard_value == "") and _("Clipboard (empty)") or _("Clipboard"),
+                    text = clipboard_value,
+                    width = math.floor(Screen:getWidth() * 0.8),
+                    height = math.floor(Screen:getHeight() * 0.39),
+                    justified = false,
                     stop_events_propagation = true,
-                    input_hint = _("empty"),
-                    input = Device.input.getClipboardText(),
-                    buttons = {
+                    buttons_table = {
                         {
                             {
-                                text = _("All"),
+                                text = _("Copy all"),
                                 callback = function()
-                                    UIManager:close(input_dialog)
+                                    UIManager:close(clipboard_dialog)
                                     Device.input.setClipboardText(table.concat(self.charlist))
                                     UIManager:show(Notification:new{
                                         text = _("All text copied to clipboard."),
@@ -185,9 +188,9 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                 end,
                             },
                             {
-                                text = _("Line"),
+                                text = _("Copy line"),
                                 callback = function()
-                                    UIManager:close(input_dialog)
+                                    UIManager:close(clipboard_dialog)
                                     local txt = table.concat(self.charlist, "", self:getStringPos({"\n", "\r"}, {"\n", "\r"}))
                                     Device.input.setClipboardText(txt)
                                     UIManager:show(Notification:new{
@@ -196,9 +199,9 @@ if Device:isTouchDevice() or Device:hasDPad() then
                                 end,
                             },
                             {
-                                text = _("Word"),
+                                text = _("Copy word"),
                                 callback = function()
-                                    UIManager:close(input_dialog)
+                                    UIManager:close(clipboard_dialog)
                                     local txt = table.concat(self.charlist, "", self:getStringPos({"\n", "\r", " "}, {"\n", "\r", " "}))
                                     Device.input.setClipboardText(txt)
                                     UIManager:show(Notification:new{
@@ -211,13 +214,13 @@ if Device:isTouchDevice() or Device:hasDPad() then
                             {
                                 text = _("Cancel"),
                                 callback = function()
-                                    UIManager:close(input_dialog)
+                                    UIManager:close(clipboard_dialog)
                                 end,
                             },
                             {
                                 text = _("Select"),
                                 callback = function()
-                                    UIManager:close(input_dialog)
+                                    UIManager:close(clipboard_dialog)
                                     UIManager:show(Notification:new{
                                         text = _("Set cursor to start of selection, then hold."),
                                     })
@@ -226,21 +229,17 @@ if Device:isTouchDevice() or Device:hasDPad() then
                             },
                             {
                                 text = _("Paste"),
-                                is_enter_default = true,
                                 callback = function()
-                                    local paste_value = input_dialog:getInputText()
-                                    if paste_value ~= "" then
-                                        UIManager:close(input_dialog)
-                                        Device.input.setClipboardText(paste_value)
-                                        self:addChars(paste_value)
+                                    if clipboard_value ~= nil and clipboard_value ~= "" then
+                                        UIManager:close(clipboard_dialog)
+                                        self:addChars(clipboard_value)
                                     end
                                 end,
                             },
                         },
                     },
                 }
-                UIManager:show(input_dialog)
-                input_dialog:onShowKeyboard(true)
+                UIManager:show(clipboard_dialog)
             end
             return true
         end
@@ -580,8 +579,6 @@ function InputText:onHideKeyboard()
         Device:stopTextInput()
         self.is_keyboard_hidden = true
     end
-
-    return self.is_keyboard_hidden
 end
 
 function InputText:onCloseKeyboard()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -61,7 +61,7 @@ local InputText = InputContainer:new{
     for_measurement_only = nil, -- When the widget is a one-off used to compute text height
     do_select = false, -- to start text selection
     selection_start_pos = nil, -- selection start position
-    is_keyboard_hidden = false, -- to be able to show the keyboard again when it was hidden (by VK itself)
+    is_keyboard_hidden = false, -- to be able to show the keyboard again when it was hidden
 }
 
 -- only use PhysicalKeyboard if the device does not have touch screen
@@ -172,7 +172,7 @@ if Device:isTouchDevice() or Device:hasDPad() then
                     title = (clipboard_value == nil or clipboard_value == "") and _("Clipboard (empty)") or _("Clipboard"),
                     text = clipboard_value,
                     width = math.floor(Screen:getWidth() * 0.8),
-                    height = math.floor(Screen:getHeight() * 0.39),
+                    height = math.floor(Screen:getHeight() * 0.4),
                     justified = false,
                     stop_events_propagation = true,
                     buttons_table = {
@@ -574,11 +574,10 @@ function InputText:onShowKeyboard(ignore_first_hold_release)
 end
 
 function InputText:onHideKeyboard()
-    if not self.has_nav_bar then
-        UIManager:close(self.keyboard)
-        Device:stopTextInput()
-        self.is_keyboard_hidden = true
-    end
+    if self.is_fullscreen or self.has_nav_bar then return end
+    UIManager:close(self.keyboard)
+    Device:stopTextInput()
+    self.is_keyboard_hidden = true
 end
 
 function InputText:onCloseKeyboard()

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -127,13 +127,6 @@ function VirtualKey:init()
         self.callback = function() self.keyboard:upLine() end
     elseif self.label == "↓" then
         self.callback = function() self.keyboard:downLine() end
-        self.hold_callback = function()
-            self.ignore_key_release = true
-            if not self.keyboard:onHideKeyboard() then
-                -- Keyboard was *not* actually hidden: refresh the key to clear the highlight
-                self:update_keyboard(false, true)
-            end
-        end
     else
         self.callback = function () self.keyboard:addChar(self.key) end
         self.hold_callback = function()
@@ -767,10 +760,6 @@ end
 function VirtualKeyboard:onClose()
     UIManager:close(self)
     return true
-end
-
-function VirtualKeyboard:onHideKeyboard()
-    return self.inputbox:onHideKeyboard()
 end
 
 function VirtualKeyboard:onPressKey()


### PR DESCRIPTION
This set of updates summarizes the discussion from https://github.com/koreader/koreader/issues/7861 and includes;

1) **New way to hide the VirtualKeyboard**
Based on https://github.com/koreader/koreader/issues/7861#issuecomment-868804312, implemented via InputDialog.
To hide the keyboard tap any point of the screen outside the inputbox and above the keyboard.
To show the keyboard tap the inputbox.
Hacky "holding the arrow-down key" is not needed anymore.

2) **InputDialog windows are movable and transparentable by default**
Based on https://github.com/koreader/koreader/issues/7861#issuecomment-867218545.

3) **Redesign of the Clipboard dialog**
Actually we do not need a (duplicating) keyboard in the Clipboard dialog.
Clipboard dialog now is a TextViewer, all buttons and functionality remain.
![1](https://user-images.githubusercontent.com/62179190/123585006-14222300-d7eb-11eb-97a9-61c2b2f7d9fe.png)

Closes https://github.com/koreader/koreader/issues/7100, https://github.com/koreader/koreader/issues/7861.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7896)
<!-- Reviewable:end -->
