### PR TITLE
Autostart Profiles

### DIFF
--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -115,7 +115,6 @@ function Profiles:getSubMenuItems()
             {
                 text = _("Autostart"),
                 help_text = _("Execute this profile when KOReader is started with 'file browser' or 'last file'."),
-                keep_menu_open = true,
                 checked_func = function()
                     return self:isAutostartProfile(k)
                 end,

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -127,7 +127,7 @@ function Profiles:getSubMenuItems()
                         self:setAutostartProfile(k)
                     end
                 end,
-            }
+            },
         }
         Dispatcher:addSubMenu(self, sub_items, self.data, k)
         table.insert(sub_item_table, {

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -10,6 +10,9 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 local T = FFIUtil.template
 
+local autostart_profile = "00_Autostart" -- gets stored as first element
+local autostart_done = false
+
 local Profiles = WidgetContainer:new{
     name = "profiles",
     profiles_file = DataStorage:getSettingsDir() .. "/profiles.lua",
@@ -21,6 +24,10 @@ local Profiles = WidgetContainer:new{
 function Profiles:init()
     Dispatcher:init()
     self.ui.menu:registerToMainMenu(self)
+--[[    table.insert(self.ui.postReaderCallback, function()
+            self:executeAutostart()
+    end)]]
+    self:executeAutostart()
 end
 
 function Profiles:loadProfiles()
@@ -69,7 +76,12 @@ function Profiles:getSubMenuItems()
                             text = _("Save"),
                             callback = function()
                                 local name = name_input:getInputText()
-                                if not self:newProfile(name) then
+                                if name == autostart_profile then
+                                    UIManager:show(InfoMessage:new{
+                                        text =  T(_("Reserved name can not be used: %1"), autostart_profile),
+                                    })
+                                    return
+                                elseif not self:newProfile(name) then
                                     UIManager:show(InfoMessage:new{
                                         text =  T(_("There is already a profile called: %1"), name),
                                     })
@@ -90,32 +102,50 @@ function Profiles:getSubMenuItems()
         }
     }
     for k,v in FFIUtil.orderedPairs(self.data) do
-        local sub_items = {
-            {
-                text = _("Delete profile"),
-                keep_menu_open = false,
-                separator = true,
-                callback = function()
-                    UIManager:show(ConfirmBox:new{
-                        text = _("Do you want to delete this profile?"),
-                        ok_text = _("Yes"),
-                        cancel_text = _("No"),
-                        ok_callback = function()
-                            self:deleteProfile(k)
-                        end,
-                    })
-                end,
+        if k ~= autostart_profile then
+            local sub_items = {
+                {
+                    text = _("Delete profile"),
+                    keep_menu_open = false,
+                    separator = true,
+                    callback = function()
+                        UIManager:show(ConfirmBox:new{
+                            text = _("Do you want to delete this profile?"),
+                            ok_text = _("Yes"),
+                            cancel_text = _("No"),
+                            ok_callback = function()
+                                self:deleteProfile(k)
+                            end,
+                        })
+                    end,
+                },
+                {
+                    text = _("Autostart"),
+                    help_text = _("Execute this profile when KOReader is started with 'file browser' or 'last file'."),
+                    keep_menu_open = true,
+                    checked_func = function()
+                        return self:isAutostartProfile(k)
+                    end,
+                    separator = true,
+                    callback = function()
+                        if self:isAutostartProfile(k) then
+                            self:deleteAutostartProfile(k)
+                        else
+                            self:setAutostartProfile(k)
+                        end
+                    end,
+                }
             }
-        }
-        Dispatcher:addSubMenu(self, sub_items, self.data, k)
-        table.insert(sub_item_table, {
-            text = k,
-            hold_keep_menu_open = false,
-            sub_item_table = sub_items,
-            hold_callback = function()
-                Dispatcher:execute(self.data[k])
-            end,
-        })
+            Dispatcher:addSubMenu(self, sub_items, self.data, k)
+            table.insert(sub_item_table, {
+                text = k,
+                hold_keep_menu_open = false,
+                sub_item_table = sub_items,
+                hold_callback = function()
+                    Dispatcher:execute(self.data[k])
+                end,
+            })
+        end
     end
     return sub_item_table
 end
@@ -133,6 +163,45 @@ end
 function Profiles:deleteProfile(name)
     self.data[name] = nil
     self.updated = true
+    self:deleteAutostartProfile(name)
+end
+
+function Profiles:isAutostartProfile(name)
+    return self.data[autostart_profile] and self.data[autostart_profile][name] == true
+end
+
+function Profiles:setAutostartProfile(name)
+    if not self.data[autostart_profile] then
+        self.data[autostart_profile] = {}
+    end
+    self.data[autostart_profile][name] = true
+    self.updated = true
+end
+
+function Profiles:deleteAutostartProfile(name)
+    if self.data[autostart_profile][name] then
+        self.data[autostart_profile][name] = nil
+        self.updated = true
+    end
+end
+
+function Profiles:executeAutostart()
+    if not autostart_done then
+        self:loadProfiles()
+        if self.data[autostart_profile] then
+            for autostart_profile_name, v in pairs(self.data[autostart_profile]) do
+                if v and self.data[autostart_profile_name] then
+                    UIManager:nextTick(function()
+                        Dispatcher:execute(self.data[autostart_profile_name])
+                    end)
+                else
+                    self.data[autostart_profile] = nil -- remove deleted profile form autostart_profile
+                    self.updated = true
+                end
+            end
+        end
+        autostart_done = true
+    end
 end
 
 return Profiles

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -78,7 +78,7 @@ function Profiles:getSubMenuItems()
                                 local name = name_input:getInputText()
                                 if name == autostart_profile then
                                     UIManager:show(InfoMessage:new{
-                                        text =  T(_("Reserved name can not be used: %1"), autostart_profile),
+                                        text =  T(_("Reserved name cannot be used: %1"), autostart_profile),
                                     })
                                     return
                                 elseif not self:newProfile(name) then

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -23,9 +23,6 @@ local Profiles = WidgetContainer:new{
 function Profiles:init()
     Dispatcher:init()
     self.ui.menu:registerToMainMenu(self)
---[[    table.insert(self.ui.postReaderCallback, function()
-            self:executeAutostart()
-    end)]]
     self:executeAutostart()
 end
 


### PR DESCRIPTION
Add the possibility to autostart profiles when KOReader is started with filemanager or lastfile.
Discussed in https://github.com/koreader/koreader/issues/8020

If more profiles are selected, they are started in alphabetically order.

![grafik](https://user-images.githubusercontent.com/36999612/128484188-6ab8b856-5c2d-494e-bc90-29c031d4acc7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8049)
<!-- Reviewable:end -->
