### PR TITLE
[fix] gettext: unescape \\ for ID matching

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -268,6 +268,8 @@ function GetText_mt.__index.changeLang(new_lang)
                     s = s:gsub("\\n", "\n")
                     -- unescape " or msgid won't match
                     s = s:gsub('\\"', '"')
+                    -- unescape \\ or msgid won't match
+                    s = s:gsub("\\\\", "\\")
                     data[what] = (data[what] or "") .. s
                 else
                     -- Don't save this fuzzy string and unset fuzzy for the next one.


### PR DESCRIPTION
Fixes <https://github.com/koreader/koreader/issues/8356>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8357)
<!-- Reviewable:end -->
