### PR TITLE
Screenshoter menu development

### DIFF
--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -48,7 +48,6 @@ local ConfirmBox = InputContainer:new{
     ok_callback = function() end,
     cancel_callback = function() end,
     other_buttons = nil,
-    keep_open = false,
     margin = Size.margin.default,
     padding = Size.padding.default,
     dismissable = true, -- set to false if any button callback is required
@@ -100,7 +99,6 @@ function ConfirmBox:init()
         text = self.ok_text,
         callback = function()
             self.ok_callback()
-            if self.keep_open then return end
             UIManager:close(self)
         end,
     },}
@@ -120,7 +118,6 @@ function ConfirmBox:init()
                         if button.callback ~= nil then
                             button.callback()
                         end
-                        if self.keep_open then return end
                         UIManager:close(self)
                     end,
                 })

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -48,6 +48,7 @@ local ConfirmBox = InputContainer:new{
     ok_callback = function() end,
     cancel_callback = function() end,
     other_buttons = nil,
+    keep_open = false,
     margin = Size.margin.default,
     padding = Size.padding.default,
     dismissable = true, -- set to false if any button callback is required
@@ -99,6 +100,7 @@ function ConfirmBox:init()
         text = self.ok_text,
         callback = function()
             self.ok_callback()
+            if self.keep_open then return end
             UIManager:close(self)
         end,
     },}
@@ -118,6 +120,7 @@ function ConfirmBox:init()
                         if button.callback ~= nil then
                             button.callback()
                         end
+                        if self.keep_open then return end
                         UIManager:close(self)
                     end,
                 })

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -756,7 +756,6 @@ function ImageViewer:onTapDiagonal()
 end
 
 function ImageViewer:onSaveImageView()
-    -- Similar behaviour as in Screenshoter:onScreenshot()
     -- We save the currently displayed blitbuffer (panned or zoomed)
     -- after getting fullscreen and removing UI elements if needed.
     local restore_settings_func
@@ -776,10 +775,9 @@ function ImageViewer:onSaveImageView()
         self:update()
         UIManager:forceRePaint()
     end
-    UIManager:sendEvent(Event:new("Screenshot"))
-    if restore_settings_func then
-        restore_settings_func()
-    end
+    local screenshots_dir = G_reader_settings:readSetting("screenshot_dir") or DataStorage:getDataDir() .. "/screenshots/"
+    local screenshot_name = os.date(screenshots_dir .. "ImageViewer" .. "_%Y-%m-%d_%H%M%S.png")
+    UIManager:sendEvent(Event:new("Screenshot", screenshot_name, restore_settings_func))
     return true
 end
 

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -7,7 +7,6 @@ local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local CloseButton = require("ui/widget/closebutton")
-local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
 local Event = require("ui/event")
@@ -27,7 +26,6 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
-local T = require("ffi/util").template
 local _ = require("gettext")
 local Screen = Device.screen
 

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -1,9 +1,7 @@
 local BD = require("ui/bidi")
-local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local GestureRange = require("ui/gesturerange")
-local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
 local Screen = require("device").screen
@@ -42,54 +40,65 @@ function Screenshoter:onScreenshot(filename)
     self.screenshot_fn_fmt = screenshots_dir .. self.prefix .. "_%Y-%m-%d_%H%M%S.png"
     local screenshot_name = filename or os.date(self.screenshot_fn_fmt)
     Screen:shot(screenshot_name)
-    local widget = ConfirmBox:new{
-        text = T( _("Saved screenshot to %1.\nWould you like to set it as screensaver?"), BD.filepath(screenshot_name)),
-        ok_text = _("Yes"),
-        ok_callback = function()
-            G_reader_settings:saveSetting("screensaver_type", "image_file")
-            G_reader_settings:saveSetting("screensaver_image", screenshot_name)
+    local confirm_box
+    confirm_box = ConfirmBox:new{
+        text = T( _("Screenshot saved to:\n%1"), BD.filepath(screenshot_name)),
+        keep_open = true,
+        cancel_text = _("Delete"),
+        cancel_callback = function()
+            local ok, err = os.remove(screenshot_name)
         end,
-        cancel_text = _("No"),
+        ok_text = _("View"),
+        ok_callback = function()
+            local image_viewer = require("ui/widget/imageviewer"):new{
+                file = screenshot_name,
+                modal = true,
+                with_title_bar = false,
+                buttons_visible = true,
+            }
+            UIManager:show(image_viewer)
+        end,
+        other_buttons = {{
+            {
+                text = _("Close"),
+                callback = function()
+                    UIManager:close(confirm_box)
+                end,
+            },
+            {
+                text = _("Set as screensaver"),
+                callback = function()
+                    G_reader_settings:saveSetting("screensaver_type", "image_file")
+                    G_reader_settings:saveSetting("screensaver_image", screenshot_name)
+                    UIManager:close(confirm_box)
+                end,
+            },
+        }},
     }
-    UIManager:show(widget)
+    UIManager:show(confirm_box)
     -- trigger full refresh
     UIManager:setDirty(nil, "full")
     return true
 end
 
 function Screenshoter:chooseFolder()
-    local buttons = {}
-    table.insert(buttons, {
-        {
-            text = _("Choose screenshot folder"),
-            callback = function()
-                UIManager:close(self.choose_dialog)
-                require("ui/downloadmgr"):new{
-                    onConfirm = function(path)
-                        G_reader_settings:saveSetting("screenshot_dir", path .. "/")
-                        UIManager:show(InfoMessage:new{
-                            text = T(_("Screenshot folder set to:\n%1"), BD.dirpath(path)),
-                            timeout = 3,
-                        })
-                    end,
-                }:chooseDir()
-            end,
-        }
-    })
-    table.insert(buttons, {
-        {
-            text = _("Close"),
-            callback = function()
-                UIManager:close(self.choose_dialog)
-            end,
-        }
-    })
     local screenshot_dir = G_reader_settings:readSetting("screenshot_dir") or DataStorage:getDataDir() .. "/screenshots/"
-    self.choose_dialog = ButtonDialogTitle:new{
-        title = T(_("Current screenshot folder:\n%1"), BD.dirpath(screenshot_dir)),
-        buttons = buttons
+    local confirm_box = ConfirmBox:new{
+        text = T(_("Screenshot folder is set to:\n%1\n\nDo you want to choose new folder for screenshots?"), screenshot_dir),
+        ok_text = _("Choose folder"),
+        ok_callback = function()
+            local path_chooser = require("ui/widget/pathchooser"):new{
+                select_file = false,
+                show_files = false,
+                path = screenshot_dir,
+                onConfirm = function(new_path)
+                    G_reader_settings:saveSetting("screenshot_dir", new_path .. "/")
+                end
+            }
+            UIManager:show(path_chooser)
+        end,
     }
-    UIManager:show(self.choose_dialog)
+    UIManager:show(confirm_box)
 end
 
 function Screenshoter:onTapDiagonal()

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -44,6 +44,7 @@ function Screenshoter:onScreenshot(filename)
     confirm_box = ConfirmBox:new{
         text = T( _("Screenshot saved to:\n%1"), BD.filepath(screenshot_name)),
         keep_open = true,
+        dismissable = false,
         cancel_text = _("Delete"),
         cancel_callback = function()
             local ok, err = os.remove(screenshot_name)

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -43,40 +43,39 @@ function Screenshoter:onScreenshot(filename)
     local confirm_box
     confirm_box = ConfirmBox:new{
         text = T( _("Screenshot saved to:\n%1"), BD.filepath(screenshot_name)),
-        keep_open = true,
-        dismissable = false,
-        cancel_text = _("Delete"),
-        cancel_callback = function()
-            local ok, err = os.remove(screenshot_name)
-        end,
-        ok_text = _("View"),
+        keep_dialog_open = true,
+        cancel_text = _("Close"),
+        ok_text = _("Set as screensaver"),
         ok_callback = function()
-            local image_viewer = require("ui/widget/imageviewer"):new{
-                file = screenshot_name,
-                modal = true,
-                with_title_bar = false,
-                buttons_visible = true,
-            }
-            UIManager:show(image_viewer)
+            G_reader_settings:saveSetting("screensaver_type", "image_file")
+            G_reader_settings:saveSetting("screensaver_image", screenshot_name)
+            UIManager:close(confirm_box)
         end,
         other_buttons = {{
             {
-                text = _("Close"),
+                text = _("Delete"),
                 callback = function()
+                    local ok, err = os.remove(screenshot_name)
                     UIManager:close(confirm_box)
                 end,
             },
             {
-                text = _("Set as screensaver"),
+                text = _("View"),
                 callback = function()
-                    G_reader_settings:saveSetting("screensaver_type", "image_file")
-                    G_reader_settings:saveSetting("screensaver_image", screenshot_name)
-                    UIManager:close(confirm_box)
+                    local image_viewer = require("ui/widget/imageviewer"):new{
+                        file = screenshot_name,
+                        modal = true,
+                        with_title_bar = false,
+                        buttons_visible = true,
+                    }
+                    UIManager:show(image_viewer)
                 end,
             },
         }},
     }
-    UIManager:show(confirm_box)
+    UIManager:nextTick(function()
+        UIManager:show(confirm_box)
+    end)
     -- trigger full refresh
     UIManager:setDirty(nil, "full")
     return true

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -55,7 +55,7 @@ function Screenshoter:onScreenshot(filename)
             {
                 text = _("Delete"),
                 callback = function()
-                    local ok, err = os.remove(screenshot_name)
+                    local __ = os.remove(screenshot_name)
                     UIManager:close(confirm_box)
                 end,
             },

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -51,7 +51,7 @@ function Screenshoter:onScreenshot(filename)
             G_reader_settings:saveSetting("screensaver_image", screenshot_name)
             UIManager:close(confirm_box)
         end,
-        other_buttons_above = true,
+        other_buttons_first = true,
         other_buttons = {{
             {
                 text = _("Delete"),

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -88,7 +88,7 @@ end
 function Screenshoter:chooseFolder()
     local screenshot_dir = G_reader_settings:readSetting("screenshot_dir") or DataStorage:getDataDir() .. "/screenshots/"
     local confirm_box = ConfirmBox:new{
-        text = T(_("Screenshot folder is set to:\n%1\n\nDo you want to choose new folder for screenshots?"), screenshot_dir),
+        text = T(_("Screenshot folder is set to:\n%1\n\nChoose a new folder for screenshots?"), screenshot_dir),
         ok_text = _("Choose folder"),
         ok_callback = function()
             local path_chooser = require("ui/widget/pathchooser"):new{

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -35,7 +35,7 @@ function Screenshoter:init()
     }
 end
 
-function Screenshoter:onScreenshot(filename)
+function Screenshoter:onScreenshot(filename, when_done_func)
     local screenshots_dir = G_reader_settings:readSetting("screenshot_dir") or DataStorage:getDataDir() .. "/screenshots/"
     self.screenshot_fn_fmt = screenshots_dir .. self.prefix .. "_%Y-%m-%d_%H%M%S.png"
     local screenshot_name = filename or os.date(self.screenshot_fn_fmt)
@@ -45,19 +45,23 @@ function Screenshoter:onScreenshot(filename)
         text = T( _("Screenshot saved to:\n%1"), BD.filepath(screenshot_name)),
         keep_dialog_open = true,
         cancel_text = _("Close"),
+        cancel_callback = function()
+            if when_done_func then when_done_func() end
+        end,
         ok_text = _("Set as screensaver"),
         ok_callback = function()
             G_reader_settings:saveSetting("screensaver_type", "image_file")
             G_reader_settings:saveSetting("screensaver_image", screenshot_name)
             UIManager:close(confirm_box)
+            if when_done_func then when_done_func() end
         end,
-        other_buttons_first = true,
         other_buttons = {{
             {
                 text = _("Delete"),
                 callback = function()
                     local __ = os.remove(screenshot_name)
                     UIManager:close(confirm_box)
+                    if when_done_func then when_done_func() end
                 end,
             },
             {
@@ -74,9 +78,7 @@ function Screenshoter:onScreenshot(filename)
             },
         }},
     }
-    UIManager:nextTick(function()
-        UIManager:show(confirm_box)
-    end)
+    UIManager:show(confirm_box)
     -- trigger full refresh
     UIManager:setDirty(nil, "full")
     return true

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -51,6 +51,7 @@ function Screenshoter:onScreenshot(filename)
             G_reader_settings:saveSetting("screensaver_image", screenshot_name)
             UIManager:close(confirm_box)
         end,
+        other_buttons_above = true,
         other_buttons = {{
             {
                 text = _("Delete"),

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -55,6 +55,7 @@ function Screenshoter:onScreenshot(filename, when_done_func)
             UIManager:close(confirm_box)
             if when_done_func then when_done_func() end
         end,
+        other_buttons_first = true,
         other_buttons = {{
             {
                 text = _("Delete"),


### PR DESCRIPTION
Some development of the screenshoter.

<kbd>![1](https://user-images.githubusercontent.com/62179190/128508894-466e2e67-ea03-4de2-95b1-1c0e5ea2f19e.png)</kbd>

We can preview the screenshot and delete it immediately if we don't like it.

Requires a small addition to the ConfirmBox to keep it open after previewing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8050)
<!-- Reviewable:end -->
