### PR TITLE
Autowarmth text formatting

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -749,7 +749,8 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
     -- t .. times
     -- num .. index in times
     local function info_line(text, t, num, easy)
-        local retval = text .. string.rep(" ", 18 - text:len()) .. self:hoursToClock(t[num])
+        local tab_width = 18
+        local retval = text .. string.rep(" ", tab_width - text:len()) .. self:hoursToClock(t[num])
         if easy then
             if t[num] and self.current_times[num] and self.current_times[num] ~= t[num] then
                 return text .. "\n"

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -795,7 +795,7 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
         width = math.floor(Screen:getWidth() * (self.easy_mode and 0.75 or 0.90)),
             text = title .. location_string .. ":\n\n" ..
             info_line(0, _("Solar midnight:"), times, 1, request_easy) ..
-            "  " .. _("Dawn\n") ..
+            "  " .. _("Dawn") .. "\n" ..
             info_line(4, _("Astronomic:"), times, 2, request_easy) ..
             info_line(4, _("Nautical:"), times, 3, request_easy)..
             info_line(4, _("Civil:"), times, 4) ..
@@ -805,11 +805,11 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
             info_line(0, _("Solar noon:"), times, 6, request_easy) ..
             "\n" ..
             info_line(0, _("Sunset:"), times, 7) ..
-            "  " .. _("Dusk\n") ..
+            "  " .. _("Dusk") .. "\n" ..
             info_line(4, _("Civil:"), times, 8) ..
             info_line(4, _("Nautical:"), times, 9, request_easy) ..
             info_line(4, _("Astronomic:"), times, 10, request_easy) ..
-            "  " .. _("Dusk\n") ..
+            "  " .. _("Dusk") .. "\n" ..
             info_line(0, _("Solar midnight:"), times, midnight_index, request_easy)
     })
 end

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -749,7 +749,7 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
     -- t .. times
     -- num .. index in times
     local function info_line(indent, text, t, num, easy)
-        local tab_width = 18
+        local tab_width = 18 - indent
         local retval = string.rep(" ", indent) .. text .. string.rep(" ", tab_width - text:len())
             .. self:hoursToClock(t[num])
         if easy then

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -720,11 +720,10 @@ function AutoWarmth:getWarmthMenu()
         },
         getWarmthMenuEntry(_("Solar noon"), 6, false),
         getWarmthMenuEntry(_("Daytime"), 5),
-        getWarmthMenuEntry(_("Darkest time of civil dawn"), 4, false),
-        getWarmthMenuEntry(_("Darkest time of civil twilight"), 4, true),
-        getWarmthMenuEntry(_("Darkest time of nautical dawn"), 3, false),
-        getWarmthMenuEntry(_("Darkest time of astronomical dawn"), 2, false),
-        getWarmthMenuEntry(_("Midnight"), 1, false),
+        getWarmthMenuEntry(_("Darkest time of civil twilight"), 4),
+        getWarmthMenuEntry(_("Darkest time of nautical twilight"), 3, false),
+        getWarmthMenuEntry(_("Darkest time of astronomical twilight"), 2, false),
+        getWarmthMenuEntry(_("Solar midnight"), 1, false),
     }
 
     return tidy_menu(retval, self.easy_mode)
@@ -750,7 +749,7 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
     -- t .. times
     -- num .. index in times
     local function info_line(text, t, num, easy)
-        local retval = text .. self:hoursToClock(t[num])
+        local retval = text .. string.rep(" ", 18 - text:len()) .. self:hoursToClock(t[num])
         if easy then
             if t[num] and self.current_times[num] and self.current_times[num] ~= t[num] then
                 return text .. "\n"
@@ -793,22 +792,23 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
         face = Font:getFace("scfont"),
         width = math.floor(Screen:getWidth() * (self.easy_mode and 0.75 or 0.90)),
             text = title .. location_string .. ":\n\n" ..
-            info_line(_("Solar midnight: "), times, 1, request_easy) ..
+            info_line(_("Solar midnight:"), times, 1, request_easy) ..
             _("  Dawn\n") ..
-            info_line(_("    Astronomic: "), times, 2, request_easy) ..
-            info_line(_("    Nautical:   "), times, 3, request_easy)..
-            info_line(_("    Civil:      "), times, 4) ..
+            info_line(_("    Astronomic:"), times, 2, request_easy) ..
+            info_line(_("    Nautical:"), times, 3, request_easy)..
+            info_line(_("    Civil:"), times, 4) ..
             _("  Dawn\n") ..
-            info_line(_("Sunrise:        "), times, 5) ..
-            info_line(_("\nSolar noon:     "), times, 6, request_easy) ..
-
-            info_line(_("\nSunset:         "), times, 7) ..
+            info_line(_("Sunrise:"), times, 5) ..
+            "\n" ..
+            info_line(_("Solar noon:"), times, 6, request_easy) ..
+            "\n" ..
+            info_line(_("Sunset:"), times, 7) ..
             _("  Dusk\n") ..
-            info_line(_("    Civil:      "), times, 8) ..
-            info_line(_("    Nautical:   "), times, 9, request_easy) ..
-            info_line(_("    Astronomic: "), times, 10, request_easy) ..
+            info_line(_("    Civil:"), times, 8) ..
+            info_line(_("    Nautical:"), times, 9, request_easy) ..
+            info_line(_("    Astronomic:"), times, 10, request_easy) ..
             _("  Dusk\n") ..
-            info_line(_("Solar midnight: "), times, midnight_index, request_easy)
+            info_line(_("Solar midnight:"), times, midnight_index, request_easy)
     })
 end
 

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -748,9 +748,10 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
     -- text to show
     -- t .. times
     -- num .. index in times
-    local function info_line(text, t, num, easy)
+    local function info_line(indent, text, t, num, easy)
         local tab_width = 18
-        local retval = text .. string.rep(" ", tab_width - text:len()) .. self:hoursToClock(t[num])
+        local retval = string.rep(" ", indent) .. text .. string.rep(" ", tab_width - text:len())
+            .. self:hoursToClock(t[num])
         if easy then
             if t[num] and self.current_times[num] and self.current_times[num] ~= t[num] then
                 return text .. "\n"
@@ -793,23 +794,23 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
         face = Font:getFace("scfont"),
         width = math.floor(Screen:getWidth() * (self.easy_mode and 0.75 or 0.90)),
             text = title .. location_string .. ":\n\n" ..
-            info_line(_("Solar midnight:"), times, 1, request_easy) ..
-            _("  Dawn\n") ..
-            info_line(_("    Astronomic:"), times, 2, request_easy) ..
-            info_line(_("    Nautical:"), times, 3, request_easy)..
-            info_line(_("    Civil:"), times, 4) ..
-            _("  Dawn\n") ..
-            info_line(_("Sunrise:"), times, 5) ..
+            info_line(0, _("Solar midnight:"), times, 1, request_easy) ..
+            "  " .. _("Dawn\n") ..
+            info_line(4, _("Astronomic:"), times, 2, request_easy) ..
+            info_line(4, _("Nautical:"), times, 3, request_easy)..
+            info_line(4, _("Civil:"), times, 4) ..
+            "  " .. _("Dawn\n") ..
+            info_line(0, _("Sunrise:"), times, 5) ..
             "\n" ..
-            info_line(_("Solar noon:"), times, 6, request_easy) ..
+            info_line(0, _("Solar noon:"), times, 6, request_easy) ..
             "\n" ..
-            info_line(_("Sunset:"), times, 7) ..
-            _("  Dusk\n") ..
-            info_line(_("    Civil:"), times, 8) ..
-            info_line(_("    Nautical:"), times, 9, request_easy) ..
-            info_line(_("    Astronomic:"), times, 10, request_easy) ..
-            _("  Dusk\n") ..
-            info_line(_("Solar midnight:"), times, midnight_index, request_easy)
+            info_line(0, _("Sunset:"), times, 7) ..
+            "  " .. _("Dusk\n") ..
+            info_line(4, _("Civil:"), times, 8) ..
+            info_line(4, _("Nautical:"), times, 9, request_easy) ..
+            info_line(4, _("Astronomic:"), times, 10, request_easy) ..
+            "  " .. _("Dusk\n") ..
+            info_line(0, _("Solar midnight:"), times, midnight_index, request_easy)
     })
 end
 


### PR DESCRIPTION
Correct wordings to twilight, where dusk and dawn are meant.

Make translation strings easier to manage in the formatted overview (no spaces at the end of a string; use string.rep instead).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8262)
<!-- Reviewable:end -->
