### PR TITLE
Android Onyx Boox Warmth toggle fixes

### DIFF
--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -1,5 +1,6 @@
 local BasePowerD = require("device/generic/powerd")
 local _, android = pcall(require, "android")
+local device_model = android.prop.product
 
 local AndroidPowerD = BasePowerD:new{
     fl_min = 0,
@@ -69,7 +70,11 @@ function AndroidPowerD:turnOffFrontlightHW()
         return
     end
     android.setScreenBrightness(self.fl_min)
-    android.setScreenWarmth(self.fl_warmth_min)
+
+    if device_model == "kon_tiki2" then
+        android.setScreenWarmth(self.fl_warmth_min)
+    end
+
     self.is_fl_on = false
     broadcastLightChanges()
 end
@@ -82,7 +87,10 @@ function AndroidPowerD:turnOnFrontlightHW()
     android.enableFrontlightSwitch()
 
     android.setScreenBrightness(math.floor(self.fl_intensity * self.bright_diff / self.fl_max))
-    android.setScreenWarmth(math.floor(self.fl_warmth * self.fl_warmth_max / 100))
+
+    if device_model == "kon_tiki2" then
+        android.setScreenWarmth(math.floor(self.fl_warmth * self.fl_warmth_max / 100))
+    end
 
     self.is_fl_on = true
     broadcastLightChanges()

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -71,7 +71,7 @@ function AndroidPowerD:turnOffFrontlightHW()
     end
     android.setScreenBrightness(self.fl_min)
 
-    if device_model == "kon_tiki2" then
+    if device_model == "kon_tiki2" then -- for Onyx Boox Kon-Tiki 2 only
         android.setScreenWarmth(self.fl_warmth_min)
     end
 
@@ -88,7 +88,7 @@ function AndroidPowerD:turnOnFrontlightHW()
 
     android.setScreenBrightness(math.floor(self.fl_intensity * self.bright_diff / self.fl_max))
 
-    if device_model == "kon_tiki2" then
+    if device_model == "kon_tiki2" then -- for Onyx Boox Kon-Tiki 2 only
         android.setScreenWarmth(math.floor(self.fl_warmth * self.fl_warmth_max / 100))
     end
 

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -20,7 +20,7 @@ function AndroidPowerD:frontlightIntensityHW()
 end
 
 function AndroidPowerD:setIntensityHW(intensity)
-    -- if frontlight switch was toggled of, turn it on
+    -- if frontlight switch was toggled off, turn it on
     android.enableFrontlightSwitch()
 
     self.fl_intensity = intensity

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -21,7 +21,7 @@ function AndroidPowerD:frontlightIntensityHW()
 end
 
 function AndroidPowerD:setIntensityHW(intensity)
-    -- if frontlight switch was toggled off, turn it on
+    -- If the frontlight switch was off, turn it on.
     android.enableFrontlightSwitch()
 
     self.fl_intensity = intensity

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -69,6 +69,7 @@ function AndroidPowerD:turnOffFrontlightHW()
         return
     end
     android.setScreenBrightness(self.fl_min)
+    android.setScreenWarmth(self.fl_warmth_min)
     self.is_fl_on = false
     broadcastLightChanges()
 end
@@ -81,6 +82,7 @@ function AndroidPowerD:turnOnFrontlightHW()
     android.enableFrontlightSwitch()
 
     android.setScreenBrightness(math.floor(self.fl_intensity * self.bright_diff / self.fl_max))
+    android.setScreenWarmth(math.floor(self.fl_warmth * self.fl_warmth_max / 100))
 
     self.is_fl_on = true
     broadcastLightChanges()


### PR DESCRIPTION
Turn off Warmth too when Frontlight is toggled to OFF. Then return it too, when it is triggered ON (default bottom-left corner tap).

@Galunid
@zwim 
Can you please have a look? It works on my Onyx Boox Kon-Tiki 2, but I don't know whether I broke something on your devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8120)
<!-- Reviewable:end -->
