### PR TITLE
Keyboard layouts: optimize, sorting

### DIFF
--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -309,7 +309,6 @@ if last_migration_date < 20210831 then
             keyboard_layouts_new[selected_layouts_count] = k
         end
     end
-    G_reader_settings:delSetting("keyboard_layouts")
     G_reader_settings:saveSetting("keyboard_layouts", keyboard_layouts_new)
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210720
+local CURRENT_MIGRATION_DATE = 20210831
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -294,6 +294,23 @@ if last_migration_date < 20210720 then
     -- started seeing the modern format unexpectedly. Therefore, reset everyone back to classic so users go back
     -- to a safe default. Users who use "modern" will need to reselect it in Time and Date settings after this migration.
     G_reader_settings:saveSetting("duration_format", "classic")
+end
+
+-- 20210831, Clean VirtualKeyboard settings of disabled layouts, https://github.com/koreader/koreader/pull/8159
+if last_migration_date < 20210831 then
+    logger.info("Performing one-time migration for 20210831")
+    local FFIUtil = require("ffi/util")
+    local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
+    local keyboard_layouts_new = {}
+    local selected_layouts_count = 0
+    for k, v in FFIUtil.orderedPairs(keyboard_layouts) do
+        if v == true and selected_layouts_count < 4 then
+            selected_layouts_count = selected_layouts_count + 1
+            keyboard_layouts_new[selected_layouts_count] = k
+        end
+    end
+    G_reader_settings:delSetting("keyboard_layouts")
+    G_reader_settings:saveSetting("keyboard_layouts", keyboard_layouts_new)
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -19,6 +19,7 @@ local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
+local util = require("util")
 local _ = require("gettext")
 local Screen = require("device").screen
 
@@ -64,7 +65,7 @@ function KeyboardLayoutDialog:init()
     self.keyboard_state.force_current_layout = true
     for k, _ in FFIUtil.orderedPairs(self.parent.keyboard.lang_to_keyboard_layout) do
         local text = Language:getLanguageName(k) .. "  (" .. string.sub(k, 1, 2) .. ")"
-        if keyboard_layouts[k] == true then
+        if util.arrayContains(keyboard_layouts, k) then
             text = text .. "  ✓"
         end
         if k == G_reader_settings:readSetting("keyboard_layout_default") then

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -61,7 +61,7 @@ function VirtualKey:init()
         self.callback = function () self.keyboard:setLayer("Shift") end
         self.skiptap = true
     elseif self.keyboard.utf8mode_keys[self.label] ~= nil then
-        self.key_chars = self:genkeyboardLayoutKeyChars()
+        self.key_chars = self:genKeyboardLayoutKeyChars()
         self.callback = function ()
             local current = G_reader_settings:readSetting("keyboard_layout")
             local default = G_reader_settings:readSetting("keyboard_layout_default")
@@ -276,7 +276,7 @@ function VirtualKey:init()
     self.flash_keyboard = G_reader_settings:nilOrTrue("flash_keyboard")
 end
 
-function VirtualKey:genkeyboardLayoutKeyChars()
+function VirtualKey:genKeyboardLayoutKeyChars()
     local positions = {
         "northeast",
         "north",

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -75,7 +75,7 @@ function VirtualKey:init()
                     layout_index = layout_index + 1
                 end
             else
-                if default then
+                if default and current ~= default then
                     next_layout = default
                 else
                     layout_index = 1

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -3,7 +3,6 @@ local BottomContainer = require("ui/widget/container/bottomcontainer")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
 local Event = require("ui/event")
-local FFIUtil = require("ffi/util")
 local FocusManager = require("ui/widget/focusmanager")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -67,33 +66,23 @@ function VirtualKey:init()
             local current = G_reader_settings:readSetting("keyboard_layout")
             local default = G_reader_settings:readSetting("keyboard_layout_default")
             local keyboard_layouts = G_reader_settings:readSetting("keyboard_layouts") or {}
-            local enabled = false
             local next_layout = nil
-            if not keyboard_layouts[current] and current ~= default then
-                next_layout = default
-            end
-            if not next_layout then
-                for k, v in FFIUtil.orderedPairs(keyboard_layouts) do
-                    if enabled and v == true then
-                        next_layout = k
-                        break
-                    end
-                    if k == current then
-                        enabled = true
-                    end
+            local layout_index = util.arrayContains(keyboard_layouts, current)
+            if layout_index then
+                if layout_index == #keyboard_layouts then
+                    layout_index = 1
+                else
+                    layout_index = layout_index + 1
+                end
+            else
+                if default then
+                    next_layout = default
+                else
+                    layout_index = 1
                 end
             end
-            if not next_layout then
-                for k, v in FFIUtil.orderedPairs(keyboard_layouts) do
-                    if v == true then
-                        next_layout = k
-                        break
-                    end
-                end
-            end
-            if next_layout then
-                self.keyboard:setKeyboardLayout(next_layout)
-            end
+            next_layout = next_layout or keyboard_layouts[layout_index] or "en"
+            self.keyboard:setKeyboardLayout(next_layout)
         end
         self.hold_callback = function()
             if util.tableSize(self.key_chars) > 5 then -- 2 or more layouts enabled
@@ -308,16 +297,11 @@ function VirtualKey:genkeyboardLayoutKeyChars()
             UIManager:show(self.keyboard_layout_dialog)
         end,
     }
-    local index = 1
-    for k, v in FFIUtil.orderedPairs(keyboard_layouts) do
-        if v == true then
-            key_chars[positions[index]] = string.sub(k, 1, 2)
-            key_chars[positions[index] .. "_func"] = function()
-                UIManager:close(self.popup)
-                self.keyboard:setKeyboardLayout(k)
-            end
-            if index >= 4 then break end
-            index = index + 1
+    for i = 1, #keyboard_layouts do
+        key_chars[positions[i]] = string.sub(keyboard_layouts[i], 1, 2)
+        key_chars[positions[i] .. "_func"] = function()
+            UIManager:close(self.popup)
+            self.keyboard:setKeyboardLayout(keyboard_layouts[i])
         end
     end
     return key_chars


### PR DESCRIPTION
Store list of layouts in settings file as array of enabled layouts only (up to 4 elements).
Optimize code.

Allows sorting of the abbreviations in the globe popup:
just check layouts in the desired order (the first checked will be northeast).

Requires onetime migration to clean up the settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8159)
<!-- Reviewable:end -->
