### PR TITLE
bump crengine: support for 'box-sizing', and other fixes

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -440,18 +440,19 @@ function ReaderFont:buildFontsTestDocument()
 <head>
 <title>%s</title>
 <style>
-section > title {
+h1 {
   font-size: large;
   font-weight: bold;
   text-align: center;
   page-break-before: always;
+  margin-top: 0;
   margin-bottom: 0.5em;
 }
 a { color: black; }
 </style>
 </head>
 <body>
-<section id="list"><title>%s</title></section>
+<h1>%s</h1>
 ]], _("Available fonts test document"), _("AVAILABLE FONTS")))
     local face_list = cre.getFontFaces()
     f:write("<div style='margin: 2em'>\n")
@@ -462,7 +463,7 @@ a { color: black; }
     f:write("</div>\n\n")
     for _, font_name in ipairs(face_list) do
         local font_id = font_name:gsub(" ", "_"):gsub("'", "_")
-        f:write(string.format("<section id='%s'><title>%s</title></section>\n", font_id, font_name))
+        f:write(string.format("<h1 id='%s'>%s</h1>\n", font_id, font_name))
         f:write(string.format("<div style='font-family: %s'>\n", font_name))
         f:write(html_sample)
         f:write("\n</div>\n\n")


### PR DESCRIPTION
Includes among others:
- https://github.com/koreader/crengine/pull/450
   - Various CHM handling fixes, and others
- https://github.com/koreader/crengine/pull/451
- https://github.com/koreader/crengine/pull/452)
- https://github.com/koreader/crengine/pull/453
   - HTML documents: rebuild TOC from headings after load
    Closes #7942.
   - Font: use metrics for underline offset and thickness
   - epub.css, html5.css: tweak ruby styling
    Discussed in #8063.
   - CSS: fix EPUB's head>style content encoding
    Closes #8034.
   - CSS: add support for 'box-sizing: content-box/border-box'
   - CSS: support for styling the `<html>` element
    Closes #7515.

ReaderFont's "Generate font test document": update the generated HTML so its ToC is build from proper HTML headings.

Also includes:
#### View HTML: allow long-press to hide "View CSS" buttons

Long pressing on any of these buttons will allow to toggle the View ... css buttons:
![image](https://user-images.githubusercontent.com/24273478/131670211-b40fad75-f61c-445f-8b02-34f64b33f688.png) <> ![image](https://user-images.githubusercontent.com/24273478/131670258-7de84d43-5e27-4196-a110-481a787883b3.png)



