### PR TITLE
Fix warmth settings on some android devices

### DIFF
--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -48,7 +48,8 @@ end
 
 function AndroidPowerD:setWarmth(warmth)
     self.fl_warmth = warmth
-    android.setScreenWarmth(warmth / self.warm_diff)
+    local new_warmth = math.floor(warmth * self.fl_warmth_max / 100)
+    android.setScreenWarmth(new_warmth)
 end
 
 function AndroidPowerD:getWarmth()


### PR DESCRIPTION
`warmth` is in `0-100` range, we need to scale it to `0-fl_warmth_max` range. 
closes #8070

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8104)
<!-- Reviewable:end -->
