### PR TITLE
fix bug on PW1 where screensaver would sometimes be overwritten by native one

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -216,7 +216,9 @@ function Kindle:intoScreenSaver()
                 -- nil it, in case user switched ScreenSaver modes during our lifetime.
                 self.orig_rotation_mode = nil
             end
-            Screensaver:show()
+            -- Wait some time, just in case the native screensaver rears its ugly head
+            local UIManager = require("ui/uimanager")
+            UIManager:scheduleIn(1, function() Screensaver:show() end)
         else
             -- Let the native system handle screensavers on SO devices...
             if os.getenv("AWESOME_STOPPED") == "yes" then


### PR DESCRIPTION
I searched high and low for a way to stop the hideous native Kindle screensavers from appearing, but failed. What would happen is: when pushing the sleep button for the first time after starting koreader, the koreader screensaver would stay put, but on subsequent sleeps, the koreader screensaver would draw and then shortly afterwards, the hideous native screensavers would draw.

I suspect because it took a little longer to process the first time, and sure enough, introducing a delay fixes the problem, although the native screensaver does display for a short moment after sleeping.

Happy to accept suggestions on how to properly disable the native screensavers - I've tried using [linkss](https://www.mobileread.com/forums/showthread.php?t=195474) (which just introduces another condition into the race to draw on screen 😆 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8671)
<!-- Reviewable:end -->
