### PR TITLE
luacheckrc: allow busted's "match" global for spec/

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -137,6 +137,7 @@ exclude_files = {
 -- don't balk on busted stuff in spec
 files["spec/unit/*"].std = "+busted"
 files["spec/unit/*"].globals = {
+    "match", -- can be removed once luacheck 0.24.0 or higher is used
     "package",
     "requireBackgroundRunner",
     "stopBackgroundRunner",


### PR DESCRIPTION
This is something luacheck should include but [the upstream PR to add
it][1] hasn't been merged yet, nor has the patch been included in the
fork.

[1]: https://github.com/mpeterv/luacheck/pull/200

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8369)
<!-- Reviewable:end -->
