### PR TITLE
[fix] Use XDG_CONFIG_HOME on Linux

### DIFF
--- a/datastorage.lua
+++ b/datastorage.lua
@@ -18,8 +18,12 @@ function DataStorage:getDataDir()
         -- confined ubuntu app has write access to this dir
         data_dir = string.format("%s/%s", os.getenv("XDG_DATA_HOME"), package_name)
     elseif os.getenv("APPIMAGE") or os.getenv("KO_MULTIUSER") then
-        local user_rw = jit.os == "OSX" and "Library/Application Support" or ".config"
-        data_dir = string.format("%s/%s/%s", os.getenv("HOME"), user_rw, "koreader")
+        if os.getenv("XDG_CONFIG_HOME") then
+            data_dir = string.format("%s/%s", os.getenv("XDG_CONFIG_HOME"), "koreader")
+        else
+            local user_rw = jit.os == "OSX" and "Library/Application Support" or ".config"
+            data_dir = string.format("%s/%s/%s", os.getenv("HOME"), user_rw, "koreader")
+        end
     else
         data_dir = "."
     end


### PR DESCRIPTION
I tried using koreader on my PC using linux, and found it crashes because there is no `$HOME/.config` in my system, instead I use `$XDG_CONFIG_HOME`. I guess this should work, can't test it since im not able to build the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8507)
<!-- Reviewable:end -->
