### PR TITLE
Menu widget: font size of shrinked items

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -342,7 +342,7 @@ function MenuItem:init()
     elseif self.multilines_show_more_text then
         -- Multi-lines, with font size decrease if needed to show more of the text.
         -- It would be costly/slow with use_xtext if we were to try all
-        -- font sizes from self.font_size to min_font_size (12).
+        -- font sizes from self.font_size to min_font_size.
         -- So, we try to optimize the search of the best font size.
         logger.dbg("multilines_show_more_text menu item font sizing start")
         local function make_item_name(font_size)
@@ -361,6 +361,8 @@ function MenuItem:init()
             -- return true if we fit
             return item_name:getSize().h <= max_item_height
         end
+        -- To keep item readable, do not decrease font size by more than 8 points
+        -- relative to the specified font size, being not smaller than 12 absolute points.
         local min_font_size = math.max(12, self.font_size - 8)
         -- First, try with specified font size: short text might fit
         if not make_item_name(self.font_size) then


### PR DESCRIPTION
Allows changing of font size of shrinked items (depending on the item font size).
Discussed in https://github.com/koreader/koreader/pull/8301#issuecomment-945069537.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8340)
<!-- Reviewable:end -->
