### PR TITLE
[BookShortcuts] folder support

### DIFF
--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -198,6 +198,16 @@ function ReadHistory:getPreviousFile(current_file)
     end
 end
 
+function ReadHistory:getFileByDirectory(directory)
+    assert(self ~= nil)
+    local real_path = realpath(directory)
+    for i=1, #self.hist do
+        if realpath(ffiutil.dirname(self.hist[i].file)) == real_path then
+             return self.hist[i].file
+        end
+    end
+end
+
 function ReadHistory:fileDeleted(path)
     if G_reader_settings:isTrue("autoremove_deleted_items_from_history") then
         self:removeItemByPath(path)

--- a/plugins/bookshortcuts.koplugin/main.lua
+++ b/plugins/bookshortcuts.koplugin/main.lua
@@ -4,10 +4,13 @@ local Dispatcher = require("dispatcher")
 local FFIUtil = require("ffi/util")
 local LuaSettings = require("luasettings")
 local PathChooser = require("ui/widget/pathchooser")
+local ReadHistory = require("readhistory")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local lfs = require("libs/libkoreader-lfs")
 local util = require("util")
 local _ = require("gettext")
+local T = FFIUtil.template
 
 local BookShortcuts = WidgetContainer:new{
     name = "bookshortcuts",
@@ -17,17 +20,32 @@ local BookShortcuts = WidgetContainer:new{
 
 function BookShortcuts:onDispatcherRegisterActions()
     for k,v in pairs(self.shortcuts.data) do
-        if util.fileExists(k) then
-            local directory, filename = util.splitFilePathName(k) -- luacheck: no unused
-            Dispatcher:registerAction(k, {category="none", event="BookShortcut", title=filename, general=true, arg=k,})
+        if util.pathExists(k) then
+            local title = k
+            if lfs.attributes(k, "mode") == "file" then
+                local directory, filename = util.splitFilePathName(k) -- luacheck: no unused
+                title = filename
+            end
+            Dispatcher:registerAction(k, {category="none", event="BookShortcut", title=title, general=true, arg=k,})
         end
     end
 end
 
 function BookShortcuts:onBookShortcut(path)
-    if util.fileExists(path) then
+    if util.pathExists(path) then
+        local file
+        if lfs.attributes(path, "mode") ~= "file" then
+            if G_reader_settings:readSetting("BookShortcuts_directory_action") == "FM" then
+                local FileManager = require("apps/filemanager/filemanager")
+                FileManager:showFiles(path)
+            else
+                file = ReadHistory:getFileByDirectory(path)
+            end
+        else
+            file = path
+        end
         local ReaderUI = require("apps/reader/readerui")
-        ReaderUI:showReader(path)
+        ReaderUI:showReader(file)
     end
 end
 
@@ -54,6 +72,9 @@ function BookShortcuts:addToMainMenu(menu_items)
 end
 
 function BookShortcuts:getSubMenuItems()
+    local FM_text = _("file browser")
+    local last_text = _("last book")
+
     local sub_item_table = {
         {
             text = _("New shortcut"),
@@ -61,11 +82,11 @@ function BookShortcuts:getSubMenuItems()
             callback = function(touchmenu_instance)
                 local path_chooser = PathChooser:new{
                     select_file = true,
-                    select_directory = false,
+                    select_directory = true,
                     detailed_file_info = true,
                     path = G_reader_settings:readSetting("home_dir"),
-                    onConfirm = function(file_path)
-                        self:addShortcut(file_path)
+                    onConfirm = function(path)
+                        self:addShortcut(path)
                         touchmenu_instance.item_table = self:getSubMenuItems()
                         touchmenu_instance.page = 1
                         touchmenu_instance:updateItems()
@@ -73,6 +94,22 @@ function BookShortcuts:getSubMenuItems()
                 }
                 UIManager:show(path_chooser)
             end,
+        },
+        {
+            text_func = function() return T(_("Directory action: %1"), G_reader_settings:readSetting("BookShortcuts_directory_action", "FM") == "FM" and FM_text or last_text) end,
+            keep_menu_open = true,
+            sub_item_table = {
+                {
+                    text = last_text,
+                    checked_func = function() return G_reader_settings:readSetting("BookShortcuts_directory_action") == "Last" end,
+                    callback = function() G_reader_settings:saveSetting("BookShortcuts_directory_action", "Last") end,
+                },
+                {
+                    text = FM_text,
+                    checked_func = function() return G_reader_settings:readSetting("BookShortcuts_directory_action") == "FM" end,
+                    callback = function() G_reader_settings:saveSetting("BookShortcuts_directory_action", "FM") end,
+                },
+            },
             separator = true,
         }
     }


### PR DESCRIPTION
Allow setting a folder (not just a file) as a book shortcut with 2 options:

1. open FM: opens the FM in that folder
2. Last file: opens the most recently read book (via ReadHistory) in that folder. (this is what I use it for. A gesture to go back to the book i am in middle of by category (folder))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8449)
<!-- Reviewable:end -->
