### PR TITLE
ReaderDeviceStatus: show only one alert

### DIFF
--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -34,9 +34,9 @@ function ReaderDeviceStatus:init()
                     if self.battery_confirm_box then
                         UIManager:close(self.battery_confirm_box)
                     end
-                    local txt = is_charging and _("High battery level") or _("Low battery level")
                     self.battery_confirm_box = ConfirmBox:new {
-                        text = T(_(txt .. ": %1%\n\nDismiss battery level alert?"), battery_capacity),
+                        text = is_charging and T(_("High battery level: %1%\n\nDismiss battery level alert?"), battery_capacity)
+                                            or T(_("Low battery level: %1%\n\nDismiss battery level alert?"), battery_capacity)
                         ok_text = _("Dismiss"),
                         dismissable = false,
                         ok_callback = function()

--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -29,22 +29,14 @@ function ReaderDeviceStatus:init()
                     powerd:setDismissBatteryStatus(false)
                 end
             else
-                if self.battery_confirm_box then
-                    UIManager:close(self.battery_confirm_box)
-                end
-                if is_charging and battery_capacity > self.battery_threshold_high then
+                if (is_charging and battery_capacity > self.battery_threshold_high) or
+                   (not is_charging and battery_capacity <= self.battery_threshold) then
+                    if self.battery_confirm_box then
+                        UIManager:close(self.battery_confirm_box)
+                    end
+                    local txt = is_charging and _("High battery level") or _("Low battery level")
                     self.battery_confirm_box = ConfirmBox:new {
-                        text = T(_("High battery level: %1%\n\nDismiss battery level alert?"), battery_capacity),
-                        ok_text = _("Dismiss"),
-                        dismissable = false,
-                        ok_callback = function()
-                            powerd:setDismissBatteryStatus(true)
-                        end,
-                    }
-                    UIManager:show(self.battery_confirm_box)
-                elseif not is_charging and battery_capacity <= self.battery_threshold then
-                    self.battery_confirm_box = ConfirmBox:new {
-                        text = T(_("Low battery level: %1%\n\nDismiss battery level alert?"), battery_capacity),
+                        text = T(_(txt .. ": %1%\n\nDismiss battery level alert?"), battery_capacity),
                         ok_text = _("Dismiss"),
                         dismissable = false,
                         ok_callback = function()

--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -36,7 +36,7 @@ function ReaderDeviceStatus:init()
                     end
                     self.battery_confirm_box = ConfirmBox:new {
                         text = is_charging and T(_("High battery level: %1%\n\nDismiss battery level alert?"), battery_capacity)
-                                            or T(_("Low battery level: %1%\n\nDismiss battery level alert?"), battery_capacity)
+                                            or T(_("Low battery level: %1%\n\nDismiss battery level alert?"), battery_capacity),
                         ok_text = _("Dismiss"),
                         dismissable = false,
                         ok_callback = function()


### PR DESCRIPTION
If an alert is on the screen waiting for a user's interaction - close it before showing the new one.
Separate battery and memory alerts.
Closes https://github.com/koreader/koreader/issues/8081.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8086)
<!-- Reviewable:end -->
