### PR TITLE
SpinWidget: keep size in rotation

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -168,7 +168,6 @@ function FileManagerMenu:setUpdateItemTable()
                             local default_perpage = Menu.items_per_page_default
                             local curr_perpage = G_reader_settings:readSetting("items_per_page") or default_perpage
                             local items = SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
                                 value = curr_perpage,
                                 value_min = 6,
                                 value_max = 24,
@@ -192,7 +191,6 @@ function FileManagerMenu:setUpdateItemTable()
                             local default_font_size = Menu.getItemFontSize(curr_perpage)
                             local curr_font_size = G_reader_settings:readSetting("items_font_size") or default_font_size
                             local items_font = SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
                                 value = curr_font_size,
                                 value_min = 10,
                                 value_max = 72,
@@ -372,7 +370,6 @@ To:
                     local default_perpage = KeyValuePage:getDefaultKeyValuesPerPage()
                     local curr_perpage = G_reader_settings:readSetting("keyvalues_per_page") or default_perpage
                     local items = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = curr_perpage,
                         value_min = 10,
                         value_max = 24,

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -82,7 +82,6 @@ function ReaderBookmark:addToMainMenu(menu_items)
             local SpinWidget = require("ui/widget/spinwidget")
             local curr_perpage = G_reader_settings:readSetting("bookmarks_items_per_page") or self.bookmarks_items_per_page_default
             local items = SpinWidget:new{
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = curr_perpage,
                 value_min = 6,
                 value_max = 24,
@@ -104,7 +103,6 @@ function ReaderBookmark:addToMainMenu(menu_items)
             local default_font_size = Menu.getItemFontSize(curr_perpage)
             local curr_font_size = G_reader_settings:readSetting("bookmarks_items_font_size") or default_font_size
             local items_font = SpinWidget:new{
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = curr_font_size,
                 value_min = 10,
                 value_max = 72,

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -325,7 +325,6 @@ function ReaderCoptListener:getAltStatusBarMenu()
                     local SpinWidget = require("ui/widget/spinwidget")
                     local start_size = G_reader_settings:readSetting("cre_header_status_font_size") or 20
                     local size_spinner = SpinWidget:new{
-                        width = math.floor(Device.screen:getWidth() * 0.6),
                         value = start_size,
                         value_min = 8,
                         value_max = 36,

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -20,7 +20,6 @@ local ffiUtil  = require("ffi/util")
 local logger = require("logger")
 local util  = require("util")
 local _ = require("gettext")
-local Screen = Device.screen
 local T = ffiUtil.template
 
 -- We'll store the list of available dictionaries as a module local
@@ -331,7 +330,6 @@ function ReaderDictionary:addToMainMenu(menu_items)
                     local SpinWidget = require("ui/widget/spinwidget")
                     local font_size = G_reader_settings:readSetting("dict_font_size") or 20
                     local items_font = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = font_size,
                         value_min = 8,
                         value_max = 32,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1088,13 +1088,12 @@ function ReaderFooter:addToMainMenu(menu_items)
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Font size (%1)"), self.settings.text_font_size)
+                            return T(_("Font size: %1"), self.settings.text_font_size)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
                             local font_size = self.settings.text_font_size
                             local items_font = SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
                                 value = font_size,
                                 value_min = 8,
                                 value_max = 36,
@@ -1142,13 +1141,12 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Container height (%1)"), self.settings.container_height)
+                    return T(_("Container height: %1"), self.settings.container_height)
                 end,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")
                     local container_height = self.settings.container_height
                     local items_font = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = container_height,
                         value_min = 7,
                         value_max = 98,
@@ -1169,13 +1167,12 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Container bottom margin (%1)"), self.settings.container_bottom_padding)
+                    return T(_("Container bottom margin: %1"), self.settings.container_bottom_padding)
                 end,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")
                     local container_bottom_padding = self.settings.container_bottom_padding
                     local items_font = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = container_bottom_padding,
                         value_min = 0,
                         value_max = 49,
@@ -1199,12 +1196,11 @@ function ReaderFooter:addToMainMenu(menu_items)
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Book title (%1%)"), self.settings.book_title_max_width_pct)
+                            return T(_("Book title: %1%"), self.settings.book_title_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
                             local items = SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
                                 value = self.settings.book_title_max_width_pct,
                                 value_min = 10,
                                 value_step = 5,
@@ -1225,12 +1221,11 @@ function ReaderFooter:addToMainMenu(menu_items)
                     },
                     {
                         text_func = function()
-                            return T(_("Current chapter (%1%)"), self.settings.book_chapter_max_width_pct)
+                            return T(_("Current chapter: %1%"), self.settings.book_chapter_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
                             local items = SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
                                 value = self.settings.book_chapter_max_width_pct,
                                 value_min = 10,
                                 value_step = 5,
@@ -1440,7 +1435,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
     if Device:hasBattery() then
         table.insert(sub_items[settings_submenu_num].sub_item_table, 4, {
             text_func = function()
-                return T(_("Hide battery status if level higher than (%1%)"), self.settings.battery_hide_threshold)
+                return T(_("Hide battery status if level higher than: %1%"), self.settings.battery_hide_threshold)
             end,
             enabled_func = function()
                 return self.settings.all_at_once == true
@@ -1449,7 +1444,6 @@ With this enabled, the current page is included, so the count goes from n to 1 i
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
                 local battery_threshold = SpinWidget:new{
-                    width = math.floor(Screen:getWidth() * 0.6),
                     value = self.settings.battery_hide_threshold,
                     value_min = 0,
                     value_max = 100,
@@ -1598,7 +1592,6 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                             end
                             local SpinWidget = require("ui/widget/spinwidget")
                             local items = SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
                                 value = value,
                                 value_min = value_min,
                                 value_step = 1,
@@ -1765,7 +1758,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
             },
             {
                 text_func = function()
-                    return T(_("Minimal width (%1%)"), self.settings.progress_bar_min_width_pct)
+                    return T(_("Minimal width: %1%"), self.settings.progress_bar_min_width_pct)
                 end,
                 enabled_func = function()
                     return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
@@ -1774,7 +1767,6 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")
                     local items = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = self.settings.progress_bar_min_width_pct,
                         value_min = 5,
                         value_step = 5,

--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -411,7 +411,6 @@ function ReaderPageMap:addToMainMenu(menu_items)
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")
                     local spin_w = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = self.label_font_size,
                         value_min = 8,
                         value_max = 20,

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1058,7 +1058,6 @@ Enabling this option will restrict display to the chapter titles of progress bar
             local SpinWidget = require("ui/widget/spinwidget")
             local curr_perpage = G_reader_settings:readSetting("toc_items_per_page") or self.toc_items_per_page_default
             local items = SpinWidget:new{
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = curr_perpage,
                 value_min = 6,
                 value_max = 24,
@@ -1084,7 +1083,6 @@ Enabling this option will restrict display to the chapter titles of progress bar
             local default_font_size = Menu.getItemFontSize(curr_perpage)
             local curr_font_size = G_reader_settings:readSetting("toc_items_font_size") or default_font_size
             local items_font = SpinWidget:new{
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = curr_font_size,
                 value_min = 10,
                 value_max = 72,

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -665,7 +665,6 @@ end
 function ReaderZooming:_zoomFactorChange(title_text, direction, precision)
     local zoom_factor, overlap = self:getNumberOf(direction)
     UIManager:show(SpinWidget:new{
-        width = math.floor(Screen:getWidth() * 0.6),
         value = zoom_factor,
         value_min = 0.1,
         value_max = 10,
@@ -683,7 +682,6 @@ end
 
 function ReaderZooming:_zoomPanChange(text, setting)
     UIManager:show(SpinWidget:new{
-        width = math.floor(Screen:getWidth() * 0.6),
         value = self[setting],
         value_min = 0,
         value_max = 90,

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -34,7 +34,6 @@ local Device = require("device")
 local Event = require("ui/event")
 local Notification = require("ui/widget/notification")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
-local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local util = require("util")
 local _ = require("gettext")
@@ -512,7 +511,6 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                             precision = "%0.1f"
                         end
                         local items = SpinWidget:new{
-                            width = math.floor(Screen:getWidth() * 0.6),
                             value = location[settings] ~= nil and location[settings][k] or settingsList[k].default or 0,
                             value_min = settingsList[k].min,
                             value_step = settingsList[k].step or 1,
@@ -559,7 +557,6 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                         end
                         local SpinWidget = require("ui/widget/spinwidget")
                         local items = SpinWidget:new{
-                            width = math.floor(Screen:getWidth() * 0.6),
                             value = location[settings] ~= nil and location[settings][k] or 0,
                             value_min = settingsList[k].min,
                             value_step = settingsList[k].step or 1,

--- a/frontend/ui/elements/page_overlap.lua
+++ b/frontend/ui/elements/page_overlap.lua
@@ -1,8 +1,6 @@
-local Device = require("device")
 local ReaderUI = require("apps/reader/readerui")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
-local Screen = Device.screen
 local T = require("ffi/util").template
 
 local PageOverlap = {
@@ -57,7 +55,6 @@ table.insert(PageOverlap.sub_item_table, {
             info_text = _([[
 When page overlap is enabled, some lines from the previous page will be displayed on the next page.
 You can set how many lines are shown.]]),
-            width = math.floor(Screen:getWidth() * 0.75),
             value = G_reader_settings:readSetting("copt_overlap_lines") or 1,
             value_min = 1,
             value_max = 10,

--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -26,7 +26,6 @@ local function spinWidgetSetDPI(touchmenu_instance)
     local SpinWidget = require("ui/widget/spinwidget")
     local UIManager = require("ui/uimanager")
     local items = SpinWidget:new{
-        width = math.floor(Screen:getWidth() * 0.6),
         value = custom() or dpi(),
         value_min = 90,
         value_max = 900,

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1252,7 +1252,6 @@ function ConfigDialog:onConfigMoreChoose(values, name, event, args, name_text, m
                 widget = SpinWidget:new{
                     title_text =  name_text or _("Set value"),
                     info_text = more_options_param.info_text,
-                    width = math.floor(Screen:getWidth() * 0.6),
                     value = curr_items,
                     value_index = value_index,
                     value_table = more_options_param.value_table,

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -109,9 +109,7 @@ function NumberPickerWidget:init()
         end
     }
 
-    local empty_space = VerticalSpan:new{
-        width = math.ceil(math.max(self.screen_width, self.screen_height) * 0.01)
-    }
+    local empty_space = VerticalSpan:new{ width = Size.span.horizontal_default }
 
     self.formatted_value = self.value
     if not self.value_table then

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -109,7 +109,7 @@ function NumberPickerWidget:init()
         end
     }
 
-    local empty_space = VerticalSpan:new{ width = Size.span.horizontal_default }
+    local empty_space = VerticalSpan:new{ width = Size.padding.large }
 
     self.formatted_value = self.value
     if not self.value_table then

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -110,7 +110,7 @@ function NumberPickerWidget:init()
     }
 
     local empty_space = VerticalSpan:new{
-        width = math.ceil(self.screen_height * 0.01)
+        width = math.ceil(math.max(self.screen_width, self.screen_height) * 0.01)
     }
 
     self.formatted_value = self.value

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -1,7 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
@@ -12,7 +11,6 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local MovableContainer = require("ui/widget/container/movablecontainer")
 local NumberPickerWidget = require("ui/widget/numberpickerwidget")
-local OverlapGroup = require("ui/widget/overlapgroup")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local TextWidget = require("ui/widget/textwidget")
@@ -26,8 +24,8 @@ local SpinWidget = InputContainer:new{
     title_text = "",
     title_face = Font:getFace("x_smalltfont"),
     info_text = nil,
-    width = math.floor(Screen:getWidth() * 0.6),
-    height = Screen:getHeight(),
+    width = nil,
+    height = nil,
     value_table = nil,
     value_index = nil,
     value = 1,
@@ -50,10 +48,9 @@ local SpinWidget = InputContainer:new{
 }
 
 function SpinWidget:init()
-    self.medium_font_face = Font:getFace("ffont")
-    self.light_bar = {}
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
+    self.width = self.width or math.floor(math.min(self.screen_width, self.screen_height) * 0.6)
     if Device:hasKeys() then
         self.key_events = {
             Close = { {"Back"}, doc = "close spin widget" }
@@ -80,7 +77,6 @@ end
 function SpinWidget:update()
     local value_widget = NumberPickerWidget:new{
         show_parent = self,
-        width = math.floor(self.screen_width * 0.2),
         value = self.value,
         value_table = self.value_table,
         value_index = self.value_index,
@@ -95,18 +91,14 @@ function SpinWidget:update()
         value_widget,
     }
 
-    local close_button = CloseButton:new{ window = self, padding_top = Size.margin.title, }
-    local btn_width = close_button:getSize().w + Size.padding.default * 2
-
     local value_title = FrameContainer:new{
         padding = Size.padding.default,
         margin = Size.margin.title,
         bordersize = 0,
         TextWidget:new{
             text = self.title_text,
-            max_width = self.width - btn_width,
+            max_width = self.width - 2 * (Size.padding.default + Size.margin.title),
             face = self.title_face,
-            bold = true,
         },
     }
     local value_line = LineWidget:new{
@@ -114,14 +106,6 @@ function SpinWidget:update()
             w = self.width,
             h = Size.line.thick,
         }
-    }
-    local value_bar = OverlapGroup:new{
-        dimen = {
-            w = self.width,
-            h = value_title:getSize().h
-        },
-        value_title,
-        close_button,
     }
     local buttons = {
         {
@@ -186,7 +170,7 @@ function SpinWidget:update()
 
     local vgroup = VerticalGroup:new{
         align = "left",
-        value_bar,
+        value_title,
         value_line,
     }
     if self.info_text then
@@ -204,7 +188,7 @@ function SpinWidget:update()
     table.insert(vgroup, CenterContainer:new{
         dimen = Geom:new{
             w = self.width,
-            h = value_group:getSize().h + math.floor(self.screen_height * 0.1),
+            h = value_group:getSize().h + math.floor(math.max(self.screen_width, self.screen_height) * 0.06),
         },
         value_group
     })

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -188,7 +188,7 @@ function SpinWidget:update()
     table.insert(vgroup, CenterContainer:new{
         dimen = Geom:new{
             w = self.width,
-            h = value_group:getSize().h + math.floor(math.max(self.screen_width, self.screen_height) * 0.06),
+            h = value_group:getSize().h + 4 * Size.padding.large,
         },
         value_group
     })

--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -141,7 +141,6 @@ function AutoStandby:genSpinMenuItem(text, cfg, min, max)
         enabled_func = function() return self:isAllowedByConfig() end,
         callback = function()
             local spin = SpinWidget:new {
-                width = math.floor(Device.screen:getWidth() * 0.6),
                 value = self.settings:readSetting(cfg),
                 value_min = min and min() or 0,
                 value_max = max and max() or 9999,

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -174,10 +174,8 @@ function AutoSuspend:addToMainMenu(menu_items)
         text = _("Autosuspend timeout"),
         callback = function()
             local InfoMessage = require("ui/widget/infomessage")
-            local Screen = Device.screen
             local SpinWidget = require("ui/widget/spinwidget")
             local autosuspend_spin = SpinWidget:new {
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = self.auto_suspend_timeout_seconds / 60,
                 value_min = 5,
                 value_max = 240,
@@ -205,10 +203,8 @@ function AutoSuspend:addToMainMenu(menu_items)
         text = _("Autoshutdown timeout"),
         callback = function()
             local InfoMessage = require("ui/widget/infomessage")
-            local Screen = Device.screen
             local SpinWidget = require("ui/widget/spinwidget")
             local autosuspend_spin = SpinWidget:new {
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = self.autoshutdown_timeout_seconds / 60 / 60,
                 -- About a minute, good for testing and battery life fanatics.
                 -- Just high enough to avoid an instant shutdown death scenario.

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -1,4 +1,3 @@
-local Device = require("device")
 local Event = require("ui/event")
 local PluginShare = require("pluginshare")
 local TimeVal = require("ui/timeval")
@@ -125,11 +124,9 @@ function AutoTurn:addToMainMenu(menu_items)
             or _("Autoturn") end,
         checked_func = function() return self:_enabled() end,
         callback = function(menu)
-            local Screen = Device.screen
             local SpinWidget = require("ui/widget/spinwidget")
             local curr_items = G_reader_settings:readSetting("autoturn_timeout_seconds") or 30
             local autoturn_spin = SpinWidget:new {
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = curr_items,
                 value_min = 0,
                 value_max = 240,
@@ -156,11 +153,9 @@ function AutoTurn:addToMainMenu(menu_items)
             UIManager:show(autoturn_spin)
         end,
         hold_callback = function(menu)
-            local Screen = Device.screen
             local SpinWidget = require("ui/widget/spinwidget")
             local curr_items = G_reader_settings:readSetting("autoturn_distance") or 1
             local autoturn_spin = SpinWidget:new {
-                width = math.floor(Screen:getWidth() * 0.6),
                 value = curr_items,
                 value_min = -20,
                 value_max = 20,

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -3,7 +3,6 @@ local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
 local BookInfoManager = require("bookinfomanager")
-local Screen = require("device").screen
 
 --[[
     This plugin provides additional display modes to file browsers (File Manager
@@ -249,7 +248,6 @@ function CoverBrowser:addToMainMenu(menu_items)
                     -- value of 10 if it hasn't.
                     local curr_items = BookInfoManager:getSetting("files_per_page") or 10
                     local items = SpinWidget:new{
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = curr_items,
                         value_min = 4,
                         value_max = 20,

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -399,7 +399,6 @@ function CoverImage:sizeSpinner(touchmenu_instance, setting, title, min, max, de
     local SpinWidget = require("ui/widget/spinwidget")
     local old_val = self[setting]
     UIManager:show(SpinWidget:new{
-        width = math.floor(Device.screen:getWidth() * 0.6),
         value = old_val,
         value_min = min,
         value_max = max,

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -291,7 +291,6 @@ function KOSync:addToMainMenu(menu_items)
                     local items = SpinWidget:new{
                         text = _([[This value determines how many page turns it takes to update book progress.
 If set to 0, updating progress based on page turns will be disabled.]]),
-                        width = math.floor(Screen:getWidth() * 0.6),
                         value = self.kosync_pages_before_update or 0,
                         value_min = 0,
                         value_max = 999,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -20,7 +20,6 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
-local Screen = require("device").screen
 local N_ = _.ngettext
 local T = FFIUtil.template
 
@@ -974,7 +973,6 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
                             UIManager:show(SpinWidget:new{
-                                width = math.floor(Screen:getWidth() * 0.6),
                                 value = self.settings.calendar_nb_book_spans,
                                 value_min = 1,
                                 value_max = 5,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -110,14 +110,13 @@ function TextEditor:getSubMenuItems()
             sub_item_table = {
                 {
                     text_func = function()
-                        return T(_("Text font size (%1)"), self.font_size)
+                        return T(_("Text font size: %1"), self.font_size)
                     end,
                     keep_menu_open = true,
                     callback = function(touchmenu_instance)
                         local SpinWidget = require("ui/widget/spinwidget")
                         local font_size = self.font_size
                         UIManager:show(SpinWidget:new{
-                            width = math.floor(Screen:getWidth() * 0.6),
                             value = font_size,
                             value_min = 8,
                             value_max = 26,
@@ -342,7 +341,6 @@ Do you want to proceed?]]),
             local path_chooser = PathChooser:new{
                 select_directory = true,
                 select_file = false,
-                height = Screen:getHeight(),
                 path = self.last_path,
                 onConfirm = function(dir_path)
                     local file_input
@@ -384,7 +382,6 @@ function TextEditor:chooseFile()
         select_file = true,
         select_directory = false,
         detailed_file_info = true,
-        height = Screen:getHeight(),
         path = self.last_path,
         onConfirm = function(file_path)
             -- Remember last_path only when we select a file from it


### PR DESCRIPTION
Changes to the SpinWidget:
(1) In landscape mode widget has the same width as in portrait mode.
(2) Default width is 0.6 of the screen width in the portrait mode.
(3) Close button `x` is removed from the title bar.

Minor change to the NumberPickerWidget to keep height.

Most of the modules use SpinWidget with the default width, so no need to duplicate, removing.

<kbd>![1](https://user-images.githubusercontent.com/62179190/133420665-beb50ce9-b06c-4d57-ab0a-e576bed7269d.png)</kbd>

<kbd>![2](https://user-images.githubusercontent.com/62179190/133420681-a9df1528-ac9d-4d79-b1f6-a3bb7fd7b20b.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8218)
<!-- Reviewable:end -->
