### PR TITLE
ReaderBookmark:renameBookmark: Better nil guard

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -621,7 +621,7 @@ function ReaderBookmark:renameBookmark(item, from_highlight)
                 break
             end
         end
-        if bookmark.text == nil then -- bookmark not found
+        if not bookmark or bookmark.text == nil then -- bookmark not found
             return
         end
     else


### PR DESCRIPTION
When matching a highlight to a bookmark *really* fails.

(Noticed in the log from #8175)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8176)
<!-- Reviewable:end -->
