### PR TITLE
Dropbox: upload file, create folder

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -1,14 +1,17 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+local CheckButton = require("ui/widget/checkbutton")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local DropBox = require("apps/cloudstorage/dropbox")
 local FFIUtil = require("ffi/util")
 local Ftp = require("apps/cloudstorage/ftp")
 local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
 local LuaSettings = require("luasettings")
 local Menu = require("ui/widget/menu")
+local PathChooser = require("ui/widget/pathchooser")
 local UIManager = require("ui/uimanager")
 local WebDav = require("apps/cloudstorage/webdav")
 local lfs = require("libs/libkoreader-lfs")
@@ -155,23 +158,26 @@ function CloudStorage:openCloudServer(url)
         end
         tbl, e = WebDav:run(self.address, self.username, self.password, url)
     end
-    if tbl and #tbl > 0 then
+    if tbl then
         self:switchItemTable(url, tbl)
-        self:setTitleBarIconAndText("home")
-        self.onExtraButtonTap = function()
-            self:init()
+        if self.type == "dropbox" then
+            self.onExtraButtonTap = function()
+                self:showPlusMenu(url)
+            end
+        else
+            self:setTitleBarIconAndText("home")
+            self.onExtraButtonTap = function()
+                self:init()
+            end
         end
         return true
-    elseif not tbl then
+    else
         logger.err("CloudStorage:", e)
         UIManager:show(InfoMessage:new{
             text = _("Cannot fetch list of folder contents\nPlease check your configuration or network connection."),
             timeout = 3,
         })
         table.remove(self.paths)
-        return false
-    else
-        UIManager:show(InfoMessage:new{ text = _("Empty folder") })
         return false
     end
 end
@@ -371,7 +377,6 @@ function CloudStorage:onMenuHold(item)
             {
                 {
                     text = _("Info"),
-                    enabled = true,
                     callback = function()
                         UIManager:close(cs_server_dialog)
                         self:infoServer(item)
@@ -379,7 +384,6 @@ function CloudStorage:onMenuHold(item)
                 },
                 {
                     text = _("Edit"),
-                    enabled = true,
                     callback = function()
                         UIManager:close(cs_server_dialog)
                         self:editCloudServer(item)
@@ -388,7 +392,6 @@ function CloudStorage:onMenuHold(item)
                 },
                 {
                     text = _("Delete"),
-                    enabled = true,
                     callback = function()
                         UIManager:close(cs_server_dialog)
                         self:deleteCloudServer(item)
@@ -408,7 +411,6 @@ function CloudStorage:onMenuHold(item)
                 },
                 {
                     text = _("Synchronize settings"),
-                    enabled = true,
                     callback = function()
                         UIManager:close(cs_server_dialog)
                         self:synchronizeSettings(item)
@@ -563,6 +565,119 @@ function CloudStorage:synchronizeSettings(item)
         }
     }
     UIManager:show(syn_dialog)
+end
+
+function CloudStorage:showPlusMenu(url)
+    local button_dialog
+    button_dialog = ButtonDialog:new{
+        buttons = {
+            {
+                {
+                    text = _("Upload file"),
+                    callback = function()
+                        UIManager:close(button_dialog)
+                        self:uploadFile(url)
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Create folder"),
+                    callback = function()
+                        UIManager:close(button_dialog)
+                        self:createFolder(url)
+                    end,
+                },
+            },
+            {},
+            {
+                {
+                    text = _("Return to Cloud storage list"),
+                    callback = function()
+                        UIManager:close(button_dialog)
+                        self:init()
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(button_dialog)
+end
+
+function CloudStorage:uploadFile(url)
+    local path_chooser
+    path_chooser = PathChooser:new{
+        select_directory = false,
+        detailed_file_info = true,
+        path = self.last_path,
+        onConfirm = function(file_path)
+            self.last_path = file_path:match("(.*)/")
+            if self.last_path == "" then self.last_path = "/" end
+            if lfs.attributes(file_path, "size") > 157286400 then
+                UIManager:show(InfoMessage:new{
+                    text = _("File size must be less than 150 MB"),
+                })
+            else
+                local callback_close = function()
+                    self:openCloudServer(url)
+                end
+                UIManager:nextTick(function()
+                    UIManager:show(InfoMessage:new{
+                        text = _("Uploading…"),
+                        timeout = 1,
+                    })
+                end)
+                UIManager:tickAfterNext(function()
+                    DropBox:uploadFile(url, self.password, file_path, callback_close)
+                end)
+            end
+        end
+    }
+    UIManager:show(path_chooser)
+end
+
+function CloudStorage:createFolder(url)
+    local input_dialog, check_button_enter_folder
+    input_dialog = InputDialog:new{
+        title = _("New folder"),
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    callback = function()
+                        UIManager:close(input_dialog)
+                    end,
+                },
+                {
+                    text = _("Create"),
+                    is_enter_default = true,
+                    callback = function()
+                        local folder_name = input_dialog:getInputText()
+                        if folder_name == "" then return end
+                        UIManager:close(input_dialog)
+                        local callback_close = function()
+                            if check_button_enter_folder.checked then
+                                table.insert(self.paths, {
+                                    url = url,
+                                })
+                                url = url .. "/" .. folder_name
+                            end
+                            self:openCloudServer(url)
+                        end
+                        DropBox:createFolder(url, self.password, folder_name, callback_close)
+                    end,
+                },
+            }
+        },
+    }
+    check_button_enter_folder = CheckButton:new{
+        text = _("Enter folder after creation"),
+        checked = false,
+        parent = input_dialog,
+    }
+    input_dialog:addWidget(check_button_enter_folder)
+    UIManager:show(input_dialog)
+    input_dialog:onShowKeyboard()
 end
 
 function CloudStorage:configCloud(type)

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -582,7 +582,7 @@ function CloudStorage:showPlusMenu(url)
             },
             {
                 {
-                    text = _("Create folder"),
+                    text = _("New folder"),
                     callback = function()
                         UIManager:close(button_dialog)
                         self:createFolder(url)
@@ -592,7 +592,7 @@ function CloudStorage:showPlusMenu(url)
             {},
             {
                 {
-                    text = _("Return to Cloud storage list"),
+                    text = _("Return to cloud storage list"),
                     callback = function()
                         UIManager:close(button_dialog)
                         self:init()
@@ -615,7 +615,7 @@ function CloudStorage:uploadFile(url)
             if self.last_path == "" then self.last_path = "/" end
             if lfs.attributes(file_path, "size") > 157286400 then
                 UIManager:show(InfoMessage:new{
-                    text = _("File size must be less than 150 MB"),
+                    text = _("File size must be less than 150 MB."),
                 })
             else
                 local callback_close = function()

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -61,6 +61,36 @@ function DropBox:downloadFileNoUI(url, password, path)
     end
 end
 
+function DropBox:uploadFile(url, password, file_path, callback_close)
+    local code_response = DropBoxApi:uploadFile(url, password, file_path)
+    local __, filename = util.splitFilePathName(file_path)
+    if code_response == 200 then
+        UIManager:show(InfoMessage:new{
+            text = T(_("File uploaded:\n%1"), filename),
+        })
+        if callback_close then
+            callback_close()
+        end
+    else
+        UIManager:show(InfoMessage:new{
+            text = T(_("Could not upload file:\n%1"), filename),
+        })
+    end
+end
+
+function DropBox:createFolder(url, password, folder_name, callback_close)
+    local code_response = DropBoxApi:createFolder(url, password, folder_name)
+    if code_response == 200 then
+        if callback_close then
+            callback_close()
+        end
+    else
+        UIManager:show(InfoMessage:new{
+            text = T(_("Could not create folder:\n%1"), folder_name),
+        })
+    end
+end
+
 function DropBox:config(item, callback)
     local text_info = "How to generate Access Token:\n"..
         "1. Open the following URL in your Browser, and log in using your account: https://www.dropbox.com/developers/apps.\n"..


### PR DESCRIPTION
New actions in Dropbox account on tap on the Plus left button:
(1) Upload file (up to 150 MB file size)
(2) Create folder
Additionally:
(3) show file size in the file list
(4) allow to enter empty folders (showing "No items", like in FM)

![01](https://user-images.githubusercontent.com/62179190/147910866-9fcdd694-9c93-4a98-b16b-f624a8a34058.png)

![02](https://user-images.githubusercontent.com/62179190/147910873-04202cc7-3086-493d-ba22-5cf53ca446af.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8610)
<!-- Reviewable:end -->
