### PR TITLE
ReaderHighlight: unlock "View HTML"

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -161,7 +161,7 @@ function ReaderHighlight:init()
     end
 
     -- cre documents only
-    if self.ui.rolling then
+    if not self.document.info.has_pages then
         self:addToHighlightDialog("09_view_html", function(_self)
             return {
                 text = _("View HTML"),


### PR DESCRIPTION
Rolling is not ready at the moment of init yet. Regression after https://github.com/koreader/koreader/pull/8541.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8573)
<!-- Reviewable:end -->
