### PR TITLE
CheckButton: fix hold when in a movable container

### DIFF
--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -91,6 +91,14 @@ function CheckButton:initCheckButton(checked)
                     range = self.dimen,
                 },
                 doc = "Hold Button",
+            },
+            -- Safe-guard for when used inside a MovableContainer
+            HoldReleaseCheckButton = {
+                GestureRange:new{
+                    ges = "hold_release",
+                    range = self.dimen,
+                },
+                doc = "Hold Release Button",
             }
         }
     end
@@ -138,6 +146,9 @@ function CheckButton:onTapCheckButton()
 end
 
 function CheckButton:onHoldCheckButton()
+    -- Make sure to also handle its hold_release below,
+    -- so it's not propagated up to a MovableContainer
+    self._hold_handled = true
     if self.enabled and self.hold_callback then
         self.hold_callback()
     elseif self.hold_input then
@@ -146,6 +157,14 @@ function CheckButton:onHoldCheckButton()
         self:onInput(self.hold_input_func())
     end
     return true
+end
+
+function CheckButton:onHoldReleaseCheckButton()
+    if self._hold_handled then
+        self._hold_handled = nil
+        return true
+    end
+    return false
 end
 
 function CheckButton:check()

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -146,15 +146,21 @@ function CheckButton:onTapCheckButton()
 end
 
 function CheckButton:onHoldCheckButton()
-    -- Make sure to also handle its hold_release below,
-    -- so it's not propagated up to a MovableContainer
-    self._hold_handled = true
-    if self.enabled and self.hold_callback then
-        self.hold_callback()
-    elseif self.hold_input then
-        self:onInput(self.hold_input)
-    elseif type(self.hold_input_func) == "function" then
-        self:onInput(self.hold_input_func())
+    -- If we're going to process this hold, we must make
+    -- sure to also handle its hold_release below, so it's
+    -- not propagated up to a MovableContainer
+    self._hold_handled = nil
+    if self.enabled then
+        if self.hold_callback then
+            self.hold_callback()
+            self._hold_handled = true
+        elseif self.hold_input then
+            self:onInput(self.hold_input, true)
+            self._hold_handled = true
+        elseif type(self.hold_input_func) == "function" then
+            self:onInput(self.hold_input_func(), true)
+            self._hold_handled = true
+        end
     end
     return true
 end


### PR DESCRIPTION
Fix issue noticed at https://github.com/koreader/koreader/pull/7947#issuecomment-876693624 : _Long-press on (hold for help) makes and leaves the input dialog translucent._
Same bits of code as used in Button.lua.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7948)
<!-- Reviewable:end -->
