### PR TITLE
DocSettings: fix settings not saved when book on read-only FS

### DIFF
--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -309,7 +309,13 @@ function DocSettings:flush()
 
     -- If we can write to sidecar_file, we do not need to write to history_file
     -- anymore.
-    local serials = { self.sidecar_file, self.history_file }
+    local serials = {}
+    if self.sidecar_file then
+        table.insert(serials, self.sidecar_file)
+    end
+    if self.history_file then
+        table.insert(serials, self.history_file)
+    end
     self:ensureSidecar(self.sidecar)
     local s_out = dump(self.data)
     os.setlocale('C', 'numeric')


### PR DESCRIPTION
Witnessed on Android with books on the external SD card.
See https://github.com/koreader/koreader/issues/8420#issuecomment-970249466. Closes #8420.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8448)
<!-- Reviewable:end -->
