### PR TITLE
Checkbutton: now multiline

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -168,6 +168,7 @@ function FileSearcher:onShowFileSearch()
         text = _("Case sensitive"),
         checked = self.case_sensitive,
         parent = self.search_dialog,
+        max_width = self.search_dialog._input_widget.width,
         callback = function()
             if not self.check_button_case.checked then
                 self.check_button_case:check()

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -152,6 +152,7 @@ function ReaderSearch:onShowFulltextSearchInput()
         text = _("Regular expression (hold for help)"),
         checked = self.use_regex,
         parent = self.input_dialog,
+        max_width = self.input_dialog._input_widget.width,
         callback = function()
             if not self.check_button_regex.checked then
                 self.check_button_regex:check()

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -140,6 +140,7 @@ function ReaderSearch:onShowFulltextSearchInput()
         text = _("Case sensitive"),
         checked = not self.case_insensitive,
         parent = self.input_dialog,
+        max_width = self.input_dialog._input_widget.width,
         callback = function()
             if not self.check_button_case.checked then
                 self.check_button_case:check()

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -22,8 +22,10 @@ local FrameContainer = require("ui/widget/container/framecontainer")
 local GestureRange = require("ui/gesturerange")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local TextWidget = require("ui/widget/textwidget")
+local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = Device.screen
 
 local CheckButton = InputContainer:new{
@@ -56,16 +58,23 @@ function CheckButton:initCheckButton(checked)
         parent = self.parent or self,
         show_parent = self.show_parent or self,
     }
-    self._textwidget = TextWidget:new{
+    self._textwidget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        max_width = self.max_width,
+        width = self.max_width,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
     }
-    self.text_truncated = self._textwidget:isTruncated()
-    self._horizontalgroup = HorizontalGroup:new{
-        self._checkmark,
+    self._verticalgroup = VerticalGroup:new{
+        align = "left",
+        VerticalSpan:new{
+            width = self.face.size * 0.18,
+        },
         self._textwidget,
+    }
+    self._horizontalgroup = HorizontalGroup:new{
+        align = "top",
+        self._checkmark,
+        self._verticalgroup,
     }
     self._frame = FrameContainer:new{
         bordersize = 0,
@@ -161,11 +170,6 @@ function CheckButton:onHoldCheckButton()
         elseif type(self.hold_input_func) == "function" then
             self:onInput(self.hold_input_func(), true)
             self._hold_handled = true
-        elseif self.text_truncated then
-            UIManager:show(require("ui/widget/infomessage"):new{
-                text = self.text,
-                show_icon = false,
-            })
         end
     end
     return true

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -62,6 +62,7 @@ function CheckButton:initCheckButton(checked)
         max_width = self.max_width,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
     }
+    self.text_truncated = self._textwidget:isTruncated()
     self._horizontalgroup = HorizontalGroup:new{
         self._checkmark,
         self._textwidget,
@@ -160,6 +161,11 @@ function CheckButton:onHoldCheckButton()
         elseif type(self.hold_input_func) == "function" then
             self:onInput(self.hold_input_func(), true)
             self._hold_handled = true
+        elseif self.text_truncated then
+            UIManager:show(require("ui/widget/infomessage"):new{
+                text = self.text,
+                show_icon = false,
+            })
         end
     end
     return true

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -38,7 +38,7 @@ local CheckButton = InputContainer:new{
     overlap_align = "right",
     text = nil,
     toggle_text = nil,
-    max_width = nil, -- required to set in the caller
+    max_width = nil, -- must be set by the caller
     window = nil,
 
     padding = Screen:scaleBySize(5),

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -61,7 +61,7 @@ function CheckButton:initCheckButton(checked)
     self._textwidget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = self.max_width,
+        width = self.max_width - self._checkmark.dimen.w,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
     }
     self._verticalgroup = VerticalGroup:new{

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -38,7 +38,7 @@ local CheckButton = InputContainer:new{
     overlap_align = "right",
     text = nil,
     toggle_text = nil,
-    max_width = nil,
+    max_width = nil, -- required to set in the caller
     window = nil,
 
     padding = Screen:scaleBySize(5),

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -399,6 +399,7 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
     local checkbutton_auto_nl = CheckButton:new({
             text = _("Auto"),
             checked = self.powerd.auto_warmth,
+            max_width = math.floor(self.screen_width * 0.3),
             callback = function()
                 if self.powerd.auto_warmth then
                     self.powerd.auto_warmth = false

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -816,6 +816,7 @@ function InputDialog:_addScrollButtons(nav_bar)
                         text = _("Case sensitive"),
                         checked = self.case_sensitive,
                         parent = input_dialog,
+                        max_width = input_dialog._input_widget.width,
                         callback = function()
                             if not self.check_button_case.checked then
                                 self.check_button_case:check()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -476,7 +476,9 @@ function InputDialog:onTap()
     if self.deny_keyboard_hiding then
         return
     end
-    self._input_widget:onCloseKeyboard()
+    if self._input_widget.onCloseKeyboard then
+        self._input_widget:onCloseKeyboard()
+    end
 end
 
 function InputDialog:getInputText()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -376,6 +376,7 @@ function InputText:initTextBox(text, char_added)
     if self.is_password_type and self.show_password_toggle then
         self._check_button = self._check_button or CheckButton:new{
             text = _("Show password"),
+            max_width = self.width,
             callback = function()
                 if self.text_type == "text" then
                     self.text_type = "password"


### PR DESCRIPTION
Some checkbutton long text (in translation) may be truncated.

<kbd>![1](https://user-images.githubusercontent.com/62179190/129183219-9f680334-8702-4886-aab3-23f03dbc8c09.png)</kbd>

Let's show the full text on hold (if no action assigned).

<kbd>![2](https://user-images.githubusercontent.com/62179190/129183257-db6a610d-6dd6-487a-b8d9-f8f6a896760b.png)</kbd>

As addition, fixing long text in Readersearch.
Before

<kbd>![3](https://user-images.githubusercontent.com/62179190/129183359-5b0eb11c-4654-45f2-ae12-87cea5060f4d.png)</kbd>

After

<kbd>![4](https://user-images.githubusercontent.com/62179190/129183374-d68cbbb1-41a2-45ba-9385-0ec684f4a602.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8066)
<!-- Reviewable:end -->
