### PR TITLE
Bookmarks: fix sort within one page

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -360,7 +360,7 @@ end
 
 function ReaderBookmark:onSaveSettings()
     self.ui.doc_settings:saveSetting("bookmarks", self.bookmarks)
-    self.ui.doc_settings:delSetting("bookmarks_sorted")
+    self.ui.doc_settings:makeTrue("bookmarks_sorted")
     self.ui.doc_settings:makeTrue("bookmarks_sorted_20220106")
     self.ui.doc_settings:makeTrue("highlights_imported")
 end

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -196,16 +196,15 @@ function ReaderBookmark:isBookmarkInTimeOrder(a, b)
 end
 
 function ReaderBookmark:isBookmarkInPageOrder(a, b)
-    if self.ui.document.info.has_pages then
+    if self.ui.paging then
         if a.page == b.page then -- both bookmarks in the same page
             if a.highlighted and b.highlighted then -- both are highlights, compare positions
                 local is_reflow = self.ui.document.configurable.text_wrap -- save reflow mode
-                if is_reflow == 1 then -- reflow mode doesn't set page in positions
-                    a.pos0.page = a.page
-                    a.pos1.page = a.page
-                    b.pos0.page = a.page
-                    b.pos1.page = a.page
-                end
+                -- reflow mode doesn't set page in positions
+                a.pos0.page = a.page
+                a.pos1.page = a.page
+                b.pos0.page = a.page
+                b.pos1.page = a.page
                 self.ui.document.configurable.text_wrap = 0 -- native positions
                 -- sort start and end positions of each highlight
                 local compare_pos, a_start, a_end, b_start, b_end, result
@@ -229,14 +228,19 @@ function ReaderBookmark:isBookmarkInPageOrder(a, b)
         end
         return a.page > b.page
     else
-        local compare_xp = self.ui.document:compareXPointers(a.page, b.page)
-        if compare_xp == 0 then -- both bookmarks with the same start
-            if a.highlighted and b.highlighted then -- both are highlights, compare ends
-                return self.ui.document:compareXPointers(a.pos1, b.pos1) == -1
+        local a_page = self.ui.document:getPageFromXPointer(a.page)
+        local b_page = self.ui.document:getPageFromXPointer(b.page)
+        if a_page == b_page then -- both bookmarks in the same page
+            local compare_xp = self.ui.document:compareXPointers(a.page, b.page)
+            if compare_xp == 0 then -- both bookmarks with the same start
+                if a.highlighted and b.highlighted then -- both are highlights, compare ends
+                    return self.ui.document:compareXPointers(a.pos1, b.pos1) == -1
+                end
+                return a.highlighted -- have page bookmarks before highlights
             end
-            return a.highlighted -- have page bookmarks before highlights
+            return compare_xp == -1
         end
-        return compare_xp == -1
+        return a_page > b_page
     end
 end
 

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -293,7 +293,8 @@ end
 function ReaderBookmark:fixBookmarkSort(config)
     -- for backward compatibility, since previously bookmarks for credocuments
     -- are not well sorted. We need to do a whole sorting for at least once.
-    if config:hasNot("bookmarks_sorted") then
+    -- 20220106: accurate sorting with isBookmarkInPositionOrder
+    if config:hasNot("bookmarks_sorted_20220106") then
         table.sort(self.bookmarks, function(a, b)
             return self:isBookmarkInPositionOrder(a, b)
         end)
@@ -359,7 +360,8 @@ end
 
 function ReaderBookmark:onSaveSettings()
     self.ui.doc_settings:saveSetting("bookmarks", self.bookmarks)
-    self.ui.doc_settings:makeTrue("bookmarks_sorted")
+    self.ui.doc_settings:delSetting("bookmarks_sorted")
+    self.ui.doc_settings:makeTrue("bookmarks_sorted_20220106")
     self.ui.doc_settings:makeTrue("highlights_imported")
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1740,12 +1740,10 @@ function ReaderHighlight:extendSelection()
         local is_reflow = self.ui.document.configurable.text_wrap
         local new_page = self.hold_pos.page
         -- reflow mode doesn't set page in positions
-        if is_reflow == 1 then
-            item1.pos0.page = new_page
-            item1.pos1.page = new_page
-            item2_pos0.page = new_page
-            item2_pos1.page = new_page
-        end
+        item1.pos0.page = new_page
+        item1.pos1.page = new_page
+        item2_pos0.page = new_page
+        item2_pos1.page = new_page
         -- pos0 and pos1 are not in order within highlights, hence sorting all
         local function comparePositions (pos1, pos2)
             return self.ui.document:comparePositions(pos1, pos2) == 1

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1737,10 +1737,10 @@ function ReaderHighlight:extendSelection()
     -- getting starting and ending positions, text and pboxes of extended highlight
     local new_pos0, new_pos1, new_text, new_pboxes
     if self.ui.document.info.has_pages then
-        local is_reflow = self.ui.document.configurable.text_wrap == 1
+        local is_reflow = self.ui.document.configurable.text_wrap
         local new_page = self.hold_pos.page
         -- reflow mode doesn't set page in positions
-        if is_reflow then
+        if is_reflow == 1 then
             item1.pos0.page = new_page
             item1.pos1.page = new_page
             item2_pos0.page = new_page
@@ -1748,13 +1748,7 @@ function ReaderHighlight:extendSelection()
         end
         -- pos0 and pos1 are not in order within highlights, hence sorting all
         local function comparePositions (pos1, pos2)
-            local box1 = self.ui.document:getWordFromPosition(pos1).pbox
-            local box2 = self.ui.document:getWordFromPosition(pos2).pbox
-            if box1.y == box2.y then
-                return box1.x < box2.x
-            else
-                return box1.y < box2.y
-            end
+            return self.ui.document:comparePositions(pos1, pos2) == 1
         end
         local positions = {item1.pos0, item1.pos1, item2_pos0, item2_pos1}
         self.ui.document.configurable.text_wrap = 0 -- native positions
@@ -1764,7 +1758,7 @@ function ReaderHighlight:extendSelection()
         local text_boxes = self.ui.document:getTextFromPositions(new_pos0, new_pos1)
         new_text = text_boxes.text
         new_pboxes = text_boxes.pboxes
-        self.ui.document.configurable.text_wrap = is_reflow and 1 or 0 -- restore reflow
+        self.ui.document.configurable.text_wrap = is_reflow -- restore reflow
         -- draw
         self.view.highlight.temp[new_page] = self.ui.document:getPageBoxesFromPositions(new_page, new_pos0, new_pos1)
     else

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -68,6 +68,10 @@ function DjvuDocument:getProps()
     return props
 end
 
+function DjvuDocument:comparePositions(pos1, pos2)
+    return self.koptinterface:comparePositions(self, pos1, pos2)
+end
+
 function DjvuDocument:getPageTextBoxes(pageno)
     return self._document:getPageText(pageno)
 end

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1241,7 +1241,7 @@ end
 --[[--
 Compare positions within one page.
 Returns 1 if positions are ordered (if ppos2 is after ppos1), -1 if not, 0 if same.
-Actually positions of the word boxes containing ppos1 and ppos2 are compared.
+Positions of the word boxes containing ppos1 and ppos2 are compared.
 --]]
 function KoptInterface:comparePositions(doc, ppos1, ppos2)
     local box1 = self:getWordFromPosition(doc, ppos1).pbox

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1212,7 +1212,6 @@ function KoptInterface:getTextFromNativePositions(doc, native_boxes, pos0, pos1)
     return text_boxes
 end
 
-
 --[[--
 Get text boxes from page positions.
 --]]
@@ -1237,6 +1236,26 @@ function KoptInterface:getPageBoxesFromPositions(doc, pageno, ppos0, ppos1)
         local text_boxes = self:getTextFromBoxes(page_boxes, ppos0, ppos1)
         return text_boxes.boxes
     end
+end
+
+--[[--
+Compare positions within one page.
+Returns 1 if positions are ordered (if ppos2 is after ppos1), -1 if not, 0 if same.
+Actually positions of the word boxes containing ppos1 and ppos2 are compared.
+--]]
+function KoptInterface:comparePositions(doc, ppos1, ppos2)
+    local box1 = self:getWordFromPosition(doc, ppos1).pbox
+    local box2 = self:getWordFromPosition(doc, ppos2).pbox
+    if box1.y == box2.y then
+        if box1.x == box2.x then
+            return 0
+        elseif box1.x > box2.x then
+            return -1
+        end
+    elseif box1.y > box2.y then
+        return -1
+    end
+    return 1
 end
 
 --[[--

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -98,6 +98,10 @@ function PdfDocument:unlock(password)
     return true
 end
 
+function PdfDocument:comparePositions(pos1, pos2)
+    return self.koptinterface:comparePositions(self, pos1, pos2)
+end
+
 function PdfDocument:getPageTextBoxes(pageno)
     local page = self._document:openPage(pageno)
     local text = page:getPageText()


### PR DESCRIPTION
Bookmarks of one page will be sorted depending on their position in the text (now they are sorted in order of adding).
Page bookmark is the first (before highlights and notes).
If two highlights start at one position, the shorter one will be the first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8616)
<!-- Reviewable:end -->
