### PR TITLE
ReaderDeviceStatus: add high battery level alert

### DIFF
--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -19,28 +19,29 @@ function ReaderDeviceStatus:init()
         self.battery_threshold = G_reader_settings:readSetting("device_status_battery_threshold") or 20
         self.battery_threshold_high = G_reader_settings:readSetting("device_status_battery_threshold_high") or 100
         self.checkLowBatteryLevel = function()
+            local is_charging = powerd:isCharging()
             local battery_capacity = powerd:getCapacity()
             if powerd:getDismissBatteryStatus() == true then  -- alerts dismissed
-                if (powerd:isCharging() and battery_capacity <= self.battery_threshold_high) or
-                   (not powerd:isCharging() and battery_capacity > self.battery_threshold) then
+                if (is_charging and battery_capacity <= self.battery_threshold_high) or
+                   (not is_charging and battery_capacity > self.battery_threshold) then
                     powerd:setDismissBatteryStatus(false)
                 end
             else
-                if powerd:isCharging() and battery_capacity > self.battery_threshold_high then
+                if is_charging and battery_capacity > self.battery_threshold_high then
                     UIManager:show(ConfirmBox:new {
-                        text = T(_("High battery level: %1%\n\nDismiss high battery alert?"), battery_capacity),
+                        text = T(_("High battery level: %1%\n\nDismiss battery level alert?"), battery_capacity),
                         ok_text = _("Dismiss"),
                         dismissable = false,
                         ok_callback = function()
                             powerd:setDismissBatteryStatus(true)
                         end,
                     })
-                elseif not powerd:isCharging() and battery_capacity <= self.battery_threshold then
+                elseif not is_charging and battery_capacity <= self.battery_threshold then
                     UIManager:show(ConfirmBox:new {
-                        text = T(_("Low battery level: %1%\n\nDismiss low battery alert?"), battery_capacity),
+                        text = T(_("Low battery level: %1%\n\nDismiss battery level alert?"), battery_capacity),
                         ok_text = _("Dismiss"),
                         dismissable = false,
-                        cancel_callback = function()
+                        ok_callback = function()
                             powerd:setDismissBatteryStatus(true)
                         end,
                     })
@@ -115,7 +116,7 @@ function ReaderDeviceStatus:addToMainMenu(menu_items)
     if Device:hasBattery() then
         table.insert(menu_items.device_status_alarm.sub_item_table,
             {
-                text = _("Low or high battery level"),
+                text = _("Battery level"),
                 checked_func = function()
                     return G_reader_settings:isTrue("device_status_battery_alarm")
                 end,

--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -158,7 +158,7 @@ function ReaderDeviceStatus:addToMainMenu(menu_items)
         table.insert(menu_items.device_status_alarm.sub_item_table,
             {
                 text_func = function()
-                    return T(_("Thresholds (%1% - %2%)"), self.battery_threshold, self.battery_threshold_high)
+                    return T(_("Thresholds (%1% – %2%)"), self.battery_threshold, self.battery_threshold_high)
                 end,
                 enabled_func = function()
                     return G_reader_settings:isTrue("device_status_battery_alarm")


### PR DESCRIPTION
Some guys take care of the battery longlife and try to avoid overcharging:
https://www.mobileread.com/forums/showthread.php?p=4142290#post4142290

Battery level alert will show up when:
(1) the device is not charging and battery level becomes lower than low_threshold (default 20%), or
(2) the device is charging and battery level becomes higher than high_threshold (default 100% i.e. no alert).

<kbd>![1](https://user-images.githubusercontent.com/62179190/127649846-b0acc84f-4636-41ef-8bcd-6b47ee6e585a.png)</kbd>

<kbd>![2](https://user-images.githubusercontent.com/62179190/127649853-4d1c411b-79de-4197-969c-76da13c5f844.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8037)
<!-- Reviewable:end -->
