### PR TITLE
[plugin] OPDS: prevent crash if link.type is nil

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -440,7 +440,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url, username, passwo
         item.acquisitions = {}
         if entry.link then
             for _, link in ipairs(entry.link) do
-                if link.type:find(self.catalog_type)
+                if link.type and link.type:find(self.catalog_type)
                         and (not link.rel
                              or link.rel == "subsection"
                              or link.rel == "http://opds-spec.org/subsection"


### PR DESCRIPTION
It can happen… somewhere, while clicking around http://arxiv.maplepop.com/catalog a bit. (The magical crash/bug finder from <https://github.com/koreader/koreader/issues/3023>.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8111)
<!-- Reviewable:end -->
