### PR TITLE
Give feedback when toggling Wi-Fi

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -70,7 +70,8 @@ local settingsList = {
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:canToggleGSensor()},
     wifi_on = {category="none", event="InfoWifiOn", title=_("Turn on Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     wifi_off = {category="none", event="InfoWifiOff", title=_("Turn off Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
-    toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle(), separator=true},
+    toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
+    show_network_info = {category="none", event="ShowNetworkInfo", title=_("Show network info"), device=true, separator=true},
     suspend = {category="none", event="SuspendEvent", title=_("Suspend"), device=true},
     exit = {category="none", event="Exit", title=_("Exit KOReader"), device=true},
     restart = {category="none", event="Restart", title=_("Restart KOReader"), device=true, condition=Device:canRestart()},
@@ -234,6 +235,7 @@ local dispatcher_menu_order = {
     "wifi_on",
     "wifi_off",
     "toggle_wifi",
+    "show_network_info",
 
     "show_frontlight_dialog",
     "toggle_frontlight",

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -493,16 +493,7 @@ function NetworkMgr:getInfoMenuTable()
         keep_menu_open = true,
         enabled_func = function() return self:isNetworkInfoAvailable() end,
         callback = function()
-            if Device.retrieveNetworkInfo then
-                UIManager:show(InfoMessage:new{
-                    text = Device:retrieveNetworkInfo(),
-                })
-            else
-                UIManager:show(InfoMessage:new{
-                    text = _("Could not retrieve network info."),
-                    timeout = 3,
-                })
-            end
+            UIManager:broadcastEvent(Event:new("ShowNetworkInfo"))
         end
     }
 end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -113,6 +113,12 @@ function NetworkMgr:restoreWifiAsync() end
 -- End of device specific methods
 
 function NetworkMgr:toggleWifiOn(complete_callback, long_press)
+    UIManager:show(InfoMessage:new{
+        text = _("Turning on Wi-Fi…"),
+        timeout = 1,
+    })
+    UIManager:forceRePaint()
+
     self.wifi_was_on = true
     G_reader_settings:makeTrue("wifi_was_on")
     self.wifi_toggle_long_press = long_press
@@ -120,6 +126,12 @@ function NetworkMgr:toggleWifiOn(complete_callback, long_press)
 end
 
 function NetworkMgr:toggleWifiOff(complete_callback)
+    UIManager:show(InfoMessage:new{
+        text = _("Turning off Wi-Fi…"),
+        timeout = 1,
+    })
+    UIManager:forceRePaint()
+
     self.wifi_was_on = false
     G_reader_settings:makeFalse("wifi_was_on")
     self:turnOffWifi(complete_callback)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -115,7 +115,7 @@ function NetworkMgr:restoreWifiAsync() end
 function NetworkMgr:toggleWifiOn(complete_callback, long_press)
     UIManager:show(InfoMessage:new{
         text = _("Turning on Wi-Fi…"),
-        timeout = 1,
+        timeout = 1, -- timeout value is necessary, the message will be deleted by next message
     })
     UIManager:forceRePaint()
 
@@ -128,7 +128,7 @@ end
 function NetworkMgr:toggleWifiOff(complete_callback)
     UIManager:show(InfoMessage:new{
         text = _("Turning off Wi-Fi…"),
-        timeout = 1,
+        timeout = 1, -- timeout value is necessary, the message will be deleted by next message
     })
     UIManager:forceRePaint()
 

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -113,28 +113,34 @@ function NetworkMgr:restoreWifiAsync() end
 -- End of device specific methods
 
 function NetworkMgr:toggleWifiOn(complete_callback, long_press)
-    UIManager:show(InfoMessage:new{
+    local toggle_im = InfoMessage:new{
         text = _("Turning on Wi-Fi…"),
         timeout = 1, -- timeout value is necessary, the message will be deleted by next message
-    })
+    }
+    UIManager:show(toggle_im)
     UIManager:forceRePaint()
 
     self.wifi_was_on = true
     G_reader_settings:makeTrue("wifi_was_on")
     self.wifi_toggle_long_press = long_press
     self:turnOnWifi(complete_callback)
+
+    UIManager:close(toggle_im)
 end
 
 function NetworkMgr:toggleWifiOff(complete_callback)
-    UIManager:show(InfoMessage:new{
+    local toggle_im = InfoMessage:new{
         text = _("Turning off Wi-Fi…"),
         timeout = 1, -- timeout value is necessary, the message will be deleted by next message
-    })
+    }
+    UIManager:show(toggle_im)
     UIManager:forceRePaint()
 
     self.wifi_was_on = false
     G_reader_settings:makeFalse("wifi_was_on")
     self:turnOffWifi(complete_callback)
+
+    UIManager:close(toggle_im)
 end
 
 function NetworkMgr:promptWifiOn(complete_callback, long_press)

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -15,7 +15,7 @@ function NetworkListener:onToggleWifi()
     if not NetworkMgr:isConnected() then
         UIManager:show(InfoMessage:new{
             text = _("Turning on Wi-Fi…"),
-            timeout = 1,
+            timeout = 1, -- timeout value is necessary, the message will be deleted by next message
         })
         UIManager:forceRePaint()
 
@@ -32,7 +32,7 @@ function NetworkListener:onToggleWifi()
         end
         UIManager:show(InfoMessage:new{
             text = _("Turning off Wi-Fi…"),
-            timeout = 1,
+            timeout = 1, -- timeout value is necessary, the message will be deleted by next message
         })
         UIManager:forceRePaint()
 

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -14,7 +14,7 @@ local NetworkListener = InputContainer:new{}
 function NetworkListener:onToggleWifi()
     if not NetworkMgr:isConnected() then
         UIManager:show(InfoMessage:new{
-            text = _("Turning on wifi…"),
+            text = _("Turning on Wi-Fi…"),
             timeout = 1, -- timeout value is necessary, the message will be deleted by next message
         })
         UIManager:forceRePaint()
@@ -31,7 +31,7 @@ function NetworkListener:onToggleWifi()
             UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         end
         UIManager:show(InfoMessage:new{
-            text = _("Turning off wifi…"),
+            text = _("Turning off Wi-Fi…"),
             timeout = 1, -- timeout value is necessary, the message will be deleted by next message
         })
         UIManager:forceRePaint()
@@ -39,7 +39,7 @@ function NetworkListener:onToggleWifi()
         NetworkMgr:turnOffWifi(complete_callback)
 
         UIManager:show(InfoMessage:new{
-            text = _("Wifi off."),
+            text = _("Wi-Fi off."),
             timeout = 1,
         })
     end
@@ -53,7 +53,7 @@ function NetworkListener:onInfoWifiOff()
     NetworkMgr:turnOffWifi(complete_callback)
 
     UIManager:show(InfoMessage:new{
-        text = _("Wifi off."),
+        text = _("Wi-Fi off."),
         timeout = 1,
     })
 end
@@ -61,7 +61,7 @@ end
 function NetworkListener:onInfoWifiOn()
     if not NetworkMgr:isOnline() then
         UIManager:show(InfoMessage:new{
-            text = _("Enabling wifi…"),
+            text = _("Enabling Wi-Fi…"),
             timeout = 1,
         })
 

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -218,5 +218,17 @@ function NetworkListener:onSuspend()
     self:onNetworkDisconnected()
 end
 
+function NetworkListener:onShowNetworkInfo()
+    if Device.retrieveNetworkInfo then
+        UIManager:show(InfoMessage:new{
+            text = Device:retrieveNetworkInfo(),
+        })
+    else
+        UIManager:show(InfoMessage:new{
+            text = _("Could not retrieve network info."),
+            timeout = 3,
+        })
+    end
+end
 
 return NetworkListener

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -17,6 +17,7 @@ function NetworkListener:onToggleWifi()
             text = _("Turning on Wi-Fi…"),
             timeout = 1,
         })
+        UIManager:forceRePaint()
 
         -- NB Normal widgets should use NetworkMgr:promptWifiOn()
         -- (or, better yet, the NetworkMgr:beforeWifiAction wrappers: NetworkMgr:runWhenOnline() & co.)
@@ -29,6 +30,12 @@ function NetworkListener:onToggleWifi()
         local complete_callback = function()
             UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         end
+        UIManager:show(InfoMessage:new{
+            text = _("Turning off Wi-Fi…"),
+            timeout = 1,
+        })
+        UIManager:forceRePaint()
+
         NetworkMgr:turnOffWifi(complete_callback)
 
         UIManager:show(InfoMessage:new{
@@ -54,7 +61,7 @@ end
 function NetworkListener:onInfoWifiOn()
     if not NetworkMgr:isOnline() then
         UIManager:show(InfoMessage:new{
-            text = _("Enabling wifi…"),
+            text = _("Enabling Wi-Fi…"),
             timeout = 1,
         })
 

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -14,7 +14,7 @@ local NetworkListener = InputContainer:new{}
 function NetworkListener:onToggleWifi()
     if not NetworkMgr:isConnected() then
         UIManager:show(InfoMessage:new{
-            text = _("Turning on Wi-Fi…"),
+            text = _("Turning on wifi…"),
             timeout = 1, -- timeout value is necessary, the message will be deleted by next message
         })
         UIManager:forceRePaint()
@@ -31,7 +31,7 @@ function NetworkListener:onToggleWifi()
             UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         end
         UIManager:show(InfoMessage:new{
-            text = _("Turning off Wi-Fi…"),
+            text = _("Turning off wifi…"),
             timeout = 1, -- timeout value is necessary, the message will be deleted by next message
         })
         UIManager:forceRePaint()
@@ -39,7 +39,7 @@ function NetworkListener:onToggleWifi()
         NetworkMgr:turnOffWifi(complete_callback)
 
         UIManager:show(InfoMessage:new{
-            text = _("Wi-Fi off."),
+            text = _("Wifi off."),
             timeout = 1,
         })
     end
@@ -53,7 +53,7 @@ function NetworkListener:onInfoWifiOff()
     NetworkMgr:turnOffWifi(complete_callback)
 
     UIManager:show(InfoMessage:new{
-        text = _("Wi-Fi off."),
+        text = _("Wifi off."),
         timeout = 1,
     })
 end
@@ -61,7 +61,7 @@ end
 function NetworkListener:onInfoWifiOn()
     if not NetworkMgr:isOnline() then
         UIManager:show(InfoMessage:new{
-            text = _("Enabling Wi-Fi…"),
+            text = _("Enabling wifi…"),
             timeout = 1,
         })
 

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -13,10 +13,11 @@ local NetworkListener = InputContainer:new{}
 
 function NetworkListener:onToggleWifi()
     if not NetworkMgr:isConnected() then
-        UIManager:show(InfoMessage:new{
+        local toggle_im = InfoMessage:new{
             text = _("Turning on Wi-Fi…"),
             timeout = 1, -- timeout value is necessary, the message will be deleted by next message
-        })
+        }
+        UIManager:show(toggle_im)
         UIManager:forceRePaint()
 
         -- NB Normal widgets should use NetworkMgr:promptWifiOn()
@@ -26,17 +27,22 @@ function NetworkListener:onToggleWifi()
             UIManager:broadcastEvent(Event:new("NetworkConnected"))
         end
         NetworkMgr:turnOnWifi(complete_callback)
+
+        UIManager:close(toggle_im)
     else
         local complete_callback = function()
             UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         end
-        UIManager:show(InfoMessage:new{
+        local toggle_im = InfoMessage:new{
             text = _("Turning off Wi-Fi…"),
             timeout = 1, -- timeout value is necessary, the message will be deleted by next message
-        })
+        }
+        UIManager:show(toggle_im)
         UIManager:forceRePaint()
 
         NetworkMgr:turnOffWifi(complete_callback)
+
+        UIManager:close(toggle_im)
 
         UIManager:show(InfoMessage:new{
             text = _("Wi-Fi off."),


### PR DESCRIPTION
On my Kobo, turning on Wi-Fi takes 13 seconds, where nothing happens and KOReader does not respond to taps. 

Similar on turning off Wi-Fi (here it is only 2 seconds delay).

This PR adds a message, about what is happening on the screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8667)
<!-- Reviewable:end -->
