### PR TITLE
A few Kobo/sunxi tweaks & fixes

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -467,6 +467,9 @@ end
 -- Device specific method for toggling the charging LED
 function Device:toggleChargingLED(toggle) end
 
+-- Device specific method for setting the charging LED to the right state
+function Device:setupChargingLED() end
+
 -- Device specific method for enabling a specific amount of CPU cores
 -- (Should only be implemented on embedded platforms where we can afford to control that without screwing with the system).
 function Device:enableCPUCores(amount) end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -33,6 +33,7 @@ local Device = {
 
     -- hardware feature tests: (these are functions!)
     hasBattery = yes,
+    hasAuxBattery = no,
     hasKeyboard = no,
     hasKeys = no,
     hasDPad = no,

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -111,6 +111,17 @@ function BasePowerD:read_int_file(file)
     end
 end
 
+function BasePowerD:unchecked_read_int_file(file)
+    local fd = io.open(file, "r")
+    if fd then
+        local int = fd:read("*number")
+        fd:close()
+        return int
+    else
+        return
+    end
+end
+
 function BasePowerD:read_str_file(file)
     local fd = io.open(file, "r")
     if fd then
@@ -160,8 +171,12 @@ function BasePowerD:getAuxCapacity()
     local now_ts = UIManager:getTime()
 
     if (now_ts - self.last_aux_capacity_pull_time):tonumber() >= 60 then
-        self.aux_batt_capacity = self:getAuxCapacityHW()
-        self.last_aux_capacity_pull_time = now_ts
+        local aux_batt_capa = self:getAuxCapacityHW()
+        -- If the read failed, don't update our cache, and retry next time.
+        if aux_batt_capa then
+            self.aux_batt_capacity = aux_batt_capa
+            self.last_aux_capacity_pull_time = now_ts
+        end
     end
     return self.aux_batt_capacity
 end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,12 +1,15 @@
+local TimeVal = require("ui/timeval")
 local logger = require("logger")
 local BasePowerD = {
     fl_min = 0,                       -- min frontlight intensity
     fl_max = 10,                      -- max frontlight intensity
     fl_intensity = nil,               -- frontlight intensity
-    battCapacity = 0,                 -- battery capacity
+    batt_capacity = 0,                -- battery capacity
+    aux_batt_capacity = 0,            -- auxiliary battery capacity
     device = nil,                     -- device object
 
-    last_capacity_pull_time = 0,      -- timestamp of last pull
+    last_capacity_pull_time = TimeVal:new{ sec = 0, usec = 0},      -- timestamp of last pull
+    last_aux_capacity_pull_time = TimeVal:new{ sec = 0, usec = 0},  -- timestamp of last pull
 
     is_fl_on = false,                 -- whether the frontlight is on
 }
@@ -27,9 +30,12 @@ end
 function BasePowerD:init() end
 function BasePowerD:setIntensityHW(intensity) end
 function BasePowerD:getCapacityHW() return 0 end
+function BasePowerD:getAuxCapacityHW() return 0 end
+function BasePowerD:isAuxBatteryConnectedHW() return false end
 function BasePowerD:getDismissBatteryStatus() return self.battery_warning end
 function BasePowerD:setDismissBatteryStatus(status) self.battery_warning = status end
 function BasePowerD:isChargingHW() return false end
+function BasePowerD:isAuxChargingHW() return false end
 function BasePowerD:frontlightIntensityHW() return 0 end
 function BasePowerD:isFrontlightOnHW() return self.fl_intensity > self.fl_min end
 function BasePowerD:turnOffFrontlightHW() self:setIntensityHW(self.fl_min) end
@@ -133,16 +139,39 @@ function BasePowerD:setIntensity(intensity)
 end
 
 function BasePowerD:getCapacity()
-    local now_ts = os.time()
-    if now_ts - self.last_capacity_pull_time >= 60 then
-        self.battCapacity = self:getCapacityHW()
+    -- NOTE: UIManager *should* be loaded at this point.
+    --       If that doesn't hold, c.f., :stateChanged below.
+    local UIManager = require("ui/uimanager")
+    local now_ts = UIManager:getTime()
+
+    if (now_ts - self.last_aux_capacity_pull_time):tonumber() >= 60 then
+        self.batt_capacity = self:getCapacityHW()
         self.last_capacity_pull_time = now_ts
     end
-    return self.battCapacity
+    return self.batt_capacity
 end
 
 function BasePowerD:isCharging()
     return self:isChargingHW()
+end
+
+function BasePowerD:getAuxCapacity()
+    local UIManager = require("ui/uimanager")
+    local now_ts = UIManager:getTime()
+
+    if (now_ts - self.last_aux_capacity_pull_time):tonumber() >= 60 then
+        self.aux_batt_capacity = self:getAuxCapacityHW()
+        self.last_aux_capacity_pull_time = now_ts
+    end
+    return self.aux_batt_capacity
+end
+
+function BasePowerD:isAuxCharging()
+    return self:isAuxChargingHW()
+end
+
+function BasePowerD:isAuxBatteryConnected()
+    return self:isAuxBatteryConnectedHW()
 end
 
 function BasePowerD:stateChanged()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -387,7 +387,7 @@ local KoboIo = Kobo:new{
     },
 }
 
-function Kobo:_refreshChargingLED()
+function Kobo:setupChargingLED()
     if G_reader_settings:nilOrTrue("enable_charging_led") then
         if self:hasAuxBattery() and self.powerd:isAuxBatteryConnected() then
             self:toggleChargingLED(self.powerd:isAuxCharging())
@@ -512,7 +512,7 @@ function Kobo:init()
     -- We have no way of querying the current state of the charging LED, so, start from scratch.
     -- Much like Nickel, start by turning it off.
     self:toggleChargingLED(false)
-    self:_refreshChargingLED()
+    self:setupChargingLED()
 
     -- Only enable a single core on startup
     self:enableCPUCores(1)
@@ -888,7 +888,7 @@ function Kobo:resume()
     end
 
     -- A full suspend may have toggled the LED off.
-    self:_refreshChargingLED()
+    self:setupChargingLED()
 end
 
 function Kobo:saveSettings()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -354,6 +354,8 @@ local KoboCadmus = Kobo:new{
     },
     boot_rota = C.FB_ROTATE_CW,
     battery_sysfs = "/sys/class/power_supply/battery",
+    hasAuxBattery = yes,
+    aux_battery_sysfs = "/sys/class/misc/cilix",
     ntx_dev = "/dev/input/by-path/platform-ntx_event0-event",
     touch_dev = "/dev/input/by-path/platform-0-0010-event",
     isSMP = yes,
@@ -431,6 +433,7 @@ function Kobo:init()
     self.powerd = require("device/kobo/powerd"):new{
         device = self,
         battery_sysfs = self.battery_sysfs,
+        aux_battery_sysfs = self.aux_battery_sysfs,
     }
     -- NOTE: For the Forma, with the buttons on the right, 193 is Top, 194 Bottom.
     self.input = require("device/input"):new{

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -100,7 +100,9 @@ function KoboPowerD:init()
         self.aux_batt_charging_file = self.aux_battery_sysfs .. "/charge_status" -- "usb_conn" would not allow us to detect the "Full" state
 
         self.getAuxCapacityHW = function(this)
-            return this:read_int_file(this.aux_batt_capacity_file)
+            -- NOTE: The first few reads after connecting to the PowerCover may fail, in which case,
+            --       we pass that detail along to PowerD so that it may retry the call sooner.
+            return this:unchecked_read_int_file(this.aux_batt_capacity_file)
         end
 
         self.isAuxBatteryConnectedHW = function(this)
@@ -110,7 +112,7 @@ function KoboPowerD:init()
         self.isAuxChargingHW = function(this)
             -- 0 when not charging
             -- 3 when full
-            -- 2 when charging via DCP and/or when battery is high (> 70%)
+            -- 2 when charging via DCP
             local charge_status = this:read_int_file(this.aux_batt_charging_file)
             return charge_status ~= 0 and charge_status ~= 3
         end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -14,6 +14,7 @@ local KoboPowerD = BasePowerD:new{
     fl = nil,
 
     battery_sysfs = nil,
+    aux_battery_sysfs = nil,
     fl_warmth_min = 0, fl_warmth_max = 100,
     fl_warmth = nil,
     fl_was_on = nil,
@@ -92,6 +93,28 @@ function KoboPowerD:init()
     -- Setup the sysfs paths
     self.batt_capacity_file = self.battery_sysfs .. "/capacity"
     self.is_charging_file = self.battery_sysfs .. "/status"
+
+    if self.device:hasAuxBattery() then
+        self.aux_batt_capacity_file = self.aux_battery_sysfs .. "/cilix_bat_capacity"
+        self.aux_batt_connected_file = self.aux_battery_sysfs .. "/cilix_conn" -- or "active"
+        self.aux_batt_charging_file = self.aux_battery_sysfs .. "/charge_status" -- "usb_conn" would not allow us to detect the "Full" state
+
+        self.getAuxCapacityHW = function(this)
+            return this:read_int_file(this.aux_batt_capacity_file)
+        end
+
+        self.isAuxBatteryConnectedHW = function(this)
+            return this:read_int_file(this.aux_batt_connected_file) == 1
+        end
+
+        self.isAuxChargingHW = function(this)
+            -- 0 when not charging
+            -- 3 when full
+            -- 2 when charging via DCP and/or when battery is high (> 70%)
+            local charge_status = this:read_int_file(this.aux_batt_charging_file)
+            return charge_status ~= 0 and charge_status ~= 3
+        end
+    end
 
     -- Default values in case self:_syncKoboLightOnStart() does not find
     -- any previously saved setting (and for unit tests where it will

--- a/frontend/document/canvascontext.lua
+++ b/frontend/document/canvascontext.lua
@@ -35,6 +35,7 @@ The following key is required for a device object:
     * isColorEnabled() -> boolean
 ]]--
 function CanvasContext:init(device)
+    self.device = device
     self.screen = device.screen
     self.isAndroid = device.isAndroid
     self.isDesktop = device.isDesktop
@@ -45,7 +46,7 @@ function CanvasContext:init(device)
     self.hasSystemFonts = device.hasSystemFonts
     self:setColorRenderingEnabled(device.screen.isColorEnabled())
 
-    -- NOTE: Kobo's fb is BGR, not RGB. Handle the conversion in MuPDF if needed.
+    -- NOTE: At 32bpp, Kobo's fb is BGR, not RGB. Handle the conversion in MuPDF if needed.
     if device:hasBGRFrameBuffer() then
         self.is_bgr = true
         Mupdf.bgr = true
@@ -75,6 +76,10 @@ end
 
 function CanvasContext:scaleBySize(px)
     return self.screen:scaleBySize(px)
+end
+
+function CanvasContext:enableCPUCores(amount)
+    return self.device:enableCPUCores(amount)
 end
 
 return CanvasContext

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -1,7 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local CacheItem = require("cacheitem")
 local Configurable = require("configurable")
-local Device = require("device")
 local DocCache = require("document/doccache")
 local DrawContext = require("ffi/drawcontext")
 local CanvasContext = require("document/canvascontext")
@@ -413,7 +412,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
     end
 
     if hinting then
-        Device:enableCPUCores(2)
+        CanvasContext:enableCPUCores(2)
     end
     self:preRenderPage()
 
@@ -429,7 +428,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
             logger.warn("aborting, since we do not have a specification for that part")
             -- required part not given, so abort
             if hinting then
-                Device:enableCPUCores(1)
+                CanvasContext:enableCPUCores(1)
             end
             return
         end
@@ -474,7 +473,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
 
     self:postRenderPage()
     if hinting then
-        Device:enableCPUCores(1)
+        CanvasContext:enableCPUCores(1)
     end
     return tile
 end

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -6,7 +6,6 @@ local CacheItem = require("cacheitem")
 local CanvasContext = require("document/canvascontext")
 local DataStorage = require("datastorage")
 local DEBUG = require("dbg")
-local Device = require("device")
 local DocCache = require("document/doccache")
 local Document = require("document/document")
 local FFIUtil = require("ffi/util")
@@ -111,7 +110,7 @@ function KoptInterface:waitForContext(kc)
 
     if waited or self.bg_thread then
         -- Background thread is done, go back to a single CPU core.
-        Device:enableCPUCores(1)
+        CanvasContext:enableCPUCores(1)
         self.bg_thread = nil
     end
 
@@ -392,7 +391,7 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, re
     local cached = DocCache:check(hash, TileCacheItem)
     if not cached then
         if hinting then
-            Device:enableCPUCores(2)
+            CanvasContext:enableCPUCores(2)
         end
 
         local page_size = Document.getNativePageDimensions(doc, pageno)
@@ -425,7 +424,7 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, re
         DocCache:insert(hash, tile)
 
         if hinting then
-            Device:enableCPUCores(1)
+            CanvasContext:enableCPUCores(1)
         end
 
         return tile
@@ -464,7 +463,7 @@ function KoptInterface:hintReflowedPage(doc, pageno, zoom, rotation, gamma, rend
     local cached = DocCache:check(hash)
     if not cached then
         if hinting then
-            Device:enableCPUCores(2)
+            CanvasContext:enableCPUCores(2)
         end
 
         local kc = self:createContext(doc, pageno, bbox)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20210925
+local CURRENT_MIGRATION_DATE = 20220116
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -317,6 +317,42 @@ if last_migration_date < 20210925 then
     logger.info("Performing one-time migration for 20210925")
     G_reader_settings:delSetting("frontlight_auto_warmth")
     G_reader_settings:delSetting("frontlight_max_warmth_hour")
+end
+
+-- OPDS, add new server, https://github.com/koreader/koreader/pull/8606
+if last_migration_date < 20220116 then
+    logger.info("Performing one-time migration for 20220116")
+
+    local opds_servers = G_reader_settings:readSetting("opds_servers")
+    if opds_servers then
+        -- Check if the user hadn't already added it
+        local found = false
+        local gutenberg_id
+        for i = #opds_servers, 1, -1 do
+            local server = opds_servers[i]
+
+            if server.url == "https://standardebooks.org/opds" then
+                found = true
+            elseif server.url == "https://m.gutenberg.org/ebooks.opds/?format=opds" then
+                gutenberg_id = i
+            end
+        end
+
+        if not found then
+            local std_ebooks = {
+                title = "Standard Ebooks",
+                url = "https://standardebooks.org/opds",
+            }
+
+            -- Append it at the same position as on stock installs, if possible
+            if gutenberg_id then
+                table.insert(opds_servers, gutenberg_id + 1, std_ebooks)
+            else
+                table.insert(opds_servers, std_ebooks)
+            end
+            G_reader_settings:saveSetting("opds_servers", opds_servers)
+        end
+    end
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1759,17 +1759,15 @@ end
 
 -- The common operations that should be performed when the device is plugged to a power source.
 function UIManager:_beforeCharging()
-    if G_reader_settings:nilOrTrue("enable_charging_led") then
-        Device:toggleChargingLED(true)
-    end
+    -- Leave the kernel some time to figure it out ;o).
+    self:scheduleIn(0.5, function() Device:setupChargingLED() end)
     self:broadcastEvent(Event:new("Charging"))
 end
 
 -- The common operations that should be performed when the device is unplugged from a power source.
 function UIManager:_afterNotCharging()
-    if G_reader_settings:nilOrTrue("enable_charging_led") then
-        Device:toggleChargingLED(false)
-    end
+    -- Leave the kernel some time to figure it out ;o).
+    self:scheduleIn(0.5, function() Device:setupChargingLED() end)
     self:broadcastEvent(Event:new("NotCharging"))
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -636,6 +636,36 @@ function TouchMenu:_recalculatePageLayout()
     self.page_num = math.ceil(#self.item_table / self.perpage)
 end
 
+local function getBatterySymbol(is_charging, capacity)
+    if is_charging then
+        return ""
+    else
+        if capacity >= 100 then
+            return ""
+        elseif capacity >= 90 then
+            return ""
+        elseif capacity >= 80 then
+            return ""
+        elseif capacity >= 70 then
+            return ""
+        elseif capacity >= 60 then
+            return ""
+        elseif capacity >= 50 then
+            return ""
+        elseif capacity >= 40 then
+            return ""
+        elseif capacity >= 30 then
+            return ""
+        elseif capacity >= 20 then
+            return ""
+        elseif capacity >= 10 then
+            return ""
+        else
+            return ""
+        end
+    end
+end
+
 function TouchMenu:updateItems()
     local old_dimen = self.dimen and self.dimen:copy()
     self:_recalculatePageLayout()
@@ -687,37 +717,16 @@ function TouchMenu:updateItems()
 
     local time_info_txt = util.secondsToHour(os.time(), G_reader_settings:isTrue("twelve_hour_clock"))
     local powerd = Device:getPowerDevice()
-    local batt_lvl = powerd:getCapacity()
-    local batt_symbol
-    if powerd:isCharging() then
-        batt_symbol = ""
-    else
-        if batt_lvl >= 100 then
-            batt_symbol = ""
-        elseif batt_lvl >= 90 then
-            batt_symbol = ""
-        elseif batt_lvl >= 80 then
-            batt_symbol = ""
-        elseif batt_lvl >= 70 then
-            batt_symbol = ""
-        elseif batt_lvl >= 60 then
-            batt_symbol = ""
-        elseif batt_lvl >= 50 then
-            batt_symbol = ""
-        elseif batt_lvl >= 40 then
-            batt_symbol = ""
-        elseif batt_lvl >= 30 then
-            batt_symbol = ""
-        elseif batt_lvl >= 20 then
-            batt_symbol = ""
-        elseif batt_lvl >= 10 then
-            batt_symbol = ""
-        else
-            batt_symbol = ""
-        end
-    end
     if Device:hasBattery() then
+        local batt_lvl = powerd:getCapacity()
+        local batt_symbol = getBatterySymbol(powerd:isCharging(), batt_lvl)
         time_info_txt = BD.wrap(time_info_txt) .. " " .. BD.wrap("⌁") .. BD.wrap(batt_symbol) ..  BD.wrap(batt_lvl .. "%")
+
+        if Device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
+            local aux_batt_lvl = powerd:getAuxCapacity()
+            local aux_batt_symbol = getBatterySymbol(powerd:isAuxCharging(), aux_batt_lvl)
+            time_info_txt = time_info_txt .. " " .. BD.wrap("+") .. BD.wrap(aux_batt_symbol) ..  BD.wrap(aux_batt_lvl .. "%")
+        end
     end
     self.time_info:setText(time_info_txt)
 

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -96,7 +96,15 @@ ko_update_check() {
         # Setup the FBInk daemon
         export FBINK_NAMED_PIPE="/tmp/koreader.fbink"
         rm -f "${FBINK_NAMED_PIPE}"
-        FBINK_PID="$(./fbink --daemon 1 %KOREADER% -q -y -6 -P 0)"
+        # We'll want to use REAGL on sunxi, because AUTO is slow, and fast merges are extremely broken outside of REAGL...
+        eval "$(fbink -e | tr ';' '\n' | grep -e isSunxi | tr '\n' ';')"
+        # shellcheck disable=SC2154
+        if [ "${isSunxi}" = "1" ]; then
+            PBAR_WFM="REAGL"
+        else
+            PBAR_WFM="AUTO"
+        fi
+        FBINK_PID="$(./fbink --daemon 1 %KOREADER% -q -y -6 -P 0 -W ${PBAR_WFM})"
         # NOTE: See frontend/ui/otamanager.lua for a few more details on how we squeeze a percentage out of tar's checkpoint feature
         # NOTE: %B should always be 512 in our case, so let stat do part of the maths for us instead of using %s ;).
         FILESIZE="$(stat -c %b "${NEWUPDATE}")"

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -251,10 +251,9 @@ fi
 # will also enforce UR... (Only actually meaningful on sunxi).
 if [ "${PLATFORM}" = "b300-ntx" ]; then
     export FBINK_FORCE_ROTA=0
-    # Screen is too fast for GL16 not to look like utter crap.
-    FBINK_WFM="GC16"
-    FBINK_FLASH="-f"
-    # And we also cannot use batched updates for the crash screens, as buffers are private,
+    # On sunxi, non-REAGL waveform modes suffer from weird merging quirks...
+    FBINK_WFM="REAGL"
+    # And we also cannot use batched updates for the crash screen, as buffers are private,
     # so each invocation essentially draws in a different buffer...
     FBINK_BATCH_FLAG=""
     # Same idea for backgroundless...
@@ -266,7 +265,6 @@ if [ "${PLATFORM}" = "b300-ntx" ]; then
     KOBO_TS_INPUT="/dev/input/by-path/platform-0-0010-event"
 else
     FBINK_WFM="GL16"
-    FBINK_FLASH=""
     FBINK_BATCH_FLAG="-b"
     FBINK_BGLESS_FLAG="-O"
     FBINK_OT_PADDING=""
@@ -410,20 +408,20 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         # Start with a big gray screen of death, and our friendly old school crash icon ;)
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039,SC3003,SC2086
-        ./fbink -q ${FBINK_BATCH_FLAG} -c -B GRAY9 -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -W ${FBINK_WFM} ${FBINK_FLASH} -- $'\xf0\x9f\x92\xa3'
+        ./fbink -q ${FBINK_BATCH_FLAG} -c -B GRAY9 -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -W ${FBINK_WFM} -- $'\xf0\x9f\x92\xa3'
         # With a little notice at the top of the screen, on a big gray screen of death ;).
         # shellcheck disable=SC2086
-        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 1 -W ${FBINK_WFM} ${FBINK_FLASH} -- "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
+        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 1 -W ${FBINK_WFM} -- "Don't Panic! (Crash n°${CRASH_COUNT} -> ${RETURN_VALUE})"
         if [ ${CRASH_COUNT} -eq 1 ]; then
             # Warn that we're waiting on a tap to continue...
             # shellcheck disable=SC2086
-            ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 2 -W ${FBINK_WFM} ${FBINK_FLASH} -- "Tap the screen to continue."
+            ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -m -y 2 -W ${FBINK_WFM} -- "Tap the screen to continue."
         fi
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
         # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
         # shellcheck disable=SC2086
-        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64))${FBINK_OT_PADDING} -W ${FBINK_WFM} ${FBINK_FLASH} -- "${crashLog}"
+        ./fbink -q ${FBINK_BATCH_FLAG} ${FBINK_BGLESS_FLAG} -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64))${FBINK_OT_PADDING} -W ${FBINK_WFM} -- "${crashLog}"
         if [ "${PLATFORM}" != "b300-ntx" ]; then
             # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
             ./fbink -q -f -s


### PR DESCRIPTION
* Initial support for the Sage PowerCover (i.e., display its status in the TouchMenu footer).
I left the footer & co alone, because I don't really care about seeing that much detail in those other contexts.
* Fix the update progress bar on sunxi. I had noticed that is was hella broken on the Elipsa & Sage with the latest FW (while I could have sworn it originally worked on the Elipsa...).
* Above fix led me to a simpler workaround for similar issues with the crash screen.
* Set the CPU governor on *all* cores if possible (that's a NOP in practice, because we don't change the governor on SMP devices).
* Accurately refresh the charging LED state on startup & resume, accounting for the PowerCover (i.e., charging == charging the *cover*).
* Stash `enableCPUCores` in `CanvasContext`, to avoid pulling in `Device` in `Document` (re #8579).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8672)
<!-- Reviewable:end -->
