### PR TITLE
Minor input tweak after #7986

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -129,6 +129,8 @@ local Input = {
     event_map = {},
     -- adapters are post processing functions that transform a given event to another event
     event_map_adapter = {},
+    -- EV_ABS event to honor for pressure event (if any)
+    pressure_event = nil,
 
     group = {
         Cursor = { "Up", "Down", "Left", "Right" },
@@ -215,10 +217,7 @@ end
 
 function Input:init()
     -- Handle default finger slot
-    if self.device.main_finger_slot then
-        self.main_finger_slot = self.device.main_finger_slot
-        self.cur_slot = self.device.main_finger_slot
-    end
+    self.cur_slot = self.main_finger_slot
     self.ev_slots = {
         [self.main_finger_slot] = {
             slot = self.main_finger_slot,
@@ -590,7 +589,7 @@ function Input:handleTouchEv(ev)
             self:setCurrentMtSlot("x", ev.value)
         elseif ev.code == C.ABS_MT_POSITION_Y then
             self:setCurrentMtSlot("y", ev.value)
-        elseif ev.code == C.ABS_MT_PRESSURE and ev.value == 0 then
+        elseif self.pressure_event and ev.code == self.pressure_event and ev.value == 0 then
             -- Drop hovering pen events
             self:setCurrentMtSlot("id", -1)
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -5,10 +5,11 @@ local logger = require("logger")
 local util = require("ffi/util")
 local _ = require("gettext")
 
--- We're going to need a few <linux/fb.h> constants...
+-- We're going to need a few <linux/fb.h> & <linux/input.h> constants...
 local ffi = require("ffi")
 local C = ffi.C
 require("ffi/linux_fb_h")
+require("ffi/linux_input_h")
 
 local function yes() return true end
 local function no() return false end
@@ -68,6 +69,8 @@ local Kobo = Generic:new{
     ntx_dev = "/dev/input/event0",
     -- Stable path to the Touch input device
     touch_dev = "/dev/input/event1",
+    -- Event code to use to detect contact pressure
+    pressure_event = nil,
 }
 
 --- @todo hasKeys for some devices?
@@ -311,6 +314,7 @@ local KoboEuropa = Kobo:new{
     hasFrontlight = yes,
     hasGSensor = yes,
     canToggleGSensor = yes,
+    pressure_event = C.ABS_MT_PRESSURE,
     misc_ntx_gsensor_protocol = true,
     display_dpi = 227,
     boot_rota = C.FB_ROTATE_CCW,
@@ -393,7 +397,9 @@ function Kobo:init()
                     return "Light"
                 end
             end,
-        }
+        },
+        main_finger_slot = self.main_finger_slot or 0,
+        pressure_event = self.pressure_event,
     }
     self.wakeup_mgr = WakeupMgr:new()
 


### PR DESCRIPTION
Some devices have wonky input streams, so, don't rock the boat too much ;).

(e.g., I never get ABS_MT_PRESSURE events set to 0 on the Forma, which is essentially what makes the whole `snow_protocol` insanity necessary... We could possibly rely on the BTN_TOUCH events, but they're not in the same stream, so matching 'em to a slot would be tricky.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8004)
<!-- Reviewable:end -->
