### PR TITLE
TextBoxWidget: Unbreak Wikipedia

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1134,7 +1134,6 @@ function TextBoxWidget:free(full)
         self.cursor_restore_bb:free()
         self.cursor_restore_bb = nil
     end
-    self.line_num_to_image = nil
     if full ~= false then -- final free(): free all remaining resources
         if self.use_xtext and self._xtext then
             -- Allow not waiting until Lua gc() to cleanup C XText malloc'ed stuff
@@ -1143,6 +1142,9 @@ function TextBoxWidget:free(full)
             self._xtext = nil
             -- logger.dbg("TextBoxWidget:_xtext:free()")
         end
+
+        self.line_num_to_image = nil
+        self.vertical_string_list = nil
     end
 end
 


### PR DESCRIPTION
Turns out we can't release line_num_to_image early, so,
delay it until the final, full widget teardown.

(Regression since #8250, c.f.,
https://github.com/koreader/koreader/pull/8250#discussion_r716646211)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8275)
<!-- Reviewable:end -->
