### PR TITLE
Update en_popup.lua

### DIFF
--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -595,7 +595,7 @@ return {
         southeast = "ʏ", -- near-close, near-front rounded vowel IPA
         southwest = "Ŷ",
         "¥", -- Japanese Yen/Chinese Yuan currency
-        "Τ", -- Greek upsilon
+        "Υ", -- Greek upsilon
     },
     _y_ = {
         "y",


### PR DESCRIPTION
Correction of the "Υ" popup, where instead of Greek upsilon (as was written) there was the Greek capital tau ("Τ").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8308)
<!-- Reviewable:end -->
