### PR TITLE
SDL keyboard input: should go to top level widget only

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -264,7 +264,7 @@ function Device:init()
                 self.window.left = ev.value.data1
                 self.window.top = ev.value.data2
             elseif ev.code == SDL_TEXTINPUT then
-                UIManager:broadcastEvent(Event:new("TextInput", ev.value))
+                UIManager:sendEvent(Event:new("TextInput", ev.value))
             end
         end,
         hasClipboardText = function()


### PR DESCRIPTION
bump base: fix doc for ffi/utf8proc https://github.com/koreader/koreader-base/pull/1385 https://github.com/koreader/koreader/pull/7956#issuecomment-880626432

SDL keyboard input: should go to top level widget only
Avoid the typed input to be added to all InputText present on the stack: only the top one should handle it.
https://github.com/koreader/koreader/pull/7981#issuecomment-880896489

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7982)
<!-- Reviewable:end -->
