### PR TITLE
dictionaries: switch to far more up-to-date JM(ne)dict

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -524,12 +524,20 @@ local dictionaries = {
         url = "https://gitlab.com/avsej/dicts-stardict-form-xdxf/raw/d636cc5e8d4a47e22ac7466f4af6d435a8a3f650/002c/stardict-comn_sdict05_italian-english-2.4.2.tar.gz"
     },
     {
-        name = "Japanese(Kanji)-English dictionary",
+        name = "JMdict Japanese-English dictionary",
         lang_in = "Japanese",
         lang_out = "English",
-        entries = 108472,
-        license = "from http://ftp.cc.monash.edu.au/pub/nihongo/",
-        url = "https://gitlab.com/avsej/dicts-stardict-form-xdxf/raw/d636cc5e8d4a47e22ac7466f4af6d435a8a3f650/002c/stardict-comn_sdict05_jap-eng-2.4.2.tar.gz"
+        entries = 188380,
+        license = "CC-BY-SA 3.0 (from https://www.edrdg.org/wiki/index.php/JMdictDB_Project)",
+        url = "https://cyphar.github.io/jpn-stardicts/JMdict-ja-en.tar.gz"
+    },
+    {
+        name = "JMnedict Japanese-English name dictionary",
+        lang_in = "Japanese",
+        lang_out = "English",
+        entries = 741290,
+        license = "CC-BY-SA 3.0 (from https://www.edrdg.org/wiki/index.php/JMdictDB_Project)",
+        url = "https://cyphar.github.io/jpn-stardicts/JMnedict-ja-en.tar.gz"
     },
     {
         name = "Latin-English dictionary",


### PR DESCRIPTION
The previous version of JMdict comes from 2009 and doesn't appear to
work at all when trying to do basic lookups (likely due to some kind of
encoding problem). In addition, the license information and sourcing was
not really in line with the requirements specified by the JMdict
license. This version is far more up-to-date and also includes synonym-based
deinflection (though because KOReader has a Japanese plugin now, this is
technically not necessary).

Since there didn't exist a nicely-maintained place to download these
dictionaries (because StarDict is not widely used for Japanese
dictionaries), I've set up a personal GitHub repository where I've
hosted them. Note that we're intentionally not pinning the commit hash
because GitHub only recommends we use gh-pages for CDN purposes, and one
of the requirements of the JMdict license is that you need to be able to
update to later versions.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8413)
<!-- Reviewable:end -->
