### PR TITLE
Readerfooter: invert direction of progressbar

### DIFF
--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -69,7 +69,7 @@ function ProgressWidget:paintTo(bb, x, y)
         h = my_size.h
     }
     if self.dimen.w == 0 or self.dimen.h == 0 then return end
-    
+
     self._mirroredUI = self.fill_from_right or (BD.mirroredUILayout() and not self.fill_from_right)
 
     -- fill background

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -52,7 +52,7 @@ local ProgressWidget = Widget:new{
     fill_from_right = false,
     allow_mirroring = true,
     alt = nil, -- table with alternate pages to mark with different color (in the form {{ini1, len1}, {ini2, len2}, ...})
-    _mirroredUI = BD.mirroredUILayout(),
+    _mirroredUI = nil,
     _orig_margin_v = nil,
     _orig_bordersize = nil,
 }
@@ -69,6 +69,8 @@ function ProgressWidget:paintTo(bb, x, y)
         h = my_size.h
     }
     if self.dimen.w == 0 or self.dimen.h == 0 then return end
+    
+    self._mirroredUI = self.fill_from_right or (BD.mirroredUILayout() and not self.fill_from_right)
 
     -- fill background
     bb:paintRoundedRect(x, y, my_size.w, my_size.h, self.bgcolor, self.radius)
@@ -101,7 +103,7 @@ function ProgressWidget:paintTo(bb, x, y)
     -- paint percentage infill
     -- note that "lightenRect" is misleading, it actualy darkens stuff
     if self.percentage >= 0 and self.percentage <= 1 then
-        if self.fill_from_right or (self._mirroredUI and not self.fill_from_right) then
+        if self._mirroredUI then
             bb:lightenRect(x+self.margin_h + math.ceil((my_size.w-2*self.margin_h)*(1-self.percentage)),
                     math.ceil(y+self.margin_v+self.bordersize),
                     math.ceil((my_size.w-2*self.margin_h)*self.percentage),


### PR DESCRIPTION
(1) Allows to set progress bar filling and toc markers from right to left. Closes https://github.com/koreader/koreader/issues/7917.

<kbd>![1](https://user-images.githubusercontent.com/62179190/135436965-b2a349bd-44b5-419e-adeb-0303ffea2f0c.png)</kbd>

(2) Progress bar `Minimal width` setting is moved to `Position` submenu, as it is enabled and applicable to `Alongside items` mode only. (Additionally, infotext was made visible in the spinwidget, added default value).

<kbd>![2](https://user-images.githubusercontent.com/62179190/135437207-83c580f2-43b5-489e-a264-84c21ec58a2d.png)</kbd>

<kbd>![3](https://user-images.githubusercontent.com/62179190/135437217-5943c7f3-fe5b-4fb5-90d5-4fe7f98b463d.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8282)
<!-- Reviewable:end -->
