### PR TITLE
OPDS: rename a book before downloading

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1334,6 +1334,7 @@ function CreDocument:register(registry)
     registry:addProvider("html", "text/html", self, 100)
     registry:addProvider("htm.zip", "application/zip", self, 100)
     registry:addProvider("html.zip", "application/zip", self, 100)
+    registry:addProvider("html.zip", "application/html+zip", self, 100) -- Alternative mimetype for OPDS.
     registry:addProvider("log", "text/plain", self)
     registry:addProvider("log.zip", "application/zip", self)
     registry:addProvider("md", "text/plain", self)
@@ -1344,10 +1345,12 @@ function CreDocument:register(registry)
     registry:addProvider("pdb", "application/vnd.palm", self, 90)
     -- Palmpilot Resource File
     registry:addProvider("prc", "application/vnd.palm", self)
+    registry:addProvider("rtf", "application/rtf", self, 90)
+    registry:addProvider("rtf.zip", "application/rtf+zip", self, 90) -- Alternative mimetype for OPDS.
     registry:addProvider("tcr", "application/tcr", self)
     registry:addProvider("txt", "text/plain", self, 90)
     registry:addProvider("txt.zip", "application/zip", self, 90)
-    registry:addProvider("rtf", "application/rtf", self, 90)
+    registry:addProvider("txt.zip", "application/txt+zip", self, 90) -- Alternative mimetype for OPDS.
     registry:addProvider("xhtml", "application/xhtml+xml", self, 100)
     registry:addProvider("xml", "application/xml", self, 90)
     registry:addProvider("zip", "application/zip", self, 10)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -6,9 +6,9 @@ local ConfirmBox = require("ui/widget/confirmbox")
 local DocumentRegistry = require("document/documentregistry")
 local Font = require("ui/font")
 local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
 local Menu = require("ui/widget/menu")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
-local InputDialog = require("ui/widget/inputdialog")
 local NetworkMgr = require("ui/network/manager")
 local OPDSParser = require("opdsparser")
 local Screen = require("device").screen
@@ -594,14 +594,9 @@ function OPDSBrowser.getCurrentDownloadDir()
     return G_reader_settings:readSetting("download_dir") or lastdir
 end
 
-function OPDSBrowser:downloadFile(item, filetype, remote_url)
+function OPDSBrowser:downloadFile(item, filename, remote_url)
     -- Download to user selected folder or last opened folder.
     local download_dir = self.getCurrentDownloadDir()
-
-    local filename = item.title .. "." .. filetype
-    if item.author then
-        filename = item.author .. " - " .. filename
-    end
 
     filename = util.getSafeFilename(filename, download_dir)
     local local_path = download_dir .. "/" .. filename
@@ -671,9 +666,10 @@ function OPDSBrowser:downloadFile(item, filetype, remote_url)
     end
 end
 
-function OPDSBrowser:createNewDownloadDialog(path, buttons)
+function OPDSBrowser:createNewDownloadDialog(path, filename, buttons)
     self.download_dialog = ButtonDialogTitle:new{
-        title = T(_("Download folder:\n%1\n\nDownload file type:"), BD.dirpath(path)),
+        title = T(_("Download folder:\n%1\n\nDownload file name:\n%2\n\nDownload file type:"),
+            BD.dirpath(path), filename),
         use_info_style = true,
         buttons = buttons
     }
@@ -681,48 +677,44 @@ end
 
 function OPDSBrowser:showDownloads(item)
     local acquisitions = item.acquisitions
-    local downloadsperline = 2
-    local lines = math.ceil(#acquisitions/downloadsperline)
-    local buttons = {}
-    for i = 1, lines do
-        local line = {}
-        for j = 1, downloadsperline do
-            local button = {}
-            local index = (i-1)*downloadsperline + j
-            local acquisition = acquisitions[index]
-            if acquisition then
-                local filetype = util.getFileNameSuffix(acquisition.href)
-                logger.dbg("Filetype for download is", filetype)
-                if not DocumentRegistry:hasProvider("dummy."..filetype) then
-                    filetype = nil
-                end
-                if not filetype and DocumentRegistry:hasProvider(nil, acquisition.type) then
-                    filetype = DocumentRegistry:mimeToExt(acquisition.type)
-                end
-
-                if filetype then
-                    filetype = string.lower(filetype)
-                    -- append DOWNWARDS BLACK ARROW ⬇ U+2B07 to format
-                    if acquisition.title then
-                        button.text = acquisition.title .. "\xE2\xAC\x87"
-                    else
-                        button.text = string.upper(filetype) .. "\xE2\xAC\x87"
-                    end
-                    button.callback = function()
-                        self:downloadFile(item, filetype, acquisition.href)
-                        UIManager:close(self.download_dialog)
-                    end
-                    table.insert(line, button)
-                end
-            elseif #acquisitions > downloadsperline then
-                table.insert(line, {text=""})
-            end
-        end
-        table.insert(buttons, line)
+    local filename = item.title
+    if item.author then
+        filename = item.author .. " - " .. filename
     end
-    table.insert(buttons, {})
-    -- Set download folder and book info buttons.
-    table.insert(buttons, {
+
+    local buttons = {} -- buttons for ButtonDialogTitle
+
+    local type_buttons = {} -- file type download buttons
+    for i = 1, #acquisitions do -- filter out unsupported file types
+        local acquisition = acquisitions[i]
+        local filetype = util.getFileNameSuffix(acquisition.href)
+        logger.dbg("Filetype for download is", filetype)
+        if not DocumentRegistry:hasProvider("dummy." .. filetype) then
+            filetype = nil
+        end
+        if not filetype and DocumentRegistry:hasProvider(nil, acquisition.type) then
+            filetype = DocumentRegistry:mimeToExt(acquisition.type)
+        end
+        if filetype then -- supported file type
+            local text = acquisition.title and acquisition.title or string.upper(filetype)
+            table.insert(type_buttons, {
+                text = text .. "\u{2B07}", -- append DOWNWARDS BLACK ARROW
+                callback = function()
+                    self:downloadFile(item, filename .. "." .. string.lower(filetype), acquisition.href)
+                    UIManager:close(self.download_dialog)
+                end,
+            })
+        end
+    end
+    if (#type_buttons % 2 == 1) then -- we need even number of type buttons
+        table.insert(type_buttons, {text = ""})
+    end
+    for i = 2, #type_buttons, 2 do
+        table.insert(buttons, {type_buttons[i - 1], type_buttons[i]}) -- type buttons, two in a row
+    end
+
+    table.insert(buttons, {}) -- separator
+    table.insert(buttons, { -- action buttons
         {
             text = _("Choose folder"),
             callback = function()
@@ -732,11 +724,52 @@ function OPDSBrowser:showDownloads(item)
                         G_reader_settings:saveSetting("download_dir", path)
                         UIManager:nextTick(function()
                             UIManager:close(self.download_dialog)
-                            self:createNewDownloadDialog(path, buttons)
+                            self:createNewDownloadDialog(path, filename, buttons)
                             UIManager:show(self.download_dialog)
                         end)
                     end,
                 }:chooseDir()
+            end,
+        },
+        {
+            text = _("Change file name"),
+            callback = function()
+                local input_dialog
+                input_dialog = InputDialog:new{
+                    title = _("Enter file name"),
+                    input = filename,
+                    buttons = {
+                        {
+                            {
+                                text = _("Cancel"),
+                                callback = function()
+                                    UIManager:close(input_dialog)
+                                end,
+                            },
+                            {
+                                text = _("Save"),
+                                is_enter_default = true,
+                                callback = function()
+                                    filename = input_dialog:getInputValue()
+                                    UIManager:close(input_dialog)
+                                    UIManager:close(self.download_dialog)
+                                    self:createNewDownloadDialog(self.getCurrentDownloadDir(), filename, buttons)
+                                    UIManager:show(self.download_dialog)
+                                end,
+                            },
+                        }
+                    },
+                }
+                UIManager:show(input_dialog)
+                input_dialog:onShowKeyboard()
+            end,
+        },
+    })
+    table.insert(buttons, {
+        {
+            text = _("Cancel"),
+            callback = function()
+                UIManager:close(self.download_dialog)
             end,
         },
         {
@@ -753,7 +786,7 @@ function OPDSBrowser:showDownloads(item)
         },
     })
 
-    self:createNewDownloadDialog(self.getCurrentDownloadDir(), buttons)
+    self:createNewDownloadDialog(self.getCurrentDownloadDir(), filename, buttons)
     UIManager:show(self.download_dialog)
 end
 

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -668,7 +668,7 @@ end
 
 function OPDSBrowser:createNewDownloadDialog(path, filename, buttons)
     self.download_dialog = ButtonDialogTitle:new{
-        title = T(_("Download folder:\n%1\n\nDownload file name:\n%2\n\nDownload file type:"),
+        title = T(_("Download folder:\n%1\n\nDownload filename:\n%2\n\nDownload file type:"),
             BD.dirpath(path), filename),
         use_info_style = true,
         buttons = buttons
@@ -732,11 +732,11 @@ function OPDSBrowser:showDownloads(item)
             end,
         },
         {
-            text = _("Change file name"),
+            text = _("Change filename"),
             callback = function()
                 local input_dialog
                 input_dialog = InputDialog:new{
-                    title = _("Enter file name"),
+                    title = _("Enter filename"),
                     input = filename,
                     buttons = {
                         {
@@ -747,7 +747,7 @@ function OPDSBrowser:showDownloads(item)
                                 end,
                             },
                             {
-                                text = _("Save"),
+                                text = _("Set filename"),
                                 is_enter_default = true,
                                 callback = function()
                                     filename = input_dialog:getInputValue()


### PR DESCRIPTION
(1) New button to rename a book before downloading. Closes https://github.com/koreader/koreader/issues/8508.

![01](https://user-images.githubusercontent.com/62179190/144837354-910ab44f-5678-4143-a079-9fd8b2b8118f.png)

![02](https://user-images.githubusercontent.com/62179190/144837370-e6e9abd8-d8d8-4936-8a26-e3096d4adff0.png)

(2) While testing I've noticed that the Flibusta OPDS dialog is broken (wide 1st button, redundant separator between type buttons).

![03](https://user-images.githubusercontent.com/62179190/144837508-106f8ae0-442b-4f3d-9737-c907688b9bbd.png)

The reason is that Flibusta gives 6 acquisitions, but 2, 3 and 4 are unsupported (missing 2nd button widens the first one, missing 3 and 4 produce the separator).
The code for building button table is rewritten to filter out unsupported formats. Flibusta looks okay.

(3) But what are the unsupported formats from Flibusta? They are just zipped html, rtf and txt. Let's add a provider (crengine) and make them supported.

![04](https://user-images.githubusercontent.com/62179190/144837932-009e08c3-a21f-410c-aa0b-214f1cb4bf65.png)

Finally we can get all formats and are sure that any (future) unsupported format shall not break our dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8520)
<!-- Reviewable:end -->
