### PR TITLE
File searcher: correct call the FM

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -214,10 +214,12 @@ function FileSearcher:onMenuHold(item)
                 callback = function()
                     UIManager:close(self.results_dialog)
                     self.close_callback()
-                    if is_file then
-                        FileManager:showFiles(item.dir, fullpath)
+                    local focused_path = is_file and item.dir or fullpath
+                    local focused_file = is_file and fullpath or nil
+                    if FileManager.instance then
+                        FileManager.instance:reinit(focused_path, focused_file)
                     else
-                        FileManager:showFiles(fullpath)
+                        FileManager:showFiles(focused_path, focused_file)
                     end
                 end,
             },


### PR DESCRIPTION
Correct call to show file manager, do not start new instance if exists.
Otherwise there was a warn in the crash.log: 
https://github.com/koreader/koreader/blob/3a01ab78994af9d232b2cd584eec6d5ea8a05b76/frontend/apps/filemanager/filemanager.lua#L1204

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8257)
<!-- Reviewable:end -->
