### PR TITLE
Bookmarks search

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -176,7 +176,7 @@ function ReaderBookmark:addToMainMenu(menu_items)
             },
         },
     }
-    menu_items.bookmarks_search = {
+    menu_items.bookmark_search = {
         text = _("Bookmark search"),
         enabled_func = function()
             return self:hasBookmarks()

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -872,7 +872,6 @@ function ReaderBookmark:onSearchBookmark(bm_menu)
     local check_button_case, separator, check_button_bookmark, check_button_highlight, check_button_note
     input_dialog = InputDialog:new{
         title = _("Search bookmarks"),
-        input_hint = _("(containing text)"),
         buttons = {
             {
                 {

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -118,7 +118,7 @@ local settingsList = {
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), reader=true},
-    bookmarks_search = {category="none", event="SearchBookmark", title=_("Bookmark search"), reader=true},
+    bookmark_search = {category="none", event="SearchBookmark", title=_("Bookmark search"), reader=true},
     book_status = {category="none", event="ShowBookStatus", title=_("Book status"), reader=true},
     book_info = {category="none", event="ShowBookInfo", title=_("Book information"), reader=true},
     book_description = {category="none", event="ShowBookDescription", title=_("Book description"), reader=true},
@@ -279,7 +279,7 @@ local dispatcher_menu_order = {
 
     "toc",
     "bookmarks",
-    "bookmarks_search",
+    "bookmark_search",
 
     "book_status",
     "book_info",

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -118,7 +118,7 @@ local settingsList = {
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), reader=true},
-    bookmarks_search = {category="none", event="SearchBookmark", title=_("Bookmarks search"), reader=true},
+    bookmarks_search = {category="none", event="SearchBookmark", title=_("Bookmark search"), reader=true},
     book_status = {category="none", event="ShowBookStatus", title=_("Book status"), reader=true},
     book_info = {category="none", event="ShowBookInfo", title=_("Book information"), reader=true},
     book_description = {category="none", event="ShowBookDescription", title=_("Book description"), reader=true},

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -118,6 +118,7 @@ local settingsList = {
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), reader=true},
+    bookmarks_search = {category="none", event="SearchBookmark", title=_("Bookmarks search"), reader=true},
     book_status = {category="none", event="ShowBookStatus", title=_("Book status"), reader=true},
     book_info = {category="none", event="ShowBookInfo", title=_("Book information"), reader=true},
     book_description = {category="none", event="ShowBookDescription", title=_("Book description"), reader=true},
@@ -278,6 +279,7 @@ local dispatcher_menu_order = {
 
     "toc",
     "bookmarks",
+    "bookmarks_search",
 
     "book_status",
     "book_info",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -187,6 +187,7 @@ local order = {
         "----------------------------",
         "find_book_in_calibre_catalog",
         "fulltext_search",
+        "bookmarks_search",
     },
     filemanager = {},
     main = {

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -187,7 +187,7 @@ local order = {
         "----------------------------",
         "find_book_in_calibre_catalog",
         "fulltext_search",
-        "bookmarks_search",
+        "bookmark_search",
     },
     filemanager = {},
     main = {

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -116,7 +116,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
     right_widget.picker_updated_callback = function(value)
         self:update(left_widget:getValue(), value)
     end
-    
+
     local text_max_width = math.floor(0.95 * self.width / 2)
     local left_vertical_group = VerticalGroup:new{
         align = "center",


### PR DESCRIPTION
Filtering bookmarks seems to work rather well (https://github.com/koreader/koreader/issues/8496), so it's time to rename it to Bookmarks search.
Also:
-accessible from the main menu and with a gesture
-case sensitive search

Closes https://github.com/koreader/koreader/issues/8496.

![01](https://user-images.githubusercontent.com/62179190/144476582-024aaf85-57d1-474d-b466-f8ab7f5f9424.png)

![02](https://user-images.githubusercontent.com/62179190/144476592-696ada38-4520-4254-87a2-e37bd801f9c1.png)

![03](https://user-images.githubusercontent.com/62179190/144476602-b706224c-f5ae-448f-bfb3-7523c1a16738.png)

![04](https://user-images.githubusercontent.com/62179190/144476617-71b6bfbd-2d4e-4f39-ac62-a584be0bded2.png)

![05](https://user-images.githubusercontent.com/62179190/144476633-37469051-3f56-4721-8667-e3586a2ad91a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8504)
<!-- Reviewable:end -->
