### PR TITLE
Backup bookmarks/highlights in incompatible engines

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -268,12 +268,16 @@ function ReaderBookmark:onReadSettings(config)
     -- Bookmark formats in crengine and mupdf are incompatible.
     -- Backup bookmarks when the document is opened with incompatible engine.
     if #self.bookmarks > 0 then
-        local bm_type = type(self.bookmarks[1].page)
-        if (self.ui.rolling and bm_type == "number") or (self.ui.paging and bm_type == "string") then
-            local bookmarks_tmp = config:readSetting("bookmarks_backup", {})
-            config:saveSetting("bookmarks", bookmarks_tmp)
-            config:saveSetting("bookmarks_backup", self.bookmarks)
-            self.bookmarks = config:readSetting("bookmarks")
+        if self.ui.rolling and type(self.bookmarks[1].page) == "number" then
+            config:saveSetting("bookmarks_paging", self.bookmarks)
+            self.bookmarks = config:readSetting("bookmarks_rolling", {})
+            config:saveSetting("bookmarks", self.bookmarks)
+            config:delSetting("bookmarks_rolling")
+        elseif self.ui.paging and type(self.bookmarks[1].page) == "string" then
+            config:saveSetting("bookmarks_rolling", self.bookmarks)
+            self.bookmarks = config:readSetting("bookmarks_paging", {})
+            config:saveSetting("bookmarks", self.bookmarks)
+            config:delSetting("bookmarks_paging")
         end
     end
     -- need to do this after initialization because checking xpointer

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -268,16 +268,12 @@ function ReaderBookmark:onReadSettings(config)
     -- Bookmark formats in crengine and mupdf are incompatible.
     -- Backup bookmarks when the document is opened with incompatible engine.
     if #self.bookmarks > 0 then
-        if self.ui.rolling and type(self.bookmarks[1].page) == "number" then
-            config:saveSetting("bookmarks_paging", self.bookmarks)
-            self.bookmarks = config:readSetting("bookmarks_rolling", {})
-            config:saveSetting("bookmarks", self.bookmarks)
-            config:delSetting("bookmarks_rolling")
-        elseif self.ui.paging and type(self.bookmarks[1].page) == "string" then
-            config:saveSetting("bookmarks_rolling", self.bookmarks)
-            self.bookmarks = config:readSetting("bookmarks_paging", {})
-            config:saveSetting("bookmarks", self.bookmarks)
-            config:delSetting("bookmarks_paging")
+        local bm_type = type(self.bookmarks[1].page)
+        if (self.ui.rolling and bm_type == "number") or (self.ui.paging and bm_type == "string") then
+            local bookmarks_tmp = config:readSetting("bookmarks_backup", {})
+            config:saveSetting("bookmarks", bookmarks_tmp)
+            config:saveSetting("bookmarks_backup", self.bookmarks)
+            self.bookmarks = config:readSetting("bookmarks")
         end
     end
     -- need to do this after initialization because checking xpointer

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -792,12 +792,16 @@ function ReaderView:onReadSettings(config)
     -- Highlight formats in crengine and mupdf are incompatible.
     -- Backup highlights when the document is opened with incompatible engine.
     if #self.highlight.saved > 0 then
-        local hl_type = type(self.highlight.saved[1][1].pos0)
-        if (self.ui.rolling and hl_type == "table") or (self.ui.paging and hl_type == "string") then
-            local highlight_tmp = config:readSetting("highlight_backup", {})
-            config:saveSetting("highlight", highlight_tmp)
-            config:saveSetting("highlight_backup", self.highlight.saved)
-            self.highlight.saved = config:readSetting("highlight")
+        if self.ui.rolling and type(self.highlight.saved[1][1].pos0) == "table" then
+            config:saveSetting("highlight_paging", self.highlight.saved)
+            self.highlight.saved = config:readSetting("highlight_rolling", {})
+            config:saveSetting("highlight", self.highlight.saved)
+            config:delSetting("highlight_rolling")
+        elseif self.ui.paging and type(self.highlight.saved[1][1].pos0) == "string" then
+            config:saveSetting("highlight_rolling", self.highlight.saved)
+            self.highlight.saved = config:readSetting("highlight_paging", {})
+            config:saveSetting("highlight", self.highlight.saved)
+            config:delSetting("highlight_paging")
         end
     end
     self.page_overlap_enable = config:isTrue("show_overlap_enable") or G_reader_settings:isTrue("page_overlap_enable") or DSHOWOVERLAP

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -792,16 +792,12 @@ function ReaderView:onReadSettings(config)
     -- Highlight formats in crengine and mupdf are incompatible.
     -- Backup highlights when the document is opened with incompatible engine.
     if #self.highlight.saved > 0 then
-        if self.ui.rolling and type(self.highlight.saved[1][1].pos0) == "table" then
-            config:saveSetting("highlight_paging", self.highlight.saved)
-            self.highlight.saved = config:readSetting("highlight_rolling", {})
-            config:saveSetting("highlight", self.highlight.saved)
-            config:delSetting("highlight_rolling")
-        elseif self.ui.paging and type(self.highlight.saved[1][1].pos0) == "string" then
-            config:saveSetting("highlight_rolling", self.highlight.saved)
-            self.highlight.saved = config:readSetting("highlight_paging", {})
-            config:saveSetting("highlight", self.highlight.saved)
-            config:delSetting("highlight_paging")
+        local hl_type = type(self.highlight.saved[1][1].pos0)
+        if (self.ui.rolling and hl_type == "table") or (self.ui.paging and hl_type == "string") then
+            local highlight_tmp = config:readSetting("highlight_backup", {})
+            config:saveSetting("highlight", highlight_tmp)
+            config:saveSetting("highlight_backup", self.highlight.saved)
+            self.highlight.saved = config:readSetting("highlight")
         end
     end
     self.page_overlap_enable = config:isTrue("show_overlap_enable") or G_reader_settings:isTrue("page_overlap_enable") or DSHOWOVERLAP

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -549,30 +549,9 @@ function ReaderUI:showReader(file, provider)
 
     -- We can now signal the existing ReaderUI/FileManager instances that it's time to go bye-bye...
     UIManager:broadcastEvent(Event:new("ShowingReader"))
-
-    -- prevent crash due to incompatible bookmarks
-    --- @todo Split bookmarks from metadata and do per-engine in conversion.
     provider = provider or DocumentRegistry:getProvider(file)
     if provider.provider then
-        local doc_settings = DocSettings:open(file)
-        local bookmarks = doc_settings:readSetting("bookmarks") or {}
-        if #bookmarks >= 1 and
-           ((provider.provider == "crengine" and type(bookmarks[1].page) == "number") or
-            (provider.provider == "mupdf" and type(bookmarks[1].page) == "string")) then
-                UIManager:show(ConfirmBox:new{
-                    text = T(_("The document '%1' with bookmarks or highlights was previously opened with a different engine. To prevent issues, bookmarks need to be deleted before continuing."),
-                        BD.filepath(file)),
-                    ok_text = _("Delete"),
-                    ok_callback = function()
-                        doc_settings:delSetting("bookmarks")
-                        doc_settings:close()
-                        self:showReaderCoroutine(file, provider)
-                    end,
-                    cancel_callback = function() self:showFileManager() end,
-                })
-        else
-            self:showReaderCoroutine(file, provider)
-        end
+        self:showReaderCoroutine(file, provider)
     end
 end
 


### PR DESCRIPTION
Bookmark/highlight formats in crengine and mupdf are incompatible.
This backups bookmarks and highlights when opening the document with an incompatible engine.
Fix crash when opening a document with highlights with different engine.
Closes https://github.com/koreader/koreader/issues/8451.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8455)
<!-- Reviewable:end -->
