### PR TITLE
[CI] Minor shellcheck cleanup

### DIFF
--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -8,7 +8,7 @@
 # NOTE: We inherit WITH_PIPEFAIL from the env via OTAManager, because of course old busybox ash versions abort on set -o failures...
 #       c.f., https://github.com/koreader/koreader/pull/5844
 if [ "${WITH_PIPEFAIL}" = "true" ]; then
-    # shellcheck disable=SC2039,SC3040
+    # shellcheck disable=SC3040
     set -o pipefail
 fi
 


### PR DESCRIPTION
`# shellcheck disable=SC2039,SC3040` is only if you want it to pass multiple versions, but I figure there's not much reason to keep the old exception for <=0.7.1 in there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8618)
<!-- Reviewable:end -->
