### PR TITLE
wbuilder: correct call of BookStatus widget

### DIFF
--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -390,7 +390,7 @@ function testBookStatus()
         thumbnail = doc:getCoverPageImage(),
         props = doc:getProps(),
         document = doc,
-        view = reader.view,
+        ui = reader,
     }
     UIManager:show(status_page)
 end


### PR DESCRIPTION
Correction required after https://github.com/koreader/koreader/pull/8318.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8342)
<!-- Reviewable:end -->
