### PR TITLE
readerhighlight: extend highlighting

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -539,9 +539,10 @@ function ReaderBookmark:onShowBookmark()
                     {
                         {
                             text = _("Remove bookmark"),
+                            enabled = not bookmark.ui.highlight.select_mode,
                             callback = function()
                                 UIManager:show(ConfirmBox:new{
-                                    text = _("Remove bookmark?"),
+                                    text = _("Remove this bookmark?"),
                                     ok_text = _("Remove"),
                                     ok_callback = function()
                                         bookmark:removeHighlight(item)
@@ -570,6 +571,7 @@ function ReaderBookmark:onShowBookmark()
                     {
                         {
                             text = _("Bulk remove"),
+                            enabled = not bookmark.ui.highlight.select_mode,
                             callback = function()
                                 self.select_mode = true
                                 self.select_count = 0

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -48,6 +48,8 @@ function ReaderHighlight:init()
     self.select_mode = false -- extended highlighting
 
     self._highlight_buttons = {
+        -- highlight and add_note are for the document itself,
+        -- so we put them first.
         ["01_select"] = function(_self)
             return {
                 text = _("Select"),
@@ -91,6 +93,8 @@ function ReaderHighlight:init()
                 enabled = _self.hold_pos ~= nil,
             }
         end,
+        -- then information lookup functions, putting on the left those that
+        -- depend on an internet connection.
         ["05_wikipedia"] = function(_self)
             return {
                 text = _("Wikipedia"),
@@ -126,6 +130,8 @@ function ReaderHighlight:init()
                 end,
             }
         end,
+        -- buttons 08-11 are conditional ones, so the number of buttons can be even or odd
+        -- let the Search button be the last, occasionally narrow or wide, less confusing
         ["12_search"] = function(_self)
             return {
                 text = _("Search"),
@@ -139,6 +145,7 @@ function ReaderHighlight:init()
         end,
     }
 
+    -- Android devices
     if Device:canShareText() then
         self:addToHighlightDialog("08_share_text", function(_self)
             return {
@@ -153,6 +160,7 @@ function ReaderHighlight:init()
         end)
     end
 
+    -- cre documents only
     if not self.ui.document.info.has_pages then
         self:addToHighlightDialog("09_view_html", function(_self)
             return {
@@ -164,6 +172,7 @@ function ReaderHighlight:init()
         end)
     end
 
+    -- User hyphenation dict
     self:addToHighlightDialog("10_user_dict", function(_self)
         return {
             text= _("Hyphenate"),
@@ -178,6 +187,7 @@ function ReaderHighlight:init()
         }
     end)
 
+    -- Links
     self:addToHighlightDialog("11_follow_link", function(_self)
         return {
             text = _("Follow Link"),

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1682,14 +1682,17 @@ function ReaderHighlight:extendHighlights(page1, i1, item2_pos0, item2_pos1)
     local new_pos1 = self.ui.document:compareXPointers(item1.pos1, item2_pos1) == 1 and item2_pos1 or item1.pos1
     self:deleteHighlight(page1, i1)
     -- construct new extended highlight
-    self.hold_pos = {}
-    self.hold_pos.page = self.ui.document:getPageFromXPointer(new_pos0)
+    self.hold_pos = {
+        page = self.ui.document:getPageFromXPointer(new_pos0),
+    }
     self.selected_text = {
         text = self.ui.document:getTextFromXPointers(new_pos0, new_pos1),
         pos0 = new_pos0,
         pos1 = new_pos1,
     }
     self:saveHighlight()
+    self.hold_pos = nil
+    self.selected_text = nil
     UIManager:setDirty(self.dialog, "ui")
 end
 


### PR DESCRIPTION
Allows to highlight bigger areas by selecting starting and ending fragments.

Issues to close: https://github.com/koreader/koreader/issues/7726, https://github.com/koreader/koreader/issues/7748

How to use: highlight starting fragment

![1](https://user-images.githubusercontent.com/62179190/140919201-700a6a54-996c-495b-b913-dcf3eedc2fdc.png)

Press `Extend highlighting`

![2](https://user-images.githubusercontent.com/62179190/140919260-70192f82-6c71-4449-832f-a1294286e173.png)

Highlight ending fragment (it was a long-press on "Features")

![3](https://user-images.githubusercontent.com/62179190/140919360-a636cb82-c45a-4cff-8c0e-6ab7f1cbd3da.png)

The ending fragment can precede, follow, intersect or include the starting fragment.

Now works for cre documents only.
If this UX and coding approach is accepted, I shall look into pdf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8432)
<!-- Reviewable:end -->
