### PR TITLE
[bug] Don't translate empty strings

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -72,7 +72,7 @@ local symbol_prefix = {
         -- @translators This is the footer letter prefix for Wi-Fi status.
         wifi_status = C_("FooterLetterPrefix", "W:"),
         -- no prefix for custom text
-        custom_text = C_("FooterLetterPrefix", ""),
+        custom_text = "",
     },
     icons = {
         time = "⌚",


### PR DESCRIPTION
Introduced in https://github.com/koreader/koreader/pull/8419

Unfortunately it's not just useless, but it causes some edge case issue.

![Screenshot_2021-11-21_20-59-34](https://user-images.githubusercontent.com/202757/142777004-514a47e3-d672-4468-831e-68a31cd1b89b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8464)
<!-- Reviewable:end -->
