### PR TITLE
Gesture intervals spinwidgets - do not show default value in info-text

### DIFF
--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -448,11 +448,9 @@ function Gestures:addIntervals(menu_items)
                     end
                     local items = SpinWidget:new{
                         title_text = _("Text selection rate"),
-                        info_text = T(_([[
+                        info_text = _([[
 The rate is how often screen will be refreshed per second while selecting text.
-Higher values mean faster screen updates, but also use more CPU.
-
-Default value: %1]]), Screen.low_pan_rate and 5.0 or 30.0),
+Higher values mean faster screen updates, but also use more CPU.]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = current_value,
                         value_min = 1.0,
@@ -478,11 +476,10 @@ Default value: %1]]), Screen.low_pan_rate and 5.0 or 30.0),
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Tap interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 Any other taps made within this interval after a first tap will be considered accidental and ignored.
 
-The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.TAP_INTERVAL/1000),
+The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_tap_interval")/1000,
                         value_min = 0,
@@ -509,8 +506,7 @@ Default value: %1]]), GestureDetector.TAP_INTERVAL/1000),
                         info_text = _([[
 Any other taps made within this interval after a first tap will be considered accidental and ignored.
 
-The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).
-Default value: 0]]),
+The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = (G_reader_settings:readSetting("ges_tap_interval_on_keyboard") or 0)/1000,
                         value_min = 0,
@@ -534,11 +530,10 @@ Default value: 0]]),
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Double tap interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 When double tap is enabled, this sets the time to wait for the second tap. A single tap will take at least this long to be detected.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.DOUBLE_TAP_INTERVAL/1000),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_double_tap_interval")/1000,
                         value_min = 100,
@@ -563,11 +558,10 @@ Default value: %1]]), GestureDetector.DOUBLE_TAP_INTERVAL/1000),
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Two finger tap duration"),
-                        info_text = T(_([[
+                        info_text = _([[
 This sets the allowed duration of any of the two fingers touch/release for the combined event to be considered a two finger tap.
 
-The duration value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.TWO_FINGER_TAP_DURATION/1000),
+The duration value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_two_finger_tap_duration")/1000,
                         value_min = 100,
@@ -592,11 +586,10 @@ Default value: %1]]), GestureDetector.TWO_FINGER_TAP_DURATION/1000),
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Long-press interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 If a touch is not released in this interval, it is considered a long-press. On document text, single word selection will then be triggered.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.HOLD_INTERVAL/1000),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_hold_interval")/1000,
                         value_min = 100,
@@ -621,11 +614,10 @@ Default value: %1]]), GestureDetector.HOLD_INTERVAL/1000),
                     local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Swipe interval"),
-                        info_text = T(_([[
+                        info_text = _([[
 This sets the maximum delay between the start and the end of a swipe for it to be considered a swipe. Above this interval, it's considered panning.
 
-The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).
-Default value: %1]]), GestureDetector.SWIPE_INTERVAL/1000),
+The interval value is in milliseconds and can range from 100 (0.1 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = GestureDetector:getInterval("ges_swipe_interval")/1000,
                         value_min = 100,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -6,12 +6,14 @@ local Dispatcher = require("dispatcher")
 local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
 local Geom = require("ui/geometry")
+local GestureDetector = require("device/gesturedetector")
 local GestureRange = require("ui/gesturerange")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("luasettings")
 local Screen = require("device").screen
+local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local util = require("util")
 local T = FFIUtil.template
@@ -441,11 +443,8 @@ function Gestures:addIntervals(menu_items)
                 text = _("Text selection rate"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local current_value = G_reader_settings:readSetting("hold_pan_rate")
-                    if not current_value then
-                        current_value = Screen.low_pan_rate and 5.0 or 30.0
-                    end
+                    local default_value = Screen.low_pan_rate and 5.0 or 30.0
+                    local current_value = G_reader_settings:readSetting("hold_pan_rate", default_value)
                     local items = SpinWidget:new{
                         title_text = _("Text selection rate"),
                         info_text = _([[
@@ -458,7 +457,7 @@ Higher values mean faster screen updates, but also use more CPU.]]),
                         value_step = 1,
                         value_hold_step = 15,
                         ok_text = _("Set rate"),
-                        default_value = Screen.low_pan_rate and 5.0 or 30.0,
+                        default_value = default_value,
                         callback = function(spin)
                             G_reader_settings:saveSetting("hold_pan_rate", spin.value)
                             UIManager:broadcastEvent(Event:new("UpdateHoldPanRate"))
@@ -472,8 +471,6 @@ Higher values mean faster screen updates, but also use more CPU.]]),
                 text = _("Tap interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Tap interval"),
                         info_text = _([[
@@ -500,7 +497,6 @@ The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (
                 text = _("Tap interval on keyboard"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
                     local items = SpinWidget:new{
                         title_text = _("Tap interval on keyboard"),
                         info_text = _([[
@@ -508,7 +504,7 @@ Any other taps made within this interval after a first tap will be considered ac
 
 The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (2 seconds).]]),
                         width = math.floor(Screen:getWidth() * 0.75),
-                        value = (G_reader_settings:readSetting("ges_tap_interval_on_keyboard") or 0)/1000,
+                        value = G_reader_settings:readSetting("ges_tap_interval_on_keyboard", 0)/1000,
                         value_min = 0,
                         value_max = 2000,
                         value_step = 50,
@@ -526,8 +522,6 @@ The interval value is in milliseconds and can range from 0 (0 seconds) to 2000 (
                 text = _("Double tap interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Double tap interval"),
                         info_text = _([[
@@ -554,8 +548,6 @@ The interval value is in milliseconds and can range from 100 (0.1 seconds) to 20
                 text = _("Two finger tap duration"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Two finger tap duration"),
                         info_text = _([[
@@ -582,8 +574,6 @@ The duration value is in milliseconds and can range from 100 (0.1 seconds) to 20
                 text = _("Long-press interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Long-press interval"),
                         info_text = _([[
@@ -610,8 +600,6 @@ The interval value is in milliseconds and can range from 100 (0.1 seconds) to 20
                 text = _("Swipe interval"),
                 keep_menu_open = true,
                 callback = function()
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local GestureDetector = require("device/gesturedetector")
                     local items = SpinWidget:new{
                         title_text = _("Swipe interval"),
                         info_text = _([[


### PR DESCRIPTION
Default value is shown in the SpinWidget default button, no need to show it in the info-text.

![1](https://user-images.githubusercontent.com/62179190/143732595-c5b85e1e-bafb-48ac-984d-95c38f980ad3.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8488)
<!-- Reviewable:end -->
