### PR TITLE
TitleBar: new options, dedicated close button

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1327,6 +1327,14 @@ function ReaderHighlight:onTranslateText(text)
 end
 
 function ReaderHighlight:onHoldRelease()
+    if self.clear_id then
+        -- Something has requested a clear id and is about to clear
+        -- the highlight: it may be a onHoldClose() that handled
+        -- "hold" and was closed, and can't handle "hold_release":
+        -- ignore this "hold_release" event.
+        return true
+    end
+
     local default_highlight_action = G_reader_settings:readSetting("default_highlight_action", "ask")
 
     if self.select_mode then -- extended highlighting, ending fragment

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -600,7 +600,7 @@ function BookMapWidget:init()
         left_icon = "notice-info",
         left_icon_tap_callback = function() self:showHelp() end,
         close_callback = function() self:onClose() end,
-        hold_close_callback = function() self:onClose(true) end,
+        close_hold_callback = function() self:onClose(true) end,
         show_parent = self,
     }
     self.title_bar_h = self.title_bar:getHeight()
@@ -1036,6 +1036,8 @@ function BookMapWidget:onClose(close_all_parents)
             -- The last one of these (which has no launcher attribute)
             -- will do the cleanup below.
             self.launcher:onClose(true)
+        else
+            UIManager:setDirty(self.launcher, "ui")
         end
     else
         -- Remove all thumbnails generated for a different target size than

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -105,7 +105,7 @@ function PageBrowserWidget:init()
         left_icon = "notice-info",
         left_icon_tap_callback = function() self:showHelp() end,
         close_callback = function() self:onClose() end,
-        hold_close_callback = function() self:onClose(true) end,
+        close_hold_callback = function() self:onClose(true) end,
         show_parent = self,
     }
     self.title_bar_h = self.title_bar:getHeight()
@@ -618,8 +618,8 @@ function PageBrowserWidget:onClose(close_all_parents)
     if self.requests_batch_id then
         self.ui.thumbnail:cancelPageThumbnailRequests(self.requests_batch_id)
     end
-    logger.dbg("closing PageBrowserWidget")
     -- Close this widget
+    logger.dbg("closing PageBrowserWidget")
     UIManager:close(self)
     if self.launcher then
         -- We were launched by a BookMapWidget, don't do any cleanup.
@@ -627,6 +627,8 @@ function PageBrowserWidget:onClose(close_all_parents)
             -- The last one of these (which has no launcher attribute)
             -- will do the cleanup below.
             self.launcher:onClose(true)
+        else
+            UIManager:setDirty(self.launcher, "ui")
         end
     else
         -- Remove all thumbnails generated for a different target size than

--- a/resources/icons/mdlight/close.svg
+++ b/resources/icons/mdlight/close.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="2 2 20 20"
+   enable-background="new 0 0 24.00 24.00"
+   xml:space="preserve"
+   id="svg4"
+   sodipodi:docname="exit.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"><metadata
+   id="metadata10"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+   id="defs8" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="2560"
+   inkscape:window-height="1381"
+   id="namedview6"
+   showgrid="true"
+   inkscape:zoom="42"
+   inkscape:cx="12"
+   inkscape:cy="12"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg4"
+   inkscape:document-rotation="0"><inkscape:grid
+     type="xygrid"
+     id="grid855" /></sodipodi:namedview>
+	
+<path
+   style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+   d="M 18,6 5,19"
+   id="path834" /><path
+   style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+   d="M 5,6 18,19"
+   id="path836"
+   sodipodi:nodetypes="cc" /></svg>


### PR DESCRIPTION
Discussions and screenshots about this in #8625 and #8627.

#### TitleBar: new options, dedicated close button

- Fix hold callback name
- Add options to handle long titles (truncated by default): "title_multines" and "title_shrink_font_to_fit" (allowing setTitle() with them makes the code a bit more complex).
- Add options to set bottom line color and horizontal padding.
- Use an added title.close.svg (based on exit.svg, tweaked to have similar size and baseline as other icons) for close button.

IconButton:
- handle hold/hold_release similar to Button.
- new option allow_flash to allow disabling flashing

#### DictQuickLookup: update to TitleBar widget

Also tweak ReaderHighlight:onHoldRelease() to avoid doing its stuff when onHold() is clearing highlight (previous CheckButton was closing/clearing on hold release, new TitleBar close button does that on hold).

#### CalendarView: update to TitleBar widget

#### KeyValuePage: update to TitleBar widget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8629)
<!-- Reviewable:end -->
