### PR TITLE
Menu widget: title bar resize

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -669,7 +669,7 @@ function Menu:init()
     local icon_size = Screen:scaleBySize(DGENERIC_ICON_SIZE * 0.6) -- left and right title buttons
     local title_text_width = self.inner_dimen.w - 2 * Size.padding.large
     self.menu_title = TextWidget:new{
-        face = Font:getFace("tfont"),
+        face = Font:getFace("smalltfont"),
         text = self.title,
         max_width = title_text_width - (Device:isTouchDevice() and 2 * icon_size or 0),
         overlap_align = "center",
@@ -701,6 +701,7 @@ function Menu:init()
     end
     self.menu_title_group = VerticalGroup:new{
         align = "center",
+        VerticalSpan:new{width = Screen:scaleBySize(3)},
         menu_title_container,
         path_text_container,
     }
@@ -925,16 +926,15 @@ function Menu:init()
     -- start to set up input event callback --
     ------------------------------------------
     if Device:isTouchDevice() then
-        local button_padding = Screen:scaleBySize(8)
-        local tap_zone_padding = 2 * icon_size
+        local button_padding = Screen:scaleBySize(11)
         if self.has_extra_button then
             self.extra_button = IconButton:new{
                 icon = self.extra_button_icon or "appbar.menu",
                 width = icon_size,
                 height = icon_size,
                 padding = button_padding,
-                padding_right = tap_zone_padding, -- extend button tap zone
-                padding_bottom = tap_zone_padding,
+                padding_right = 2 * icon_size, -- extend button tap zone
+                padding_bottom = icon_size,
                 overlap_align = "left",
                 callback = function() self:onExtraButtonTap() end,
                 hold_callback = function() self:onExtraButtonHold() end,
@@ -947,8 +947,8 @@ function Menu:init()
                 width = icon_size,
                 height = icon_size,
                 padding = button_padding,
-                padding_left = tap_zone_padding, -- extend button tap zone
-                padding_bottom = tap_zone_padding,
+                padding_left = 2 * icon_size, -- extend button tap zone
+                padding_bottom = icon_size,
                 overlap_align = "right",
                 callback = function() self:onClose() end,
             }

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -666,7 +666,7 @@ function Menu:init()
     -----------------------------------
     -- start to set up widget layout --
     -----------------------------------
-    local icon_size = Screen:scaleBySize(DGENERIC_ICON_SIZE * 0.8) -- left and right title buttons
+    local icon_size = Screen:scaleBySize(DGENERIC_ICON_SIZE * 0.6) -- left and right title buttons
     local title_text_width = self.inner_dimen.w - 2 * Size.padding.large
     self.menu_title = TextWidget:new{
         face = Font:getFace("tfont"),
@@ -701,7 +701,6 @@ function Menu:init()
     end
     self.menu_title_group = VerticalGroup:new{
         align = "center",
-        VerticalSpan:new{width = self.header_padding},
         menu_title_container,
         path_text_container,
     }
@@ -927,14 +926,15 @@ function Menu:init()
     ------------------------------------------
     if Device:isTouchDevice() then
         local button_padding = Screen:scaleBySize(8)
+        local tap_zone_padding = 2 * icon_size
         if self.has_extra_button then
             self.extra_button = IconButton:new{
                 icon = self.extra_button_icon or "appbar.menu",
                 width = icon_size,
                 height = icon_size,
                 padding = button_padding,
-                padding_right = icon_size, -- extend button tap zone
-                padding_bottom = 0,
+                padding_right = tap_zone_padding, -- extend button tap zone
+                padding_bottom = tap_zone_padding,
                 overlap_align = "left",
                 callback = function() self:onExtraButtonTap() end,
                 hold_callback = function() self:onExtraButtonHold() end,
@@ -947,8 +947,8 @@ function Menu:init()
                 width = icon_size,
                 height = icon_size,
                 padding = button_padding,
-                padding_left = icon_size, -- extend button tap zone
-                padding_bottom = 0,
+                padding_left = tap_zone_padding, -- extend button tap zone
+                padding_bottom = tap_zone_padding,
                 overlap_align = "right",
                 callback = function() self:onClose() end,
             }


### PR DESCRIPTION
Resize of the Menu widget title bar elements (discussed in https://github.com/koreader/koreader/issues/8549):
(1) No padding above the title
(2) Smaller left and right buttons icons
(3) Extended left and right buttons tap zones

![06](https://user-images.githubusercontent.com/62179190/147828257-fd992597-e263-4d4f-8df5-49ac6c7dc555.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8603)
<!-- Reviewable:end -->
