### PR TITLE
Pocketbook: switch the Wi-Fi on before attempting to connect (#4747)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -342,6 +342,7 @@ end
 
 function PocketBook:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOnWifi(complete_callback)
+        inkview.WiFiPower(1)
         if inkview.NetConnect(nil) ~= C.NET_OK then
             logger.info('NetConnect failed')
         end


### PR DESCRIPTION
Apparently, inkview.NetConnect() doesn’t enable the Wi-Fi on its own,
this results in a failure if the device has been put into the sleep or
standby mode, when the Wi-Fi hardware is powered down.

This fixes the bug #4747.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8546)
<!-- Reviewable:end -->
