### PR TITLE
Update en_popup.lua

### DIFF
--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -16,6 +16,7 @@ return {
         northwest = "¡",
         east = "…",
         west = "!",
+        "·",
     },
     _at = {
         "@",


### PR DESCRIPTION
I added the Greek semicolon (upper dot) to the dot pop-up menu. Can this addition be done? There is no Greek semicolon anywhere.

Thank you!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8283)
<!-- Reviewable:end -->
