### PR TITLE
Add PocketBook InkPad Lite (PB970)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -611,6 +611,14 @@ local PocketBook840 = PocketBook:new{
     display_dpi = 250,
 }
 
+-- PocketBook InkPad Lite (970)
+local PocketBook970 = PocketBook:new{
+    model = "PB970",
+    display_dpi = 150,
+    isAlwaysPortrait = yes,
+    hasNaturalLight = yes,
+}
+
 -- PocketBook InkPad X (1040)
 local PocketBook1040 = PocketBook:new{
     model = "PB1040",
@@ -677,6 +685,8 @@ elseif codename == "PB741" then
     return PocketBook741
 elseif codename == "PocketBook 840" then
     return PocketBook840
+elseif codename == "PB970" then
+    return PocketBook970
 elseif codename == "PB1040" then
     return PocketBook1040
 elseif codename == "PocketBook Color Lux" then


### PR DESCRIPTION
Support for the new device PocketBook InkPad Lite (PB970)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8335)
<!-- Reviewable:end -->
