### PR TITLE
toggle wifi when connected even if offline

### DIFF
--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -12,7 +12,7 @@ local T = require("ffi/util").template
 local NetworkListener = InputContainer:new{}
 
 function NetworkListener:onToggleWifi()
-    if not NetworkMgr:isOnline() then
+    if not NetworkMgr:isConnected() then
         UIManager:show(InfoMessage:new{
             text = _("Turning on Wi-Fi…"),
             timeout = 1,


### PR DESCRIPTION
I have a kindle & have restricted it via iptables to the local network so it will never be online. (There is no easy way to just allow traffic from koreader) 

This PR allows the wifi toggle (gesture) to turn off wifi when only connected to the local network as opposed to just re-turning on the wifi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8468)
<!-- Reviewable:end -->
