### PR TITLE
Add unencrypted wifi support

### DIFF
--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -59,7 +59,7 @@ end
 --- Authenticates network.
 function WpaSupplicant:authenticateNetwork(network)
     local err, wcli, nw_id
-    
+
     wcli, err = WpaClient.new(self.wpa_supplicant.ctrl_interface)
     if not wcli then
         return false, T(CLIENT_INIT_ERR_MSG, err)
@@ -74,7 +74,7 @@ function WpaSupplicant:authenticateNetwork(network)
         return false, _("An error occurred while selecting network.")
     end
     -- if password is empty it’s an open AP
-    if network.password and (network.password == nil or string.len(network.password) == 0) then -- Open AP
+    if network.password and #network.password == 0 then -- Open AP
         re = wcli:setNetwork(nw_id, "key_mgmt", "NONE")
         if re == "FAIL" then
             wcli:removeNetwork(nw_id)

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -59,7 +59,7 @@ end
 --- Authenticates network.
 function WpaSupplicant:authenticateNetwork(network)
     local err, wcli, nw_id
-    --- @todo support passwordless network
+    
     wcli, err = WpaClient.new(self.wpa_supplicant.ctrl_interface)
     if not wcli then
         return false, T(CLIENT_INIT_ERR_MSG, err)
@@ -73,14 +73,24 @@ function WpaSupplicant:authenticateNetwork(network)
         wcli:removeNetwork(nw_id)
         return false, _("An error occurred while selecting network.")
     end
-    if not network.psk then
-        network.psk = calculatePsk(network.ssid, network.password)
-        self:saveNetwork(network)
-    end
-    re = wcli:setNetwork(nw_id, "psk", network.psk)
-    if re == 'FAIL' then
-        wcli:removeNetwork(nw_id)
-        return false, _("An error occurred while setting password.")
+    -- if password is empty it’s an open AP
+    if network.password and (network.password == nil or string.len(network.password) == 0) then -- Open AP
+        re = wcli:setNetwork(nw_id, "key_mgmt", "NONE")
+        if re == 'FAIL' then
+            wcli:removeNetwork(nw_id)
+            return false, _("An error occurred while setting passwordless mode.")
+        end
+    -- else it’s a WPA AP
+    else
+        if not network.psk then
+            network.psk = calculatePsk(network.ssid, network.password)
+            self:saveNetwork(network)
+        end
+        re = wcli:setNetwork(nw_id, "psk", network.psk)
+        if re == 'FAIL' then
+            wcli:removeNetwork(nw_id)
+            return false, _("An error occurred while setting password.")
+        end
     end
     wcli:enableNetworkByID(nw_id)
 

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -53,7 +53,7 @@ local function calculatePsk(ssid, pwd)
     local fp = io.popen(("wpa_passphrase %q %q"):format(ssid, pwd))
     local out = fp:read("*a")
     fp:close()
-    return string.match(out, 'psk=([a-f0-9]+)')
+    return string.match(out, "psk=([a-f0-9]+)")
 end
 
 --- Authenticates network.
@@ -69,14 +69,14 @@ function WpaSupplicant:authenticateNetwork(network)
     if err then return false, err end
 
     local re = wcli:setNetwork(nw_id, "ssid", string.format("\"%s\"", network.ssid))
-    if re == 'FAIL' then
+    if re == "FAIL" then
         wcli:removeNetwork(nw_id)
         return false, _("An error occurred while selecting network.")
     end
     -- if password is empty it’s an open AP
     if network.password and (network.password == nil or string.len(network.password) == 0) then -- Open AP
         re = wcli:setNetwork(nw_id, "key_mgmt", "NONE")
-        if re == 'FAIL' then
+        if re == "FAIL" then
             wcli:removeNetwork(nw_id)
             return false, _("An error occurred while setting passwordless mode.")
         end
@@ -87,7 +87,7 @@ function WpaSupplicant:authenticateNetwork(network)
             self:saveNetwork(network)
         end
         re = wcli:setNetwork(nw_id, "psk", network.psk)
-        if re == 'FAIL' then
+        if re == "FAIL" then
             wcli:removeNetwork(nw_id)
             return false, _("An error occurred while setting password.")
         end
@@ -118,7 +118,7 @@ function WpaSupplicant:authenticateNetwork(network)
             elseif ev:isAuthFailed() then
                 failure_cnt = failure_cnt + 1
                 if failure_cnt > 3 then
-                    re, msg = false, _('Failed to authenticate')
+                    re, msg = false, _("Failed to authenticate")
                     break
                 end
             end
@@ -132,7 +132,7 @@ function WpaSupplicant:authenticateNetwork(network)
     UIManager:close(info)
     UIManager:forceRePaint()
     if cnt >= max_retry then
-        re, msg = false, _('Timed out')
+        re, msg = false, _("Timed out")
     end
     return re, msg
 end

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -265,7 +265,8 @@ end
 
 function NetworkItem:saveAndConnectToNetwork(password_input)
     local new_passwd = password_input:getInputText()
-    if new_passwd == nil or string.len(new_passwd) == 0 then
+    -- Dont set a empty password if WPA encryption, go through if it’s an open AP
+    if (new_passwd == nil or string.len(new_passwd) == 0) and string.find(self.info.flags, "WPA") then
         UIManager:show(InfoMessage:new{
             text = _("Password cannot be empty."),
         })
@@ -286,7 +287,7 @@ function NetworkItem:onEditNetwork()
     password_input = InputDialog:new{
         title = self.info.ssid,
         input = self.info.password,
-        input_hint = "password",
+        input_hint = _("password (leave empty if open network)"),
         input_type = "text",
         text_type = "password",
         buttons = {
@@ -328,7 +329,7 @@ function NetworkItem:onAddNetwork()
     password_input = InputDialog:new{
         title = self.info.ssid,
         input = "",
-        input_hint = "password",
+        input_hint = _("password (leave empty if open network)"),
         input_type = "text",
         text_type = "password",
         buttons = {
@@ -355,9 +356,11 @@ function NetworkItem:onAddNetwork()
 end
 
 function NetworkItem:onTapSelect(arg, ges_ev)
-    if not string.find(self.info.flags, "WPA") then
+    -- Open AP dont have specific flag so we can’t include them alongside WPA
+    -- so we exclude WEP instead (more encryption to exclude? not really future proof)
+    if string.find(self.info.flags, "WEP") then
         UIManager:show(InfoMessage:new{
-            text = _("Networks without WPA/WPA2 encryption are not supported.")
+            text = _("Networks with WEP encryption are not supported.")
         })
         return
     end

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -266,7 +266,7 @@ end
 function NetworkItem:saveAndConnectToNetwork(password_input)
     local new_passwd = password_input:getInputText()
     -- Dont set a empty password if WPA encryption, go through if it’s an open AP
-    if (new_passwd == nil or string.len(new_passwd) == 0) and string.find(self.info.flags, "WPA") then
+    if (new_passwd == nil or #new_passwd == 0) and string.find(self.info.flags, "WPA") then
         UIManager:show(InfoMessage:new{
             text = _("Password cannot be empty."),
         })

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -287,7 +287,7 @@ function NetworkItem:onEditNetwork()
     password_input = InputDialog:new{
         title = self.info.ssid,
         input = self.info.password,
-        input_hint = _("password (leave empty if open network)"),
+        input_hint = _("password (leave empty for open networks)"),
         input_type = "text",
         text_type = "password",
         buttons = {
@@ -329,7 +329,7 @@ function NetworkItem:onAddNetwork()
     password_input = InputDialog:new{
         title = self.info.ssid,
         input = "",
-        input_hint = _("password (leave empty if open network)"),
+        input_hint = _("password (leave empty for open networks)"),
         input_type = "text",
         text_type = "password",
         buttons = {


### PR DESCRIPTION
Add support for AP without encryption

Note :
- open network have empty password (that how wpa_supplicant.lua recognize it)
- we still use the "set/edit password" widget so we can add/forgive the network
- we exclude WEP encrytion only now

#2784

It’s a bit hacky but work great on my H2O

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8196)
<!-- Reviewable:end -->
