### PR TITLE
Various fixes: footnotes, HTML dictionary, Button

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -729,9 +729,11 @@ This only works with footnotes that have specific attributes set by the publishe
                 -- Restrict this to non-FB2 documents, as FB2 can have <a type="note">
                 css = [[
 *[type~="note"],
+*[type~="endnote"],
 *[type~="footnote"],
 *[type~="rearnote"],
 *[role~="doc-note"],
+*[role~="doc-endnote"],
 *[role~="doc-footnote"],
 *[role~="doc-rearnote"]
 {
@@ -751,9 +753,11 @@ This only works with footnotes that have specific attributes set by the publishe
                 -- and we don't want to have them smaller
                 css = [[
 *[type~="note"],
+*[type~="endnote"],
 *[type~="footnote"],
 *[type~="rearnote"],
 *[role~="doc-note"],
+*[role~="doc-endnote"],
 *[role~="doc-footnote"],
 *[role~="doc-rearnote"]
 {

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -109,7 +109,11 @@ function Button:init()
                         bold = self.text_font_bold,
                         face = Font:getFace(self.text_font_face, font_size_2_lines)
                     }
-                    break
+                    if not self.label_widget.has_split_inside_word then
+                        break
+                    end
+                    -- No good wrap opportunity (split inside a word): ignore this TextBoxWidget
+                    -- and go on with a TextWidget with the smaller font size
                 end
                 if new_size < 8 then -- don't go too small
                     break

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -751,7 +751,18 @@ function DictQuickLookup:getHtmlDictionaryCss()
         blockquote, dd {
             margin: 0 1em;
         }
+
+        ol, ul, menu {
+            margin: 0; padding: 0 1.7em;
+        }
     ]]
+    -- For reference, MuPDF declarations with absolute units:
+    --  "blockquote{margin:1em 40px}"
+    --  "dd{margin:0 0 0 40px}"
+    --  "ol,ul,menu {margin:1em 0;padding:0 0 0 30pt}"
+    --  "hr{border-width:1px;}"
+    --  "td,th{padding:1px}"
+    --
     -- MuPDF doesn't currently scale CSS pixels, so we have to use a font-size based measurement.
     -- Unfortunately MuPDF doesn't properly support `rem` either, which it bases on a hard-coded
     -- value of `16px`, so we have to go with `em` (or `%`).
@@ -761,6 +772,11 @@ function DictQuickLookup:getHtmlDictionaryCss()
     -- We also keep left and right margin the same so it'll display as expected in RTL.
     -- Because MuPDF doesn't currently support `margin-start`, this results in a slightly
     -- unconventional but hopefully barely noticeable right margin for <dd>.
+    --
+    -- For <ul> and <ol>, bullets and numbers are displayed in the margin/padding, so
+    -- we need a bit more for them to not get truncated (1.7em allows for 2 digits list
+    -- item numbers). Unfortunately, because we want this also for RTL, this space is
+    -- wasted on the other side...
 
     if self.css then
         return css .. self.css


### PR DESCRIPTION
`Footnote popups/in-page: support type/role=endnote` closes #8033

`Dict: avoid list items bullet/digit truncation with HTML dicts` closes #7946

`Button: avoid cut words when switching to multilines` See https://github.com/koreader/koreader/pull/8078#issuecomment-899242126

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8092)
<!-- Reviewable:end -->
