### PR TITLE
KeyboardLayoutDialog movable

### DIFF
--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -12,6 +12,7 @@ local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Language = require("ui/language")
 local LineWidget = require("ui/widget/linewidget")
+local MovableContainer = require("ui/widget/container/movablecontainer")
 local RadioButtonTable = require("ui/widget/radiobuttontable")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
@@ -25,6 +26,7 @@ local KeyboardLayoutDialog = InputContainer:new{
     is_always_active = true,
     title = _("Keyboard layout"),
     modal = true,
+    stop_events_propagation = true,
     width = math.floor(Screen:getWidth() * 0.8),
     face = Font:getFace("cfont", 22),
     title_face = Font:getFace("x_smalltfont"),
@@ -137,12 +139,15 @@ function KeyboardLayoutDialog:init()
         }
     }
 
+    self.movable = MovableContainer:new{
+        self.dialog_frame,
+    }
     self[1] = CenterContainer:new{
         dimen = Geom:new{
             w = Screen:getWidth(),
             h = Screen:getHeight(),
         },
-        self.dialog_frame,
+        self.movable,
     }
 end
 


### PR DESCRIPTION
We've been locked in landscape.

![1](https://user-images.githubusercontent.com/62179190/123942969-517de080-d9a4-11eb-8920-39d3afd77d9b.png)

Now

![2](https://user-images.githubusercontent.com/62179190/123942979-55a9fe00-d9a4-11eb-9cf6-f02ac4c49ca4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7911)
<!-- Reviewable:end -->
