### PR TITLE
CenterContainer: manage bigger content

### DIFF
--- a/frontend/ui/widget/container/centercontainer.lua
+++ b/frontend/ui/widget/container/centercontainer.lua
@@ -8,11 +8,19 @@ local CenterContainer = WidgetContainer:new()
 
 function CenterContainer:paintTo(bb, x, y)
     local content_size = self[1]:getSize()
-    --- @fixme
-    -- if content_size.w > self.dimen.w or content_size.h > self.dimen.h then
-        -- throw error? paint to scrap buffer and blit partially?
-        -- for now, we ignore this
-    -- end
+
+    -- check if content is bigger than container
+    if self.ignore_if_over == "height" then -- align upper borders
+        if self.dimen.h < content_size.h then
+            self.ignore = "height"
+        end
+    end
+    if self.ignore_if_over == "width" then -- align left borders
+        if self.dimen.w < content_size.w then
+            self.ignore = "width"
+        end
+    end
+
     local x_pos = x
     local y_pos = y
     if self.ignore ~= "height" then

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -462,6 +462,7 @@ function InputDialog:init()
             w = self.screen_width,
             h = self.screen_height - keyboard_height,
         },
+        ignore_if_over = "height",
         frame
     }
     if Device:isTouchDevice() then -- is used to hide the keyboard with a tap outside of inputbox

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -159,8 +159,9 @@ function KeyboardLayoutDialog:init()
     self[1] = CenterContainer:new{
         dimen = Geom:new{
             w = Screen:getWidth(),
-            h = math.max(Screen:getHeight(), self.dialog_frame:getSize().h),
+            h = Screen:getHeight(),
         },
+        ignore_if_over = "height",
         self.movable,
     }
 end

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -123,9 +123,9 @@ function MultiInputDialog:init()
     self[1] = CenterContainer:new{
         dimen = Geom:new{
             w = Screen:getWidth(),
-            h = math.max(Screen:getHeight() - self._input_widget:getKeyboardDimen().h,
-                self.dialog_frame:getSize().h),
+            h = Screen:getHeight() - self._input_widget:getKeyboardDimen().h,
         },
+        ignore_if_over = "height",
         self.dialog_frame,
     }
     UIManager:setDirty(self, "ui")


### PR DESCRIPTION
New property `ignore_if_over` allows to move the content (if it is bigger than the container) within the container to align upper or left borders (not both at once, analogue to existing `ignore`). Applicable, for example, to show the title of high dialogs in landscape mode.

Before

<kbd>![1](https://user-images.githubusercontent.com/62179190/135088164-80b76b33-5dee-450f-96e6-818acdf2fda6.png)</kbd>

After

<kbd>![2](https://user-images.githubusercontent.com/62179190/135088171-b56c251f-a11a-4802-9fa0-9d220547b8b1.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8277)
<!-- Reviewable:end -->
