### PR TITLE
TileCache: Preserve BlitBuffer's inversion & rotation

### DIFF
--- a/frontend/document/tilecacheitem.lua
+++ b/frontend/document/tilecacheitem.lua
@@ -24,6 +24,8 @@ function TileCacheItem:totable()
             h = self.bb.h,
             stride = tonumber(self.bb.stride),
             fmt = self.bb:getType(),
+            rotation = self.bb:getRotation(),
+            inverse = self.bb:getInverse(),
             data = Blitbuffer.tostring(self.bb),
         },
     }
@@ -54,7 +56,7 @@ function TileCacheItem:fromtable(t)
     self.excerpt = t.excerpt
     self.created_ts = t.created_ts
     self.persistent = t.persistent
-    self.bb = Blitbuffer.fromstring(t.bb.w, t.bb.h, t.bb.fmt, t.bb.data, t.bb.stride)
+    self.bb = Blitbuffer.fromstring(t.bb.w, t.bb.h, t.bb.fmt, t.bb.data, t.bb.stride, t.bb.rotation, t.bb.inverse)
 end
 
 function TileCacheItem:load(filename)


### PR DESCRIPTION
This somehow fell through the cracks for all these years ;).

Requires https://github.com/koreader/koreader-base/pull/1440

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8547)
<!-- Reviewable:end -->
