### PR TITLE
 Fix link for Portuguese dictionary “Dicionário Aberto”

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -88,7 +88,7 @@ local dictionaries = {
         lang_out = "Portuguese",
         entries = 128521,
         license = _("CC-BY-SA 2.5"),
-        url = "http://www.dicionario-aberto.net/stardict-DicAberto.tar.bz2",
+        url = "http://dicionario-aberto.net/resources/stardict-DicAberto.tar.bz2",
     },
     {
         name = "GNU/FDL Anglicko/Český slovník",

--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -88,7 +88,7 @@ local dictionaries = {
         lang_out = "Portuguese",
         entries = 128521,
         license = _("CC-BY-SA 2.5"),
-        url = "http://dicionario-aberto.net/resources/stardict-DicAberto.tar.bz2",
+        url = "http://www.dicionario-aberto.net/resources/stardict-DicAberto.tar.bz2",
     },
     {
         name = "GNU/FDL Anglicko/Český slovník",


### PR DESCRIPTION
Current link causes “could not save file to” error and just redirects to https://dicionario-aberto.net 's main page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8118)
<!-- Reviewable:end -->
