### PR TITLE
InputDialog: extend input box with a hint

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -169,6 +169,7 @@ local InputDialog = InputContainer:new{
 
     text_width = nil,
     text_height = nil,
+    text_height_from_hint = false, -- set to true to measure input box height based on the hint string
 
     title_face = Font:getFace("x_smalltfont"),
     description_face = Font:getFace("x_smallinfofont"),
@@ -317,7 +318,8 @@ function InputDialog:init()
         -- We need to find the best height to avoid screen overflow
         -- Create a dummy input widget to get some metrics
         local input_widget = InputText:new{
-            text = self.fullscreen and "-" or self.input,
+            text = self.fullscreen and "-"
+                or (self.text_height_from_hint and self.input_hint or self.input),
             input_type = self.input_type,
             face = self.input_face,
             width = self.text_width,


### PR DESCRIPTION
Allows to set input box height based on the hint string.
For example, to have an input box of 3-lines height just set `input_hint = "\n\n\n"`.

We have something similar in MultiInputDialog:
https://github.com/koreader/koreader/blob/e9ba854ff080e50fb5760f68e878cd3a0dc92f7e/frontend/apps/cloudstorage/dropbox.lua#L75

Inspired by and can be used in https://github.com/koreader/koreader/pull/8467.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8477)
<!-- Reviewable:end -->
