### PR TITLE
SpinWidget fix enable/disable OK button

### DIFF
--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -227,7 +227,7 @@ function NumberPickerWidget:update()
         return "ui", self.dimen
     end)
     if self.picker_updated_callback then
-        self.picker_updated_callback(self.value)
+        self.picker_updated_callback(self.value, self.value_index)
     end
 end
 

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -52,7 +52,9 @@ local SpinWidget = InputContainer:new{
 }
 
 function SpinWidget:init()
-    self.original_value = self.value -- used to enable ok_button, self.value may be changed in extra callback
+    -- used to enable ok_button, self.value may be changed in extra callback
+    self.original_value = self.value_table and self.value_table[self.value_index or 1] or self.value
+
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
     if not self.width then
@@ -84,20 +86,20 @@ function SpinWidget:init()
     self:update()
 end
 
-function SpinWidget:update(numberpicker_value)
+function SpinWidget:update(numberpicker_value, numberpicker_value_index)
     local value_widget = NumberPickerWidget:new{
         show_parent = self,
         value = numberpicker_value or self.value,
         value_table = self.value_table,
-        value_index = self.value_index,
+        value_index = numberpicker_value_index or self.value_index,
         value_min = self.value_min,
         value_max = self.value_max,
         value_step = self.value_step,
         value_hold_step = self.value_hold_step,
         precision = self.precision,
         wrap = self.wrap,
-        picker_updated_callback = function(value)
-            self:update(value)
+        picker_updated_callback = function(value, value_index)
+            self:update(value, value_index)
         end,
     }
     local value_group = HorizontalGroup:new{


### PR DESCRIPTION
Regression since https://github.com/koreader/koreader/pull/8495. SpinWidget with `value_table` didn't work.
To reproduce: bottom menu, fine tune Contrast.
Fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8529)
<!-- Reviewable:end -->
