### PR TITLE
SpinWidget buttons move

### DIFF
--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -35,6 +35,8 @@ local SpinWidget = InputContainer:new{
     value_min = 0,
     value_step = 1,
     value_hold_step = 4,
+    precision = nil,
+    wrap = false,
     cancel_text = _("Close"),
     ok_text = _("Apply"),
     cancel_callback = nil,
@@ -92,7 +94,7 @@ function SpinWidget:update()
         value_step = self.value_step,
         value_hold_step = self.value_hold_step,
         precision = self.precision,
-        wrap = self.wrap or false,
+        wrap = self.wrap,
     }
     local value_group = HorizontalGroup:new{
         align = "center",
@@ -120,7 +122,8 @@ function SpinWidget:update()
     if self.default_value then
         table.insert(buttons, {
             {
-                text = self.default_text or T(_("Default value: %1"), self.default_value),
+                text = self.default_text or T(_("Default value: %1"),
+                    self.precision and string.format(self.precision, self.default_value) or self.default_value),
                 callback = function()
                     value_widget.value = self.default_value
                     value_widget:update()

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -19,6 +19,7 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 local Screen = Device.screen
+local T = require("ffi/util").template
 
 local SpinWidget = InputContainer:new{
     title_text = "",
@@ -42,7 +43,7 @@ local SpinWidget = InputContainer:new{
     keep_shown_on_apply = false,
     -- Set this to add default button that restores number to its default value
     default_value = nil,
-    default_text = _("Use default"),
+    default_text = nil,
     -- Optional extra button on bottom
     extra_text = nil,
     extra_callback = nil,
@@ -114,36 +115,12 @@ function SpinWidget:update()
             h = Size.line.thick,
         }
     }
-    local buttons = {
-        {
-            {
-                text = self.cancel_text,
-                callback = function()
-                    if self.cancel_callback then
-                        self.cancel_callback()
-                    end
-                    self:onClose()
-                end,
-            },
-            {
-                text = self.ok_text,
-                callback = function()
-                    if self.callback then
-                        self.value, self.value_index = value_widget:getValue()
-                        self.callback(self)
-                    end
-                    if not self.keep_shown_on_apply then
-                        self:onClose()
-                    end
-                end,
-            },
-        }
-    }
 
+    local buttons = {}
     if self.default_value then
-        table.insert(buttons,{
+        table.insert(buttons, {
             {
-                text = self.default_text,
+                text = self.default_text or T(_("Default value: %1"), self.default_value),
                 callback = function()
                     value_widget.value = self.default_value
                     value_widget:update()
@@ -152,7 +129,7 @@ function SpinWidget:update()
         })
     end
     if self.extra_text then
-        table.insert(buttons,{
+        table.insert(buttons, {
             {
                 text = self.extra_text,
                 callback = function()
@@ -167,6 +144,29 @@ function SpinWidget:update()
             },
         })
     end
+    table.insert(buttons, {
+        {
+            text = self.cancel_text,
+            callback = function()
+                if self.cancel_callback then
+                    self.cancel_callback()
+                end
+                self:onClose()
+            end,
+        },
+        {
+            text = self.ok_text,
+            callback = function()
+                if self.callback then
+                    self.value, self.value_index = value_widget:getValue()
+                    self.callback(self)
+                end
+                if not self.keep_shown_on_apply then
+                    self:onClose()
+                end
+            end,
+        },
+    })
 
     local ok_cancel_buttons = ButtonTable:new{
         width = self.width - 2*Size.padding.default,

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -31,11 +31,11 @@ local SpinWidget = InputContainer:new{
     value_table = nil,
     value_index = nil,
     value = 1,
-    value_max = 20,
     value_min = 0,
+    value_max = 20,
     value_step = 1,
     value_hold_step = 4,
-    precision = nil,
+    precision = nil, -- default "%02d" in NumberPickerWidget
     wrap = false,
     cancel_text = _("Close"),
     ok_text = _("Apply"),
@@ -43,10 +43,10 @@ local SpinWidget = InputContainer:new{
     callback = nil,
     close_callback = nil,
     keep_shown_on_apply = false,
-    -- Set this to add default button that restores number to its default value
+    -- Set this to add upper default button that restores number to its default value
     default_value = nil,
     default_text = nil,
-    -- Optional extra button on bottom
+    -- Optional extra button above ok/cancel buttons row
     extra_text = nil,
     extra_callback = nil,
 }

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -12,7 +12,6 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("luasettings")
 local Screen = require("device").screen
-local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local util = require("util")
 local T = FFIUtil.template
@@ -442,15 +441,18 @@ function Gestures:addIntervals(menu_items)
                 text = _("Text selection rate"),
                 keep_menu_open = true,
                 callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local current_value = G_reader_settings:readSetting("hold_pan_rate")
                     if not current_value then
                         current_value = Screen.low_pan_rate and 5.0 or 30.0
                     end
                     local items = SpinWidget:new{
                         title_text = _("Text selection rate"),
-                        info_text = _([[
+                        info_text = T(_([[
 The rate is how often screen will be refreshed per second while selecting text.
-Higher values mean faster screen updates, but also use more CPU.]]),
+Higher values mean faster screen updates, but also use more CPU.
+
+Default value: %1]]), Screen.low_pan_rate and 5.0 or 30.0),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = current_value,
                         value_min = 1.0,
@@ -472,13 +474,15 @@ Higher values mean faster screen updates, but also use more CPU.]]),
                 text = _("Tap interval"),
                 keep_menu_open = true,
                 callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Tap interval"),
-                        info_text = _([[
+                        info_text = T(_([[
 Any other taps made within this interval after a first tap will be considered accidental and ignored.
 
-The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).]]),
+The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).
+Default value: %1]]), GestureDetector.TAP_INTERVAL/1000),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_tap_interval")/1000,
                         value_min = 0,
@@ -499,12 +503,14 @@ The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (
                 text = _("Tap interval on keyboard"),
                 keep_menu_open = true,
                 callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local items = SpinWidget:new{
                         title_text = _("Tap interval on keyboard"),
                         info_text = _([[
 Any other taps made within this interval after a first tap will be considered accidental and ignored.
 
-The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).]]),
+The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).
+Default value: 0]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = (G_reader_settings:readSetting("ges_tap_interval_on_keyboard") or 0)/1000,
                         value_min = 0,
@@ -524,13 +530,15 @@ The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (
                 text = _("Double tap interval"),
                 keep_menu_open = true,
                 callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Double tap interval"),
-                        info_text = _([[
+                        info_text = T(_([[
 When double tap is enabled, this sets the time to wait for the second tap. A single tap will take at least this long to be detected.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
+Default value: %1]]), GestureDetector.DOUBLE_TAP_INTERVAL/1000),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_double_tap_interval")/1000,
                         value_min = 100,
@@ -551,13 +559,15 @@ The interval value is in milliseconds and can range from 100 (0.1 seconds) to 20
                 text = _("Two finger tap duration"),
                 keep_menu_open = true,
                 callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Two finger tap duration"),
-                        info_text = _([[
+                        info_text = T(_([[
 This sets the allowed duration of any of the two fingers touch/release for the combined event to be considered a two finger tap.
 
-The duration value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
+The duration value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
+Default value: %1]]), GestureDetector.TWO_FINGER_TAP_DURATION/1000),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_two_finger_tap_duration")/1000,
                         value_min = 100,
@@ -578,13 +588,15 @@ The duration value is in milliseconds and can range from 100 (0.1 seconds) to 20
                 text = _("Long-press interval"),
                 keep_menu_open = true,
                 callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Long-press interval"),
-                        info_text = _([[
+                        info_text = T(_([[
 If a touch is not released in this interval, it is considered a long-press. On document text, single word selection will then be triggered.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
+Default value: %1]]), GestureDetector.HOLD_INTERVAL/1000),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_hold_interval")/1000,
                         value_min = 100,
@@ -605,13 +617,15 @@ The interval value is in milliseconds and can range from 100 (0.1 seconds) to 20
                 text = _("Swipe interval"),
                 keep_menu_open = true,
                 callback = function()
+                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Swipe interval"),
-                        info_text = _([[
+                        info_text = T(_([[
 This sets the maximum delay between the start and the end of a swipe for it to be considered a swipe. Above this interval, it's considered panning.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
+Default value: %1]]), GestureDetector.SWIPE_INTERVAL/1000),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_swipe_interval")/1000,
                         value_min = 100,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -12,6 +12,7 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("luasettings")
 local Screen = require("device").screen
+local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local util = require("util")
 local T = FFIUtil.template
@@ -441,18 +442,15 @@ function Gestures:addIntervals(menu_items)
                 text = _("Text selection rate"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local current_value = G_reader_settings:readSetting("hold_pan_rate")
                     if not current_value then
                         current_value = Screen.low_pan_rate and 5.0 or 30.0
                     end
                     local items = SpinWidget:new{
                         title_text = _("Text selection rate"),
-                        info_text = T(_([[
+                        info_text = _([[
 The rate is how often screen will be refreshed per second while selecting text.
-Higher values mean faster screen updates, but also use more CPU.
-
-Default value: %1]]), Screen.low_pan_rate and 5.0 or 30.0),
+Higher values mean faster screen updates, but also use more CPU.]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = current_value,
                         value_min = 1.0,
@@ -474,15 +472,13 @@ Default value: %1]]), Screen.low_pan_rate and 5.0 or 30.0),
                 text = _("Tap interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Tap interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 Any other taps made within this interval after a first tap will be considered accidental and ignored.
 
-The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.TAP_INTERVAL/1000),
+The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_tap_interval")/1000,
                         value_min = 0,
@@ -503,14 +499,12 @@ Default value: %1]]), GestureDetector.TAP_INTERVAL/1000),
                 text = _("Tap interval on keyboard"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local items = SpinWidget:new{
                         title_text = _("Tap interval on keyboard"),
                         info_text = _([[
 Any other taps made within this interval after a first tap will be considered accidental and ignored.
 
-The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).
-Default value: 0]]),
+The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = (G_reader_settings:readSetting("ges_tap_interval_on_keyboard") or 0)/1000,
                         value_min = 0,
@@ -530,15 +524,13 @@ Default value: 0]]),
                 text = _("Double tap interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Double tap interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 When double tap is enabled, this sets the time to wait for the second tap. A single tap will take at least this long to be detected.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.DOUBLE_TAP_INTERVAL/1000),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_double_tap_interval")/1000,
                         value_min = 100,
@@ -559,15 +551,13 @@ Default value: %1]]), GestureDetector.DOUBLE_TAP_INTERVAL/1000),
                 text = _("Two finger tap duration"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Two finger tap duration"),
-                        info_text = T(_([[
+                        info_text = _([[
 This sets the allowed duration of any of the two fingers touch/release for the combined event to be considered a two finger tap.
 
-The duration value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.TWO_FINGER_TAP_DURATION/1000),
+The duration value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_two_finger_tap_duration")/1000,
                         value_min = 100,
@@ -588,15 +578,13 @@ Default value: %1]]), GestureDetector.TWO_FINGER_TAP_DURATION/1000),
                 text = _("Long-press interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Long-press interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 If a touch is not released in this interval, it is considered a long-press. On document text, single word selection will then be triggered.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.HOLD_INTERVAL/1000),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_hold_interval")/1000,
                         value_min = 100,
@@ -617,15 +605,13 @@ Default value: %1]]), GestureDetector.HOLD_INTERVAL/1000),
                 text = _("Swipe interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Swipe interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 This sets the maximum delay between the start and the end of a swipe for it to be considered a swipe. Above this interval, it's considered panning.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.SWIPE_INTERVAL/1000),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_swipe_interval")/1000,
                         value_min = 100,


### PR DESCRIPTION
`Default value` moved up, showing the default value.

![1](https://user-images.githubusercontent.com/62179190/143587239-993f92b5-d31a-4eec-9eff-0d36a83615b6.png)

`Extra` button moved up.

![2](https://user-images.githubusercontent.com/62179190/143587273-c3daca29-d43d-4835-b80a-8bbe24e35b33.png)

![3](https://user-images.githubusercontent.com/62179190/143587279-8748c108-a9c4-417a-8fa5-2ba472467e9c.png)

`Default` is upper.

![4](https://user-images.githubusercontent.com/62179190/143587320-d80530ca-db7a-4ac0-994b-302c5ef7b183.png)

This is a mockup of configdialog just to discuss is it worth to show the default value there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8485)
<!-- Reviewable:end -->
