### PR TITLE
Filemanager select mode: add folder buttons

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -723,7 +723,7 @@ function FileManager:tapPlus()
                     text = _("New folder"),
                     callback = function()
                         UIManager:close(self.file_dialog)
-                        self:createFolderDialog()
+                        self:createFolder()
                     end,
                 },
                 {
@@ -752,7 +752,7 @@ function FileManager:tapPlus()
                     text = _("New folder"),
                     callback = function()
                         UIManager:close(self.file_dialog)
-                        self:createFolderDialog()
+                        self:createFolder()
                     end,
                 },
             },
@@ -1079,20 +1079,7 @@ function FileManager:pasteHere(file)
     end
 end
 
-function FileManager:createFolder(folder)
-    local code = BaseUtil.execute(self.mkdir_bin, folder)
-    if code == 0 then
-        self:onRefresh()
-        return true
-    else
-        UIManager:show(InfoMessage:new{
-            text = T(_("Failed to create folder:\n%1"), BD.directory(BaseUtil.basename(folder))),
-            icon = "notice-warning",
-        })
-    end
-end
-
-function FileManager:createFolderDialog()
+function FileManager:createFolder()
     local input_dialog, check_button_enter_folder
     input_dialog = InputDialog:new{
         title = _("New folder"),
@@ -1108,12 +1095,21 @@ function FileManager:createFolderDialog()
                     text = _("Create"),
                     is_enter_default = true,
                     callback = function()
-                        local new_folder = input_dialog:getInputText()
-                        if new_folder == "" then return end
+                        local new_folder_name = input_dialog:getInputText()
+                        if new_folder_name == "" then return end
                         UIManager:close(input_dialog)
-                        new_folder = string.format("%s/%s", self.file_chooser.path, new_folder)
-                        if self:createFolder(new_folder) and check_button_enter_folder.checked then
-                            self.file_chooser:changeToPath(new_folder)
+                        local new_folder = string.format("%s/%s", self.file_chooser.path, new_folder_name)
+                        if BaseUtil.execute(self.mkdir_bin, new_folder) == 0 then
+                            if check_button_enter_folder.checked then
+                                self.file_chooser:changeToPath(new_folder)
+                            else
+                                self.file_chooser:refreshPath()
+                            end
+                        else
+                            UIManager:show(InfoMessage:new{
+                                text = T(_("Failed to create folder:\n%1"), BD.directory(new_folder_name)),
+                                icon = "notice-warning",
+                            })
                         end
                     end,
                 },

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -3,6 +3,7 @@ local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local CenterContainer = require("ui/widget/container/centercontainer")
+local CheckButton = require("ui/widget/checkbutton")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local DeviceListener = require("device/devicelistener")
@@ -716,6 +717,23 @@ function FileManager:tapPlus()
                     end
                 },
             },
+            {},
+            {
+                {
+                    text = _("New folder"),
+                    callback = function()
+                        UIManager:close(self.file_dialog)
+                        self:createFolderDialog()
+                    end,
+                },
+                {
+                    text = _("Folder shortcuts"),
+                    callback = function()
+                        UIManager:close(self.file_dialog)
+                        self:handleEvent(Event:new("ShowFolderShortcutsDialog"))
+                    end
+                },
+            },
         }
     else
         title = BD.dirpath(filemanagerutil.abbreviate(self.file_chooser.path))
@@ -734,31 +752,7 @@ function FileManager:tapPlus()
                     text = _("New folder"),
                     callback = function()
                         UIManager:close(self.file_dialog)
-                        self.input_dialog = InputDialog:new{
-                            title = _("New folder"),
-                            buttons = {
-                                {
-                                    {
-                                        text = _("Cancel"),
-                                        callback = function()
-                                            self:closeInputDialog()
-                                        end,
-                                    },
-                                    {
-                                        text = _("Create"),
-                                        callback = function()
-                                            local new_folder = self.input_dialog:getInputText()
-                                            if new_folder and new_folder ~= "" then
-                                                self:createFolder(self.file_chooser.path, new_folder)
-                                                self:closeInputDialog()
-                                            end
-                                        end,
-                                    },
-                                }
-                            },
-                        }
-                        UIManager:show(self.input_dialog)
-                        self.input_dialog:onShowKeyboard()
+                        self:createFolderDialog()
                     end,
                 },
             },
@@ -1085,17 +1079,55 @@ function FileManager:pasteHere(file)
     end
 end
 
-function FileManager:createFolder(curr_folder, new_folder)
-    local folder = string.format("%s/%s", curr_folder, new_folder)
+function FileManager:createFolder(folder)
     local code = BaseUtil.execute(self.mkdir_bin, folder)
     if code == 0 then
         self:onRefresh()
+        return true
     else
         UIManager:show(InfoMessage:new{
-            text = T(_("Failed to create folder:\n%1"), BD.directory(new_folder)),
+            text = T(_("Failed to create folder:\n%1"), BD.directory(BaseUtil.basename(folder))),
             icon = "notice-warning",
         })
     end
+end
+
+function FileManager:createFolderDialog()
+    local input_dialog, check_button_enter_folder
+    input_dialog = InputDialog:new{
+        title = _("New folder"),
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    callback = function()
+                        UIManager:close(input_dialog)
+                    end,
+                },
+                {
+                    text = _("Create"),
+                    is_enter_default = true,
+                    callback = function()
+                        local new_folder = input_dialog:getInputText()
+                        if new_folder == "" then return end
+                        UIManager:close(input_dialog)
+                        new_folder = string.format("%s/%s", self.file_chooser.path, new_folder)
+                        if self:createFolder(new_folder) and check_button_enter_folder.checked then
+                            self.file_chooser:changeToPath(new_folder)
+                        end
+                    end,
+                },
+            }
+        },
+    }
+    check_button_enter_folder = CheckButton:new{
+        text = _("Enter folder after creation"),
+        checked = false,
+        parent = input_dialog,
+    }
+    input_dialog:addWidget(check_button_enter_folder)
+    UIManager:show(input_dialog)
+    input_dialog:onShowKeyboard()
 end
 
 function FileManager:deleteFile(file)


### PR DESCRIPTION
In select mode there is no access to the Plus menu.
For easy navigation let's add `New folder` and `Folder shortcuts` buttons to the select popup menu.

Additionally: new checkbox `Enter folder after creation` in the folder creation dialog.

![01](https://user-images.githubusercontent.com/62179190/147443275-226a12ec-9418-480a-898a-5a63a7148834.png)

![02](https://user-images.githubusercontent.com/62179190/147443287-b3baa4ae-d5c4-48a0-885c-b2e8f1cb7c90.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8595)
<!-- Reviewable:end -->
