### PR TITLE
File browser: Settings submenu reordering

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -150,17 +150,7 @@ function FileManagerMenu:setUpdateItemTable()
                 text = _("Show unsupported files"),
                 checked_func = function() return self.ui.file_chooser.show_unsupported end,
                 callback = function() self.ui:toggleUnsupportedFiles() end,
-            },
-            {
-                text = _("Hide folders count"),
-                checked_func = function()
-                    return G_reader_settings:isTrue("hide_folders_count")
-                end,
-                callback = function()
-                    G_reader_settings:flipNilOrFalse("hide_folders_count")
-                    self.ui:onRefresh()
-                end,
-            separator = true,
+                separator = true,
             },
             {
                 text = _("Classic mode settings"),
@@ -281,7 +271,7 @@ function FileManagerMenu:setUpdateItemTable()
                         end,
                     },
                     {
-                        text = _("Auto-remove deleted items from history"),
+                        text = _("Auto-remove deleted or purged items from history"),
                         checked_func = function()
                             return G_reader_settings:isTrue("autoremove_deleted_items_from_history")
                         end,
@@ -362,7 +352,7 @@ To:
                         end,
                         callback = function()
                             G_reader_settings:flipNilOrFalse("lock_home_folder")
-                            UIManager:broadcastEvent(Event:new("Refresh"))
+                            self.ui:onRefresh()
                         end,
                     },
                 },

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -259,11 +259,11 @@ function FileManagerMenu:setUpdateItemTable()
                 text = _("History settings"),
                 sub_item_table = {
                     {
-                        text = _("Clean history of deleted items"),
+                        text = _("Clear history of deleted files"),
                         callback = function()
                             UIManager:show(ConfirmBox:new{
-                                text = _("Clean history of deleted items?"),
-                                ok_text = _("Clean"),
+                                text = _("Clear history of deleted files?"),
+                                ok_text = _("Clear"),
                                 ok_callback = function()
                                     require("readhistory"):clearMissing()
                                 end,

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -136,12 +136,6 @@ function FileManagerMenu:onOpenLastDoc()
 end
 
 function FileManagerMenu:setUpdateItemTable()
-    for _, widget in pairs(self.registered_widgets) do
-        local ok, err = pcall(widget.addToMainMenu, widget, self.menu_items)
-        if not ok then
-            logger.err("failed to register widget", widget.name, err)
-        end
-    end
 
     -- setting tab
     self.menu_items.filebrowser_settings = {
@@ -156,134 +150,199 @@ function FileManagerMenu:setUpdateItemTable()
                 text = _("Show unsupported files"),
                 checked_func = function() return self.ui.file_chooser.show_unsupported end,
                 callback = function() self.ui:toggleUnsupportedFiles() end,
-                separator = true,
             },
             {
-                text = _("Items per page"),
-                help_text = _([[This sets the number of items per page in:
-- File browser, history and favorites in 'classic' display mode
-- Search results and folder shortcuts
-- File and directory selection
-- Calibre and OPDS browsers/search results]]),
-                keep_menu_open = true,
-                callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local Menu = require("ui/widget/menu")
-                    local default_perpage = Menu.items_per_page_default
-                    local curr_perpage = G_reader_settings:readSetting("items_per_page") or default_perpage
-                    local items = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
-                        value = curr_perpage,
-                        value_min = 6,
-                        value_max = 24,
-                        default_value = default_perpage,
-                        title_text =  _("Items per page"),
-                        keep_shown_on_apply = true,
-                        callback = function(spin)
-                            G_reader_settings:saveSetting("items_per_page", spin.value)
-                            self.ui:onRefresh()
-                        end
-                    }
-                    UIManager:show(items)
-                end,
-            },
-            {
-                text = _("Item font size"),
-                keep_menu_open = true,
-                callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local Menu = require("ui/widget/menu")
-                    local curr_perpage = G_reader_settings:readSetting("items_per_page") or Menu.items_per_page_default
-                    local default_font_size = Menu.getItemFontSize(curr_perpage)
-                    local curr_font_size = G_reader_settings:readSetting("items_font_size") or default_font_size
-                    local items_font = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
-                        value = curr_font_size,
-                        value_min = 10,
-                        value_max = 72,
-                        default_value = default_font_size,
-                        keep_shown_on_apply = true,
-                        title_text =  _("Item font size"),
-                        callback = function(spin)
-                            if spin.value == default_font_size then
-                                -- We can't know if the user has set a size or hit "Use default", but
-                                -- assume that if it is the default font size, he will prefer to have
-                                -- our default font size if he later updates per-page
-                                G_reader_settings:delSetting("items_font_size")
-                            else
-                                G_reader_settings:saveSetting("items_font_size", spin.value)
-                            end
-                            self.ui:onRefresh()
-                        end
-                    }
-                    UIManager:show(items_font)
-                end,
-            },
-            {
-                text = _("Shrink item font size to fit more text"),
-                keep_menu_open = true,
+                text = _("Hide folders count"),
                 checked_func = function()
-                    return G_reader_settings:isTrue("items_multilines_show_more_text")
+                    return G_reader_settings:isTrue("hide_folders_count")
                 end,
                 callback = function()
-                    G_reader_settings:flipNilOrFalse("items_multilines_show_more_text")
+                    G_reader_settings:flipNilOrFalse("hide_folders_count")
                     self.ui:onRefresh()
                 end,
+            separator = true,
             },
             {
-                text_func = function()
-                    local current_state = _("Show new files in bold")
-                    if G_reader_settings:readSetting("show_file_in_bold") == "opened" then
-                        current_state = _("Show opened files in bold")
-                    elseif G_reader_settings:isFalse("show_file_in_bold") then
-                        current_state = _("Show files in bold") -- with checkmark unchecked
-                    end
-                    -- Inform that this settings applies only to classic file chooser
-                    current_state = T(_("(Classic file browser) %1"), current_state)
-                    return current_state
-                end,
-                checked_func = function() return not G_reader_settings:isFalse("show_file_in_bold") end,
+                text = _("Classic mode settings"),
                 sub_item_table = {
                     {
-                        text = _("Don't show files in bold"),
-                        checked_func = function() return G_reader_settings:isFalse("show_file_in_bold") end,
+                        text = _("Items per page"),
+                        help_text = _([[This sets the number of items per page in:
+- File browser, history and favorites in 'classic' display mode
+- Search results and folder shortcuts
+- File and folder selection
+- Calibre and OPDS browsers/search results]]),
                         callback = function()
-                            G_reader_settings:saveSetting("show_file_in_bold", false)
-                            self.ui:onRefresh()
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            local Menu = require("ui/widget/menu")
+                            local default_perpage = Menu.items_per_page_default
+                            local curr_perpage = G_reader_settings:readSetting("items_per_page") or default_perpage
+                            local items = SpinWidget:new{
+                                width = math.floor(Screen:getWidth() * 0.6),
+                                value = curr_perpage,
+                                value_min = 6,
+                                value_max = 24,
+                                default_value = default_perpage,
+                                title_text =  _("Items per page"),
+                                keep_shown_on_apply = true,
+                                callback = function(spin)
+                                    G_reader_settings:saveSetting("items_per_page", spin.value)
+                                    self.ui:onRefresh()
+                                end
+                            }
+                            UIManager:show(items)
                         end,
                     },
                     {
-                        text = _("Show opened files in bold"),
-                        checked_func = function() return G_reader_settings:readSetting("show_file_in_bold") == "opened" end,
+                        text = _("Item font size"),
                         callback = function()
-                            G_reader_settings:saveSetting("show_file_in_bold", "opened")
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            local Menu = require("ui/widget/menu")
+                            local curr_perpage = G_reader_settings:readSetting("items_per_page") or Menu.items_per_page_default
+                            local default_font_size = Menu.getItemFontSize(curr_perpage)
+                            local curr_font_size = G_reader_settings:readSetting("items_font_size") or default_font_size
+                            local items_font = SpinWidget:new{
+                                width = math.floor(Screen:getWidth() * 0.6),
+                                value = curr_font_size,
+                                value_min = 10,
+                                value_max = 72,
+                                default_value = default_font_size,
+                                keep_shown_on_apply = true,
+                                title_text =  _("Item font size"),
+                                callback = function(spin)
+                                    if spin.value == default_font_size then
+                                        -- We can't know if the user has set a size or hit "Use default", but
+                                        -- assume that if it is the default font size, he will prefer to have
+                                        -- our default font size if he later updates per-page
+                                        G_reader_settings:delSetting("items_font_size")
+                                    else
+                                        G_reader_settings:saveSetting("items_font_size", spin.value)
+                                    end
+                                    self.ui:onRefresh()
+                                end
+                            }
+                            UIManager:show(items_font)
+                        end,
+                    },
+                    {
+                        text = _("Shrink item font size to fit more text"),
+                        checked_func = function()
+                            return G_reader_settings:isTrue("items_multilines_show_more_text")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrFalse("items_multilines_show_more_text")
+                            self.ui:onRefresh()
+                        end,
+                        separator = true,
+                    },
+                    {
+                        text = _("Show opened files in bold"),
+                        checked_func = function()
+                            return G_reader_settings:readSetting("show_file_in_bold") == "opened"
+                        end,
+                        callback = function()
+                            if G_reader_settings:readSetting("show_file_in_bold") == "opened" then
+                                G_reader_settings:saveSetting("show_file_in_bold", false)
+                            else
+                                G_reader_settings:saveSetting("show_file_in_bold", "opened")
+                            end
                             self.ui:onRefresh()
                         end,
                     },
                     {
                         text = _("Show new (not yet opened) files in bold"),
                         checked_func = function()
-                            return not G_reader_settings:isFalse("show_file_in_bold") and G_reader_settings:readSetting("show_file_in_bold") ~= "opened"
+                            return G_reader_settings:hasNot("show_file_in_bold")
                         end,
                         callback = function()
-                            G_reader_settings:delSetting("show_file_in_bold")
+                            if G_reader_settings:hasNot("show_file_in_bold") then
+                                G_reader_settings:saveSetting("show_file_in_bold", false)
+                            else
+                                G_reader_settings:delSetting("show_file_in_bold")
+                            end
                             self.ui:onRefresh()
                         end,
                     },
                 },
-                separator = true,
             },
             {
-                text = _("Shorten home folder"),
-                checked_func = function()
-                    return G_reader_settings:nilOrTrue("shorten_home_dir")
-                end,
-                callback = function()
-                    G_reader_settings:flipNilOrTrue("shorten_home_dir")
-                    local FileManager = require("apps/filemanager/filemanager")
-                    if FileManager.instance then FileManager.instance:reinit() end
-                end,
-                help_text = _([[
+                text = _("History settings"),
+                sub_item_table = {
+                    {
+                        text = _("Clean history of deleted items"),
+                        callback = function()
+                            UIManager:show(ConfirmBox:new{
+                                text = _("Clean history of deleted items?"),
+                                ok_text = _("Clean"),
+                                ok_callback = function()
+                                    require("readhistory"):clearMissing()
+                                end,
+                            })
+                        end,
+                    },
+                    {
+                        text = _("Auto-remove deleted items from history"),
+                        checked_func = function()
+                            return G_reader_settings:isTrue("autoremove_deleted_items_from_history")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrFalse("autoremove_deleted_items_from_history")
+                        end,
+                        separator = true,
+                    },
+                    {
+                        text = _("Show filename in Open last/previous menu items"),
+                        checked_func = function()
+                            return G_reader_settings:isTrue("open_last_menu_show_filename")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrFalse("open_last_menu_show_filename")
+                        end,
+                    },
+                },
+            },
+            {
+                text = _("Home folder settings"),
+                sub_item_table = {
+                    {
+                        text = _("Set home folder"),
+                        callback = function()
+                            local text
+                            local home_dir = G_reader_settings:readSetting("home_dir")
+                            if home_dir then
+                                text = T(_("Home folder is set to:\n%1"), home_dir)
+                            else
+                                text = _("Home folder is not set.")
+                                home_dir = Device.home_dir
+                            end
+                            UIManager:show(ConfirmBox:new{
+                                text = text .. "\nChoose new folder to set as home?",
+                                ok_text = _("Choose folder"),
+                                ok_callback = function()
+                                    local path_chooser = require("ui/widget/pathchooser"):new{
+                                        select_file = false,
+                                        show_files = false,
+                                        path = home_dir,
+                                        onConfirm = function(new_path)
+                                            G_reader_settings:saveSetting("home_dir", new_path)
+                                        end
+                                    }
+                                    UIManager:show(path_chooser)
+                                end,
+                            })
+                        end,
+                    },
+                    {
+                        text = _("Shorten home folder"),
+                        checked_func = function()
+                            return G_reader_settings:nilOrTrue("shorten_home_dir")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrTrue("shorten_home_dir")
+                            local FileManager = require("apps/filemanager/filemanager")
+                            if FileManager.instance then FileManager.instance:reinit() end
+                        end,
+                        help_text = _([[
 "Shorten home folder" will display the home folder itself as "Home" instead of its full path.
 
 Assuming the home folder is:
@@ -292,16 +351,21 @@ A subfolder will be shortened from:
 `/mnt/onboard/.books/Manga/Cells at Work`
 To:
 `Manga/Cells at Work`.]]),
-            },
-            {
-                text = _("Show filename in Open last/previous menu items"),
-                checked_func = function() return G_reader_settings:isTrue("open_last_menu_show_filename") end,
-                callback = function() G_reader_settings:flipNilOrFalse("open_last_menu_show_filename") end,
-            },
-            {
-                text = _("Auto-remove deleted or purged items from history"),
-                checked_func = function() return G_reader_settings:isTrue("autoremove_deleted_items_from_history") end,
-                callback = function() G_reader_settings:flipNilOrFalse("autoremove_deleted_items_from_history") end,
+                    },
+                    {
+                        text = _("Lock home folder"),
+                        enabled_func = function()
+                            return G_reader_settings:has("home_dir")
+                        end,
+                        checked_func = function()
+                            return G_reader_settings:isTrue("lock_home_folder")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrFalse("lock_home_folder")
+                            UIManager:broadcastEvent(Event:new("Refresh"))
+                        end,
+                    },
+                },
                 separator = true,
             },
             {
@@ -340,6 +404,14 @@ To:
             },
         }
     }
+
+    for _, widget in pairs(self.registered_widgets) do
+        local ok, err = pcall(widget.addToMainMenu, widget, self.menu_items)
+        if not ok then
+            logger.err("failed to register widget", widget.name, err)
+        end
+    end
+
     self.menu_items.sort_by = self.ui:getSortingMenuTable()
     self.menu_items.reverse_sorting = {
         text = _("Reverse sorting"),

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -272,16 +272,13 @@ function FileChooser:genItemTableFromPath(path)
 
     local item_table = {}
     for i, dir in ipairs(dirs) do
+        -- count sume of directories and files inside dir
+        local sub_dirs = {}
+        local dir_files = {}
         local subdir_path = self.path.."/"..dir.name
-        local istr = ""
-        if G_reader_settings:hasNot("hide_folders_count") then
-            -- count sume of directories and files inside dir
-            local sub_dirs = {}
-            local dir_files = {}
-            self.list(subdir_path, sub_dirs, dir_files, true)
-            local num_items = #sub_dirs + #dir_files
-            istr = ffiUtil.template(N_("1 item", "%1 items", num_items), num_items)
-        end
+        self.list(subdir_path, sub_dirs, dir_files, true)
+        local num_items = #sub_dirs + #dir_files
+        local istr = ffiUtil.template(N_("1 item", "%1 items", num_items), num_items)
         local text
         local bidi_wrap_func
         if dir.name == ".." then

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -264,18 +264,24 @@ function FileChooser:genItemTableFromPath(path)
         table.sort(dirs, sorting)
         table.sort(files, sorting)
     end
-    if path ~= "/" then table.insert(dirs, 1, {name = ".."}) end
+    if path ~= "/" and not (G_reader_settings:isTrue("lock_home_folder") and
+                            path == G_reader_settings:readSetting("home_dir")) then
+        table.insert(dirs, 1, {name = ".."})
+    end
     if self.show_current_dir_for_hold then table.insert(dirs, 1, {name = "."}) end
 
     local item_table = {}
     for i, dir in ipairs(dirs) do
-        -- count sume of directories and files inside dir
-        local sub_dirs = {}
-        local dir_files = {}
         local subdir_path = self.path.."/"..dir.name
-        self.list(subdir_path, sub_dirs, dir_files, true)
-        local num_items = #sub_dirs + #dir_files
-        local istr = ffiUtil.template(N_("1 item", "%1 items", num_items), num_items)
+        local istr = ""
+        if G_reader_settings:hasNot("hide_folders_count") then
+            -- count sume of directories and files inside dir
+            local sub_dirs = {}
+            local dir_files = {}
+            self.list(subdir_path, sub_dirs, dir_files, true)
+            local num_items = #sub_dirs + #dir_files
+            istr = ffiUtil.template(N_("1 item", "%1 items", num_items), num_items)
+        end
         local text
         local bidi_wrap_func
         if dir.name == ".." then
@@ -394,7 +400,10 @@ function FileChooser:changeToPath(path, focused_path)
 end
 
 function FileChooser:onFolderUp()
-    self:changeToPath(string.format("%s/..", self.path), self.path)
+    if not (G_reader_settings:isTrue("lock_home_folder") and
+            self.path == G_reader_settings:readSetting("home_dir")) then
+        self:changeToPath(string.format("%s/..", self.path), self.path)
+    end
 end
 
 function FileChooser:changePageToPath(path)

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -235,12 +235,12 @@ function CoverBrowser:addToMainMenu(menu_items)
     -- next to Classic mode settings
     if menu_items.filebrowser_settings == nil then return end
     table.insert (menu_items.filebrowser_settings.sub_item_table, 4, {
-        text = _("Mosaic / Detailed list modes settings"),
+        text = _("Mosaic and detailed list settings"),
         separator = true,
         sub_item_table = {
             {
                 text = _("Items per page"),
-                help_text = _([[This sets the number of files and folders per page in non-'classic' display modes.]]),
+                help_text = _([[This sets the number of files and folders per page in display modes other than classic.]]),
                 -- Best to not "keep_menu_open = true", to see how this apply on the full view
                 callback = function()
                     local SpinWidget = require("ui/widget/spinwidget")
@@ -450,7 +450,6 @@ function CoverBrowser:addToMainMenu(menu_items)
             },
         },
     })
-
 end
 
 function CoverBrowser:refreshFileManagerInstance(cleanup, post_init)

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -233,7 +233,7 @@ function CoverBrowser:addToMainMenu(menu_items)
 
     -- add Mosaic / Detailed list mode settings to File browser Settings submenu
     -- next to Classic mode settings
-    table.insert (menu_items.filebrowser_settings.sub_item_table, 5, {
+    table.insert (menu_items.filebrowser_settings.sub_item_table, 4, {
         text = _("Mosaic / Detailed list modes settings"),
         separator = true,
         sub_item_table = {

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -233,6 +233,7 @@ function CoverBrowser:addToMainMenu(menu_items)
 
     -- add Mosaic / Detailed list mode settings to File browser Settings submenu
     -- next to Classic mode settings
+    if menu_items.filebrowser_settings == nil then return end
     table.insert (menu_items.filebrowser_settings.sub_item_table, 4, {
         text = _("Mosaic / Detailed list modes settings"),
         separator = true,

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -178,7 +178,6 @@ function CoverBrowser:addToMainMenu(menu_items)
                         callback = function()
                            self:setupHistoryDisplayMode("list_image_filename")
                         end,
-                        separator = true,
                     },
                 },
             },
@@ -226,152 +225,154 @@ function CoverBrowser:addToMainMenu(menu_items)
                         callback = function()
                             self:setupCollectionDisplayMode("list_image_filename")
                         end,
-                        separator = true,
                     },
                 },
-                separator = true,
             },
-            -- Misc settings
+        },
+    }
+
+    -- add Mosaic / Detailed list mode settings to File browser Settings submenu
+    -- next to Classic mode settings
+    table.insert (menu_items.filebrowser_settings.sub_item_table, 5, {
+        text = _("Mosaic / Detailed list modes settings"),
+        separator = true,
+        sub_item_table = {
             {
-                text = _("Mosaic and detailed list settings"),
+                text = _("Items per page"),
+                help_text = _([[This sets the number of files and folders per page in non-'classic' display modes.]]),
+                -- Best to not "keep_menu_open = true", to see how this apply on the full view
+                callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    -- "files_per_page" should have been saved with an adequate value
+                    -- the first time Detailed list was shown. Fallback to a start
+                    -- value of 10 if it hasn't.
+                    local curr_items = BookInfoManager:getSetting("files_per_page") or 10
+                    local items = SpinWidget:new{
+                        width = math.floor(Screen:getWidth() * 0.6),
+                        value = curr_items,
+                        value_min = 4,
+                        value_max = 20,
+                        default_value = 10,
+                        keep_shown_on_apply = true,
+                        title_text =  _("Items per page"),
+                        callback = function(spin)
+                            BookInfoManager:saveSetting("files_per_page", spin.value)
+                            self.ui:onRefresh()
+                        end
+                    }
+                    UIManager:show(items)
+                end,
+            },
+            {
+                text = _("Display hints"),
                 sub_item_table = {
                     {
-                        text = _("Display hints"),
-                        sub_item_table = {
-                            {
-                                text = _("Show hint for books with description"),
-                                checked_func = function() return not BookInfoManager:getSetting("no_hint_description") end,
-                                callback = function()
-                                    if BookInfoManager:getSetting("no_hint_description") then
-                                        BookInfoManager:saveSetting("no_hint_description", false)
-                                    else
-                                        BookInfoManager:saveSetting("no_hint_description", true)
-                                    end
-                                    self:refreshFileManagerInstance()
-                                end,
-                            },
-                            {
-                                text = _("Show hint for opened books in history"),
-                                checked_func = function() return BookInfoManager:getSetting("history_hint_opened") end,
-                                callback = function()
-                                    if BookInfoManager:getSetting("history_hint_opened") then
-                                        BookInfoManager:saveSetting("history_hint_opened", false)
-                                    else
-                                        BookInfoManager:saveSetting("history_hint_opened", true)
-                                    end
-                                    self:refreshFileManagerInstance()
-                                end,
-                            },
-                            {
-                                text = _("Show hint for opened books in favorites"),
-                                checked_func = function() return BookInfoManager:getSetting("collections_hint_opened") end,
-                                callback = function()
-                                    if BookInfoManager:getSetting("collections_hint_opened") then
-                                        BookInfoManager:saveSetting("collections_hint_opened", false)
-                                    else
-                                        BookInfoManager:saveSetting("collections_hint_opened", true)
-                                    end
-                                    self:refreshFileManagerInstance()
-                                end,
-                            }
-                        }
-                    },
-                    {
-                        text = _("Series"),
-                        sub_item_table = {
-                            {
-                                text = _("Append series metadata to authors"),
-                                checked_func = function() return series_mode == "append_series_to_authors" end,
-                                callback = function()
-                                    if series_mode == "append_series_to_authors" then
-                                        series_mode = nil
-                                    else
-                                        series_mode = "append_series_to_authors"
-                                    end
-                                    BookInfoManager:saveSetting("series_mode", series_mode)
-                                    self:refreshFileManagerInstance()
-                                end,
-                            },
-                            {
-                                text = _("Append series metadata to title"),
-                                checked_func = function() return series_mode == "append_series_to_title" end,
-                                callback = function()
-                                    if series_mode == "append_series_to_title" then
-                                        series_mode = nil
-                                    else
-                                        series_mode = "append_series_to_title"
-                                    end
-                                    BookInfoManager:saveSetting("series_mode", series_mode)
-                                    self:refreshFileManagerInstance()
-                                end,
-                            },
-                            {
-                                text = _("Show series metadata in separate line"),
-                                checked_func = function() return series_mode == "series_in_separate_line" end,
-                                callback = function()
-                                    if series_mode == "series_in_separate_line" then
-                                        series_mode = nil
-                                    else
-                                        series_mode = "series_in_separate_line"
-                                    end
-                                    BookInfoManager:saveSetting("series_mode", series_mode)
-                                    self:refreshFileManagerInstance()
-                                end,
-                            },
-                        },
-                        separator = true
-                    },
-                    {
-                        text = _("(Detailed list) Files per page"),
-                        help_text = _([[This sets the number of files and directories per page in non-'classic' display modes.]]),
-                        -- Best to not "keep_menu_open = true", to see how this apply on the full view
+                        text = _("Show hint for books with description"),
+                        checked_func = function() return not BookInfoManager:getSetting("no_hint_description") end,
                         callback = function()
-                            local SpinWidget = require("ui/widget/spinwidget")
-                            -- "files_per_page" should have been saved with an adequate value
-                            -- the first time Detailed list was shown. Fallback to a start
-                            -- value of 10 if it hasn't.
-                            local curr_items = BookInfoManager:getSetting("files_per_page") or 10
-                            local items = SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
-                                value = curr_items,
-                                value_min = 4,
-                                value_max = 20,
-                                keep_shown_on_apply = true,
-                                title_text =  _("Files per page"),
-                                callback = function(spin)
-                                    BookInfoManager:saveSetting("files_per_page", spin.value)
-                                    self.ui:onRefresh()
-                                end
-                            }
-                            UIManager:show(items)
-                        end,
-                    },
-                    {
-                        text = _("Show number of pages read instead of progress %"),
-                        checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,
-                        callback = function()
-                            if BookInfoManager:getSetting("show_pages_read_as_progress") then
-                                BookInfoManager:saveSetting("show_pages_read_as_progress", false)
+                            if BookInfoManager:getSetting("no_hint_description") then
+                                BookInfoManager:saveSetting("no_hint_description", false)
                             else
-                                BookInfoManager:saveSetting("show_pages_read_as_progress", true)
+                                BookInfoManager:saveSetting("no_hint_description", true)
                             end
                             self:refreshFileManagerInstance()
                         end,
                     },
                     {
-                        text = _("Show number of pages left to read"),
-                        checked_func = function() return BookInfoManager:getSetting("show_pages_left_in_progress") end,
+                        text = _("Show hint for opened books in history"),
+                        checked_func = function() return BookInfoManager:getSetting("history_hint_opened") end,
                         callback = function()
-                            if BookInfoManager:getSetting("show_pages_left_in_progress") then
-                                BookInfoManager:saveSetting("show_pages_left_in_progress", false)
+                            if BookInfoManager:getSetting("history_hint_opened") then
+                                BookInfoManager:saveSetting("history_hint_opened", false)
                             else
-                                BookInfoManager:saveSetting("show_pages_left_in_progress", true)
+                                BookInfoManager:saveSetting("history_hint_opened", true)
                             end
                             self:refreshFileManagerInstance()
                         end,
-                        separator = true
+                    },
+                    {
+                        text = _("Show hint for opened books in favorites"),
+                        checked_func = function() return BookInfoManager:getSetting("collections_hint_opened") end,
+                        callback = function()
+                            if BookInfoManager:getSetting("collections_hint_opened") then
+                                BookInfoManager:saveSetting("collections_hint_opened", false)
+                            else
+                                BookInfoManager:saveSetting("collections_hint_opened", true)
+                            end
+                            self:refreshFileManagerInstance()
+                        end,
+                    }
+                }
+            },
+            {
+                text = _("Series"),
+                sub_item_table = {
+                    {
+                        text = _("Append series metadata to authors"),
+                        checked_func = function() return series_mode == "append_series_to_authors" end,
+                        callback = function()
+                            if series_mode == "append_series_to_authors" then
+                                series_mode = nil
+                            else
+                                series_mode = "append_series_to_authors"
+                            end
+                            BookInfoManager:saveSetting("series_mode", series_mode)
+                            self:refreshFileManagerInstance()
+                        end,
+                    },
+                    {
+                        text = _("Append series metadata to title"),
+                        checked_func = function() return series_mode == "append_series_to_title" end,
+                        callback = function()
+                            if series_mode == "append_series_to_title" then
+                                series_mode = nil
+                            else
+                                series_mode = "append_series_to_title"
+                            end
+                            BookInfoManager:saveSetting("series_mode", series_mode)
+                            self:refreshFileManagerInstance()
+                        end,
+                    },
+                    {
+                        text = _("Show series metadata in separate line"),
+                        checked_func = function() return series_mode == "series_in_separate_line" end,
+                        callback = function()
+                            if series_mode == "series_in_separate_line" then
+                                series_mode = nil
+                            else
+                                series_mode = "series_in_separate_line"
+                            end
+                            BookInfoManager:saveSetting("series_mode", series_mode)
+                            self:refreshFileManagerInstance()
+                        end,
                     },
                 },
+                separator = true
+            },
+            {
+                text = _("Show number of pages read instead of progress %"),
+                checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,
+                callback = function()
+                    if BookInfoManager:getSetting("show_pages_read_as_progress") then
+                        BookInfoManager:saveSetting("show_pages_read_as_progress", false)
+                    else
+                        BookInfoManager:saveSetting("show_pages_read_as_progress", true)
+                    end
+                    self:refreshFileManagerInstance()
+                end,
+            },
+            {
+                text = _("Show number of pages left to read"),
+                checked_func = function() return BookInfoManager:getSetting("show_pages_left_in_progress") end,
+                callback = function()
+                    if BookInfoManager:getSetting("show_pages_left_in_progress") then
+                        BookInfoManager:saveSetting("show_pages_left_in_progress", false)
+                    else
+                        BookInfoManager:saveSetting("show_pages_left_in_progress", true)
+                    end
+                    self:refreshFileManagerInstance()
+                end,
+                separator = true,
             },
             {
                 text = _("Book info cache management"),
@@ -447,7 +448,8 @@ function CoverBrowser:addToMainMenu(menu_items)
                 },
             },
         },
-    }
+    })
+
 end
 
 function CoverBrowser:refreshFileManagerInstance(cleanup, post_init)


### PR DESCRIPTION
Reordering of the file browser Settings menu and a couple of new features.

Main menu. No changes.

<kbd>![01](https://user-images.githubusercontent.com/62179190/126475633-998d813c-7109-4980-8484-596cc427cb6c.png)</kbd>

`Display mode` submenu. No settings here, moved to `Settings` submenu.

<kbd>![02](https://user-images.githubusercontent.com/62179190/126475637-96b63f93-64c1-4b96-a940-0fdc77e5845a.png)</kbd>

`Settings` submenu. **Main changes here.**

<kbd>![03](https://user-images.githubusercontent.com/62179190/126475639-50eb58e7-86b7-492b-8ef4-4aa459917f41.png)</kbd>

New item `Hide folders count`.
I do not need to know the quantity of elements in subfolders, prevent extra scanning and wearing of the device memory.
Default: unchecked (show count). If checked, looks like:

<kbd>![04](https://user-images.githubusercontent.com/62179190/126475641-5d0f02a9-d1aa-406b-b62f-c8dd59e67190.png)</kbd>

`Classic mode settings` submenu.

<kbd>![05](https://user-images.githubusercontent.com/62179190/126475643-d48e174d-399e-4617-b1e4-88526ae063cf.png)</kbd>

`Items per page` and `Item font size` now close the menu, to view full screen to adjust the size.
`Show files in bold` has 3 options, so 2 checkboxes are enough.

`Mosaic / Detailed list modes settings` submenu.

<kbd>![06](https://user-images.githubusercontent.com/62179190/126475645-42c3fe45-d613-4f7b-a369-541e63514a94.png)</kbd>

`History settings` submenu.

<kbd>![07](https://user-images.githubusercontent.com/62179190/126475649-c820ab27-2ecf-4936-a30a-a5dd96be590f.png)</kbd>

New item `Clean history of deleted items`, with confirmation.
I would remove this item from the context menu in History, which cleans the History without any warnings.
<kbd>![08](https://user-images.githubusercontent.com/62179190/126475650-37d4ead2-7f2a-4c8b-a3b1-712bd60a58c0.png)</kbd>

`Home folder settings` submenu.

<kbd>![09](https://user-images.githubusercontent.com/62179190/126475651-6937b248-75b2-44e2-8c5b-0255636b4f3c.png)</kbd>

New item `Set home folder`.

<kbd>![10](https://user-images.githubusercontent.com/62179190/126475653-aa901cac-d416-4ef2-9ab4-d0602408aa26.png)</kbd>

New item `Lock home folder`.
When in Home folder, it removes ".." element, and action FolderUp doesn't work as well.
This might be useful for setting the program for unexperienced users, to prevent damaging system files or to restrict access to other books in library (for children).
Default: unchecked (no lock). If checked, looks like:

<kbd>![11](https://user-images.githubusercontent.com/62179190/126475657-f6992720-31ae-492b-b162-de7ecb3366a2.png)</kbd>

Hope this reordering looks logical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8000)
<!-- Reviewable:end -->
