### PR TITLE
Kindle: don't kill kb service on start

### DIFF
--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -65,7 +65,7 @@ USED_WMCTRL="no"
 PASSCODE_DISABLED="no"
 
 # List of services we stop in order to reclaim a tiny sliver of RAM...
-TOGGLED_SERVICES="stored kb webreader kfxreader kfxview todo tmd rcm archive scanner otav3 otaupd"
+TOGGLED_SERVICES="stored webreader kfxreader kfxview todo tmd rcm archive scanner otav3 otaupd"
 
 REEXEC_FLAGS=""
 # Keep track of if we were started through KUAL


### PR DESCRIPTION
https://github.com/koreader/koreader/pull/6233#issuecomment-903300554
Tested on my Voyage with KOL 1.1, very nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8122)
<!-- Reviewable:end -->
