### PR TITLE
Icon in button: correct size

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -305,6 +305,8 @@ function ReaderSearch:onShowSearchDialog(text, direction, regex, case_insensitiv
                 },
                 {
                     icon = "appbar.search",
+                    icon_width = Screen:scaleBySize(DGENERIC_ICON_SIZE * 0.8),
+                    icon_height = Screen:scaleBySize(DGENERIC_ICON_SIZE * 0.8),
                     callback = function()
                         self.search_dialog:onClose()
                         self.last_search_text = text

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -36,10 +36,8 @@ local Button = InputContainer:new{
     text = nil, -- mandatory (unless icon is provided)
     text_func = nil,
     icon = nil,
-    icon_width = Screen:scaleBySize(DGENERIC_ICON_SIZE * 0.8), -- our icons are square
-    icon_height = Screen:scaleBySize(DGENERIC_ICON_SIZE * 0.8),
-        -- Reduced size of the icons (0.8) nicely match the size of the default font
-        -- of text buttons ("cfont", 20), when mixing both text and icon buttons.
+    icon_width = Screen:scaleBySize(DGENERIC_ICON_SIZE), -- our icons are square
+    icon_height = Screen:scaleBySize(DGENERIC_ICON_SIZE),
     icon_rotation_angle = 0,
     preselect = false,
     callback = nil,

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -53,6 +53,8 @@ function ButtonTable:init()
                 text = btn_entry.text,
                 text_func = btn_entry.text_func,
                 icon = btn_entry.icon,
+                icon_width = btn_entry.icon_width,
+                icon_height = btn_entry.icon_height,
                 enabled = btn_entry.enabled,
                 callback = btn_entry.callback,
                 hold_callback = btn_entry.hold_callback,


### PR DESCRIPTION
Reducing icon size in button in https://github.com/koreader/koreader/pull/8190 has affected other modules.
Restoring default icon size, reducing icon in Readersearch only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8206)
<!-- Reviewable:end -->
