### PR TITLE
DictQuickLookup: two minor fixes

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -64,16 +64,15 @@ local highlight_strings = {
 }
 
 function DictQuickLookup:canSearch()
-    if self:isDocless() then
-        return false
-    end
-
     if self.is_wiki then
         -- In the Wiki variant of this widget, the Search button is coopted to cycle between enabled languages.
         if #self.wiki_languages > 1 then
             return true
         end
     else
+        if self:isDocless() then
+            return false
+        end
         -- This is to prevent an ineffective button when we're launched from the Reader's menu.
         if self.highlight then
             return true
@@ -853,6 +852,7 @@ function DictQuickLookup:update()
         -- Re-use our ScrollTextWidget (self.stw_widget)
         -- Update properties that may change across results (as done in DictQuickLookup:_instantiateScrollWidget())
         self.text_widget.text_widget.text = self.definition
+        self.text_widget.text_widget.charlist = nil -- (required when use_xtext=false for proper re-init)
         self.text_widget.text_widget.lang = self.lang and self.lang:lower()
         self.text_widget.text_widget.para_direction_rtl = self.rtl_lang
         self.text_widget.text_widget.images = self.images


### PR DESCRIPTION
- Allow Wikipedia languages cycling when invoked from File browser.
Noticed at https://github.com/koreader/koreader/issues/8241#issuecomment-924659226.

- Fix TextBoxWidget content not updated when next/prev when use_xtext=false.
Noticed https://github.com/koreader/koreader/pull/8312#issuecomment-941038227.
See https://github.com/koreader/koreader/pull/8312#issuecomment-944245780

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8333)
<!-- Reviewable:end -->
