### PR TITLE
FileSearcher honor filemanagers sorting order

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1101,7 +1101,7 @@ function FileManager:getSortingMenuTable()
     local fm = self
     local collates = {
         strcoll = {_("filename"), _("Sort by filename")},
-        numeric = {_("numeric"), _("Sort by filename (natural sorting)")},
+        natural = {_("natural"), _("Sort by filename (natural sorting)")},
         strcoll_mixed = {_("name mixed"), _("Sort by name – mixed files and folders")},
         access = {_("date read"), _("Sort by last read date")},
         change = {_("date added"), _("Sort by date added")},
@@ -1137,7 +1137,7 @@ function FileManager:getSortingMenuTable()
         end,
         sub_item_table = {
             set_collate_table("strcoll"),
-            set_collate_table("numeric"),
+            set_collate_table("natural"),
             set_collate_table("strcoll_mixed"),
             set_collate_table("access"),
             set_collate_table("change"),

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -46,7 +46,11 @@ function FileSearcher:readDir()
                 local fullpath = d.."/"..f
                 local attributes = lfs.attributes(fullpath) or {}
                 -- Don't traverse hidden folders if we're not showing them
-                if attributes.mode == "directory" and f ~= "." and f ~= ".." and (G_reader_settings:isTrue("show_hidden") or not util.stringStartsWith(f, ".")) then
+                if attributes.mode == "directory" and f ~= "." and f ~= ".."
+                    and (G_reader_settings:isTrue("show_hidden") or not util.stringStartsWith(f, "."))
+                    and FileChooser:show_dir(f)
+                    and FileChooser:show_file(f)
+                then
                     table.insert(new_dirs, fullpath)
                     table.insert(self.files, {
                         name = f,
@@ -57,7 +61,11 @@ function FileSearcher:readDir()
                         end,
                     })
                 -- Always ignore macOS resource forks, too.
-                elseif attributes.mode == "file" and not util.stringStartsWith(f, "._") and (show_unsupported or DocumentRegistry:hasProvider(fullpath)) then
+                elseif attributes.mode == "file" and not util.stringStartsWith(f, "._")
+                    and (show_unsupported or DocumentRegistry:hasProvider(fullpath))
+                    and FileChooser:show_dir(f)
+                    and FileChooser:show_file(f)
+                then
                     table.insert(self.files, {
                         name = f,
                         text = f,
@@ -90,11 +98,11 @@ function FileSearcher:setSearchResults()
         keywords = keywords:gsub("%?","%.")
         for __,f in pairs(self.files) do
             if self.case_sensitive then
-                if string.find(f.name, keywords) and string.sub(f.name,-4) ~= ".sdr" then
+                if string.find(f.name, keywords) then
                     table.insert(self.results, f)
                 end
             else
-                if string.find(Utf8Proc.lowercase(util.fixUtf8(f.name, "?")), keywords) and string.sub(f.name,-4) ~= ".sdr" then
+                if string.find(Utf8Proc.lowercase(util.fixUtf8(f.name, "?")), keywords) then
                     table.insert(self.results, f)
                 end
             end
@@ -129,7 +137,6 @@ function FileSearcher:onShowFileSearch()
             {
                 {
                     text = _("Cancel"),
-                    enabled = true,
                     callback = function()
                         self.search_dialog:onClose()
                         UIManager:close(self.search_dialog)
@@ -147,7 +154,6 @@ function FileSearcher:onShowFileSearch()
                 },
                 {
                     text = _("Current folder"),
-                    enabled = true,
                     is_enter_default = true,
                     callback = function()
                         self.search_value = self.search_dialog:getInputText()

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -1,6 +1,7 @@
 local CheckButton = require("ui/widget/checkbutton")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local DocumentRegistry = require("document/documentregistry")
+local FileChooser = require("ui/widget/filechooser")
 local Font = require("ui/font")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
@@ -207,7 +208,12 @@ function FileSearcher:showSearchResults()
     self.search_menu.close_callback = function()
         UIManager:close(menu_container)
     end
-    table.sort(self.results, function(v1,v2) return v1.text < v2.text end)
+
+    local collate = G_reader_settings:readSetting("collate") or "strcoll"
+    local reverse_collate = G_reader_settings:isTrue("reverse_collate")
+    local sorting = FileChooser:getSortingFunction(collate, reverse_collate)
+
+    table.sort(self.results, sorting)
     self.search_menu:switchItemTable(_("Search results"), self.results)
     UIManager:show(menu_container)
 end

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -49,7 +49,6 @@ function FileSearcher:readDir()
                 if attributes.mode == "directory" and f ~= "." and f ~= ".."
                     and (G_reader_settings:isTrue("show_hidden") or not util.stringStartsWith(f, "."))
                     and FileChooser:show_dir(f)
-                    and FileChooser:show_file(f)
                 then
                     table.insert(new_dirs, fullpath)
                     table.insert(self.files, {
@@ -63,7 +62,6 @@ function FileSearcher:readDir()
                 -- Always ignore macOS resource forks, too.
                 elseif attributes.mode == "file" and not util.stringStartsWith(f, "._")
                     and (show_unsupported or DocumentRegistry:hasProvider(fullpath))
-                    and FileChooser:show_dir(f)
                     and FileChooser:show_file(f)
                 then
                     table.insert(self.files, {

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -80,7 +80,7 @@ function FileSearcher:setSearchResults()
         self.results = self.files
     else
         if not self.case_sensitive then
-            keywords = Utf8Proc.lowercase(keywords)
+            keywords = Utf8Proc.lowercase(util.fixUtf8(keywords, "?"))
         end
         -- replace '.' with '%.'
         keywords = keywords:gsub("%.","%%%.")
@@ -94,7 +94,7 @@ function FileSearcher:setSearchResults()
                     table.insert(self.results, f)
                 end
             else
-                if string.find(Utf8Proc.lowercase(f.name), keywords) and string.sub(f.name,-4) ~= ".sdr" then
+                if string.find(Utf8Proc.lowercase(util.fixUtf8(f.name, "?")), keywords) and string.sub(f.name,-4) ~= ".sdr" then
                     table.insert(self.results, f)
                 end
             end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -665,6 +665,8 @@ To:
 Wildcards for one '?' or more '*' characters can be used.
 A search for '*' will show all files.
 
+The sorting order is the same as in filemanager.
+
 Tap a book in the search results to open it.]]),
         callback = function()
             self.ui:handleEvent(Event:new("ShowFileSearch"))

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210629
+local CURRENT_MIGRATION_DATE = 20210715
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -272,6 +272,17 @@ if last_migration_date < 20210629 then
         local user_format = footer:readSetting("duration_format")
         G_reader_settings:saveSetting("duration_format", user_format)
         footer:delSetting("duration_format")
+    end
+end
+
+-- 20210715, Rename `numeric` to `natural`, https://github.com/koreader/koreader/pull/7978
+if last_migration_date < 20210715 then
+    logger.info("Performing one-time migration for 20210715")
+    if G_reader_settings:has("collate") then
+        local collate = G_reader_settings:readSetting("collate")
+        if collate == "numeric" then
+            G_reader_settings:saveSetting("collate", "natural")
+        end
     end
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -74,22 +74,22 @@ local FileChooser = Menu:extend{
 -- from readable /storage/emulated/0/ - so we know it contains "0/")
 local unreadable_dir_content = {}
 
+function FileChooser:show_dir(dirname)
+    for _, pattern in ipairs(self.exclude_dirs) do
+        if dirname:match(pattern) then return false end
+    end
+    return true
+end
+
+function FileChooser:show_file(filename)
+    for _, pattern in ipairs(self.exclude_files) do
+        if filename:match(pattern) then return false end
+    end
+    return true
+end
+
 function FileChooser:init()
     self.width = Screen:getWidth()
-    -- Standard dir exclusion list
-    self.show_dir = function(dirname)
-        for _, pattern in ipairs(self.exclude_dirs) do
-            if dirname:match(pattern) then return false end
-        end
-        return true
-    end
-    -- Standard file exclusion list
-    self.show_file = function(filename)
-        for _, pattern in ipairs(self.exclude_files) do
-            if filename:match(pattern) then return false end
-        end
-        return true
-    end
     self.list = function(path, dirs, files, count_only)
         -- lfs.dir directory without permission will give error
         local ok, iter, dir_obj = pcall(lfs.dir, path)
@@ -99,8 +99,8 @@ function FileChooser:init()
                 if count_only then
                     if ((not self.show_hidden and not util.stringStartsWith(f, "."))
                          or (self.show_hidden and f ~= "." and f ~= ".." and not util.stringStartsWith(f, "._")))
-                         and self.show_dir(f)
-                         and self.show_file(f)
+                         and self:show_dir(f)
+                         and self:show_file(f)
                     then
                         table.insert(dirs, true)
                     end
@@ -109,7 +109,7 @@ function FileChooser:init()
                     local attributes = lfs.attributes(filename)
                     if attributes ~= nil then
                         if attributes.mode == "directory" and f ~= "." and f ~= ".." then
-                            if self.show_dir(f) then
+                            if self:show_dir(f) then
                                 table.insert(dirs, {name = f,
                                                     suffix = getFileNameSuffix(f),
                                                     fullpath = filename,
@@ -117,7 +117,7 @@ function FileChooser:init()
                             end
                         -- Always ignore macOS resource forks.
                         elseif attributes.mode == "file" and not util.stringStartsWith(f, "._") then
-                            if self.show_file(f) then
+                            if self:show_file(f) then
                                 if self.file_filter == nil or self.file_filter(filename) or self.show_unsupported then
                                     local percent_finished = 0
                                     if self.collate == "percent_unopened_first" or self.collate == "percent_unopened_last" then

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -227,7 +227,7 @@ function FileChooser:getSortingFunction(collate, reverse_collate)
 
             return a.percent_finished < b.percent_finished
         end
-    elseif collate == "numeric" then
+    elseif collate == "natural" then
         -- adapted from: http://notebook.kulchenko.com/algorithms/alphanumeric-natural-sorting-for-humans-in-lua
         local function addLeadingZeroes(d)
             local dec, n = string.match(d, "(%.?)0*(.+)")


### PR DESCRIPTION
When using file search in filemanager, the found files are shown in the sorting order selected in filemanager.

BTW: The naming of natural/numeric sorting is inconsistent. In filemanager you can select "Sort by filename (natural sorting)", but in the menu before "Sort by: numeric" is shown. Shouldn't this be changed to "natural" as well? (and the `collate` setting migrated too)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7978)
<!-- Reviewable:end -->
