### PR TITLE
change "full" to "best" (kerning info)

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -610,7 +610,7 @@ If a font variation is not available, as well as for fractional adjustments, it 
 
 - off: no kerning.
 - fast: use FreeType's kerning implementation (no ligatures).
-- good: use HarfBuzz's light kerning implementation (faster than full but no ligatures and limited support for non-western scripts)
+- good: use HarfBuzz's light kerning implementation (faster than best but no ligatures and limited support for non-western scripts)
 - best: use HarfBuzz's full kerning implementation (slower, but may support ligatures with some fonts; also needed to properly display joined arabic glyphs and some other scripts).
 
 (Font Hinting may need to be adjusted for the best result with either kerning implementation.)]]),


### PR DESCRIPTION
I guess `full` was in one of the old iterations. Might affect translations though

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8141)
<!-- Reviewable:end -->
