### PR TITLE
ReadTimer: More QoL tweaks

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -183,7 +183,7 @@ function util.secondsToHClock(seconds, withoutSeconds, hmsFormat)
                 hours = string.format("%d", hours + 1)
             end
             if hours == "0" then
-                -- We can pptimize out the % 3600 since the branch ensures we're < than 3600
+                -- We can optimize out the % 3600 since the branch ensures we're < than 3600
                 mins = string.format("%d", round(seconds / 60))
                 if hmsFormat then
                     return T(_("%1m"), mins)

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -98,6 +98,11 @@ function util.gsplit(str, pattern, capture, capture_empty_entity)
     end)
 end
 
+-- Stupid helper for the duration stuff
+local function passthrough(n)
+    return n
+end
+
 --[[--
 Converts seconds to a clock string.
 
@@ -115,8 +120,8 @@ function util.secondsToClock(seconds, withoutSeconds)
             return "00:00:00"
         end
     else
-        local round = withoutSeconds and require("optmath").round or math.floor
-        local hours = string.format("%02d", math.floor(seconds / 3600))
+        local round = withoutSeconds and require("optmath").round or passthrough
+        local hours = string.format("%02d", seconds / 3600)
         local mins = string.format("%02d", round(seconds % 3600 / 60))
         if withoutSeconds then
             if mins == "60" then
@@ -126,7 +131,7 @@ function util.secondsToClock(seconds, withoutSeconds)
             end
             return hours .. ":" .. mins
         else
-            local secs = string.format("%02d", math.floor(seconds % 60))
+            local secs = string.format("%02d", seconds % 60)
             return hours .. ":" .. mins .. ":" .. secs
         end
     end
@@ -168,14 +173,14 @@ function util.secondsToHClock(seconds, withoutSeconds, hmsFormat)
             end
         else
             if hmsFormat then
-                return T(_("%1m%2s"), "0", string.format("%02d", math.floor(seconds)))
+                return T(_("%1m%2s"), "0", string.format("%02d", seconds))
             else
                 return "0'" .. string.format("%02d", seconds) .. "''"
             end
         end
     else
-        local round = withoutSeconds and require("optmath").round or math.floor
-        local hours = string.format("%d", math.floor(seconds / 3600))
+        local round = withoutSeconds and require("optmath").round or passthrough
+        local hours = string.format("%d", seconds / 3600)
         local mins = string.format("%02d", round(seconds % 3600 / 60))
         if withoutSeconds then
             if mins == "60" then
@@ -194,7 +199,7 @@ function util.secondsToHClock(seconds, withoutSeconds, hmsFormat)
             -- @translators This is the 'h' for hour, like in 1h30. This is a duration.
             return T(_("%1h%2"), hours, mins)
         else
-            local secs = string.format("%02d", math.floor(seconds % 60))
+            local secs = string.format("%02d", seconds % 60)
             if hours == "0" then
                 mins = string.format("%d", round(seconds / 60))
                 if hmsFormat then

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -433,7 +433,7 @@ function ListMenuItem:update()
                         pages_str = T(_("%1, %2 to read"), pages_str, Math.round(pages-percent_finished*pages), pages)
                     end
                 else
-                    pages_str = string.format("%d %%", math.floor(100*percent_finished))
+                    pages_str = string.format("%d %%", 100*percent_finished)
                 end
             else
                 if pages then

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -93,6 +93,7 @@ function ReadTimer:addToMainMenu(menu_items)
                             local then_t = now_t
                             then_t.hour = time.hour
                             then_t.min = time.min
+                            then_t.sec = 0
                             local seconds = os.difftime(os.time(then_t), os.time())
                             if seconds > 0 then
                                 self.time = os.time() + seconds

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -104,7 +104,7 @@ function ReadTimer:addToMainMenu(menu_items)
                                 self:rescheduleIn(seconds)
                                 local user_duration_format = G_reader_settings:readSetting("duration_format")
                                 UIManager:show(InfoMessage:new{
-                                    text = T(_("Timer set to: %1:%2.\n\nThat's %3 from now."),
+                                    text = T(_("Timer set for %1:%2.\n\nThat's %3 from now."),
                                         string.format("%02d", time.hour), string.format("%02d", time.min),
                                         util.secondsToClockDuration(user_duration_format, seconds, false)),
                                     timeout = 5,
@@ -147,7 +147,7 @@ function ReadTimer:addToMainMenu(menu_items)
                                 self:rescheduleIn(seconds)
                                 local user_duration_format = G_reader_settings:readSetting("duration_format")
                                 UIManager:show(InfoMessage:new{
-                                    text = T(_("Timer set for %1."),
+                                    text = T(_("Timer will expire in %1."),
                                              util.secondsToClockDuration(user_duration_format, seconds, true)),
                                     timeout = 5,
                                 })

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -175,7 +175,7 @@ function ReadTimer:addToMainMenu(menu_items)
     }
 end
 
--- The UI ticks on a monotonic time domain, while this plugin deals with REAL wall clock time.
+-- The UI ticks on a MONOTONIC time domain, while this plugin deals with REAL wall clock time.
 function ReadTimer:onResume()
     if self:scheduled() then
         logger.dbg("ReadTimer: onResume with an active timer")

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -175,7 +175,7 @@ function ReadTimer:addToMainMenu(menu_items)
     }
 end
 
--- The UI ticks on a monotonic time domain, while this plugin deals with real time.
+-- The UI ticks on a monotonic time domain, while this plugin deals with REAL wall clock time.
 function ReadTimer:onResume()
     if self:scheduled() then
         logger.dbg("ReadTimer: onResume with an active timer")

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -82,7 +82,6 @@ function ReadTimer:addToMainMenu(menu_items)
                     local now_t = os.date("*t")
                     local curr_hour = now_t.hour
                     local curr_min = now_t.min
-                    local curr_sec_from_midnight = curr_hour*3600 + curr_min*60
                     local time_widget = TimeWidget:new{
                         hour = curr_hour,
                         min = curr_min,
@@ -91,26 +90,23 @@ function ReadTimer:addToMainMenu(menu_items)
                         callback = function(time)
                             touchmenu_instance:closeMenu()
                             self:unschedule()
-                            local timer_sec_from_mignight = time.hour*3600 + time.min*60
-                            local seconds
-                            if timer_sec_from_mignight > curr_sec_from_midnight then
-                                seconds = timer_sec_from_mignight - curr_sec_from_midnight
-                            else
-                                seconds = 24*3600 - (curr_sec_from_midnight - timer_sec_from_mignight)
-                            end
-                            if seconds > 0 and seconds < 18*3600 then
+                            local then_t = now_t
+                            then_t.hour = time.hour
+                            then_t.min = time.min
+                            local seconds = os.difftime(os.time(then_t), os.time())
+                            if seconds > 0 then
                                 self.time = os.time() + seconds
                                 UIManager:scheduleIn(seconds, self.alarm_callback)
                                 local user_duration_format = G_reader_settings:readSetting("duration_format")
                                 UIManager:show(InfoMessage:new{
                                     text = T(_("Timer set to: %1:%2.\n\nThat's %3 from now."),
                                         string.format("%02d", time.hour), string.format("%02d", time.min),
-                                        util.secondsToClockDuration(user_duration_format, seconds, true)),
+                                        util.secondsToClockDuration(user_duration_format, seconds, false)),
                                     timeout = 5,
                                 })
-                            elseif seconds <= 0 or seconds >= 18*3600 then
+                            else
                                 UIManager:show(InfoMessage:new{
-                                    text = _("Timer could not be set. The selected time is in the past or too far in the future."),
+                                    text = _("Timer could not be set. The selected time is in the past."),
                                     timeout = 5,
                                 })
                             end

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -198,20 +198,16 @@ function ReadTimer:onResume()
             -- (This would be much simpler if we didn't have legacy constraints preventing us from using BOOTTIME...).
             local sleep_duration = os.difftime(os.time(), self.sleepy_time)
             local expiry = os.difftime(remainder, sleep_duration)
-            logger.dbg("ReadTimer: Slept for ", sleep_duration, " seconds")
-            logger.dbg("ReadTimer: With ", remainder, " seconds left in the timer")
+            logger.dbg("ReadTimer: Slept for", sleep_duration, "seconds")
+            logger.dbg("ReadTimer: With", remainder, "seconds left in the timer")
 
             self:unschedule()
             if expiry > 0 then
-                logger.dbg("ReadTimer: Rescheduling in ", expiry)
+                logger.dbg("ReadTimer: Rescheduling in", expiry, "seconds")
                 UIManager:scheduleIn(expiry, self.alarm_callback)
             end
         end
 
-    end
-    if self:remainingMinutes() == 0 then
-        self:alarm_callback()
-        self:unschedule()
     end
 end
 

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -104,6 +104,7 @@ function ReadTimer:addToMainMenu(menu_items)
                                 self:rescheduleIn(seconds)
                                 local user_duration_format = G_reader_settings:readSetting("duration_format")
                                 UIManager:show(InfoMessage:new{
+                                    -- @translators %1:%2 is a clock time (HH:MM), %3 is a duration
                                     text = T(_("Timer set for %1:%2.\n\nThat's %3 from now."),
                                         string.format("%02d", time.hour), string.format("%02d", time.min),
                                         util.secondsToClockDuration(user_duration_format, seconds, false)),
@@ -147,6 +148,7 @@ function ReadTimer:addToMainMenu(menu_items)
                                 self:rescheduleIn(seconds)
                                 local user_duration_format = G_reader_settings:readSetting("duration_format")
                                 UIManager:show(InfoMessage:new{
+                                    -- @translators This is a duration
                                     text = T(_("Timer will expire in %1."),
                                              util.secondsToClockDuration(user_duration_format, seconds, true)),
                                     timeout = 5,

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -60,6 +60,11 @@ function ReadTimer:unschedule()
     end
 end
 
+function ReadTimer:rescheduleIn(seconds)
+    self.time = os.time() + seconds
+    UIManager:scheduleIn(seconds, self.alarm_callback)
+end
+
 function ReadTimer:addToMainMenu(menu_items)
     menu_items.read_timer = {
         text_func = function()
@@ -96,8 +101,7 @@ function ReadTimer:addToMainMenu(menu_items)
                             then_t.sec = 0
                             local seconds = os.difftime(os.time(then_t), os.time())
                             if seconds > 0 then
-                                self.time = os.time() + seconds
-                                UIManager:scheduleIn(seconds, self.alarm_callback)
+                                self:rescheduleIn(seconds)
                                 local user_duration_format = G_reader_settings:readSetting("duration_format")
                                 UIManager:show(InfoMessage:new{
                                     text = T(_("Timer set to: %1:%2.\n\nThat's %3 from now."),
@@ -140,8 +144,7 @@ function ReadTimer:addToMainMenu(menu_items)
                             self:unschedule()
                             local seconds = time.hour * 3600 + time.min * 60
                             if seconds > 0 then
-                                self.time = os.time() + seconds
-                                UIManager:scheduleIn(seconds, self.alarm_callback)
+                                self:rescheduleIn(seconds)
                                 local user_duration_format = G_reader_settings:readSetting("duration_format")
                                 UIManager:show(InfoMessage:new{
                                     text = T(_("Timer set for %1."),
@@ -201,7 +204,7 @@ function ReadTimer:onResume()
             self:unschedule()
             if expiry > 0 then
                 logger.dbg("ReadTimer: Rescheduling in", expiry, "seconds")
-                UIManager:scheduleIn(expiry, self.alarm_callback)
+                self:rescheduleIn(expiry)
             end
         end
 


### PR DESCRIPTION
Re: #8106 

* Cleanup util.secondsFrom*Clock stuff (simpler maths, tail calls, meaningful printf tokens).
* Use util.secondsToClockDuration in ReadTimer instead of reinventing the wheel three different ways.
* Reschedule unexpired timers properly on resume (as best as we can, given the unreliable nature of REALTIME).
* Make clock timers tick on the dot, instead of at the same second as when being set.
* Speaking of clock timers, leave the math to os.date & os.time, don't reinvent the wheel yet again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8107)
<!-- Reviewable:end -->
