### PR TITLE
docsettings: fix open/delete file with empty name

### DIFF
--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -115,7 +115,7 @@ function DocSettings:open(docfile)
         -- can handle two files with only different suffixes.
         new.sidecar_file = self:getSidecarFile(docfile)
         new.legacy_sidecar_file = sidecar.."/"..
-                                  docfile:match("([^%/]+%..+)")..".lua"
+                                  ffiutil.basename(docfile)..".lua"
     end
 
     local candidates = {}


### PR DESCRIPTION
When trying to open/delete a supported document with empty name (eg `.txt`) got an error

`./luajit: frontend/docsettings.lua:118: attempt to concatenate a nil value`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8517)
<!-- Reviewable:end -->
