### PR TITLE
Set 'last' page number

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1863,7 +1863,7 @@ function ReaderFooter:setTocMarkers(reset)
     if self.settings.disable_progress_bar or self.settings.progress_style_thin then return end
     if reset then
         self.progress_bar.ticks = nil
-        self.pages = self.ui.doc_settings:readSetting("doc_pages_max") or self.ui.document:getPageCount()
+        self.pages = self:getUserLastPage() or self.ui.document:getPageCount()
     end
     if self.settings.toc_markers then
         self.progress_bar.tick_width = Screen:scaleBySize(self.settings.toc_markers_width)
@@ -1887,7 +1887,7 @@ function ReaderFooter:setTocMarkers(reset)
                 self.progress_bar.ticks = self.ui.toc:getTocTicksFlattened()
             end
             if self.view.view_mode == "page" then
-                self.progress_bar.last = self.ui.doc_settings:readSetting("doc_pages_max") or self.ui.document:getPageCount()
+                self.progress_bar.last = self:getUserLastPage() or self.pages or self.ui.document:getPageCount()
             else
                 -- in scroll mode, convert pages to positions
                 if self.ui.toc then
@@ -2080,14 +2080,7 @@ function ReaderFooter:onPageUpdate(pageno)
     end
     self.ui.doc_settings:saveSetting("doc_pages", self.pages) -- for Book information
     if not self.ui.document:hasHiddenFlows() then  -- check for 'last' page number set by a user
-        local doc_pages_max = self.ui.doc_settings:readSetting("doc_pages_max")
-        if doc_pages_max then
-            if doc_pages_max > self.pages then
-                doc_pages_max = self.pages
-                self.ui.doc_settings:saveSetting("doc_pages_max", doc_pages_max)
-            end
-            self.pages = doc_pages_max
-        end
+        self.pages = self:getUserLastPage() or self.pages
     end
     self:updateFooterPage()
 end
@@ -2347,6 +2340,14 @@ end
 function ReaderFooter:onScreenResize()
     self:updateFooterContainer()
     self:resetLayout(true)
+end
+
+function ReaderFooter:getUserLastPage()
+    local doc_pages_max = self.ui.doc_settings:readSetting("doc_pages_max")
+    if type(doc_pages_max) == "string" then
+        doc_pages_max = self.ui.document:getPageFromXPointer(doc_pages_max)
+    end
+    return doc_pages_max
 end
 
 return ReaderFooter

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -963,6 +963,38 @@ See Style tweaks → Miscellaneous → Alternative ToC hints.]]),
             end,
         }
     end
+    -- Allow to set "last" page of the book, to display in status bar.
+    -- Available only in "page" view mode without hidden non-linear flows.
+    menu_items.doc_pages_max = {
+        text_func = function()
+            local doc_pages = self.ui.document:getPageCount()
+            local doc_pages_max = self.ui.doc_settings:readSetting("doc_pages_max") or doc_pages
+            return T(_("Last page number: %1 (%2)"), doc_pages_max, doc_pages)
+        end,
+        keep_menu_open = true,
+        callback = function(touchmenu_instance)
+            local SpinWidget = require("ui/widget/spinwidget")
+            local doc_pages = self.ui.document:getPageCount()
+            local doc_pages_max = self.ui.doc_settings:readSetting("doc_pages_max") or doc_pages
+            local widget = SpinWidget:new{
+                value = doc_pages_max,
+                value_min = 1,
+                value_max = doc_pages,
+                value_hold_step = 10,
+                default_value = doc_pages,
+                title_text =  _("Last page number"),
+                info_text =  _("Set 'last' page number in the book to display in status bar.\nDefault: actual last page."),
+                callback = function(spin)
+                    self.ui.doc_settings:saveSetting("doc_pages_max", spin.value)
+                    self.view.footer.pages = spin.value
+                    self:onUpdateToc()
+                    self.view.footer:onUpdateFooter(self.view.footer_visible)
+                    touchmenu_instance:updateItems()
+                end
+            }
+            UIManager:show(widget)
+        end
+    }
     -- Allow to have getTocTicksFlattened() get rid of all items at some depths, which
     -- might be useful to have the footer and SkimTo progress bar less crowded.
     -- This also affects the footer current chapter title, but leave the ToC itself unchanged.

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -29,6 +29,7 @@ local order = {
     navi_settings = {
         "toc_alt_toc",
         "----------------------------",
+        "doc_pages_max",
         "toc_ticks_level_ignore",
         "----------------------------",
         "toc_items_per_page",

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -121,6 +121,7 @@ function ProgressWidget:paintTo(bb, x, y)
         local y_pos = y + self.margin_v + self.bordersize
         local bar_height = my_size.h-2*(self.margin_v+self.bordersize)
         for i, tick in ipairs(self.ticks) do
+            if tick > self.last then break end
             local tick_x = bar_width*(tick/self.last)
             if self._mirroredUI then
                 tick_x = bar_width - tick_x


### PR DESCRIPTION
Allows to set 'last' page number in the book.
Closes https://github.com/koreader/koreader/issues/8254.

Affects indicators in the status bar:
-current page (total number of pages is shown in parenthesis)
-pages left in book
-progress percentage
-progress bar

Doesn't affect ToC, GoTo, SkimToWidget.
Unavailable in scroll mode or with hidden non-linear fragments.

'Last' page number is not set

<kbd>![1](https://user-images.githubusercontent.com/62179190/134799455-045fcf96-bddb-4596-8c38-12f72e8de63f.png)</kbd>

Setting

<kbd>![2](https://user-images.githubusercontent.com/62179190/134799456-7dc07698-22ce-47cd-bbd3-70d756c0aaa2.png)</kbd>

Appplied

<kbd>![3](https://user-images.githubusercontent.com/62179190/134799458-4b07e8cf-75e9-4008-8b20-d283584e338a.png)</kbd>

Compare with SkimToWidget

<kbd>![4](https://user-images.githubusercontent.com/62179190/134799459-d50c763a-a7fc-4879-9175-fa8739514a67.png)</kbd>

Less ticks (Level 1 only)

<kbd>![5](https://user-images.githubusercontent.com/62179190/134799460-3b031f09-c66f-4fe7-8d5d-93857e188604.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8265)
<!-- Reviewable:end -->
