### PR TITLE
ReaderBookmark: fix issue with unit tests

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -481,6 +481,10 @@ function ReaderBookmark:onShowBookmark(match_table)
     local multilines_show_more_text = G_reader_settings:isTrue("bookmarks_items_multilines_show_more_text")
     local show_separator = G_reader_settings:isTrue("bookmarks_items_show_separator")
 
+    self.bookmark_menu = CenterContainer:new{
+        dimen = Screen:getSize(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
+    }
     local bm_menu = Menu:new{
         title = self.filtered_mode and _("Bookmarks (search results)") or _("Bookmarks"),
         item_table = item_table,
@@ -504,7 +508,9 @@ function ReaderBookmark:onShowBookmark(match_table)
                 direction = BD.flipDirectionIfMirroredUILayout("east")
             }
         },
+        show_parent = self.bookmark_menu,
     }
+    table.insert(self.bookmark_menu, bm_menu)
 
     -- buid up menu widget method as closure
     local bookmark = self
@@ -815,7 +821,7 @@ function ReaderBookmark:onShowBookmark(match_table)
     end
 
     bm_menu.close_callback = function()
-        UIManager:close(bm_menu)
+        UIManager:close(self.bookmark_menu)
     end
 
     self.refresh = function()
@@ -823,7 +829,7 @@ function ReaderBookmark:onShowBookmark(match_table)
         self:onSaveSettings()
     end
 
-    UIManager:show(bm_menu)
+    UIManager:show(self.bookmark_menu)
     return true
 end
 


### PR DESCRIPTION
Revert some bits from 55532b13 (#8639 , commit https://github.com/koreader/koreader/pull/8639/commits/89327a22e8fadceb215c2a0f8e3fc5e239fbd9af), as the otherwise uneeded CenterContainer is used by unit tests.
See https://github.com/koreader/koreader/pull/8639#pullrequestreview-848337420

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8645)
<!-- Reviewable:end -->
