### PR TITLE
[fix] gettext: don't replace backslash characters

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -61,7 +61,7 @@ function GetText_mt.__call(gettext, msgid)
     return gettext.translation[msgid] or gettext.wrapUntranslated(msgid)
 end
 
-local function c_escape(what)
+local function c_escape(what_full, what)
     if what == "\n" then return ""
     elseif what == "a" then return "\a"
     elseif what == "b" then return "\b"
@@ -72,7 +72,7 @@ local function c_escape(what)
     elseif what == "v" then return "\v"
     elseif what == "0" then return "\0" -- shouldn't happen, though
     else
-        return what
+        return what_full
     end
 end
 
@@ -138,7 +138,7 @@ end
 
 local function addTranslation(msgctxt, msgid, msgstr, n)
     -- translated string
-    local unescaped_string = string.gsub(msgstr, "\\(.)", c_escape)
+    local unescaped_string = string.gsub(msgstr, "(\\(.))", c_escape)
     if msgctxt and msgctxt ~= "" then
         if not GetText.context[msgctxt] then
             GetText.context[msgctxt] = {}


### PR DESCRIPTION
Everything in string.gsub() is replaced, not only the matching group. By using two groups, we can correctly return the full matched string when none of the special conditions apply.

Fixes <https://github.com/koreader/koreader/issues/8486>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8511)
<!-- Reviewable:end -->
