### PR TITLE
File manager: group operations

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -134,7 +134,7 @@ function FileManager:setupLayout()
         height = icon_size,
         padding = Size.padding.default,
         padding_left = Size.padding.large,
-        padding_right = Size.padding.large,
+        padding_right = Size.padding.default,
         padding_bottom = 0,
         callback = function() self:onShowPlusMenu() end,
     }

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -858,7 +858,6 @@ function FileManager:tapPlus()
     self.file_dialog = ButtonDialogTitle:new{
         title = title,
         title_align = "center",
-        use_info_style = true,
         buttons = buttons,
         select_mode = self.select_mode, -- for coverbrowser
     }

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -797,6 +797,7 @@ function FileManager:tapPlus()
         title_align = "center",
         use_info_style = true,
         buttons = buttons,
+        select_mode = self.select_mode, -- for coverbrowser
     }
     UIManager:show(self.file_dialog)
 end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -97,6 +97,7 @@ local settingsList = {
     -- filemanager settings
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
     show_plus_menu = {category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true},
+    toggle_select_mode = {category="none", event="ToggleSelectMode", title=_("Toggle select mode"), filemanager=true},
     refresh_content = {category="none", event="RefreshContent", title=_("Refresh content"), filemanager=true},
     folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, separator=true},
 
@@ -254,6 +255,7 @@ local dispatcher_menu_order = {
     -- filemanager
     "folder_up",
     "show_plus_menu",
+    "toggle_select_mode",
     "refresh_content",
     "folder_shortcuts",
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -324,7 +324,7 @@ function FileChooser:genItemTableFromPath(path)
             text = file.name,
             bidi_wrap_func = BD.filename,
             mandatory = sstr,
-            path = full_path
+            path = full_path,
         }
         if show_file_in_bold ~= false then
             file_item.bold = DocSettings:hasSidecarFile(full_path)
@@ -332,7 +332,7 @@ function FileChooser:genItemTableFromPath(path)
                 file_item.bold = not file_item.bold
             end
         end
-        if self.clipboard and self.clipboard[full_path] then -- selected file
+        if self.filemanager.selected_files and self.filemanager.selected_files[full_path] then
             file_item.dim = true
         end
         table.insert(item_table, file_item)
@@ -495,7 +495,7 @@ function FileChooser:getNextFile(curr_file)
     return next_file
 end
 
-function FileChooser:showSetProviderButtons(file, filemanager_instance, one_time_providers)
+function FileChooser:showSetProviderButtons(file, one_time_providers)
     local ReaderUI = require("apps/reader/readerui")
 
     local __, filename_pure = util.splitFilePathName(file)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -496,6 +496,8 @@ function FileChooser:getNextFile(curr_file)
     return next_file
 end
 
+-- Used in file manager select mode to select all files in a folder,
+-- that are visible in all file browser pages, without subfolders.
 function FileChooser:selectAllFilesInFolder()
     for _, item in pairs(self.item_table) do
         if item.is_file then

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -333,7 +333,7 @@ function FileChooser:genItemTableFromPath(path)
                 file_item.bold = not file_item.bold
             end
         end
-        if self.filemanager.selected_files and self.filemanager.selected_files[full_path] then
+        if self.filemanager and self.filemanager.selected_files and self.filemanager.selected_files[full_path] then
             file_item.dim = true
         end
         table.insert(item_table, file_item)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -325,6 +325,7 @@ function FileChooser:genItemTableFromPath(path)
             bidi_wrap_func = BD.filename,
             mandatory = sstr,
             path = full_path,
+            is_file = true,
         }
         if show_file_in_bold ~= false then
             file_item.bold = DocSettings:hasSidecarFile(full_path)
@@ -497,7 +498,7 @@ end
 
 function FileChooser:selectAllFilesInFolder()
     for _, item in pairs(self.item_table) do
-        if item.bidi_wrap_func == BD.filename then
+        if item.is_file then
             self.filemanager.selected_files[item.path] = true
         end
     end

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -495,6 +495,14 @@ function FileChooser:getNextFile(curr_file)
     return next_file
 end
 
+function FileChooser:selectAllFilesInFolder()
+    for _, item in pairs(self.item_table) do
+        if item.bidi_wrap_func == BD.filename then
+            self.filemanager.selected_files[item.path] = true
+        end
+    end
+end
+
 function FileChooser:showSetProviderButtons(file, one_time_providers)
     local ReaderUI = require("apps/reader/readerui")
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -332,6 +332,9 @@ function FileChooser:genItemTableFromPath(path)
                 file_item.bold = not file_item.bold
             end
         end
+        if self.clipboard and self.clipboard[full_path] then -- selected file
+            file_item.dim = true
+        end
         table.insert(item_table, file_item)
     end
 

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -158,4 +158,11 @@ function IconButton:onTapSelect()
     self:onTapIconButton()
 end
 
+function IconButton:setIcon(icon)
+    if icon ~= self.icon then
+        self.icon = icon
+        self:init()
+    end
+end
+
 return IconButton

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -994,7 +994,7 @@ function Menu:init()
             }
         end
         -- delegate swipe gesture to GestureManager in filemanager
-        if self.is_file_manager ~= true then
+        if not self.filemanager then
             self.ges_events.Swipe = {
                 GestureRange:new{
                     ges = "swipe",

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -698,6 +698,7 @@ function CoverMenu:tapPlus()
     -- Call original function: it will create a ButtonDialogTitle
     -- and store it as self.file_dialog, and UIManager:show() it.
     CoverMenu._FileManager_tapPlus_orig(self)
+    if self.file_dialog.select_mode then return end -- do not change select menu
 
     -- Remember some of this original ButtonDialogTitle properties
     local orig_title = self.file_dialog.title

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -729,6 +729,7 @@ function CoverMenu:tapPlus()
     self.file_dialog = ButtonDialogTitle:new{
         title = orig_title,
         title_align = orig_title_align,
+        use_info_style = true,
         buttons = orig_buttons,
     }
     UIManager:show(self.file_dialog)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -703,7 +703,6 @@ function CoverMenu:tapPlus()
     -- Remember some of this original ButtonDialogTitle properties
     local orig_title = self.file_dialog.title
     local orig_title_align = self.file_dialog.title_align
-    local orig_use_info_style = self.file_dialog.use_info_style
     local orig_buttons = self.file_dialog.buttons
     -- Close original ButtonDialogTitle (it has not yet been painted
     -- on screen, so we won't see it)
@@ -730,7 +729,6 @@ function CoverMenu:tapPlus()
     self.file_dialog = ButtonDialogTitle:new{
         title = orig_title,
         title_align = orig_title_align,
-        use_info_style = orig_use_info_style,
         buttons = orig_buttons,
     }
     UIManager:show(self.file_dialog)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -703,6 +703,7 @@ function CoverMenu:tapPlus()
     -- Remember some of this original ButtonDialogTitle properties
     local orig_title = self.file_dialog.title
     local orig_title_align = self.file_dialog.title_align
+    local orig_use_info_style = self.file_dialog.use_info_style
     local orig_buttons = self.file_dialog.buttons
     -- Close original ButtonDialogTitle (it has not yet been painted
     -- on screen, so we won't see it)
@@ -729,7 +730,7 @@ function CoverMenu:tapPlus()
     self.file_dialog = ButtonDialogTitle:new{
         title = orig_title,
         title_align = orig_title_align,
-        use_info_style = true,
+        use_info_style = orig_use_info_style,
         buttons = orig_buttons,
     }
     UIManager:show(self.file_dialog)

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -262,7 +262,8 @@ function ListMenuItem:update()
             },
         }
     else
-        local is_file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
+        local is_file_selected = self.menu.filemanager and self.menu.filemanager.selected_files
+            and self.menu.filemanager.selected_files[self.filepath]
         if file_mode ~= "file" or is_file_selected then
             self.file_deleted = true -- dim file
         end

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -262,8 +262,10 @@ function ListMenuItem:update()
             },
         }
     else
-        if file_mode ~= "file" then
-            self.file_deleted = true
+        local filemanager = require("apps/filemanager/filemanager").instance
+        local file_selected = filemanager.selected_files and filemanager.selected_files[self.filepath]
+        if file_mode ~= "file" or file_selected then
+            self.file_deleted = true -- dim file
         end
         -- File
 

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -262,8 +262,7 @@ function ListMenuItem:update()
             },
         }
     else
-        local filemanager = require("apps/filemanager/filemanager").instance
-        local file_selected = filemanager.selected_files and filemanager.selected_files[self.filepath]
+        local file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
         if file_mode ~= "file" or file_selected then
             self.file_deleted = true -- dim file
         end

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -262,8 +262,8 @@ function ListMenuItem:update()
             },
         }
     else
-        local file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
-        if file_mode ~= "file" or file_selected then
+        local is_file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
+        if file_mode ~= "file" or is_file_selected then
             self.file_deleted = true -- dim file
         end
         -- File

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -521,7 +521,8 @@ function MosaicMenuItem:update()
             },
         }
     else
-        local is_file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
+        local is_file_selected = self.menu.filemanager and self.menu.filemanager.selected_files
+            and self.menu.filemanager.selected_files[self.filepath]
         if file_mode ~= "file" or is_file_selected then
             self.file_deleted = true -- dim file
         end

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -521,8 +521,8 @@ function MosaicMenuItem:update()
             },
         }
     else
-        local file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
-        if file_mode ~= "file" or file_selected then
+        local is_file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
+        if file_mode ~= "file" or is_file_selected then
             self.file_deleted = true -- dim file
         end
         -- File : various appearances

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -521,8 +521,7 @@ function MosaicMenuItem:update()
             },
         }
     else
-        local filemanager = require("apps/filemanager/filemanager").instance
-        local file_selected = filemanager.selected_files and filemanager.selected_files[self.filepath]
+        local file_selected = self.menu.filemanager.selected_files and self.menu.filemanager.selected_files[self.filepath]
         if file_mode ~= "file" or file_selected then
             self.file_deleted = true -- dim file
         end

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -521,8 +521,10 @@ function MosaicMenuItem:update()
             },
         }
     else
-        if file_mode ~= "file" then
-            self.file_deleted = true
+        local filemanager = require("apps/filemanager/filemanager").instance
+        local file_selected = filemanager.selected_files and filemanager.selected_files[self.filepath]
+        if file_mode ~= "file" or file_selected then
+            self.file_deleted = true -- dim file
         end
         -- File : various appearances
 


### PR DESCRIPTION
New button in the Plus menu.

![01](https://user-images.githubusercontent.com/62179190/145250191-cd302c7b-b2db-45ce-9237-0d5c57a09731.png)

In select mode:
-Plus icon is changing to indicate the select mode
-tap a file to select/deselect
-selected file is dimmed
-browsing in folders in usual way
-folders cannot be selected
-long-press on files and folders is disabled

![02](https://user-images.githubusercontent.com/62179190/145250352-9aee6180-241d-4458-91cf-d47cc5460d5b.png)

After selection, tap a Check icon for actions.

![03](https://user-images.githubusercontent.com/62179190/145250449-f25ca966-10c9-41db-831b-ca5eeea93788.png)

If the approach is accepted, I shall continue with more actions and non-classic display modes.

Closes https://github.com/koreader/koreader/issues/8524.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8536)
<!-- Reviewable:end -->
