### PR TITLE
PDF text selection & highlights: various fixes

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1287,16 +1287,20 @@ function ReaderHighlight:onUnhighlight(bookmark_item)
         sel_pos0 = self.selected_text.pos0
     end
     if self.ui.document.info.has_pages then -- We can safely use page
+        -- As we may have changed spaces and hyphens handling in the extracted
+        -- text over the years, check text identities with them removed
+        local sel_text_cleaned = sel_text:gsub("[ -]", ""):gsub("\xC2\xAD", "")
         for index = 1, #self.view.highlight.saved[page] do
             local highlight = self.view.highlight.saved[page][index]
             -- pos0 are tables and can't be compared directly, except when from
             -- DictQuickLookup where these are the same object.
             -- If bookmark_item provided, just check datetime
-            if highlight.text == sel_text and (
-                    (datetime == nil and highlight.pos0 == sel_pos0) or
-                    (datetime ~= nil and highlight.datetime == datetime)) then
-                idx = index
-                break
+            if ( (datetime == nil and highlight.pos0 == sel_pos0) or
+                 (datetime ~= nil and highlight.datetime == datetime) ) then
+                if highlight.text:gsub("[ -]", ""):gsub("\xC2\xAD", "") == sel_text_cleaned then
+                    idx = index
+                    break
+                end
             end
         end
     else -- page is a xpointer

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -760,6 +760,7 @@ In combination with zoom to fit page, page height, content height, content or co
 end
 
 function ReaderView:onReadSettings(config)
+    self.document:setTileCacheValidity(config:readSetting("tile_cache_validity_ts"))
     self.render_mode = config:readSetting("render_mode") or 0
     local rotation_mode = nil
     local locked = G_reader_settings:isTrue("lock_rotation")
@@ -888,6 +889,7 @@ function ReaderView:onPageGapUpdate(page_gap)
 end
 
 function ReaderView:onSaveSettings()
+    self.ui.doc_settings:saveSetting("tile_cache_validity_ts", self.document:getTileCacheValidity())
     self.ui.doc_settings:saveSetting("render_mode", self.render_mode)
     -- Don't etch the current rotation in stone when sticky rotation is enabled
     local locked = G_reader_settings:isTrue("lock_rotation")

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -208,6 +208,20 @@ local function _quadpointsFromPboxes(pboxes)
     return quadpoints, n
 end
 
+local function _quadpointsToPboxes(quadpoints, n)
+    -- reverse of previous function
+    local pboxes = {}
+    for i=1, n do
+        table.insert(pboxes, {
+            x = quadpoints[8*i-4],
+            y = quadpoints[8*i-3],
+            w = quadpoints[8*i-6] - quadpoints[8*i-4],
+            h = quadpoints[8*i-5] - quadpoints[8*i-3],
+        })
+    end
+    return pboxes
+end
+
 function PdfDocument:saveHighlight(pageno, item)
     local can_write = self:_checkIfWritable()
     if can_write ~= true then return can_write end
@@ -223,8 +237,12 @@ function PdfDocument:saveHighlight(pageno, item)
     elseif item.drawer == "strikeout" then
         annot_type = C.PDF_ANNOT_STRIKEOUT
     end
-    page:addMarkupAnnotation(quadpoints, n, annot_type)
+    page:addMarkupAnnotation(quadpoints, n, annot_type) -- may update/adjust quadpoints
+    -- Update pboxes with the possibly adjusted coordinates (this will have it updated
+    -- in self.view.highlight.saved[page])
+    item.pboxes = _quadpointsToPboxes(quadpoints, n)
     page:close()
+    self:resetTileCacheValidity()
 end
 
 function PdfDocument:deleteHighlight(pageno, item)
@@ -237,6 +255,7 @@ function PdfDocument:deleteHighlight(pageno, item)
     local annot = page:getMarkupAnnotation(quadpoints, n)
     if annot ~= nil then
         page:deleteMarkupAnnotation(annot)
+        self:resetTileCacheValidity()
     end
     page:close()
 end
@@ -251,6 +270,7 @@ function PdfDocument:updateHighlightContents(pageno, item, contents)
     local annot = page:getMarkupAnnotation(quadpoints, n)
     if annot ~= nil then
         page:updateMarkupAnnotation(annot, contents)
+        self:resetTileCacheValidity()
     end
     page:close()
 end

--- a/frontend/document/tilecacheitem.lua
+++ b/frontend/document/tilecacheitem.lua
@@ -17,6 +17,7 @@ function TileCacheItem:totable()
         size = self.size,
         pageno = self.pageno,
         excerpt = self.excerpt,
+        created_ts = self.created_ts,
         persistent = self.persistent,
         bb = {
             w = self.bb.w,
@@ -51,6 +52,7 @@ function TileCacheItem:fromtable(t)
     self.size = t.size
     self.pageno = t.pageno
     self.excerpt = t.excerpt
+    self.created_ts = t.created_ts
     self.persistent = t.persistent
     self.bb = Blitbuffer.fromstring(t.bb.w, t.bb.h, t.bb.fmt, t.bb.data, t.bb.stride)
 end


### PR DESCRIPTION
`PDF text selection: fix/tweak spacing between words/boxes`

We may get multiple boxes when selecting texts, one for each word, and we have to add spaces between the extracted words ourselves. Previously, we were only adding a space if the last char of previous word was ASCII, so missing spaces after accents or greek words.
Try to do better by measuring the distances between boxes and comparing to box heights, with a few heuristics.

`PDF written highlights: fix boxes, trash cached tiles`

TileCacheItem: add created_ts property.
Document: manage a tile_cache_validity_ts and ignore older cached tiles.
This timestamps is updated when highlights are written as annotations in, or deleted from, the PDF, so we can get the most current rendered bitmap from MuPDF and avoid highlight ghosts on old tiles.
Save this timestamp in doc settings so older cached to disk tiles will also be ignored across re-openings.
This commit will be added a bump for https://github.com/koreader/koreader-base/pull/1388.

See https://github.com/koreader/koreader/issues/7928#issuecomment-882089306.
Hopefully close #7928.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/7988)
<!-- Reviewable:end -->
