### PR TITLE
[frontlight, kobo, cervantes] Remove auto_warmth

### DIFF
--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -1,14 +1,11 @@
 local BasePowerD = require("device/generic/powerd")
 local SysfsLight = require ("device/sysfs_light")
-local PluginShare = require("pluginshare")
 
 local battery_sysfs = "/sys/devices/platform/pmic_battery.1/power_supply/mc13892_bat/"
 
 local CervantesPowerD = BasePowerD:new{
     fl = nil,
     fl_warmth = nil,
-    auto_warmth = false,
-    max_warmth_hour = 23,
 
     fl_min = 0,
     fl_max = 100,
@@ -23,11 +20,10 @@ function CervantesPowerD:_syncLightOnStart()
     -- Use last values stored in koreader settings.
     local new_intensity = G_reader_settings:readSetting("frontlight_intensity") or nil
     local is_frontlight_on = G_reader_settings:readSetting("is_frontlight_on") or nil
-    local new_warmth, auto_warmth = nil
+    local new_warmth = nil
 
     if self.fl_warmth ~= nil then
         new_warmth = G_reader_settings:readSetting("frontlight_warmth") or nil
-        auto_warmth = G_reader_settings:readSetting("frontlight_auto_warmth") or nil
     end
 
     if new_intensity ~= nil then
@@ -38,15 +34,7 @@ function CervantesPowerD:_syncLightOnStart()
         self.initial_is_fl_on = is_frontlight_on
     end
 
-    local max_warmth_hour =
-        G_reader_settings:readSetting("frontlight_max_warmth_hour")
-    if max_warmth_hour then
-        self.max_warmth_hour = max_warmth_hour
-    end
-    if auto_warmth then
-        self.auto_warmth = true
-        self:calculateAutoWarmth()
-    elseif new_warmth ~= nil then
+    if new_warmth ~= nil then
         self.fl_warmth = new_warmth
     end
 
@@ -61,7 +49,6 @@ function CervantesPowerD:init()
     -- not be called)
     self.hw_intensity = 20
     self.initial_is_fl_on = true
-    self.autowarmth_job_running = false
 
     if self.device:hasFrontlight() then
         if self.device:hasNaturalLight() then
@@ -101,15 +88,11 @@ function CervantesPowerD:saveSettings()
         local cur_intensity = self.fl_intensity
         local cur_is_fl_on = self.is_fl_on
         local cur_warmth = self.fl_warmth
-        local cur_auto_warmth = self.auto_warmth
-        local cur_max_warmth_hour = self.max_warmth_hour
         -- Save intensity to koreader settings
         G_reader_settings:saveSetting("frontlight_intensity", cur_intensity)
         G_reader_settings:saveSetting("is_frontlight_on", cur_is_fl_on)
         if cur_warmth ~= nil then
             G_reader_settings:saveSetting("frontlight_warmth", cur_warmth)
-            G_reader_settings:saveSetting("frontlight_auto_warmth", cur_auto_warmth)
-            G_reader_settings:saveSetting("frontlight_max_warmth_hour", cur_max_warmth_hour)
         end
     end
 end
@@ -141,10 +124,7 @@ end
 
 function CervantesPowerD:setWarmth(warmth)
     if self.fl == nil then return end
-    if not warmth and self.auto_warmth then
-        self:calculateAutoWarmth()
-    end
-    self.fl_warmth = warmth or self.fl_warmth
+    self.fl_warmth = warmth
     self.fl:setWarmth(self.fl_warmth)
     self:stateChanged()
 end
@@ -152,45 +132,6 @@ end
 function CervantesPowerD:getWarmth()
     if self.fl == nil then return end
     return self.fl_warmth
-end
-
-function CervantesPowerD:calculateAutoWarmth()
-    local current_time = os.date("%H") + os.date("%M")/60
-    local max_hour = self.max_warmth_hour
-    local diff_time = max_hour - current_time
-    if diff_time < 0 then
-        diff_time = diff_time + 24
-    end
-    if diff_time < 12 then
-        -- We are before bedtime. Use a slower progression over 5h.
-        self.fl_warmth = math.max(20 * (5 - diff_time), 0)
-    elseif diff_time > 22 then
-        -- Keep warmth at maximum for two hours after bedtime.
-        self.fl_warmth = 100
-    else
-        -- Between 2-4h after bedtime, return to zero.
-        self.fl_warmth = math.max(100 - 50 * (22 - diff_time), 0)
-    end
-    self.fl_warmth = math.floor(self.fl_warmth + 0.5)
-
-    -- Enable background job for setting Warmth, if not already done.
-    if not self.autowarmth_job_running then
-        table.insert(PluginShare.backgroundJobs, {
-                         when = 180,
-                         repeated = true,
-                         executable = function()
-                             if self.auto_warmth then
-                                 self:setWarmth()
-                             end
-                         end,
-        })
-        if package.loaded["ui/uimanager"] ~= nil then
-            local Event = require("ui/event")
-            local UIManager = require("ui/uimanager")
-            UIManager:broadcastEvent(Event:new("BackgroundJobsUpdated"))
-        end
-        self.autowarmth_job_running = true
-    end
 end
 
 function CervantesPowerD:getCapacityHW()
@@ -213,9 +154,6 @@ function CervantesPowerD:afterResume()
     if self.fl_warmth == nil then
         self.fl:setBrightness(self.hw_intensity)
     else
-        if self.auto_warmth then
-            self:calculateAutoWarmth()
-        end
         self.fl:setNaturalBrightness(self.hw_intensity, self.fl_warmth)
     end
 end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -170,11 +170,6 @@ if Device:hasFrontlight() then
         local powerd = Device:getPowerDevice()
         if powerd.fl_warmth == nil then return false end
 
-        if powerd.auto_warmth then
-            Notification:notify(_("Warmth is handled automatically."))
-            return true
-        end
-
         local delta_int
         --received gesture
 

--- a/frontend/device/kobo/nickel_conf.lua
+++ b/frontend/device/kobo/nickel_conf.lua
@@ -9,22 +9,17 @@ local NickelConf = {}
 NickelConf.frontLightLevel = {}
 NickelConf.frontLightState = {}
 NickelConf.colorSetting = {}
-NickelConf.autoColorEnabled = {}
 
 local kobo_conf_path = '/mnt/onboard/.kobo/Kobo/Kobo eReader.conf'
 local front_light_level_str = "FrontLightLevel"
 local front_light_state_str = "FrontLightState"
 local color_setting_str = "ColorSetting"
-local auto_color_enabled_str = "AutoColorEnabled"
 -- Nickel will set FrontLightLevel to 0 - 100
 local re_FrontLightLevel = "^" .. front_light_level_str .. "%s*=%s*([0-9]+)%s*$"
 -- Nickel will set FrontLightState to true (light on) or false (light off)
 local re_FrontLightState = "^" .. front_light_state_str .. "%s*=%s*(.+)%s*$"
 -- Nickel will set ColorSetting to 1500 - 6400
 local re_ColorSetting = "^" .. color_setting_str .. "%s*=%s*([0-9]+)%s*$"
--- AutoColorEnabled is 'true' or 'false'
--- We do not support 'BedTime' (it is saved as QVariant in Nickel)
-local re_AutoColorEnabled = "^" .. auto_color_enabled_str .. "%s*=%s*([a-z]+)%s*$"
 local re_PowerOptionsSection = "^%[PowerOptions%]%s*"
 local re_AnySection = "^%[.*%]%s*"
 
@@ -102,18 +97,6 @@ function NickelConf.colorSetting.get()
     local new_colorsetting = NickelConf._read_kobo_conf(re_ColorSetting)
     if new_colorsetting then
         return tonumber(new_colorsetting)
-    end
-end
-
---[[--
-Get auto color enabled.
-
-@treturn bool Auto color enabled.
---]]
-function NickelConf.autoColorEnabled.get()
-    local new_autocolor = NickelConf._read_kobo_conf(re_AutoColorEnabled)
-    if new_autocolor then
-        return (new_autocolor == "true")
     end
 end
 
@@ -235,22 +218,6 @@ dbg:guard(NickelConf.colorSetting, "set",
             "Wrong color value type (expected number)!")
         assert(new_color >= 1500 and new_color <= 6400,
             "Wrong colorSetting value given!")
-    end)
-
---[[--
-Set auto color enabled.
-
-@bool new_autocolor
---]]
-function NickelConf.autoColorEnabled.set(new_autocolor)
-    return NickelConf._write_kobo_conf(re_AutoColorEnabled,
-                                       auto_color_enabled_str,
-                                       new_autocolor)
-end
-dbg:guard(NickelConf.autoColorEnabled, "set",
-    function(new_autocolor)
-        assert(type(new_autocolor) == "boolean",
-            "Wrong type for autocolor (expected boolean)!")
     end)
 
 return NickelConf

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210902
+local CURRENT_MIGRATION_DATE = 20210925
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -313,8 +313,8 @@ if last_migration_date < 20210831 then
 end
 
 -- 20210902, Remove unneeded auto_warmth settings after #8154
-if last_migration_date < 20210902 then
-    logger.info("Performing one-time migration for 20210902")
+if last_migration_date < 20210925 then
+    logger.info("Performing one-time migration for 20210925")
     G_reader_settings:delSetting("frontlight_auto_warmth")
     G_reader_settings:delSetting("frontlight_max_warmth_hour")
 end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210831
+local CURRENT_MIGRATION_DATE = 20210902
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -296,6 +296,7 @@ if last_migration_date < 20210720 then
     G_reader_settings:saveSetting("duration_format", "classic")
 end
 
+<<<<<<< HEAD
 -- 20210831, Clean VirtualKeyboard settings of disabled layouts, https://github.com/koreader/koreader/pull/8159
 if last_migration_date < 20210831 then
     logger.info("Performing one-time migration for 20210831")

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -296,7 +296,6 @@ if last_migration_date < 20210720 then
     G_reader_settings:saveSetting("duration_format", "classic")
 end
 
-<<<<<<< HEAD
 -- 20210831, Clean VirtualKeyboard settings of disabled layouts, https://github.com/koreader/koreader/pull/8159
 if last_migration_date < 20210831 then
     logger.info("Performing one-time migration for 20210831")
@@ -314,7 +313,7 @@ if last_migration_date < 20210831 then
 end
 
 -- 20210902, Remove unneeded auto_warmth settings after #8154
-if last_migration_date < 20210830 then
+if last_migration_date < 20210902 then
     logger.info("Performing one-time migration for 20210902")
     G_reader_settings:delSetting("frontlight_auto_warmth")
     G_reader_settings:delSetting("frontlight_max_warmth_hour")

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -312,5 +312,12 @@ if last_migration_date < 20210831 then
     G_reader_settings:saveSetting("keyboard_layouts", keyboard_layouts_new)
 end
 
+-- 20210902, Remove unneeded auto_warmth settings after #8154
+if last_migration_date < 20210830 then
+    logger.info("Performing one-time migration for 20210902")
+    G_reader_settings:delSetting("frontlight_auto_warmth")
+    G_reader_settings:delSetting("frontlight_max_warmth_hour")
+end
+
 -- We're done, store the current migration date
 G_reader_settings:saveSetting("last_migration_date", CURRENT_MIGRATION_DATE)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -1,7 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CheckButton = require("ui/widget/checkbutton")
 local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -39,7 +38,6 @@ local FrontLightWidget = InputContainer:new{
 
 function FrontLightWidget:init()
     self.medium_font_face = Font:getFace("ffont")
-    self.larger_font_face = Font:getFace("cfont")
     self.light_bar = {}
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
@@ -71,7 +69,6 @@ function FrontLightWidget:init()
     local button_margin = Size.margin.tiny
     local button_padding = Size.padding.button
     local button_bordersize = Size.border.button
-    self.auto_nl = false
     self.button_width = math.floor(self.screen_width * 0.9 / self.steps) -
             2 * (button_margin + button_padding + button_bordersize)
 
@@ -285,11 +282,9 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
     local button_group_down = HorizontalGroup:new{ align = "center" }
     local button_group_up = HorizontalGroup:new{ align = "center" }
     local warmth_group = HorizontalGroup:new{ align = "center" }
-    local auto_nl_group = HorizontalGroup:new{ align = "center" }
     local padding_span = VerticalSpan:new{ width = self.span }
     local enable_button_plus = true
     local enable_button_minus = true
-    local button_color = Blitbuffer.COLOR_WHITE
 
     if self[1] then
         --- @note Don't set the same value twice, to play nice with the update() sent by the swipe handler on the FL bar
@@ -298,23 +293,12 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         end
     end
 
-    if self.powerd.auto_warmth then
-        enable_button_plus = false
-        enable_button_minus = false
-        button_color = Blitbuffer.COLOR_DARK_GRAY
-    else
-        if math.floor(num_warmth / self.nl_scale) <= self.nl_min then enable_button_minus = false end
-        if math.ceil(num_warmth / self.nl_scale) >= self.nl_max then enable_button_plus = false end
-    end
-
     if self.natural_light and num_warmth then
         local curr_warmth_step = math.floor(num_warmth / step)
         for i = 0, curr_warmth_step do
             table.insert(warmth_group, self.fl_prog_button:new{
                              text = "",
                              preselect = curr_warmth_step > 0 and true or false,
-                             enabled = not self.powerd.auto_warmth,
-                             background = curr_warmth_step > 0 and button_color or nil,
                              callback = function()
                                  self:setProgress(self.fl_cur, step, i * step)
                              end
@@ -324,13 +308,15 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         for i = curr_warmth_step + 1, self.steps - 1 do
             table.insert(warmth_group, self.fl_prog_button:new{
                              text = "",
-                             enabled = not self.powerd.auto_warmth,
                              callback = function()
                                  self:setProgress(self.fl_cur, step, i * step)
                              end
             })
         end
     end
+
+    if num_warmth == self.fl_max then enable_button_plus = false end
+    if num_warmth == self.fl_min then enable_button_minus = false end
 
     local text_warmth = TextBoxWidget:new{
         text = "\n" .. _("Warmth"),
@@ -367,7 +353,7 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         text = _("Min"),
         margin = Size.margin.small,
         radius = 0,
-        enabled = not self.powerd.auto_warmth,
+        enabled = true,
         width = math.floor(self.screen_width * 0.2),
         show_parent = self,
         callback = function() self:setProgress(self.fl_cur, step, self.nl_min) end,
@@ -376,7 +362,7 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         text = _("Max"),
         margin = Size.margin.small,
         radius = 0,
-        enabled = not self.powerd.auto_warmth,
+        enabled = true,
         width = math.floor(self.screen_width * 0.2),
         show_parent = self,
         callback = function() self:setProgress(self.fl_cur, step, (self.nl_max * self.nl_scale)) end,
@@ -396,92 +382,10 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         empty_space,
         button_max,
     }
-    local checkbutton_auto_nl = CheckButton:new({
-            text = _("Auto"),
-            checked = self.powerd.auto_warmth,
-            max_width = math.floor(self.screen_width * 0.15),
-            callback = function()
-                if self.powerd.auto_warmth then
-                    self.powerd.auto_warmth = false
-                else
-                    self.powerd.auto_warmth = true
-                    self.powerd:calculateAutoWarmth()
-                end
-                self:setProgress(self.fl_cur, step)
-            end
-        })
-
-    local text_auto_nl, text_hour, button_minus_one_hour, button_plus_one_hour
-
-    if not self.has_nl_api then
-        text_auto_nl = TextBoxWidget:new{
-            --- @todo Implement padding_right (etc.) on TextBoxWidget and remove the two-space hack.
-            text = _("Max. at:") .. "  ",
-            face = self.larger_font_face,
-            alignment = "right",
-            fgcolor = self.powerd.auto_warmth and Blitbuffer.COLOR_BLACK or
-                Blitbuffer.COLOR_DARK_GRAY,
-            width = math.floor(self.screen_width * 0.3),
-        }
-        text_hour = TextBoxWidget:new{
-            text = " " .. math.floor(self.powerd.max_warmth_hour) .. ":" ..
-                self.powerd.max_warmth_hour % 1 * 6 .. "0",
-            face = self.larger_font_face,
-            alignment = "center",
-            fgcolor =self.powerd.auto_warmth and Blitbuffer.COLOR_BLACK or
-                Blitbuffer.COLOR_DARK_GRAY,
-            width = math.floor(self.screen_width * 0.15),
-        }
-        button_minus_one_hour = Button:new{
-            text = "−",
-            margin = Size.margin.small,
-            radius = 0,
-            enabled = self.powerd.auto_warmth,
-            width = math.floor(self.screen_width * 0.1),
-            show_parent = self,
-            callback = function()
-                self.powerd.max_warmth_hour =
-                    (self.powerd.max_warmth_hour - 1) % 24
-                self.powerd:calculateAutoWarmth()
-                self:setProgress(self.fl_cur, step)
-            end,
-            hold_callback = function()
-                self.powerd.max_warmth_hour =
-                    (self.powerd.max_warmth_hour - 0.5) % 24
-                self.powerd:calculateAutoWarmth()
-                self:setProgress(self.fl_cur, step)
-            end,
-        }
-        button_plus_one_hour = Button:new{
-            text = "＋",
-            margin = Size.margin.small,
-            radius = 0,
-            enabled = self.powerd.auto_warmth,
-            width = math.floor(self.screen_width * 0.1),
-            show_parent = self,
-            callback = function()
-                self.powerd.max_warmth_hour =
-                    (self.powerd.max_warmth_hour + 1) % 24
-                self.powerd:calculateAutoWarmth()
-                self:setProgress(self.fl_cur, step)
-            end,
-            hold_callback = function()
-                self.powerd.max_warmth_hour =
-                    (self.powerd.max_warmth_hour + 0.5) % 24
-                self.powerd:calculateAutoWarmth()
-                self:setProgress(self.fl_cur, step)
-            end,
-        }
-    end
 
     table.insert(vertical_group, text_warmth)
     table.insert(button_group_up, button_table_up)
     table.insert(button_group_down, button_table_down)
-    table.insert(auto_nl_group, checkbutton_auto_nl)
-    table.insert(auto_nl_group, text_auto_nl)
-    table.insert(auto_nl_group, button_minus_one_hour)
-    table.insert(auto_nl_group, text_hour)
-    table.insert(auto_nl_group, button_plus_one_hour)
 
     table.insert(vertical_group, padding_span)
     table.insert(vertical_group, button_group_up)
@@ -491,9 +395,6 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
     table.insert(vertical_group, button_group_down)
     table.insert(vertical_group, padding_span)
 
-    if not self.has_nl_api then
-        table.insert(vertical_group, auto_nl_group)
-    end
 end
 
 function FrontLightWidget:setFrontLightIntensity(num)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -315,8 +315,8 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
         end
     end
 
-    if num_warmth == self.fl_max then enable_button_plus = false end
-    if num_warmth == self.fl_min then enable_button_minus = false end
+    if math.floor(num_warmth / self.nl_scale) <= self.nl_min then enable_button_minus = false end
+    if math.ceil(num_warmth / self.nl_scale) >= self.nl_max then enable_button_plus = false end
 
     local text_warmth = TextBoxWidget:new{
         text = "\n" .. _("Warmth"),


### PR DESCRIPTION
Remove autowarmth from `frontlightdialog` as well as on kobo and cervantes `powerd`. If someone wants an advanced warmth setting, the upcoming `From dusk till dawn` plugin can be used. (https://github.com/koreader/koreader/pull/8129#issuecomment-905658485)

~~Missing is a onetime migration to remove the saved settings from `settings.reader.lua`.~~

Because I don't own a kobo or a cervantes this is a draft PR, as it has to be tested on these devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8154)
<!-- Reviewable:end -->
