### PR TITLE
Filemanager/History: fix book move/rename

### DIFF
--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -258,6 +258,7 @@ function ReadHistory:updateItemByPath(old_path, new_path)
             self.hist[i].file = new_path
             self.hist[i].text = new_path:gsub(".*/", "")
             self:_flush()
+            self:reload()
             self.hist[i].callback = function()
                 selectCallback(new_path)
             end


### PR DESCRIPTION
Fix: cannot open a book from History immediately after moving or renaming the file in the file browser.
Closes https://github.com/koreader/koreader/issues/8574.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8575)
<!-- Reviewable:end -->
