### PR TITLE
SpinWidget in Dispatcher fix

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -523,6 +523,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                             value_max = settingsList[k].max,
                             default_value = settingsList[k].default,
                             title_text = Dispatcher:getNameFromItem(k, location, settings),
+                            ok_always_enabled = true,
                             callback = function(spin)
                                 if location[settings] == nil then
                                     location[settings] = {}
@@ -570,6 +571,7 @@ function Dispatcher:addItem(caller, menu, location, settings, section)
                             default_value = 0,
                             title_text = Dispatcher:getNameFromItem(k, location, settings),
                             info_text = _([[If called by a gesture the amount of the gesture will be used]]),
+                            ok_always_enabled = true,
                             callback = function(spin)
                                 if location[settings] == nil then
                                     location[settings] = {}

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -39,6 +39,7 @@ local SpinWidget = InputContainer:new{
     wrap = false,
     cancel_text = _("Close"),
     ok_text = _("Apply"),
+    ok_always_enabled = false, -- set to true to enable OK button for unchanged value
     cancel_callback = nil,
     callback = nil,
     close_callback = nil,
@@ -165,7 +166,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         },
         {
             text = self.ok_text,
-            enabled = self.original_value ~= value_widget:getValue(),
+            enabled = self.ok_always_enabled or self.original_value ~= value_widget:getValue(),
             callback = function()
                 self.value, self.value_index = value_widget:getValue()
                 self.original_value = self.value


### PR DESCRIPTION
Regression after https://github.com/koreader/koreader/pull/8495: in assigning an action for a gesture OK button in SpinWidget was disabled for current value of a setting (until changing the value). Fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8558)
<!-- Reviewable:end -->
