### PR TITLE
Screensaver: add method to set a threshold for stretching

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -318,22 +318,17 @@ function Device:setDateTime(year, month, day, hour, min, sec)
     end
 end
 
+function Device:supportsScreensaver() return true end
+
 function Emulator:simulateSuspend()
-    local InfoMessage = require("ui/widget/infomessage")
-    local UIManager = require("ui/uimanager")
-    local _ = require("gettext")
-    UIManager:show(InfoMessage:new{
-        text = _("Suspend")
-    })
+    local Screensaver = require("ui/screensaver")
+    Screensaver:setup()
+    Screensaver:show()
 end
 
 function Emulator:simulateResume()
-    local InfoMessage = require("ui/widget/infomessage")
-    local UIManager = require("ui/uimanager")
-    local _ = require("gettext")
-    UIManager:show(InfoMessage:new{
-        text = _("Resume")
-    })
+    local Screensaver = require("ui/screensaver")
+    Screensaver:close()
 end
 
 -- fake network manager for the emulator

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -318,7 +318,7 @@ function Device:setDateTime(year, month, day, hour, min, sec)
     end
 end
 
-function Device:supportsScreensaver() return true end
+function Emulator:supportsScreensaver() return true end
 
 function Emulator:simulateSuspend()
     local Screensaver = require("ui/screensaver")

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -156,12 +156,11 @@ return {
                     {
                         text_func = function()
                             if G_reader_settings:nilOrFalse("screensaver_stretch_images") then
-                                return _("Stretch to fit screen: off")
+                                return _("Stretch to fit screen")
                             elseif G_reader_settings:readSetting("screensaver_stretch_limit_percentage") then
-                                return T(_("Stretch to fit screen: limit to %1%"),
-                                    G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
+                                return _("Stretch to fit screen (with limit)")
                             else
-                                return _("Stretch to fit screen: full")
+                                return _("Stretch to fit screen")
                             end
                         end,
                         checked_func = function()

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -156,19 +156,19 @@ return {
                     {
                         text_func = function()
                             if G_reader_settings:nilOrFalse("screensaver_stretch_images") then
-                                return _("Stretch to fit screen")
+                                return _("Stretch to fit screen: off")
                             elseif G_reader_settings:readSetting("screensaver_stretch_limit_percentage") then
                                 return T(_("Stretch to fit screen: limit to %1%"),
                                     G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
                             else
-                                return _("Stretch to fit screen: unlimited")
+                                return _("Stretch to fit screen: full")
                             end
                         end,
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_stretch_images")
                         end,
                         help_text_func = function()
-                            return T(_("If the image and the screen have a similar aspect ratio (±%1%), stretch the image instead of keeping its aspect ratio."), G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
+                            return _("If the image and the screen have similar aspect ratios, stretch the image instead of keeping its aspect ratio.")
                         end,
                         callback = function(touchmenu_instance)
                             Screensaver:setStretchLimit(touchmenu_instance)

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -155,8 +155,14 @@ return {
                     },
                     {
                         text_func = function()
-                            return T(_("Stretch covers and images to fit screen: %1%"),
-                                G_reader_settings:readSetting("screensaver_stretch_limit_percentage", 8))
+                            if G_reader_settings:nilOrFalse("screensaver_stretch_images") then
+                                return _("Stretch covers and images to fit screen")
+                            elseif G_reader_settings:readSetting("screensaver_stretch_limit_percentage") then
+                                return T(_("Stretch covers and images to fit screen: %1%"),
+                                    G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
+                            else
+                                return _("Stretch covers and images to fit screen: always")
+                            end
                         end,
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_stretch_images")

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -158,10 +158,10 @@ return {
                             if G_reader_settings:nilOrFalse("screensaver_stretch_images") then
                                 return _("Stretch to fit screen")
                             elseif G_reader_settings:readSetting("screensaver_stretch_limit_percentage") then
-                                return T(_("Stretch to fit screen: %1%"),
+                                return T(_("Stretch to fit screen: limit to %1%"),
                                     G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
                             else
-                                return _("Stretch to fit screen: always")
+                                return _("Stretch to fit screen: unlimited")
                             end
                         end,
                         checked_func = function()

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -1,6 +1,5 @@
 local Screensaver = require("ui/screensaver")
 local _ = require("gettext")
-local T = require("ffi/util").template
 
 local function hasLastFile()
     if G_reader_settings:hasNot("lastfile") then
@@ -165,9 +164,6 @@ return {
                         end,
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_stretch_images")
-                        end,
-                        help_text_func = function()
-                            return _("If the image and the screen have similar aspect ratios, stretch the image instead of keeping its aspect ratio.")
                         end,
                         callback = function(touchmenu_instance)
                             Screensaver:setStretchLimit(touchmenu_instance)

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -1,6 +1,6 @@
 local Screensaver = require("ui/screensaver")
-local T = require("ffi/util").template
 local _ = require("gettext")
+local T = require("ffi/util").template
 
 local function hasLastFile()
     if G_reader_settings:hasNot("lastfile") then
@@ -156,14 +156,13 @@ return {
                     {
                         text_func = function()
                             return T(_("Stretch covers and images to fit screen: %1%"),
-                                G_reader_settings:readSetting("screensaver_stretch_limit_percentage",8))
+                                G_reader_settings:readSetting("screensaver_stretch_limit_percentage", 8))
                         end,
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_stretch_images")
                         end,
                         help_text_func = function()
-                            return T(_("If the image and the screen have a similar aspect ratio (±%1%), stretch the image instead of keeping its aspect ratio."),
-                                G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
+                            return T(_("If the image and the screen have a similar aspect ratio (±%1%), stretch the image instead of keeping its aspect ratio."), G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
                         end,
                         callback = function(touchmenu_instance)
                             Screensaver:setStretchLimit(touchmenu_instance)

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -127,7 +127,7 @@ return {
                 text = _("Covers and images settings"),
                 sub_item_table = {
                     {
-                        text = _("Black background behind covers and images"),
+                        text = _("Black background"),
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_img_background") == "black"
                         end,
@@ -136,7 +136,7 @@ return {
                         end,
                     },
                     {
-                        text = _("White background behind covers and images"),
+                        text = _("White background"),
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_img_background") == "white"
                         end,
@@ -145,7 +145,7 @@ return {
                         end,
                     },
                     {
-                        text = _("Leave background as-is behind covers and images"),
+                        text = _("Leave background as-is"),
                         checked_func = function()
                             return G_reader_settings:readSetting("screensaver_img_background") == "none"
                         end,
@@ -156,12 +156,12 @@ return {
                     {
                         text_func = function()
                             if G_reader_settings:nilOrFalse("screensaver_stretch_images") then
-                                return _("Stretch covers and images to fit screen")
+                                return _("Stretch to fit screen")
                             elseif G_reader_settings:readSetting("screensaver_stretch_limit_percentage") then
-                                return T(_("Stretch covers and images to fit screen: %1%"),
+                                return T(_("Stretch to fit screen: %1%"),
                                     G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
                             else
-                                return _("Stretch covers and images to fit screen: always")
+                                return _("Stretch to fit screen: always")
                             end
                         end,
                         checked_func = function()

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -1,4 +1,5 @@
 local Screensaver = require("ui/screensaver")
+local T = require("ffi/util").template
 local _ = require("gettext")
 
 local function hasLastFile()
@@ -153,12 +154,19 @@ return {
                         end,
                     },
                     {
-                        text = _("Stretch covers and images to fit screen"),
+                        text_func = function()
+                            return T(_("Stretch covers and images to fit screen: %1%"),
+                                G_reader_settings:readSetting("screensaver_stretch_limit_percentage",8))
+                        end,
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_stretch_images")
                         end,
-                        callback = function()
-                            G_reader_settings:toggle("screensaver_stretch_images")
+                        help_text_func = function()
+                            return T(_("If the image and the screen have a similar aspect ratio (±%1%), stretch the image instead of keeping its aspect ratio."),
+                                G_reader_settings:readSetting("screensaver_stretch_limit_percentage"))
+                        end,
+                        callback = function(touchmenu_instance)
+                            Screensaver:setStretchLimit(touchmenu_instance)
                         end,
                         separator = true,
                     },

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -403,7 +403,7 @@ function Screensaver:setStretchLimit(touchmenu_instance)
             G_reader_settings:makeFalse("screensaver_stretch_images")
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
-        option_text = _("Stretch always"),
+        option_text = _("Always stretch"),
         option_callback = function()
             G_reader_settings:makeTrue("screensaver_stretch_images")
             G_reader_settings:delSetting("screensaver_stretch_limit_percentage")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -14,6 +14,7 @@ local ImageWidget = require("ui/widget/imagewidget")
 local Math = require("optmath")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local ScreenSaverWidget = require("ui/widget/screensaverwidget")
+local SpinWidget = require("ui/widget/spinwidget")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local TopContainer = require("ui/widget/container/topcontainer")
 local UIManager = require("ui/uimanager")
@@ -383,6 +384,27 @@ function Screensaver:setMessage()
     self.input_dialog:onShowKeyboard()
 end
 
+function Screensaver:setStretchLimit(touchmenu_instance)
+    UIManager:show(SpinWidget:new{
+        value = G_reader_settings:readSetting("screensaver_stretch_limit_percentage", 8),
+        value_min = 0,
+        value_max = 25,
+        default_value = 8, -- percent
+        title_text = _("Set maximum stretch limit"),
+        ok_text = _("Set"),
+        callback = function(spin)
+            G_reader_settings:saveSetting("screensaver_stretch_limit_percentage", spin.value)
+            G_reader_settings:makeTrue("screensaver_stretch_images")
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+        extra_text = _("Disable"),
+        extra_callback = function()
+            G_reader_settings:makeFalse("screensaver_stretch_images")
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+    })
+end
+
 -- When called after setup(), may not match the saved settings, because it accounts for fallbacks that might have kicked in.
 function Screensaver:getMode()
    return self.screensaver_type
@@ -543,6 +565,7 @@ function Screensaver:show()
             width = Screen:getWidth(),
             height = Screen:getHeight(),
             scale_factor = G_reader_settings:isFalse("screensaver_stretch_images") and 0 or nil,
+            stretch_limit_percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage"),
         }
     elseif self.screensaver_type == "bookstatus" then
         local ReaderUI = require("apps/reader/readerui")
@@ -565,6 +588,7 @@ function Screensaver:show()
             width = Screen:getWidth(),
             height = Screen:getHeight(),
             scale_factor = G_reader_settings:isFalse("screensaver_stretch_images") and 0 or nil,
+            stretch_limit_percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage"),
         }
     elseif self.screensaver_type == "readingprogress" then
         widget = Screensaver.getReaderProgress()

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -392,6 +392,7 @@ function Screensaver:setStretchLimit(touchmenu_instance)
         default_value = 8, -- percent
         title_text = _("Set maximum stretch limit"),
         ok_text = _("Set"),
+        ok_always_enabled = true,
         callback = function(spin)
             G_reader_settings:saveSetting("screensaver_stretch_limit_percentage", spin.value)
             G_reader_settings:makeTrue("screensaver_stretch_images")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -403,7 +403,7 @@ function Screensaver:setStretchLimit(touchmenu_instance)
             G_reader_settings:makeFalse("screensaver_stretch_images")
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
-        option_text = _("Always stretch"),
+        option_text = _("Full stretch"),
         option_callback = function()
             G_reader_settings:makeTrue("screensaver_stretch_images")
             G_reader_settings:delSetting("screensaver_stretch_limit_percentage")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -398,9 +398,15 @@ function Screensaver:setStretchLimit(touchmenu_instance)
             G_reader_settings:makeTrue("screensaver_stretch_images")
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
-        extra_text = _("Disable"),
+        extra_text = _("Disable stretch"),
         extra_callback = function()
             G_reader_settings:makeFalse("screensaver_stretch_images")
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+        option_text = _("Stretch always"),
+        option_callback = function()
+            G_reader_settings:makeTrue("screensaver_stretch_images")
+            G_reader_settings:delSetting("screensaver_stretch_limit_percentage")
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -86,9 +86,11 @@ local ImageWidget = Widget:new{
     --   Special case: scale_factor == 0 : image will be scaled to best fit provided
     --   width and height, keeping aspect ratio (scale_factor will be updated
     --   from 0 to the factor used at _render() time)
-    -- If scale_factor is nil and the aspect ratios of the image and the widget don't differ
-    --   more than stretch_limit_percentage, the image will be stretched to fill widget.
-    -- In all other cases the image will be stretched to fill widget.
+    -- If scale_factor is nil and stretch_limit_percantage is provided,
+    --   then stretch the image to fit the container if the aspect ratios of the image
+    --   and the widget don't differ more than stretch_limit_percentage,
+    --   or scale the image to best fit the container.
+    -- In all other cases the image will be stretched to best fit the container.
     scale_factor = nil,
     stretch_limit_percentage = nil,
 
@@ -285,7 +287,9 @@ function ImageWidget:_render()
         self.scale_factor = self.scale_factor * DPI_SCALE
     end
 
-    local function calc_scale_factor()
+
+    if self.scale_factor == 0 then
+        -- scale to best fit container: compute scale_factor for that
         if self.width and self.height then
             self.scale_factor = math.min(self.width / bb_w, self.height / bb_h)
             logger.dbg("ImageWidget: scale to fit, setting scale_factor to", self.scale_factor)
@@ -293,18 +297,20 @@ function ImageWidget:_render()
             -- no width and height provided (inconsistencies from caller),
             self.scale_factor = 1 -- native image size
         end
-    end
-
-    if self.scale_factor == 0 then
-        -- scale to best fit container: compute scale_factor for that
-        calc_scale_factor()
     elseif not self.scale_factor and self.stretch_limit_percentage then
         -- stretch or scale to fit container, depending on self.stretch_limit_percentage
         local screen_ratio = self.width / self.height
         local image_ratio = bb_w / bb_h
         local ratio_divergence_percent = math.abs(100 - image_ratio / screen_ratio * 100)
         if ratio_divergence_percent > self.stretch_limit_percentage then
-            calc_scale_factor()
+            -- scale to best fit container: see above
+            if self.width and self.height then
+                self.scale_factor = math.min(self.width / bb_w, self.height / bb_h)
+                logger.dbg("ImageWidget: scale to fit, setting scale_factor to", self.scale_factor)
+            else
+                -- no width and height provided (inconsistencies from caller),
+                self.scale_factor = 1 -- native image size
+            end
         end
     end
 

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -87,10 +87,9 @@ local ImageWidget = Widget:new{
     --   width and height, keeping aspect ratio (scale_factor will be updated
     --   from 0 to the factor used at _render() time)
     -- If scale_factor is nil and stretch_limit_percantage is provided:
-    --   If the aspect ratios of the image and the widget don't differ more than stretch_limit_percentage,
-    --      then stretch
-    --      else scale
-    --   the image to best fit the container.
+    --   If the aspect ratios of the image and the width/height provided don't differ by more than
+    --   stretch_limit_percentage, then stretch the image (as scale_factor=nil);
+    --   otherwise, scale to best fit (as scale_factor=0)
     -- In all other cases the image will be stretched to best fit the container.
     scale_factor = nil,
     stretch_limit_percentage = nil,
@@ -288,6 +287,15 @@ function ImageWidget:_render()
         self.scale_factor = self.scale_factor * DPI_SCALE
     end
 
+    if self.stretch_limit_percentage and not self.scale_factor then
+        -- stretch or scale to fit container, depending on self.stretch_limit_percentage
+        local screen_ratio = self.width / self.height
+        local image_ratio = bb_w / bb_h
+        local ratio_divergence_percent = math.abs(100 - image_ratio / screen_ratio * 100)
+        if ratio_divergence_percent > self.stretch_limit_percentage then
+            self.scale_factor = 0
+        end
+    end
 
     if self.scale_factor == 0 then
         -- scale to best fit container: compute scale_factor for that
@@ -297,21 +305,6 @@ function ImageWidget:_render()
         else
             -- no width and height provided (inconsistencies from caller),
             self.scale_factor = 1 -- native image size
-        end
-    elseif not self.scale_factor and self.stretch_limit_percentage then
-        -- stretch or scale to fit container, depending on self.stretch_limit_percentage
-        local screen_ratio = self.width / self.height
-        local image_ratio = bb_w / bb_h
-        local ratio_divergence_percent = math.abs(100 - image_ratio / screen_ratio * 100)
-        if ratio_divergence_percent > self.stretch_limit_percentage then
-            -- scale to best fit container: see above
-            if self.width and self.height then
-                self.scale_factor = math.min(self.width / bb_w, self.height / bb_h)
-                logger.dbg("ImageWidget: scale to fit, setting scale_factor to", self.scale_factor)
-            else
-                -- no width and height provided (inconsistencies from caller),
-                self.scale_factor = 1 -- native image size
-            end
         end
     end
 

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -86,10 +86,11 @@ local ImageWidget = Widget:new{
     --   Special case: scale_factor == 0 : image will be scaled to best fit provided
     --   width and height, keeping aspect ratio (scale_factor will be updated
     --   from 0 to the factor used at _render() time)
-    -- If scale_factor is nil and stretch_limit_percantage is provided,
-    --   then stretch the image to fit the container if the aspect ratios of the image
-    --   and the widget don't differ more than stretch_limit_percentage,
-    --   or scale the image to best fit the container.
+    -- If scale_factor is nil and stretch_limit_percantage is provided:
+    --   If the aspect ratios of the image and the widget don't differ more than stretch_limit_percentage,
+    --      then stretch
+    --      else scale
+    --   the image to best fit the container.
     -- In all other cases the image will be stretched to best fit the container.
     scale_factor = nil,
     stretch_limit_percentage = nil,

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -81,12 +81,16 @@ local ImageWidget = Widget:new{
     -- If scale_for_dpi is true image will be rescaled according to screen dpi
     scale_for_dpi = false,
 
-    -- When scale_factor is not nil, native image is scaled by this factor
-    -- (if scale_factor == 1, native image size is kept)
-    -- Special case : scale_factor == 0 : image will be scaled to best fit provided
-    -- width and height, keeping aspect ratio (scale_factor will be updated
-    -- from 0 to the factor used at _render() time)
+    -- When scale_factor is not nil, native image is scaled by this factor,
+    --   (if scale_factor == 1, native image size is kept)
+    --   Special case: scale_factor == 0 : image will be scaled to best fit provided
+    --   width and height, keeping aspect ratio (scale_factor will be updated
+    --   from 0 to the factor used at _render() time)
+    -- If scale_factor is nil and the aspect ratios of the image and the widget don't differ
+    --   more than stretch_limit_percentage, the image will be stretched to fill widget.
+    -- In all other cases the image will be stretched to fill widget.
     scale_factor = nil,
+    stretch_limit_percentage = nil,
 
     -- Whether to use former blitbuffer:scale() (default to using MuPDF)
     use_legacy_image_scaling = G_reader_settings:isTrue("legacy_image_scaling"),
@@ -281,14 +285,26 @@ function ImageWidget:_render()
         self.scale_factor = self.scale_factor * DPI_SCALE
     end
 
-    -- scale to best fit container : compute scale_factor for that
-    if self.scale_factor == 0 then
+    local function calc_scale_factor()
         if self.width and self.height then
             self.scale_factor = math.min(self.width / bb_w, self.height / bb_h)
             logger.dbg("ImageWidget: scale to fit, setting scale_factor to", self.scale_factor)
         else
             -- no width and height provided (inconsistencies from caller),
             self.scale_factor = 1 -- native image size
+        end
+    end
+
+    if self.scale_factor == 0 then
+        -- scale to best fit container: compute scale_factor for that
+        calc_scale_factor()
+    elseif not self.scale_factor and self.stretch_limit_percentage then
+        -- stretch or scale to fit container, depending on self.stretch_limit_percentage
+        local screen_ratio = self.width / self.height
+        local image_ratio = bb_w / bb_h
+        local ratio_divergence_percent = math.abs(100 - image_ratio / screen_ratio * 100)
+        if ratio_divergence_percent > self.stretch_limit_percentage then
+            calc_scale_factor()
         end
     end
 

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -47,9 +47,12 @@ local SpinWidget = InputContainer:new{
     -- Set this to add upper default button that restores number to its default value
     default_value = nil,
     default_text = nil,
-    -- Optional extra button above ok/cancel buttons row
+    -- Optional extra button
     extra_text = nil,
     extra_callback = nil,
+    -- Optional extra button above ok/cancel buttons row
+    option_text = nil,
+    option_callback = nil,
 }
 
 function SpinWidget:init()

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -141,37 +141,37 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
             },
         })
     end
-    if self.extra_text then
-        table.insert(buttons, {
-            {
-                text = self.extra_text,
-                callback = function()
-                    if self.extra_callback then
-                        self.value, self.value_index = value_widget:getValue()
-                        self.extra_callback(self)
-                    end
-                    if not self.keep_shown_on_apply then -- assume extra wants it same as ok
-                        self:onClose()
-                    end
-                end,
-            },
-        })
-    end
-    if self.option_text then
-        table.insert(buttons, {
-            {
-                text = self.option_text,
-                callback = function()
-                    if self.option_callback then
-                        self.value, self.value_index = value_widget:getValue()
-                        self.option_callback(self)
-                    end
-                    if not self.keep_shown_on_apply then -- assume option wants it same as ok
-                        self:onClose()
-                    end
-                end,
-            },
-        })
+
+    local extra_button = {
+        text = self.extra_text,
+        callback = function()
+            if self.extra_callback then
+                self.value, self.value_index = value_widget:getValue()
+                self.extra_callback(self)
+            end
+            if not self.keep_shown_on_apply then -- assume extra wants it same as ok
+                self:onClose()
+            end
+        end,
+    }
+    local option_button = {
+        text = self.option_text,
+        callback = function()
+            if self.option_callback then
+                self.value, self.value_index = value_widget:getValue()
+                self.option_callback(self)
+            end
+            if not self.keep_shown_on_apply then -- assume option wants it same as ok
+                self:onClose()
+            end
+        end,
+    }
+    if self.extra_text and not self.option_text then
+        table.insert(buttons, {extra_button})
+    elseif self.option_text and not self.extra_text then
+        table.insert(buttons, {option_button})
+    elseif self.extra_text and self.option_text then
+        table.insert(buttons, {extra_button, option_button})
     end
     table.insert(buttons, {
         {

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -154,6 +154,22 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
             },
         })
     end
+    if self.option_text then
+        table.insert(buttons, {
+            {
+                text = self.option_text,
+                callback = function()
+                    if self.option_callback then
+                        self.value, self.value_index = value_widget:getValue()
+                        self.option_callback(self)
+                    end
+                    if not self.keep_shown_on_apply then -- assume option wants it same as ok
+                        self:onClose()
+                    end
+                end,
+            },
+        })
+    end
     table.insert(buttons, {
         {
             text = self.cancel_text,


### PR DESCRIPTION
The `screensaver` has much more possibilities as the `coverimage.plugin`. The only thing I am missing, is to set a threshold for stretching the image: If the aspect ratios of the image (cover) and the screen don't differ too much then stretch, else scale the image (cover).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8570)
<!-- Reviewable:end -->
