### PR TITLE
Add warmth to status line

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -37,13 +37,13 @@ local MODE = {
     book_time_to_read = 7,
     chapter_time_to_read = 8,
     frontlight = 9,
-    frontlight_warmth = 10,
-    mem_usage = 11,
-    wifi_status = 12,
-    book_title = 13,
-    book_chapter = 14,
-    bookmark_count = 15,
-    chapter_progress = 16,
+    mem_usage = 10,
+    wifi_status = 11,
+    book_title = 12,
+    book_chapter = 13,
+    bookmark_count = 14,
+    chapter_progress = 15,
+    frontlight_warmth = 16,
 }
 
 local symbol_prefix = {
@@ -155,7 +155,7 @@ local footerTextGeneratorMap = {
         if powerd:isFrontlightOn() then
             if Device:isCervantes() or Device:isKobo() then
                 return (prefix .. " %d"):format(powerd:getWarmth())
-            else
+            elseif powerd:getWarmth() then
                 local warmth = math.floor(powerd:getWarmth()/100*powerd.fl_warmth_max)
                 if warmth and Device:hasNaturalLight() then
                     return (prefix .. " %d"):format(warmth)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -64,7 +64,7 @@ local symbol_prefix = {
         -- @translators This is the footer letter prefix for frontlight level.
         frontlight = C_("FooterLetterPrefix", "L:"),
         -- @translators This is the footer letter prefix for frontlight warmth (redshift).
-        frontlight = C_("FooterLetterPrefix", "R:"),
+        frontlight_warmth = C_("FooterLetterPrefix", "R:"),
         -- @translators This is the footer letter prefix for memory usage.
         mem_usage = C_("FooterLetterPrefix", "M:"),
         -- @translators This is the footer letter prefix for Wi-Fi status.
@@ -154,7 +154,7 @@ local footerTextGeneratorMap = {
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
             if Device:isCervantes() or Device:isKobo() then
-                return (prefix .. " %d%%"):format(powerd:frontlightIntensity())
+                return (prefix .. " %d"):format(powerd:getWarmth())
             else
                 local warmth = math.floor(powerd:getWarmth()/100*powerd.fl_warmth_max)
                 if warmth and Device:hasNaturalLight() then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -153,13 +153,9 @@ local footerTextGeneratorMap = {
         local prefix = symbol_prefix[symbol_type].frontlight_warmth
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
-            if Device:isCervantes() or Device:isKobo() then
-                return (prefix .. " %d%%"):format(powerd:getWarmth())
-            elseif powerd:getWarmth() then
-                local warmth = math.floor(powerd:getWarmth())
-                if warmth and Device:hasNaturalLight() then
-                    return (prefix .. " %d%%"):format(warmth)
-                end
+            local warmth = powerd:getWarmth()
+            if warmth then
+                return (prefix .. " %d%%"):format(warmth)
             end
         else
             if footer.settings.all_at_once and footer.settings.hide_empty_generators then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -154,11 +154,11 @@ local footerTextGeneratorMap = {
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
             if Device:isCervantes() or Device:isKobo() then
-                return (prefix .. " %d"):format(powerd:getWarmth())
+                return (prefix .. " %d%%"):format(powerd:getWarmth())
             elseif powerd:getWarmth() then
-                local warmth = math.floor(powerd:getWarmth()/100*powerd.fl_warmth_max)
+                local warmth = math.floor(powerd:getWarmth())
                 if warmth and Device:hasNaturalLight() then
-                    return (prefix .. " %d"):format(warmth)
+                    return (prefix .. " %d%%"):format(warmth)
                 end
             end
         else

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -37,12 +37,13 @@ local MODE = {
     book_time_to_read = 7,
     chapter_time_to_read = 8,
     frontlight = 9,
-    mem_usage = 10,
-    wifi_status = 11,
-    book_title = 12,
-    book_chapter = 13,
-    bookmark_count = 14,
-    chapter_progress = 15,
+    frontlight_warmth = 10,
+    mem_usage = 11,
+    wifi_status = 12,
+    book_title = 13,
+    book_chapter = 14,
+    bookmark_count = 15,
+    chapter_progress = 16,
 }
 
 local symbol_prefix = {
@@ -62,6 +63,8 @@ local symbol_prefix = {
         chapter_time_to_read = C_("FooterLetterPrefix", "TC:"),
         -- @translators This is the footer letter prefix for frontlight level.
         frontlight = C_("FooterLetterPrefix", "L:"),
+        -- @translators This is the footer letter prefix for frontlight warmth (redshift).
+        frontlight = C_("FooterLetterPrefix", "R:"),
         -- @translators This is the footer letter prefix for memory usage.
         mem_usage = C_("FooterLetterPrefix", "M:"),
         -- @translators This is the footer letter prefix for Wi-Fi status.
@@ -77,6 +80,7 @@ local symbol_prefix = {
         book_time_to_read = "⏳",
         chapter_time_to_read = BD.mirroredUILayout() and "⥖" or "⤻",
         frontlight = "☼",
+        frontlight_warmth = "💡",
         mem_usage = "",
         wifi_status = "",
         wifi_status_off = "",
@@ -135,6 +139,27 @@ local footerTextGeneratorMap = {
                 return (prefix .. " %d%%"):format(powerd:frontlightIntensity())
             else
                 return (prefix .. " %d"):format(powerd:frontlightIntensity())
+            end
+        else
+            if footer.settings.all_at_once and footer.settings.hide_empty_generators then
+                return ""
+            else
+                return T(_("%1 Off"), prefix)
+            end
+        end
+    end,
+    frontlight_warmth = function(footer)
+        local symbol_type = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_type].frontlight_warmth
+        local powerd = Device:getPowerDevice()
+        if powerd:isFrontlightOn() then
+            if Device:isCervantes() or Device:isKobo() then
+                return (prefix .. " %d%%"):format(powerd:frontlightIntensity())
+            else
+                local warmth = math.floor(powerd:getWarmth()/100*powerd.fl_warmth_max)
+                if warmth and Device:hasNaturalLight() then
+                    return (prefix .. " %d"):format(warmth)
+                end
             end
         else
             if footer.settings.all_at_once and footer.settings.hide_empty_generators then
@@ -869,6 +894,7 @@ function ReaderFooter:textOptionTitles(option)
             and T(_("Book time to read (%1)"),symbol_prefix[symbol].book_time_to_read) or _("Book time to read"),
         chapter_time_to_read = T(_("Chapter time to read (%1)"), symbol_prefix[symbol].chapter_time_to_read),
         frontlight = T(_("Frontlight level (%1)"), symbol_prefix[symbol].frontlight),
+        frontlight_warmth = T(_("Frontlight warmth (%1)"), symbol_prefix[symbol].frontlight_warmth),
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
         book_title = _("Book title"),
@@ -1787,6 +1813,9 @@ With this enabled, the current page is included, so the count goes from n to 1 i
     table.insert(sub_items, getMinibarOption("chapter_time_to_read"))
     if Device:hasFrontlight() then
         table.insert(sub_items, getMinibarOption("frontlight"))
+    end
+    if Device:hasNaturalLight() then
+        table.insert(sub_items, getMinibarOption("frontlight_warmth"))
     end
     table.insert(sub_items, getMinibarOption("mem_usage"))
     if Device:hasFastWifiStatusQuery() then

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -50,6 +50,7 @@ function AndroidPowerD:setWarmth(warmth)
     self.fl_warmth = warmth
     local new_warmth = math.floor(warmth * self.fl_warmth_max / 100)
     android.setScreenWarmth(new_warmth)
+    self:stateChanged()
 end
 
 function AndroidPowerD:getWarmth()

--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -146,6 +146,12 @@ function CervantesPowerD:setWarmth(warmth)
     end
     self.fl_warmth = warmth or self.fl_warmth
     self.fl:setWarmth(self.fl_warmth)
+    self:stateChanged()
+end
+
+function CervantesPowerD:getWarmth()
+    if self.fl == nil then return end
+    return self.fl_warmth
 end
 
 function CervantesPowerD:calculateAutoWarmth()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -60,7 +60,7 @@ function DeviceListener:onShowWarmth(value)
     if powerd.fl_warmth ~= nil then
         -- powerd.fl_warmth holds the warmth-value in the internal koreader scale [0,100]
         -- powerd.fl_warmth_max is the maximum value the hardware accepts
-        Notification:notify(T(_("Warmth set to %1."), math.floor(powerd.fl_warmth/100*powerd.fl_warmth_max)))
+        Notification:notify(T(_("Warmth set to %1%."), math.floor(powerd.fl_warmth)))
     end
     return true
 end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -252,6 +252,7 @@ function KoboPowerD:setWarmth(warmth)
     if self.fl == nil then return end
     if not warmth and self.auto_warmth then
         self:calculateAutoWarmth()
+        self:stateChanged()
     end
     self.fl_warmth = warmth or self.fl_warmth
     -- Don't turn the light back on on legacy NaturalLight devices just for the sake of setting the warmth!
@@ -259,6 +260,14 @@ function KoboPowerD:setWarmth(warmth)
     -- On older ones, calling setWarmth *will* actually set the brightness, too!
     if self.device:hasNaturalLightMixer() or self:isFrontlightOnHW() then
         self.fl:setWarmth(self.fl_warmth)
+        self:stateChanged()
+    end
+end
+
+function KoboPowerD:getWarmth()
+    if self.fl == nil then return end
+    if self.device:hasNaturalLightMixer() or self:isFrontlightOnHW() then
+        return self.fl_warmth
     end
 end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -266,7 +266,7 @@ end
 
 function KoboPowerD:getWarmth()
     if self.fl == nil then return end
-    if self.device:hasNaturalLightMixer() or self:isFrontlightOnHW() then
+    if self.device:hasNaturalLight() then
         return self.fl_warmth
     end
 end

--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -64,6 +64,13 @@ function PocketBookPowerD:setWarmth(level)
     if self.fl_warmth then
         self.fl_warmth = level or self.fl_warmth
         inkview.SetFrontlightColor(self.fl_warmth)
+        self:stateChanged()
+    end
+end
+
+function PocketBookPowerD:getWarmth()
+    if self.fl_warmth then
+        return self.fl_warmth
     end
 end
 

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -24,6 +24,12 @@ end
 function SDLPowerD:setWarmth(level)
     require("logger").info("set warmth to", level)
     self.fl_warmth = level or self.fl_warmth
+    self:stateChanged()
+end
+
+function SDLPowerD:getWarmth()
+    if self_hw_intensity == 0 then return end
+    return self.fl_warmth
 end
 
 function SDLPowerD:getCapacityHW()

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -28,7 +28,7 @@ function SDLPowerD:setWarmth(level)
 end
 
 function SDLPowerD:getWarmth()
-    if self_hw_intensity == 0 then return end
+    if self.hw_intensity == 0 then return end
     return self.fl_warmth
 end
 


### PR DESCRIPTION
This PR adds the possibility to add a frontlight warmth indicator to the bottom status bar.

Tested on Android (mobile and Tolino) and with the emulator.
Not tested on Kobos, Cervantes, Pocketbook. Could/wants someone to check these please.

![grafik](https://user-images.githubusercontent.com/36999612/128915347-adec211b-d298-4bfb-bd18-4bce4a7f59e5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8060)
<!-- Reviewable:end -->
