### PR TITLE
Page overlap menu

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -175,6 +175,9 @@ function ReaderMenu:setUpdateItemTable()
         end
     end
 
+    -- typeset tab
+    self.menu_items.page_overlap = require("ui/elements/page_overlap")
+
     -- settings tab
     -- insert common settings
     for id, common_setting in pairs(dofile("frontend/ui/elements/common_settings_menu_table.lua")) do

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -35,7 +35,6 @@ local ReaderPaging = InputContainer:new{
     number_of_pages = 0,
     visible_area = nil,
     page_area = nil,
-    show_overlap_enable = nil,
     overlap = Screen:scaleBySize(DOVERLAPPIXELS),
 
     inverse_reading_order = nil,
@@ -192,8 +191,6 @@ end
 function ReaderPaging:onReadSettings(config)
     self.page_positions = config:readSetting("page_positions") or {}
     self:_gotoPage(config:readSetting("last_page") or 1)
-    self.show_overlap_enable = config:isTrue("show_overlap_enable") or
-        G_reader_settings:isTrue("show_overlap_enable") or DSHOWOVERLAP
     self.flipping_zoom_mode = config:readSetting("flipping_zoom_mode") or "page"
     self.flipping_scroll_mode = config:isTrue("flipping_scroll_mode")
     self.is_reflowed = config:has("kopt_text_wrap") and config:readSetting("kopt_text_wrap") == 1
@@ -212,7 +209,6 @@ function ReaderPaging:onSaveSettings()
     self.ui.doc_settings:saveSetting("page_positions", self.page_positions)
     self.ui.doc_settings:saveSetting("last_page", self:getTopPage())
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
-    self.ui.doc_settings:saveSetting("show_overlap_enable", self.show_overlap_enable)
     self.ui.doc_settings:saveSetting("flipping_zoom_mode", self.flipping_zoom_mode)
     self.ui.doc_settings:saveSetting("flipping_scroll_mode", self.flipping_scroll_mode)
     self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
@@ -1045,7 +1041,7 @@ function ReaderPaging:onGotoPageRel(diff)
     self.view:PanningUpdate(panned_x, panned_y)
 
     -- Update dim area in ReaderView
-    if self.show_overlap_enable then
+    if self.view.page_overlap_enable then
         if self.current_page ~= old_page then
             self.view.dim_area:clear()
         else

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -47,7 +47,6 @@ local ReaderRolling = InputContainer:new{
     current_page= nil,
     xpointer = nil,
     panning_steps = ReaderPanning.panning_steps,
-    show_overlap_enable = nil,
     cre_top_bar_enabled = false,
     visible_pages = 1,
     -- With visible_pages=2, in 2-pages mode, ensure the first
@@ -209,8 +208,6 @@ function ReaderRolling:onReadSettings(config)
             end
         end
     end
-    self.show_overlap_enable = config:isTrue("show_overlap_enable") or
-        G_reader_settings:isTrue("show_overlap_enable") or DSHOWOVERLAP
 
     if config:has("inverse_reading_order") then
         self.inverse_reading_order = config:isTrue("inverse_reading_order")
@@ -305,7 +302,6 @@ function ReaderRolling:onSaveSettings()
     if self.ui.document then
         self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
     end
-    self.ui.doc_settings:saveSetting("show_overlap_enable", self.show_overlap_enable)
     self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
     self.ui.doc_settings:saveSetting("visible_pages", self.visible_pages)
     self.ui.doc_settings:saveSetting("hide_nonlinear_flows", self.hide_nonlinear_flows)
@@ -817,7 +813,7 @@ function ReaderRolling:onGotoViewRel(diff)
         local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()
         local page_visible_height = self.ui.dimen.h - footer_height
         local pan_diff = diff * page_visible_height
-        if self.show_overlap_enable then
+        if self.view.page_overlap_enable then
             local overlap_lines = G_reader_settings:readSetting("copt_overlap_lines") or 1
             local overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0) * overlap_lines
             if pan_diff > overlap_h then
@@ -1006,7 +1002,7 @@ function ReaderRolling:_gotoPos(new_pos, do_dim_area)
     local max_pos = self.ui.document.info.doc_height - self.ui.dimen.h + self.view.footer:getHeight()
     if new_pos > max_pos then new_pos = max_pos end
     -- adjust dim_area according to new_pos
-    if self.view.view_mode ~= "page" and self.show_overlap_enable and do_dim_area then
+    if self.view.view_mode ~= "page" and self.view.page_overlap_enable and do_dim_area then
         local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()
         local page_visible_height = self.ui.dimen.h - footer_height
         local panned_step = new_pos - self.current_pos

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -3,7 +3,6 @@ ReaderView module handles all the screen painting for document browsing.
 ]]
 
 local Blitbuffer = require("ffi/blitbuffer")
-local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Geom = require("ui/geometry")
 local Event = require("ui/event")

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -789,6 +789,7 @@ function ReaderView:onReadSettings(config)
     local page_scroll = config:readSetting("kopt_page_scroll") or self.document.configurable.page_scroll
     self.page_scroll = page_scroll == 1 and true or false
     self.highlight.saved = config:readSetting("highlight") or {}
+    self.page_overlap_enable = config:isTrue("show_overlap_enable") or G_reader_settings:isTrue("page_overlap_enable") or DSHOWOVERLAP
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
     self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height")
                                               or G_reader_settings:readSetting("kopt_page_gap_height")
@@ -903,6 +904,7 @@ function ReaderView:onSaveSettings()
     end
     self.ui.doc_settings:saveSetting("gamma", self.state.gamma)
     self.ui.doc_settings:saveSetting("highlight", self.highlight.saved)
+    self.ui.doc_settings:saveSetting("show_overlap_enable", self.page_overlap_enable)
     self.ui.doc_settings:saveSetting("page_overlap_style", self.page_overlap_style)
 end
 

--- a/frontend/ui/elements/page_overlap.lua
+++ b/frontend/ui/elements/page_overlap.lua
@@ -20,11 +20,12 @@ local PageOverlap = {
                 return ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
             end,
             callback = function()
-                if ReaderUI.instance.view:isOverlapAllowed() then
-                    if ReaderUI.instance.view.page_overlap_enable then
-                        ReaderUI.instance.view.dim_area:clear()
+                local view = ReaderUI.instance.view
+                if view:isOverlapAllowed() then
+                    if view.page_overlap_enable then
+                        view.dim_area:clear()
                     end
-                    ReaderUI.instance.view.page_overlap_enable = not ReaderUI.instance.view.page_overlap_enable
+                    view.page_overlap_enable = not view.page_overlap_enable
                 else
                     UIManager:show(require("ui/widget/infomessage"):new{
                         text = _("Page overlap cannot be enabled in the current view mode."),

--- a/frontend/ui/elements/page_overlap.lua
+++ b/frontend/ui/elements/page_overlap.lua
@@ -1,0 +1,116 @@
+local Device = require("device")
+local ReaderUI = require("apps/reader/readerui")
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+local Screen = Device.screen
+local T = require("ffi/util").template
+
+local function isOverlapEnabled()
+    if ReaderUI.instance.document.info.has_pages then
+        return ReaderUI.instance.paging.show_overlap_enable
+    else
+        return ReaderUI.instance.rolling.show_overlap_enable
+    end
+end
+
+local PageOverlap = {
+    text = _("Page overlap"),
+    sub_item_table = {
+        {
+            text_func = function()
+                local text = _("Page overlap")
+                if G_reader_settings:isTrue("page_overlap_enable") then
+                    text = text .. "   ★"
+                end
+                return text
+            end,
+            checked_func = function()
+                return ReaderUI.instance.view:isOverlapAllowed() and isOverlapEnabled()
+            end,
+            callback = function()
+                if ReaderUI.instance.view:isOverlapAllowed() then
+                    local is_overlap_enabled = isOverlapEnabled()
+                    if ReaderUI.instance.document.info.has_pages then
+                        ReaderUI.instance.paging.show_overlap_enable = not is_overlap_enabled
+                    else
+                        ReaderUI.instance.rolling.show_overlap_enable = not is_overlap_enabled
+                    end
+                    if is_overlap_enabled then
+                        ReaderUI.instance.view.dim_area:clear()
+                    end
+                else
+                    UIManager:show(require("ui/widget/infomessage"):new{
+                        text = _("Page overlap cannot be enabled in the current view mode."),
+                        timeout = 2,
+                    })
+                end
+            end,
+            hold_callback = function(touchmenu_instance)
+                G_reader_settings:flipNilOrFalse("page_overlap_enable")
+                touchmenu_instance:updateItems()
+            end,
+        },
+    }
+}
+
+table.insert(PageOverlap.sub_item_table, {
+    keep_menu_open = true,
+    text_func = function()
+        return T(_("Number of lines: %1"), G_reader_settings:readSetting("copt_overlap_lines") or 1)
+    end,
+    enabled_func = function()
+        return not ReaderUI.instance.document.info.has_pages and
+            ReaderUI.instance.view:isOverlapAllowed() and isOverlapEnabled()
+    end,
+    callback = function(touchmenu_instance)
+        local SpinWidget = require("ui/widget/spinwidget")
+        UIManager:show(SpinWidget:new{
+            title_text =  _("Number of overlapped lines"),
+            info_text = _([[
+When page overlap is enabled, some lines from the previous page will be displayed on the next page.
+You can set how many lines are shown.]]),
+            width = math.floor(Screen:getWidth() * 0.75),
+            value = G_reader_settings:readSetting("copt_overlap_lines") or 1,
+            value_min = 1,
+            value_max = 10,
+            default_value = 1,
+            precision = "%d",
+            callback = function(spin)
+                G_reader_settings:saveSetting("copt_overlap_lines", spin.value)
+                touchmenu_instance:updateItems()
+            end,
+        })
+    end,
+    separator = true,
+})
+
+local page_overlap_styles = {
+    arrow = _("Arrow"),
+    dim = _("Gray out"),
+}
+for k, v in pairs(page_overlap_styles) do
+    table.insert(PageOverlap.sub_item_table, {
+        text_func = function()
+            local text = v
+            if G_reader_settings:readSetting("page_overlap_style") == k then
+                text = text .. "   ★"
+            end
+            return text
+        end,
+        enabled_func = function()
+            return ReaderUI.instance.view:isOverlapAllowed() and isOverlapEnabled()
+        end,
+        checked_func = function()
+            return ReaderUI.instance.view.page_overlap_style == k
+        end,
+        callback = function()
+            ReaderUI.instance.view.page_overlap_style = k
+        end,
+        hold_callback = function(touchmenu_instance)
+            G_reader_settings:saveSetting("page_overlap_style", k)
+            touchmenu_instance:updateItems()
+        end,
+    })
+end
+
+return PageOverlap

--- a/frontend/ui/elements/page_overlap.lua
+++ b/frontend/ui/elements/page_overlap.lua
@@ -5,14 +5,6 @@ local _ = require("gettext")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
-local function isOverlapEnabled()
-    if ReaderUI.instance.document.info.has_pages then
-        return ReaderUI.instance.paging.show_overlap_enable
-    else
-        return ReaderUI.instance.rolling.show_overlap_enable
-    end
-end
-
 local PageOverlap = {
     text = _("Page overlap"),
     sub_item_table = {
@@ -25,19 +17,14 @@ local PageOverlap = {
                 return text
             end,
             checked_func = function()
-                return ReaderUI.instance.view:isOverlapAllowed() and isOverlapEnabled()
+                return ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
             end,
             callback = function()
                 if ReaderUI.instance.view:isOverlapAllowed() then
-                    local is_overlap_enabled = isOverlapEnabled()
-                    if ReaderUI.instance.document.info.has_pages then
-                        ReaderUI.instance.paging.show_overlap_enable = not is_overlap_enabled
-                    else
-                        ReaderUI.instance.rolling.show_overlap_enable = not is_overlap_enabled
-                    end
-                    if is_overlap_enabled then
+                    if ReaderUI.instance.view.page_overlap_enable then
                         ReaderUI.instance.view.dim_area:clear()
                     end
+                    ReaderUI.instance.view.page_overlap_enable = not ReaderUI.instance.view.page_overlap_enable
                 else
                     UIManager:show(require("ui/widget/infomessage"):new{
                         text = _("Page overlap cannot be enabled in the current view mode."),
@@ -60,7 +47,7 @@ table.insert(PageOverlap.sub_item_table, {
     end,
     enabled_func = function()
         return not ReaderUI.instance.document.info.has_pages and
-            ReaderUI.instance.view:isOverlapAllowed() and isOverlapEnabled()
+            ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
     end,
     callback = function(touchmenu_instance)
         local SpinWidget = require("ui/widget/spinwidget")
@@ -98,7 +85,7 @@ for k, v in pairs(page_overlap_styles) do
             return text
         end,
         enabled_func = function()
-            return ReaderUI.instance.view:isOverlapAllowed() and isOverlapEnabled()
+            return ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
         end,
         checked_func = function()
             return ReaderUI.instance.view.page_overlap_style == k


### PR DESCRIPTION
Add a default option for Page overlap enabled/disabled for new books (long-press as usual).
Closes https://github.com/koreader/koreader/issues/7757.

<kbd>![1](https://user-images.githubusercontent.com/62179190/132100043-5e5b4a9d-70af-4a25-b80f-60d94d94a149.png)</kbd>

Page overlap menu is a separate module.
Cleaned readerpaging, readerrolling, readerview of duplicated code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8180)
<!-- Reviewable:end -->
