### PR TITLE
A bunch of tweaks & fixes

### DIFF
--- a/doc/Hacking.md
+++ b/doc/Hacking.md
@@ -17,7 +17,12 @@ Anything printed by `logger.dbg` starts with `DEBUG`.
 04/06/17-21:44:53 DEBUG foo
 ```
 
-## Bug hunting in kpv
+In production code, remember that arguments are *always* evaluated in Lua, so,
+don't inline complex computations in logger functions' arguments.
+If you *really* have to, hide the whole thing behind a `dbg.is_on` branch,
+like in [frontend/device/input.lua](https://github.com/koreader/koreader/blob/ba6fef4d7ba217ca558072f090849000e72ba142/frontend/device/input.lua#L1131-L1134).
+
+## Bug hunting in KPV (KOReader's predecessor)
 
 A real example of bug hunting in KPV's cache system: <https://github.com/koreader/kindlepdfviewer/pull/475>
 

--- a/frontend/device/kobo/ntx_io.lua
+++ b/frontend/device/kobo/ntx_io.lua
@@ -1,0 +1,18 @@
+-- Stupid wrapper so that we can send simple ntx_io ioctls from shell scripts...
+
+local ffi = require("ffi")
+local bor = bit.bor
+local C = ffi.C
+
+require("ffi/posix_h")
+
+assert(#arg == 2, "must pass an ioctl command & an ioctl argument")
+local ioc_cmd = tonumber(arg[1])
+local ioc_arg = tonumber(arg[2])
+
+local fd = C.open("/dev/ntx_io", bor(C.O_RDONLY, C.O_NONBLOCK, C.O_CLOEXEC))
+assert(fd ~= -1, "cannot open ntx_io character device")
+
+assert(C.ioctl(fd, ioc_cmd, ffi.cast("int", ioc_arg)) == 0, "ioctl failed")
+
+C.close(fd)

--- a/platform/kobo/disable-wifi.sh
+++ b/platform/kobo/disable-wifi.sh
@@ -58,3 +58,9 @@ if grep -q "sdio_wifi_pwr" "/proc/modules"; then
     usleep 250000
     rmmod sdio_wifi_pwr
 fi
+
+# Poke the kernel via ioctl on platforms without the dedicated power module...
+if [ ! -e "/drivers/${PLATFORM}/wifi/sdio_wifi_pwr.ko" ]; then
+    usleep 250000
+    ./luajit frontend/device/kobo/ntx_io.lua 208 0
+fi

--- a/platform/kobo/enable-wifi.sh
+++ b/platform/kobo/enable-wifi.sh
@@ -33,11 +33,23 @@ fi
 usleep 250000
 # NOTE: Used to be exported in WIFI_MODULE_PATH before FW 4.23
 if ! grep -q "${WIFI_MODULE}" "/proc/modules"; then
+    # Set the Wi-Fi regulatory domain properly if necessary...
+    WIFI_COUNTRY_CODE_PARM=""
+    if grep -q "^WifiRegulatoryDomain=" "/mnt/onboard/.kobo/Kobo/Kobo eReader.conf"; then
+        WIFI_COUNTRY_CODE="$(grep "^WifiRegulatoryDomain=" "/mnt/onboard/.kobo/Kobo/Kobo eReader.conf" | cut -d '=' -f2)"
+
+        case "${WIFI_MODULE}" in
+            "8821cs")
+                WIFI_COUNTRY_CODE_PARM="rtw_country_code=${WIFI_COUNTRY_CODE}"
+                ;;
+        esac
+    fi
+
     if [ -e "/drivers/${PLATFORM}/wifi/${WIFI_MODULE}.ko" ]; then
-        insmod "/drivers/${PLATFORM}/wifi/${WIFI_MODULE}.ko"
+        insmod "/drivers/${PLATFORM}/wifi/${WIFI_MODULE}.ko" "${WIFI_COUNTRY_CODE_PARM}"
     elif [ -e "/drivers/${PLATFORM}/${WIFI_MODULE}.ko" ]; then
         # NOTE: Modules are unsorted on Mk. 8
-        insmod "/drivers/${PLATFORM}/${WIFI_MODULE}.ko"
+        insmod "/drivers/${PLATFORM}/${WIFI_MODULE}.ko" "${WIFI_COUNTRY_CODE_PARM}"
     fi
 fi
 # Race-y as hell, don't try to optimize this!

--- a/platform/kobo/enable-wifi.sh
+++ b/platform/kobo/enable-wifi.sh
@@ -23,6 +23,10 @@ if ! grep -q "sdio_wifi_pwr" "/proc/modules"; then
         fi
 
         insmod "/drivers/${PLATFORM}/wifi/sdio_wifi_pwr.ko"
+    else
+        # Poke the kernel via ioctl on platforms without the dedicated power module...
+        # 208 is CM_WIFI_CTRL
+        ./luajit frontend/device/kobo/ntx_io.lua 208 1
     fi
 fi
 # Moar sleep!

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -183,7 +183,7 @@ if [ "${VIA_NICKEL}" = "true" ]; then
     #       as we want to be able to use our own per-if processes w/ custom args later on.
     #       A SIGTERM does not break anything, it'll just prevent automatic lease renewal until the time
     #       KOReader actually sets the if up itself (i.e., it'll do)...
-    killall -q -TERM nickel hindenburg sickel fickel adobehost foxitpdf iink dhcpcd-dbus dhcpcd fmon
+    killall -q -TERM nickel hindenburg sickel fickel adobehost foxitpdf iink dhcpcd-dbus dhcpcd fmon nanoclock.lua
 
     # Wait for Nickel to die... (oh, procps with killall -w, how I miss you...)
     kill_timeout=0

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -13,7 +13,7 @@ export QT_GSTREAMER_PLAYBIN_AUDIOSINK=alsasink
 cd /
 unset OLDPWD
 unset LC_ALL TESSDATA_PREFIX STARDICT_DATA_DIR EXT_FONT_DIR
-unset KOREADER_DIR KO_DONT_GRAB_INPUT
+unset KO_DONT_GRAB_INPUT
 unset FBINK_FORCE_ROTA
 
 # Ensures fmon will restart. Note that we don't have to worry about reaping this, nickel kills on-animator.sh on start.
@@ -75,8 +75,15 @@ if grep -q "${WIFI_MODULE}" "/proc/modules"; then
         usleep 250000
         rmmod sdio_wifi_pwr
     fi
+
+    # Poke the kernel via ioctl on platforms without the dedicated power module...
+    if [ ! -e "/drivers/${PLATFORM}/wifi/sdio_wifi_pwr.ko" ]; then
+        usleep 250000
+        "${KOREADER_DIR}"/luajit "${KOREADER_DIR}"/frontend/device/kobo/ntx_io.lua 208 0
+    fi
 fi
 
+unset KOREADER_DIR
 unset CPUFREQ_DVFS CPUFREQ_CONSERVATIVE
 
 # Recreate Nickel's FIFO ourselves, like rcS does, because udev *will* write to it!

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -7,6 +7,7 @@ PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/lib:"
 export LD_LIBRARY_PATH="/usr/local/Kobo"
 # Ditto, 4.28+
 export QT_GSTREAMER_PLAYBIN_AUDIOSINK=alsasink
+export QT_GSTREAMER_PLAYBIN_AUDIOSINK_DEVICE_PARAMETER=bluealsa:DEV=00:00:00:00:00:00
 
 # Reset PWD, and clear up our own custom stuff from the env while we're there, otherwise, USBMS may become very wonky on newer FW...
 # shellcheck disable=SC2164


### PR DESCRIPTION
* Kill NanoClock on startup (xref: https://www.mobileread.com/forums/showpost.php?p=4144385&postcount=72)
* Fix Wi-Fi toggle on the Elipsa (xref: https://www.mobileread.com/forums/showpost.php?p=4140835&postcount=3317)
* Set the Wi-Fi regulatory domain properly on the Elipsa, to avoid mishaps on the 5G band.
* Also, minor doc updates re: logger.dbg and evalution of function arguments in Lua.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8057)
<!-- Reviewable:end -->
