### PR TITLE
File browser select mode fix (disable long-press)

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -243,7 +243,6 @@ function FileManager:setupLayout()
     local setHome = function(path) self:setHome(path) end
 
     function file_chooser:onFileHold(file)  -- luacheck: ignore
-        if file_manager.select_mode then return true end
         local is_file = lfs.attributes(file, "mode") == "file"
         local is_folder = lfs.attributes(file, "mode") == "directory"
         local is_not_parent_folder = BaseUtil.basename(file) ~= ".."

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -462,6 +462,7 @@ function FileChooser:onMenuSelect(item)
 end
 
 function FileChooser:onMenuHold(item)
+    if self.filemanager and self.filemanager.select_mode then return true end
     self:onFileHold(item.path)
     return true
 end


### PR DESCRIPTION
Long-press was not disabled in non-classic display modes, caused errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8567)
<!-- Reviewable:end -->
