### PR TITLE
Fulltext search save settings

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -105,8 +105,8 @@ function ReaderSearch:onShowFulltextSearchInput()
     self.input_dialog = InputDialog:new{
         title = _("Enter text to search for"),
         input = self.last_search_text,
-        use_regex_checked = self.use_regex,
-        case_insensitive_checked = not self.case_insensitive,
+--        use_regex_checked = self.use_regex,
+--        case_insensitive_checked = not self.case_insensitive,
         buttons = {
             {
                 {


### PR DESCRIPTION
The search value and parameters are cached as long as reader is left (independently of save settings).

If save settings is checked, the settings are stored in 'settings.reader.lua' and can be used on consecutive openings of other files (mupdf, crengine). `use_regex` is saved/stored to but is only applied in files opened with crengine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7965)
<!-- Reviewable:end -->
