### PR TITLE
Don't pass a NULL to SetSubtaskInfo

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -264,7 +264,7 @@ function PocketBook:notifyBookState(title, document)
         fo:write(fn)
         fo:close()
     end
-    inkview.SetSubtaskInfo(inkview.GetCurrentTask(), 0, title and (title .. " - koreader") or "koreader", fn or "[nil]")
+    inkview.SetSubtaskInfo(inkview.GetCurrentTask(), 0, title and (title .. " - koreader") or "koreader", fn or "")
 end
 
 function PocketBook:setDateTime(year, month, day, hour, min, sec)

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -264,7 +264,7 @@ function PocketBook:notifyBookState(title, document)
         fo:write(fn)
         fo:close()
     end
-    inkview.SetSubtaskInfo(inkview.GetCurrentTask(), 0, title and (title .. " - koreader") or "koreader", fn)
+    inkview.SetSubtaskInfo(inkview.GetCurrentTask(), 0, title and (title .. " - koreader") or "koreader", fn or "[nil]")
 end
 
 function PocketBook:setDateTime(year, month, day, hour, min, sec)


### PR DESCRIPTION
Fixes a blocking problem when closing Koreader on some older pocketbook devices : https://github.com/koreader/koreader/issues/8053#issuecomment-897496109

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8087)
<!-- Reviewable:end -->
