### PR TITLE
Add another mimetype alias for FB2 files for OPDS

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1342,6 +1342,7 @@ function CreDocument:register(registry)
     registry:addProvider("epub", "application/epub+zip", self, 100)
     registry:addProvider("epub3", "application/epub+zip", self, 100)
     registry:addProvider("fb2", "application/fb2", self, 90)
+    registry:addProvider("fb2", "text/fb2+xml", self, 90) -- Alternative mimetype for OPDS.
     registry:addProvider("fb2.zip", "application/zip", self, 90)
     registry:addProvider("fb2.zip", "application/fb2+zip", self, 90) -- Alternative mimetype for OPDS.
     registry:addProvider("fb3", "application/fb3", self, 90)


### PR DESCRIPTION
I've encountered an issue when Calibre Content Server's OPDS feed produced ``text/fb2-xml`` mimetype. Don't know if it is actually Calibre to blame, but thought this simple fix will save some poor souls' time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7932)
<!-- Reviewable:end -->
