### PR TITLE
bump crengine: avoid re-renderings, hanging punctuation tweaks

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -323,7 +323,7 @@ function ReaderCoptListener:getAltStatusBarMenu()
                 text_func = function()
                     return T(_("Font size: %1"), G_reader_settings:readSetting("cre_header_status_font_size", CRE_HEADER_DEFAULT_SIZE))
                 end,
-                callback = function(touchmenu_instance)
+                callback = function()
                     local SpinWidget = require("ui/widget/spinwidget")
                     local start_size = G_reader_settings:readSetting("cre_header_status_font_size", CRE_HEADER_DEFAULT_SIZE)
                     local size_spinner = SpinWidget:new{
@@ -335,14 +335,9 @@ function ReaderCoptListener:getAltStatusBarMenu()
                         title_text =  _("Size of top status bar"),
                         ok_text = _("Set size"),
                         callback = function(spin)
-                            -- This could change the header height, and as we refresh only on the
-                            -- new height, we could get part of a previous taller status bar
-                            -- still displayed. But as all this is covered by this menu that
-                            -- we keep open, no need to handle this case.
                             self:setAndSave("cre_header_status_font_size", "crengine.page.header.font.size", spin.value)
-                            if touchmenu_instance then touchmenu_instance:updateItems() end
-                            -- Repaint the whole page, as changing this should cause a re-rendering
-                            UIManager:setDirty(self.view.dialog, "ui")
+                            -- This will probably needs a re-rendering, so make sure it happens now.
+                            self.ui:handleEvent(Event:new("UpdatePos"))
                         end
                     }
                     UIManager:show(size_spinner)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -900,7 +900,7 @@ function ReaderRolling:updatePos()
     end
     self:onUpdateTopStatusBarMarkers()
     UIManager:setDirty(self.view.dialog, "partial")
-    self.current_header_height = self.ui.document:getHeaderHeight()
+    self.current_header_height = self.view.view_mode == "page" and self.ui.document:getHeaderHeight() or 0
     -- Allow for the new rendering to be shown before possibly showing
     -- the "Styles have changed..." ConfirmBox so the user can decide
     -- if it is really needed
@@ -909,14 +909,9 @@ function ReaderRolling:updatePos()
     end)
 end
 
---[[
-    switching screen mode should not change current page number
---]]
 function ReaderRolling:onChangeViewMode()
-    self.rendering_hash = self.ui.document:getDocumentRenderingHash()
-    self.ui.document:_readMetadata()
-    self.current_header_height = self.ui.document:getHeaderHeight()
-    self.ui:handleEvent(Event:new("UpdateToc"))
+    self.current_header_height = self.view.view_mode == "page" and self.ui.document:getHeaderHeight() or 0
+    -- Restore current position when switching page/scroll mode
     if self.xpointer then
         self:_gotoXPointer(self.xpointer)
         -- Ensure a whole screen refresh is always enqueued
@@ -952,8 +947,7 @@ function ReaderRolling:onSetDimensions(dimen)
         self.ui.document:enableInternalHistory(true)
         -- Set document dimensions
         self.ui.document:setViewDimen(Screen:getSize())
-        -- Re-setup previous position
-        self:onChangeViewMode()
+        -- Re-render document (and update TOC, re set position)
         self:onUpdatePos()
         -- Re-disable internal history, with required redraw
         self.ui.document:enableInternalHistory(false)


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/461 : 
- setStatusFontSize/Face(): avoid spurious re-rendering.
- Hanging punctuation: include it in native highlighting.
- Hanging punctuation: tweak hanging ratios again.

cre.cpp: don't Render() in setViewDimen(), we'll do that in a more controlled fashion in frontend https://github.com/koreader/koreader-base/pull/1438
Also bump Freetype to 2.11.1 https://github.com/koreader/koreader-base/pull/1436
Also include ffi/utf8proc.count() https://github.com/koreader/koreader-base/pull/1414

Also: ReaderRolling/ReaderCoptListener: fix a few re-rendering issues:

- When switching screen rotation, have the re-rendering properly done only via :onUpdatePos() - see https://github.com/koreader/koreader/pull/8501#issuecomment-986948160
- When changing alt status bar font size, also have it done via :onUpdatePos() instead of the next painting (this also update any dogear position after the resize, see https://github.com/koreader/koreader/pull/7312#issuecomment-986180114).
- When in scroll mode (no alt status bar), be sure to draw crengine progress bar at top (and not below the not shown alt status bar).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8528)
<!-- Reviewable:end -->
