### PR TITLE
filechooser: istr needs a string

### DIFF
--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -229,7 +229,7 @@ function ListMenuItem:update()
         self.is_directory = true
         -- nb items on the right, directory name on the left
         local wright = TextWidget:new{
-            text = self.mandatory_func and self.mandatory_func() or self.mandatory,
+            text = self.mandatory_func and self.mandatory_func() or (self.mandatory and self.mandatory or ""),
             face = Font:getFace("infont", _fontSize(14, 18)),
         }
         local pad_width = Screen:scaleBySize(10) -- on the left, in between, and on the right


### PR DESCRIPTION
Caused by #8598

Trips this dbg guard.
https://github.com/koreader/koreader/blob/ec280f874f0cfce660bdb4d396589939503d3c8b/frontend/ui/widget/textwidget.lua#L178-L182

There is probably a better way to fix this.


Stack trace:
```
./luajit: frontend/ui/widget/textwidget.lua:180: Wrong text type (expected string)
stack traceback:
	[C]: in function 'assert'
	frontend/ui/widget/textwidget.lua:180: in function 'pre_guard'
	frontend/dbg.lua:64: in function 'updateSize'
	frontend/ui/widget/textwidget.lua:300: in function 'getWidth'
	plugins/coverbrowser.koplugin/listmenu.lua:236: in function 'update'
	plugins/coverbrowser.koplugin/listmenu.lua:178: in function 'init'
	frontend/ui/widget/widget.lua:48: in function 'new'
	plugins/coverbrowser.koplugin/listmenu.lua:1000: in function '_updateItemsBuildUI'
	plugins/coverbrowser.koplugin/covermenu.lua:101: in function 'updateItems'
	frontend/ui/widget/menu.lua:1217: in function 'switchItemTable'
	frontend/ui/widget/filechooser.lua:381: in function 'refreshPath'
	frontend/ui/widget/filechooser.lua:405: in function 'changeToPath'
	plugins/coverbrowser.koplugin/main.lua:471: in function 'refreshFileManagerInstance'
	plugins/coverbrowser.koplugin/main.lua:563: in function 'action'
	frontend/ui/uimanager.lua:1201: in function '_checkTasks'
	frontend/ui/uimanager.lua:1622: in function 'handleInput'
	frontend/ui/uimanager.lua:1730: in function 'run'
	./reader.lua:323: in main chunk
	[C]: at 0x564a60dda794

```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8620)
<!-- Reviewable:end -->
