### PR TITLE
WebDAV: Handle non-self-closing tag for empty collection

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -116,6 +116,9 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
             end
             local is_current_dir = self:isCurrentDirectory( item_fullpath, address, path )
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
+            local is_not_collection = item:find("<[^:]*:resourcetype/>") or
+                item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
+
             local item_path = path .. "/" .. item_name
             if item:find("<[^:]*:collection/>") then
                 item_name = item_name .. "/"
@@ -126,7 +129,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
                         type = "folder",
                     })
                 end
-            elseif item:find("<[^:]*:resourcetype/>") and (DocumentRegistry:hasProvider(item_name)
+            elseif is_not_collection and (DocumentRegistry:hasProvider(item_name)
                 or G_reader_settings:isTrue("show_unsupported")) then
                 table.insert(webdav_file, {
                     text = item_name,


### PR DESCRIPTION
Some servers serve <D:resourcetype></D:resourcetype> rather
than <D:resourcetype/>. So handle this case when deciding
if an item is not a collection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8121)
<!-- Reviewable:end -->
