### PR TITLE
Customize page turns tap zones

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -792,7 +792,7 @@ function ReaderView:onReadSettings(config)
     self.highlight.saved = config:readSetting("highlight", {})
     -- Highlight formats in crengine and mupdf are incompatible.
     -- Backup highlights when the document is opened with incompatible engine.
-    local _, page_highlights = next(self.highlight.saved)
+    local _, page_highlights = next(self.highlight.saved) -- get the first page with highlights
     if page_highlights then
         local highlight_type = type(page_highlights[1].pos0)
         if self.ui.rolling and highlight_type == "table" then
@@ -1038,7 +1038,7 @@ function ReaderView:getTapZones()
             ratio_w = DTAP_ZONE_BACKWARD.w, ratio_h = DTAP_ZONE_BACKWARD.h,
         }
     else -- user defined page turns tap zones
-        local tap_zone_forward_w = G_reader_settings:readSetting("page_turns_tap_zone_forward_size", DTAP_ZONE_FORWARD.w)
+        local tap_zone_forward_w = G_reader_settings:readSetting("page_turns_tap_zone_forward_size_ratio", DTAP_ZONE_FORWARD.w)
         local tap_zone_backward_w = 1 - tap_zone_forward_w
         if tap_zones_type == "left_right" then
             forward_zone = {

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -40,7 +40,7 @@ table.insert(page_turns_tap_zones_sub_items, {
         local size = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_forward_size_ratio", DTAP_ZONE_FORWARD.w) * 100)
         UIManager:show(require("ui/widget/spinwidget"):new{
             title_text = is_left_right and _("Forward tap zone width") or _("Forward tap zone height"),
-            info_text = is_left_right and _("In percentage of screen width") or _("In percentage of screen height"),
+            info_text = is_left_right and _("Percentage of screen width") or _("Percentage of screen height"),
             value = size,
             value_min = 0,
             value_max = 100,

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -1,7 +1,17 @@
 local Device = require("device")
 local Event = require("ui/event")
+local ReaderUI = require("apps/reader/readerui")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
+local T = require("ffi/util").template
+
+local ReaderView = ReaderUI.instance.view
+
+local tap_zones = {
+    default = _("Default"),
+    left_right = _("Left/right"),
+    top_bottom = _("Top/bottom"),
+}
 
 local PageTurns = {
     text = _("Page turns"),
@@ -23,6 +33,16 @@ local PageTurns = {
             callback = function()
                 G_reader_settings:flipNilOrFalse("page_turns_disable_swipe")
             end,
+        },
+        {
+            text_func = function()
+                local tap_zones_type = G_reader_settings:readSetting("page_turns_tap_zones", "default")
+                return T(_("Tap zones: %1"), tap_zones[tap_zones_type]:lower())
+            end,
+            enabled_func = function()
+                return G_reader_settings:nilOrFalse("page_turns_disable_tap")
+            end,
+            sub_item_table = {},
             separator = true,
         },
         {
@@ -34,8 +54,7 @@ local PageTurns = {
                 return text
             end,
             checked_func = function()
-                local ui = require("apps/reader/readerui"):_getRunningInstance()
-                return ui.view.inverse_reading_order
+                return ReaderView.inverse_reading_order
             end,
             callback = function()
                 UIManager:broadcastEvent(Event:new("ToggleReadingOrder"))
@@ -78,4 +97,48 @@ if Device:hasKeys() then
         end,
     })
 end
+
+local function genTapZonesMenu(tap_zones_type)
+    table.insert(PageTurns.sub_item_table[3].sub_item_table, {
+        text = tap_zones[tap_zones_type],
+        checked_func = function()
+            return G_reader_settings:readSetting("page_turns_tap_zones", "default") == tap_zones_type
+        end,
+        callback = function()
+            G_reader_settings:saveSetting("page_turns_tap_zones", tap_zones_type)
+            ReaderView:setupTouchZones()
+        end,
+    })
+end
+genTapZonesMenu("default")
+genTapZonesMenu("left_right")
+genTapZonesMenu("top_bottom")
+table.insert(PageTurns.sub_item_table[3].sub_item_table, {
+    text_func = function()
+        local size = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_forward_size", DTAP_ZONE_FORWARD.w) * 100)
+        return T(_("Forward tap zone size: %1%"), size)
+    end,
+    enabled_func = function()
+        return G_reader_settings:readSetting("page_turns_tap_zones", "default") ~= "default"
+    end,
+    keep_menu_open = true,
+    callback = function(touchmenu_instance)
+        local is_left_right = G_reader_settings:readSetting("page_turns_tap_zones") == "left_right"
+        local size = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_forward_size", DTAP_ZONE_FORWARD.w) * 100)
+        UIManager:show(require("ui/widget/spinwidget"):new{
+            title_text = is_left_right and _("Forward tap zone width") or _("Forward tap zone height"),
+            info_text = is_left_right and _("In percentage of screen width") or _("In percentage of screen height"),
+            value = size,
+            value_min = 0,
+            value_max = 100,
+            default_value = math.floor(DTAP_ZONE_FORWARD.w * 100),
+            callback = function(spin)
+                G_reader_settings:saveSetting("page_turns_tap_zone_forward_size", spin.value / 100)
+                ReaderView:setupTouchZones()
+                if touchmenu_instance then touchmenu_instance:updateItems() end
+            end,
+        })
+    end,
+})
+
 return PageTurns


### PR DESCRIPTION
Allows to choose a configuration of page turns tap zones.

`Default`: settings taken from defaults.lua/defaults.persistent.lua
`Left/Right`: full screen divided with a vertical border
`Top/Bottom`: full screen divided with a horizontal border (forward zone is at the bottom)
Customizable position of the border.

Other tap zones (menus, corners) unchanged.
`Invert page turn taps and swipes` doesn't swap `Top/bottom` zones.

![01](https://user-images.githubusercontent.com/62179190/143015064-b5d0bf6f-1b6f-43d9-aca0-0375bd7deb72.png)

![02](https://user-images.githubusercontent.com/62179190/143015077-7240975a-c225-4e20-824f-a9b63083aa94.png)

![03](https://user-images.githubusercontent.com/62179190/143015083-10079424-25b4-4264-9c67-076edbe2530d.png)

![04](https://user-images.githubusercontent.com/62179190/143015089-312ca778-728c-41c6-8d65-b8f66e289968.png)

![05](https://user-images.githubusercontent.com/62179190/143015095-ff454e44-4870-40ff-8241-6806e28fc5d6.png)

![06](https://user-images.githubusercontent.com/62179190/143015100-99ec8176-7c9b-4f27-b20c-0f9bd7d2fa4b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8475)
<!-- Reviewable:end -->
