### PR TITLE
Highlights backup fix

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -795,14 +795,10 @@ function ReaderView:onReadSettings(config)
     local page, page_highlights
     while true do -- remove empty tables for pages without highlights and get the first page with highlights
         page, page_highlights = next(self.highlight.saved)
-        if page then
-            if #page_highlights == 0 then
-                self.highlight.saved[page] = nil
-            else
-                break
-            end
+        if not page or #page_highlights > 0 then
+            break -- we're done (there is none, or there is some usable)
         else
-            break
+            self.highlight.saved[page] = nil -- clean it up while we're at it, and find another one
         end
     end
     if page_highlights then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -792,7 +792,19 @@ function ReaderView:onReadSettings(config)
     self.highlight.saved = config:readSetting("highlight", {})
     -- Highlight formats in crengine and mupdf are incompatible.
     -- Backup highlights when the document is opened with incompatible engine.
-    local _, page_highlights = next(self.highlight.saved) -- get the first page with highlights
+    local page, page_highlights
+    while true do -- remove empty tables for pages without highlights and get the first page with highlights
+        page, page_highlights = next(self.highlight.saved, page)
+        if page then
+            if #page_highlights == 0 then
+                self.highlight.saved[page] = nil
+            else
+                break
+            end
+        else
+            break
+        end
+    end
     if page_highlights then
         local highlight_type = type(page_highlights[1].pos0)
         if self.ui.rolling and highlight_type == "table" then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -794,7 +794,7 @@ function ReaderView:onReadSettings(config)
     -- Backup highlights when the document is opened with incompatible engine.
     local page, page_highlights
     while true do -- remove empty tables for pages without highlights and get the first page with highlights
-        page, page_highlights = next(self.highlight.saved, page)
+        page, page_highlights = next(self.highlight.saved)
         if page then
             if #page_highlights == 0 then
                 self.highlight.saved[page] = nil


### PR DESCRIPTION
Fix for the backup of highlights/bookmarks (introduced in https://github.com/koreader/koreader/pull/8455).
Fixes opening book with old highlights, when (after deleting the last highlight on a page) empty table of highlights for this page was not deleted.
Thanks https://github.com/koreader/koreader/pull/8473#issuecomment-977818299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8479)
<!-- Reviewable:end -->
