### PR TITLE
Added Date along with time in touchmenu

### DIFF
--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -685,7 +685,7 @@ function TouchMenu:updateItems()
     self.page_info_left_chev:enableDisable(self.page > 1)
     self.page_info_right_chev:enableDisable(self.page < self.page_num)
 
-    local time_info_txt = util.secondsToHour(os.time(), G_reader_settings:isTrue("twelve_hour_clock"))
+    local time_info_txt = util.secondsToDate(os.time(), G_reader_settings:isTrue("twelve_hour_clock"))
     local powerd = Device:getPowerDevice()
     local batt_lvl = powerd:getCapacity()
     local batt_symbol


### PR DESCRIPTION
Added Date along with existing time, display in touchmenu.lua file, so user can always see the date also while pulling down the settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8337)
<!-- Reviewable:end -->
