### PR TITLE
Make the DHCP request include the device hostname on Cervantes.

### DIFF
--- a/platform/cervantes/obtain-ip.sh
+++ b/platform/cervantes/obtain-ip.sh
@@ -2,5 +2,7 @@
 
 ./release-ip.sh
 
+hostname=$(hostname -s)
+
 # Use udhcpc to obtain IP.
-udhcpc -S -i eth0 -s /etc/udhcpc/default.script -t15 -T10 -A3 -b -q
+udhcpc -S -i eth0 -s /etc/udhcpc/default.script -t15 -T10 -A3 -b -q -F "${hostname}"


### PR DESCRIPTION
This changes Cervantes' obtain-ip.sh so that it sends the hostname with the DHCP request.

This is useful because in some networks the DHCP server creates DNS records with the provided hostname, so you can use "ssh $HOSTNAME" instead of "ssh $IP_ADDRESS".

I don't know what hostname -s returns on an unmodified Cervantes, as I have long ago changed the hostname on mine. If anyone has a device with the original hostname and can run hostname -s on it so we can know if it's something reasonable it would be nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8481)
<!-- Reviewable:end -->
