### PR TITLE
Fix #8617: WiFi network returns connected without connection for PB741 color

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -3,7 +3,6 @@ local logger = require("logger")
 local ffi = require("ffi")
 local C = ffi.C
 local inkview = ffi.load("inkview")
-local band = require("bit").band
 local util = require("util")
 
 require("ffi/posix_h")

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -20,6 +20,8 @@ local function no() return false end
 local ext_path = "/mnt/ext1/system/config/extensions.cfg"
 local app_name = "koreader.app"
 
+local pb741_color_connected = 515
+
 local PocketBook = Generic:new{
     model = "PocketBook",
     isPocketBook = yes,
@@ -358,7 +360,7 @@ function PocketBook:initNetworkManager(NetworkMgr)
     end
 
     function NetworkMgr:isWifiOn()
-        return band(inkview.QueryNetwork(), C.CONNECTED) ~= 0
+        return inkview.QueryNetwork() == C.CONNECTED or inkview.QueryNetwork() == pb741_color_connected
     end
 end
 

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -359,7 +359,6 @@ function PocketBook:initNetworkManager(NetworkMgr)
 
     function NetworkMgr:isWifiOn()
         local state = inkview.QueryNetwork()
-        
         -- Some devices (PB741) return state = 515 for connected and state = 3
         -- when not connected. We guess the reason is deprecation of the old API
         -- for this reason when state is higher than C.CONNECTED we try the new API


### PR DESCRIPTION
When using the PB741 color the wifi is checked connected when there is
actually no connection yet. This is caused by a different connected state
being returned by the PB741 color.

More info found in #8617

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8621)
<!-- Reviewable:end -->
