### PR TITLE
bump crengine and button-listen.c for reMarkable

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -159,13 +159,26 @@ h1 + h6, h2 + h6, h3 + h6, h4 + h6, h5 + h6 { page-break-before: avoid !importan
                 id = "text_align_most_justify",
                 title = _("Justify most text"),
                 description = _("Text justification is the default, but it may be overridden by publisher styles. This will re-enable it for most common text elements."),
-                css = [[body, p, li { text-align: justify !important; }]],
+                css = [[
+body, p, li { text-align: justify !important; }
+pre {
+    -cr-only-if: txt-document;
+        text-align: justify !important;
+        white-space: normal;
+}
+                ]],
             },
             {
                 id = "text_align_all_justify",
                 title = _("Justify all elements"),
                 description = _("Text justification is the default, but it may be overridden by publisher styles. This will force justification on all elements, some of which may not be centered as expected."),
-                css = [[* { text-align: justify !important; }]],
+                css = [[
+* { text-align: justify !important; }
+pre {
+    -cr-only-if: txt-document;
+        white-space: normal;
+}
+                ]],
                 separator = true,
             },
             {


### PR DESCRIPTION
Includes:
- bump crengine: adds CSS "-cr-only-if: txt-document" https://github.com/koreader/koreader-base/pull/1435
- Update button-listen for reMarkable firmware update https://github.com/koreader/koreader-base/pull/1428 . Closes #8242.

Style tweaks: have "Justify most/all text" work on txt documents. Closes #8456. Closes #8216.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8487)
<!-- Reviewable:end -->
