### PR TITLE
Input dialogs: keep size in rotation

### DIFF
--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -7,7 +7,6 @@ local MultiInputDialog = require("ui/widget/multiinputdialog")
 local UIManager = require("ui/uimanager")
 local ReaderUI = require("apps/reader/readerui")
 local util = require("util")
-local Screen = require("device").screen
 local T = require("ffi/util").template
 local _ = require("gettext")
 
@@ -136,8 +135,6 @@ function DropBox:config(item, callback)
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
         input_type = "text",
     }
     UIManager:show(self.settings_dialog)

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -5,7 +5,6 @@ local FtpApi = require("apps/cloudstorage/ftpapi")
 local InfoMessage = require("ui/widget/infomessage")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local ReaderUI = require("apps/reader/readerui")
-local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local ltn12 = require("ltn12")
 local logger = require("logger")
@@ -160,8 +159,6 @@ Username and password are optional.]])
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
         input_type = "text",
     }
     UIManager:show(self.settings_dialog)

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -8,7 +8,6 @@ local ReaderUI = require("apps/reader/readerui")
 local WebDavApi = require("apps/cloudstorage/webdavapi")
 local util = require("util")
 local _ = require("gettext")
-local Screen = require("device").screen
 local T = require("ffi/util").template
 
 local WebDav = {}
@@ -153,8 +152,6 @@ The start folder is appended to the server path.]])
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
         input_type = "text",
     }
     UIManager:show(self.settings_dialog)

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -122,7 +122,6 @@ function FileSearcher:onShowFileSearch(search_string)
     self.search_dialog = InputDialog:new{
         title = _("Enter filename to search for"),
         input = search_string or self.search_value,
-        width = math.floor(Screen:getWidth() * 0.9),
         buttons = {
             {
                 {

--- a/frontend/apps/filemanager/filemanagersetdefaults.lua
+++ b/frontend/apps/filemanager/filemanagersetdefaults.lua
@@ -56,6 +56,10 @@ function SetDefaults:ConfirmEdit()
 end
 
 function SetDefaults:init()
+    self.screen_width = Screen:getWidth()
+    self.screen_height = Screen:getHeight()
+    self.dialog_width = math.floor(math.min(self.screen_width, self.screen_height) * 0.95)
+
     self.results = {}
 
     local defaults = {}
@@ -90,8 +94,8 @@ function SetDefaults:init()
     end
 
     self.defaults_menu = Menu:new{
-        width = Screen:getWidth() - (Size.margin.fullscreen_popout * 2),
-        height = Screen:getHeight() - (Size.margin.fullscreen_popout * 2),
+        width = self.screen_width - (Size.margin.fullscreen_popout * 2),
+        height = self.screen_height - (Size.margin.fullscreen_popout * 2),
         cface = Font:getFace("smallinfofont"),
         show_parent = menu_container,
         _manager = self,
@@ -157,7 +161,7 @@ function SetDefaults:init()
                         },
                     },
                     input_type = setting_type,
-                    width = math.floor(Screen:getWidth() * 0.95),
+                    width = self.dialog_width,
                 }
                 UIManager:show(self.set_dialog)
                 self.set_dialog:onShowKeyboard()
@@ -208,8 +212,7 @@ function SetDefaults:init()
                             },
                         },
                     },
-                    width = math.floor(Screen:getWidth() * 0.95),
-                    height = math.floor(Screen:getHeight() * 0.2),
+                    width = self.dialog_width,
                 }
                 UIManager:show(self.set_dialog)
                 self.set_dialog:onShowKeyboard()
@@ -247,7 +250,7 @@ function SetDefaults:init()
                         },
                     },
                     input_type = setting_type,
-                    width = math.floor(Screen:getWidth() * 0.95),
+                    width = self.dialog_width,
                 }
                 UIManager:show(self.set_dialog)
                 self.set_dialog:onShowKeyboard()

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -153,7 +153,10 @@ function ReaderSearch:onShowFulltextSearchInput()
             self.check_button_regex:toggleCheck()
         end,
         hold_callback = function()
-            UIManager:show(InfoMessage:new{ text = help_text })
+            UIManager:show(InfoMessage:new{
+                text = help_text,
+                width = Screen:getWidth() * 0.9,
+            })
         end,
     }
     self.input_dialog:addWidget(self.check_button_regex)

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -107,7 +107,7 @@ function ReaderSearch:onShowFulltextSearchInput()
     end
     self.input_dialog = InputDialog:new{
         title = _("Enter text to search for"),
-        width = math.floor(Screen:getWidth() * 0.9),
+        width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.9),
         input = self.last_search_text,
         buttons = {
             {

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -202,13 +202,15 @@ local InputDialog = InputContainer:new{
 }
 
 function InputDialog:init()
+    self.screen_width = Screen:getWidth()
+    self.screen_height = Screen:getHeight()
     if self.fullscreen then
         self.is_movable = false
         self.border_size = 0
-        self.width = Screen:getWidth() - 2*self.border_size
+        self.width = self.screen_width - 2*self.border_size
         self.covers_fullscreen = true -- hint for UIManager:_repaint()
     else
-        self.width = self.width or math.floor(Screen:getWidth() * 0.8)
+        self.width = self.width or math.floor(math.min(self.screen_width, self.screen_height) * 0.8)
     end
     if self.condensed then
         self.text_width = self.width - 2*(self.border_size + self.input_padding + self.input_margin)
@@ -334,7 +336,7 @@ function InputDialog:init()
         end
         input_widget:onCloseWidget() -- free() textboxwidget and keyboard
         -- Find out available height
-        local available_height = Screen:getHeight()
+        local available_height = self.screen_height
                                     - 2*self.border_size
                                     - self.title_widget:getSize().h
                                     - self.title_bar:getSize().h
@@ -457,8 +459,8 @@ function InputDialog:init()
                                 or self._input_widget:getKeyboardDimen().h
     self[1] = CenterContainer:new{
         dimen = Geom:new{
-            w = Screen:getWidth(),
-            h = Screen:getHeight() - keyboard_height,
+            w = self.screen_width,
+            h = self.screen_height - keyboard_height,
         },
         frame
     }

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -123,7 +123,8 @@ function MultiInputDialog:init()
     self[1] = CenterContainer:new{
         dimen = Geom:new{
             w = Screen:getWidth(),
-            h = Screen:getHeight() - self._input_widget:getKeyboardDimen().h,
+            h = math.max(Screen:getHeight() - self._input_widget:getKeyboardDimen().h,
+                self.dialog_frame:getSize().h),
         },
         self.dialog_frame,
     }

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -226,8 +226,6 @@ function CalibreSearch:ShowSearch()
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.8),
-        height = math.floor(Screen:getHeight() * 0.2),
     }
     UIManager:show(self.search_dialog)
     self.search_dialog:onShowKeyboard()

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -161,8 +161,6 @@ function OPDSBrowser:addNewCatalog()
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
     }
     UIManager:show(self.add_server_dialog)
     self.add_server_dialog:onShowKeyboard()
@@ -213,8 +211,6 @@ function OPDSBrowser:editCalibreServer()
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
     }
     UIManager:show(self.add_server_dialog)
     self.add_server_dialog:onShowKeyboard()
@@ -890,8 +886,6 @@ function OPDSBrowser:editOPDSServer(item)
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
     }
     UIManager:show(self.edit_server_dialog)
     self.edit_server_dialog:onShowKeyboard()

--- a/plugins/perceptionexpander.koplugin/main.lua
+++ b/plugins/perceptionexpander.koplugin/main.lua
@@ -152,8 +152,6 @@ function PerceptionExpander:showSettingsDialog()
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.8),
-        height = math.floor(Screen:getHeight() * 0.3),
     }
     UIManager:show(self.settings_dialog)
     self.settings_dialog:onShowKeyboard()

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -226,7 +226,6 @@ function Terminal:editCommands(item)
     edit_dialog = InputDialog:new{
         title = T(_('Edit commands for "%1"'), item.text),
         input = item.commands,
-        width = Screen:getWidth() * 0.9,
         para_direction_rtl = false, -- force LTR
         input_type = "string",
         allow_newline = true,
@@ -262,7 +261,6 @@ function Terminal:editName(item)
     edit_dialog = InputDialog:new{
         title = _("Edit name"),
         input = item.text,
-        width = Screen:getWidth() * 0.9,
         para_direction_rtl = false, -- force LTR
         input_type = "string",
         allow_newline = false,

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -30,7 +30,6 @@ local socketutil = require("socketutil")
 local util = require("util")
 local _ = require("gettext")
 local T = FFIUtil.template
-local Screen = require("device").screen
 
 -- constants
 local article_id_prefix = "[w-id_"
@@ -973,8 +972,6 @@ Restart KOReader after editing the config file.]]), BD.dirpath(DataStorage:getSe
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
         input_type = "string",
     }
     UIManager:show(self.settings_dialog)
@@ -1013,8 +1010,6 @@ function Wallabag:editClientSettings()
                 },
             },
         },
-        width = math.floor(Screen:getWidth() * 0.95),
-        height = math.floor(Screen:getHeight() * 0.2),
         input_type = "string",
     }
     UIManager:show(self.client_settings_dialog)


### PR DESCRIPTION
(1) InputDialog: default width set to 0.8 of the screen width in portrait mode, keep in rotation.

<kbd>![1](https://user-images.githubusercontent.com/62179190/133770683-2d379374-740a-4d99-a5a2-6906c68b0184.png)</kbd>

<kbd>![2](https://user-images.githubusercontent.com/62179190/133770693-f4132a66-2641-419a-aed3-f85ae8218424.png)</kbd>

(2) MultiInputDialog: default width is set by InputDialog, some modules (filemanagersetdefaults, readersearch) require wider dialogs, keep in rotation.
Fixed an issue: cut of a high dialog in landscape mode.
Before

<kbd>![3](https://user-images.githubusercontent.com/62179190/133770704-fe63334c-fcbf-477a-8a0e-b94ac7116a16.png)</kbd>

After

<kbd>![4](https://user-images.githubusercontent.com/62179190/133770716-83bf4dd7-03dc-47e0-b601-ccbd2d3fd9d3.png)</kbd>

(3) Modules keep the width of input dialogs in rotation, removing duplicated default values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8223)
<!-- Reviewable:end -->
