### PR TITLE
Input: Only ignore hovering *pen* events on the Elipsa

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -643,7 +643,7 @@ function GestureDetector:handleSwipe(tev)
     if #self.multiswipe_directions > 1 then
         ges = "multiswipe"
         multiswipe_directions = ""
-        for k, v in pairs(self.multiswipe_directions) do
+        for k, v in ipairs(self.multiswipe_directions) do
             local sep = ""
             if k > 1 then
                 sep = " "

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -439,20 +439,22 @@ function Input:handleKeyBoardEv(ev)
     if self.snow_protocol then
         if ev.code == C.BTN_TOUCH and ev.value == 0 then
             -- Loss of contact for *all* slots
-            if #self.MTSlots ~= 0 then
-                -- Unlikely, since we clear this on SYN_REPORT, and this is usually in its own event stream,
-                -- meaning we've *just* dropped it...
-                for _, MTSlot in pairs(self.MTSlots) do
-                    logger.dbg("UP for MTSlot", MTSlot.slot)
-                    self:setMtSlot(MTSlot.slot, "id", -1)
-                end
-            else
+            if #self.MTSlots == 0 then
+                -- Likely, since this is usually in its own event stream,
+                -- meaning self.MTSlots has *just* been cleared...
+                -- So, poke at the actual data, and re-populate a minimal self.MTSlots ;).
                 for _, slot in pairs(self.ev_slots) do
                     if slot.id ~= -1 then
                         table.insert(self.MTSlots, slot)
                         slot.id = -1
                         logger.dbg("UP for Slot", slot.slot)
                     end
+                end
+            else
+                -- Unlikely, given what we mentioned above...
+                for _, MTSlot in pairs(self.MTSlots) do
+                    logger.dbg("UP for MTSlot", MTSlot.slot)
+                    self:setMtSlot(MTSlot.slot, "id", -1)
                 end
             end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -442,7 +442,7 @@ function Input:handleKeyBoardEv(ev)
             -- only once the final contact point has been lifted.
             if #self.MTSlots == 0 then
                 -- Likely, since this is usually in its own event stream,
-                -- meaning self.MTSlots has *just* been cleared...
+                -- meaning self.MTSlots has *just* been cleared by our last EV_SYN:SYN_REPORT handler...
                 -- So, poke at the actual data to find the slots that are currently active (i.e., in the down state),
                 -- and re-populate a minimal self.MTSlots array that simply switches them to the up state ;).
                 for _, slot in pairs(self.ev_slots) do

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -445,14 +445,12 @@ function Input:handleKeyBoardEv(ev)
                 for _, MTSlot in pairs(self.MTSlots) do
                     logger.dbg("UP for MTSlot", MTSlot.slot)
                     self:setMtSlot(MTSlot.slot, "id", -1)
-                    self:setMtSlot(MTSlot.slot, "active", false)
                 end
             else
                 for _, slot in pairs(self.ev_slots) do
-                    if slot.active then
+                    if slot.id ~= -1 then
                         table.insert(self.MTSlots, slot)
                         slot.id = -1
-                        slot.active = false
                         logger.dbg("UP for Slot", slot.slot)
                     end
                 end
@@ -613,9 +611,6 @@ function Input:handleTouchEv(ev)
                 -- We'll never get an ABS_MT_SLOT event,
                 -- instead we have slot-like ABS_MT_TRACKING_ID...
                 self:addSlotIfChanged(ev.value)
-                -- We need to remember the active slots across different SYN_REPORTs,
-                -- so we can't rely on self.MTSlots...
-                self:setCurrentMtSlot("active", true)
             end
             self:setCurrentMtSlot("id", ev.value)
         elseif ev.code == C.ABS_MT_TOOL_TYPE then

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -438,7 +438,8 @@ function Input:handleKeyBoardEv(ev)
     -- Detect loss of contact for the "snow" protocol...
     if self.snow_protocol then
         if ev.code == C.BTN_TOUCH and ev.value == 0 then
-            -- Loss of contact for *all* slots
+            -- Kernel sends it after loss of contact for *all* slots,
+            -- only once the final contact point has been lifted.
             if #self.MTSlots == 0 then
                 -- Likely, since this is usually in its own event stream,
                 -- meaning self.MTSlots has *just* been cleared...
@@ -611,7 +612,7 @@ function Input:handleTouchEv(ev)
         elseif ev.code == C.ABS_MT_TRACKING_ID then
             if self.snow_protocol then
                 -- We'll never get an ABS_MT_SLOT event,
-                -- instead we have slot-like ABS_MT_TRACKING_ID...
+                -- instead we have a slot-like ABS_MT_TRACKING_ID value...
                 self:addSlotIfChanged(ev.value)
             end
             self:setCurrentMtSlot("id", ev.value)

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1164,7 +1164,7 @@ function Input:waitEvent(now, deadline)
                 end
             elseif event.type == C.EV_ABS or event.type == C.EV_SYN then
                 local handled_ev = self:handleTouchEv(event)
-                -- We don't gnerate an Event for *every* input event, so, make sure we don't push nil values to the array
+                -- We don't generate an Event for *every* input event, so, make sure we don't push nil values to the array
                 if handled_ev then
                     table.insert(handled, handled_ev)
                 end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -445,12 +445,16 @@ function Input:handleKeyBoardEv(ev)
                 for _, MTSlot in pairs(self.MTSlots) do
                     logger.dbg("UP for MTSlot", MTSlot.slot)
                     self:setMtSlot(MTSlot.slot, "id", -1)
+                    self:setMtSlot(MTSlot.slot, "active", false)
                 end
             else
                 for _, slot in pairs(self.ev_slots) do
-                    table.insert(self.MTSlots, slot)
-                    slot.id = -1
-                    logger.dbg("UP for Slot", slot.slot)
+                    if slot.active then
+                        table.insert(self.MTSlots, slot)
+                        slot.id = -1
+                        slot.active = false
+                        logger.dbg("UP for Slot", slot.slot)
+                    end
                 end
             end
 
@@ -609,6 +613,9 @@ function Input:handleTouchEv(ev)
                 -- We'll never get an ABS_MT_SLOT event,
                 -- instead we have slot-like ABS_MT_TRACKING_ID...
                 self:addSlotIfChanged(ev.value)
+                -- We need to remember the active slots across different SYN_REPORTs,
+                -- so we can't rely on self.MTSlots...
+                self:setCurrentMtSlot("active", true)
             end
             self:setCurrentMtSlot("id", ev.value)
         elseif ev.code == C.ABS_MT_TOOL_TYPE then
@@ -927,8 +934,8 @@ end
 function Input:addSlotIfChanged(value)
     if self.cur_slot ~= value then
         table.insert(self.MTSlots, self:getMtSlot(value))
+        self.cur_slot = value
     end
-    self.cur_slot = value
 end
 
 function Input:confirmAbsxy()

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -83,6 +83,7 @@ local linux_evdev_syn_code_map = {
 }
 
 local linux_evdev_key_code_map = {
+    [C.KEY_BATTERY] = "KEY_BATTERY",
     [C.BTN_TOOL_PEN] = "BTN_TOOL_PEN",
     [C.BTN_TOOL_FINGER] = "BTN_TOOL_FINGER",
     [C.BTN_TOOL_RUBBER] = "BTN_TOOL_RUBBER",

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -455,7 +455,7 @@ function Input:handleKeyBoardEv(ev)
                 -- Unlikely, given what we mentioned above...
                 -- Note that, funnily enough, its EV_KEY:BTN_TOUCH:1 counterpart
                 -- *can* be in the same initial event stream as the EV_ABS batch...
-                for _, MTSlot in pairs(self.MTSlots) do
+                for _, MTSlot in ipairs(self.MTSlots) do
                     self:setMtSlot(MTSlot.slot, "id", -1)
                 end
             end
@@ -650,7 +650,7 @@ function Input:handleTouchEv(ev)
         if ev.code == C.SYN_REPORT then
             -- Promote our event's time table to a real TimeVal
             setmetatable(ev.time, TimeVal)
-            for _, MTSlot in pairs(self.MTSlots) do
+            for _, MTSlot in ipairs(self.MTSlots) do
                 self:setMtSlot(MTSlot.slot, "timev", ev.time)
             end
             -- feed ev in all slots to state machine
@@ -713,7 +713,7 @@ function Input:handleTouchEvPhoenix(ev)
     elseif ev.type == C.EV_SYN then
         if ev.code == C.SYN_REPORT then
             setmetatable(ev.time, TimeVal)
-            for _, MTSlot in pairs(self.MTSlots) do
+            for _, MTSlot in ipairs(self.MTSlots) do
                 self:setMtSlot(MTSlot.slot, "timev", ev.time)
             end
             -- feed ev in all slots to state machine
@@ -749,7 +749,7 @@ function Input:handleTouchEvLegacy(ev)
     elseif ev.type == C.EV_SYN then
         if ev.code == C.SYN_REPORT then
             setmetatable(ev.time, TimeVal)
-            for _, MTSlot in pairs(self.MTSlots) do
+            for _, MTSlot in ipairs(self.MTSlots) do
                 self:setMtSlot(MTSlot.slot, "timev", ev.time)
             end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -453,6 +453,8 @@ function Input:handleKeyBoardEv(ev)
                 end
             else
                 -- Unlikely, given what we mentioned above...
+                -- Note that, funnily enough, its EV_KEY:BTN_TOUCH:1 counterpart
+                -- *can* be in the same initial event stream as the EV_ABS batch...
                 for _, MTSlot in pairs(self.MTSlots) do
                     logger.dbg("UP for MTSlot", MTSlot.slot)
                     self:setMtSlot(MTSlot.slot, "id", -1)

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -586,13 +586,19 @@ function Input:handleTouchEv(ev)
                 self:addSlotIfChanged(ev.value)
             end
             self:setCurrentMtSlot("id", ev.value)
+        elseif ev.code == C.ABS_MT_TOOL_TYPE then
+            -- NOTE: On the Elipsa: Finger == 0; Pen == 1
+            self:setCurrentMtSlot("tool", ev.value)
         elseif ev.code == C.ABS_MT_POSITION_X then
             self:setCurrentMtSlot("x", ev.value)
         elseif ev.code == C.ABS_MT_POSITION_Y then
             self:setCurrentMtSlot("y", ev.value)
         elseif self.pressure_event and ev.code == self.pressure_event and ev.value == 0 then
-            -- Drop hovering pen events
-            self:setCurrentMtSlot("id", -1)
+            -- Drop hovering *pen* events
+            local tool = self:getCurrentMtSlotData("tool")
+            if tool and tool == 1 then
+                self:setCurrentMtSlot("id", -1)
+            end
 
         -- code to emulate mt protocol on kobos
         -- we "confirm" abs_x, abs_y only when pressure ~= 0
@@ -904,6 +910,15 @@ end
 
 function Input:getCurrentMtSlot()
     return self:getMtSlot(self.cur_slot)
+end
+
+function Input:getCurrentMtSlotData(key)
+    local slot = self:getCurrentMtSlot()
+    if slot then
+        return slot[key]
+    end
+
+    return nil
 end
 
 function Input:addSlotIfChanged(value)

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -448,7 +448,6 @@ function Input:handleKeyBoardEv(ev)
                     if slot.id ~= -1 then
                         table.insert(self.MTSlots, slot)
                         slot.id = -1
-                        logger.dbg("UP for Slot", slot.slot)
                     end
                 end
             else
@@ -456,7 +455,6 @@ function Input:handleKeyBoardEv(ev)
                 -- Note that, funnily enough, its EV_KEY:BTN_TOUCH:1 counterpart
                 -- *can* be in the same initial event stream as the EV_ABS batch...
                 for _, MTSlot in pairs(self.MTSlots) do
-                    logger.dbg("UP for MTSlot", MTSlot.slot)
                     self:setMtSlot(MTSlot.slot, "id", -1)
                 end
             end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -443,7 +443,8 @@ function Input:handleKeyBoardEv(ev)
             if #self.MTSlots == 0 then
                 -- Likely, since this is usually in its own event stream,
                 -- meaning self.MTSlots has *just* been cleared...
-                -- So, poke at the actual data, and re-populate a minimal self.MTSlots ;).
+                -- So, poke at the actual data to find the slots that are currently active (i.e., in the down state),
+                -- and re-populate a minimal self.MTSlots array that simply switches them to the up state ;).
                 for _, slot in pairs(self.ev_slots) do
                     if slot.id ~= -1 then
                         table.insert(self.MTSlots, slot)


### PR DESCRIPTION
The kernel currently reports an ungodly amount of bogus 0-pressure *finger down* events, making the previously dumb logic highly annoying.

I can deal with missed pen taps (somewhat, it's still annoying). But missed *finger* taps are highly aggravating.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8021)
<!-- Reviewable:end -->
