### PR TITLE
Widgets: keep size in rotation

### DIFF
--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -41,7 +41,6 @@ function ButtonDialog:init()
             alpha = self.alpha,
             FrameContainer:new{
                 ButtonTable:new{
-                    width = math.floor(Screen:getWidth() * 0.9),
                     buttons = self.buttons,
                     show_parent = self,
                 },

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -65,14 +65,13 @@ function ButtonDialogTitle:init()
                         bordersize = 0,
                         TextBoxWidget:new{
                             text = self.title,
-                            width = math.floor(Screen:getWidth() * 0.8),
+                            width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.8),
                             face = self.use_info_style and self.info_face or self.title_face,
                             alignment = self.title_align or "left",
                         },
                     },
                     VerticalSpan:new{ width = Size.span.vertical_default },
                     ButtonTable:new{
-                        width = math.floor(Screen:getWidth() * 0.9),
                         buttons = self.buttons,
                         zero_sep = true,
                         show_parent = self,

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -11,7 +11,7 @@ local Geom = require("ui/geometry")
 local Screen = Device.screen
 
 local ButtonTable = FocusManager:new{
-    width = Screen:getWidth(),
+    width = nil,
     buttons = {
         {
             {text="OK", enabled=true, callback=nil},
@@ -27,6 +27,7 @@ local ButtonTable = FocusManager:new{
 }
 
 function ButtonTable:init()
+    self.width = self.width or math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.9)
     self.selected = { x = 1, y = 1 }
     self.buttons_layout = {}
     self.button_by_id = {}

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -80,7 +80,7 @@ function ConfirmBox:init()
     local text_widget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = math.floor(Screen:getWidth() * 2/3),
+        width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 2/3),
     }
     local content = HorizontalGroup:new{
         align = "center",

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -178,8 +178,8 @@ if Device:isTouchDevice() or Device:hasDPad() then
                     title = _("Clipboard"),
                     text = is_clipboard_empty and _("(empty)") or clipboard_value,
                     fgcolor = is_clipboard_empty and Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_BLACK,
-                    width = math.floor(Screen:getWidth() * 0.8),
-                    height = math.floor(Screen:getHeight() * 0.4),
+                    width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.8),
+                    height = math.floor(math.max(Screen:getWidth(), Screen:getHeight()) * 0.4),
                     justified = false,
                     stop_events_propagation = true,
                     buttons_table = {
@@ -522,7 +522,6 @@ function InputText:initKeyboard()
     self.keyboard = Keyboard:new{
         keyboard_layer = keyboard_layer,
         inputbox = self,
-        width = Screen:getWidth(),
     }
 end
 

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -29,7 +29,7 @@ local KeyboardLayoutDialog = InputContainer:new{
     modal = true,
     stop_events_propagation = true,
     keyboard_state = nil,
-    width = math.floor(Screen:getWidth() * 0.8),
+    width = nil,
     face = Font:getFace("cfont", 22),
     title_face = Font:getFace("x_smalltfont"),
     title_padding = Size.padding.default,
@@ -40,6 +40,7 @@ local KeyboardLayoutDialog = InputContainer:new{
 
 
 function KeyboardLayoutDialog:init()
+    self.width = self.width or math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.8)
     -- Title & description
     self.title_widget = FrameContainer:new{
         padding = self.title_padding,
@@ -158,7 +159,7 @@ function KeyboardLayoutDialog:init()
     self[1] = CenterContainer:new{
         dimen = Geom:new{
             w = Screen:getWidth(),
-            h = Screen:getHeight(),
+            h = math.max(Screen:getHeight(), self.dialog_frame:getSize().h),
         },
         self.movable,
     }

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -86,7 +86,7 @@ function MultiConfirmBox:init()
         TextBoxWidget:new{
             text = self.text,
             face = self.face,
-            width = math.floor(Screen:getWidth() * 2/3),
+            width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 2/3),
         }
     }
 

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -91,6 +91,7 @@ function Notification:init()
     local text_widget = TextWidget:new{
         text = self.text,
         face = self.face,
+        max_width = Screen:getWidth() - 2 * (self.margin + self.padding)
     }
     local widget_size = text_widget:getSize()
     self.frame = FrameContainer:new{

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -47,7 +47,7 @@ function SkimToWidget:init()
     self.buttons_layout = {}
     self.selected = { x = 1, y = 2 }
 
-    local frame_width = math.floor(screen_width * 0.95)
+    local frame_width = math.floor(math.min(screen_width, screen_height) * 0.95)
     local frame_border_size = Size.border.window
     local frame_padding = Size.padding.fullscreen -- large padding for airy feeling
     local inner_width = frame_width - 2 * (frame_border_size + frame_padding)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -736,7 +736,7 @@ local VirtualKeyboard = FocusManager:new{
     umlautmode = false,
     layout = {},
 
-    width = Screen:scaleBySize(600),
+    width = nil, -- non-fullscreen keyboard may cause design issues (eg Text editor)
     height = nil,
     bordersize = Size.border.default,
     padding = 0,
@@ -776,6 +776,7 @@ function VirtualKeyboard:init()
     self.symbolmode_keys = keyboard.symbolmode_keys
     self.utf8mode_keys = keyboard.utf8mode_keys
     self.umlautmode_keys = keyboard.umlautmode_keys
+    self.width = self.width or Screen:getWidth()
     local keys_height = G_reader_settings:isTrue("keyboard_key_compact") and 48 or 64
     self.height = Screen:scaleBySize(keys_height * #self.KEYS)
     self.min_layer = keyboard.min_layer

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -736,7 +736,6 @@ local VirtualKeyboard = FocusManager:new{
     umlautmode = false,
     layout = {},
 
-    width = nil,
     height = nil,
     bordersize = Size.border.default,
     padding = 0,

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -736,7 +736,7 @@ local VirtualKeyboard = FocusManager:new{
     umlautmode = false,
     layout = {},
 
-    width = nil, -- non-fullscreen keyboard may cause design issues (eg Text editor)
+    width = nil,
     height = nil,
     bordersize = Size.border.default,
     padding = 0,
@@ -776,7 +776,7 @@ function VirtualKeyboard:init()
     self.symbolmode_keys = keyboard.symbolmode_keys
     self.utf8mode_keys = keyboard.utf8mode_keys
     self.umlautmode_keys = keyboard.umlautmode_keys
-    self.width = self.width or Screen:getWidth()
+    self.width = Screen:getWidth()
     local keys_height = G_reader_settings:isTrue("keyboard_key_compact") and 48 or 64
     self.height = Screen:scaleBySize(keys_height * #self.KEYS)
     self.min_layer = keyboard.min_layer


### PR DESCRIPTION
The final round of setting the width of widgets in rotation (with https://github.com/koreader/koreader/pull/8212, https://github.com/koreader/koreader/pull/8223, https://github.com/koreader/koreader/pull/8226)

(1) ButtonTable, ButtonDialog, ButtonDialogTitle, ConfirmBox, MultiConfirmBox, SkimToWidget - keep size in rotation.

Before

<kbd>![1](https://user-images.githubusercontent.com/62179190/134162390-5006078d-5f04-463e-add3-9ea884d36bc4.png)</kbd>

<kbd>![2](https://user-images.githubusercontent.com/62179190/134162396-8e7608e9-64d6-45c8-8fff-d0bc17cddc4d.png)</kbd>

After

<kbd>![3](https://user-images.githubusercontent.com/62179190/134162398-97046ee8-4417-42f6-b2b5-bd6c0992a570.png)</kbd>

<kbd>![4](https://user-images.githubusercontent.com/62179190/134162403-64c3da70-8379-4607-9896-d10993a53144.png)</kbd>

(2) KeyboardLayoutDialog - keep size in rotation, initially move the dialog down to show the title in landscape mode.

Before

<kbd>![5](https://user-images.githubusercontent.com/62179190/134162404-f7738308-a267-4842-923b-ba9d94de5229.png)</kbd>

After

<kbd>![6](https://user-images.githubusercontent.com/62179190/134162405-8cff89bb-303f-4d74-91f7-90ba68870823.png)</kbd>

(3) InputText - keep size of Clipboard dialog in rotation.

Before

<kbd>![7](https://user-images.githubusercontent.com/62179190/134162407-056aae5b-b1d2-47b0-8444-0c7bd98934d8.png)</kbd>

After

<kbd>![8](https://user-images.githubusercontent.com/62179190/134162409-78ccd55b-1dd0-4d5f-a39f-c4eac64624b7.png)</kbd>

(4) Notification - truncate long text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8238)
<!-- Reviewable:end -->
