### PR TITLE
FileChooser: fix and show number of files

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -282,7 +282,10 @@ function FileChooser:genItemTableFromPath(path)
         local dir_files = {}
         local subdir_path = self.path.."/"..dir.name
         self.list(subdir_path, sub_dirs, dir_files, true)
-        local istr = T("%1 • %2", #sub_dirs, #dir_files)
+        local istr = T("%1 \u{F016}", #dir_files)
+        if #sub_dirs > 0 then
+            istr = T("%1 \u{F114} ", #sub_dirs) .. istr
+        end
         local text
         local bidi_wrap_func
         if dir.name == ".." then

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -277,17 +277,8 @@ function FileChooser:genItemTableFromPath(path)
 
     local item_table = {}
     for i, dir in ipairs(dirs) do
-        -- count number of folders and files inside dir
-        local sub_dirs = {}
-        local dir_files = {}
         local subdir_path = self.path.."/"..dir.name
-        self.list(subdir_path, sub_dirs, dir_files, true)
-        local istr = T("%1 \u{F016}", #dir_files)
-        if #sub_dirs > 0 then
-            istr = T("%1 \u{F114} ", #sub_dirs) .. istr
-        end
-        local text
-        local bidi_wrap_func
+        local text, bidi_wrap_func, istr
         if dir.name == ".." then
             text = up_folder_arrow
         elseif dir.name == "." then -- possible with show_current_dir_for_hold
@@ -297,6 +288,14 @@ function FileChooser:genItemTableFromPath(path)
         else
             text = dir.name.."/"
             bidi_wrap_func = BD.directory
+            -- count number of folders and files inside dir
+            local sub_dirs = {}
+            local dir_files = {}
+            self.list(subdir_path, sub_dirs, dir_files, true)
+            istr = T("%1 \u{F016}", #dir_files)
+            if #sub_dirs > 0 then
+                istr = T("%1 \u{F114} ", #sub_dirs) .. istr
+            end
         end
         table.insert(item_table, {
             text = text,


### PR DESCRIPTION
(1) If files filtering is enabled, PathChooser shows full number of files in subfolders, instead of the number of filtered files.
Example: choose an image for screensaver. Only image files are filtered, but the total number of files in subfolders is displayed. 
Fixed.
(2) Number of folders and number of files in subfolders are displayed separately.

![01](https://user-images.githubusercontent.com/62179190/147567055-050e851a-7ccd-458a-ac79-8981c6807d68.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8598)
<!-- Reviewable:end -->
