### PR TITLE
InputText: accurate handle hold, Clipboard empty hint

### DIFF
--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -54,6 +54,7 @@ local TextViewer = InputContainer:new{
 
     title_face = Font:getFace("x_smalltfont"),
     text_face = Font:getFace("x_smallinfofont"),
+    fgcolor = Blitbuffer.COLOR_BLACK,
     title_padding = Size.padding.default,
     title_margin = Size.margin.title,
     text_padding = Size.padding.large,
@@ -167,6 +168,7 @@ function TextViewer:init()
     self.scroll_text_w = ScrollTextWidget:new{
         text = self.text,
         face = self.text_face,
+        fgcolor = self.fgcolor,
         width = self.width - 2*self.text_padding - 2*self.text_margin,
         height = textw_height - 2*self.text_padding -2*self.text_margin,
         dialog = self,


### PR DESCRIPTION
(1) Before: when holding the input box in input dialogs for calling the Clipboard, hold release was passed to movable container and input dialog moved a little bit. Fixed.
(2) Before: empty clipboard title was **Clipboard (empty)**. Made consistent with input text hints.
(3) Now text color can be passed to the Text viewer.

<kbd>![1](https://user-images.githubusercontent.com/62179190/129720210-bc4d34df-1d27-4850-8c0e-4a657f752e5b.png)</kbd>

<kbd>![2](https://user-images.githubusercontent.com/62179190/129720219-b263f46b-5abb-4ca8-9660-afca61781128.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8091)
<!-- Reviewable:end -->
