### PR TITLE
TextViewer: fix refresh

### DIFF
--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -63,7 +63,6 @@ local TextViewer = InputContainer:new{
 }
 
 function TextViewer:init()
-    local orig_dimen = self.frame and self.frame.dimen or Geom:new{}
     -- calculate window dimension
     self.align = "center"
     self.region = Geom:new{
@@ -221,9 +220,7 @@ function TextViewer:init()
         self.movable,
     }
     UIManager:setDirty(self, function()
-        local update_region = self.frame.dimen:combine(orig_dimen)
-        logger.dbg("update region", update_region)
-        return "partial", update_region
+        return "partial", self.frame.dimen
     end)
 end
 


### PR DESCRIPTION
When TextViewer is showing up, it causes screen refresh of the rectangle from the upper left corner of the screen (0,0) till the lower right corner of the TextViewer window (the result of `combine`).
So when the TextViewer is not full-screen, left and upper parts of the screen are refreshed.
This unpleasent screen flashing can be seen, for exampe, when showing book description from the Book information page, or when calling the clipboard (long-press on the text input box).
Let's show the TextViewer in a usual way, as (almost) all other widgets do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8576)
<!-- Reviewable:end -->
