### PR TITLE
[Non-Touch] Don't add touch-related menu items

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -358,7 +358,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
     menu_items.translation_settings = Translator:genSettingsMenu()
 
     if not Device:isTouchDevice() then
-        -- Menu items below aren't needed
+        -- Menu items below aren't needed.
         return
     end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -356,6 +356,12 @@ function ReaderHighlight:addToMainMenu(menu_items)
         }
     end
     menu_items.translation_settings = Translator:genSettingsMenu()
+
+    if not Device:isTouchDevice() then
+        -- Menu items below aren't needed
+        return
+    end
+
     menu_items.long_press = {
         text = _("Long-press on text"),
         sub_item_table = {

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -151,6 +151,25 @@ end
 
 function ReaderLink:addToMainMenu(menu_items)
     -- insert table to main reader menu
+    menu_items.go_to_previous_location = {
+        text = _("Go back to previous location"),
+        enabled_func = function() return #self.location_stack > 0 end,
+        callback = function() self:onGoBackLink() end,
+        hold_callback = function(touchmenu_instance)
+            UIManager:show(ConfirmBox:new{
+                text = _("Clear location history?"),
+                ok_text = _("Clear"),
+                ok_callback = function()
+                    self:onClearLocationStack()
+                    touchmenu_instance:closeMenu()
+                end,
+            })
+        end,
+    }
+    if not Device:isTouchDevice() then
+        -- Menu items below aren't needed
+        return
+    end
     menu_items.follow_links = {
         text = _("Links"),
         sub_item_table = {
@@ -342,21 +361,6 @@ This allows you to specify how much smaller or larger it should be relative to t
             separator = true,
         })
     end
-    menu_items.go_to_previous_location = {
-        text = _("Go back to previous location"),
-        enabled_func = function() return #self.location_stack > 0 end,
-        callback = function() self:onGoBackLink() end,
-        hold_callback = function(touchmenu_instance)
-            UIManager:show(ConfirmBox:new{
-                text = _("Clear location history?"),
-                ok_text = _("Clear"),
-                ok_callback = function()
-                    self:onClearLocationStack()
-                    touchmenu_instance:closeMenu()
-                end,
-            })
-        end,
-    }
 end
 
 --- Check if a xpointer to <a> node really points to itself

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -167,7 +167,7 @@ function ReaderLink:addToMainMenu(menu_items)
         end,
     }
     if not Device:isTouchDevice() then
-        -- Menu items below aren't needed
+        -- Menu items below aren't needed.
         return
     end
     menu_items.follow_links = {

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -204,7 +204,7 @@ function ReaderMenu:setUpdateItemTable()
     if Device:isTouchDevice() then
         self.menu_items.page_turns = require("ui/elements/page_turns")
     else
-        -- Placed elsewhere than in Taps and gestures, with only a subset of menu items
+        -- Placed elsewhere than in Taps and gestures, with only a subset of menu items.
         self.menu_items.page_turns_non_touch = require("ui/elements/page_turns")
     end
     -- insert DjVu render mode submenu just before the last entry (show advanced)

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -200,7 +200,13 @@ function ReaderMenu:setUpdateItemTable()
     for id, common_setting in pairs(dofile("frontend/ui/elements/common_settings_menu_table.lua")) do
         self.menu_items[id] = common_setting
     end
-    self.menu_items.page_turns = require("ui/elements/page_turns")
+
+    if Device:isTouchDevice() then
+        self.menu_items.page_turns = require("ui/elements/page_turns")
+    else
+        -- Placed elsewhere than in Taps and gestures, with only a subset of menu items
+        self.menu_items.page_turns_non_touch = require("ui/elements/page_turns")
+    end
     -- insert DjVu render mode submenu just before the last entry (show advanced)
     -- this is a bit of a hack
     if self.ui.document.is_djvu then

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -238,17 +238,20 @@ common_settings.screen_rotation = require("ui/elements/screen_rotation_menu_tabl
 common_settings.screen_dpi = require("ui/elements/screen_dpi_menu_table")
 common_settings.screen_eink_opt = require("ui/elements/screen_eink_opt_menu_table")
 common_settings.screen_notification = require("ui/elements/screen_notification_menu_table")
-common_settings.menu_activate = require("ui/elements/menu_activate")
-common_settings.screen_disable_double_tab = require("ui/elements/screen_disable_double_tap_table")
-common_settings.ignore_hold_corners = {
-    text = _("Ignore long-press on corners"),
-    checked_func = function()
-        return G_reader_settings:isTrue("ignore_hold_corners")
-    end,
-    callback = function()
-        UIManager:broadcastEvent(Event:new("IgnoreHoldCorners"))
-    end,
-}
+
+if Device:isTouchDevice() then
+    common_settings.menu_activate = require("ui/elements/menu_activate")
+    common_settings.screen_disable_double_tab = require("ui/elements/screen_disable_double_tap_table")
+    common_settings.ignore_hold_corners = {
+        text = _("Ignore long-press on corners"),
+        checked_func = function()
+            return G_reader_settings:isTrue("ignore_hold_corners")
+        end,
+        callback = function()
+            UIManager:broadcastEvent(Event:new("IgnoreHoldCorners"))
+        end,
+    }
+end
 
 -- NOTE: Allow disabling color if it's mistakenly enabled on a Grayscale screen (after a settings import?)
 if Screen:isColorEnabled() or Screen:isColorScreen() then

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -141,7 +141,7 @@ end
 
 if not Device:isTouchDevice() then
     if Device:hasKeys() then
-        -- We just need the last item added above
+        -- We just need the last item added above.
         PageTurns = PageTurns.sub_item_table[#PageTurns.sub_item_table]
     else
         PageTurns = {} -- no menu item

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -139,4 +139,13 @@ if Device:hasKeys() then
     })
 end
 
+if not Device:isTouchDevice() then
+    if Device:hasKeys() then
+        -- We just need the last item added above
+        PageTurns = PageTurns.sub_item_table[#PageTurns.sub_item_table]
+    else
+        PageTurns = {} -- no menu item
+    end
+end
+
 return PageTurns

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -98,6 +98,8 @@ local order = {
         "back_to_exit",
         "back_in_filemanager",
         "back_in_reader",
+        "----------------------------",
+        "page_turns_non_touch",
         "android_volume_keys",
         "android_camera_key",
         "android_haptic_feedback",


### PR DESCRIPTION
They were ending up orphaned as `NEW:` in the top menu first tab, as we don't add any `Taps and gestures>` menu where most of them usually end up:
![image](https://user-images.githubusercontent.com/24273478/147876450-3ed3a743-7e23-4409-8f75-00d27f433c94.png)
![image](https://user-images.githubusercontent.com/24273478/147876487-b4199ae9-c803-41e0-9241-eefd0003fcda.png)

Only small hack is that we probably need `Invert page turn buttons` from `Page turns>` on non-touch devices, so I moved that single item into the `Navigation>` sub menu that is still there on NT devices.

There are probably other menu items/features that should not be made available on NT devices like `Panel zoom`, `Highlight style` (we can't highlight - but we could show highlights made on another device...), `Translation settings>` (we can't translate anything if we can't select text I think)... but well, would need taking a longer tour of everything that I'm not ready to make :) So, just cleaning the ugly "NEW:".

Note: I only tested all this on the emulator with hacked `isTouchDevice = no`, I don't own any real non-touch device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8608)
<!-- Reviewable:end -->
