### PR TITLE
[fix] koreader not using XDG_DATA_HOME to search for fonts

### DIFF
--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -7,7 +7,7 @@ local _ = require("gettext")
 
 local LINUX_FONT_PATH = os.getenv("XDG_DATA_HOME")
     and string.format("%s/fonts", os.getenv("XDG_DATA_HOME"))
-    or string.format("%s/%s", home, ".local/share/fonts")
+    or string.format("%s/%s", Device.home_dir, ".local/share/fonts")
 local MACOS_FONT_PATH = "Library/fonts"
 
 local function getDir(isUser)

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -10,8 +10,8 @@ local function getDir(isUser)
 
     local XDG_DATA_HOME = os.getenv("XDG_DATA_HOME")
     local LINUX_FONT_PATH = XDG_DATA_HOME
-        and string.format("%s/fonts", XDG_DATA_HOME)
-        or string.format("%s/%s", home, ".local/share/fonts")
+        and XDG_DATA_HOME .. "/fonts"
+        or home .. "/.local/share/fonts"
     local LINUX_SYS_FONT_PATH = "/usr/share/fonts"
     local MACOS_FONT_PATH = "Library/fonts"
 
@@ -31,8 +31,8 @@ local function getDir(isUser)
     elseif Device:isDesktop() or Device:isEmulator() then
         if jit.os == "OSX" then
             return isUser
-                and string.format("%s/%s", home, MACOS_FONT_PATH)
-                or string.format("/%s", MACOS_FONT_PATH)
+                and home .. "/" .. MACOS_FONT_PATH
+                or "/" .. MACOS_FONT_PATH
         else
             return isUser
                 and LINUX_FONT_PATH

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -5,7 +5,9 @@ local _ = require("gettext")
 
 --[[ Font settings for systems with multiple font dirs ]]--
 
-local LINUX_FONT_PATH = "share/fonts"
+local LINUX_FONT_PATH = os.getenv("XDG_DATA_HOME")
+    and string.format("%s/fonts", os.getenv("XDG_DATA_HOME"))
+    or string.format("%s/%s", home, ".local/share/fonts")
 local MACOS_FONT_PATH = "Library/fonts"
 
 local function getDir(isUser)
@@ -24,15 +26,13 @@ local function getDir(isUser)
             return "/ebrmain/adobefonts;/ebrmain/fonts"
         end
     elseif Device:isRemarkable() then
-        return isUser and string.format("%s/.local/%s", home, LINUX_FONT_PATH)
-            or string.format("/usr/%s", LINUX_FONT_PATH)
+        return isUser and LINUX_FONT_PATH or "/usr/share/fonts"
     elseif Device:isDesktop() or Device:isEmulator() then
         if jit.os == "OSX" then
             return isUser and string.format("%s/%s", home, MACOS_FONT_PATH)
                 or string.format("/%s", MACOS_FONT_PATH)
         else
-            return isUser and string.format("%s/.local/%s", home, LINUX_FONT_PATH)
-                or string.format("/usr/%s", LINUX_FONT_PATH)
+            return isUser and LINUX_FONT_PATH or "/usr/share/fonts"
         end
     end
 end

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -9,34 +9,29 @@ local function getDir(isUser)
     local home = Device.home_dir
 
     local XDG_DATA_HOME = os.getenv("XDG_DATA_HOME")
-    local LINUX_FONT_PATH = XDG_DATA_HOME
-        and XDG_DATA_HOME .. "/fonts"
-        or home .. "/.local/share/fonts"
+    local LINUX_FONT_PATH = XDG_DATA_HOME and XDG_DATA_HOME .. "/fonts"
+                                           or home .. "/.local/share/fonts"
     local LINUX_SYS_FONT_PATH = "/usr/share/fonts"
     local MACOS_FONT_PATH = "Library/fonts"
 
     if isUser and not home then return end
+
     if Device:isAndroid() then
-        return isUser
-            and home .. "/fonts;" .. home .. "/koreader/fonts"
-            or "/system/fonts"
+        return isUser and home .. "/fonts;" .. home .. "/koreader/fonts"
+                       or "/system/fonts"
     elseif Device:isPocketBook() then
-        return isUser
-            and "/mnt/ext1/system/fonts"
-            or "/ebrmain/adobefonts;/ebrmain/fonts"
+        return isUser and "/mnt/ext1/system/fonts"
+                       or "/ebrmain/adobefonts;/ebrmain/fonts"
     elseif Device:isRemarkable() then
-        return isUser
-            and LINUX_FONT_PATH
-            or LINUX_SYS_FONT_PATH
+        return isUser and LINUX_FONT_PATH
+                       or LINUX_SYS_FONT_PATH
     elseif Device:isDesktop() or Device:isEmulator() then
         if jit.os == "OSX" then
-            return isUser
-                and home .. "/" .. MACOS_FONT_PATH
-                or "/" .. MACOS_FONT_PATH
+            return isUser and home .. "/" .. MACOS_FONT_PATH
+                           or "/" .. MACOS_FONT_PATH
         else
-            return isUser
-                and LINUX_FONT_PATH
-                or LINUX_SYS_FONT_PATH
+            return isUser and LINUX_FONT_PATH
+                           or LINUX_SYS_FONT_PATH
         end
     end
 end

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -5,34 +5,38 @@ local _ = require("gettext")
 
 --[[ Font settings for systems with multiple font dirs ]]--
 
-local LINUX_FONT_PATH = os.getenv("XDG_DATA_HOME")
-    and string.format("%s/fonts", os.getenv("XDG_DATA_HOME"))
-    or string.format("%s/%s", Device.home_dir, ".local/share/fonts")
-local MACOS_FONT_PATH = "Library/fonts"
-
 local function getDir(isUser)
     local home = Device.home_dir
+
+    local XDG_DATA_HOME = os.getenv("XDG_DATA_HOME")
+    local LINUX_FONT_PATH = XDG_DATA_HOME
+        and string.format("%s/fonts", XDG_DATA_HOME)
+        or string.format("%s/%s", home, ".local/share/fonts")
+    local LINUX_SYS_FONT_PATH = "/usr/share/fonts"
+    local MACOS_FONT_PATH = "Library/fonts"
+
     if isUser and not home then return end
     if Device:isAndroid() then
-        if isUser then
-            return home .. "/fonts;" .. home .. "/koreader/fonts"
-        else
-            return "/system/fonts"
-        end
+        return isUser
+            and home .. "/fonts;" .. home .. "/koreader/fonts"
+            or "/system/fonts"
     elseif Device:isPocketBook() then
-        if isUser then
-            return "/mnt/ext1/system/fonts"
-        else
-            return "/ebrmain/adobefonts;/ebrmain/fonts"
-        end
+        return isUser
+            and "/mnt/ext1/system/fonts"
+            or "/ebrmain/adobefonts;/ebrmain/fonts"
     elseif Device:isRemarkable() then
-        return isUser and LINUX_FONT_PATH or "/usr/share/fonts"
+        return isUser
+            and LINUX_FONT_PATH
+            or LINUX_SYS_FONT_PATH
     elseif Device:isDesktop() or Device:isEmulator() then
         if jit.os == "OSX" then
-            return isUser and string.format("%s/%s", home, MACOS_FONT_PATH)
+            return isUser
+                and string.format("%s/%s", home, MACOS_FONT_PATH)
                 or string.format("/%s", MACOS_FONT_PATH)
         else
-            return isUser and LINUX_FONT_PATH or "/usr/share/fonts"
+            return isUser
+                and LINUX_FONT_PATH
+                or LINUX_SYS_FONT_PATH
         end
     end
 end


### PR DESCRIPTION
As with the config, koreader wasnt loading my fonts, because they are in `$XDG_DATA_HOME`.

Already tested this fix and it works perfectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8521)
<!-- Reviewable:end -->
