### PR TITLE
Menu widget: avoid truncation in "Go to letter" dialog

### DIFF
--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -7,8 +7,6 @@ local _ = require("gettext")
 local T = require("ffi/util").template
 
 local ReaderGoto = InputContainer:new{
-    goto_menu_title = _("Go to page"),
-    skim_menu_title = _("Skim document"),
 }
 
 function ReaderGoto:init()
@@ -16,15 +14,14 @@ function ReaderGoto:init()
 end
 
 function ReaderGoto:addToMainMenu(menu_items)
-    -- insert goto command to main reader menu
     menu_items.go_to = {
-        text = self.goto_menu_title,
+        text = _("Go to page"),
         callback = function()
             self:onShowGotoDialog()
         end,
     }
     menu_items.skim_to = {
-        text = self.skim_menu_title,
+        text = _("Skim document"),
         callback = function()
             self:onShowSkimtoDialog()
         end,
@@ -59,14 +56,21 @@ x for an absolute page number
             {
                 {
                     text = _("Cancel"),
-                    enabled = true,
                     callback = function()
                         self:close()
                     end,
                 },
                 {
-                    text = _("Skim"),
-                    enabled = true,
+                    text = _("Go to page"),
+                    is_enter_default = true,
+                    callback = function()
+                        self:gotoPage()
+                    end,
+                }
+            },
+            {
+                {
+                    text = _("Skim document"),
                     callback = function()
                         self:close()
                         self.skimto = SkimToWidget:new{
@@ -81,12 +85,6 @@ x for an absolute page number
 
                     end,
                 },
-                {
-                    text = _("Go to page"),
-                    enabled = true,
-                    is_enter_default = true,
-                    callback = function() self:gotoPage() end,
-                }
             },
         },
         input_type = "number",

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -827,9 +827,8 @@ function Menu:init()
             -- @translators First group is a page number range, second group the standard range for alphabetic searches
             return T(_("(1 - %1) or (a - z)"), self.page_num)
         end
-        table.insert(buttons[1], {
+        table.insert(buttons[1], 1, {
             text = _("Go to letter"),
-            is_enter_default = true,
             callback = function()
                 local search_string = self.page_info_text.input_dialog:getInputText()
                 if search_string == "" then return end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -845,8 +845,7 @@ function Menu:init()
                 self.page_info_text:closeInputDialog()
             end,
         })
-        table.insert(buttons, {})
-        table.insert(buttons[2], cancel_button)
+        table.insert(buttons, {cancel_button})
     else
         title_goto = _("Enter page number")
         type_goto = "number"

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -832,10 +832,8 @@ function Menu:init()
             {
                 text = _("File search"),
                 callback = function()
-                    local search_string = self.page_info_text.input_dialog:getInputText()
-                    if search_string == "" then return end
                     self.page_info_text:closeInputDialog()
-                    UIManager:sendEvent(Event:new("ShowFileSearch", search_string))
+                    UIManager:sendEvent(Event:new("ShowFileSearch", self.page_info_text.input_dialog:getInputText()))
                 end,
             },
             {


### PR DESCRIPTION
Two rows of the buttons. Closes https://github.com/koreader/koreader/issues/8051.

<kbd>![1](https://user-images.githubusercontent.com/62179190/128622972-7c8546c4-8983-440b-991a-c9cd178d7b4f.png)</kbd>
--
As addition, fix of 
https://github.com/koreader/koreader/blob/ba6fef4d7ba217ca558072f090849000e72ba142/frontend/ui/widget/menu.lua#L833

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8056)
<!-- Reviewable:end -->
