### PR TITLE
Newsdownloader: Fix warnings from luacheck

### DIFF
--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -15,7 +15,6 @@ function FeedView:getList(feed_config, callback, edit_feed_attribute_callback, d
     -- Loop through the feed.
     for idx, feed in ipairs(feed_config) do
         local feed_item_content = {}
-        local feed_list_content = {}
 
         local vc_feed_item = FeedView:getItem(
             idx,
@@ -73,11 +72,6 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
     local filter_element = feed.filter_element
         or feed.filter_element == nil
 
-    --- @todo: Strip the http:// or https:// from the URL
-    local sPre, sLink, sPost = url:match( "(.+)%s+(https?%S+)%s+(.*)$" )
-    local pretty_url = sLink
-
-    local view_content = {}
     local vc = {
         {
             _("URL"),

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -50,9 +50,9 @@ local FEED_TYPE_ATOM = "atom"
 --local feed_config_file_name = "feed_config.lua"
 --local news_downloader_config_file = "news_downloader_settings.lua
 
--- if a title looks like <title>blabla</title> it'll just be feed.title
--- if a title looks like <title attr="alb">blabla</title> then we get a table
--- where [1] is the title string and the attributes are also available
+-- If a title looks like <title>blabla</title> it'll just be feed.title.
+-- If a title looks like <title attr="alb">blabla</title> then we get a table
+-- where [1] is the title string and the attributes are also available.
 local function getFeedTitle(possible_title)
     if type(possible_title) == "string" then
         return util.htmlEntitiesToUtf8(possible_title)
@@ -61,12 +61,12 @@ local function getFeedTitle(possible_title)
     end
 end
 
--- there can be multiple links
--- for now we just assume the first link is probably the right one
---- @todo write unit tests
--- some feeds that can be used for unit test
--- http://fransdejonge.com/feed/ for multiple links
--- https://github.com/koreader/koreader/commits/master.atom for single link with attributes
+-- There can be multiple links.
+-- For now we just assume the first link is probably the right one.
+--- @todo Write unit tests.
+-- Some feeds that can be used for unit test.
+-- http://fransdejonge.com/feed/ for multiple links.
+-- https://github.com/koreader/koreader/commits/master.atom for single link with attributes.
 local function getFeedLink(possible_link)
     local E = {}
     if type(possible_link) == "string" then
@@ -174,7 +174,7 @@ function NewsDownloader:getSubMenuItems()
     return sub_item_table
 end
 -- lazyInitialization sets up variables that point to the
--- downloads folder and the feeds configuration file
+-- Downloads folder and the feeds configuration file.
 function NewsDownloader:lazyInitialization()
     if not self.initialized then
         logger.dbg("NewsDownloader: obtaining news folder")
@@ -347,7 +347,7 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
         feeds = self:deserializeXMLString(response)
     end
     -- If the response is not available (for a reason that we don't know),
-    -- add the URL to the unsupported feeds list
+    -- add the URL to the unsupported feeds list.
     if not ok or not feeds then
         local error_message
         if not ok then
@@ -514,7 +514,7 @@ function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_artic
 end
 
 local function parseDate(dateTime)
-    -- uses lua-feedparser https://github.com/slact/lua-feedparser
+    -- Uses lua-feedparser https://github.com/slact/lua-feedparser
     -- feedparser is available under the (new) BSD license.
     -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
     local date = dateparser.parse(dateTime)

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -7,7 +7,6 @@ local ReadHistory = require("readhistory")
 local FFIUtil = require("ffi/util")
 local FeedView = require("feed_view")
 local InfoMessage = require("ui/widget/infomessage")
-local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("frontend/luasettings")
 local UIManager = require("ui/uimanager")
 local KeyValuePage = require("ui/widget/keyvaluepage")
@@ -51,9 +50,9 @@ local FEED_TYPE_ATOM = "atom"
 --local feed_config_file_name = "feed_config.lua"
 --local news_downloader_config_file = "news_downloader_settings.lua
 
--- If a title looks like <title>blabla</title> it'll just be feed.title.
--- If a title looks like <title attr="alb">blabla</title> then we get a table.
--- Where [1] is the title string and the attributes are also available.
+-- if a title looks like <title>blabla</title> it'll just be feed.title
+-- if a title looks like <title attr="alb">blabla</title> then we get a table
+-- where [1] is the title string and the attributes are also available
 local function getFeedTitle(possible_title)
     if type(possible_title) == "string" then
         return util.htmlEntitiesToUtf8(possible_title)
@@ -62,12 +61,12 @@ local function getFeedTitle(possible_title)
     end
 end
 
--- There can be multiple links
--- for now we just assume the first link is probably the right one.
---- @todo Write unit tests.
--- Some feeds that can be used for unit test.
--- http://fransdejonge.com/feed/ for multiple links.
--- https://github.com/koreader/koreader/commits/master.atom for single link with attributes.
+-- there can be multiple links
+-- for now we just assume the first link is probably the right one
+--- @todo write unit tests
+-- some feeds that can be used for unit test
+-- http://fransdejonge.com/feed/ for multiple links
+-- https://github.com/koreader/koreader/commits/master.atom for single link with attributes
 local function getFeedLink(possible_link)
     local E = {}
     if type(possible_link) == "string" then
@@ -175,7 +174,7 @@ function NewsDownloader:getSubMenuItems()
     return sub_item_table
 end
 -- lazyInitialization sets up variables that point to the
--- downloads folder and the feeds configuration file.
+-- downloads folder and the feeds configuration file
 function NewsDownloader:lazyInitialization()
     if not self.initialized then
         logger.dbg("NewsDownloader: obtaining news folder")
@@ -348,7 +347,7 @@ function NewsDownloader:processFeedSource(url, limit, unsupported_feeds_urls, do
         feeds = self:deserializeXMLString(response)
     end
     -- If the response is not available (for a reason that we don't know),
-    -- add the URL to the unsupported feeds list.
+    -- add the URL to the unsupported feeds list
     if not ok or not feeds then
         local error_message
         if not ok then
@@ -446,59 +445,10 @@ function NewsDownloader:deserializeXMLString(xml_str)
     return xmlhandler.root
 end
 
-function NewsDownloader:processAtom(feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
-    -- Get the path to the output directory.
-    local feed_output_dir = string.format(
-        "%s%s/",
-        self.download_dir,
-        util.getSafeFilename(getFeedTitle(feeds.feed.title))
-    )
-    -- Create the output directory if it doesn't exist.
-    if not lfs.attributes(feed_outpnnut_dir, "mode") then
-        lfs.mkdir(feed_output_dir)
-    end
-    -- Download the feed.
-    for index, feed in pairs(feeds.feed.entry) do
-        -- If limit has been met, stop downloading feed.
-        if limit ~= 0 and index - 1 == limit then
-            break
-        end
-        local total_articles = limit == 0
-            and #feeds.rss.channel.item
-            or limit
-        -- Create a message to display during processing.
-        local article_message = T(
-            _("%1\n\nFetching article %2/%3:"),
-            message,
-            index,
-            total
-        )
-        -- Download the feed.
-        if download_full_article then
-            self:downloadFeed(
-                feed,
-                feed_output_dir,
-                include_images,
-                article_message,
-                enable_filter,
-                filter_element
-            )
-        else
-            self:createFromDescription(
-                feed,
-                feed.content[1],
-                feed_output_dir,
-                include_images,
-                article_message
-            )
-        end
-    end
-end
-
 function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_article, include_images, message, enable_filter, filter_element)
     local feed_title
     local feed_item
-    local total_feeds
+    local total_items
     -- Setup the above vars based on feed type.
     if feed_type == FEED_TYPE_RSS then
         feed_title = util.htmlEntitiesToUtf8(feeds.rss.channel.title)
@@ -564,7 +514,7 @@ function NewsDownloader:processFeed(feed_type, feeds, limit, download_full_artic
 end
 
 local function parseDate(dateTime)
-    -- Uses lua-feedparser https://github.com/slact/lua-feedparser
+    -- uses lua-feedparser https://github.com/slact/lua-feedparser
     -- feedparser is available under the (new) BSD license.
     -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
     local date = dateparser.parse(dateTime)
@@ -667,7 +617,7 @@ function NewsDownloader:viewFeedList()
     -- Protected call to see if feed config path returns a file that can be opened.
     local ok, feed_config = pcall(dofile, self.feed_config_path)
     if not ok or not feed_config then
-        change_feed_config = UI:confirm(
+        local change_feed_config = UI:confirm(
             _("Could not open feed list. Feeds configuration file is invalid. "),
             _("Close"),
             _("View file")
@@ -723,7 +673,6 @@ function NewsDownloader:viewFeedList()
         }
     )
     -- Show the list of feeds.
-    local kv = self.kv
     if #self.kv ~= 0 then
         UIManager:close(self.kv)
     end
@@ -739,7 +688,6 @@ function NewsDownloader:viewFeedList()
 end
 
 function NewsDownloader:viewFeedItem(data)
-    local kv = self.kv
     if #self.kv ~= 0 then
         UIManager:close(self.kv)
     end
@@ -844,7 +792,7 @@ function NewsDownloader:editFeedAttribute(id, key, value)
 end
 
 function NewsDownloader:updateFeedConfig(id, key, value)
-    local kv = self.kv
+    local UI = require("ui/trapper")
     -- Because this method is called at the menu,
     -- we might not have an active view. So this conditional
     -- statement avoids closing a null reference.
@@ -979,8 +927,8 @@ function NewsDownloader:updateFeedConfig(id, key, value)
     local feed_item_vc = FeedView:getItem(
         id,
         new_config[id],
-        function(id, edit_key, value)
-            self:editFeedAttribute(id, edit_key, value)
+        function(cb_id, cb_edit_key, cb_value)
+            self:editFeedAttribute(cb_id, cb_edit_key, cb_value)
         end
     )
     self:viewFeedItem(
@@ -990,6 +938,7 @@ function NewsDownloader:updateFeedConfig(id, key, value)
 end
 
 function NewsDownloader:deleteFeed(id)
+    local UI = require("ui/trapper")
     logger.dbg("Newsdownloader: attempting to delete feed")
     -- Check to see if we can get the config file.
     local ok, feed_config = pcall(dofile, self.feed_config_path)


### PR DESCRIPTION
As per: https://github.com/koreader/koreader/pull/8145#issuecomment-918493892

Also: removed an unused function (`processAtom`).
Also: fixed punctuation and casing in comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8214)
<!-- Reviewable:end -->
