### PR TITLE
TextBoxWidget: fix crash in legacy mode

### DIFF
--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -216,6 +216,11 @@ end
 function TextBoxWidget:_evalCharWidthList()
     -- if self.charlist is provided, use it directly
     if self.charlist == nil then
+        if not self.text then
+            self.text = ""
+        elseif type(self.text) ~= "string" then
+            self.text = tostring(self.text)
+        end
         self.charlist = util.splitToChars(self.text)
     end
     -- get width of each distinct char


### PR DESCRIPTION
Just do as in _measureWithXText(): convert to string when text is not (ie. a number).
Closes #8542.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8545)
<!-- Reviewable:end -->
