### PR TITLE
OTAManager: Limit number of saved update packages

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -6,7 +6,6 @@ local Device = require("device")
 local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local OTAManager = require("ui/otamanager")
 local PluginLoader = require("pluginloader")
 local SetDefaults = require("apps/filemanager/filemanagersetdefaults")
 local Size = require("ui/size")
@@ -703,10 +702,6 @@ To:
             touchmenu_instance:updateItems()
         end,
     })
-    if OTAManager:getOTAType() == "link" then
-        table.insert(self.menu_items.developer_options.sub_item_table,
-            OTAManager:getOTASettingMenuEntry())
-    end
 
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -6,6 +6,7 @@ local Device = require("device")
 local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local OTAManager = require("ui/otamanager")
 local PluginLoader = require("pluginloader")
 local SetDefaults = require("apps/filemanager/filemanagersetdefaults")
 local Size = require("ui/size")
@@ -702,6 +703,10 @@ To:
             touchmenu_instance:updateItems()
         end,
     })
+    if OTAManager:getOTAType() == "link" then
+        table.insert(self.menu_items.developer_options.sub_item_table,
+            OTAManager:getOTASettingMenuEntry())
+    end
 
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),

--- a/reader.lua
+++ b/reader.lua
@@ -179,6 +179,9 @@ CanvasContext:init(Device)
 -- Handle one time migration stuff (settings, deprecation, ...) in case of an upgrade...
 require("ui/data/onetime_migration")
 
+-- Clean the update package that belongs to the current version (on supported devices: Android, AppImage)
+require("ui/otamanager"):cleanUpdates()
+
 -- Touch screen (this may display some widget, on first install on Kobo Touch,
 -- so have it done after CanvasContext:init() but before Bidi.setup() to not
 -- have mirroring mess x/y probing).


### PR DESCRIPTION
Over the time there are a lot of downloaded update packages on the device.

Added a menu entry to set the maximum number of saved download packages and a method to clean the download directory.

Only tested on the emulator and on an Android mobile, so someone should test it on other devices too.


![grafik](https://user-images.githubusercontent.com/36999612/145445490-5f5268b4-792a-4f6c-8a29-7290f64b2094.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8538)
<!-- Reviewable:end -->
