### PR TITLE
Fix djvu crash

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -668,10 +668,9 @@ function KoptInterface:getNativeTextBoxesFromScratch(doc, pageno)
         local page = doc._document:openPage(pageno)
         page:getPagePix(kc)
         local boxes, nr_word = kc:getNativeWordBoxes("src", 0, 0, page_size.w, page_size.h)
-        if not boxes then
-            return
+        if boxes then
+            DocCache:insert(hash, CacheItem:new{ scratchnativepgboxes = boxes, size = 192 * nr_word }) -- estimation
         end
-        DocCache:insert(hash, CacheItem:new{ scratchnativepgboxes = boxes, size = 192 * nr_word }) -- estimation
         page:close()
         kc:free()
         return boxes

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -668,6 +668,9 @@ function KoptInterface:getNativeTextBoxesFromScratch(doc, pageno)
         local page = doc._document:openPage(pageno)
         page:getPagePix(kc)
         local boxes, nr_word = kc:getNativeWordBoxes("src", 0, 0, page_size.w, page_size.h)
+        if not boxes then
+            return
+        end
         DocCache:insert(hash, CacheItem:new{ scratchnativepgboxes = boxes, size = 192 * nr_word }) -- estimation
         page:close()
         kc:free()

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -12,19 +12,17 @@ local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local Geom = require("ui/geometry")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local LineWidget = require("ui/widget/linewidget")
 local MovableContainer = require("ui/widget/container/movablecontainer")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local ScrollTextWidget = require("ui/widget/scrolltextwidget")
 local Size = require("ui/size")
-local TextBoxWidget = require("ui/widget/textboxwidget")
+local TitleBar = require("ui/widget/titlebar")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -103,40 +101,15 @@ function TextViewer:init()
         }
     end
 
-    local closeb = CloseButton:new{ window = self, padding_top = Size.padding.tiny, }
-    local title_text = TextBoxWidget:new{
-        text = self.title,
-        face = self.title_face,
-        bold = true,
-        width = self.width - 2*self.title_padding - 2*self.title_margin - closeb:getSize().w,
+    local titlebar = TitleBar:new{
+        width = self.width,
+        align = "left",
+        with_bottom_line = true,
+        title = self.title,
+        title_face = self.title_face,
+        close_callback = function() self:onClose() end,
     }
-    local titlew = FrameContainer:new{
-        padding = self.title_padding,
-        -- TextBoxWidget has less text top & bottom padding than TextWidget
-        -- (for a reasonable line height with multi lines), but we
-        -- can get the same as TextWidget by simply adding Size.padding.small
-        padding_top = self.title_padding + Size.padding.small,
-        padding_bottom = self.title_padding + Size.padding.small,
-        margin = self.title_margin,
-        bordersize = 0,
-        title_text
-    }
-    titlew = OverlapGroup:new{
-        dimen = {
-            w = self.width,
-            h = titlew:getSize().h
-        },
-        titlew,
-        closeb,
-    }
-
-    local separator = LineWidget:new{
-        dimen = Geom:new{
-            w = self.width,
-            h = Size.line.thick,
-        }
-    }
-
+    
     local buttons
     if self.buttons_table == nil then
         buttons = {
@@ -161,7 +134,7 @@ function TextViewer:init()
         show_parent = self,
     }
 
-    local textw_height = self.height - titlew:getSize().h - separator:getSize().h - button_table:getSize().h
+    local textw_height = self.height - titlebar:getSize().h - button_table:getSize().h
 
     self.scroll_text_w = ScrollTextWidget:new{
         text = self.text,
@@ -190,9 +163,7 @@ function TextViewer:init()
         margin = 0,
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
-            align = "left",
-            titlew,
-            separator,
+            titlebar,
             CenterContainer:new{
                 dimen = Geom:new{
                     w = self.width,

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -12,16 +12,19 @@ local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
+local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local Geom = require("ui/geometry")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local LineWidget = require("ui/widget/linewidget")
 local MovableContainer = require("ui/widget/container/movablecontainer")
+local OverlapGroup = require("ui/widget/overlapgroup")
 local ScrollTextWidget = require("ui/widget/scrolltextwidget")
 local Size = require("ui/size")
-local TitleBar = require("ui/widget/titlebar")
+local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -100,13 +103,38 @@ function TextViewer:init()
         }
     end
 
-    local titlebar = TitleBar:new{
-        width = self.width,
-        align = "left",
-        with_bottom_line = true,
-        title = self.title,
-        title_face = self.title_face,
-        close_callback = function() self:onClose() end,
+    local closeb = CloseButton:new{ window = self, padding_top = Size.padding.tiny, }
+    local title_text = TextBoxWidget:new{
+        text = self.title,
+        face = self.title_face,
+        bold = true,
+        width = self.width - 2*self.title_padding - 2*self.title_margin - closeb:getSize().w,
+    }
+    local titlew = FrameContainer:new{
+        padding = self.title_padding,
+        -- TextBoxWidget has less text top & bottom padding than TextWidget
+        -- (for a reasonable line height with multi lines), but we
+        -- can get the same as TextWidget by simply adding Size.padding.small
+        padding_top = self.title_padding + Size.padding.small,
+        padding_bottom = self.title_padding + Size.padding.small,
+        margin = self.title_margin,
+        bordersize = 0,
+        title_text
+    }
+    titlew = OverlapGroup:new{
+        dimen = {
+            w = self.width,
+            h = titlew:getSize().h
+        },
+        titlew,
+        closeb,
+    }
+
+    local separator = LineWidget:new{
+        dimen = Geom:new{
+            w = self.width,
+            h = Size.line.thick,
+        }
     }
 
     local buttons
@@ -133,7 +161,7 @@ function TextViewer:init()
         show_parent = self,
     }
 
-    local textw_height = self.height - titlebar:getSize().h - button_table:getSize().h
+    local textw_height = self.height - titlew:getSize().h - separator:getSize().h - button_table:getSize().h
 
     self.scroll_text_w = ScrollTextWidget:new{
         text = self.text,
@@ -162,7 +190,9 @@ function TextViewer:init()
         margin = 0,
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
-            titlebar,
+            align = "left",
+            titlew,
+            separator,
             CenterContainer:new{
                 dimen = Geom:new{
                     w = self.width,

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -19,7 +19,6 @@ local FrameContainer = require("ui/widget/container/framecontainer")
 local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local MovableContainer = require("ui/widget/container/movablecontainer")
-local OverlapGroup = require("ui/widget/overlapgroup")
 local ScrollTextWidget = require("ui/widget/scrolltextwidget")
 local Size = require("ui/size")
 local TitleBar = require("ui/widget/titlebar")
@@ -109,7 +108,7 @@ function TextViewer:init()
         title_face = self.title_face,
         close_callback = function() self:onClose() end,
     }
-    
+
     local buttons
     if self.buttons_table == nil then
         buttons = {


### PR DESCRIPTION
Fix crash when trying to select text in djvu (reflow off).

```
./luajit: frontend/document/koptinterface.lua:671: attempt to perform arithmetic on local 'nr_word' (a nil value)
stack traceback:
	frontend/document/koptinterface.lua:671: in function 'getTextBoxes'
	frontend/document/koptinterface.lua:1156: in function 'getTextFromPositions'
	frontend/apps/reader/modules/readerhighlight.lua:1082: in function 'handler'
	frontend/ui/widget/container/inputcontainer.lua:255: in function 'handleEvent'
	frontend/ui/uimanager.lua:1119: in function 'sendEvent'
	frontend/ui/uimanager.lua:53: in function '__default__'
	frontend/ui/uimanager.lua:1603: in function 'handleInputEvent'
	frontend/ui/uimanager.lua:1683: in function 'handleInput'
	frontend/ui/uimanager.lua:1730: in function 'run'
	./reader.lua:323: in main chunk
	[C]: at 0x00013ef9

```
The same crash for reflow mode was reported in https://github.com/koreader/koreader/issues/7850 and fixed in https://github.com/koreader/koreader/commit/e4a333a9805a1668860f0a5d134772e21e7904fb.
So here the same fix.

Unfortunately I cannot test the fix, seems my Kindle Voyage doesn't have enough memory to show the highlighted text:

```
01/07/22-09:47:24 INFO  opening file /mnt/us/books/6 TMP/Маленькие сказки про мушонка.djvu
ffi.load: libs/liblept.so.5
ffi.load: libs/libk2pdfopt.so.2
07/01/22-09:47:24 INFO  setting zoom mode to pagewidth
rendering page:0,0,4908,6382
Warning in boxaSelectBySize: boxas is empty
Warning in boxaSelectBySize: boxas is empty
Error in boxaSort2d: boxas is empty
Error in pixaSort2dByIndex: naindex not defined
Error in pixaaFlattenToPixa: paa not defined
Error in pixaGetBoxa: pixa not defined
rendering page:0,0,4908,6382
Warning in boxaSelectBySize: boxas is empty
Warning in boxaSelectBySize: boxas is empty
Error in boxaSort2d: boxas is empty
Error in pixaSort2dByIndex: naindex not defined
Error in pixaaFlattenToPixa: paa not defined
Error in pixaGetBoxa: pixa not defined
rendering page:0,0,4908,6382
Warning in boxaSelectBySize: boxas is empty
Warning in boxaSelectBySize: boxas is empty
Error in boxaSort2d: boxas is empty
Error in pixaSort2dByIndex: naindex not defined
Error in pixaaFlattenToPixa: paa not defined
Error in pixaGetBoxa: pixa not defined
rendering page:0,0,4908,6382
Warning in boxaSelectBySize: boxas is empty
Warning in boxaSelectBySize: boxas is empty
Error in boxaSort2d: boxas is empty
Error in pixaSort2dByIndex: naindex not defined
Error in pixaaFlattenToPixa: paa not defined
Error in pixaGetBoxa: pixa not defined
rendering page:0,0,4908,6382
Killed

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8626)
<!-- Reviewable:end -->
