### PR TITLE
File search: add hold in search results

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -238,7 +238,7 @@ function FileSearcher:onMenuHold(item)
                 end,
             },
             {
-                text = _("Go to"),
+                text = _("Show folder"),
                 callback = function()
                     UIManager:close(self.results_dialog)
                     self.close_callback()


### PR DESCRIPTION
Currently we see filenames only.

<kbd>![1](https://user-images.githubusercontent.com/62179190/129892488-78d664db-0a52-4b43-b9e5-6a8cb14c7d32.png)</kbd>

Added hold action to show the full path. `Go to` on a file will open the folder with a focused file.

<kbd>![2](https://user-images.githubusercontent.com/62179190/129892648-3c6c8d2f-01e2-494d-b65c-56f7823dc210.png)</kbd>

<kbd>![3](https://user-images.githubusercontent.com/62179190/129892653-c601338e-8de3-45ca-9ab4-eb80f6f99c13.png)</kbd>

Minor optimization of the checkbutton code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8100)
<!-- Reviewable:end -->
