### PR TITLE
Add slash to WebDAV starting URL if missing

### DIFF
--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -126,6 +126,14 @@ The start folder is appended to the server path.]])
                     text = text_button_ok,
                     callback = function()
                         local fields = MultiInputDialog:getFields()
+
+                        -- make sure the URL is a valid path
+                        if fields[5] ~= "" then
+                            if string.sub(fields[5], 1, 1) ~= '/' then
+                                fields[5] = '/' .. fields[5]
+                            end
+                        end
+
                         if fields[1] ~= "" and fields[2] ~= "" then
                             if item then
                                 -- edit

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -161,6 +161,7 @@ end
 
 function WebDavApi:downloadFile(file_url, user, pass, local_path)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+    logger.dbg("WebDavApi: downloading file: ", file_url)
     local code, _, status = socket.skip(1, http.request{
         url      = file_url,
         method   = "GET",


### PR DESCRIPTION
If this is not done, the URL when the file is downloaded will be
something like hostdir/path, rather than host/dir/path.

Also add a debug log to make it more clear when a bogus URL
is being fetched,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8137)
<!-- Reviewable:end -->
