### PR TITLE
File browser, Path chooser: fix margin of the long folder name in the header

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -134,7 +134,7 @@ function FileManager:setupLayout()
     self.path_text = TextWidget:new{
         face = Font:getFace("xx_smallinfofont"),
         text = BD.directory(filemanagerutil.abbreviate(self.root_path)),
-        max_width = Screen:getWidth() - 2*Size.padding.small,
+        max_width = Screen:getWidth() - 2*Size.padding.large,
         truncate_left = true,
     }
 

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -729,7 +729,7 @@ function Menu:init()
         self.path_text = TextWidget:new{
             face = Font:getFace("xx_smallinfofont"),
             text = BD.directory(self.path),
-            max_width = self.inner_dimen.w - 2*Size.padding.small,
+            max_width = self.inner_dimen.w - 2*Size.padding.large,
             truncate_left = true,
         }
         path_text_container = CenterContainer:new{


### PR DESCRIPTION
A minor design fix: margins of the folder name in the header made consistent with other elements.

Before

<kbd>![1](https://user-images.githubusercontent.com/62179190/130013507-9a85818b-953a-45ed-b680-5313f7c031b5.png)</kbd>

<kbd>![2](https://user-images.githubusercontent.com/62179190/130013512-99e238f9-ee86-4702-a0a4-bdea3d17d88c.png)</kbd>

After

<kbd>![3](https://user-images.githubusercontent.com/62179190/130013520-71482062-d99b-4ec3-82f9-a198fa4ae371.png)</kbd>

<kbd>![4](https://user-images.githubusercontent.com/62179190/130013526-e4d9d0e7-f5eb-453a-9065-ba2083c5695c.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8103)
<!-- Reviewable:end -->
