### PR TITLE
Exporter plugin: html template fix

### DIFF
--- a/plugins/exporter.koplugin/note.tpl
+++ b/plugins/exporter.koplugin/note.tpl
@@ -50,37 +50,37 @@
 }#
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta charset="utf-8"/>
-  </head>
-  <body>
-    <div style="width:90%; max-width:600px; margin:0px auto; padding:5px; font-size:12pt; font-family:Georgia">
-      <h2 style="font-size:18pt; text-align:right;">#{= htmlescape(booknotes.title) }#</h2>
-      <h5 style="font-size:12pt; text-align:right; color:gray;">#{= htmlescape(booknotes.author) }#</h5>
-      #{ for  _, chapter in ipairs(booknotes) do }#
-        #{ if chapter.title then }#
-          <div style="font-size:14pt; font-weight:bold; text-align:center; margin:0.5em;"><span>#{= htmlescape(chapter.title) }#</span></div>
-        #{ end }#
-        #{ for index, clipping in ipairs(chapter) do }#
-          <div style="padding-top:0.5em; padding-bottom:0.5em;#{ if index > 1 then }# border-top:1px dotted lightgray;#{ end }#">
-            <div style="font-size:10pt; margin-bottom:0.2em; color:darkgray">
-              <div style="display:inline-block; width:0.2em; height:0.9em; margin-right:0.2em; background-color:#{= timecolor(clipping.time)}#;"></div>
-              <span>#{= os.date("%x", clipping.time) }#</span><span style="float:right">#{ if clipping.chapter then }#<b>#{= clipping.chapter }#</b>: #{ end }# #{= clipping.page }#</span>
-            </div>
-            <div style="font-size:12pt">
-              <span>#{= newline_to_br(htmlescape(clipping.text)) }#</span>
-              #{ if clipping.image then }#
-                <en-media type="image/png" hash="#{= clipping.image.hash }#"/>
-              #{ end }#
-            </div>
-            #{ if clipping.note then }#
-              <div style="font-size:11pt; margin-top:0.2em; margin-left:2em;">
-                <span style="color:#888888">#{= newline_to_br(htmlescape(clipping.note)) }#</span>
-              </div>
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <div style="width:90%; max-width:600px; margin:0px auto; padding:5px; font-size:12pt; font-family:Georgia">
+    <h2 style="font-size:18pt; text-align:right;">#{= htmlescape(booknotes.title) }#</h2>
+    <h5 style="font-size:12pt; text-align:right; color:gray;">#{= htmlescape(booknotes.author) }#</h5>
+    #{ for  _, chapter in ipairs(booknotes) do }#
+      #{ if chapter.title then }#
+        <div style="font-size:14pt; font-weight:bold; text-align:center; margin:0.5em;"><span>#{= htmlescape(chapter.title) }#</span></div>
+      #{ end }#
+      #{ for index, clipping in ipairs(chapter) do }#
+        <div style="padding-top:0.5em; padding-bottom:0.5em;#{ if index > 1 then }# border-top:1px dotted lightgray;#{ end }#">
+          <div style="font-size:10pt; margin-bottom:0.2em; color:darkgray">
+            <div style="display:inline-block; width:0.2em; height:0.9em; margin-right:0.2em; background-color:#{= timecolor(clipping.time)}#;"></div>
+            <span>#{= os.date("%x", clipping.time) }#</span><span style="float:right">#{ if clipping.chapter then }#<b>#{= clipping.chapter }#</b>: #{ end }# #{= clipping.page }#</span>
+          </div>
+          <div style="font-size:12pt">
+            <span>#{= newline_to_br(htmlescape(clipping.text)) }#</span>
+            #{ if clipping.image then }#
+              <en-media type="image/png" hash="#{= clipping.image.hash }#"/>
             #{ end }#
           </div>
-        #{ end }#
+          #{ if clipping.note then }#
+            <div style="font-size:11pt; margin-top:0.2em; margin-left:2em;">
+              <span style="color:#888888">#{= newline_to_br(htmlescape(clipping.note)) }#</span>
+            </div>
+          #{ end }#
+        </div>
       #{ end }#
-    </div>
-  </body>
+    #{ end }#
+  </div>
+</body>
 </html>

--- a/plugins/exporter.koplugin/note.tpl
+++ b/plugins/exporter.koplugin/note.tpl
@@ -55,7 +55,7 @@
   <title>#{= htmlescape(booknotes.title) }#</title>
 </head>
 <body>
-  <div style="width:90%; max-width:600px; margin:0px auto; padding:5px; font-size:12pt; font-family:Georgia">
+  <div style="width:90%; max-width:600px; margin:0 auto; padding:5px; font-size:12pt; font-family:Georgia, serif">
     <h2 style="font-size:18pt; text-align:right;">#{= htmlescape(booknotes.title) }#</h2>
     <h5 style="font-size:12pt; text-align:right; color:gray;">#{= htmlescape(booknotes.author) }#</h5>
     #{ for  _, chapter in ipairs(booknotes) do }#

--- a/plugins/exporter.koplugin/note.tpl
+++ b/plugins/exporter.koplugin/note.tpl
@@ -49,33 +49,38 @@
   end
 }#
 <!DOCTYPE html>
-<meta charset="utf-8"/>
-<div style="width:90%; max-width:600px; margin:0px auto; padding:5px; font-size:12pt; font-family:Georgia">
-  <h2 style="font-size:18pt; text-align:right;">#{= htmlescape(booknotes.title) }#</h2>
-  <h5 style="font-size:12pt; text-align:right; color:gray;">#{= htmlescape(booknotes.author) }#</h5>
-  #{ for  _, chapter in ipairs(booknotes) do }#
-    #{ if chapter.title then }#
-      <div style="font-size:14pt; font-weight:bold; text-align:center; margin:0.5em;"><span>#{= htmlescape(chapter.title) }#</span></div>
-    #{ end }#
-    #{ for index, clipping in ipairs(chapter) do }#
-      <div style="padding-top:0.5em; padding-bottom:0.5em;#{ if index > 1 then }# border-top:1px dotted lightgray;#{ end }#">
-        <div style="font-size:10pt; margin-bottom:0.2em; color:darkgray">
-          <div style="display:inline-block; width:0.2em; height:0.9em; margin-right:0.2em; background-color:#{= timecolor(clipping.time)}#;"></div>
-          <span>#{= os.date("%x", clipping.time) }#</span><span style="float:right">#{ if clipping.chapter then }#<b>#{= clipping.chapter }#</b>: #{ end }# #{= clipping.page }#</span>
-        </div>
-        <div style="font-size:12pt">
-          <span>#{= newline_to_br(htmlescape(clipping.text)) }#</span>
-          #{ if clipping.image then }#
-            <en-media type="image/png" hash="#{= clipping.image.hash }#"/>
-          #{ end }#
-        </div>
-        #{ if clipping.note then }#
-          <div style="font-size:11pt; margin-top:0.2em;">
-            <span style="font-weight:bold;">#{= htmlescape(notemarks) }#</span>
-            <span style="color:#888888">#{= newline_to_br(htmlescape(clipping.note)) }#</span>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8"/>
+  </head>
+  <body>
+    <div style="width:90%; max-width:600px; margin:0px auto; padding:5px; font-size:12pt; font-family:Georgia">
+      <h2 style="font-size:18pt; text-align:right;">#{= htmlescape(booknotes.title) }#</h2>
+      <h5 style="font-size:12pt; text-align:right; color:gray;">#{= htmlescape(booknotes.author) }#</h5>
+      #{ for  _, chapter in ipairs(booknotes) do }#
+        #{ if chapter.title then }#
+          <div style="font-size:14pt; font-weight:bold; text-align:center; margin:0.5em;"><span>#{= htmlescape(chapter.title) }#</span></div>
+        #{ end }#
+        #{ for index, clipping in ipairs(chapter) do }#
+          <div style="padding-top:0.5em; padding-bottom:0.5em;#{ if index > 1 then }# border-top:1px dotted lightgray;#{ end }#">
+            <div style="font-size:10pt; margin-bottom:0.2em; color:darkgray">
+              <div style="display:inline-block; width:0.2em; height:0.9em; margin-right:0.2em; background-color:#{= timecolor(clipping.time)}#;"></div>
+              <span>#{= os.date("%x", clipping.time) }#</span><span style="float:right">#{ if clipping.chapter then }#<b>#{= clipping.chapter }#</b>: #{ end }# #{= clipping.page }#</span>
+            </div>
+            <div style="font-size:12pt">
+              <span>#{= newline_to_br(htmlescape(clipping.text)) }#</span>
+              #{ if clipping.image then }#
+                <en-media type="image/png" hash="#{= clipping.image.hash }#"/>
+              #{ end }#
+            </div>
+            #{ if clipping.note then }#
+              <div style="font-size:11pt; margin-top:0.2em; margin-left:2em;">
+                <span style="color:#888888">#{= newline_to_br(htmlescape(clipping.note)) }#</span>
+              </div>
+            #{ end }#
           </div>
         #{ end }#
-      </div>
-    #{ end }#
-  #{ end }#
-</div>
+      #{ end }#
+    </div>
+  </body>
+</html>

--- a/plugins/exporter.koplugin/note.tpl
+++ b/plugins/exporter.koplugin/note.tpl
@@ -52,6 +52,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8"/>
+  <title>#{= htmlescape(booknotes.title) }#</title>
 </head>
 <body>
   <div style="width:90%; max-width:600px; margin:0px auto; padding:5px; font-size:12pt; font-family:Georgia">


### PR DESCRIPTION
Changes in accordance with https://github.com/koreader/koreader/issues/8535:
-add `html` and `body` tags to support older embedded browsers
-bookmark note formatting: grey letters, indented, without title
(Massive changes are caused with the indentation along the tags).

Screenshots: original text with 2 highlights, the note to the 2nd highlight, exported html.

![01](https://user-images.githubusercontent.com/62179190/147406712-635f690c-2cb7-48c6-bece-ce6823228c4a.png)

![02](https://user-images.githubusercontent.com/62179190/147406713-38b816c8-e8cb-424c-b142-dcc7c5156aea.png)

![03](https://user-images.githubusercontent.com/62179190/147406715-8c525044-09ff-4f9d-9de5-0af9b1e8f48a.png)

Closes https://github.com/koreader/koreader/issues/8535.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8592)
<!-- Reviewable:end -->
