### PR TITLE
kopt: allow pdf auto straighten

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -144,7 +144,7 @@ local settingsList = {
     -- the rest of the table elements are built from their counterparts in CreOptions
     rotation_mode = {category="string", device=true},
     visible_pages = {category="string", rolling=true, separator=true},
-    h_page_margins = {category="string", rolling=true},
+    h_page_margins = {category="absolutenumber", rolling=true},
     sync_t_b_page_margins = {category="string", rolling=true},
     t_page_margin = {category="absolutenumber", rolling=true},
     b_page_margin = {category="absolutenumber", rolling=true, separator=true},
@@ -153,8 +153,8 @@ local settingsList = {
     render_dpi = {category="string", rolling=true},
     line_spacing = {category="absolutenumber", rolling=true, separator=true},
     font_size = {category="absolutenumber", title=_("Set font size to %1"), rolling=true, step=0.5},
-    font_base_weight = {category="string", rolling=true},
-    font_gamma = {category="string", rolling=true},
+    font_base_weight = {category="absolutenumber", rolling=true},
+    font_gamma = {category="absolutenumber", rolling=true},
     font_hinting = {category="string", rolling=true},
     font_kerning = {category="string", rolling=true, separator=true},
     status_line = {category="string", rolling=true},
@@ -166,8 +166,8 @@ local settingsList = {
     -- parsed from KoptOptions
     kopt_trim_page = {category="string", paging=true},
     kopt_page_margin = {category="string", paging=true},
-    kopt_zoom_overlap_h = {category="string", paging=true},
-    kopt_zoom_overlap_v = {category="string", paging=true},
+    kopt_zoom_overlap_h = {category="absolutenumber", paging=true},
+    kopt_zoom_overlap_v = {category="absolutenumber", paging=true},
     kopt_zoom_mode_type = {category="string", paging=true},
     kopt_zoom_range_number = {category="string", paging=true},
     kopt_zoom_factor = {category="string", paging=true},
@@ -182,7 +182,7 @@ local settingsList = {
     kopt_font_fine_tune = {category="string", paging=true},
     kopt_word_spacing = {category="configurable", paging=true},
     kopt_text_wrap = {category="string", paging=true},
-    kopt_contrast = {category="string", paging=true},
+    kopt_contrast = {category="absolutenumber", paging=true},
     kopt_page_opt = {category="configurable", paging=true},
     kopt_hw_dithering = {category="configurable", paging=true, condition=Device:hasEinkScreen() and Device:canHWDither()},
     kopt_quality = {category="configurable", paging=true},
@@ -190,7 +190,7 @@ local settingsList = {
     kopt_forced_ocr = {category="configurable", paging=true},
     kopt_writing_direction = {category="configurable", paging=true},
     kopt_defect_size = {category="string", paging=true, condition=false},
-    kopt_auto_straighten = {category="configurable", paging=true, condition=false},
+    kopt_auto_straighten = {category="absolutenumber", paging=true},
     kopt_detect_indent = {category="configurable", paging=true, condition=false},
     kopt_max_columns = {category="configurable", paging=true},
 }
@@ -394,10 +394,10 @@ function Dispatcher:init()
                     end
                 elseif settingsList[name].category == "absolutenumber" then
                     if settingsList[name].min == nil then
-                        settingsList[name].min = option.args[1]
+                        settingsList[name].min = option.args and option.args[1] or option.values[1]
                     end
                     if settingsList[name].max == nil then
-                        settingsList[name].max = option.args[#option.args]
+                        settingsList[name].max = option.args and option.args[#option.args] or option.values[#option.values]
                     end
                     if settingsList[name].default == nil then
                         settingsList[name].default = option.default_value

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -334,7 +334,7 @@ end
 function KoptInterface:renderPage(doc, pageno, rect, zoom, rotation, gamma, render_mode, hinting)
     if doc.configurable.text_wrap == 1 then
         return self:renderReflowedPage(doc, pageno, rect, zoom, rotation, render_mode, hinting)
-    elseif doc.configurable.page_opt == 1 then
+    elseif doc.configurable.page_opt == 1 or doc.configurable.auto_straighten > 0 then
         return self:renderOptimizedPage(doc, pageno, rect, zoom, rotation, render_mode, hinting)
     else
         return Document.renderPage(doc, pageno, rect, zoom, rotation, gamma, render_mode, hinting)
@@ -439,7 +439,7 @@ function KoptInterface:hintPage(doc, pageno, zoom, rotation, gamma, render_mode)
 
     if doc.configurable.text_wrap == 1 then
         self:hintReflowedPage(doc, pageno, zoom, rotation, gamma, render_mode, true)
-    elseif doc.configurable.page_opt == 1 then
+    elseif doc.configurable.page_opt == 1 or doc.configurable.auto_straighten > 0 then
         self:renderOptimizedPage(doc, pageno, nil, zoom, rotation, gamma, render_mode, true)
     else
         Document.hintPage(doc, pageno, zoom, rotation, gamma, render_mode)
@@ -487,7 +487,7 @@ end
 function KoptInterface:drawPage(doc, target, x, y, rect, pageno, zoom, rotation, gamma, render_mode)
     if doc.configurable.text_wrap == 1 then
         self:drawContextPage(doc, target, x, y, rect, pageno, zoom, rotation, render_mode)
-    elseif doc.configurable.page_opt == 1 then
+    elseif doc.configurable.page_opt == 1 or doc.configurable.auto_straighten > 0 then
         self:drawContextPage(doc, target, x, y, rect, pageno, zoom, rotation, render_mode)
     else
         Document.drawPage(doc, target, x, y, rect, pageno, zoom, rotation, gamma, render_mode)

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -110,6 +110,19 @@ In 'semi-auto' and 'manual' modes, you may need to define areas once on an odd p
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Set margins to be applied after page-crop and zoom modes are applied.]]),
             },
+            {
+                name = "auto_straighten",
+                name_text = _("Auto Straighten"),
+                toggle = {_("0°"), _("5°"), _("10°"), _("15°"), _("25°")},
+                values = {0, 5, 10, 15, 25},
+                event = "DummyEvent",
+                args = {0, 5, 10, 15, 25},
+                more_options = true,
+                default_value = DKOPTREADER_CONFIG_AUTO_STRAIGHTEN,
+                name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[Attempt to automatically straighten tilted source pages.
+Will rotate up to specified value.]]),
+            },
         }
     },
     {
@@ -565,19 +578,6 @@ This can also be used to remove some gray background or to convert a grayscale o
                     return optionsutil.enableIfEquals(configurable, "text_wrap", 1)
                 end,
                 name_text_hold_callback = optionsutil.showValues,
-            },
-            {
-                name = "auto_straighten",
-                name_text = _("Auto Straighten"),
-                toggle = {_("0°"), _("5°"), _("10°"), _("15°"), _("25°")},
-                values = {0, 5, 10, 15, 25},
-                event = "DummyEvent",
-                args = {0, 5, 10, 15, 25},
-                more_options = true,
-                default_value = DKOPTREADER_CONFIG_AUTO_STRAIGHTEN,
-                name_text_hold_callback = optionsutil.showValues,
-                help_text = _([[Attempt to automatically straighten tilted source pages.
-Will rotate up to specified value.]]),
             },
             {
                 name = "detect_indent",

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -123,7 +123,7 @@ In 'semi-auto' and 'manual' modes, you may need to define areas once on an odd p
                     return optionsutil.enableIfEquals(configurable, "text_wrap", 0)
                 end,
                 buttonprogress = true,
-                fine_tune = true,
+                more_options = true,
                 values = {0, 12, 24, 36, 48, 60, 72, 84},
                 default_pos = 4,
                 default_value = 36,
@@ -145,7 +145,7 @@ In 'semi-auto' and 'manual' modes, you may need to define areas once on an odd p
                     return optionsutil.enableIfEquals(configurable, "text_wrap", 0)
                 end,
                 buttonprogress = true,
-                fine_tune = true,
+                more_options = true,
                 values = {0, 12, 24, 36, 48, 60, 72, 84},
                 default_pos = 4,
                 default_value = 36,
@@ -569,14 +569,15 @@ This can also be used to remove some gray background or to convert a grayscale o
             {
                 name = "auto_straighten",
                 name_text = _("Auto Straighten"),
-                toggle = {_("0 deg"), _("5 deg"), _("10 deg")},
-                values = {0, 5, 10},
+                toggle = {_("0°"), _("5°"), _("10°"), _("15°"), _("25°")},
+                values = {0, 5, 10, 15, 25},
+                event = "DummyEvent",
+                args = {0, 5, 10, 15, 25},
+                more_options = true,
                 default_value = DKOPTREADER_CONFIG_AUTO_STRAIGHTEN,
-                show = false, -- does not work (and slows rendering)
-                enabled_func = function(configurable)
-                    return optionsutil.enableIfEquals(configurable, "text_wrap", 1)
-                end,
                 name_text_hold_callback = optionsutil.showValues,
+                help_text = _([[Attempt to automatically straighten tilted source pages.
+Will rotate up to specified value.]]),
             },
             {
                 name = "detect_indent",


### PR DESCRIPTION
Fixes: #8286

Can we decouple k2pdfopt usage from reflow (text_wrap)?
this option like many is only enabled when reflow is on as only then is k2pdfopt used to render the page: https://github.com/koreader/koreader/blob/2b87b1d8ed0b71e8830615106b6d8fba86e67182/frontend/document/koptinterface.lua#L334-L342

like what optimized page does (for some reason it is only used for dewatermark):
https://github.com/koreader/koreader/blob/2b87b1d8ed0b71e8830615106b6d8fba86e67182/frontend/document/koptinterface.lua#L384

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8287)
<!-- Reviewable:end -->
