### PR TITLE
ScreenSaver: Saner close behavior

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -89,7 +89,6 @@ function ReaderCoptListener:onTimeFormatChanged()
 end
 
 function ReaderCoptListener:updateHeader()
-    logger.dbg("ReaderCoptListener:updateHeader")
     -- Have crengine display accurate time and battery on its next drawing
     self.ui.rolling:updateBatteryState()
     self.ui.document:resetBufferCache() -- be sure next repaint is a redrawing

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -52,11 +52,14 @@ function ReaderCoptListener:onReadSettings(config)
 
     -- Have this ready in case auto-refresh is enabled, now or later
     self.headerRefresh = function()
-        -- Only draw it if something has changed
-        local new_battery_level = Device:getPowerDevice():getCapacity()
-        if self.clock == 1 or (self.battery == 1 and new_battery_level ~= self.old_battery_level) then
-            self.old_battery_level = new_battery_level
-            self:updateHeader()
+        -- Only draw it if the header is shown...
+        if self.document.configurable.status_line == 0 and self.view.view_mode == "page" then
+            -- ...and something has changed
+            local new_battery_level = Device:getPowerDevice():getCapacity()
+            if self.clock == 1 or (self.battery == 1 and new_battery_level ~= self.old_battery_level) then
+                self.old_battery_level = new_battery_level
+                self:updateHeader()
+            end
         end
         self:rescheduleHeaderRefreshIfNeeded() -- schedule (or not) next refresh
     end
@@ -86,6 +89,7 @@ function ReaderCoptListener:onTimeFormatChanged()
 end
 
 function ReaderCoptListener:updateHeader()
+    logger.dbg("ReaderCoptListener:updateHeader")
     -- Have crengine display accurate time and battery on its next drawing
     self.ui.rolling:updateBatteryState()
     self.ui.document:resetBufferCache() -- be sure next repaint is a redrawing

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2207,7 +2207,6 @@ function ReaderFooter:refreshFooter(refresh, signal)
 end
 
 function ReaderFooter:onResume()
-    logger.dbg("ReaderFooter:onResume", self.view.footer_visible)
     -- Don't repaint the footer until OutOfScreenSaver if screensaver_delay is enabled...
     local screensaver_delay = G_reader_settings:readSetting("screensaver_delay")
     if screensaver_delay and screensaver_delay ~= "disable" then
@@ -2215,19 +2214,16 @@ function ReaderFooter:onResume()
         return
     end
 
-    logger.dbg("ReaderFooter:onResume will update footer")
     -- Force a footer repaint on resume if it was visible
     self:onUpdateFooter(self.view.footer_visible)
     self:rescheduleFooterAutoRefreshIfNeeded()
 end
 
 function ReaderFooter:onOutOfScreenSaver()
-    logger.dbg("ReaderFooter:onOutOfScreenSaver", self._delayed_screensaver)
     if not self._delayed_screensaver then
         return
     end
 
-    logger.dbg("ReaderFooter:onOutOfScreenSaver will update footer")
     self._delayed_screensaver = nil
     -- Force a footer repaint on resume if it was visible
     self:onUpdateFooter(self.view.footer_visible)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2207,6 +2207,7 @@ function ReaderFooter:refreshFooter(refresh, signal)
 end
 
 function ReaderFooter:onResume()
+    logger.dbg("ReaderFooter:onResume", self.view.footer_visible)
     -- Don't repaint the footer until OutOfScreenSaver if screensaver_delay is enabled...
     local screensaver_delay = G_reader_settings:readSetting("screensaver_delay")
     if screensaver_delay and screensaver_delay ~= "disable" then
@@ -2214,16 +2215,19 @@ function ReaderFooter:onResume()
         return
     end
 
+    logger.dbg("ReaderFooter:onResume will update footer")
     -- Force a footer repaint on resume if it was visible
     self:onUpdateFooter(self.view.footer_visible)
     self:rescheduleFooterAutoRefreshIfNeeded()
 end
 
 function ReaderFooter:onOutOfScreenSaver()
+    logger.dbg("ReaderFooter:onOutOfScreenSaver", self._delayed_screensaver)
     if not self._delayed_screensaver then
         return
     end
 
+    logger.dbg("ReaderFooter:onOutOfScreenSaver will update footer")
     self._delayed_screensaver = nil
     -- Force a footer repaint on resume if it was visible
     self:onUpdateFooter(self.view.footer_visible)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -692,14 +692,14 @@ function Screensaver:close()
         UIManager:scheduleIn(screensaver_delay_number, function()
             logger.dbg("close screensaver")
             if self.screensaver_widget then
-                UIManager:close(self.screensaver_widget, "full")
+                UIManager:close(self.screensaver_widget)
                 self.screensaver_widget = nil
             end
         end)
     elseif screensaver_delay == "disable" then
         logger.dbg("close screensaver")
         if self.screensaver_widget then
-            UIManager:close(self.screensaver_widget, "full")
+            UIManager:close(self.screensaver_widget)
             self.screensaver_widget = nil
         end
     else

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -53,8 +53,7 @@ function ScreenSaverWidget:update()
     self.dithered = true
     self[1] = self.main_frame
     UIManager:setDirty(self, function()
-        local update_region = self.main_frame.dimen
-        return "full", update_region
+        return "full", self.main_frame.dimen
     end)
 end
 
@@ -73,9 +72,7 @@ function ScreenSaverWidget:onTap(_, ges)
 end
 
 function ScreenSaverWidget:onClose()
-    UIManager:close(self, "full")
-    -- Will come after the Resume event (how much later depends on screensaver_delay).
-    UIManager:broadcastEvent(Event:new("OutOfScreenSaver"))
+    UIManager:close(self)
     return true
 end
 
@@ -88,6 +85,10 @@ function ScreenSaverWidget:onCloseWidget()
     UIManager:setDirty(nil, function()
         return "full", self.main_frame.dimen
     end)
+
+    -- Will come after the Resume event, iff screensaver_delay is set.
+    -- Comes *before* it otherwise.
+    UIManager:broadcastEvent(Event:new("OutOfScreenSaver"))
 end
 
 return ScreenSaverWidget


### PR DESCRIPTION
* Simplify & cleanup weird useless duplicate refreshes, and move the OutOfScreenSaver event to the right place.

Fix #7643

* Also fix a bogus refresh on Resume if the CRe header is not actually enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7929)
<!-- Reviewable:end -->
