### PR TITLE
Fixes and changes to newsdownloader.koplugin

### DIFF
--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -33,9 +33,8 @@ return {--do NOT change this line
 
  -- LIST YOUR FEEDS HERE:
 
- { "https://ourworldindata.org/atom.xml", limit = 2, download_full_article=true, include_images=true, enable_filter=true},
- { "https://hnrss.org/bestcomments", limit = 10, download_full_article=true, include_images=false},
- { "https://www.pcworld.com/index.rss", limit = 7 , download_full_article=false},
+ { "https://github.com/koreader/koreader/releases.atom", limit = 3, download_full_article=true, include_images=false},
+ { "https://github.com/koreader/koreader/commits/master.atom", limit = 3 , download_full_article=false},
 
 -- { "http://www.football.co.uk/international/rss.xml", limit = 2},
 

--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -33,9 +33,7 @@ return {--do NOT change this line
 
  -- LIST YOUR FEEDS HERE:
 
- { "https://github.com/koreader/koreader/releases.atom", limit = 3, download_full_article=true, include_images=false},
- { "https://github.com/koreader/koreader/commits/master.atom", limit = 3 , download_full_article=false},
-
--- { "http://www.football.co.uk/international/rss.xml", limit = 2},
+ { "https://github.com/koreader/koreader/releases.atom", limit = 3, download_full_article=true, include_images=false, enable_filter=true, filter_element = "div.release-main-section"},
+ { "https://ourworldindata.org/atom.xml", limit = 5 , download_full_article=true, include_images=true, enable_filter=false, filter_element = ""},
 
 }--do NOT change this line

--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -33,7 +33,7 @@ return {--do NOT change this line
 
  -- LIST YOUR FEEDS HERE:
 
- { "http://feeds.reuters.com/Reuters/worldNews?format=xml", limit = 2, download_full_article=true, include_images=true, enable_filter=true},
+ { "https://ourworldindata.org/atom.xml", limit = 2, download_full_article=true, include_images=true, enable_filter=true},
 
  { "https://www.pcworld.com/index.rss", limit = 7 , download_full_article=false},
 

--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -34,7 +34,7 @@ return {--do NOT change this line
  -- LIST YOUR FEEDS HERE:
 
  { "https://ourworldindata.org/atom.xml", limit = 2, download_full_article=true, include_images=true, enable_filter=true},
-
+ { "https://hnrss.org/bestcomments", limit = 10, download_full_article=true, include_images=false},
  { "https://www.pcworld.com/index.rss", limit = 7 , download_full_article=false},
 
 -- { "http://www.football.co.uk/international/rss.xml", limit = 2},

--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -73,7 +73,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
     local filter_element = feed.filter_element
         or feed.filter_element == nil
 
-    -- TODO: Strip the http:// or https:// from the URL
+    --- @todo: Strip the http:// or https:// from the URL
     local sPre, sLink, sPost = url:match( "(.+)%s+(https?%S+)%s+(.*)$" )
     local pretty_url = sLink
 

--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -146,16 +146,28 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
                 )
             end
         },
-        {
-            "Delete feed",
-            "",
-            callback = function()
-                delete_feed_callback(
-                    id
-                )
-            end
-        }
     }
+
+    -- We don't always display this. For instance: if a feed
+    -- is being created, this button is not necessary.
+    if delete_feed_callback then
+        table.insert(
+            vc,
+            "---"
+        )
+        table.insert(
+            vc,
+            {
+                "Delete feed",
+                "",
+                callback = function()
+                    delete_feed_callback(
+                        id
+                    )
+                end
+            }
+        )
+    end
 
     return vc
 end

--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -1,0 +1,198 @@
+local logger = require("logger")
+local _ = require("gettext")
+
+local FeedView = {
+    URL = "url",
+    LIMIT = "limit",
+    DOWNLOAD_FULL_ARTICLE = "download_full_article",
+    INCLUDE_IMAGES = "include_images",
+    ENABLE_FILTER = "enable_filter",
+    FILTER_ELEMENT = "filter_element"
+}
+
+function FeedView:getList(feed_config, callback, edit_feed_attribute_callback, delete_feed_callback)
+    local view_content = {}
+    -- Loop through the feed.
+    for idx, feed in ipairs(feed_config) do
+        local feed_item_content = {}
+        local feed_list_content = {}
+
+        local vc_feed_item = FeedView:getItem(
+            idx,
+            feed,
+            edit_feed_attribute_callback,
+            delete_feed_callback
+        )
+
+        if not vc_feed_item then
+            logger.warn('NewsDownloader: invalid feed config entry', feed)
+        else
+            feed_item_content = FeedView:flattenArray(feed_item_content, vc_feed_item)
+            local url = feed[1]
+            table.insert(
+                view_content,
+                {
+                    url,
+                    "",
+                    callback = function()
+                        -- Here is where we trigger the single feed item display
+                        callback(feed_item_content)
+                    end
+                }
+            )
+            -- Insert a divider.
+            table.insert(
+                view_content,
+                "---"
+            )
+        end
+    end
+    return view_content
+end
+
+function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
+
+    logger.dbg("NewsDownloader:", feed)
+
+    local url = feed[1]
+    local limit = feed.limit
+
+    -- If there's no URL or limit we don't care about this
+    -- because we can't use it.
+    if not url and limit then
+        return nil
+    end
+
+    -- Collect this stuff for later, with the single view.
+    local download_full_article = feed.download_full_article == nil
+        or feed.download_full_article
+    local include_images = not never_download_images
+        and feed.include_images
+    local enable_filter = feed.enable_filter
+        or feed.enable_filter == nil
+    local filter_element = feed.filter_element
+        or feed.filter_element == nil
+
+    -- TODO: Strip the http:// or https:// from the URL
+    local sPre, sLink, sPost = url:match( "(.+)%s+(https?%S+)%s+(.*)$" )
+    local pretty_url = sLink
+
+    local view_content = {}
+    local vc = {
+        {
+            "URL",
+            url,
+            callback = function()
+                edit_feed_callback(
+                    id,
+                    FeedView.URL,
+                    url
+                )
+            end
+        },
+        {
+            "Limit",
+            limit,
+            callback = function()
+                edit_feed_callback(
+                    id,
+                    FeedView.LIMIT,
+                    limit
+                )
+            end
+        },
+        {
+            "Download full article",
+            download_full_article,
+            callback = function()
+                edit_feed_callback(
+                    id,
+                    FeedView.DOWNLOAD_FULL_ARTICLE,
+                    download_full_article
+                )
+            end
+        },
+        {
+            "Include images",
+            include_images,
+            callback = function()
+                edit_feed_callback(
+                    id,
+                    FeedView.INCLUDE_IMAGES,
+                    include_images
+                )
+            end
+        },
+        {
+            "Enable filter",
+            enable_filter,
+            callback = function()
+                edit_feed_callback(
+                    id,
+                    FeedView.ENABLE_FILTER,
+                    enable_filter
+                )
+            end
+
+        },
+        {
+            "Filter element",
+            filter_element,
+            callback = function()
+                edit_feed_callback(
+                    id,
+                    FeedView.FILTER_ELEMENT,
+                    filter_element
+                )
+            end
+        },
+        {
+            "Delete feed",
+            "",
+            callback = function()
+                delete_feed_callback(
+                    id
+                )
+            end
+        }
+    }
+
+    return vc
+end
+
+--
+-- KeyValuePage doesn't like to get a table with sub tables.
+-- This function flattens an array, moving all nested tables
+-- up the food chain, so to speak
+--
+function FeedView:flattenArray(base_array, source_array)
+    for key, value in pairs(source_array) do
+        if value[2] == nil then
+            -- If the value is empty, then it's probably supposed to be a line
+            table.insert(
+                base_array,
+                "---"
+            )
+        else
+            if value["callback"] then
+                table.insert(
+                    base_array,
+                    {
+                        value[1], value[2], callback = value["callback"]
+                    }
+                )
+            else
+                table.insert(
+                    base_array,
+                    {
+                        value[1], value[2]
+                    }
+                )
+            end
+        end
+    end
+    return base_array
+end
+
+
+return FeedView

--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -80,7 +80,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
     local view_content = {}
     local vc = {
         {
-            "URL",
+            _("URL"),
             url,
             callback = function()
                 edit_feed_callback(
@@ -91,7 +91,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
             end
         },
         {
-            "Limit",
+            _("Limit"),
             limit,
             callback = function()
                 edit_feed_callback(
@@ -102,7 +102,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
             end
         },
         {
-            "Download full article",
+            _("Download full article"),
             download_full_article,
             callback = function()
                 edit_feed_callback(
@@ -113,7 +113,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
             end
         },
         {
-            "Include images",
+            _("Include images"),
             include_images,
             callback = function()
                 edit_feed_callback(
@@ -124,7 +124,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
             end
         },
         {
-            "Enable filter",
+            _("Enable filter"),
             enable_filter,
             callback = function()
                 edit_feed_callback(
@@ -136,7 +136,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
 
         },
         {
-            "Filter element",
+            _("Filter element"),
             filter_element,
             callback = function()
                 edit_feed_callback(
@@ -158,7 +158,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
         table.insert(
             vc,
             {
-                "Delete feed",
+                _("Delete feed"),
                 "",
                 callback = function()
                     delete_feed_callback(

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -9,8 +9,6 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("frontend/luasettings")
 local UIManager = require("ui/uimanager")
-local KeyValuePage = require("ui/widget/keyvaluepage")
---local ConfirmBox = require("ui/widget/confirmbox")
 local NetworkMgr = require("ui/network/manager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local dateparser = require("lib.dateparser")
@@ -20,17 +18,17 @@ local _ = require("gettext")
 local T = FFIUtil.template
 
 local NewsDownloader = WidgetContainer:new{
-   name = "news_downloader",
-   initialized = false,
-   feed_config_file = "feed_config.lua",
-   feed_config_path = nil,
-   news_config_file = "news_settings.lua",
-   settings = nil,
-   download_dir_name = "news",
-   download_dir = nil,
-   file_extension = ".epub",
-   config_key_custom_dl_dir = "custom_dl_dir",
-   kv = {}
+    name = "news_downloader",
+    initialized = false,
+    feed_config_file = "feed_config.lua",
+    feed_config_path = nil,
+    news_config_file = "news_settings.lua",
+    settings = nil,
+    download_dir_name = "news",
+    download_dir = nil,
+    file_extension = ".epub",
+    config_key_custom_dl_dir = "custom_dl_dir",
+    kv = {}
 }
 
 local FEED_TYPE_RSS = "rss"
@@ -44,11 +42,11 @@ local FEED_TYPE_ATOM = "atom"
 -- if a title looks like <title attr="alb">blabla</title> then we get a table
 -- where [1] is the title string and the attributes are also available
 local function getFeedTitle(possible_title)
-   if type(possible_title) == "string" then
-      return util.htmlEntitiesToUtf8(possible_title)
-   elseif possible_title[1] and type(possible_title[1]) == "string" then
-      return util.htmlEntitiesToUtf8(possible_title[1])
-   end
+    if type(possible_title) == "string" then
+        return util.htmlEntitiesToUtf8(possible_title)
+    elseif possible_title[1] and type(possible_title[1]) == "string" then
+        return util.htmlEntitiesToUtf8(possible_title[1])
+    end
 end
 
 -- there can be multiple links
@@ -58,21 +56,22 @@ end
 -- http://fransdejonge.com/feed/ for multiple links
 -- https://github.com/koreader/koreader/commits/master.atom for single link with attributes
 local function getFeedLink(possible_link)
-   local E = {}
-   if type(possible_link) == "string" then
-      return possible_link
-   elseif (possible_link._attr or E).href then
-      return possible_link._attr.href
-   elseif ((possible_link[1] or E)._attr or E).href then
-      return possible_link[1]._attr.href
-   end
+    local E = {}
+    if type(possible_link) == "string" then
+        return possible_link
+    elseif (possible_link._attr or E).href then
+        return possible_link._attr.href
+    elseif ((possible_link[1] or E)._attr or E).href then
+        return possible_link[1]._attr.href
+    end
 end
 
 function NewsDownloader:init()
-   self.ui.menu:registerToMainMenu(self)
+    self.ui.menu:registerToMainMenu(self)
 end
 
 function NewsDownloader:addToMainMenu(menu_items)
+<<<<<<< HEAD
    menu_items.news_downloader = {
       text = _("News (RSS/Atom) downloader"),
       sub_item_table_func = function()
@@ -84,7 +83,7 @@ end
 function NewsDownloader:getSubMenuItems()
    self:lazyInitialization()
    local sub_item_table
-   sub_item_table = {        
+   sub_item_table = {
       {
 	 text = _("Go to news folder"),
 	 callback = function()
@@ -140,532 +139,601 @@ function NewsDownloader:getSubMenuItems()
       },
    }
    return sub_item_table
+=======
+    menu_items.news_downloader = {
+        text = _("News (RSS/Atom) downloader"),
+        sub_item_table_func = function()
+            return self:getSubMenuItems()
+        end,
+    }
+end
+
+function NewsDownloader:getSubMenuItems()
+    self:lazyInitialization()
+    local sub_item_table
+    sub_item_table = {
+        {
+            text = _("Go to news folder"),
+            callback = function()
+                self:openDownloadsFolder()
+            end,
+        },
+        {
+            text = _("Download news feeds"),
+            callback = function()
+                NetworkMgr:runWhenOnline(function() self:loadConfigAndProcessFeedsWithUI() end)
+            end,
+        },
+        {
+            text = _("Remove all downloaded items"),
+            keep_menu_open = true,
+            callback = function() self:removeNewsButKeepFeedConfig() end,
+        },
+        {
+            text = _("Settings"),
+            sub_item_table = {
+                {
+                    text = _("Edit feeds configuration file"),
+                    keep_menu_open = true,
+                    callback = function() self:changeFeedConfig() end,
+                },
+                {
+                    text = _("Set custom download folder"),
+                    keep_menu_open = true,
+                    callback = function() self:setCustomDownloadDirectory() end,
+                },
+                {
+                    text = _("Never download images"),
+                    keep_menu_open = true,
+                    checked_func = function()
+                        return self.settings:isTrue("never_download_images")
+                    end,
+                    callback = function()
+                        self.settings:toggle("never_download_images")
+                        self.settings:flush()
+                    end,
+                },
+            },
+        },
+        {
+            text = _("Help"),
+            keep_menu_open = true,
+            callback = function()
+                UIManager:show(InfoMessage:new{
+                                   text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
+                                            BD.dirpath(self.download_dir))
+                })
+            end,
+        },
+    }
+    return sub_item_table
+>>>>>>> dev
 end
 -- lazyInitialization sets up variables that point to the
 -- downloads folder and the feeds configuration file
 function NewsDownloader:lazyInitialization()
-   if not self.initialized then
-      logger.dbg("NewsDownloader: obtaining news folder")
-      self.settings = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), self.news_config_file))
-      -- Check to see if a custom download directory has been set
-      if self.settings:has(self.config_key_custom_dl_dir) then
-	 self.download_dir = self.settings:readSetting(self.config_key_custom_dl_dir)
-      else
-	 self.download_dir =
-	    ("%s/%s/"):format(
-	       DataStorage:getFullDataDir(),
-	       self.download_dir_name)
-      end
-      logger.dbg("NewsDownloader: Custom directory set to:", self.download_dir)
-      -- If the directory doesn't exist we will create it
-      if not lfs.attributes(self.download_dir, "mode") then
-	 logger.dbg("NewsDownloader: Creating initial directory")
-	 lfs.mkdir(self.download_dir)
-      end
-      -- Now set the path to the feed configuration file
-      self.feed_config_path = self.download_dir .. self.feed_config_file
-      -- If the configuration file doesn't exist create it
-      if not lfs.attributes(self.feed_config_path, "mode") then
-	 logger.dbg("NewsDownloader: Creating initial feed config.")
-	 FFIUtil.copyFile(FFIUtil.joinPath(self.path, self.feed_config_file),
-			  self.feed_config_path)
-      end
-      self.initialized = true
-   end
+    if not self.initialized then
+        logger.dbg("NewsDownloader: obtaining news folder")
+        self.settings = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), self.news_config_file))
+        -- Check to see if a custom download directory has been set
+        if self.settings:has(self.config_key_custom_dl_dir) then
+            self.download_dir = self.settings:readSetting(self.config_key_custom_dl_dir)
+        else
+            self.download_dir =
+                ("%s/%s/"):format(
+                    DataStorage:getFullDataDir(),
+                    self.download_dir_name)
+        end
+        logger.dbg("NewsDownloader: Custom directory set to:", self.download_dir)
+        -- If the directory doesn't exist we will create it
+        if not lfs.attributes(self.download_dir, "mode") then
+            logger.dbg("NewsDownloader: Creating initial directory")
+            lfs.mkdir(self.download_dir)
+        end
+        -- Now set the path to the feed configuration file
+        self.feed_config_path = self.download_dir .. self.feed_config_file
+        -- If the configuration file doesn't exist create it
+        if not lfs.attributes(self.feed_config_path, "mode") then
+            logger.dbg("NewsDownloader: Creating initial feed config.")
+            FFIUtil.copyFile(FFIUtil.joinPath(self.path, self.feed_config_file),
+                             self.feed_config_path)
+        end
+        self.initialized = true
+    end
 end
 
 function NewsDownloader:loadConfigAndProcessFeeds()
-   local UI = require("ui/trapper")
-   UI:info("Loading news feed config…")
-   logger.dbg("force repaint due to upcoming blocking calls")
+    local UI = require("ui/trapper")
+    UI:info("Loading news feed config…")
+    logger.dbg("force repaint due to upcoming blocking calls")
 
-   local ok, feed_config = pcall(dofile, self.feed_config_path)
-   if not ok or not feed_config then
-      UI:info(T(_("Invalid configuration file. Detailed error message:\n%1"), feed_config))
-      return
-   end
-   -- If the file contains no table elements, then the user hasn't set any feeds
-   if #feed_config <= 0 then
-      logger.err('NewsDownloader: empty feed list.', self.feed_config_path)
-      -- TODO: Ask them to set the first feed. Perhaps even suggest something?!
-      return
-   end
+    local ok, feed_config = pcall(dofile, self.feed_config_path)
+    if not ok or not feed_config then
+        UI:info(T(_("Invalid configuration file. Detailed error message:\n%1"), feed_config))
+        return
+    end
+    -- If the file contains no table elements, then the user hasn't set any feeds
+    if #feed_config <= 0 then
+        logger.err('NewsDownloader: empty feed list.', self.feed_config_path)
+        -- TODO: Ask them to set the first feed. Perhaps even suggest something?!
+        return
+    end
 
-   local never_download_images = self.settings:isTrue("never_download_images")
-   local unsupported_feeds_urls = {}
-   local total_feed_entries = #feed_config
-   local feed_message
-   
-   for idx, feed in ipairs(feed_config) do
-      local url = feed[1]
-      local limit = feed.limit
-      local download_full_article = feed.download_full_article == nil or feed.download_full_article
-      local include_images = not never_download_images and feed.include_images
-      local enable_filter = feed.enable_filter or feed.enable_filter == nil
-      local filter_element = feed.filter_element or feed.filter_element == nil
-      -- Check if the two required attributes are set
-      if url and limit then
-	 feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
-	 UI:info(feed_message)
-	 -- Process, i.e.: "Download"
-	 self:processFeedSource(
-	    url,
-	    tonumber(limit),
-	    unsupported_feeds_urls,
-	    download_full_article,
-	    include_images,
-	    feed_message,
-	    enable_filter,
-	    filter_element)
-      else
-	 logger.warn('NewsDownloader: invalid feed config entry.', feed)
-      end
-   end
-   
-   if #unsupported_feeds_urls <= 0 then
-      -- When no errors are present, we get a happy message.
-      feed_message = "Downloading news finished. "
-   else
-      -- When some errors are present, we get a sour message.
-      local unsupported_urls = ""
-      for key, value in pairs(unsupported_feeds_urls) do
-	 -- Create the error message
-	 unsupported_urls = unsupported_urls .. " " .. value[1] .. " " .. value[2]
-	 -- Not sure what this does
-	 if key ~= #unsupported_feeds_urls then
-	    unsupported_urls = BD.url(unsupported_urls) .. ", "
-	 end
-      end
-      -- Tell the user there were problems
-      feed_message = "Downloading news finished with errors. "
-      go_to_config_file = UI:confirm(
-	 T(
-	    [[
+    local never_download_images = self.settings:isTrue("never_download_images")
+    local unsupported_feeds_urls = {}
+    local total_feed_entries = #feed_config
+    local feed_message
+
+    for idx, feed in ipairs(feed_config) do
+        local url = feed[1]
+        local limit = feed.limit
+        local download_full_article = feed.download_full_article == nil or feed.download_full_article
+        local include_images = not never_download_images and feed.include_images
+        local enable_filter = feed.enable_filter or feed.enable_filter == nil
+        local filter_element = feed.filter_element or feed.filter_element == nil
+        -- Check if the two required attributes are set
+        if url and limit then
+            feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
+            UI:info(feed_message)
+            -- Process, i.e.: "Download"
+            self:processFeedSource(
+                url,
+                tonumber(limit),
+                unsupported_feeds_urls,
+                download_full_article,
+                include_images,
+                feed_message,
+                enable_filter,
+                filter_element)
+        else
+            logger.warn('NewsDownloader: invalid feed config entry.', feed)
+        end
+    end
+
+    if #unsupported_feeds_urls <= 0 then
+        -- When no errors are present, we get a happy message.
+        feed_message = "Downloading news finished. "
+    else
+        -- When some errors are present, we get a sour message.
+        local unsupported_urls = ""
+        for key, value in pairs(unsupported_feeds_urls) do
+            -- Create the error message
+            unsupported_urls = unsupported_urls .. " " .. value[1] .. " " .. value[2]
+            -- Not sure what this does
+            if key ~= #unsupported_feeds_urls then
+                unsupported_urls = BD.url(unsupported_urls) .. ", "
+            end
+        end
+        -- Tell the user there were problems
+        feed_message = "Downloading news finished with errors. "
+        go_to_config_file = UI:confirm(
+            T(
+                [[
 Could not process some feeds.
 Unsupported format in: %1. Please
 review your feed configuration file.]], unsupported_urls),
-	 "Continue",
-	 ""	 
-      )
-   end   
-   -- Clear the info widgets before displaying the confirm box
-   UI:clear()
-   -- Ask the user if they want to see their downloads
-   feed_message = feed_message .. "Go to downloaders folder?"
-   return_to_menu = UI:confirm(feed_message, "Go to downloads", "Return to menu")
-   
-   if return_to_menu then
-      NetworkMgr:afterWifiAction()
-      return
-   else
-      -- Go to downloads folder
-      UI:clear()
-      self:openDownloadsFolder()
-      NetworkMgr:afterWifiAction()
-      return
-   end
+            "Continue",
+            ""
+        )
+    end
+    -- Clear the info widgets before displaying the confirm box
+    UI:clear()
+    -- Ask the user if they want to see their downloads
+    feed_message = feed_message .. "Go to downloaders folder?"
+    return_to_menu = UI:confirm(feed_message, "Go to downloads", "Close")
+
+    if return_to_menu then
+        NetworkMgr:afterWifiAction()
+        return
+    else
+        -- Go to downloads folder
+        UI:clear()
+        self:openDownloadsFolder()
+        NetworkMgr:afterWifiAction()
+        return
+    end
 end
 
 function NewsDownloader:loadConfigAndProcessFeedsWithUI()
-   local Trapper = require("ui/trapper")
-   Trapper:wrap(function()
-	 self:loadConfigAndProcessFeeds()
-   end)
+    local Trapper = require("ui/trapper")
+    Trapper:wrap(function()
+            self:loadConfigAndProcessFeeds()
+    end)
 end
 
 function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, download_full_article, include_images, message, enable_filter, filter_element)
-   local ok, response = pcall(function()
-	 return DownloadBackend:getResponseAsString(url)
-   end)
-   local feeds
-   -- Check to see if the response is OK to deserialize
-   if ok then
-      feeds = self:deserializeXMLString(response)
-   end
-   -- If the response is not OK, or feeds returned nil,
-   -- add the URL to the unsupported feeds list
-   if not ok or not feeds then
-      local error_message
-      if not ok then
-	 error_message = "(Reason: Failed to download content)"
-      else
-	 error_message = "(Reason: Error during feed deserialization)"
-      end
-      table.insert(
-	 unsupported_feeds_urls,
-	 {
-	    url,
-	    error_message
-	 }
-      )
-      return
-   end
-   -- Check to see if the feed uses RSS
-   local is_rss = feeds.rss
-      and feeds.rss.channel
-      and feeds.rss.channel.title
-      and feeds.rss.channel.item
-      and feeds.rss.channel.item[1]
-      and feeds.rss.channel.item[1].title
-      and feeds.rss.channel.item[1].link
-   -- Check to see if the feed uses Atom
-   local is_atom = feeds.feed
-      and feeds.feed.title
-      and feeds.feed.entry[1]
-      and feeds.feed.entry[1].title
-      and feeds.feed.entry[1].link
-   -- Process the feeds accordingly. 
-   if is_atom then
-      ok = pcall(function()	    
-            return self:processFeed(
-	       FEED_TYPE_ATOM,
-	       feeds,
-	       limit,
-	       download_full_article,
-	       include_images,
-	       message,
-	       enable_filter,
-	       filter_element
-	    )
-      end)
-   elseif is_rss then
-      ok = pcall(function()
-            return self:processFeed(
-	       FEED_TYPE_RSS,
-	       feeds,
-	       limit,
-	       download_full_article,
-	       include_images,
-	       message,
-	       enable_filter,
-	       filter_element
-	    )
-      end)
-   end
-   -- If the feed can't be processed, or it is neither
-   -- Atom or RSS, then add it to the unsupported feeds list
-   -- and return an error message
-   if not ok or (not is_rss and not is_atom) then
-      local error_message
-      if not ok then
-	 error_message = "(Reason: Failed to download content)"
-      elseif not is_rss then
-	 error_message = "(Reason: Couldn't process RSS)"
-      elseif not is_atom then
-	 error_message = "(Reason: Couldn't process Atom)"
-      end	 
-      table.insert(
-	 unsupported_feeds_urls,
-	 {
-	    url,
-	    error_message
-	 }
-      )
-   end
+    local ok, response = pcall(function()
+            return DownloadBackend:getResponseAsString(url)
+    end)
+    local feeds
+    -- Check to see if the response is OK to deserialize
+    if ok then
+        feeds = self:deserializeXMLString(response)
+    end
+    -- If the response is not OK, or feeds returned nil,
+    -- add the URL to the unsupported feeds list
+    if not ok or not feeds then
+        local error_message
+        if not ok then
+            error_message = "(Reason: Failed to download content)"
+        else
+            error_message = "(Reason: Error during feed deserialization)"
+        end
+        table.insert(
+            unsupported_feeds_urls,
+            {
+                url,
+                error_message
+            }
+        )
+        return
+    end
+    -- Check to see if the feed uses RSS
+    local is_rss = feeds.rss
+        and feeds.rss.channel
+        and feeds.rss.channel.title
+        and feeds.rss.channel.item
+        and feeds.rss.channel.item[1]
+        and feeds.rss.channel.item[1].title
+        and feeds.rss.channel.item[1].link
+    -- Check to see if the feed uses Atom
+    local is_atom = feeds.feed
+        and feeds.feed.title
+        and feeds.feed.entry[1]
+        and feeds.feed.entry[1].title
+        and feeds.feed.entry[1].link
+    -- Process the feeds accordingly.
+    if is_atom then
+        ok = pcall(function()
+                return self:processFeed(
+                    FEED_TYPE_ATOM,
+                    feeds,
+                    limit,
+                    download_full_article,
+                    include_images,
+                    message,
+                    enable_filter,
+                    filter_element
+                )
+        end)
+    elseif is_rss then
+        ok = pcall(function()
+                return self:processFeed(
+                    FEED_TYPE_RSS,
+                    feeds,
+                    limit,
+                    download_full_article,
+                    include_images,
+                    message,
+                    enable_filter,
+                    filter_element
+                )
+        end)
+    end
+    -- If the feed can't be processed, or it is neither
+    -- Atom or RSS, then add it to the unsupported feeds list
+    -- and return an error message
+    if not ok or (not is_rss and not is_atom) then
+        local error_message
+        if not ok then
+            error_message = "(Reason: Failed to download content)"
+        elseif not is_rss then
+            error_message = "(Reason: Couldn't process RSS)"
+        elseif not is_atom then
+            error_message = "(Reason: Couldn't process Atom)"
+        end
+        table.insert(
+            unsupported_feeds_urls,
+            {
+                url,
+                error_message
+            }
+        )
+    end
 end
 
 function NewsDownloader:deserializeXMLString(xml_str)
-   -- uses LuaXML https://github.com/manoelcampos/LuaXML
-   -- The MIT License (MIT)
-   -- Copyright (c) 2016 Manoel Campos da Silva Filho
-   -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENSE_LuaXML
-   local treehdl = require("lib/handler")
-   local libxml = require("lib/xml")
-   --Instantiate the object that states the XML file as a Lua table
-   local xmlhandler = treehdl.simpleTreeHandler()
-   --Instantiate the object that parses the XML to a Lua table
-   local ok = pcall(function()
-	 libxml.xmlParser(xmlhandler):parse(xml_str)
-   end)
-   if not ok then return end
-   return xmlhandler.root
+    -- uses LuaXML https://github.com/manoelcampos/LuaXML
+    -- The MIT License (MIT)
+    -- Copyright (c) 2016 Manoel Campos da Silva Filho
+    -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENSE_LuaXML
+    local treehdl = require("lib/handler")
+    local libxml = require("lib/xml")
+    --Instantiate the object that states the XML file as a Lua table
+    local xmlhandler = treehdl.simpleTreeHandler()
+    --Instantiate the object that parses the XML to a Lua table
+    local ok = pcall(function()
+            libxml.xmlParser(xmlhandler):parse(xml_str)
+    end)
+    if not ok then return end
+    return xmlhandler.root
 end
 
 function NewsDownloader:processAtom(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-   -- Get the path to the output directory
-   local feed_output_dir = string.format(
-      "%s%s/",
-      self.download_dir,
-      util.getSafeFilename(getFeedTitle(feeds.feed.title))
-   )
-   -- Create the output directory if it doesn't exist
-   if not lfs.attributes(feed_output_dir, "mode") then
-      lfs.mkdir(feed_output_dir)
-   end
-   -- Download the feed
-   for index, feed in pairs(feeds.feed.entry) do
-      -- If limit has been met, stop downloading feed
-      if limit ~= 0 and index - 1 == limit then
-	 break
-      end
-      local total_articles = limit == 0
-	 and #feeds.rss.channel.item
-	 or limit
-      -- Create a message to display during the processing
-      local article_message = T(
-	 _("%1\n\nFetching article %2/%3:"),
-	 message,
-	 index,
-	 total
-      )
-      -- Download the feed
-      if download_full_article then
-	 self:downloadFeed(
-	    feed,
-	    feed_output_dir,
-	    include_images,
-	    article_message,
-	    enable_filter,
-	    filter_element
-	 )
-      else
-	 self:createFromDescription(
-	    feed,
-	    feed.content[1],
-	    feed_output_dir,
-	    include_images,
-	    article_message
-	 )
-      end
-   end
+    -- Get the path to the output directory
+    local feed_output_dir = string.format(
+        "%s%s/",
+        self.download_dir,
+        util.getSafeFilename(getFeedTitle(feeds.feed.title))
+    )
+    -- Create the output directory if it doesn't exist
+    if not lfs.attributes(feed_output_dir, "mode") then
+        lfs.mkdir(feed_output_dir)
+    end
+    -- Download the feed
+    for index, feed in pairs(feeds.feed.entry) do
+        -- If limit has been met, stop downloading feed
+        if limit ~= 0 and index - 1 == limit then
+            break
+        end
+        local total_articles = limit == 0
+            and #feeds.rss.channel.item
+            or limit
+        -- Create a message to display during the processing
+        local article_message = T(
+            _("%1\n\nFetching article %2/%3:"),
+            message,
+            index,
+            total
+        )
+        -- Download the feed
+        if download_full_article then
+            self:downloadFeed(
+                feed,
+                feed_output_dir,
+                include_images,
+                article_message,
+                enable_filter,
+                filter_element
+            )
+        else
+            self:createFromDescription(
+                feed,
+                feed.content[1],
+                feed_output_dir,
+                include_images,
+                article_message
+            )
+        end
+    end
 end
 
 function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-   local feed_title
-   local feed_item
-   local total_feeds
-   -- Setup the above vars based on feed type
-   if feed_type == FEED_TYPE_RSS then
-      feed_title = util.htmlEntitiesToUtf8(feeds.rss.channel.title)
-      feed_item = feeds.rss.channel.item
-      total_items = (limit == 0)
-	 and #feeds.rss.channel.item
-	 or limit
-   else
-      logger.dbg(feeds)
-      feed_title = getFeedTitle(feeds.feed.title)
-      feed_item = feeds.feed.entry
-      total_items = (limit == 0)
-	 and #feeds.feed.entry
-	 or limit
-   end
-   -- Get the path to the output directory
-   local feed_output_dir = ("%s%s/"):format(
-      self.download_dir,
-      util.getSafeFilename(util.htmlEntitiesToUtf8(feed_title)))
-   -- Create the output directory if it doesn't exist
-   if not lfs.attributes(feed_output_dir, "mode") then
-      lfs.mkdir(feed_output_dir)
-   end
-   -- Download the feed
-   for index, feed in pairs(feed_item) do
-      -- If limit has been met, stop downloading feed
-      if limit ~= 0 and index - 1 == limit then
-	 break
-      end
-      -- Create a message to display during the processing
-      local article_message = T(
-	 _("%1\n\nFetching article %2/%3:"),
-	 message,
-	 index,
-	 total_items
-      )
-      -- Get the feed description
-      local feed_description
-      if feed_type == FEED_TYPE_RSS then
-	 feed_description = feed.description
-      else
-	 feed_description = feed.summary
-      end
-      -- Download the article
-      if download_full_article then
-	 self:downloadFeed(
-	    feed,
-	    feed_output_dir,
-	    include_images,
-	    article_message,
-	    enable_filter,
-	    filter_element
-	 )
-      else
-	 self:createFromDescription(
-	    feed,
-	    feed_description,
-	    feed_output_dir,
-	    include_images,
-	    article_message
-	 )
-      end
-   end
+    local feed_title
+    local feed_item
+    local total_feeds
+    -- Setup the above vars based on feed type
+    if feed_type == FEED_TYPE_RSS then
+        feed_title = util.htmlEntitiesToUtf8(feeds.rss.channel.title)
+        feed_item = feeds.rss.channel.item
+        total_items = (limit == 0)
+            and #feeds.rss.channel.item
+            or limit
+    else
+        logger.dbg(feeds)
+        feed_title = getFeedTitle(feeds.feed.title)
+        feed_item = feeds.feed.entry
+        total_items = (limit == 0)
+            and #feeds.feed.entry
+            or limit
+    end
+    -- Get the path to the output directory
+    local feed_output_dir = ("%s%s/"):format(
+        self.download_dir,
+        util.getSafeFilename(util.htmlEntitiesToUtf8(feed_title)))
+    -- Create the output directory if it doesn't exist
+    if not lfs.attributes(feed_output_dir, "mode") then
+        lfs.mkdir(feed_output_dir)
+    end
+    -- Download the feed
+    for index, feed in pairs(feed_item) do
+        -- If limit has been met, stop downloading feed
+        if limit ~= 0 and index - 1 == limit then
+            break
+        end
+        -- Create a message to display during the processing
+        local article_message = T(
+            _("%1\n\nFetching article %2/%3:"),
+            message,
+            index,
+            total_items
+        )
+        -- Get the feed description
+        local feed_description
+        if feed_type == FEED_TYPE_RSS then
+            feed_description = feed.description
+        else
+            feed_description = feed.summary
+        end
+        -- Download the article
+        if download_full_article then
+            self:downloadFeed(
+                feed,
+                feed_output_dir,
+                include_images,
+                article_message,
+                enable_filter,
+                filter_element
+            )
+        else
+            self:createFromDescription(
+                feed,
+                feed_description,
+                feed_output_dir,
+                include_images,
+                article_message
+            )
+        end
+    end
 end
 
 local function parseDate(dateTime)
-   -- uses lua-feedparser https://github.com/slact/lua-feedparser
-   -- feedparser is available under the (new) BSD license.
-   -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
-   local date = dateparser.parse(dateTime)
-   return os.date("%y-%m-%d_%H-%M_", date)
+    -- uses lua-feedparser https://github.com/slact/lua-feedparser
+    -- feedparser is available under the (new) BSD license.
+    -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
+    local date = dateparser.parse(dateTime)
+    return os.date("%y-%m-%d_%H-%M_", date)
 end
 
 -- This appears to be used by Atom feeds in processFeed
 local function getTitleWithDate(feed)
-   local title = util.getSafeFilename(getFeedTitle(feed.title))
-   if feed.updated then
-      title = parseDate(feed.updated) .. title
-   elseif feed.pubDate then
-      title = parseDate(feed.pubDate) .. title
-   elseif feed.published then
-      title = parseDate(feed.published) .. title
-   end
-   return title
+    local title = util.getSafeFilename(getFeedTitle(feed.title))
+    if feed.updated then
+        title = parseDate(feed.updated) .. title
+    elseif feed.pubDate then
+        title = parseDate(feed.pubDate) .. title
+    elseif feed.published then
+        title = parseDate(feed.published) .. title
+    end
+    return title
 end
 
 function NewsDownloader:downloadFeed(feed, feed_output_dir, include_images, message, enable_filter, filter_element)
-   local title_with_date = getTitleWithDate(feed)
-   local news_file_path = ("%s%s%s"):format(feed_output_dir,
-					    title_with_date,
-					    self.file_extension)
+    local title_with_date = getTitleWithDate(feed)
+    local news_file_path = ("%s%s%s"):format(feed_output_dir,
+                                             title_with_date,
+                                             self.file_extension)
 
-   local file_mode = lfs.attributes(news_file_path, "mode")
-   if file_mode == "file" then
-      logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
-   else
-      logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
-      local article_message = T(_("%1\n%2"), message, title_with_date)
-      local link = getFeedLink(feed.link)
-      local html = DownloadBackend:loadPage(link)
-      DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message, enable_filter, filter_element)
-   end
+    local file_mode = lfs.attributes(news_file_path, "mode")
+    if file_mode == "file" then
+        logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
+    else
+        logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
+        local article_message = T(_("%1\n%2"), message, title_with_date)
+        local link = getFeedLink(feed.link)
+        local html = DownloadBackend:loadPage(link)
+        DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message, enable_filter, filter_element)
+    end
 end
 
 function NewsDownloader:createFromDescription(feed, content, feed_output_dir, include_images, message)
-   local title_with_date = getTitleWithDate(feed)
-   local news_file_path = ("%s%s%s"):format(feed_output_dir,
-					    title_with_date,
-					    self.file_extension)
-   local file_mode = lfs.attributes(news_file_path, "mode")
-   if file_mode == "file" then
-      logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
-   else
-      logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
-      local article_message = T(_("%1\n%2"), message, title_with_date)
-      local footer = _("This is just a description of the feed. To download the full article instead, go to the News Downloader settings and change 'download_full_article' to 'true'.")
+    local title_with_date = getTitleWithDate(feed)
+    local news_file_path = ("%s%s%s"):format(feed_output_dir,
+                                             title_with_date,
+                                             self.file_extension)
+    local file_mode = lfs.attributes(news_file_path, "mode")
+    if file_mode == "file" then
+        logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
+    else
+        logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
+        local article_message = T(_("%1\n%2"), message, title_with_date)
+        local footer = _("This is just a description of the feed. To download the full article instead, go to the News Downloader settings and change 'download_full_article' to 'true'.")
 
-      local html = string.format([[<!DOCTYPE html>
+        local html = string.format([[<!DOCTYPE html>
 <html>
 <head><meta charset='UTF-8'><title>%s</title></head>
 <body><header><h2>%s</h2></header><article>%s</article>
 <br><footer><small>%s</small></footer>
 </body>
 </html>]], feed.title, feed.title, content, footer)
-      local link = getFeedLink(feed.link)
-      DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message)
-   end
+        local link = getFeedLink(feed.link)
+        DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message)
+    end
 end
 
 function NewsDownloader:removeNewsButKeepFeedConfig()
-   logger.dbg("NewsDownloader: Removing news from :", self.download_dir)
-   for entry in lfs.dir(self.download_dir) do
-      if entry ~= "." and entry ~= ".." and entry ~= self.feed_config_file then
-	 local entry_path = self.download_dir .. "/" .. entry
-	 local entry_mode = lfs.attributes(entry_path, "mode")
-	 if entry_mode == "file" then
-	    os.remove(entry_path)
-	 elseif entry_mode == "directory" then
-	    FFIUtil.purgeDir(entry_path)
-	 end
-      end
-   end
-   UIManager:show(InfoMessage:new{
-		     text = _("All news removed.")
-   })
+    logger.dbg("NewsDownloader: Removing news from :", self.download_dir)
+    for entry in lfs.dir(self.download_dir) do
+        if entry ~= "." and entry ~= ".." and entry ~= self.feed_config_file then
+            local entry_path = self.download_dir .. "/" .. entry
+            local entry_mode = lfs.attributes(entry_path, "mode")
+            if entry_mode == "file" then
+                os.remove(entry_path)
+            elseif entry_mode == "directory" then
+                FFIUtil.purgeDir(entry_path)
+            end
+        end
+    end
+    UIManager:show(InfoMessage:new{
+                       text = _("All news removed.")
+    })
 end
 
 function NewsDownloader:setCustomDownloadDirectory()
-   require("ui/downloadmgr"):new{
-      onConfirm = function(path)
-	 logger.dbg("NewsDownloader: set download directory to: ", path)
-	 self.settings:saveSetting(self.config_key_custom_dl_dir, ("%s/"):format(path))
-	 self.settings:flush()
+    require("ui/downloadmgr"):new{
+        onConfirm = function(path)
+            logger.dbg("NewsDownloader: set download directory to: ", path)
+            self.settings:saveSetting(self.config_key_custom_dl_dir, ("%s/"):format(path))
+            self.settings:flush()
 
-	 logger.dbg("NewsDownloader: Coping to new download folder previous self.feed_config_file from: ", self.feed_config_path)
-	 FFIUtil.copyFile(self.feed_config_path, ("%s/%s"):format(path, self.feed_config_file))
+            logger.dbg("NewsDownloader: Coping to new download folder previous self.feed_config_file from: ", self.feed_config_path)
+            FFIUtil.copyFile(self.feed_config_path, ("%s/%s"):format(path, self.feed_config_file))
 
-	 self.initialized = false
-	 self:lazyInitialization()
-      end,
-				}:chooseDir()
+            self.initialized = false
+            self:lazyInitialization()
+        end,
+                                 }:chooseDir()
 end
 
 function NewsDownloader:editFeedUrl(url, id)
-   -- How should this work?
-   -- WEll, it needs to know where the url is 'coming from', which is to say,
-   -- where in the config file it exists. we need an id, like, element 1, or element 3
+    -- How should this work?
+    -- WEll, it needs to know where the url is 'coming from', which is to say,
+    -- where in the config file it exists. we need an id, like, element 1, or element 3
 end
 
 function NewsDownloader:changeFeedConfig()
-   local feed_config_file = io.open(self.feed_config_path, "rb")
-   local config = feed_config_file:read("*all")
-   feed_config_file:close()
-   local config_editor
-   config_editor = InputDialog:new{
-      title = T(_("Config: %1"), BD.filepath(self.feed_config_path)),
-      input = config,
-      input_type = "string",
-      para_direction_rtl = false, -- force LTR
-      fullscreen = true,
-      condensed = true,
-      allow_newline = true,
-      cursor_at_end = false,
-      add_nav_bar = true,
-      reset_callback = function()
-         return config
-      end,
-      save_callback = function(content)
-         if content and #content > 0 then
-            local parse_error = util.checkLuaSyntax(content)
-            if not parse_error then
-               local syntax_okay, syntax_error = pcall(loadstring(content))
-               if syntax_okay then
-                  feed_config_file = io.open(self.feed_config_path, "w")
-                  feed_config_file:write(content)
-                  feed_config_file:close()
-                  return true, _("Configuration saved")
-               else
-                  return false, T(_("Configuration invalid: %1"), syntax_error)
-               end
-            else
-               return false, T(_("Configuration invalid: %1"), parse_error)
+    local feed_config_file = io.open(self.feed_config_path, "rb")
+    local config = feed_config_file:read("*all")
+    feed_config_file:close()
+    local config_editor
+    config_editor = InputDialog:new{
+        title = T(_("Config: %1"), BD.filepath(self.feed_config_path)),
+        input = config,
+        input_type = "string",
+        para_direction_rtl = false, -- force LTR
+        fullscreen = true,
+        condensed = true,
+        allow_newline = true,
+        cursor_at_end = false,
+        add_nav_bar = true,
+        reset_callback = function()
+            return config
+        end,
+        save_callback = function(content)
+            if content and #content > 0 then
+                local parse_error = util.checkLuaSyntax(content)
+                if not parse_error then
+                    local syntax_okay, syntax_error = pcall(loadstring(content))
+                    if syntax_okay then
+                        feed_config_file = io.open(self.feed_config_path, "w")
+                        feed_config_file:write(content)
+                        feed_config_file:close()
+                        return true, _("Configuration saved")
+                    else
+                        return false, T(_("Configuration invalid: %1"), syntax_error)
+                    end
+                else
+                    return false, T(_("Configuration invalid: %1"), parse_error)
+                end
             end
-         end
-         return false, _("Configuration empty")
-      end,
-   }
-   UIManager:show(config_editor)
-   config_editor:onShowKeyboard()
+            return false, _("Configuration empty")
+        end,
+    }
+    UIManager:show(config_editor)
+    config_editor:onShowKeyboard()
 end
 function NewsDownloader:openDownloadsFolder()
-   local FileManager = require("apps/filemanager/filemanager")
-   if self.ui.document then
-      self.ui:onClose()
-   end
-   if FileManager.instance then
-      FileManager.instance:reinit(self.download_dir)
-   else
-      FileManager:showFiles(self.download_dir)
-   end
+    local FileManager = require("apps/filemanager/filemanager")
+    if self.ui.document then
+        self.ui:onClose()
+    end
+    if FileManager.instance then
+        FileManager.instance:reinit(self.download_dir)
+    else
+        FileManager:showFiles(self.download_dir)
+    end
 end
 
 function NewsDownloader:onCloseDocument()
-   local document_full_path = self.ui.document.file
-   if  document_full_path and self.download_dir and self.download_dir == string.sub(document_full_path, 1, string.len(self.download_dir)) then
-      logger.dbg("NewsDownloader: document_full_path:", document_full_path)
-      logger.dbg("NewsDownloader: self.download_dir:", self.download_dir)
-      logger.dbg("NewsDownloader: removing NewsDownloader file from history.")
-      ReadHistory:removeItemByPath(document_full_path)
-      local doc_dir = util.splitFilePathName(document_full_path)
-      self.ui:setLastDirForFileBrowser(doc_dir)
-   end
+    local document_full_path = self.ui.document.file
+    if  document_full_path and self.download_dir and self.download_dir == string.sub(document_full_path, 1, string.len(self.download_dir)) then
+        logger.dbg("NewsDownloader: document_full_path:", document_full_path)
+        logger.dbg("NewsDownloader: self.download_dir:", self.download_dir)
+        logger.dbg("NewsDownloader: removing NewsDownloader file from history.")
+        ReadHistory:removeItemByPath(document_full_path)
+        local doc_dir = util.splitFilePathName(document_full_path)
+        self.ui:setLastDirForFileBrowser(doc_dir)
+    end
 end
 
 --
@@ -674,32 +742,32 @@ end
 -- up the food chain, so to speak
 --
 function NewsDownloader:flattenArray(base_array, source_array)
-   for key, value in pairs(source_array) do
-      if value[2] == nil then
-         -- If the value is empty, then it's probably supposed to be a line
-         table.insert(
-            base_array,
-            "---"
-         )
-      else
-         if value["callback"] then
+    for key, value in pairs(source_array) do
+        if value[2] == nil then
+            -- If the value is empty, then it's probably supposed to be a line
             table.insert(
-               base_array,
-               {
-                  value[1], value[2], callback = value["callback"]
-               }
+                base_array,
+                "---"
             )
-         else
-            table.insert(
-               base_array,
-               {
-                  value[1], value[2]
-               }
-            )
-         end
-      end
-   end
-   return base_array
+        else
+            if value["callback"] then
+                table.insert(
+                    base_array,
+                    {
+                        value[1], value[2], callback = value["callback"]
+                    }
+                )
+            else
+                table.insert(
+                    base_array,
+                    {
+                        value[1], value[2]
+                    }
+                )
+            end
+        end
+    end
+    return base_array
 end
 
 return NewsDownloader

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -150,15 +150,15 @@ function NewsDownloader:getSubMenuItems()
                     callback = function()
                         local Trapper = require("ui/trapper")
                         Trapper:wrap(function()
-                                local should_not_delete = Trapper:confirm(
+                                local should_delete = Trapper:confirm(
                                     _("Are you sure you want to delete all downloaded items?"),
-                                    _("Yes"),
-                                    _("Cancel")
+                                    _("Cancel"),
+                                    _("Yes")
                                 )
-                                if should_not_delete then
+                                if should_delete then
+                                    self:removeNewsButKeepFeedConfig()
                                     Trapper:reset()
                                 else
-                                    self:removeNewsButKeepFeedConfig()
                                     Trapper:reset()
                                 end
                         end)
@@ -224,12 +224,12 @@ function NewsDownloader:loadConfigAndProcessFeeds()
     -- If the file contains no table elements, then the user hasn't set any feeds.
     if #feed_config <= 0 then
         logger.err("NewsDownloader: empty feed list.", self.feed_config_path)
-        local should_close = UI:confirm(
+        local should_edit_feed_list = UI:confirm(
             T(_("Feed list is empty. If you want to download news, you'll have to add a feed first.")),
-            _("Edit feed list"),
-            _("Close")
+            _("Close"),
+            _("Edit feed list")
         )
-        if not should_close then
+        if should_edit_feed_list then
             -- Show the user a blank feed view so they can
             -- add a feed to their list.
             local feed_item_vc = FeedView:getItem(
@@ -311,19 +311,19 @@ review your feed configuration file.]])
     -- Ask the user if they want to go to their downloads folder
     -- or if they'd rather remain at the menu.
     feed_message = feed_message .. _("Go to downloaders folder?")
-    local should_return_to_menu = UI:confirm(
+    local should_go_to_downloads = UI:confirm(
         feed_message,
-        _("Go to downloads"),
-        _("Close")
+        _("Close"),
+        _("Go to downloads")
     )
-    if should_return_to_menu then
-        -- Return to the menu.
-        NetworkMgr:afterWifiAction()
-        return
-    else
+    if should_go_to_downloads then
         -- Go to downloads folder.
         UI:clear()
         self:openDownloadsFolder()
+        NetworkMgr:afterWifiAction()
+        return
+    else
+        -- Return to the menu.
         NetworkMgr:afterWifiAction()
         return
     end
@@ -639,7 +639,7 @@ function NewsDownloader:removeNewsButKeepFeedConfig()
         end
     end
     UIManager:show(InfoMessage:new{
-                       text = _("All news removed.")
+                       text = _("All downloaded news feed items deleted.")
     })
 end
 

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -71,75 +71,6 @@ function NewsDownloader:init()
 end
 
 function NewsDownloader:addToMainMenu(menu_items)
-<<<<<<< HEAD
-   menu_items.news_downloader = {
-      text = _("News (RSS/Atom) downloader"),
-      sub_item_table_func = function()
-	 return self:getSubMenuItems()
-      end,
-   }
-end
-
-function NewsDownloader:getSubMenuItems()
-   self:lazyInitialization()
-   local sub_item_table
-   sub_item_table = {
-      {
-	 text = _("Go to news folder"),
-	 callback = function()
-	    self:openDownloadsFolder()
-	 end,
-      },
-      {
-	 text = _("Download news feeds"),
-	 callback = function()
-	    NetworkMgr:runWhenOnline(function() self:loadConfigAndProcessFeedsWithUI() end)
-	 end,
-      },
-      {
-	 text = _("Remove all downloaded items"),
-	 keep_menu_open = true,
-	 callback = function() self:removeNewsButKeepFeedConfig() end,
-      },
-      {
-	 text = _("Settings"),
-	 sub_item_table = {
-	    {
-	       text = _("Edit feeds configuration file"),
-	       keep_menu_open = true,
-	       callback = function() self:changeFeedConfig() end,
-	    },
-	    {
-	       text = _("Set custom download folder"),
-	       keep_menu_open = true,
-	       callback = function() self:setCustomDownloadDirectory() end,
-	    },
-	    {
-	       text = _("Never download images"),
-	       keep_menu_open = true,
-	       checked_func = function()
-		  return self.settings:isTrue("never_download_images")
-	       end,
-	       callback = function()
-		  self.settings:toggle("never_download_images")
-		  self.settings:flush()
-	       end,
-	    },
-	 },
-      },
-      {
-	 text = _("Help"),
-	 keep_menu_open = true,
-	 callback = function()
-	    UIManager:show(InfoMessage:new{
-			      text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
-				       BD.dirpath(self.download_dir))
-	    })
-	 end,
-      },
-   }
-   return sub_item_table
-=======
     menu_items.news_downloader = {
         text = _("News (RSS/Atom) downloader"),
         sub_item_table_func = function()
@@ -207,7 +138,6 @@ function NewsDownloader:getSubMenuItems()
         },
     }
     return sub_item_table
->>>>>>> dev
 end
 -- lazyInitialization sets up variables that point to the
 -- downloads folder and the feeds configuration file

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -51,9 +51,9 @@ local FEED_TYPE_ATOM = "atom"
 --local feed_config_file_name = "feed_config.lua"
 --local news_downloader_config_file = "news_downloader_settings.lua
 
--- if a title looks like <title>blabla</title> it'll just be feed.title
--- if a title looks like <title attr="alb">blabla</title> then we get a table
--- where [1] is the title string and the attributes are also available
+-- If a title looks like <title>blabla</title> it'll just be feed.title.
+-- If a title looks like <title attr="alb">blabla</title> then we get a table.
+-- Where [1] is the title string and the attributes are also available.
 local function getFeedTitle(possible_title)
     if type(possible_title) == "string" then
         return util.htmlEntitiesToUtf8(possible_title)
@@ -62,12 +62,12 @@ local function getFeedTitle(possible_title)
     end
 end
 
--- there can be multiple links
--- for now we just assume the first link is probably the right one
---- @todo write unit tests
--- some feeds that can be used for unit test
--- http://fransdejonge.com/feed/ for multiple links
--- https://github.com/koreader/koreader/commits/master.atom for single link with attributes
+-- There can be multiple links
+-- for now we just assume the first link is probably the right one.
+--- @todo Write unit tests.
+-- Some feeds that can be used for unit test.
+-- http://fransdejonge.com/feed/ for multiple links.
+-- https://github.com/koreader/koreader/commits/master.atom for single link with attributes.
 local function getFeedLink(possible_link)
     local E = {}
     if type(possible_link) == "string" then
@@ -175,7 +175,7 @@ function NewsDownloader:getSubMenuItems()
     return sub_item_table
 end
 -- lazyInitialization sets up variables that point to the
--- downloads folder and the feeds configuration file
+-- downloads folder and the feeds configuration file.
 function NewsDownloader:lazyInitialization()
     if not self.initialized then
         logger.dbg("NewsDownloader: obtaining news folder")
@@ -348,7 +348,7 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
         feeds = self:deserializeXMLString(response)
     end
     -- If the response is not available (for a reason that we don't know),
-    -- add the URL to the unsupported feeds list
+    -- add the URL to the unsupported feeds list.
     if not ok or not feeds then
         local error_message
         if not ok then
@@ -564,7 +564,7 @@ function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_artic
 end
 
 local function parseDate(dateTime)
-    -- uses lua-feedparser https://github.com/slact/lua-feedparser
+    -- Uses lua-feedparser https://github.com/slact/lua-feedparser
     -- feedparser is available under the (new) BSD license.
     -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
     local date = dateparser.parse(dateTime)

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -10,9 +10,12 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("frontend/luasettings")
 local UIManager = require("ui/uimanager")
+<<<<<<< HEAD
+=======
 local KeyValuePage = require("ui/widget/keyvaluepage")
 local InputDialog = require("ui/widget/inputdialog")
 local MultiConfirmBox = require("ui/widget/multiconfirmbox")
+>>>>>>> feed_view
 local NetworkMgr = require("ui/network/manager")
 local Persist = require("persist")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -33,6 +36,8 @@ local NewsDownloader = WidgetContainer:new{
     download_dir = nil,
     file_extension = ".epub",
     config_key_custom_dl_dir = "custom_dl_dir",
+<<<<<<< HEAD
+=======
     empty_feed = {
         [1] = "https://",
         limit = 5,
@@ -41,6 +46,7 @@ local NewsDownloader = WidgetContainer:new{
         enable_filter = false,
         filter_element = ""
     },
+>>>>>>> feed_view
     kv = {}
 }
 
@@ -64,7 +70,7 @@ end
 
 -- there can be multiple links
 -- for now we just assume the first link is probably the right one
--- @todo write unit tests
+--- @todo write unit tests
 -- some feeds that can be used for unit test
 -- http://fransdejonge.com/feed/ for multiple links
 -- https://github.com/koreader/koreader/commits/master.atom for single link with attributes
@@ -85,7 +91,11 @@ end
 
 function NewsDownloader:addToMainMenu(menu_items)
     menu_items.news_downloader = {
+<<<<<<< HEAD
+        text = _("News (RSS/Atom) downloader"),
+=======
         text = _("News downloader (RSS/Atom)"),
+>>>>>>> feed_view
         sub_item_table_func = function()
             return self:getSubMenuItems()
         end,
@@ -103,6 +113,17 @@ function NewsDownloader:getSubMenuItems()
             end,
         },
         {
+<<<<<<< HEAD
+            text = _("Download news feeds"),
+            callback = function()
+                NetworkMgr:runWhenOnline(function() self:loadConfigAndProcessFeedsWithUI() end)
+            end,
+        },
+        {
+            text = _("Remove all downloaded items"),
+            keep_menu_open = true,
+            callback = function() self:removeNewsButKeepFeedConfig() end,
+=======
             text = _("Sync news feeds"),
             keep_menu_open = true,
             callback = function(touchmenu_instance)
@@ -119,12 +140,22 @@ function NewsDownloader:getSubMenuItems()
                 end)
 
             end,
+>>>>>>> feed_view
         },
         {
             text = _("Settings"),
             sub_item_table = {
                 {
+<<<<<<< HEAD
+                    text = _("Edit feeds configuration file"),
+                    keep_menu_open = true,
+                    callback = function() self:changeFeedConfig() end,
+                },
+                {
                     text = _("Set custom download folder"),
+=======
+                    text = _("Set download folder"),
+>>>>>>> feed_view
                     keep_menu_open = true,
                     callback = function() self:setCustomDownloadDirectory() end,
                 },
@@ -139,6 +170,16 @@ function NewsDownloader:getSubMenuItems()
                         self.settings:flush()
                     end,
                 },
+<<<<<<< HEAD
+            },
+        },
+        {
+            text = _("Help"),
+            keep_menu_open = true,
+            callback = function()
+                UIManager:show(InfoMessage:new{
+                                   text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
+=======
                 {
                     text = _("Delete all downloaded items"),
                     keep_menu_open = true,
@@ -167,6 +208,7 @@ function NewsDownloader:getSubMenuItems()
             callback = function()
                 UIManager:show(InfoMessage:new{
                                    text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate EPUB file that can be browsed by KOReader.\nFeeds can be configured with download limits and other customization through the Edit Feeds menu item."),
+>>>>>>> feed_view
                                             BD.dirpath(self.download_dir))
                 })
             end,
@@ -180,7 +222,11 @@ function NewsDownloader:lazyInitialization()
     if not self.initialized then
         logger.dbg("NewsDownloader: obtaining news folder")
         self.settings = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), self.news_config_file))
+<<<<<<< HEAD
+        -- Check to see if a custom download directory has been set
+=======
         -- Check to see if a custom download directory has been set.
+>>>>>>> feed_view
         if self.settings:has(self.config_key_custom_dl_dir) then
             self.download_dir = self.settings:readSetting(self.config_key_custom_dl_dir)
         else
@@ -190,14 +236,24 @@ function NewsDownloader:lazyInitialization()
                     self.download_dir_name)
         end
         logger.dbg("NewsDownloader: Custom directory set to:", self.download_dir)
+<<<<<<< HEAD
+        -- If the directory doesn't exist we will create it
+=======
         -- If the directory doesn't exist we will create it.
+>>>>>>> feed_view
         if not lfs.attributes(self.download_dir, "mode") then
             logger.dbg("NewsDownloader: Creating initial directory")
             lfs.mkdir(self.download_dir)
         end
+<<<<<<< HEAD
+        -- Now set the path to the feed configuration file
+        self.feed_config_path = self.download_dir .. self.feed_config_file
+        -- If the configuration file doesn't exist create it
+=======
         -- Now set the path to the feed configuration file.
         self.feed_config_path = self.download_dir .. self.feed_config_file
         -- If the configuration file doesn't exist create it.
+>>>>>>> feed_view
         if not lfs.attributes(self.feed_config_path, "mode") then
             logger.dbg("NewsDownloader: Creating initial feed config.")
             FFIUtil.copyFile(FFIUtil.joinPath(self.path, self.feed_config_file),
@@ -207,8 +263,14 @@ function NewsDownloader:lazyInitialization()
     end
 end
 
+<<<<<<< HEAD
+function NewsDownloader:loadConfigAndProcessFeeds()
+    local UI = require("ui/trapper")
+    UI:info("Loading news feed config…")
+=======
 function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
     local UI = require("ui/trapper")
+>>>>>>> feed_view
     logger.dbg("force repaint due to upcoming blocking calls")
 
     local ok, feed_config = pcall(dofile, self.feed_config_path)
@@ -216,6 +278,12 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
         UI:info(T(_("Invalid configuration file. Detailed error message:\n%1"), feed_config))
         return
     end
+<<<<<<< HEAD
+    -- If the file contains no table elements, then the user hasn't set any feeds
+    if #feed_config <= 0 then
+        logger.err('NewsDownloader: empty feed list.', self.feed_config_path)
+        -- TODO: Ask them to set the first feed. Perhaps even suggest something?!
+=======
     -- If the file contains no table elements, then the user hasn't set any feeds.
     if #feed_config <= 0 then
         logger.err("NewsDownloader: empty feed list.", self.feed_config_path)
@@ -238,6 +306,7 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
                 feed_item_vc
             )
         end
+>>>>>>> feed_view
         return
     end
 
@@ -253,11 +322,19 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
         local include_images = not never_download_images and feed.include_images
         local enable_filter = feed.enable_filter or feed.enable_filter == nil
         local filter_element = feed.filter_element or feed.filter_element == nil
+<<<<<<< HEAD
+        -- Check if the two required attributes are set
+        if url and limit then
+            feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
+            UI:info(feed_message)
+            -- Process, i.e.: "Download"
+=======
         -- Check if the two required attributes are set.
         if url and limit then
             feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
             UI:info(feed_message)
             -- Process the feed source.
+>>>>>>> feed_view
             self:processFeedSource(
                 url,
                 tonumber(limit),
@@ -268,12 +345,26 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
                 enable_filter,
                 filter_element)
         else
+<<<<<<< HEAD
+            logger.warn('NewsDownloader: invalid feed config entry.', feed)
+=======
             logger.warn("NewsDownloader: invalid feed config entry.", feed)
+>>>>>>> feed_view
         end
     end
 
     if #unsupported_feeds_urls <= 0 then
         -- When no errors are present, we get a happy message.
+<<<<<<< HEAD
+        feed_message = "Downloading news finished. "
+    else
+        -- When some errors are present, we get a sour message.
+        local unsupported_urls = ""
+        for key, value in pairs(unsupported_feeds_urls) do
+            -- Create the error message
+            unsupported_urls = unsupported_urls .. " " .. value[1] .. " " .. value[2]
+            -- Not sure what this does
+=======
         feed_message = _("Downloading news finished. ")
     else
         -- When some errors are present, we get a sour message that includes
@@ -283,10 +374,47 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
             -- Create the error message.
             unsupported_urls = unsupported_urls .. " " .. value[1] .. " " .. value[2]
             -- Not sure what this does.
+>>>>>>> feed_view
             if key ~= #unsupported_feeds_urls then
                 unsupported_urls = BD.url(unsupported_urls) .. ", "
             end
         end
+<<<<<<< HEAD
+        -- Tell the user there were problems
+        feed_message = "Downloading news finished with errors. "
+        go_to_config_file = UI:confirm(
+            T(
+                [[
+Could not process some feeds.
+Unsupported format in: %1. Please
+review your feed configuration file.]], unsupported_urls),
+            "Continue",
+            ""
+        )
+    end
+    -- Clear the info widgets before displaying the confirm box
+    UI:clear()
+    -- Ask the user if they want to see their downloads
+    feed_message = feed_message .. "Go to downloaders folder?"
+    return_to_menu = UI:confirm(feed_message, "Go to downloads", "Close")
+
+    if return_to_menu then
+        NetworkMgr:afterWifiAction()
+        return
+    else
+        -- Go to downloads folder
+        UI:clear()
+        self:openDownloadsFolder()
+        NetworkMgr:afterWifiAction()
+        return
+    end
+end
+
+function NewsDownloader:loadConfigAndProcessFeedsWithUI()
+    local Trapper = require("ui/trapper")
+    Trapper:wrap(function()
+            self:loadConfigAndProcessFeeds()
+=======
         -- Tell the user there were problems.
         feed_message = _("Downloading news finished with errors. ")
         -- Display a dialogue that requires the user to acknowledge
@@ -335,6 +463,7 @@ function NewsDownloader:loadConfigAndProcessFeedsWithUI(touchmenu_instance)
     local Trapper = require("ui/trapper")
     Trapper:wrap(function()
             self:loadConfigAndProcessFeeds(touchmenu_instance)
+>>>>>>> feed_view
     end)
 end
 
@@ -343,18 +472,32 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
             return DownloadBackend:getResponseAsString(url)
     end)
     local feeds
+<<<<<<< HEAD
+    -- Check to see if the response is OK to deserialize
+    if ok then
+        feeds = self:deserializeXMLString(response)
+    end
+    -- If the response is not OK, or feeds returned nil,
+=======
     -- Check to see if a response is available to deserialize.
     if ok then
         feeds = self:deserializeXMLString(response)
     end
     -- If the response is not available (for a reason that we don't know),
+>>>>>>> feed_view
     -- add the URL to the unsupported feeds list
     if not ok or not feeds then
         local error_message
         if not ok then
+<<<<<<< HEAD
+            error_message = "(Reason: Failed to download content)"
+        else
+            error_message = "(Reason: Error during feed deserialization)"
+=======
             error_message = _("(Reason: Failed to download content)")
         else
             error_message = _("(Reason: Error during feed deserialization)")
+>>>>>>> feed_view
         end
         table.insert(
             unsupported_feeds_urls,
@@ -365,7 +508,11 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
         )
         return
     end
+<<<<<<< HEAD
+    -- Check to see if the feed uses RSS
+=======
     -- Check to see if the feed uses RSS.
+>>>>>>> feed_view
     local is_rss = feeds.rss
         and feeds.rss.channel
         and feeds.rss.channel.title
@@ -373,7 +520,11 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
         and feeds.rss.channel.item[1]
         and feeds.rss.channel.item[1].title
         and feeds.rss.channel.item[1].link
+<<<<<<< HEAD
+    -- Check to see if the feed uses Atom
+=======
     -- Check to see if the feed uses Atom.
+>>>>>>> feed_view
     local is_atom = feeds.feed
         and feeds.feed.title
         and feeds.feed.entry[1]
@@ -409,6 +560,17 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
     end
     -- If the feed can't be processed, or it is neither
     -- Atom or RSS, then add it to the unsupported feeds list
+<<<<<<< HEAD
+    -- and return an error message
+    if not ok or (not is_rss and not is_atom) then
+        local error_message
+        if not ok then
+            error_message = "(Reason: Failed to download content)"
+        elseif not is_rss then
+            error_message = "(Reason: Couldn't process RSS)"
+        elseif not is_atom then
+            error_message = "(Reason: Couldn't process Atom)"
+=======
     -- and return an error message.
     if not ok or (not is_rss and not is_atom) then
         local error_message
@@ -418,6 +580,7 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
             error_message = _("(Reason: Couldn't process RSS)")
         elseif not is_atom then
             error_message = _("(Reason: Couldn't process Atom)")
+>>>>>>> feed_view
         end
         table.insert(
             unsupported_feeds_urls,
@@ -436,9 +599,15 @@ function NewsDownloader:deserializeXMLString(xml_str)
     -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENSE_LuaXML
     local treehdl = require("lib/handler")
     local libxml = require("lib/xml")
+<<<<<<< HEAD
+    --Instantiate the object that states the XML file as a Lua table
+    local xmlhandler = treehdl.simpleTreeHandler()
+    --Instantiate the object that parses the XML to a Lua table
+=======
     -- Instantiate the object that parses the XML file as a Lua table.
     local xmlhandler = treehdl.simpleTreeHandler()
     -- Instantiate the object that parses the XML to a Lua table.
+>>>>>>> feed_view
     local ok = pcall(function()
             libxml.xmlParser(xmlhandler):parse(xml_str)
     end)
@@ -447,12 +616,25 @@ function NewsDownloader:deserializeXMLString(xml_str)
 end
 
 function NewsDownloader:processAtom(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
+<<<<<<< HEAD
+    -- Get the path to the output directory
+=======
     -- Get the path to the output directory.
+>>>>>>> feed_view
     local feed_output_dir = string.format(
         "%s%s/",
         self.download_dir,
         util.getSafeFilename(getFeedTitle(feeds.feed.title))
     )
+<<<<<<< HEAD
+    -- Create the output directory if it doesn't exist
+    if not lfs.attributes(feed_output_dir, "mode") then
+        lfs.mkdir(feed_output_dir)
+    end
+    -- Download the feed
+    for index, feed in pairs(feeds.feed.entry) do
+        -- If limit has been met, stop downloading feed
+=======
     -- Create the output directory if it doesn't exist.
     if not lfs.attributes(feed_outpnnut_dir, "mode") then
         lfs.mkdir(feed_output_dir)
@@ -460,20 +642,29 @@ function NewsDownloader:processAtom(feeds, limit, download_full_article, include
     -- Download the feed.
     for index, feed in pairs(feeds.feed.entry) do
         -- If limit has been met, stop downloading feed.
+>>>>>>> feed_view
         if limit ~= 0 and index - 1 == limit then
             break
         end
         local total_articles = limit == 0
             and #feeds.rss.channel.item
             or limit
+<<<<<<< HEAD
+        -- Create a message to display during the processing
+=======
         -- Create a message to display during processing.
+>>>>>>> feed_view
         local article_message = T(
             _("%1\n\nFetching article %2/%3:"),
             message,
             index,
             total
         )
+<<<<<<< HEAD
+        -- Download the feed
+=======
         -- Download the feed.
+>>>>>>> feed_view
         if download_full_article then
             self:downloadFeed(
                 feed,
@@ -499,7 +690,11 @@ function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_artic
     local feed_title
     local feed_item
     local total_feeds
+<<<<<<< HEAD
+    -- Setup the above vars based on feed type
+=======
     -- Setup the above vars based on feed type.
+>>>>>>> feed_view
     if feed_type == FEED_TYPE_RSS then
         feed_title = util.htmlEntitiesToUtf8(feeds.rss.channel.title)
         feed_item = feeds.rss.channel.item
@@ -507,41 +702,69 @@ function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_artic
             and #feeds.rss.channel.item
             or limit
     else
+<<<<<<< HEAD
+        logger.dbg(feeds)
+=======
+>>>>>>> feed_view
         feed_title = getFeedTitle(feeds.feed.title)
         feed_item = feeds.feed.entry
         total_items = (limit == 0)
             and #feeds.feed.entry
             or limit
     end
+<<<<<<< HEAD
+    -- Get the path to the output directory
+    local feed_output_dir = ("%s%s/"):format(
+        self.download_dir,
+        util.getSafeFilename(util.htmlEntitiesToUtf8(feed_title)))
+    -- Create the output directory if it doesn't exist
+=======
     -- Get the path to the output directory.
     local feed_output_dir = ("%s%s/"):format(
         self.download_dir,
         util.getSafeFilename(util.htmlEntitiesToUtf8(feed_title)))
     -- Create the output directory if it doesn't exist.
+>>>>>>> feed_view
     if not lfs.attributes(feed_output_dir, "mode") then
         lfs.mkdir(feed_output_dir)
     end
     -- Download the feed
     for index, feed in pairs(feed_item) do
+<<<<<<< HEAD
+        -- If limit has been met, stop downloading feed
+        if limit ~= 0 and index - 1 == limit then
+            break
+        end
+        -- Create a message to display during the processing
+=======
         -- If limit has been met, stop downloading feed.
         if limit ~= 0 and index - 1 == limit then
             break
         end
         -- Create a message to display during processing.
+>>>>>>> feed_view
         local article_message = T(
             _("%1\n\nFetching article %2/%3:"),
             message,
             index,
             total_items
         )
+<<<<<<< HEAD
+        -- Get the feed description
+=======
         -- Get the feed description.
+>>>>>>> feed_view
         local feed_description
         if feed_type == FEED_TYPE_RSS then
             feed_description = feed.description
         else
             feed_description = feed.summary
         end
+<<<<<<< HEAD
+        -- Download the article
+=======
         -- Download the article.
+>>>>>>> feed_view
         if download_full_article then
             self:downloadFeed(
                 feed,
@@ -637,6 +860,36 @@ function NewsDownloader:removeNewsButKeepFeedConfig()
                 os.remove(entry_path)
             elseif entry_mode == "directory" then
                 FFIUtil.purgeDir(entry_path)
+<<<<<<< HEAD
+            end
+        end
+    end
+    UIManager:show(InfoMessage:new{
+                       text = _("All news removed.")
+    })
+end
+
+function NewsDownloader:setCustomDownloadDirectory()
+    require("ui/downloadmgr"):new{
+        onConfirm = function(path)
+            logger.dbg("NewsDownloader: set download directory to: ", path)
+            self.settings:saveSetting(self.config_key_custom_dl_dir, ("%s/"):format(path))
+            self.settings:flush()
+
+            logger.dbg("NewsDownloader: Coping to new download folder previous self.feed_config_file from: ", self.feed_config_path)
+            FFIUtil.copyFile(self.feed_config_path, ("%s/%s"):format(path, self.feed_config_file))
+
+            self.initialized = false
+            self:lazyInitialization()
+        end,
+                                 }:chooseDir()
+end
+
+function NewsDownloader:editFeedUrl(url, id)
+    -- How should this work?
+    -- WEll, it needs to know where the url is 'coming from', which is to say,
+    -- where in the config file it exists. we need an id, like, element 1, or element 3
+=======
             end
         end
     end
@@ -667,8 +920,6 @@ function NewsDownloader:viewFeedList()
     -- Protected call to see if feed config path returns a file that can be opened.
     local ok, feed_config = pcall(dofile, self.feed_config_path)
     if not ok or not feed_config then
-        --   UI:info(T(_("Invalid configuration file. Detailed error message:\n%1"), feed_config))
-        -- TODO: Proper error message with action. Maybe a confirm box?
         change_feed_config = UI:confirm(
             _("Could not open feed list. Feeds configuration file is invalid. "),
             _("Close"),
@@ -870,8 +1121,7 @@ function NewsDownloader:updateFeedConfig(id, key, value)
     end
     -- If the file contains no table elements, then the user hasn't set any feeds.
     if #feed_config <= 0 then
-        logger.err("NewsDownloader: empty feed list.", self.feed_config_path)
-        -- TODO: Ask them to set the first feed. Perhaps even suggest something?!
+        logger.dbg("NewsDownloader: empty feed list.", self.feed_config_path)
     end
 
     -- Check to see if the id is larger than the number of feeds. If it is,
@@ -1037,6 +1287,7 @@ function NewsDownloader:saveConfig(config)
         UI:info(_("News feed config updated successfully."))
     end
     UI:reset()
+>>>>>>> feed_view
 end
 
 function NewsDownloader:changeFeedConfig()
@@ -1044,7 +1295,10 @@ function NewsDownloader:changeFeedConfig()
     local config = feed_config_file:read("*all")
     feed_config_file:close()
     local config_editor
+<<<<<<< HEAD
+=======
     logger.info("NewsDownloader: opening configuration file", self.feed_config_path)
+>>>>>>> feed_view
     config_editor = InputDialog:new{
         title = T(_("Config: %1"), BD.filepath(self.feed_config_path)),
         input = config,

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -9,6 +9,8 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("frontend/luasettings")
 local UIManager = require("ui/uimanager")
+local KeyValuePage = require("ui/widget/keyvaluepage")
+--local ConfirmBox = require("ui/widget/confirmbox")
 local NetworkMgr = require("ui/network/manager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local dateparser = require("lib.dateparser")
@@ -18,27 +20,35 @@ local _ = require("gettext")
 local T = FFIUtil.template
 
 local NewsDownloader = WidgetContainer:new{
-    name = "newsdownloader",
+   name = "news_downloader",
+   initialized = false,
+   feed_config_file = "feed_config.lua",
+   feed_config_path = nil,
+   news_config_file = "news_settings.lua",
+   settings = nil,
+   download_dir_name = "news",
+   download_dir = nil,
+   file_extension = ".epub",
+   config_key_custom_dl_dir = "custom_dl_dir",
+   kv = {}
 }
 
-local initialized = false
-local feed_config_file_name = "feed_config.lua"
-local news_downloader_config_file = "news_downloader_settings.lua"
-local news_downloader_settings
-local config_key_custom_dl_dir = "custom_dl_dir"
-local file_extension = ".epub"
-local news_download_dir_name = "news"
-local news_download_dir_path, feed_config_path
+local FEED_TYPE_RSS = "rss"
+local FEED_TYPE_ATOM = "atom"
+
+--local initialized = false
+--local feed_config_file_name = "feed_config.lua"
+--local news_downloader_config_file = "news_downloader_settings.lua
 
 -- if a title looks like <title>blabla</title> it'll just be feed.title
 -- if a title looks like <title attr="alb">blabla</title> then we get a table
 -- where [1] is the title string and the attributes are also available
 local function getFeedTitle(possible_title)
-    if type(possible_title) == "string" then
-        return util.htmlEntitiesToUtf8(possible_title)
-    elseif possible_title[1] and type(possible_title[1]) == "string" then
-        return util.htmlEntitiesToUtf8(possible_title[1])
-    end
+   if type(possible_title) == "string" then
+      return util.htmlEntitiesToUtf8(possible_title)
+   elseif possible_title[1] and type(possible_title[1]) == "string" then
+      return util.htmlEntitiesToUtf8(possible_title[1])
+   end
 end
 
 -- there can be multiple links
@@ -48,415 +58,648 @@ end
 -- http://fransdejonge.com/feed/ for multiple links
 -- https://github.com/koreader/koreader/commits/master.atom for single link with attributes
 local function getFeedLink(possible_link)
-    local E = {}
-    if type(possible_link) == "string" then
-        return possible_link
-    elseif (possible_link._attr or E).href then
-        return possible_link._attr.href
-    elseif ((possible_link[1] or E)._attr or E).href then
-        return possible_link[1]._attr.href
-    end
+   local E = {}
+   if type(possible_link) == "string" then
+      return possible_link
+   elseif (possible_link._attr or E).href then
+      return possible_link._attr.href
+   elseif ((possible_link[1] or E)._attr or E).href then
+      return possible_link[1]._attr.href
+   end
 end
 
 function NewsDownloader:init()
-    self.ui.menu:registerToMainMenu(self)
+   self.ui.menu:registerToMainMenu(self)
 end
 
 function NewsDownloader:addToMainMenu(menu_items)
-    self:lazyInitialization()
-    menu_items.news_downloader = {
-        text = _("News (RSS/Atom) downloader"),
-        sub_item_table = {
-            {
-                text = _("Download news"),
-                keep_menu_open = true,
-                callback = function()
-                    NetworkMgr:runWhenOnline(function() self:loadConfigAndProcessFeedsWithUI() end)
-                end,
-            },
-            {
-                text = _("Go to news folder"),
-                callback = function()
-                    local FileManager = require("apps/filemanager/filemanager")
-                    if self.ui.document then
-                        self.ui:onClose()
-                    end
-                    if FileManager.instance then
-                        FileManager.instance:reinit(news_download_dir_path)
-                    else
-                        FileManager:showFiles(news_download_dir_path)
-                    end
-                end,
-            },
-            {
-                text = _("Remove news"),
-                keep_menu_open = true,
-                callback = function() self:removeNewsButKeepFeedConfig() end,
-            },
-            {
-                text = _("Never download images"),
-                keep_menu_open = true,
-                checked_func = function()
-                    return news_downloader_settings:isTrue("never_download_images")
-                end,
-                callback = function()
-                    news_downloader_settings:toggle("never_download_images")
-                    news_downloader_settings:flush()
-                end,
-            },
-            {
-                text = _("Settings"),
-                sub_item_table = {
-                    {
-                        text = _("Change feeds configuration"),
-                        keep_menu_open = true,
-                        callback = function() self:changeFeedConfig() end,
-                    },
-                    {
-                        text = _("Set custom download folder"),
-                        keep_menu_open = true,
-                        callback = function() self:setCustomDownloadDirectory() end,
-                    },
-                },
-            },
-            {
-                text = _("Help"),
-                keep_menu_open = true,
-                callback = function()
-                    UIManager:show(InfoMessage:new{
-                        text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
-                                 BD.dirpath(news_download_dir_path))
-                    })
-                end,
-            },
-        },
-    }
+   menu_items.news_downloader = {
+      text = _("News (RSS/Atom) downloader"),
+      sub_item_table_func = function()
+	 return self:getSubMenuItems()
+      end,
+   }
 end
 
+function NewsDownloader:getSubMenuItems()
+   self:lazyInitialization()
+   local sub_item_table
+   sub_item_table = {        
+      {
+	 text = _("Go to news folder"),
+	 callback = function()
+	    self:openDownloadsFolder()
+	 end,
+      },
+      {
+	 text = _("Download news feeds"),
+	 callback = function()
+	    NetworkMgr:runWhenOnline(function() self:loadConfigAndProcessFeedsWithUI() end)
+	 end,
+      },
+      {
+	 text = _("Remove all downloaded items"),
+	 keep_menu_open = true,
+	 callback = function() self:removeNewsButKeepFeedConfig() end,
+      },
+      {
+	 text = _("Settings"),
+	 sub_item_table = {
+	    {
+	       text = _("Edit feeds configuration file"),
+	       keep_menu_open = true,
+	       callback = function() self:changeFeedConfig() end,
+	    },
+	    {
+	       text = _("Set custom download folder"),
+	       keep_menu_open = true,
+	       callback = function() self:setCustomDownloadDirectory() end,
+	    },
+	    {
+	       text = _("Never download images"),
+	       keep_menu_open = true,
+	       checked_func = function()
+		  return self.settings:isTrue("never_download_images")
+	       end,
+	       callback = function()
+		  self.settings:toggle("never_download_images")
+		  self.settings:flush()
+	       end,
+	    },
+	 },
+      },
+      {
+	 text = _("Help"),
+	 keep_menu_open = true,
+	 callback = function()
+	    UIManager:show(InfoMessage:new{
+			      text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
+				       BD.dirpath(self.download_dir))
+	    })
+	 end,
+      },
+   }
+   return sub_item_table
+end
+-- lazyInitialization sets up variables that point to the
+-- downloads folder and the feeds configuration file
 function NewsDownloader:lazyInitialization()
-   if not initialized then
-        logger.dbg("NewsDownloader: obtaining news folder")
-        news_downloader_settings = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), news_downloader_config_file))
-        if news_downloader_settings:has(config_key_custom_dl_dir) then
-            news_download_dir_path = news_downloader_settings:readSetting(config_key_custom_dl_dir)
-        else
-            news_download_dir_path = ("%s/%s/"):format(DataStorage:getFullDataDir(), news_download_dir_name)
-        end
-
-        if not lfs.attributes(news_download_dir_path, "mode") then
-            logger.dbg("NewsDownloader: Creating initial directory")
-            lfs.mkdir(news_download_dir_path)
-        end
-        feed_config_path = news_download_dir_path .. feed_config_file_name
-
-        if not lfs.attributes(feed_config_path, "mode") then
-            logger.dbg("NewsDownloader: Creating initial feed config.")
-            FFIUtil.copyFile(FFIUtil.joinPath(self.path, feed_config_file_name),
-                         feed_config_path)
-        end
-        initialized = true
-    end
+   if not self.initialized then
+      logger.dbg("NewsDownloader: obtaining news folder")
+      self.settings = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), self.news_config_file))
+      -- Check to see if a custom download directory has been set
+      if self.settings:has(self.config_key_custom_dl_dir) then
+	 self.download_dir = self.settings:readSetting(self.config_key_custom_dl_dir)
+      else
+	 self.download_dir =
+	    ("%s/%s/"):format(
+	       DataStorage:getFullDataDir(),
+	       self.download_dir_name)
+      end
+      logger.dbg("NewsDownloader: Custom directory set to:", self.download_dir)
+      -- If the directory doesn't exist we will create it
+      if not lfs.attributes(self.download_dir, "mode") then
+	 logger.dbg("NewsDownloader: Creating initial directory")
+	 lfs.mkdir(self.download_dir)
+      end
+      -- Now set the path to the feed configuration file
+      self.feed_config_path = self.download_dir .. self.feed_config_file
+      -- If the configuration file doesn't exist create it
+      if not lfs.attributes(self.feed_config_path, "mode") then
+	 logger.dbg("NewsDownloader: Creating initial feed config.")
+	 FFIUtil.copyFile(FFIUtil.joinPath(self.path, self.feed_config_file),
+			  self.feed_config_path)
+      end
+      self.initialized = true
+   end
 end
 
 function NewsDownloader:loadConfigAndProcessFeeds()
-    local UI = require("ui/trapper")
-    UI:info("Loading news feed config…")
-    logger.dbg("force repaint due to upcoming blocking calls")
+   local UI = require("ui/trapper")
+   UI:info("Loading news feed config…")
+   logger.dbg("force repaint due to upcoming blocking calls")
 
-    local ok, feed_config = pcall(dofile, feed_config_path)
-    if not ok or not feed_config then
-        UI:info(T(_("Invalid configuration file. Detailed error message:\n%1"), feed_config))
-        return
-    end
+   local ok, feed_config = pcall(dofile, self.feed_config_path)
+   if not ok or not feed_config then
+      UI:info(T(_("Invalid configuration file. Detailed error message:\n%1"), feed_config))
+      return
+   end
+   -- If the file contains no table elements, then the user hasn't set any feeds
+   if #feed_config <= 0 then
+      logger.err('NewsDownloader: empty feed list.', self.feed_config_path)
+      -- TODO: Ask them to set the first feed. Perhaps even suggest something?!
+      return
+   end
 
-    if #feed_config <= 0 then
-        logger.err('NewsDownloader: empty feed list.', feed_config_path)
-        return
-    end
-
-    local never_download_images = news_downloader_settings:isTrue("never_download_images")
-
-    local unsupported_feeds_urls = {}
-
-    local total_feed_entries = #feed_config
-    for idx, feed in ipairs(feed_config) do
-        local url = feed[1]
-        local limit = feed.limit
-        local download_full_article = feed.download_full_article == nil or feed.download_full_article
-        local include_images = not never_download_images and feed.include_images
-        local enable_filter = feed.enable_filter or feed.enable_filter == nil
-        local filter_element = feed.filter_element or feed.filter_element == nil
-        if url and limit then
-            local feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
-            UI:info(feed_message)
-            NewsDownloader:processFeedSource(url, tonumber(limit), unsupported_feeds_urls, download_full_article, include_images, feed_message, enable_filter, filter_element)
-        else
-            logger.warn('NewsDownloader: invalid feed config entry', feed)
-        end
-    end
-
-    if #unsupported_feeds_urls <= 0 then
-        UI:info("Downloading news finished.")
-    else
-        local unsupported_urls = ""
-        for k,url in pairs(unsupported_feeds_urls) do
-            unsupported_urls = unsupported_urls .. url
-            if k ~= #unsupported_feeds_urls then
-                unsupported_urls = BD.url(unsupported_urls) .. ", "
-            end
-        end
-        UI:info(T(_("Downloading news finished. Could not process some feeds. Unsupported format in: %1"), unsupported_urls))
-    end
-    NetworkMgr:afterWifiAction()
+   local never_download_images = self.settings:isTrue("never_download_images")
+   local unsupported_feeds_urls = {}
+   local total_feed_entries = #feed_config
+   local feed_message
+   
+   for idx, feed in ipairs(feed_config) do
+      local url = feed[1]
+      local limit = feed.limit
+      local download_full_article = feed.download_full_article == nil or feed.download_full_article
+      local include_images = not never_download_images and feed.include_images
+      local enable_filter = feed.enable_filter or feed.enable_filter == nil
+      local filter_element = feed.filter_element or feed.filter_element == nil
+      -- Check if the two required attributes are set
+      if url and limit then
+	 feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
+	 UI:info(feed_message)
+	 -- Process, i.e.: "Download"
+	 self:processFeedSource(
+	    url,
+	    tonumber(limit),
+	    unsupported_feeds_urls,
+	    download_full_article,
+	    include_images,
+	    feed_message,
+	    enable_filter,
+	    filter_element)
+      else
+	 logger.warn('NewsDownloader: invalid feed config entry.', feed)
+      end
+   end
+   
+   if #unsupported_feeds_urls <= 0 then
+      -- When no errors are present, we get a happy message.
+      feed_message = "Downloading news finished. "
+   else
+      -- When some errors are present, we get a sour message.
+      local unsupported_urls = ""
+      for key, value in pairs(unsupported_feeds_urls) do
+	 -- Create the error message
+	 unsupported_urls = unsupported_urls .. " " .. value[1] .. " " .. value[2]
+	 -- Not sure what this does
+	 if key ~= #unsupported_feeds_urls then
+	    unsupported_urls = BD.url(unsupported_urls) .. ", "
+	 end
+      end
+      -- Tell the user there were problems
+      feed_message = "Downloading news finished with errors. "
+      go_to_config_file = UI:confirm(
+	 T(
+	    [[
+Could not process some feeds.
+Unsupported format in: %1. Please
+review your feed configuration file.]], unsupported_urls),
+	 "Continue",
+	 ""	 
+      )
+   end   
+   -- Clear the info widgets before displaying the confirm box
+   UI:clear()
+   -- Ask the user if they want to see their downloads
+   feed_message = feed_message .. "Go to downloaders folder?"
+   return_to_menu = UI:confirm(feed_message, "Go to downloads", "Return to menu")
+   
+   if return_to_menu then
+      NetworkMgr:afterWifiAction()
+      return
+   else
+      -- Go to downloads folder
+      UI:clear()
+      self:openDownloadsFolder()
+      NetworkMgr:afterWifiAction()
+      return
+   end
 end
 
 function NewsDownloader:loadConfigAndProcessFeedsWithUI()
-    local Trapper = require("ui/trapper")
-    Trapper:wrap(function()
-        self.loadConfigAndProcessFeeds()
-    end)
+   local Trapper = require("ui/trapper")
+   Trapper:wrap(function()
+	 self:loadConfigAndProcessFeeds()
+   end)
 end
 
 function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, download_full_article, include_images, message, enable_filter, filter_element)
-
-    local ok, response = pcall(function()
-        return DownloadBackend:getResponseAsString(url)
-    end)
-    local feeds
-    if ok then
-        feeds = self:deserializeXMLString(response)
-    end
-
-    if not ok or not feeds then
-        table.insert(unsupported_feeds_urls, url)
-        return
-    end
-
-    local is_rss = feeds.rss and feeds.rss.channel and feeds.rss.channel.title and feeds.rss.channel.item and feeds.rss.channel.item[1] and feeds.rss.channel.item[1].title and feeds.rss.channel.item[1].link
-    local is_atom = feeds.feed and feeds.feed.title and feeds.feed.entry[1] and feeds.feed.entry[1].title and feeds.feed.entry[1].link
-
-    if is_atom then
-        ok = pcall(function()
-            return self:processAtom(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-        end)
-    elseif is_rss then
-        ok = pcall(function()
-            return self:processRSS(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-        end)
-    end
-    if not ok or (not is_rss and not is_atom) then
-        table.insert(unsupported_feeds_urls, url)
-    end
+   local ok, response = pcall(function()
+	 return DownloadBackend:getResponseAsString(url)
+   end)
+   local feeds
+   -- Check to see if the response is OK to deserialize
+   if ok then
+      feeds = self:deserializeXMLString(response)
+   end
+   -- If the response is not OK, or feeds returned nil,
+   -- add the URL to the unsupported feeds list
+   if not ok or not feeds then
+      local error_message
+      if not ok then
+	 error_message = "(Reason: Failed to download content)"
+      else
+	 error_message = "(Reason: Error during feed deserialization)"
+      end
+      table.insert(
+	 unsupported_feeds_urls,
+	 {
+	    url,
+	    error_message
+	 }
+      )
+      return
+   end
+   -- Check to see if the feed uses RSS
+   local is_rss = feeds.rss
+      and feeds.rss.channel
+      and feeds.rss.channel.title
+      and feeds.rss.channel.item
+      and feeds.rss.channel.item[1]
+      and feeds.rss.channel.item[1].title
+      and feeds.rss.channel.item[1].link
+   -- Check to see if the feed uses Atom
+   local is_atom = feeds.feed
+      and feeds.feed.title
+      and feeds.feed.entry[1]
+      and feeds.feed.entry[1].title
+      and feeds.feed.entry[1].link
+   -- Process the feeds accordingly. 
+   if is_atom then
+      ok = pcall(function()	    
+            return self:processFeed(
+	       FEED_TYPE_ATOM,
+	       feeds,
+	       limit,
+	       download_full_article,
+	       include_images,
+	       message,
+	       enable_filter,
+	       filter_element
+	    )
+      end)
+   elseif is_rss then
+      ok = pcall(function()
+            return self:processFeed(
+	       FEED_TYPE_RSS,
+	       feeds,
+	       limit,
+	       download_full_article,
+	       include_images,
+	       message,
+	       enable_filter,
+	       filter_element
+	    )
+      end)
+   end
+   -- If the feed can't be processed, or it is neither
+   -- Atom or RSS, then add it to the unsupported feeds list
+   -- and return an error message
+   if not ok or (not is_rss and not is_atom) then
+      local error_message
+      if not ok then
+	 error_message = "(Reason: Failed to download content)"
+      elseif not is_rss then
+	 error_message = "(Reason: Couldn't process RSS)"
+      elseif not is_atom then
+	 error_message = "(Reason: Couldn't process Atom)"
+      end	 
+      table.insert(
+	 unsupported_feeds_urls,
+	 {
+	    url,
+	    error_message
+	 }
+      )
+   end
 end
 
 function NewsDownloader:deserializeXMLString(xml_str)
-    -- uses LuaXML https://github.com/manoelcampos/LuaXML
-    -- The MIT License (MIT)
-    -- Copyright (c) 2016 Manoel Campos da Silva Filho
-    -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENSE_LuaXML
-    local treehdl = require("lib/handler")
-    local libxml = require("lib/xml")
-
-    --Instantiate the object the states the XML file as a Lua table
-    local xmlhandler = treehdl.simpleTreeHandler()
-    --Instantiate the object that parses the XML to a Lua table
-    local ok = pcall(function()
-        libxml.xmlParser(xmlhandler):parse(xml_str)
-    end)
-    if not ok then return end
-    return xmlhandler.root
+   -- uses LuaXML https://github.com/manoelcampos/LuaXML
+   -- The MIT License (MIT)
+   -- Copyright (c) 2016 Manoel Campos da Silva Filho
+   -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENSE_LuaXML
+   local treehdl = require("lib/handler")
+   local libxml = require("lib/xml")
+   --Instantiate the object that states the XML file as a Lua table
+   local xmlhandler = treehdl.simpleTreeHandler()
+   --Instantiate the object that parses the XML to a Lua table
+   local ok = pcall(function()
+	 libxml.xmlParser(xmlhandler):parse(xml_str)
+   end)
+   if not ok then return end
+   return xmlhandler.root
 end
 
 function NewsDownloader:processAtom(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-    local feed_output_dir = string.format("%s%s/",
-                                          news_download_dir_path,
-                                          util.getSafeFilename(getFeedTitle(feeds.feed.title)))
-    if not lfs.attributes(feed_output_dir, "mode") then
-        lfs.mkdir(feed_output_dir)
-    end
-
-    for index, feed in pairs(feeds.feed.entry) do
-        if limit ~= 0 and index - 1 == limit then
-            break
-        end
-        local article_message = T(_("%1\n\nFetching article %2/%3:"), message, index, limit == 0 and #feeds.rss.channel.item or limit)
-        if download_full_article then
-            self:downloadFeed(feed, feed_output_dir, include_images, article_message, enable_filter, filter_element)
-        else
-            self:createFromDescription(feed, feed.content[1], feed_output_dir, include_images, article_message)
-        end
-    end
+   -- Get the path to the output directory
+   local feed_output_dir = string.format(
+      "%s%s/",
+      self.download_dir,
+      util.getSafeFilename(getFeedTitle(feeds.feed.title))
+   )
+   -- Create the output directory if it doesn't exist
+   if not lfs.attributes(feed_output_dir, "mode") then
+      lfs.mkdir(feed_output_dir)
+   end
+   -- Download the feed
+   for index, feed in pairs(feeds.feed.entry) do
+      -- If limit has been met, stop downloading feed
+      if limit ~= 0 and index - 1 == limit then
+	 break
+      end
+      local total_articles = limit == 0
+	 and #feeds.rss.channel.item
+	 or limit
+      -- Create a message to display during the processing
+      local article_message = T(
+	 _("%1\n\nFetching article %2/%3:"),
+	 message,
+	 index,
+	 total
+      )
+      -- Download the feed
+      if download_full_article then
+	 self:downloadFeed(
+	    feed,
+	    feed_output_dir,
+	    include_images,
+	    article_message,
+	    enable_filter,
+	    filter_element
+	 )
+      else
+	 self:createFromDescription(
+	    feed,
+	    feed.content[1],
+	    feed_output_dir,
+	    include_images,
+	    article_message
+	 )
+      end
+   end
 end
 
-function NewsDownloader:processRSS(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-    local feed_output_dir = ("%s%s/"):format(
-        news_download_dir_path, util.getSafeFilename(util.htmlEntitiesToUtf8(feeds.rss.channel.title)))
-    if not lfs.attributes(feed_output_dir, "mode") then
-        lfs.mkdir(feed_output_dir)
-    end
-
-    for index, feed in pairs(feeds.rss.channel.item) do
-        if limit ~= 0 and index - 1 == limit then
-            break
-        end
-        local article_message = T(_("%1\n\nFetching article %2/%3:"), message, index, limit == 0 and #feeds.rss.channel.item or limit)
-        if download_full_article then
-            self:downloadFeed(feed, feed_output_dir, include_images, article_message, enable_filter, filter_element)
-        else
-            self:createFromDescription(feed, feed.description, feed_output_dir, include_images, article_message)
-        end
-    end
+function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
+   local feed_title
+   local feed_item
+   local total_feeds
+   -- Setup the above vars based on feed type
+   if feed_type == FEED_TYPE_RSS then
+      feed_title = util.htmlEntitiesToUtf8(feeds.rss.channel.title)
+      feed_item = feeds.rss.channel.item
+      total_items = (limit == 0)
+	 and #feeds.rss.channel.item
+	 or limit
+   else
+      logger.dbg(feeds)
+      feed_title = getFeedTitle(feeds.feed.title)
+      feed_item = feeds.feed.entry
+      total_items = (limit == 0)
+	 and #feeds.feed.entry
+	 or limit
+   end
+   -- Get the path to the output directory
+   local feed_output_dir = ("%s%s/"):format(
+      self.download_dir,
+      util.getSafeFilename(util.htmlEntitiesToUtf8(feed_title)))
+   -- Create the output directory if it doesn't exist
+   if not lfs.attributes(feed_output_dir, "mode") then
+      lfs.mkdir(feed_output_dir)
+   end
+   -- Download the feed
+   for index, feed in pairs(feed_item) do
+      -- If limit has been met, stop downloading feed
+      if limit ~= 0 and index - 1 == limit then
+	 break
+      end
+      -- Create a message to display during the processing
+      local article_message = T(
+	 _("%1\n\nFetching article %2/%3:"),
+	 message,
+	 index,
+	 total_items
+      )
+      -- Get the feed description
+      local feed_description
+      if feed_type == FEED_TYPE_RSS then
+	 feed_description = feed.description
+      else
+	 feed_description = feed.summary
+      end
+      -- Download the article
+      if download_full_article then
+	 self:downloadFeed(
+	    feed,
+	    feed_output_dir,
+	    include_images,
+	    article_message,
+	    enable_filter,
+	    filter_element
+	 )
+      else
+	 self:createFromDescription(
+	    feed,
+	    feed_description,
+	    feed_output_dir,
+	    include_images,
+	    article_message
+	 )
+      end
+   end
 end
 
 local function parseDate(dateTime)
-    -- uses lua-feedparser https://github.com/slact/lua-feedparser
-    -- feedparser is available under the (new) BSD license.
-    -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
-    local date = dateparser.parse(dateTime)
-    return os.date("%y-%m-%d_%H-%M_", date)
+   -- uses lua-feedparser https://github.com/slact/lua-feedparser
+   -- feedparser is available under the (new) BSD license.
+   -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
+   local date = dateparser.parse(dateTime)
+   return os.date("%y-%m-%d_%H-%M_", date)
 end
 
+-- This appears to be used by Atom feeds in processFeed
 local function getTitleWithDate(feed)
-    local title = util.getSafeFilename(getFeedTitle(feed.title))
-    if feed.updated then
-       title = parseDate(feed.updated) .. title
-    elseif feed.pubDate then
-       title = parseDate(feed.pubDate) .. title
-    elseif feed.published then
-        title = parseDate(feed.published) .. title
-    end
-    return title
+   local title = util.getSafeFilename(getFeedTitle(feed.title))
+   if feed.updated then
+      title = parseDate(feed.updated) .. title
+   elseif feed.pubDate then
+      title = parseDate(feed.pubDate) .. title
+   elseif feed.published then
+      title = parseDate(feed.published) .. title
+   end
+   return title
 end
 
 function NewsDownloader:downloadFeed(feed, feed_output_dir, include_images, message, enable_filter, filter_element)
-    local title_with_date = getTitleWithDate(feed)
-    local news_file_path = ("%s%s%s"):format(feed_output_dir,
-                                             title_with_date,
-                                             file_extension)
+   local title_with_date = getTitleWithDate(feed)
+   local news_file_path = ("%s%s%s"):format(feed_output_dir,
+					    title_with_date,
+					    self.file_extension)
 
-    local file_mode = lfs.attributes(news_file_path, "mode")
-    if file_mode == "file" then
-        logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
-    else
-        logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
-        local article_message = T(_("%1\n%2"), message, title_with_date)
-        local link = getFeedLink(feed.link)
-        local html = DownloadBackend:loadPage(link)
-        DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message, enable_filter, filter_element)
-    end
+   local file_mode = lfs.attributes(news_file_path, "mode")
+   if file_mode == "file" then
+      logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
+   else
+      logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
+      local article_message = T(_("%1\n%2"), message, title_with_date)
+      local link = getFeedLink(feed.link)
+      local html = DownloadBackend:loadPage(link)
+      DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message, enable_filter, filter_element)
+   end
 end
 
 function NewsDownloader:createFromDescription(feed, content, feed_output_dir, include_images, message)
-    local title_with_date = getTitleWithDate(feed)
-    local news_file_path = ("%s%s%s"):format(feed_output_dir,
-                                             title_with_date,
-                                             file_extension)
-    local file_mode = lfs.attributes(news_file_path, "mode")
-    if file_mode == "file" then
-        logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
-    else
-        logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
-        local article_message = T(_("%1\n%2"), message, title_with_date)
-        local footer = _("This is just a description of the feed. To download the full article instead, go to the News Downloader settings and change 'download_full_article' to 'true'.")
+   local title_with_date = getTitleWithDate(feed)
+   local news_file_path = ("%s%s%s"):format(feed_output_dir,
+					    title_with_date,
+					    self.file_extension)
+   local file_mode = lfs.attributes(news_file_path, "mode")
+   if file_mode == "file" then
+      logger.dbg("NewsDownloader:", news_file_path, "already exists. Skipping")
+   else
+      logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
+      local article_message = T(_("%1\n%2"), message, title_with_date)
+      local footer = _("This is just a description of the feed. To download the full article instead, go to the News Downloader settings and change 'download_full_article' to 'true'.")
 
-        local html = string.format([[<!DOCTYPE html>
+      local html = string.format([[<!DOCTYPE html>
 <html>
 <head><meta charset='UTF-8'><title>%s</title></head>
 <body><header><h2>%s</h2></header><article>%s</article>
 <br><footer><small>%s</small></footer>
 </body>
 </html>]], feed.title, feed.title, content, footer)
-        local link = getFeedLink(feed.link)
-        DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message)
-    end
+      local link = getFeedLink(feed.link)
+      DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message)
+   end
 end
 
 function NewsDownloader:removeNewsButKeepFeedConfig()
-    logger.dbg("NewsDownloader: Removing news from :", news_download_dir_path)
-    for entry in lfs.dir(news_download_dir_path) do
-        if entry ~= "." and entry ~= ".." and entry ~= feed_config_file_name then
-            local entry_path = news_download_dir_path .. "/" .. entry
-            local entry_mode = lfs.attributes(entry_path, "mode")
-            if entry_mode == "file" then
-                os.remove(entry_path)
-            elseif entry_mode == "directory" then
-                FFIUtil.purgeDir(entry_path)
-            end
-        end
-    end
-    UIManager:show(InfoMessage:new{
-       text = _("All news removed.")
-    })
+   logger.dbg("NewsDownloader: Removing news from :", self.download_dir)
+   for entry in lfs.dir(self.download_dir) do
+      if entry ~= "." and entry ~= ".." and entry ~= self.feed_config_file then
+	 local entry_path = self.download_dir .. "/" .. entry
+	 local entry_mode = lfs.attributes(entry_path, "mode")
+	 if entry_mode == "file" then
+	    os.remove(entry_path)
+	 elseif entry_mode == "directory" then
+	    FFIUtil.purgeDir(entry_path)
+	 end
+      end
+   end
+   UIManager:show(InfoMessage:new{
+		     text = _("All news removed.")
+   })
 end
 
 function NewsDownloader:setCustomDownloadDirectory()
-    require("ui/downloadmgr"):new{
-       onConfirm = function(path)
-           logger.dbg("NewsDownloader: set download directory to: ", path)
-           news_downloader_settings:saveSetting(config_key_custom_dl_dir, ("%s/"):format(path))
-           news_downloader_settings:flush()
+   require("ui/downloadmgr"):new{
+      onConfirm = function(path)
+	 logger.dbg("NewsDownloader: set download directory to: ", path)
+	 self.settings:saveSetting(self.config_key_custom_dl_dir, ("%s/"):format(path))
+	 self.settings:flush()
 
-           logger.dbg("NewsDownloader: Coping to new download folder previous feed_config_file_name from: ", feed_config_path)
-           FFIUtil.copyFile(feed_config_path, ("%s/%s"):format(path, feed_config_file_name))
+	 logger.dbg("NewsDownloader: Coping to new download folder previous self.feed_config_file from: ", self.feed_config_path)
+	 FFIUtil.copyFile(self.feed_config_path, ("%s/%s"):format(path, self.feed_config_file))
 
-           initialized = false
-           self:lazyInitialization()
-       end,
-    }:chooseDir()
+	 self.initialized = false
+	 self:lazyInitialization()
+      end,
+				}:chooseDir()
+end
+
+function NewsDownloader:editFeedUrl(url, id)
+   -- How should this work?
+   -- WEll, it needs to know where the url is 'coming from', which is to say,
+   -- where in the config file it exists. we need an id, like, element 1, or element 3
 end
 
 function NewsDownloader:changeFeedConfig()
-    local feed_config_file = io.open(feed_config_path, "rb")
-    local config = feed_config_file:read("*all")
-    feed_config_file:close()
-    local config_editor
-    config_editor = InputDialog:new{
-        title = T(_("Config: %1"), BD.filepath(feed_config_path)),
-        input = config,
-        input_type = "string",
-        para_direction_rtl = false, -- force LTR
-        fullscreen = true,
-        condensed = true,
-        allow_newline = true,
-        cursor_at_end = false,
-        add_nav_bar = true,
-        reset_callback = function()
-            return config
-        end,
-        save_callback = function(content)
-            if content and #content > 0 then
-                local parse_error = util.checkLuaSyntax(content)
-                if not parse_error then
-                    local syntax_okay, syntax_error = pcall(loadstring(content))
-                    if syntax_okay then
-                        feed_config_file = io.open(feed_config_path, "w")
-                        feed_config_file:write(content)
-                        feed_config_file:close()
-                        return true, _("Configuration saved")
-                    else
-                        return false, T(_("Configuration invalid: %1"), syntax_error)
-                    end
-                else
-                        return false, T(_("Configuration invalid: %1"), parse_error)
-                    end
+   local feed_config_file = io.open(self.feed_config_path, "rb")
+   local config = feed_config_file:read("*all")
+   feed_config_file:close()
+   local config_editor
+   config_editor = InputDialog:new{
+      title = T(_("Config: %1"), BD.filepath(self.feed_config_path)),
+      input = config,
+      input_type = "string",
+      para_direction_rtl = false, -- force LTR
+      fullscreen = true,
+      condensed = true,
+      allow_newline = true,
+      cursor_at_end = false,
+      add_nav_bar = true,
+      reset_callback = function()
+         return config
+      end,
+      save_callback = function(content)
+         if content and #content > 0 then
+            local parse_error = util.checkLuaSyntax(content)
+            if not parse_error then
+               local syntax_okay, syntax_error = pcall(loadstring(content))
+               if syntax_okay then
+                  feed_config_file = io.open(self.feed_config_path, "w")
+                  feed_config_file:write(content)
+                  feed_config_file:close()
+                  return true, _("Configuration saved")
+               else
+                  return false, T(_("Configuration invalid: %1"), syntax_error)
+               end
+            else
+               return false, T(_("Configuration invalid: %1"), parse_error)
             end
-            return false, _("Configuration empty")
-        end,
-    }
-    UIManager:show(config_editor)
-    config_editor:onShowKeyboard()
+         end
+         return false, _("Configuration empty")
+      end,
+   }
+   UIManager:show(config_editor)
+   config_editor:onShowKeyboard()
+end
+function NewsDownloader:openDownloadsFolder()
+   local FileManager = require("apps/filemanager/filemanager")
+   if self.ui.document then
+      self.ui:onClose()
+   end
+   if FileManager.instance then
+      FileManager.instance:reinit(self.download_dir)
+   else
+      FileManager:showFiles(self.download_dir)
+   end
 end
 
 function NewsDownloader:onCloseDocument()
-    local document_full_path = self.ui.document.file
-    if  document_full_path and news_download_dir_path and news_download_dir_path == string.sub(document_full_path, 1, string.len(news_download_dir_path)) then
-        logger.dbg("NewsDownloader: document_full_path:", document_full_path)
-        logger.dbg("NewsDownloader: news_download_dir_path:", news_download_dir_path)
-        logger.dbg("NewsDownloader: removing NewsDownloader file from history.")
-        ReadHistory:removeItemByPath(document_full_path)
-        local doc_dir = util.splitFilePathName(document_full_path)
-        self.ui:setLastDirForFileBrowser(doc_dir)
-    end
+   local document_full_path = self.ui.document.file
+   if  document_full_path and self.download_dir and self.download_dir == string.sub(document_full_path, 1, string.len(self.download_dir)) then
+      logger.dbg("NewsDownloader: document_full_path:", document_full_path)
+      logger.dbg("NewsDownloader: self.download_dir:", self.download_dir)
+      logger.dbg("NewsDownloader: removing NewsDownloader file from history.")
+      ReadHistory:removeItemByPath(document_full_path)
+      local doc_dir = util.splitFilePathName(document_full_path)
+      self.ui:setLastDirForFileBrowser(doc_dir)
+   end
+end
+
+--
+-- KeyValuePage doesn't like to get a table with sub tables.
+-- This function flattens an array, moving all nested tables
+-- up the food chain, so to speak
+--
+function NewsDownloader:flattenArray(base_array, source_array)
+   for key, value in pairs(source_array) do
+      if value[2] == nil then
+         -- If the value is empty, then it's probably supposed to be a line
+         table.insert(
+            base_array,
+            "---"
+         )
+      else
+         if value["callback"] then
+            table.insert(
+               base_array,
+               {
+                  value[1], value[2], callback = value["callback"]
+               }
+            )
+         else
+            table.insert(
+               base_array,
+               {
+                  value[1], value[2]
+               }
+            )
+         end
+      end
+   end
+   return base_array
 end
 
 return NewsDownloader

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -10,12 +10,9 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("frontend/luasettings")
 local UIManager = require("ui/uimanager")
-<<<<<<< HEAD
-=======
 local KeyValuePage = require("ui/widget/keyvaluepage")
 local InputDialog = require("ui/widget/inputdialog")
 local MultiConfirmBox = require("ui/widget/multiconfirmbox")
->>>>>>> feed_view
 local NetworkMgr = require("ui/network/manager")
 local Persist = require("persist")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -36,8 +33,6 @@ local NewsDownloader = WidgetContainer:new{
     download_dir = nil,
     file_extension = ".epub",
     config_key_custom_dl_dir = "custom_dl_dir",
-<<<<<<< HEAD
-=======
     empty_feed = {
         [1] = "https://",
         limit = 5,
@@ -46,7 +41,6 @@ local NewsDownloader = WidgetContainer:new{
         enable_filter = false,
         filter_element = ""
     },
->>>>>>> feed_view
     kv = {}
 }
 
@@ -91,11 +85,7 @@ end
 
 function NewsDownloader:addToMainMenu(menu_items)
     menu_items.news_downloader = {
-<<<<<<< HEAD
-        text = _("News (RSS/Atom) downloader"),
-=======
         text = _("News downloader (RSS/Atom)"),
->>>>>>> feed_view
         sub_item_table_func = function()
             return self:getSubMenuItems()
         end,
@@ -113,17 +103,6 @@ function NewsDownloader:getSubMenuItems()
             end,
         },
         {
-<<<<<<< HEAD
-            text = _("Download news feeds"),
-            callback = function()
-                NetworkMgr:runWhenOnline(function() self:loadConfigAndProcessFeedsWithUI() end)
-            end,
-        },
-        {
-            text = _("Remove all downloaded items"),
-            keep_menu_open = true,
-            callback = function() self:removeNewsButKeepFeedConfig() end,
-=======
             text = _("Sync news feeds"),
             keep_menu_open = true,
             callback = function(touchmenu_instance)
@@ -140,22 +119,12 @@ function NewsDownloader:getSubMenuItems()
                 end)
 
             end,
->>>>>>> feed_view
         },
         {
             text = _("Settings"),
             sub_item_table = {
                 {
-<<<<<<< HEAD
-                    text = _("Edit feeds configuration file"),
-                    keep_menu_open = true,
-                    callback = function() self:changeFeedConfig() end,
-                },
-                {
-                    text = _("Set custom download folder"),
-=======
                     text = _("Set download folder"),
->>>>>>> feed_view
                     keep_menu_open = true,
                     callback = function() self:setCustomDownloadDirectory() end,
                 },
@@ -170,16 +139,6 @@ function NewsDownloader:getSubMenuItems()
                         self.settings:flush()
                     end,
                 },
-<<<<<<< HEAD
-            },
-        },
-        {
-            text = _("Help"),
-            keep_menu_open = true,
-            callback = function()
-                UIManager:show(InfoMessage:new{
-                                   text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate html file, that can be browsed by KOReader file manager.\nItems download limit can be configured in Settings."),
-=======
                 {
                     text = _("Delete all downloaded items"),
                     keep_menu_open = true,
@@ -208,7 +167,6 @@ function NewsDownloader:getSubMenuItems()
             callback = function()
                 UIManager:show(InfoMessage:new{
                                    text = T(_("News downloader retrieves RSS and Atom news entries and stores them to:\n%1\n\nEach entry is a separate EPUB file that can be browsed by KOReader.\nFeeds can be configured with download limits and other customization through the Edit Feeds menu item."),
->>>>>>> feed_view
                                             BD.dirpath(self.download_dir))
                 })
             end,
@@ -222,11 +180,7 @@ function NewsDownloader:lazyInitialization()
     if not self.initialized then
         logger.dbg("NewsDownloader: obtaining news folder")
         self.settings = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), self.news_config_file))
-<<<<<<< HEAD
-        -- Check to see if a custom download directory has been set
-=======
         -- Check to see if a custom download directory has been set.
->>>>>>> feed_view
         if self.settings:has(self.config_key_custom_dl_dir) then
             self.download_dir = self.settings:readSetting(self.config_key_custom_dl_dir)
         else
@@ -236,24 +190,14 @@ function NewsDownloader:lazyInitialization()
                     self.download_dir_name)
         end
         logger.dbg("NewsDownloader: Custom directory set to:", self.download_dir)
-<<<<<<< HEAD
-        -- If the directory doesn't exist we will create it
-=======
         -- If the directory doesn't exist we will create it.
->>>>>>> feed_view
         if not lfs.attributes(self.download_dir, "mode") then
             logger.dbg("NewsDownloader: Creating initial directory")
             lfs.mkdir(self.download_dir)
         end
-<<<<<<< HEAD
-        -- Now set the path to the feed configuration file
-        self.feed_config_path = self.download_dir .. self.feed_config_file
-        -- If the configuration file doesn't exist create it
-=======
         -- Now set the path to the feed configuration file.
         self.feed_config_path = self.download_dir .. self.feed_config_file
         -- If the configuration file doesn't exist create it.
->>>>>>> feed_view
         if not lfs.attributes(self.feed_config_path, "mode") then
             logger.dbg("NewsDownloader: Creating initial feed config.")
             FFIUtil.copyFile(FFIUtil.joinPath(self.path, self.feed_config_file),
@@ -263,14 +207,8 @@ function NewsDownloader:lazyInitialization()
     end
 end
 
-<<<<<<< HEAD
-function NewsDownloader:loadConfigAndProcessFeeds()
-    local UI = require("ui/trapper")
-    UI:info("Loading news feed config…")
-=======
 function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
     local UI = require("ui/trapper")
->>>>>>> feed_view
     logger.dbg("force repaint due to upcoming blocking calls")
 
     local ok, feed_config = pcall(dofile, self.feed_config_path)
@@ -278,12 +216,6 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
         UI:info(T(_("Invalid configuration file. Detailed error message:\n%1"), feed_config))
         return
     end
-<<<<<<< HEAD
-    -- If the file contains no table elements, then the user hasn't set any feeds
-    if #feed_config <= 0 then
-        logger.err('NewsDownloader: empty feed list.', self.feed_config_path)
-        -- TODO: Ask them to set the first feed. Perhaps even suggest something?!
-=======
     -- If the file contains no table elements, then the user hasn't set any feeds.
     if #feed_config <= 0 then
         logger.err("NewsDownloader: empty feed list.", self.feed_config_path)
@@ -306,7 +238,6 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
                 feed_item_vc
             )
         end
->>>>>>> feed_view
         return
     end
 
@@ -322,19 +253,11 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
         local include_images = not never_download_images and feed.include_images
         local enable_filter = feed.enable_filter or feed.enable_filter == nil
         local filter_element = feed.filter_element or feed.filter_element == nil
-<<<<<<< HEAD
-        -- Check if the two required attributes are set
-        if url and limit then
-            feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
-            UI:info(feed_message)
-            -- Process, i.e.: "Download"
-=======
         -- Check if the two required attributes are set.
         if url and limit then
             feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
             UI:info(feed_message)
             -- Process the feed source.
->>>>>>> feed_view
             self:processFeedSource(
                 url,
                 tonumber(limit),
@@ -345,26 +268,12 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
                 enable_filter,
                 filter_element)
         else
-<<<<<<< HEAD
-            logger.warn('NewsDownloader: invalid feed config entry.', feed)
-=======
             logger.warn("NewsDownloader: invalid feed config entry.", feed)
->>>>>>> feed_view
         end
     end
 
     if #unsupported_feeds_urls <= 0 then
         -- When no errors are present, we get a happy message.
-<<<<<<< HEAD
-        feed_message = "Downloading news finished. "
-    else
-        -- When some errors are present, we get a sour message.
-        local unsupported_urls = ""
-        for key, value in pairs(unsupported_feeds_urls) do
-            -- Create the error message
-            unsupported_urls = unsupported_urls .. " " .. value[1] .. " " .. value[2]
-            -- Not sure what this does
-=======
         feed_message = _("Downloading news finished. ")
     else
         -- When some errors are present, we get a sour message that includes
@@ -374,47 +283,10 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
             -- Create the error message.
             unsupported_urls = unsupported_urls .. " " .. value[1] .. " " .. value[2]
             -- Not sure what this does.
->>>>>>> feed_view
             if key ~= #unsupported_feeds_urls then
                 unsupported_urls = BD.url(unsupported_urls) .. ", "
             end
         end
-<<<<<<< HEAD
-        -- Tell the user there were problems
-        feed_message = "Downloading news finished with errors. "
-        go_to_config_file = UI:confirm(
-            T(
-                [[
-Could not process some feeds.
-Unsupported format in: %1. Please
-review your feed configuration file.]], unsupported_urls),
-            "Continue",
-            ""
-        )
-    end
-    -- Clear the info widgets before displaying the confirm box
-    UI:clear()
-    -- Ask the user if they want to see their downloads
-    feed_message = feed_message .. "Go to downloaders folder?"
-    return_to_menu = UI:confirm(feed_message, "Go to downloads", "Close")
-
-    if return_to_menu then
-        NetworkMgr:afterWifiAction()
-        return
-    else
-        -- Go to downloads folder
-        UI:clear()
-        self:openDownloadsFolder()
-        NetworkMgr:afterWifiAction()
-        return
-    end
-end
-
-function NewsDownloader:loadConfigAndProcessFeedsWithUI()
-    local Trapper = require("ui/trapper")
-    Trapper:wrap(function()
-            self:loadConfigAndProcessFeeds()
-=======
         -- Tell the user there were problems.
         feed_message = _("Downloading news finished with errors. ")
         -- Display a dialogue that requires the user to acknowledge
@@ -463,7 +335,6 @@ function NewsDownloader:loadConfigAndProcessFeedsWithUI(touchmenu_instance)
     local Trapper = require("ui/trapper")
     Trapper:wrap(function()
             self:loadConfigAndProcessFeeds(touchmenu_instance)
->>>>>>> feed_view
     end)
 end
 
@@ -472,32 +343,18 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
             return DownloadBackend:getResponseAsString(url)
     end)
     local feeds
-<<<<<<< HEAD
-    -- Check to see if the response is OK to deserialize
-    if ok then
-        feeds = self:deserializeXMLString(response)
-    end
-    -- If the response is not OK, or feeds returned nil,
-=======
     -- Check to see if a response is available to deserialize.
     if ok then
         feeds = self:deserializeXMLString(response)
     end
     -- If the response is not available (for a reason that we don't know),
->>>>>>> feed_view
     -- add the URL to the unsupported feeds list
     if not ok or not feeds then
         local error_message
         if not ok then
-<<<<<<< HEAD
-            error_message = "(Reason: Failed to download content)"
-        else
-            error_message = "(Reason: Error during feed deserialization)"
-=======
             error_message = _("(Reason: Failed to download content)")
         else
             error_message = _("(Reason: Error during feed deserialization)")
->>>>>>> feed_view
         end
         table.insert(
             unsupported_feeds_urls,
@@ -508,11 +365,7 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
         )
         return
     end
-<<<<<<< HEAD
-    -- Check to see if the feed uses RSS
-=======
     -- Check to see if the feed uses RSS.
->>>>>>> feed_view
     local is_rss = feeds.rss
         and feeds.rss.channel
         and feeds.rss.channel.title
@@ -520,11 +373,7 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
         and feeds.rss.channel.item[1]
         and feeds.rss.channel.item[1].title
         and feeds.rss.channel.item[1].link
-<<<<<<< HEAD
-    -- Check to see if the feed uses Atom
-=======
     -- Check to see if the feed uses Atom.
->>>>>>> feed_view
     local is_atom = feeds.feed
         and feeds.feed.title
         and feeds.feed.entry[1]
@@ -560,17 +409,6 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
     end
     -- If the feed can't be processed, or it is neither
     -- Atom or RSS, then add it to the unsupported feeds list
-<<<<<<< HEAD
-    -- and return an error message
-    if not ok or (not is_rss and not is_atom) then
-        local error_message
-        if not ok then
-            error_message = "(Reason: Failed to download content)"
-        elseif not is_rss then
-            error_message = "(Reason: Couldn't process RSS)"
-        elseif not is_atom then
-            error_message = "(Reason: Couldn't process Atom)"
-=======
     -- and return an error message.
     if not ok or (not is_rss and not is_atom) then
         local error_message
@@ -580,7 +418,6 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
             error_message = _("(Reason: Couldn't process RSS)")
         elseif not is_atom then
             error_message = _("(Reason: Couldn't process Atom)")
->>>>>>> feed_view
         end
         table.insert(
             unsupported_feeds_urls,
@@ -599,15 +436,9 @@ function NewsDownloader:deserializeXMLString(xml_str)
     -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENSE_LuaXML
     local treehdl = require("lib/handler")
     local libxml = require("lib/xml")
-<<<<<<< HEAD
-    --Instantiate the object that states the XML file as a Lua table
-    local xmlhandler = treehdl.simpleTreeHandler()
-    --Instantiate the object that parses the XML to a Lua table
-=======
     -- Instantiate the object that parses the XML file as a Lua table.
     local xmlhandler = treehdl.simpleTreeHandler()
     -- Instantiate the object that parses the XML to a Lua table.
->>>>>>> feed_view
     local ok = pcall(function()
             libxml.xmlParser(xmlhandler):parse(xml_str)
     end)
@@ -616,25 +447,12 @@ function NewsDownloader:deserializeXMLString(xml_str)
 end
 
 function NewsDownloader:processAtom(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-<<<<<<< HEAD
-    -- Get the path to the output directory
-=======
     -- Get the path to the output directory.
->>>>>>> feed_view
     local feed_output_dir = string.format(
         "%s%s/",
         self.download_dir,
         util.getSafeFilename(getFeedTitle(feeds.feed.title))
     )
-<<<<<<< HEAD
-    -- Create the output directory if it doesn't exist
-    if not lfs.attributes(feed_output_dir, "mode") then
-        lfs.mkdir(feed_output_dir)
-    end
-    -- Download the feed
-    for index, feed in pairs(feeds.feed.entry) do
-        -- If limit has been met, stop downloading feed
-=======
     -- Create the output directory if it doesn't exist.
     if not lfs.attributes(feed_outpnnut_dir, "mode") then
         lfs.mkdir(feed_output_dir)
@@ -642,29 +460,20 @@ function NewsDownloader:processAtom(feeds, limit, download_full_article, include
     -- Download the feed.
     for index, feed in pairs(feeds.feed.entry) do
         -- If limit has been met, stop downloading feed.
->>>>>>> feed_view
         if limit ~= 0 and index - 1 == limit then
             break
         end
         local total_articles = limit == 0
             and #feeds.rss.channel.item
             or limit
-<<<<<<< HEAD
-        -- Create a message to display during the processing
-=======
         -- Create a message to display during processing.
->>>>>>> feed_view
         local article_message = T(
             _("%1\n\nFetching article %2/%3:"),
             message,
             index,
             total
         )
-<<<<<<< HEAD
-        -- Download the feed
-=======
         -- Download the feed.
->>>>>>> feed_view
         if download_full_article then
             self:downloadFeed(
                 feed,
@@ -690,11 +499,7 @@ function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_artic
     local feed_title
     local feed_item
     local total_feeds
-<<<<<<< HEAD
-    -- Setup the above vars based on feed type
-=======
     -- Setup the above vars based on feed type.
->>>>>>> feed_view
     if feed_type == FEED_TYPE_RSS then
         feed_title = util.htmlEntitiesToUtf8(feeds.rss.channel.title)
         feed_item = feeds.rss.channel.item
@@ -702,69 +507,41 @@ function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_artic
             and #feeds.rss.channel.item
             or limit
     else
-<<<<<<< HEAD
-        logger.dbg(feeds)
-=======
->>>>>>> feed_view
         feed_title = getFeedTitle(feeds.feed.title)
         feed_item = feeds.feed.entry
         total_items = (limit == 0)
             and #feeds.feed.entry
             or limit
     end
-<<<<<<< HEAD
-    -- Get the path to the output directory
-    local feed_output_dir = ("%s%s/"):format(
-        self.download_dir,
-        util.getSafeFilename(util.htmlEntitiesToUtf8(feed_title)))
-    -- Create the output directory if it doesn't exist
-=======
     -- Get the path to the output directory.
     local feed_output_dir = ("%s%s/"):format(
         self.download_dir,
         util.getSafeFilename(util.htmlEntitiesToUtf8(feed_title)))
     -- Create the output directory if it doesn't exist.
->>>>>>> feed_view
     if not lfs.attributes(feed_output_dir, "mode") then
         lfs.mkdir(feed_output_dir)
     end
     -- Download the feed
     for index, feed in pairs(feed_item) do
-<<<<<<< HEAD
-        -- If limit has been met, stop downloading feed
-        if limit ~= 0 and index - 1 == limit then
-            break
-        end
-        -- Create a message to display during the processing
-=======
         -- If limit has been met, stop downloading feed.
         if limit ~= 0 and index - 1 == limit then
             break
         end
         -- Create a message to display during processing.
->>>>>>> feed_view
         local article_message = T(
             _("%1\n\nFetching article %2/%3:"),
             message,
             index,
             total_items
         )
-<<<<<<< HEAD
-        -- Get the feed description
-=======
         -- Get the feed description.
->>>>>>> feed_view
         local feed_description
         if feed_type == FEED_TYPE_RSS then
             feed_description = feed.description
         else
             feed_description = feed.summary
         end
-<<<<<<< HEAD
-        -- Download the article
-=======
         -- Download the article.
->>>>>>> feed_view
         if download_full_article then
             self:downloadFeed(
                 feed,
@@ -860,36 +637,6 @@ function NewsDownloader:removeNewsButKeepFeedConfig()
                 os.remove(entry_path)
             elseif entry_mode == "directory" then
                 FFIUtil.purgeDir(entry_path)
-<<<<<<< HEAD
-            end
-        end
-    end
-    UIManager:show(InfoMessage:new{
-                       text = _("All news removed.")
-    })
-end
-
-function NewsDownloader:setCustomDownloadDirectory()
-    require("ui/downloadmgr"):new{
-        onConfirm = function(path)
-            logger.dbg("NewsDownloader: set download directory to: ", path)
-            self.settings:saveSetting(self.config_key_custom_dl_dir, ("%s/"):format(path))
-            self.settings:flush()
-
-            logger.dbg("NewsDownloader: Coping to new download folder previous self.feed_config_file from: ", self.feed_config_path)
-            FFIUtil.copyFile(self.feed_config_path, ("%s/%s"):format(path, self.feed_config_file))
-
-            self.initialized = false
-            self:lazyInitialization()
-        end,
-                                 }:chooseDir()
-end
-
-function NewsDownloader:editFeedUrl(url, id)
-    -- How should this work?
-    -- WEll, it needs to know where the url is 'coming from', which is to say,
-    -- where in the config file it exists. we need an id, like, element 1, or element 3
-=======
             end
         end
     end
@@ -1287,7 +1034,6 @@ function NewsDownloader:saveConfig(config)
         UI:info(_("News feed config updated successfully."))
     end
     UI:reset()
->>>>>>> feed_view
 end
 
 function NewsDownloader:changeFeedConfig()
@@ -1295,10 +1041,7 @@ function NewsDownloader:changeFeedConfig()
     local config = feed_config_file:read("*all")
     feed_config_file:close()
     local config_editor
-<<<<<<< HEAD
-=======
     logger.info("NewsDownloader: opening configuration file", self.feed_config_path)
->>>>>>> feed_view
     config_editor = InputDialog:new{
         title = T(_("Config: %1"), BD.filepath(self.feed_config_path)),
         input = config,


### PR DESCRIPTION
This PR includes the following changes:
- Changed the scope of a bunch of variables in `main.lua`
- Replaced `processRSS` and `processAtom` with `processFeed`.
- Fixed XML/Atom feeds not being downloaded because of a missing description
- Moved settings for downloading images to settings menu
- Changed some of the menu labels
- Added more verbose error messages during the downloads process
- Added a user flow with option to "Go to downloads" after feeds are downloaded

I've tried to follow the code styles for this project. Inevitably, I've probably introduced some of my own style biases.  

Please discuss!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8145)
<!-- Reviewable:end -->
