### PR TITLE
More Kobo Mk.8 tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -95,7 +95,8 @@ local symbol_prefix = {
         percentage = nil,
         book_time_to_read = nil,
         chapter_time_to_read = BD.mirroredUILayout() and "«" or "»",
-        frontlight = "*",
+        frontlight = "✺",
+        frontlight_warmth = "⊛",
         -- @translators This is the footer compact item prefix for memory usage.
         mem_usage = C_("FooterCompactItemsPrefix", "M"),
         wifi_status = "",

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -9,7 +9,8 @@ local Geom = require("ui/geometry")
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
-local T = require("ffi/util").template
+local ffiUtil = require("ffi/util")
+local T = ffiUtil.template
 
 local function yes() return true end
 local function no() return false end
@@ -307,6 +308,11 @@ function Device:onPowerEvent(ev)
                     self.screen:clear()
                 end
                 self.screen:refreshFull()
+
+                -- On Kobo, on sunxi SoCs with a recent kernel, wait a tiny bit more to avoid weird refresh glitches...
+                if self:isKobo() and self:isSunxi() then
+                    ffiUtil.usleep(150 * 1000)
+                end
             end
         else
             -- nil it, in case user switched ScreenSaver modes during our lifetime.

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -187,6 +187,7 @@ function ProgressWidget:updateStyle(thick, height)
         self.bordersize = Screen:scaleBySize(1)
         self.radius = Screen:scaleBySize(2)
         self.bgcolor = Blitbuffer.COLOR_WHITE
+        self.fillcolor = Blitbuffer.COLOR_DARK_GRAY
         self._orig_margin_v = nil
         self._orig_bordersize = nil
         if height then
@@ -198,6 +199,7 @@ function ProgressWidget:updateStyle(thick, height)
         self.bordersize = 0
         self.radius = 0
         self.bgcolor = Blitbuffer.COLOR_GRAY
+        self.fillcolor = Blitbuffer.COLOR_DIM_GRAY
         self.ticks = nil
         self._orig_margin_v = nil
         self._orig_bordersize = nil

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -245,6 +245,9 @@ fi
 # will also enforce UR... (Only actually meaningful on sunxi).
 if [ "${PLATFORM}" = "b300-ntx" ]; then
     export FBINK_FORCE_ROTA=0
+    # Screen is too fast for GL16 not to look like utter crap.
+    FBINK_WFM="GC16"
+    FBINK_FLASH="-f"
     # And we also cannot use batched updates for the crash screens, as buffers are private,
     # so each invocation essentially draws in a different buffer...
     FBINK_BATCH_FLAG=""
@@ -256,6 +259,8 @@ if [ "${PLATFORM}" = "b300-ntx" ]; then
     # Make sure we poke the right input device
     KOBO_TS_INPUT="/dev/input/by-path/platform-0-0010-event"
 else
+    FBINK_WFM="GL16"
+    FBINK_FLASH=""
     FBINK_BATCH_FLAG="-b"
     FBINK_BGLESS_FLAG="-O"
     FBINK_OT_PADDING=""
@@ -398,19 +403,21 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         bombMargin=$((FONTH + FONTH / 2))
         # Start with a big gray screen of death, and our friendly old school crash icon ;)
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
-        # shellcheck disable=SC2039,SC3003
-        ./fbink -q ${FBINK_BATCH_FLAG} -c -B GRAY9 -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -W GL16 -- $'\xf0\x9f\x92\xa3'
+        # shellcheck disable=SC2039,SC3003,SC2086
+        ./fbink -q ${FBINK_BATCH_FLAG} -c -B GRAY9 -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -W ${FBINK_WFM} ${FBINK_FLASH} -- $'\xf0\x9f\x92\xa3'
         # With a little notice at the top of the screen, on a big gray screen of death ;).
-        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 1 "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})" -W GL16
+        # shellcheck disable=SC2086
+        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 1 -W ${FBINK_WFM} ${FBINK_FLASH} -- "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         if [ ${CRASH_COUNT} -eq 1 ]; then
             # Warn that we're waiting on a tap to continue...
-            ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 2 "Tap the screen to continue." -W GL16
+            # shellcheck disable=SC2086
+            ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 2 -W ${FBINK_WFM} ${FBINK_FLASH} -- "Tap the screen to continue."
         fi
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
         # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
         # shellcheck disable=SC2086
-        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64))${FBINK_OT_PADDING} -W GL16 -- "${crashLog}"
+        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64))${FBINK_OT_PADDING} -W ${FBINK_WFM} ${FBINK_FLASH} -- "${crashLog}"
         if [ "${PLATFORM}" != "b300-ntx" ]; then
             # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
             ./fbink -q -f -s


### PR DESCRIPTION
* Slightly more readable crash screen on the Sage, because the screen is too fast and GL16 too fugly otherwise.
* Workaround (maybe) a weird flash race in the sleep screen, where the secod flash may not cover the full screen region based on what was on screen *prior* to the white flash (??!!).
* NetworkManager: handle the case of a global preffered AP being sorted earlier than a KO preferred AP screwing everything up, because we attempted to associate to our own AP while wpa_supplicant was in the process of associating to its own AP.
(Fairly edge-casey, exposed by the fact that I have two different APs for the GHz and 2GHz band, the system's preferred AP is the 5G one, and KO's is the 2G one because I migrated my setting from a device with no 5G support, and I'm far enough away that the 2G one often appears with slightly better signal quality in scans, which meant we were sorting it higher).

The extra STATUS call during the "preferred" authentication code-flow may not actually be necessary, as I fixed the actual logic *after* implementing this failsafe, and may or may not be actively harmful, so, this needs testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8393)
<!-- Reviewable:end -->
