### PR TITLE
Add 'Set notebook GUID' dialogue for exporter.koplugin

### DIFF
--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -196,6 +196,44 @@ function Exporter:addToMainMenu(menu_items)
                         end
                     },
                     {
+                        text = _("Set notebook GUID"),
+                        keep_menu_open = true,
+                        callback = function()
+                            local MultiInputDialog = require("ui/widget/multiinputdialog")
+                            local auth_dialog
+                            auth_dialog = MultiInputDialog:new{
+                                title = _("Set GUID for Joplin notebook"),
+                                fields = {
+                                    {
+                                        text = self.joplin_notebook_guid,
+                                        input_type = "string"
+                                    }
+                                },
+                                buttons = {
+                                    {
+                                        {
+                                            text = _("Cancel"),
+                                            callback = function()
+                                                UIManager:close(auth_dialog)
+                                            end
+                                        },
+                                        {
+                                            text = _("Set token"),
+                                            callback = function()
+                                                local auth_field = auth_dialog:getFields()
+                                                self.joplin_notebook_guid = auth_field[1]
+                                                self:saveSettings()
+                                                UIManager:close(auth_dialog)
+                                            end
+                                        }
+                                    }
+                                }
+                            }
+                            UIManager:show(auth_dialog)
+                            auth_dialog:onShowKeyboard()
+                        end
+                    },
+                    {
                         text = _("Export to Joplin"),
                         checked_func = function() return self.joplin_export end,
                         callback = function()

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -259,6 +259,10 @@ For Windows: netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenpo
 
 For Linux: $socat tcp-listen:41185,reuseaddr,fork tcp:localhost:41184
 
+Do make sure you have add correct firewall rules for those ports.
+
+Leave the notebook GUID field blank while connecting a new Joplin server, the plugin will create a new notebook named "KOReader Notes" and save its GUID. Or fill in the correct GUID if you try to export to an existing notebook. You can get the GUID by copying its external link.
+
 For more information, please visit https://github.com/koreader/koreader/wiki/Evernote-export.]])
                             , BD.dirpath(DataStorage:getDataDir()))
                             })


### PR DESCRIPTION
The dialogue is added below "Set authorization token". The user could change it to a desired notebook GUID while connecting to different Joplin servers or leave it blank to let the plugin to crate a new notebook by itself. User should be aware of the "hidden" notebook GUID setting while troubleshooting. The error handling part is kept as it is, which still leads to some crashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8505)
<!-- Reviewable:end -->
