### PR TITLE
WebDAV: Unescape XML entities when reading the item list

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -115,7 +115,10 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
                 item_fullpath = string.sub( item_fullpath, 1, -2 )
             end
             local is_current_dir = self:isCurrentDirectory( item_fullpath, address, path )
+
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
+            item_name = util.htmlEntitiesToUtf8(item_name)
+
             local is_not_collection = item:find("<[^:]*:resourcetype/>") or
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
 


### PR DESCRIPTION
Without this, a file named `A & B.epub` is read as `A &amp; B.pdf`
and will 404 when fetched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8138)
<!-- Reviewable:end -->
