### PR TITLE
Reset everyone's duration time to classic

### DIFF
--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210715
+local CURRENT_MIGRATION_DATE = 20210720
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -284,6 +284,16 @@ if last_migration_date < 20210715 then
             G_reader_settings:saveSetting("collate", "natural")
         end
     end
+end
+
+-- 20210720, Reset all user's duration time to classic, 
+if last_migration_date < 20210720 then
+    logger.info("Performing one-time migration for 20210720")
+    -- With PR 7897 and migration date 20210629, we migrated everyone's duration format to the combined setting. 
+    -- However, the footer previously defaulted to "modern", so users who were used to seeing "classic" in the UI 
+    -- started seeing the modern format unexpectedly. Therefore, reset everyone back to classic so users go back
+    -- to a safe default. Users who use "modern" will need to reselect it in Time and Date settings after this migration.
+    G_reader_settings:saveSetting("duration_format", "classic")
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -286,7 +286,7 @@ if last_migration_date < 20210715 then
     end
 end
 
--- 20210720, Reset all user's duration time to classic, 
+-- 20210720, Reset all user's duration time to classic, https://github.com/koreader/koreader/pull/8008
 if last_migration_date < 20210720 then
     logger.info("Performing one-time migration for 20210720")
     -- With PR 7897 and migration date 20210629, we migrated everyone's duration format to the combined setting. 


### PR DESCRIPTION
Do a reset of the duration format to use Classic, which is better for existing users of KOReader.

If existing users don't change their duration format for the footer it defaulted to "modern" so users were getting migrated to using "modern" setting which can look... pretty different. :)

Users can of course change the setting, but probably better to do a one time switch of everyone back to Classic to make sure everyone is using the intended default. If people do want to switch back to Modern, they can do so in the Time and Date settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8008)
<!-- Reviewable:end -->
