### PR TITLE
Readerpaging, readerrolling: remove duplicated code

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -927,12 +927,8 @@ function ReaderHighlight:onHoldPan(_, ges)
         -- With CreDocuments, allow text selection across multiple pages
         -- by (temporarily) switching to scroll mode when panning to the
         -- top left or bottom right corners.
-        local mirrored_reading = BD.mirroredUILayout()
-        if self.ui.rolling and self.ui.rolling.inverse_reading_order then
-            mirrored_reading = not mirrored_reading
-        end
         local is_in_prev_page_corner, is_in_next_page_corner
-        if mirrored_reading then
+        if self.view.inverse_reading_order ~= BD.mirroredUILayout() then
             -- Note: this might not be really usable, as crengine native selection
             -- is not adapted to RTL text
             -- top right corner

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -927,8 +927,12 @@ function ReaderHighlight:onHoldPan(_, ges)
         -- With CreDocuments, allow text selection across multiple pages
         -- by (temporarily) switching to scroll mode when panning to the
         -- top left or bottom right corners.
+        local mirrored_reading = BD.mirroredUILayout()
+        if self.view.inverse_reading_order then
+            mirrored_reading = not mirrored_reading
+        end
         local is_in_prev_page_corner, is_in_next_page_corner
-        if self.view.inverse_reading_order ~= BD.mirroredUILayout() then
+        if mirrored_reading then
             -- Note: this might not be really usable, as crengine native selection
             -- is not adapted to RTL text
             -- top right corner

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -107,9 +107,7 @@ function ReaderPaging:onReaderReady()
     self:setupTouchZones()
 end
 
--- This method will be called in onSetDimensions handler
 function ReaderPaging:setupTouchZones()
-    -- deligate gesture listener to readerui
     self.ges_events = {}
     self.onGesture = nil
     if not Device:isTouchDevice() then return end

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -107,35 +107,9 @@ function ReaderPaging:onReaderReady()
     self:setupTouchZones()
 end
 
-function ReaderPaging:setupTapTouchZones()
-
-    local forward_zone, backward_zone = self.view:getTapZones()
-
-    self.ui:registerTouchZones({
-        {
-            id = "tap_forward",
-            ges = "tap",
-            screen_zone = forward_zone,
-            handler = function()
-                if G_reader_settings:nilOrFalse("page_turns_disable_tap") then
-                    return self:onGotoViewRel(1)
-                end
-            end,
-        },
-        {
-            id = "tap_backward",
-            ges = "tap",
-            screen_zone = backward_zone,
-            handler = function()
-                if G_reader_settings:nilOrFalse("page_turns_disable_tap") then
-                    return self:onGotoViewRel(-1)
-                end
-            end,
-        },
-    })
-end
-
+-- This method will be called in onSetDimensions handler
 function ReaderPaging:setupTouchZones()
+    -- deligate gesture listener to readerui
     self.ges_events = {}
     self.onGesture = nil
     if not Device:isTouchDevice() then return end

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -37,7 +37,6 @@ local ReaderPaging = InputContainer:new{
     page_area = nil,
     overlap = Screen:scaleBySize(DOVERLAPPIXELS),
 
-    inverse_reading_order = nil,
     page_flipping_mode = false,
     bookmark_flipping_mode = false,
     flip_steps = {0,1,2,5,10,20,50,100},
@@ -109,23 +108,8 @@ function ReaderPaging:onReaderReady()
 end
 
 function ReaderPaging:setupTapTouchZones()
-    local forward_zone = {
-        ratio_x = DTAP_ZONE_FORWARD.x, ratio_y = DTAP_ZONE_FORWARD.y,
-        ratio_w = DTAP_ZONE_FORWARD.w, ratio_h = DTAP_ZONE_FORWARD.h,
-    }
-    local backward_zone = {
-        ratio_x = DTAP_ZONE_BACKWARD.x, ratio_y = DTAP_ZONE_BACKWARD.y,
-        ratio_w = DTAP_ZONE_BACKWARD.w, ratio_h = DTAP_ZONE_BACKWARD.h,
-    }
 
-    local do_mirror = BD.mirroredUILayout()
-    if self.inverse_reading_order then
-        do_mirror = not do_mirror
-    end
-    if do_mirror then
-        forward_zone.ratio_x = 1 - forward_zone.ratio_x - forward_zone.ratio_w
-        backward_zone.ratio_x = 1 - backward_zone.ratio_x - backward_zone.ratio_w
-    end
+    local forward_zone, backward_zone = self.view:getTapZones()
 
     self.ui:registerTouchZones({
         {
@@ -151,16 +135,34 @@ function ReaderPaging:setupTapTouchZones()
     })
 end
 
--- This method will be called in onSetDimensions handler
 function ReaderPaging:setupTouchZones()
-    -- deligate gesture listener to readerui
     self.ges_events = {}
     self.onGesture = nil
-
     if not Device:isTouchDevice() then return end
 
-    self:setupTapTouchZones()
+    local forward_zone, backward_zone = self.view:getTapZones()
+
     self.ui:registerTouchZones({
+        {
+            id = "tap_forward",
+            ges = "tap",
+            screen_zone = forward_zone,
+            handler = function()
+                if G_reader_settings:nilOrFalse("page_turns_disable_tap") then
+                    return self:onGotoViewRel(1)
+                end
+            end,
+        },
+        {
+            id = "tap_backward",
+            ges = "tap",
+            screen_zone = backward_zone,
+            handler = function()
+                if G_reader_settings:nilOrFalse("page_turns_disable_tap") then
+                    return self:onGotoViewRel(-1)
+                end
+            end,
+        },
         {
             id = "paging_swipe",
             ges = "swipe",
@@ -194,11 +196,6 @@ function ReaderPaging:onReadSettings(config)
     self.flipping_zoom_mode = config:readSetting("flipping_zoom_mode") or "page"
     self.flipping_scroll_mode = config:isTrue("flipping_scroll_mode")
     self.is_reflowed = config:has("kopt_text_wrap") and config:readSetting("kopt_text_wrap") == 1
-    if config:has("inverse_reading_order") then
-        self.inverse_reading_order = config:isTrue("inverse_reading_order")
-    else
-        self.inverse_reading_order = G_reader_settings:isTrue("inverse_reading_order")
-    end
     for _, v in ipairs(ReaderZooming.zoom_pan_settings) do
         self[v] = config:readSetting(v) or G_reader_settings:readSetting(v) or ReaderZooming[v]
     end
@@ -211,7 +208,6 @@ function ReaderPaging:onSaveSettings()
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
     self.ui.doc_settings:saveSetting("flipping_zoom_mode", self.flipping_zoom_mode)
     self.ui.doc_settings:saveSetting("flipping_scroll_mode", self.flipping_scroll_mode)
-    self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
 end
 
 function ReaderPaging:getLastProgress()
@@ -400,7 +396,7 @@ function ReaderPaging:onSwipe(_, ges)
         return true
     elseif direction == "west" then
         if G_reader_settings:nilOrFalse("page_turns_disable_swipe") then
-            if self.inverse_reading_order then
+            if self.view.inverse_reading_order then
                 self:onGotoViewRel(-1)
             else
                 self:onGotoViewRel(1)
@@ -409,7 +405,7 @@ function ReaderPaging:onSwipe(_, ges)
         end
     elseif direction == "east" then
         if G_reader_settings:nilOrFalse("page_turns_disable_swipe") then
-            if self.inverse_reading_order then
+            if self.view.inverse_reading_order then
                 self:onGotoViewRel(1)
             else
                 self:onGotoViewRel(-1)
@@ -1139,20 +1135,6 @@ end
 function ReaderPaging:onToggleReflow()
     self.view.document.configurable.text_wrap = bit.bxor(self.view.document.configurable.text_wrap, 1)
     self:onReflowUpdated()
-end
-
--- Duplicated in ReaderRolling
-function ReaderPaging:onToggleReadingOrder()
-    self.inverse_reading_order = not self.inverse_reading_order
-    self:setupTouchZones()
-    local is_rtl = BD.mirroredUILayout()
-    if self.inverse_reading_order then
-        is_rtl = not is_rtl
-    end
-    UIManager:show(Notification:new{
-        text = is_rtl and _("RTL page turning.") or _("LTR page turning."),
-    })
-    return true
 end
 
 return ReaderPaging

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -42,7 +42,6 @@ local ReaderRolling = InputContainer:new{
     pan_rate = 30,  -- default 30 ops, will be adjusted in readerui
     rendering_hash = 0,
     current_pos = 0,
-    inverse_reading_order = nil,
     -- only used for page view mode
     current_page= nil,
     xpointer = nil,
@@ -209,12 +208,6 @@ function ReaderRolling:onReadSettings(config)
         end
     end
 
-    if config:has("inverse_reading_order") then
-        self.inverse_reading_order = config:isTrue("inverse_reading_order")
-    else
-        self.inverse_reading_order = G_reader_settings:isTrue("inverse_reading_order")
-    end
-
     -- This self.visible_pages may not be the current nb of visible pages
     -- as crengine may decide to not ensure that in some conditions.
     -- It's the one we got from settings, the one the user has decided on
@@ -302,7 +295,6 @@ function ReaderRolling:onSaveSettings()
     if self.ui.document then
         self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
     end
-    self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
     self.ui.doc_settings:saveSetting("visible_pages", self.visible_pages)
     self.ui.doc_settings:saveSetting("hide_nonlinear_flows", self.hide_nonlinear_flows)
 end
@@ -320,23 +312,7 @@ function ReaderRolling:setupTouchZones()
     self.onGesture = nil
     if not Device:isTouchDevice() then return end
 
-    local forward_zone = {
-        ratio_x = DTAP_ZONE_FORWARD.x, ratio_y = DTAP_ZONE_FORWARD.y,
-        ratio_w = DTAP_ZONE_FORWARD.w, ratio_h = DTAP_ZONE_FORWARD.h,
-    }
-    local backward_zone = {
-        ratio_x = DTAP_ZONE_BACKWARD.x, ratio_y = DTAP_ZONE_BACKWARD.y,
-        ratio_w = DTAP_ZONE_BACKWARD.w, ratio_h = DTAP_ZONE_BACKWARD.h,
-    }
-
-    local do_mirror = BD.mirroredUILayout()
-    if self.inverse_reading_order then
-        do_mirror = not do_mirror
-    end
-    if do_mirror then
-        forward_zone.ratio_x = 1 - forward_zone.ratio_x - forward_zone.ratio_w
-        backward_zone.ratio_x = 1 - backward_zone.ratio_x - backward_zone.ratio_w
-    end
+    local forward_zone, backward_zone = self.view:getTapZones()
 
     self.ui:registerTouchZones({
         {
@@ -470,7 +446,7 @@ function ReaderRolling:onSwipe(_, ges)
     local direction = BD.flipDirectionIfMirroredUILayout(ges.direction)
     if direction == "west" then
         if G_reader_settings:nilOrFalse("page_turns_disable_swipe") then
-            if self.inverse_reading_order then
+            if self.view.inverse_reading_order then
                 self:onGotoViewRel(-1)
             else
                 self:onGotoViewRel(1)
@@ -479,7 +455,7 @@ function ReaderRolling:onSwipe(_, ges)
         end
     elseif direction == "east" then
         if G_reader_settings:nilOrFalse("page_turns_disable_swipe") then
-            if self.inverse_reading_order then
+            if self.view.inverse_reading_order then
                 self:onGotoViewRel(1)
             else
                 self:onGotoViewRel(-1)
@@ -1470,20 +1446,6 @@ function ReaderRolling:onToggleHideNonlinear()
     -- the footer needs updating, and TOC markers may come or go.
     self.ui.document:cacheFlows()
     self.ui:handleEvent(Event:new("UpdateToc"))
-end
-
--- Duplicated in ReaderPaging
-function ReaderRolling:onToggleReadingOrder()
-    self.inverse_reading_order = not self.inverse_reading_order
-    self:setupTouchZones()
-    local is_rtl = BD.mirroredUILayout()
-    if self.inverse_reading_order then
-        is_rtl = not is_rtl
-    end
-    UIManager:show(Notification:new{
-        text = is_rtl and _("RTL page turning.") or _("LTR page turning."),
-    })
-    return true
 end
 
 return ReaderRolling

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -989,7 +989,7 @@ function ReaderView:onToggleReadingOrder()
     else
         self.ui.rolling:setupTouchZones()
     end
-    local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout()
+    local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout() -- mirrored reading
     UIManager:show(Notification:new{
         text = is_rtl and _("RTL page turning.") or _("LTR page turning."),
     })
@@ -1005,7 +1005,7 @@ function ReaderView:getTapZones()
         ratio_x = DTAP_ZONE_BACKWARD.x, ratio_y = DTAP_ZONE_BACKWARD.y,
         ratio_w = DTAP_ZONE_BACKWARD.w, ratio_h = DTAP_ZONE_BACKWARD.h,
     }
-    if self.inverse_reading_order ~= BD.mirroredUILayout() then
+    if self.inverse_reading_order ~= BD.mirroredUILayout() then -- mirrored reading
         forward_zone.ratio_x = 1 - forward_zone.ratio_x - forward_zone.ratio_w
         backward_zone.ratio_x = 1 - backward_zone.ratio_x - backward_zone.ratio_w
     end

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -35,11 +35,7 @@ local PageTurns = {
             end,
             checked_func = function()
                 local ui = require("apps/reader/readerui"):_getRunningInstance()
-                if ui.document.info.has_pages then
-                    return ui.paging.inverse_reading_order
-                else
-                    return ui.rolling.inverse_reading_order
-                end
+                return ui.view.inverse_reading_order
             end,
             callback = function()
                 UIManager:broadcastEvent(Event:new("ToggleReadingOrder"))


### PR DESCRIPTION
(1) inverse_reading_order moved to readerview
(2) setting forward and backward tap zones moved to readerview

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8445)
<!-- Reviewable:end -->
