### PR TITLE
DoubleSpinWidget: keep size in rotation

### DIFF
--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -374,7 +374,6 @@ When the book's language tag is not among our presets, no specific features will
                 right_default = alg_right_hyphen_min,
                 -- let room on the widget sides so we can see
                 -- the hyphenation changes happening
-                width = math.floor(Screen:getWidth() * 0.6),
                 default_values = true,
                 default_text = _("Use language defaults"),
                 title_text = _("Hyphenation limits"),

--- a/frontend/ui/elements/refresh_menu_table.lua
+++ b/frontend/ui/elements/refresh_menu_table.lua
@@ -2,7 +2,6 @@ local Device = require("device")
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
-local Screen = Device.screen
 local T = require("ffi/util").template
 
 local function custom(refresh_rate_num)

--- a/frontend/ui/elements/refresh_menu_table.lua
+++ b/frontend/ui/elements/refresh_menu_table.lua
@@ -26,7 +26,6 @@ local function spinWidgetSetRefresh(touchmenu_instance, refresh_rate_num)
     local left, right = custom(refresh_rate_num)
     local DoubleSpinWidget = require("ui/widget/doublespinwidget")
     local items = DoubleSpinWidget:new{
-        width = math.floor(Screen:getWidth() * 0.6),
         info_text = _("For every chapter set -1"),
         left_value = left,
         left_min = -1,

--- a/frontend/ui/elements/refresh_menu_table.lua
+++ b/frontend/ui/elements/refresh_menu_table.lua
@@ -1,4 +1,3 @@
-local Device = require("device")
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1155,7 +1155,6 @@ function ConfigDialog:onConfigMoreChoose(values, name, event, args, name_text, m
                 widget = DoubleSpinWidget:new{
                     title_text =  name_text or _("Set values"),
                     info_text = more_options_param.info_text,
-                    width = math.floor(Screen:getWidth() * 0.6),
                     left_text = more_options_param.left_text,
                     right_text = more_options_param.right_text,
                     left_value = curr_values[1],

--- a/frontend/ui/widget/datewidget.lua
+++ b/frontend/ui/widget/datewidget.lua
@@ -1,7 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
@@ -10,7 +9,6 @@ local Font = require("ui/font")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
-local OverlapGroup = require("ui/widget/overlapgroup")
 local NumberPickerWidget = require("ui/widget/numberpickerwidget")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
@@ -27,17 +25,15 @@ local DateWidget = InputContainer:new{
     height = nil,
     day = 1,
     month = 1,
-    year = 2017,
-    ok_text = _("OK"),
-    cancel_text = _("Cancel"),
+    year = 2021,
+    ok_text = _("Apply"),
+    cancel_text = _("Close"),
 }
 
 function DateWidget:init()
-    self.medium_font_face = Font:getFace("ffont")
-    self.light_bar = {}
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
-    self.width = math.floor(self.screen_width * 0.95)
+    self.width = self.width or math.floor(math.min(self.screen_width, self.screen_height) * 0.8)
     if Device:hasKeys() then
         self.key_events = {
             Close = { {"Back"}, doc = "close date widget" }
@@ -64,16 +60,14 @@ end
 function DateWidget:update()
     local year_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = math.floor(self.screen_width * 0.2),
         value = self.year,
-        value_min = 2017,
-        value_max = 2037,
+        value_min = 2021,
+        value_max = 2041,
         value_step = 1,
         value_hold_step = 4,
     }
     local month_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = math.floor(self.screen_width * 0.2),
         value = self.month,
         value_min = 1,
         value_max = 12,
@@ -82,7 +76,6 @@ function DateWidget:update()
     }
     local day_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = math.floor(self.screen_width * 0.2),
         value = self.day,
         value_min = 1,
         value_max = 31,
@@ -96,7 +89,7 @@ function DateWidget:update()
         alignment = "center",
         face = self.title_face,
         bold = true,
-        width = math.floor(self.screen_width * 0.1),
+        width = math.floor(self.screen_width * 0.02),
     }
     local date_group = HorizontalGroup:new{
         align = "center",
@@ -114,8 +107,7 @@ function DateWidget:update()
         TextWidget:new{
             text = self.title_text,
             face = self.title_face,
-            bold = true,
-            width = math.floor(self.screen_width * 0.95),
+            max_width = self.width - 2 * (Size.padding.default + Size.margin.title),
         },
     }
     local date_line = LineWidget:new{
@@ -123,14 +115,6 @@ function DateWidget:update()
             w = self.width,
             h = Size.line.thick,
         }
-    }
-    local date_bar = OverlapGroup:new{
-        dimen = {
-            w = self.width,
-            h = date_title:getSize().h
-        },
-        date_title,
-        CloseButton:new{ window = self, padding_top = Size.margin.title, },
     }
     local buttons = {
         {
@@ -170,11 +154,11 @@ function DateWidget:update()
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
             align = "left",
-            date_bar,
+            date_title,
             date_line,
             CenterContainer:new{
                 dimen = Geom:new{
-                    w = math.floor(self.screen_width * 0.95),
+                    w = self.width,
                     h = math.floor(date_group:getSize().h * 1.2),
                 },
                 date_group

--- a/frontend/ui/widget/datewidget.lua
+++ b/frontend/ui/widget/datewidget.lua
@@ -89,7 +89,7 @@ function DateWidget:update()
         alignment = "center",
         face = self.title_face,
         bold = true,
-        width = math.floor(self.screen_width * 0.02),
+        width = math.floor(math.min(self.screen_width, self.screen_height) * 0.02),
     }
     local date_group = HorizontalGroup:new{
         align = "center",

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -1,7 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
@@ -11,7 +10,6 @@ local HorizontalGroup = require("ui/widget/horizontalgroup")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local MovableContainer = require("ui/widget/container/movablecontainer")
-local OverlapGroup = require("ui/widget/overlapgroup")
 local NumberPickerWidget = require("ui/widget/numberpickerwidget")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
@@ -54,11 +52,9 @@ local DoubleSpinWidget = InputContainer:new{
 }
 
 function DoubleSpinWidget:init()
-    self.medium_font_face = Font:getFace("ffont")
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
-    self.width = self.width or math.floor(self.screen_width * 0.8)
-    self.picker_width = math.floor(self.screen_width * 0.25)
+    self.width = self.width or math.floor(math.min(self.screen_width, self.screen_height) * 0.6)
     if Device:hasKeys() then
         self.key_events = {
             Close = { {"Back"}, doc = "close time widget" }
@@ -85,7 +81,6 @@ end
 function DoubleSpinWidget:update()
     local left_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = self.picker_width,
         value = self.left_value,
         value_min = self.left_min,
         value_max = self.left_max,
@@ -95,7 +90,6 @@ function DoubleSpinWidget:update()
     }
     local right_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = self.picker_width,
         value = self.right_value,
         value_min = self.right_min,
         value_max = self.right_max,
@@ -109,7 +103,7 @@ function DoubleSpinWidget:update()
         TextWidget:new{
             text = self.left_text,
             face = self.title_face,
-            max_width = 0.95 * self.width / 2,
+            max_width = math.floor(0.95 * self.width / 2),
         },
         left_widget,
     }
@@ -119,7 +113,7 @@ function DoubleSpinWidget:update()
         TextWidget:new{
             text = self.right_text,
             face = self.title_face,
-            max_width = 0.95 * self.width / 2,
+            max_width = math.floor(0.95 * self.width / 2),
         },
         right_widget,
     }
@@ -147,8 +141,7 @@ function DoubleSpinWidget:update()
         TextWidget:new{
             text = self.title_text,
             face = self.title_face,
-            bold = true,
-            width = self.width,
+            max_width = self.width - 2 * (Size.padding.default + Size.margin.title),
         },
     }
     local widget_line = LineWidget:new{
@@ -156,14 +149,6 @@ function DoubleSpinWidget:update()
             w = self.width,
             h = Size.line.thick,
         }
-    }
-    local widget_bar = OverlapGroup:new{
-        dimen = {
-            w = self.width,
-            h = widget_title:getSize().h
-        },
-        widget_title,
-        CloseButton:new{ window = self, padding_top = Size.margin.title, },
     }
     local widget_info
     if self.info_text then
@@ -248,7 +233,7 @@ function DoubleSpinWidget:update()
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
             align = "left",
-            widget_bar,
+            widget_title,
             widget_line,
             widget_info,
             VerticalSpan:new{ width = Size.span.vertical_large },

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -53,9 +53,7 @@ local NumberPickerWidget = InputContainer:new{
 function NumberPickerWidget:init()
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
-    if self.width == nil then
-        self.width = math.floor(self.screen_width * 0.2)
-    end
+    self.width = self.width or math.floor(math.min(self.screen_width, self.screen_height) * 0.2)
     if self.value_table then
         self.value_index = self.value_index or 1
         self.value = self.value_table[self.value_index]

--- a/frontend/ui/widget/timewidget.lua
+++ b/frontend/ui/widget/timewidget.lua
@@ -1,7 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
@@ -10,7 +9,6 @@ local Font = require("ui/font")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
-local OverlapGroup = require("ui/widget/overlapgroup")
 local NumberPickerWidget = require("ui/widget/numberpickerwidget")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
@@ -28,16 +26,14 @@ local TimeWidget = InputContainer:new{
     hour = 0,
     hour_max = 23,
     min = 0,
-    ok_text = _("OK"),
-    cancel_text = _("Cancel"),
+    ok_text = _("Apply"),
+    cancel_text = _("Close"),
 }
 
 function TimeWidget:init()
-    self.medium_font_face = Font:getFace("ffont")
-    self.light_bar = {}
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
-    self.width = math.floor(self.screen_width * 0.95)
+    self.width = self.width or math.floor(math.min(self.screen_width, self.screen_height) * 0.6)
     if Device:hasKeys() then
         self.key_events = {
             Close = { {"Back"}, doc = "close time widget" }
@@ -64,7 +60,6 @@ end
 function TimeWidget:update()
     local hour_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = math.floor(self.screen_width * 0.2),
         value = self.hour,
         value_min = 0,
         value_max = self.hour_max,
@@ -73,7 +68,6 @@ function TimeWidget:update()
     }
     local min_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = math.floor(self.screen_width * 0.2),
         value = self.min,
         value_min = 0,
         value_max = 59,
@@ -85,7 +79,7 @@ function TimeWidget:update()
         alignment = "center",
         face = self.title_face,
         bold = true,
-        width = math.floor(self.screen_width * 0.2),
+        width = math.floor(self.screen_width * 0.05),
     }
     local time_group = HorizontalGroup:new{
         align = "center",
@@ -94,7 +88,6 @@ function TimeWidget:update()
         min_widget,
     }
 
-    local closebutton = CloseButton:new{ window = self, padding_top = Size.margin.title, }
     local time_title = FrameContainer:new{
         padding = Size.padding.default,
         margin = Size.margin.title,
@@ -102,8 +95,7 @@ function TimeWidget:update()
         TextWidget:new{
             text = self.title_text,
             face = self.title_face,
-            bold = true,
-            max_width = math.floor(self.screen_width * 0.95) - closebutton:getSize().w,
+            max_width = self.width - 2 * (Size.padding.default + Size.margin.title),
         },
     }
     local time_line = LineWidget:new{
@@ -111,14 +103,6 @@ function TimeWidget:update()
             w = self.width,
             h = Size.line.thick,
         }
-    }
-    local time_bar = OverlapGroup:new{
-        dimen = {
-            w = self.width,
-            h = time_title:getSize().h
-        },
-        time_title,
-        closebutton,
     }
     local buttons = {
         {
@@ -156,11 +140,11 @@ function TimeWidget:update()
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
             align = "left",
-            time_bar,
+            time_title,
             time_line,
             CenterContainer:new{
                 dimen = Geom:new{
-                    w = math.floor(self.screen_width * 0.95),
+                    w = self.width,
                     h = math.floor(time_group:getSize().h * 1.2),
                 },
                 time_group

--- a/frontend/ui/widget/timewidget.lua
+++ b/frontend/ui/widget/timewidget.lua
@@ -79,7 +79,7 @@ function TimeWidget:update()
         alignment = "center",
         face = self.title_face,
         bold = true,
-        width = math.floor(self.screen_width * 0.05),
+        width = math.floor(math.min(self.screen_width, self.screen_height) * 0.05),
     }
     local time_group = HorizontalGroup:new{
         align = "center",


### PR DESCRIPTION
Changes to DoubleSpinWidget, TimeWidget, DateWidget.
(1) In landscape mode widgets have the same width as in portrait mode.
(2) Default width is 0.6 of the screen width in the portrait mode.
(3) Close button `x` removed from the title bar.
(4) Fixed a bug of long title in DoubleSpinWidget (https://github.com/koreader/koreader/issues/8192#issuecomment-917560853).

<kbd>![1](https://user-images.githubusercontent.com/62179190/133115746-a5a9f86c-fc33-4c1c-ab55-54d6f50e7125.png)</kbd>

<kbd>![2](https://user-images.githubusercontent.com/62179190/133115759-27f3d2c4-ce62-4f92-89cf-b9d5ef8060ed.png)</kbd>

<kbd>![3](https://user-images.githubusercontent.com/62179190/133115770-c6dcfbbf-cb0e-4722-a39a-07a485d1f5fb.png)</kbd>

<kbd>![4](https://user-images.githubusercontent.com/62179190/133115773-d6d5688b-640d-4eba-abc2-38cb43e01832.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8212)
<!-- Reviewable:end -->
