### PR TITLE
book shortcuts plugin

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -17,7 +17,7 @@ Each setting contains:
     * configurable: like string but instead of an event it updates the configurable (used by kopt)
 * event: what to call.
 * title: for use in ui.
-* section: under which menu to display (currently: device, filemanager, rolling, paging)
+* section: under which menu to display (currently: general, device, screen, filemanager, reader, rolling, paging)
     and optionally
 * min/max: for number
 * step: for number
@@ -46,49 +46,53 @@ local Dispatcher = {
 
 -- See above for description.
 local settingsList = {
+    -- Screen & Lights
+    show_frontlight_dialog = {category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), screen=true, condition=Device:hasFrontlight()},
+    toggle_frontlight = {category="none", event="ToggleFrontlight", title=_("Toggle frontlight"), screen=true, condition=Device:hasFrontlight()},
+    set_frontlight = {category="absolutenumber", event="SetFlIntensity", min=0, max=Device:getPowerDevice().fl_max, title=_("Set frontlight brightness to %1"), screen=true, condition=Device:hasFrontlight()},
+    increase_frontlight = {category="incrementalnumber", event="IncreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Increase frontlight brightness by %1"), screen=true, condition=Device:hasFrontlight()},
+    decrease_frontlight = {category="incrementalnumber", event="DecreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Decrease frontlight brightness by %1"), screen=true, condition=Device:hasFrontlight()},
+    set_frontlight_warmth = {category="absolutenumber", event="SetFlWarmth", min=0, max=100, title=_("Set frontlight warmth to %1"), screen=true, condition=Device:hasNaturalLight()},
+    increase_frontlight_warmth = {category="incrementalnumber", event="IncreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Increase frontlight warmth by %1"), screen=true, condition=Device:hasNaturalLight()},
+    decrease_frontlight_warmth = {category="incrementalnumber", event="DecreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Decrease frontlight warmth by %1"), screen=true, condition=Device:hasNaturalLight(), separator=true},
+    full_refresh = {category="none", event="FullRefresh", title=_("Full screen refresh"), screen=true},
+    night_mode = {category="none", event="ToggleNightMode", title=_("Toggle night mode"), screen=true},
+    set_night_mode = {category="string", event="SetNightMode", title=_("Set night mode"), screen=true, args={true, false}, toggle={_("On"), _("Off")}, separator=true},
+    set_refresh_rate = {category="absolutenumber", event="SetBothRefreshRates", min=-1, max=200, title=_("Flash every %1 pages (always)"), screen=true, condition=Device:hasEinkScreen()},
+    set_day_refresh_rate = {category="absolutenumber", event="SetDayRefreshRate", min=-1, max=200, title=_("Flash every %1 pages (not in night mode)"), screen=true, condition=Device:hasEinkScreen()},
+    set_night_refresh_rate = {category="absolutenumber", event="SetNightRefreshRate", min=-1, max=200, title=_("Flash every %1 pages (in night mode)"), screen=true, condition=Device:hasEinkScreen()},
+    set_flash_on_chapter_boundaries = {category="string", event="SetFlashOnChapterBoundaries", title=_("Always flash on chapter boundaries"), screen=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("On"), _("Off")}},
+    toggle_flash_on_chapter_boundaries = {category="none", event="ToggleFlashOnChapterBoundaries", title=_("Toggle flashing on chapter boundaries"), screen=true, condition=Device:hasEinkScreen()},
+    set_no_flash_on_second_chapter_page = {category="string", event="SetNoFlashOnSecondChapterPage", title=_("Never flash on chapter's 2nd page"), screen=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("On"), _("Off")}},
+    toggle_no_flash_on_second_chapter_page = {category="none", event="ToggleNoFlashOnSecondChapterPage", title=_("Toggle flashing on chapter's 2nd page"), screen=true, condition=Device:hasEinkScreen(), separator=true},
+
     -- Device settings
-    show_frontlight_dialog = {category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), device=true, condition=Device:hasFrontlight()},
-    toggle_frontlight = {category="none", event="ToggleFrontlight", title=_("Toggle frontlight"), device=true, condition=Device:hasFrontlight()},
-    set_frontlight = {category="absolutenumber", event="SetFlIntensity", min=0, max=Device:getPowerDevice().fl_max, title=_("Set frontlight brightness to %1"), device=true, condition=Device:hasFrontlight()},
-    increase_frontlight = {category="incrementalnumber", event="IncreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Increase frontlight brightness by %1"), device=true, condition=Device:hasFrontlight()},
-    decrease_frontlight = {category="incrementalnumber", event="DecreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Decrease frontlight brightness by %1"), device=true, condition=Device:hasFrontlight()},
-    set_frontlight_warmth = {category="absolutenumber", event="SetFlWarmth", min=0, max=100, title=_("Set frontlight warmth to %1"), device=true, condition=Device:hasNaturalLight()},
-    increase_frontlight_warmth = {category="incrementalnumber", event="IncreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Increase frontlight warmth by %1"), device=true, condition=Device:hasNaturalLight()},
-    decrease_frontlight_warmth = {category="incrementalnumber", event="DecreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Decrease frontlight warmth by %1"), device=true, condition=Device:hasNaturalLight(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:canToggleGSensor()},
     wifi_on = {category="none", event="InfoWifiOn", title=_("Turn on Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     wifi_off = {category="none", event="InfoWifiOff", title=_("Turn off Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle(), separator=true},
-    reading_progress = {category="none", event="ShowReaderProgress", title=_("Reading progress"), device=true},
-    history = {category="none", event="ShowHist", title=_("History"), device=true},
-    open_previous_document = {category="none", event="OpenLastDoc", title=_("Open previous document"), device=true},
-    filemanager = {category="none", event="Home", title=_("File browser"), device=true},
-    dictionary_lookup = {category="none", event="ShowDictionaryLookup", title=_("Dictionary lookup"), device=true},
-    wikipedia_lookup = {category="none", event="ShowWikipediaLookup", title=_("Wikipedia lookup"), device=true},
-    fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), device=true},
-    file_search = {category="none", event="ShowFileSearch", title=_("File search"), device=true, separator=true},
-    full_refresh = {category="none", event="FullRefresh", title=_("Full screen refresh"), device=true},
-    night_mode = {category="none", event="ToggleNightMode", title=_("Toggle night mode"), device=true},
-    set_night_mode = {category="string", event="SetNightMode", title=_("Set night mode"), device=true, args={true, false}, toggle={_("On"), _("Off")}},
     suspend = {category="none", event="SuspendEvent", title=_("Suspend"), device=true},
     exit = {category="none", event="Exit", title=_("Exit KOReader"), device=true},
     restart = {category="none", event="Restart", title=_("Restart KOReader"), device=true, condition=Device:canRestart()},
     reboot = {category="none", event="Reboot", title=_("Reboot the device"), device=true, condition=Device:canReboot()},
     poweroff = {category="none", event="PowerOff", title=_("Power off"), device=true, condition=Device:canPowerOff(), separator=true},
-    show_menu = {category="none", event="ShowMenu", title=_("Show menu"), device=true},
     toggle_hold_corners = {category="none", event="IgnoreHoldCorners", title=_("Toggle hold corners"), device=true, separator=true},
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
     iterate_rotation = {category="none", event="IterateRotation", title=_("Rotate by 90° CW"), device=true, separator=true},
-    set_refresh_rate = {category="absolutenumber", event="SetBothRefreshRates", min=-1, max=200, title=_("Flash every %1 pages (always)"), device=true, condition=Device:hasEinkScreen()},
-    set_day_refresh_rate = {category="absolutenumber", event="SetDayRefreshRate", min=-1, max=200, title=_("Flash every %1 pages (not in night mode)"), device=true, condition=Device:hasEinkScreen()},
-    set_night_refresh_rate = {category="absolutenumber", event="SetNightRefreshRate", min=-1, max=200, title=_("Flash every %1 pages (in night mode)"), device=true, condition=Device:hasEinkScreen()},
-    set_flash_on_chapter_boundaries = {category="string", event="SetFlashOnChapterBoundaries", title=_("Always flash on chapter boundaries"), device=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("On"), _("Off")}},
-    toggle_flash_on_chapter_boundaries = {category="none", event="ToggleFlashOnChapterBoundaries", title=_("Toggle flashing on chapter boundaries"), device=true, condition=Device:hasEinkScreen()},
-    set_no_flash_on_second_chapter_page = {category="string", event="SetNoFlashOnSecondChapterPage", title=_("Never flash on chapter's 2nd page"), device=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("On"), _("Off")}},
-    toggle_no_flash_on_second_chapter_page = {category="none", event="ToggleNoFlashOnSecondChapterPage", title=_("Toggle flashing on chapter's 2nd page"), device=true, condition=Device:hasEinkScreen(), separator=true},
-    favorites = {category="none", event="ShowColl", arg="favorites", title=_("Favorites"), device=true},
-    screenshot = {category="none", event="Screenshot", title=_("Screenshot"), device=true, separator=true},
+
+    -- General
+    reading_progress = {category="none", event="ShowReaderProgress", title=_("Reading progress"), general=true},
+    history = {category="none", event="ShowHist", title=_("History"), general=true},
+    open_previous_document = {category="none", event="OpenLastDoc", title=_("Open previous document"), general=true},
+    filemanager = {category="none", event="Home", title=_("File browser"), general=true, separator=true},
+    dictionary_lookup = {category="none", event="ShowDictionaryLookup", title=_("Dictionary lookup"), general=true},
+    wikipedia_lookup = {category="none", event="ShowWikipediaLookup", title=_("Wikipedia lookup"), general=true},
+    fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), general=true},
+    file_search = {category="none", event="ShowFileSearch", title=_("File search"), general=true, separator=true},
+    show_menu = {category="none", event="ShowMenu", title=_("Show menu"), general=true},
+    favorites = {category="none", event="ShowColl", arg="favorites", title=_("Favorites"), general=true},
+    screenshot = {category="none", event="Screenshot", title=_("Screenshot"), general=true, separator=true},
 
     -- filemanager settings
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
@@ -97,33 +101,33 @@ local settingsList = {
     folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, separator=true},
 
     -- reader settings
-    toggle_status_bar = {category="none", event="TapFooter", title=_("Toggle status bar"), rolling=true, paging=true, separator=true},
-    prev_chapter = {category="none", event="GotoPrevChapter", title=_("Previous chapter"), rolling=true, paging=true},
-    next_chapter = {category="none", event="GotoNextChapter", title=_("Next chapter"), rolling=true, paging=true},
-    first_page = {category="none", event="GoToBeginning", title=_("First page"), rolling=true, paging=true},
-    last_page = {category="none", event="GoToEnd", title=_("Last page"), rolling=true, paging=true},
-    prev_bookmark = {category="none", event="GotoPreviousBookmarkFromPage", title=_("Previous bookmark"), rolling=true, paging=true},
-    next_bookmark = {category="none", event="GotoNextBookmarkFromPage", title=_("Next bookmark"), rolling=true, paging=true},
-    go_to = {category="none", event="ShowGotoDialog", title=_("Go to page"), filemanager=true, rolling=true, paging=true},
-    skim = {category="none", event="ShowSkimtoDialog", title=_("Skim document"), rolling=true, paging=true},
-    back = {category="none", event="Back", title=_("Back"), rolling=true, paging=true},
-    previous_location = {category="none", event="GoBackLink", arg=true, title=_("Back to previous location"), rolling=true, paging=true},
-    latest_bookmark = {category="none", event="GoToLatestBookmark", title=_("Go to latest bookmark"), rolling=true, paging=true},
-    follow_nearest_link = {category="arg", event="GoToPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest link"), rolling=true, paging=true},
-    follow_nearest_internal_link = {category="arg", event="GoToInternalPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest internal link"), rolling=true, paging=true},
-    clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), rolling=true, paging=true, separator=true},
-    toc = {category="none", event="ShowToc", title=_("Table of contents"), rolling=true, paging=true},
-    bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), rolling=true, paging=true},
-    book_status = {category="none", event="ShowBookStatus", title=_("Book status"), rolling=true, paging=true},
-    book_info = {category="none", event="ShowBookInfo", title=_("Book information"), rolling=true, paging=true},
-    book_description = {category="none", event="ShowBookDescription", title=_("Book description"), rolling=true, paging=true},
-    book_cover = {category="none", event="ShowBookCover", title=_("Book cover"), rolling=true, paging=true, separator=true},
-    show_config_menu = {category="none", event="ShowConfigMenu", title=_("Show bottom menu"), rolling=true, paging=true},
-    toggle_bookmark = {category="none", event="ToggleBookmark", title=_("Toggle bookmark"), rolling=true, paging=true},
-    toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), rolling=true, paging=true, separator=true},
-    cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), rolling=true, paging=true},
-    cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), rolling=true, paging=true},
-    page_jmp = {category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), rolling=true, paging=true},
+    toggle_status_bar = {category="none", event="TapFooter", title=_("Toggle status bar"), reader=true, separator=true},
+    prev_chapter = {category="none", event="GotoPrevChapter", title=_("Previous chapter"), reader=true},
+    next_chapter = {category="none", event="GotoNextChapter", title=_("Next chapter"), reader=true},
+    first_page = {category="none", event="GoToBeginning", title=_("First page"), reader=true},
+    last_page = {category="none", event="GoToEnd", title=_("Last page"), reader=true},
+    prev_bookmark = {category="none", event="GotoPreviousBookmarkFromPage", title=_("Previous bookmark"), reader=true},
+    next_bookmark = {category="none", event="GotoNextBookmarkFromPage", title=_("Next bookmark"), reader=true},
+    go_to = {category="none", event="ShowGotoDialog", title=_("Go to page"), filemanager=true, reader=true},
+    skim = {category="none", event="ShowSkimtoDialog", title=_("Skim document"), reader=true},
+    back = {category="none", event="Back", title=_("Back"), reader=true},
+    previous_location = {category="none", event="GoBackLink", arg=true, title=_("Back to previous location"), reader=true},
+    latest_bookmark = {category="none", event="GoToLatestBookmark", title=_("Go to latest bookmark"), reader=true},
+    follow_nearest_link = {category="arg", event="GoToPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest link"), reader=true},
+    follow_nearest_internal_link = {category="arg", event="GoToInternalPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest internal link"), reader=true},
+    clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
+    toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
+    bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), reader=true},
+    book_status = {category="none", event="ShowBookStatus", title=_("Book status"), reader=true},
+    book_info = {category="none", event="ShowBookInfo", title=_("Book information"), reader=true},
+    book_description = {category="none", event="ShowBookDescription", title=_("Book description"), reader=true},
+    book_cover = {category="none", event="ShowBookCover", title=_("Book cover"), reader=true, separator=true},
+    show_config_menu = {category="none", event="ShowConfigMenu", title=_("Show bottom menu"), reader=true},
+    toggle_bookmark = {category="none", event="ToggleBookmark", title=_("Toggle bookmark"), reader=true},
+    toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), reader=true, separator=true},
+    cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
+    cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true},
+    page_jmp = {category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), reader=true},
     panel_zoom_toggle = {category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), paging=true, separator=true},
 
     -- rolling reader settings
@@ -138,7 +142,7 @@ local settingsList = {
 
     -- parsed from CreOptions
     -- the rest of the table elements are built from their counterparts in CreOptions
-    rotation_mode = {category="string", device=true, separator=true},
+    rotation_mode = {category="string", device=true},
     visible_pages = {category="string", rolling=true, separator=true},
     h_page_margins = {category="string", rolling=true},
     sync_t_b_page_margins = {category="string", rolling=true},
@@ -195,8 +199,8 @@ local settingsList = {
 local dispatcher_menu_order = {
     -- device
     "reading_progress",
-    "history",
     "open_previous_document",
+    "history",
     "favorites",
     "filemanager",
 
@@ -205,17 +209,26 @@ local dispatcher_menu_order = {
     "fulltext_search",
     "file_search",
 
-    "full_refresh",
-    "night_mode",
-    "set_night_mode",
+    "show_menu",
+    "screenshot",
+
     "suspend",
     "exit",
     "restart",
     "reboot",
     "poweroff",
 
-    "show_menu",
-    "show_config_menu",
+    "toggle_hold_corners",
+    "toggle_gsensor",
+    "rotation_mode",
+    "toggle_rotation",
+    "invert_rotation",
+    "iterate_rotation",
+
+    "wifi_on",
+    "wifi_off",
+    "toggle_wifi",
+
     "show_frontlight_dialog",
     "toggle_frontlight",
     "set_frontlight",
@@ -225,13 +238,10 @@ local dispatcher_menu_order = {
     "increase_frontlight_warmth",
     "decrease_frontlight_warmth",
 
-    "toggle_hold_corners",
+    "night_mode",
+    "set_night_mode",
 
-    "toggle_gsensor",
-    "toggle_rotation",
-    "invert_rotation",
-    "iterate_rotation",
-
+    "full_refresh",
     "set_refresh_rate",
     "set_day_refresh_rate",
     "set_night_refresh_rate",
@@ -240,13 +250,6 @@ local dispatcher_menu_order = {
     "set_no_flash_on_second_chapter_page",
     "toggle_no_flash_on_second_chapter_page",
 
-    "wifi_on",
-    "wifi_off",
-    "toggle_wifi",
-
-    "rotation_mode",
-    "screenshot",
-
     -- filemanager
     "folder_up",
     "show_plus_menu",
@@ -254,6 +257,7 @@ local dispatcher_menu_order = {
     "folder_shortcuts",
 
     -- reader
+    "show_config_menu",
     "toggle_status_bar",
 
     "prev_chapter",
@@ -417,7 +421,7 @@ Adds settings at runtime.
 
 @usage
     function Hello:onDispatcherRegisterActions()
-        Dispatcher:registerAction("helloworld_action", {category="none", event="HelloWorld", title=_("Hello World"), filemanager=true})
+        Dispatcher:registerAction("helloworld_action", {category="none", event="HelloWorld", title=_("Hello World"), general=true})
     end
 
     function Hello:init()
@@ -644,8 +648,11 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         end,
     })
     local section_list = {
+        {"general", _("General")},
         {"device", _("Device")},
+        {"screen", _("Screen & Lights")},
         {"filemanager", _("File browser")},
+        {"reader", _("Reader")},
         {"rolling", _("Reflowable documents (epub, fb2, txt…)")},
         {"paging", _("Fixed layout documents (pdf, djvu, pics…)")},
     }

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -36,6 +36,7 @@ local Notification = require("ui/widget/notification")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
 local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
+local util = require("util")
 local _ = require("gettext")
 local C_ = _.pgettext
 local T = require("ffi/util").template
@@ -440,6 +441,20 @@ function Dispatcher:registerAction(name, value)
     return true
 end
 
+--[[--
+Removes settings at runtime.
+
+@param name the key to use in the table
+--]]--
+function Dispatcher:removeAction(name)
+    local k = util.arrayContains(dispatcher_menu_order, name)
+    if k then
+        table.remove(dispatcher_menu_order, k)
+        settingsList[name] = nil
+    end
+    return true
+end
+
 -- Returns a display name for the item.
 function Dispatcher:getNameFromItem(item, location, settings)
     if settingsList[item] == nil then
@@ -631,7 +646,7 @@ arguments are:
     3) the object (table) in which the settings table is found
     4) the name of the settings table
 example usage:
-    Dispatcher.addSubMenu(self, sub_items, self.data, "profile1")
+    Dispatcher:addSubMenu(self, sub_items, self.data, "profile1")
 --]]--
 function Dispatcher:addSubMenu(caller, menu, location, settings)
     Dispatcher:init()

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -115,6 +115,7 @@ local order = {
     more_tools = {
         "auto_frontlight",
         "battery_statistics",
+        "book_shortcuts",
         "synchronize_time",
         "keep_alive",
         "doc_setting_tweak",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -160,6 +160,7 @@ local order = {
     more_tools = {
         "auto_frontlight",
         "battery_statistics",
+        "book_shortcuts",
         "synchronize_time",
         "keep_alive",
         "doc_setting_tweak",

--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -200,7 +200,7 @@ function SSH:addToMainMenu(menu_items)
 end
 
 function SSH:onDispatcherRegisterActions()
-    Dispatcher:registerAction("toggle_ssh_server", { category = "none", event = "ToggleSSHServer", title = _("Toggle SSH server"), device = true})
+    Dispatcher:registerAction("toggle_ssh_server", { category = "none", event = "ToggleSSHServer", title = _("Toggle SSH server"), general=true})
 end
 
 return SSH

--- a/plugins/bookshortcuts.koplugin/_meta.lua
+++ b/plugins/bookshortcuts.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = "bookshortcuts",
+    fullname = _("Book shortcuts"),
+    description = _([[This plugin allows adding a book shortcut to a gesture.]]),
+}

--- a/plugins/bookshortcuts.koplugin/main.lua
+++ b/plugins/bookshortcuts.koplugin/main.lua
@@ -1,0 +1,112 @@
+local ConfirmBox = require("ui/widget/confirmbox")
+local DataStorage = require("datastorage")
+local Dispatcher = require("dispatcher")
+local FFIUtil = require("ffi/util")
+local LuaSettings = require("luasettings")
+local PathChooser = require("ui/widget/pathchooser")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local util = require("util")
+local _ = require("gettext")
+
+local BookShortcuts = WidgetContainer:new{
+    name = "bookshortcuts",
+    shortcuts = LuaSettings:open(DataStorage:getSettingsDir() .. "/bookshortcuts.lua"),
+    updated = false,
+}
+
+function BookShortcuts:onDispatcherRegisterActions()
+    for k,v in pairs(self.shortcuts.data) do
+        if util.fileExists(k) then
+            local directory, filename = util.splitFilePathName(k) -- luacheck: no unused
+            Dispatcher:registerAction(k, {category="none", event="BookShortcut", title=filename, general=true, arg=k,})
+        end
+    end
+end
+
+function BookShortcuts:onBookShortcut(path)
+    if util.fileExists(path) then
+        local ReaderUI = require("apps/reader/readerui")
+        ReaderUI:showReader(path)
+    end
+end
+
+function BookShortcuts:init()
+    self:onDispatcherRegisterActions()
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function BookShortcuts:onFlushSettings()
+    if self.shortcuts and self.updated then
+        self.shortcuts:flush()
+        self.updated = false
+    end
+end
+
+function BookShortcuts:addToMainMenu(menu_items)
+    menu_items.book_shortcuts = {
+        text = _("Book shortcuts"),
+        sorting_hint = "more_tools",
+        sub_item_table_func = function()
+            return self:getSubMenuItems()
+        end,
+    }
+end
+
+function BookShortcuts:getSubMenuItems()
+    local sub_item_table = {
+        {
+            text = _("New shortcut"),
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local path_chooser = PathChooser:new{
+                    select_file = true,
+                    select_directory = false,
+                    detailed_file_info = true,
+                    path = G_reader_settings:readSetting("home_dir"),
+                    onConfirm = function(file_path)
+                        self:addShortcut(file_path)
+                        touchmenu_instance.item_table = self:getSubMenuItems()
+                        touchmenu_instance.page = 1
+                        touchmenu_instance:updateItems()
+                    end
+                }
+                UIManager:show(path_chooser)
+            end,
+            separator = true,
+        }
+    }
+    for k,v in FFIUtil.orderedPairs(self.shortcuts.data) do
+        table.insert(sub_item_table, {
+            text = k,
+            callback = function() self:onBookShortcut(k) end,
+            hold_callback = function(touchmenu_instance)
+                UIManager:show(ConfirmBox:new{
+                    text = _("Do you want to delete this shortcut?"),
+                    ok_text = _("Delete"),
+                    ok_callback = function()
+                        self:deleteShortcut(k)
+                        touchmenu_instance.item_table = self:getSubMenuItems()
+                        touchmenu_instance.page = 1
+                        touchmenu_instance:updateItems()
+                    end,
+                })
+            end,
+        })
+    end
+    return sub_item_table
+end
+
+function BookShortcuts:addShortcut(name)
+    self.shortcuts.data[name] = true
+    self.updated = true
+    self:onDispatcherRegisterActions()
+end
+
+function BookShortcuts:deleteShortcut(name)
+    self.shortcuts.data[name] = nil
+    Dispatcher:removeAction(name)
+    self.updated = true
+end
+
+return BookShortcuts

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -60,9 +60,9 @@ function Calibre:closeWirelessConnection()
 end
 
 function Calibre:onDispatcherRegisterActions()
-    Dispatcher:registerAction("calibre_search", { category="none", event="CalibreSearch", title=_("Calibre metadata search"), device=true,})
-    Dispatcher:registerAction("calibre_browse_tags", { category="none", event="CalibreBrowseTags", title=_("Browse all calibre tags"), device=true,})
-    Dispatcher:registerAction("calibre_browse_series", { category="none", event="CalibreBrowseSeries", title=_("Browse all calibre series"), device=true, separator=true,})
+    Dispatcher:registerAction("calibre_search", { category="none", event="CalibreSearch", title=_("Calibre metadata search"), general=true,})
+    Dispatcher:registerAction("calibre_browse_tags", { category="none", event="CalibreBrowseTags", title=_("Browse all calibre tags"), general=true,})
+    Dispatcher:registerAction("calibre_browse_series", { category="none", event="CalibreBrowseSeries", title=_("Browse all calibre series"), general=true, separator=true,})
 end
 
 function Calibre:init()

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -240,7 +240,7 @@ function Gestures:genSubItem(ges, separator, hold_callback)
     return {
         text_func = function() return self:gestureTitleFunc(ges) end,
         enabled_func = enabled_func,
-        sub_item_table = self:genMenu(ges),
+        sub_item_table_func = function() return self:genMenu(ges) end,
         separator = separator,
         hold_callback = hold_callback,
     }

--- a/plugins/hello.koplugin/main.lua
+++ b/plugins/hello.koplugin/main.lua
@@ -21,7 +21,7 @@ local Hello = WidgetContainer:new{
 }
 
 function Hello:onDispatcherRegisterActions()
-    Dispatcher:registerAction("helloworld_action", {category="none", event="HelloWorld", title=_("Hello World"), filemanager=true,})
+    Dispatcher:registerAction("helloworld_action", {category="none", event="HelloWorld", title=_("Hello World"), general=true,})
 end
 
 function Hello:init()

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -105,8 +105,8 @@ local function validateUser(user, pass)
 end
 
 function KOSync:onDispatcherRegisterActions()
-    Dispatcher:registerAction("kosync_push_progress", { category="none", event="KOSyncPushProgress", title=_("Push progress from this device"), rolling=true, paging=true,})
-    Dispatcher:registerAction("kosync_pull_progress", { category="none", event="KOSyncPullProgress", title=_("Pull progress from other devices"), rolling=true, paging=true, separator=true,})
+    Dispatcher:registerAction("kosync_push_progress", { category="none", event="KOSyncPushProgress", title=_("Push progress from this device"), reader=true,})
+    Dispatcher:registerAction("kosync_pull_progress", { category="none", event="KOSyncPullProgress", title=_("Pull progress from other devices"), reader=true, separator=true,})
 end
 
 function KOSync:onReaderReady()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -140,8 +140,8 @@ ReaderStatistics.default_settings = {
 }
 
 function ReaderStatistics:onDispatcherRegisterActions()
-    Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), device=true, separator=true})
-    Dispatcher:registerAction("book_statistics", {category="none", event="ShowBookStats", title=_("Book statistics"), rolling=true, paging=true, separator=true})
+    Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), general=true, separator=true})
+    Dispatcher:registerAction("book_statistics", {category="none", event="ShowBookStats", title=_("Book statistics"), reader=true, separator=true})
 end
 
 function ReaderStatistics:init()

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -32,7 +32,7 @@ local Terminal = WidgetContainer:new{
 }
 
 function Terminal:onDispatcherRegisterActions()
-    Dispatcher:registerAction("show_terminal", { category = "none", event = "TerminalStart", title = _("Show terminal"), device = true, })
+    Dispatcher:registerAction("show_terminal", { category = "none", event = "TerminalStart", title = _("Show terminal"), general=true, })
 end
 
 function Terminal:init()

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -39,7 +39,7 @@ local TextEditor = WidgetContainer:new{
 }
 
 function TextEditor:onDispatcherRegisterActions()
-    Dispatcher:registerAction("edit_last_edited_file", { category = "none", event = "OpenLastEditedFile", title = _("Text editor: open last file"), device = true, separator = true})
+    Dispatcher:registerAction("edit_last_edited_file", { category = "none", event = "OpenLastEditedFile", title = _("Text editor: open last file"), general=true, separator = true})
 end
 
 function TextEditor:init()

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -42,7 +42,7 @@ local Wallabag = WidgetContainer:new{
 }
 
 function Wallabag:onDispatcherRegisterActions()
-    Dispatcher:registerAction("wallabag_download", { category="none", event="SynchronizeWallabag", title=_("Wallabag retrieval"), device=true,})
+    Dispatcher:registerAction("wallabag_download", { category="none", event="SynchronizeWallabag", title=_("Wallabag retrieval"), general=true,})
 end
 
 function Wallabag:init()


### PR DESCRIPTION
`Dispatcher: Revamp sections and item order`
` Dispatcher:removeAction()
Gestures: use sub_item_table_func to allow the menu to refresh on change`
`book shortcuts plugin`

---

Adds a plugin to allow adding a gesture to open a specific book.

Motivation: I use my kindle for daily study and am constantly switching between the same few books. I personally added a few custom ones already in one of my other [personal plugins](https://github.com/yparitcher/chitas.koplugin/blob/863a8ad0c549af878e830fe790eefb990f5efb85/main.lua#L36-L38), but they are getting hard to manage. This allows adding them easily on device.

Please let me know if this interests anyone, if it is ok for core or should be in contrib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8200)
<!-- Reviewable:end -->
