### PR TITLE
Virtual keyboard: default layout, compact mode

### DIFF
--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -111,11 +111,11 @@ local sub_item_table = {
     },
 }
 
-local layouts_number = 0
+local selected_layouts_count = 0
 local _keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
 for k, __ in FFIUtil.orderedPairs(VirtualKeyboard.lang_to_keyboard_layout) do
     if _keyboard_layouts[k] == true then
-        layouts_number = layouts_number + 1
+        selected_layouts_count = selected_layouts_count + 1
     end
     table.insert(sub_item_table[1].sub_item_table, {
         text_func = function()
@@ -133,11 +133,11 @@ for k, __ in FFIUtil.orderedPairs(VirtualKeyboard.lang_to_keyboard_layout) do
             local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
             if keyboard_layouts[k] == true then
                 keyboard_layouts[k] = false
-                layouts_number = layouts_number - 1
+                selected_layouts_count = selected_layouts_count - 1
             else
-                if layouts_number < 4 then
+                if selected_layouts_count < 4 then
                     keyboard_layouts[k] = true
-                    layouts_number = layouts_number + 1
+                    selected_layouts_count = selected_layouts_count + 1
                 else -- no more space in the 'globe' popup
                     UIManager:show(require("ui/widget/infomessage"):new{
                         text = _("Up to 4 layouts can be enabled."),

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -140,7 +140,7 @@ for k, __ in FFIUtil.orderedPairs(VirtualKeyboard.lang_to_keyboard_layout) do
                     selected_layouts_count = selected_layouts_count + 1
                 else -- no more space in the 'globe' popup
                     UIManager:show(require("ui/widget/infomessage"):new{
-                        text = _("Up to 4 layouts can be enabled."),
+                        text = _("Up to four layouts can be enabled."),
                         timeout = 2,
                     })
                     return

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -8,12 +8,22 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local VirtualKeyboard = require("ui/widget/virtualkeyboard")
 local _ = require("gettext")
 
-local input_dialog, check_button_bold, check_button_border
+local input_dialog, check_button_bold, check_button_border, check_button_compact
 
 local sub_item_table = {
     {
         text = _("Keyboard layout"),
         sub_item_table = {},
+    },
+    {
+        text = _("Remember last layout"),
+        checked_func = function()
+            return G_reader_settings:nilOrTrue("keyboard_remember_layout")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrTrue("keyboard_remember_layout")
+        end,
+        separator = true,
     },
     {
         text = _("Keyboard font size"),
@@ -40,6 +50,7 @@ local sub_item_table = {
                                     G_reader_settings:saveSetting("keyboard_key_font_size", font_size)
                                     G_reader_settings:saveSetting("keyboard_key_bold", check_button_bold.checked)
                                     G_reader_settings:saveSetting("keyboard_key_border", check_button_border.checked)
+                                    G_reader_settings:saveSetting("keyboard_key_compact", check_button_compact.checked)
                                     input_dialog._input_widget:onCloseKeyboard()
                                     input_dialog._input_widget:initKeyboard()
                                     input_dialog:onShowKeyboard()
@@ -69,6 +80,15 @@ local sub_item_table = {
                     check_button_border:toggleCheck()
                 end,
             }
+            check_button_compact = CheckButton:new{
+                text = _("compact"),
+                checked = G_reader_settings:isTrue("keyboard_key_compact"),
+                parent = input_dialog,
+                max_width = input_dialog._input_widget.width,
+                callback = function()
+                    check_button_compact:toggleCheck()
+                end,
+            }
 
             local checkbox_shift = math.floor((input_dialog.width - input_dialog._input_widget.width) / 2 + 0.5)
             local check_buttons = HorizontalGroup:new{
@@ -77,6 +97,7 @@ local sub_item_table = {
                     align = "left",
                     check_button_bold,
                     check_button_border,
+                    check_button_compact,
                 },
             }
 
@@ -90,11 +111,16 @@ local sub_item_table = {
     },
 }
 
-for k, _ in FFIUtil.orderedPairs(VirtualKeyboard.lang_to_keyboard_layout) do
+local layouts_number = 0
+local _keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
+for k, __ in FFIUtil.orderedPairs(VirtualKeyboard.lang_to_keyboard_layout) do
+    if _keyboard_layouts[k] == true then
+        layouts_number = layouts_number + 1
+    end
     table.insert(sub_item_table[1].sub_item_table, {
         text_func = function()
             local text = Language:getLanguageName(k)
-            if VirtualKeyboard:getKeyboardLayout() == k then
+            if G_reader_settings:readSetting("keyboard_layout_default") == k then
                 text = text .. "   ★"
             end
             return text
@@ -105,11 +131,25 @@ for k, _ in FFIUtil.orderedPairs(VirtualKeyboard.lang_to_keyboard_layout) do
         end,
         callback = function()
             local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
-            keyboard_layouts[k] = not keyboard_layouts[k]
+            if keyboard_layouts[k] == true then
+                keyboard_layouts[k] = false
+                layouts_number = layouts_number - 1
+            else
+                if layouts_number < 4 then
+                    keyboard_layouts[k] = true
+                    layouts_number = layouts_number + 1
+                else -- no more space in the 'globe' popup
+                    UIManager:show(require("ui/widget/infomessage"):new{
+                        text = _("Up to 4 layouts can be enabled."),
+                        timeout = 2,
+                    })
+                    return
+                end
+            end
             G_reader_settings:saveSetting("keyboard_layouts", keyboard_layouts)
         end,
         hold_callback = function(touchmenu_instance)
-            G_reader_settings:saveSetting("keyboard_layout", k)
+            G_reader_settings:saveSetting("keyboard_layout_default", k)
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -63,12 +63,12 @@ function KeyboardLayoutDialog:init()
     local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
     self.keyboard_state.force_current_layout = true
     for k, _ in FFIUtil.orderedPairs(self.parent.keyboard.lang_to_keyboard_layout) do
-        local text = Language:getLanguageName(k)
+        local text = Language:getLanguageName(k) .. "  (" .. string.sub(k, 1, 2) .. ")"
         if keyboard_layouts[k] == true then
-            text = text .. " ✓"
+            text = text .. "  ✓"
         end
         if k == G_reader_settings:readSetting("keyboard_layout_default") then
-            text = text .. " ★"
+            text = text .. "  ★"
         end
         table.insert(radio_buttons, {
             {

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -58,15 +58,26 @@ function KeyboardLayoutDialog:init()
 
     local buttons = {}
     local radio_buttons = {}
+
+    local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
+    G_reader_settings:makeTrue("keyboard_force_current_layout")
     for k, _ in FFIUtil.orderedPairs(self.parent.keyboard.lang_to_keyboard_layout) do
+        local text = Language:getLanguageName(k)
+        if keyboard_layouts[k] == true then
+            text = "✓ " .. text
+        end
+        if k == G_reader_settings:readSetting("keyboard_layout_default") then
+            text = text .. "   ★"
+        end
         table.insert(radio_buttons, {
             {
-            text = Language:getLanguageName(k),
+            text = text,
             checked = self.parent.keyboard:getKeyboardLayout() == k,
             provider = k,
             },
         })
     end
+    G_reader_settings:delSetting("keyboard_force_current_layout")
 
     table.insert(buttons, {
         {

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -27,6 +27,7 @@ local KeyboardLayoutDialog = InputContainer:new{
     title = _("Keyboard layout"),
     modal = true,
     stop_events_propagation = true,
+    keyboard_state = nil,
     width = math.floor(Screen:getWidth() * 0.8),
     face = Font:getFace("cfont", 22),
     title_face = Font:getFace("x_smalltfont"),
@@ -60,14 +61,14 @@ function KeyboardLayoutDialog:init()
     local radio_buttons = {}
 
     local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
-    G_reader_settings:makeTrue("keyboard_force_current_layout")
+    self.keyboard_state.force_current_layout = true
     for k, _ in FFIUtil.orderedPairs(self.parent.keyboard.lang_to_keyboard_layout) do
         local text = Language:getLanguageName(k)
         if keyboard_layouts[k] == true then
-            text = "✓ " .. text
+            text = text .. " ✓"
         end
         if k == G_reader_settings:readSetting("keyboard_layout_default") then
-            text = text .. "   ★"
+            text = text .. " ★"
         end
         table.insert(radio_buttons, {
             {
@@ -77,7 +78,7 @@ function KeyboardLayoutDialog:init()
             },
         })
     end
-    G_reader_settings:delSetting("keyboard_force_current_layout")
+    self.keyboard_state.force_current_layout = false
 
     table.insert(buttons, {
         {

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -797,14 +797,12 @@ function VirtualKeyboard:init()
 end
 
 function VirtualKeyboard:getKeyboardLayout()
-    local lang
-    if G_reader_settings:nilOrTrue("keyboard_remember_layout") or keyboard_state.force_current_layout then
-        lang = G_reader_settings:readSetting("keyboard_layout")
-    else
-        lang = G_reader_settings:readSetting("keyboard_layout_default")
+    if G_reader_settings:isFalse("keyboard_remember_layout") and not keyboard_state.force_current_layout then
+        local lang = G_reader_settings:readSetting("keyboard_layout_default")
+            or G_reader_settings:readSetting("keyboard_layout")
         G_reader_settings:saveSetting("keyboard_layout", lang)
     end
-    return lang or G_reader_settings:readSetting("language")
+    return G_reader_settings:readSetting("keyboard_layout") or G_reader_settings:readSetting("language")
 end
 
 function VirtualKeyboard:setKeyboardLayout(layout)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -799,7 +799,7 @@ end
 function VirtualKeyboard:getKeyboardLayout()
     if G_reader_settings:isFalse("keyboard_remember_layout") and not keyboard_state.force_current_layout then
         local lang = G_reader_settings:readSetting("keyboard_layout_default")
-            or G_reader_settings:readSetting("keyboard_layout")
+            or G_reader_settings:readSetting("keyboard_layout") or "en"
         G_reader_settings:saveSetting("keyboard_layout", lang)
     end
     return G_reader_settings:readSetting("keyboard_layout") or G_reader_settings:readSetting("language")

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -26,7 +26,7 @@ local util = require("util")
 local Screen = Device.screen
 
 local keyboard_state = {
-    force_current_layout = false,
+    force_current_layout = false, -- Set to true to get/set current layout (instead of default layout)
 }
 
 local VirtualKeyPopup
@@ -806,7 +806,6 @@ function VirtualKeyboard:getKeyboardLayout()
 end
 
 function VirtualKeyboard:setKeyboardLayout(layout)
-    -- Save this flag for the case of 'Keyboard height change' that causes keyboard re-init
     keyboard_state.force_current_layout = true
     local prev_keyboard_height = self.dimen and self.dimen.h
     G_reader_settings:saveSetting("keyboard_layout", layout)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -65,11 +65,12 @@ function VirtualKey:init()
         self.key_chars = self:genkeyboardLayoutKeyChars()
         self.callback = function ()
             local current = G_reader_settings:readSetting("keyboard_layout")
+            local default = G_reader_settings:readSetting("keyboard_layout_default")
             local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
             local enabled = false
             local next_layout = nil
-            if not keyboard_layouts[current] then
-                next_layout = G_reader_settings:readSetting("keyboard_layout_default")
+            if not keyboard_layouts[current] and current ~= default then
+                next_layout = default
             end
             if not next_layout then
                 for k, v in FFIUtil.orderedPairs(keyboard_layouts) do


### PR DESCRIPTION
Legend:
KLM - main menu item `Keyboard layout` (with checkboxes)
KLD - KeyboardLayoutDialog (with radiobuttons)

Changes:

(1) KLM: limit the number of enabled layouts to 4.
Because of lack of space in the "globe" popup.

<kbd>![1](https://user-images.githubusercontent.com/62179190/131209388-2da69062-0b2a-4e70-bb49-d5a7e3dbf260.png)</kbd>

(2) KLM: long-press the layout to set it as "default".
Every new keyboard will be opened with "default" layout (except hide/show keyboard with a tap outside of input box).
Checkbox `Remember last layout`, default state: checked.

<kbd>![2](https://user-images.githubusercontent.com/62179190/131209394-029fbbeb-a36d-4f34-b103-3f98fcdfbf5c.png)</kbd>

(3) "Globe" button: tap remains enabled after selecting a layout via KLD.
If selected layout is enabled, a tap switches to the next enabled layout.
If selected layout is not enabled, a tap switches to the default layout
(if the deafult is not set - to the next (alphabatically) enabled layout).

(4) KLD: show marks for enabled and default layouts.
Just for information, cannot be toggled here (do it in KLM).

<kbd>![3](https://user-images.githubusercontent.com/62179190/131209401-09ad120d-ef04-4f81-81e9-80888cdbc391.png)</kbd>

(5) Compact keyboard

<kbd>![4](https://user-images.githubusercontent.com/62179190/131209406-dddd0645-b094-4731-8c28-2262bff823dc.png)</kbd>

Closes https://github.com/koreader/koreader/issues/8133.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8142)
<!-- Reviewable:end -->
