### PR TITLE
Fix crash in readerhighlight

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -179,7 +179,8 @@ function ReaderHighlight:init()
         return {
             text= _("Hyphenate"),
             show_in_highlight_dialog_func = function()
-                return _self.ui.userhyph and _self.ui.userhyph:isAvailable() and not _self.selected_text.text:find("[ ,;-%.\n]")
+                return _self.ui.userhyph and _self.ui.userhyph:isAvailable()
+                    and not _self.selected_text.text:find("[ ,;-%.\n]")
             end,
             callback = function()
                 _self.ui.userhyph:modifyUserEntry(_self.selected_text.text)
@@ -746,6 +747,10 @@ function ReaderHighlight:removeFromHighlightDialog(idx)
 end
 
 function ReaderHighlight:onShowHighlightMenu()
+    if not self.selected_text then
+        return
+    end
+
     local highlight_buttons = {{}}
 
     local columns = 2


### PR DESCRIPTION
This PR fixes a crash in readerhighlight. 

This bug was probably introduced with https://github.com/koreader/koreader/commit/7a0e3d5e68e4d119cdd60060a01303380e497c74#diff-db51db4b48e0314c642050876de6cd601d148eaaa00d4511523f811531d63ccf

To hit the bug, add a Gesture for going to `next bookmark`. Add a few bookmarks. Go to the first page. Apply the gesture for going to `next bookmark`.
-> Then KOReader jumps to the right page (wanted) and shows a HighlightMenu (which is not wanted).
-> Tap on e.g. Hyphenate (if you have enabled it) or Translate 
-> Crash
```
10/31/21-10:12:58 DEBUG setDirty fast from widget nil w/ region 27 404 242 37 
./luajit: frontend/apps/reader/modules/readerhighlight.lua:1239: attempt to index local 'selected_text' (a nil value)
stack traceback:
	frontend/apps/reader/modules/readerhighlight.lua:1239: in function 'translate'
	frontend/apps/reader/modules/readerhighlight.lua:125: in function 'callback'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8396)
<!-- Reviewable:end -->
