### PR TITLE
Translator: add "Translate from book language" option

### DIFF
--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -113,6 +113,8 @@ for __, v in ipairs(LANGUAGES) do
         ReaderTypography.HYPH_DICT_NAME_TO_LANG_NAME_TAG[hyph_filename] = { lang_name, lang_tag }
     end
 end
+-- Make lang aliases available to other modules (can be used by Translator)
+ReaderTypography.LANG_ALIAS_TO_LANG_TAG = LANG_ALIAS_TO_LANG_TAG
 
 function ReaderTypography:init()
     self.menu_table = {}

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -220,7 +220,7 @@ function Translator:genSettingsMenu()
         sub_item_table = {
             {
                 text = _("Auto-detect source language"),
-                help_text = _("This setting is best suited for foreign sentences or text fragments found in books written in your native language."),
+                help_text = _("This setting is best suited for foreign text found in books written in your native language."),
                 enabled_func = function()
                     return not (G_reader_settings:isTrue("translator_from_doc_lang") and self:getDocumentLanguage() ~= nil)
                 end,
@@ -250,8 +250,8 @@ function Translator:genSettingsMenu()
                     return T(_("Translate from book language: %1"), name or _("N/A"))
                 end,
                 help_text = _([[
-With books that specify their main language in their metadata (most EPUBs and FB2s), enabling this option will make this language the source language (otherwise, auto-detection or the specified languages will be used).
-This is interesting:
+With books that specify their main language in their metadata (most EPUBs and FB2s), enabling this option will make this language the source language. Otherwise, auto-detection or the specified languages will be used.
+This is useful:
 - For books in a foreign language, where consistent translation is needed and words in other languages are rare.
 - For books in your native language, to get definitions for words from the translation service.]]),
                 enabled_func = function()

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -220,7 +220,7 @@ function Translator:genSettingsMenu()
         sub_item_table = {
             {
                 text = _("Auto-detect source language"),
-                help_text = _("Auto-detect language is best suited for foreign phrases or texts on books in your native language."),
+                help_text = _("This setting is best suited for foreign sentences or text fragments found in books written in your native language."),
                 enabled_func = function()
                     return not (G_reader_settings:isTrue("translator_from_doc_lang") and self:getDocumentLanguage() ~= nil)
                 end,
@@ -236,7 +236,7 @@ function Translator:genSettingsMenu()
                     local lang = G_reader_settings:readSetting("translator_from_language")
                     return T(_("Translate from: %1"), self:getLanguageName(lang, ""))
                 end,
-                help_text = _("Selecting a specific source language will have it used with all text on all your books."),
+                help_text = _("If a specific source language is manually selected, it will be used everywhere, in all your books."),
                 enabled_func = function()
                     return not G_reader_settings:nilOrTrue("translator_from_auto_detect")
                         and not (G_reader_settings:isTrue("translator_from_doc_lang") and self:getDocumentLanguage() ~= nil)
@@ -250,9 +250,9 @@ function Translator:genSettingsMenu()
                     return T(_("Translate from book language: %1"), name or _("N/A"))
                 end,
                 help_text = _([[
-With books that specify their main language in their metadata (most EPUBs), enabling this option will have this language used as the source language (otherwise, auto-detect or the specified languages will be used).
+With books that specify their main language in their metadata (most EPUBs), enabling this option will make this language the source language (otherwise, auto-detection or the specified languages will be used).
 This is interesting:
-- For books in your non-native language, where consistent translation is needed and foreign words are exceptional on the text.
+- For books in a foreign language, where consistent translation is needed and words in other languages are rare.
 - For books in your native language, to get definitions for words from the translation service.]]),
                 enabled_func = function()
                     return self:getDocumentLanguage() ~= nil

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -250,10 +250,10 @@ function Translator:genSettingsMenu()
                     return T(_("Translate from book language: %1"), name or _("N/A"))
                 end,
                 help_text = _([[
-With books that specify their main language in their metadata (most EPUBs and FB2s), enabling this option will make this language the source language. Otherwise, auto-detection or the specified languages will be used.
+With books that specify their main language in their metadata (most EPUBs and FB2s), enabling this option will make this language the source language. Otherwise, auto-detection or the selected language will be used.
 This is useful:
 - For books in a foreign language, where consistent translation is needed and words in other languages are rare.
-- For books in your native language, to get definitions for words from the translation service.]]),
+- For books in familiar languages, to get definitions for words from the translation service.]]),
                 enabled_func = function()
                     return self:getDocumentLanguage() ~= nil
                 end,

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -220,6 +220,7 @@ function Translator:genSettingsMenu()
         sub_item_table = {
             {
                 text = _("Auto-detect source language"),
+                help_text = _("Auto-detect language is best suited for foreign phrases or texts on books in your native language."),
                 enabled_func = function()
                     return not (G_reader_settings:isTrue("translator_from_doc_lang") and self:getDocumentLanguage() ~= nil)
                 end,
@@ -235,6 +236,7 @@ function Translator:genSettingsMenu()
                     local lang = G_reader_settings:readSetting("translator_from_language")
                     return T(_("Translate from: %1"), self:getLanguageName(lang, ""))
                 end,
+                help_text = _("Selecting a specific source language will have it used with all text on all your books."),
                 enabled_func = function()
                     return not G_reader_settings:nilOrTrue("translator_from_auto_detect")
                         and not (G_reader_settings:isTrue("translator_from_doc_lang") and self:getDocumentLanguage() ~= nil)
@@ -247,6 +249,11 @@ function Translator:genSettingsMenu()
                     local __, name = self:getDocumentLanguage()
                     return T(_("Translate from book language: %1"), name or _("N/A"))
                 end,
+                help_text = _([[
+With books that specify their main language in their metadata (most EPUBs), enabling this option will have this language used as the source language (otherwise, auto-detect or the specified languages will be used).
+This is interesting:
+- For books in your non-native language, where consistent translation is needed and foreign words are exceptional on the text.
+- For books in your native language, to get definitions for words from the translation service.]]),
                 enabled_func = function()
                     return self:getDocumentLanguage() ~= nil
                 end,

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -250,7 +250,7 @@ function Translator:genSettingsMenu()
                     return T(_("Translate from book language: %1"), name or _("N/A"))
                 end,
                 help_text = _([[
-With books that specify their main language in their metadata (most EPUBs), enabling this option will make this language the source language (otherwise, auto-detection or the specified languages will be used).
+With books that specify their main language in their metadata (most EPUBs and FB2s), enabling this option will make this language the source language (otherwise, auto-detection or the specified languages will be used).
 This is interesting:
 - For books in a foreign language, where consistent translation is needed and words in other languages are rare.
 - For books in your native language, to get definitions for words from the translation service.]]),


### PR DESCRIPTION
When enabled, if the book has some supported language tag in its metadata, use it as the source language. Otherwise,
fallback to the current settings (auto-detect or selected source language).
See https://github.com/koreader/koreader/issues/8063#issuecomment-899440719.
Closes #8063 (not exactly the solution requested, but simple and good enough).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8094)
<!-- Reviewable:end -->
