### PR TITLE
BD: allow inverting for Document UI elements (TOC)

### DIFF
--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -24,7 +24,6 @@ local ReaderPageMap = InputContainer:new{
     label_color = Blitbuffer.COLOR_BLACK,
     show_page_labels = nil,
     use_page_labels = nil,
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function ReaderPageMap:init()
@@ -139,7 +138,7 @@ function ReaderPageMap:updateVisibleLabels()
     local max_y = Screen:getHeight() - footer_height
     local last_label_bottom_y = 0
     for _, page in ipairs(page_labels) do
-        local in_left_margin = self._mirroredUI
+        local in_left_margin = BD.mirroredUILayout()
         if self.ui.document:getVisiblePageCount() > 1 then
             -- Pages in 2-page mode are not mirrored, so we'll
             -- have to handle any mirroring tweak ourselves

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -644,6 +644,10 @@ function ReaderToc:expandParentNode(index)
 end
 
 function ReaderToc:onShowToc()
+    if self.view.inverse_reading_order then
+        BD.invert()
+    end
+
     self:fillToc()
     -- build menu items
     if #self.toc > 0 and not self.toc[1].text then
@@ -813,6 +817,7 @@ function ReaderToc:onShowToc()
 
     toc_menu.close_callback = function()
         UIManager:close(menu_container)
+        BD.resetInvert()
     end
 
     toc_menu.show_parent = menu_container

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -856,10 +856,9 @@ end
 
 -- expand TOC node of index in raw toc table
 function ReaderToc:expandToc(index)
-    for k, v in ipairs(self.expanded_nodes) do
-        if v == index then return end
-    end
-    table.insert(self.expanded_nodes, index)
+    if self.expanded_nodes[index] == true then return end
+
+    self.expanded_nodes[index] = true
     local cur_node = self.toc[index]
     local cur_depth = cur_node.depth
     local collapsed_index = nil
@@ -891,11 +890,8 @@ end
 
 -- collapse TOC node of index in raw toc table
 function ReaderToc:collapseToc(index)
-    for k, v in ipairs(self.expanded_nodes) do
-        if v == index then
-            table.remove(self.expanded_nodes, k)
-            break
-        end
+    if self.expanded_nodes[index] == true then
+        self.expanded_nodes[index] = nil
     end
     local cur_node = self.toc[index]
     local cur_depth = cur_node.depth
@@ -910,11 +906,8 @@ function ReaderToc:collapseToc(index)
             if v.state then
                 v.state:free()
                 v.state = self.expand_button:new{}
-                for y, z in ipairs(self.expanded_nodes) do
-                    if z == v.index then
-                        table.remove(self.expanded_nodes, y)
-                        break
-                    end
+                if self.expanded_nodes[v.index] == true then
+                    self.expanded_nodes[v.index] = nil
                 end
             end
             table.remove(self.collapsed_toc, i)

--- a/frontend/ui/bidi.lua
+++ b/frontend/ui/bidi.lua
@@ -43,6 +43,7 @@ local _ = require("gettext")
 local Bidi = {
     _mirrored_ui_layout = false,
     _rtl_ui_text = false,
+    _inverted = false,
 }
 
 -- Setup UI mirroring and RTL text for UI language
@@ -124,6 +125,22 @@ end
 -- is to be done
 function Bidi.mirroredUILayout()
     return Bidi._mirrored_ui_layout
+end
+
+-- This fuction can be used by document widgets to temporarily match a widget
+-- to the document page turn direction instead of the UI layout direction.
+function Bidi.invert()
+    if G_reader_settings:isTrue("invert_ui_layout_mirroring") and not Bidi._inverted then
+        Bidi._mirrored_ui_layout = not Bidi._mirrored_ui_layout
+        Bidi._inverted = true
+    end
+end
+
+function Bidi.resetInvert()
+    if Bidi._inverted then
+        Bidi._mirrored_ui_layout = not Bidi._mirrored_ui_layout
+        Bidi._inverted = false
+    end
 end
 
 -- This function might only be useful in some rare cases (RTL text

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -122,6 +122,21 @@ local PageTurns = {
                     end,
                 })
             end,
+        },
+        {
+            text = _("Also invert document-related dialogs"),
+            checked_func = function()
+                return G_reader_settings:isTrue("invert_ui_layout_mirroring")
+            end,
+            enabled_func = function()
+                return ReaderUI.instance.view.inverse_reading_order
+            end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("invert_ui_layout_mirroring")
+            end,
+            help_text = _([[
+When enabled the UI direction for the Table of Contents, Book Map, and Page Browser dialogs will follow the page turn direction instead of the default UI direction.]]),
+            separator = true,
         }
     }
 }

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -40,17 +40,16 @@ local BookMapRow = InputContainer:new{
     toc_items = nil, -- Arrays[levels] of arrays[items at this level to show as spans]
     -- Many other options not described here, see BookMapWidget:update()
     -- for the complete list.
-
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function BookMapRow:getPageX(page, right_edge)
+    local _mirroredUI = BD.mirroredUILayout()
     if right_edge then
-        if (not self._mirroredUI and page == self.end_page) or
-               (self._mirroredUI and page == self.start_page) then
+        if (not _mirroredUI and page == self.end_page) or
+               (_mirroredUI and page == self.start_page) then
             return self.pages_frame_inner_width
         else
-            if self._mirroredUI then
+            if _mirroredUI then
                 return self:getPageX(page-1)
             else
                 return self:getPageX(page+1)
@@ -58,7 +57,7 @@ function BookMapRow:getPageX(page, right_edge)
         end
     end
     local slot_idx
-    if self._mirroredUI then
+    if _mirroredUI then
         slot_idx = self.end_page - page
     else
         slot_idx = page - self.start_page
@@ -75,7 +74,7 @@ function BookMapRow:getPageAtX(x)
     end
     -- Reverse of the computation in :getPageX():
     local slot_idx = math.floor(x / (self.page_slot_width + self.page_slot_extra / self.nb_page_slots))
-    if self._mirroredUI then
+    if BD.mirroredUILayout() then
         return self.end_page - slot_idx
     else
         return self.start_page + slot_idx
@@ -97,6 +96,7 @@ function BookMapRow:getLeftSpacingForNumberOfPageSlots(nb_pages, pages_per_row, 
 end
 
 function BookMapRow:init()
+    local _mirroredUI = BD.mirroredUILayout()
     self.dimen = Geom:new{ w = self.width, h = self.height }
 
     -- Keep one span_height under baseline (frame bottom border) for indicators (current page, bookmarks)
@@ -116,7 +116,7 @@ function BookMapRow:init()
         self.pages_frame_width = self.pages_frame_inner_width + 2*self.pages_frame_border
     end
 
-    if self._mirroredUI then
+    if _mirroredUI then
         self.pages_frame_offset_x = self.width - self.pages_frame_width - self.left_spacing + self.pages_frame_border
     end
 
@@ -132,7 +132,7 @@ function BookMapRow:init()
         },
         allow_mirroring = false, -- we handle mirroring ourselves below
         FrameContainer:new{
-            overlap_align = self._mirroredUI and "right" or "left",
+            overlap_align = _mirroredUI and "right" or "left",
             margin = 0,
             padding = 0,
             bordersize = self.pages_frame_border,
@@ -160,7 +160,7 @@ function BookMapRow:init()
                 local text = item.title
                 local p_start, p_end = item.p_start, item.p_end
                 local started_before, continues_after = item.started_before, item.continues_after
-                if self._mirroredUI then
+                if _mirroredUI then
                     -- Just flip these (beware below, we need to use item.p_start to get
                     -- the real start page to account in prev_p_start)
                     p_start, p_end = p_end, p_start
@@ -175,7 +175,7 @@ function BookMapRow:init()
                     -- the previous overwritten span and we can know this
                     -- page slot contains multiple chapters
                     if width > same_p_start_offset_dx then
-                        if not self._mirroredUI then
+                        if not _mirroredUI then
                             offset_x = offset_x + same_p_start_offset_dx
                         end
                         width = width - same_p_start_offset_dx
@@ -252,7 +252,7 @@ function BookMapRow:init()
             width = self.left_spacing - spacing,
             face = self.smaller_font_face,
             line_height = 0, -- no additional line height
-            alignment = self._mirroredUI and "left" or "right",
+            alignment = _mirroredUI and "left" or "right",
             alignment_strict = true,
         })
         table.insert(self.hgroup, HorizontalSpan:new{ width = spacing })
@@ -268,7 +268,7 @@ function BookMapRow:init()
                 local r_start = math.max(f_start, self.start_page)
                 local r_end = math.min(f_end, self.end_page)
                 local x, w
-                if self._mirroredUI then
+                if _mirroredUI then
                     x = self:getPageX(r_end)
                     w = self:getPageX(r_start, true) - x
                 else
@@ -316,10 +316,10 @@ function BookMapRow:init()
                 x = x + 1
                 w = w - 1
                 if w > 2 then
-                    if page == self.end_page and not self._mirroredUI then
+                    if page == self.end_page and not _mirroredUI then
                         w = w - 1 -- some spacing before right border (like we had at start)
                     end
-                    if page == self.start_page and self._mirroredUI then
+                    if page == self.start_page and _mirroredUI then
                         w = w - 1
                     end
                 end
@@ -338,7 +338,7 @@ function BookMapRow:init()
             if self.with_page_sep and not prev_page_was_read then
                 local w = Size.line.thin
                 local x
-                if self._mirroredUI then
+                if _mirroredUI then
                     x = self:getPageX(page, true) - w
                 else
                     x = self:getPageX(page)
@@ -521,8 +521,6 @@ local BookMapWidget = InputContainer:new{
     launcher = nil,
     -- Extra symbols to show below pages
     extra_symbols_pages = nil,
-
-    _mirroredUI = BD.mirroredUILayout(),
 
     -- Make this local subwidget available for reuse by PageBrowser
     BookMapRow = BookMapRow,
@@ -1224,9 +1222,10 @@ function BookMapWidget:updatePagesPerRow(value, relative)
 end
 
 function BookMapWidget:onSwipe(arg, ges)
+    local _mirroredUI = BD.mirroredUILayout()
     local direction = BD.flipDirectionIfMirroredUILayout(ges.direction)
-    if (not self._mirroredUI and ges.pos.x < Screen:getWidth() * 1/8) or
-           (self._mirroredUI and ges.pos.x > Screen:getWidth() * 7/8) then
+    if (not _mirroredUI and ges.pos.x < Screen:getWidth() * 1/8) or
+           (_mirroredUI and ges.pos.x > Screen:getWidth() * 7/8) then
         -- Swipe along the left screen edge: increase/decrease toc levels shown
         if direction == "north" or direction == "south" then
             local rel = direction == "south" and 1 or -1
@@ -1348,7 +1347,7 @@ function BookMapWidget:onTap(arg, ges)
         -- not a BookMapRow, probably a TOC title
         return true
     end
-    if self._mirroredUI then
+    if BD.mirroredUILayout() then
         x = x - self.scrollbar_width
     end
     local page = row:getPageAtX(x)
@@ -1380,7 +1379,7 @@ function BookMapWidget:paintLeftVerticalSwipeHint(bb, x, y)
         -- Compute and remember sizes, positions and info
         v = {}
         v.width = self.swipe_hint_bar_width
-        if self._mirroredUI then
+        if BD.mirroredUILayout() then
             v.left = Screen:getWidth() - v.width
         else
             v.left = 0
@@ -1432,7 +1431,7 @@ function BookMapWidget:paintBottomHorizontalSwipeHint(bb, x, y)
     local cur = self.pages_per_row - self.min_pages_per_row
     local max = self.max_pages_per_row - self.min_pages_per_row
     local dx = math.floor(h.max_dx*(1-math.log(1+cur)/math.log(1+max)))
-    if self._mirroredUI then
+    if BD.mirroredUILayout() then
         dx = h.max_dx - dx
     end
     bb:paintRect(h.left + dx, h.top, h.hint_w, h.height, Blitbuffer.COLOR_DARK_GRAY)

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -527,6 +527,10 @@ local BookMapWidget = InputContainer:new{
 }
 
 function BookMapWidget:init()
+    if self.ui.view.inverse_reading_order then
+        BD.invert()
+    end
+
     -- Compute non-settings-dependant sizes and options
     self.dimen = Geom:new{
         w = Screen:getWidth(),
@@ -1042,6 +1046,7 @@ function BookMapWidget:onClose(close_all_parents)
             UIManager:setDirty(self.launcher, "ui")
         end
     else
+        BD.resetInvert()
         -- Remove all thumbnails generated for a different target size than
         -- the last one used (no need to keep old sizes if the user played
         -- with nb_cols/nb_rows, as on next opening, we just need the ones

--- a/frontend/ui/widget/checkmark.lua
+++ b/frontend/ui/widget/checkmark.lua
@@ -29,14 +29,13 @@ local CheckMark = InputContainer:new{
     width = 0,
     height = 0,
     baseline = 0,
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function CheckMark:init()
     -- Adjust these checkmarks if mirroring UI (para_direction_rtl should
     -- follow BD.mirroredUILayout(), and not the set or reverted text
     -- direction, for proper rendering on the right).
-    local para_direction_rtl = self._mirroredUI
+    local para_direction_rtl = BD.mirroredUILayout()
     local checked_widget = TextWidget:new{
         text = " ✓", -- preceded by thin space for better alignment
         face = self.face,

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -40,7 +40,6 @@ local FrameContainer = WidgetContainer:new{
     height = nil,
     invert = false,
     allow_mirroring = true,
-    _mirroredUI = BD.mirroredUILayout(),
     focusable = false,
     focus_border_size = Size.border.window * 2,
     focus_border_color = Blitbuffer.COLOR_BLACK,
@@ -52,7 +51,7 @@ function FrameContainer:getSize()
     self._padding_right = self.padding_right or self.padding
     self._padding_bottom = self.padding_bottom or self.padding
     self._padding_left = self.padding_left or self.padding
-    if self._mirroredUI and self.allow_mirroring then
+    if BD.mirroredUILayout() and self.allow_mirroring then
         self._padding_left, self._padding_right = self._padding_right, self._padding_left
     end
     return Geom:new{
@@ -93,7 +92,7 @@ function FrameContainer:paintTo(bb, x, y)
     local container_height = self.height or my_size.h
 
     local shift_x = 0
-    if self._mirroredUI and self.allow_mirroring then
+    if BD.mirroredUILayout() and self.allow_mirroring then
         shift_x = container_width - my_size.w
     end
 

--- a/frontend/ui/widget/container/leftcontainer.lua
+++ b/frontend/ui/widget/container/leftcontainer.lua
@@ -7,7 +7,6 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local LeftContainer = WidgetContainer:new{
     allow_mirroring = true,
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function LeftContainer:paintTo(bb, x, y)
@@ -17,7 +16,7 @@ function LeftContainer:paintTo(bb, x, y)
         -- throw error? paint to scrap buffer and blit partially?
         -- for now, we ignore this
     -- end
-    if self._mirroredUI and self.allow_mirroring then
+    if BD.mirroredUILayout() and self.allow_mirroring then
         x = x + (self.dimen.w - contentSize.w) -- as in RightContainer
     end
     self[1]:paintTo(bb, x , y + math.floor((self.dimen.h - contentSize.h)/2))

--- a/frontend/ui/widget/container/rightcontainer.lua
+++ b/frontend/ui/widget/container/rightcontainer.lua
@@ -7,7 +7,6 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local RightContainer = WidgetContainer:new{
     allow_mirroring = true,
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function RightContainer:paintTo(bb, x, y)
@@ -17,7 +16,7 @@ function RightContainer:paintTo(bb, x, y)
         -- throw error? paint to scrap buffer and blit partially?
         -- for now, we ignore this
     -- end
-    if not self._mirroredUI or not self.allow_mirroring then
+    if not BD.mirroredUILayout() or not self.allow_mirroring then
         x = x + (self.dimen.w - contentSize.w)
     -- else: keep x, as in LeftContainer
     end

--- a/frontend/ui/widget/container/scrollablecontainer.lua
+++ b/frontend/ui/widget/container/scrollablecontainer.lua
@@ -49,7 +49,6 @@ local ScrollableContainer = InputContainer:new{
     _crop_w = nil,
     _crop_h = nil,
     _crop_dx = 0,
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function ScrollableContainer:getScrollbarWidth(scroll_bar_width)
@@ -140,7 +139,7 @@ function ScrollableContainer:initState()
             }
             self._crop_h = self.dimen.h - 3*self.scroll_bar_width
         end
-        if self._mirroredUI then
+        if BD.mirroredUILayout() then
             if self._v_scroll_bar then
                 self._crop_dx = self.dimen.w - self._crop_w
             end
@@ -198,7 +197,7 @@ function ScrollableContainer:scrollToRatio(ratio_x, ratio_y)
 end
 
 function ScrollableContainer:_scrollBy(dx, dy)
-    if self._mirroredUI then
+    if BD.mirroredUILayout() then
         dx = -dx
     end
     self._scroll_offset_x = self._scroll_offset_x + Math.round(dx)
@@ -263,9 +262,11 @@ function ScrollableContainer:paintTo(bb, x, y)
         self:initState()
     end
 
+    local _mirroredUI = BD.mirroredUILayout()
+
     if not self._is_scrollable then
         -- nothing to scroll: pass-through
-        if self._mirroredUI then -- behave as LeftContainer
+        if _mirroredUI then -- behave as LeftContainer
             x = x + (self.dimen.w - self[1]:getSize().w)
         end
         self[1]:paintTo(bb, x, y)
@@ -286,7 +287,7 @@ function ScrollableContainer:paintTo(bb, x, y)
     -- to erase bits that may not be overwritten after a scroll
     self._bb:fill(Blitbuffer.COLOR_WHITE)
     local dx
-    if self._mirroredUI then
+    if _mirroredUI then
         dx = self._max_scroll_offset_x - self._scroll_offset_x - self._crop_dx
     else
         dx = self._scroll_offset_x
@@ -296,14 +297,14 @@ function ScrollableContainer:paintTo(bb, x, y)
 
     -- Draw our scrollbars over
     if self._h_scroll_bar then
-        if self._mirroredUI then
+        if _mirroredUI then
             self._h_scroll_bar:paintTo(bb, x + self._h_scroll_bar_shift, y + self.dimen.h - 2*self.scroll_bar_width)
         else
             self._h_scroll_bar:paintTo(bb, x, y + self.dimen.h - 2*self.scroll_bar_width)
         end
     end
     if self._v_scroll_bar then
-        if self._mirroredUI then
+        if _mirroredUI then
             self._v_scroll_bar:paintTo(bb, x + self.scroll_bar_width, y)
         else
             self._v_scroll_bar:paintTo(bb, x + self.dimen.w - 2*self.scroll_bar_width, y)

--- a/frontend/ui/widget/horizontalgroup.lua
+++ b/frontend/ui/widget/horizontalgroup.lua
@@ -9,15 +9,15 @@ local util = require("util")
 local HorizontalGroup = WidgetContainer:new{
     align = "center",
     allow_mirroring = true,
-    _mirroredUI = BD.mirroredUILayout(),
     _size = nil,
 }
 
 function HorizontalGroup:getSize()
     if not self._size then
+        local _mirroredUI = BD.mirroredUILayout()
         self._size = { w = 0, h = 0 }
         self._offsets = { }
-        if self._mirroredUI and self.allow_mirroring then
+        if _mirroredUI and self.allow_mirroring then
             util.arrayReverse(self)
         end
         for i, widget in ipairs(self) do
@@ -31,7 +31,7 @@ function HorizontalGroup:getSize()
                 self._size.h = w_size.h
             end
         end
-        if self._mirroredUI and self.allow_mirroring then
+        if _mirroredUI and self.allow_mirroring then
             util.arrayReverse(self)
         end
     end
@@ -40,8 +40,9 @@ end
 
 function HorizontalGroup:paintTo(bb, x, y)
     local size = self:getSize()
+    local _mirroredUI = BD.mirroredUILayout()
 
-    if self._mirroredUI and self.allow_mirroring then
+    if _mirroredUI and self.allow_mirroring then
         util.arrayReverse(self)
     end
     for i, widget in ipairs(self) do
@@ -58,7 +59,7 @@ function HorizontalGroup:paintTo(bb, x, y)
                             self.align)
         end
     end
-    if self._mirroredUI and self.allow_mirroring then
+    if _mirroredUI and self.allow_mirroring then
         util.arrayReverse(self)
     end
 end

--- a/frontend/ui/widget/horizontalscrollbar.lua
+++ b/frontend/ui/widget/horizontalscrollbar.lua
@@ -24,7 +24,6 @@ local HorizontalScrollBar = InputContainer:new{
     -- extra touchable height (for scrolling with pan) can be larger than
     -- the provided height (this is added on each side)
     extra_touch_on_side_heightratio = 1, -- make it 3 x height
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function HorizontalScrollBar:init()
@@ -77,7 +76,7 @@ end
 function HorizontalScrollBar:onTapScroll(arg, ges)
     if self.scroll_callback then
         local ratio = (ges.pos.x - self.touch_dimen.x) / self.width
-        if self._mirroredUI then
+        if BD.mirroredUILayout() then
             ratio = 1 - ratio
         end
         self.scroll_callback(ratio)
@@ -112,7 +111,7 @@ function HorizontalScrollBar:paintTo(bb, x, y)
     }
     bb:paintBorder(x, y, self.width, self.height,
                    self.bordersize, self.bordercolor, self.radius)
-    if self._mirroredUI then
+    if BD.mirroredUILayout() then
         bb:paintRect(x + self.bordersize + (1-self.high) * self.width, y + self.bordersize,
                      math.max((self.width - 2 * self.bordersize) * (self.high - self.low), self.min_thumb_size),
                      self.height - 2 * self.bordersize,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -167,17 +167,14 @@ function MenuItem:init()
     end
 
     -- State button and indentation for tree expand/collapse (for TOC)
-    local state_button_width = self.state_size.w or 0
-    local state_button = self.state or HorizontalSpan:new{
-        width = state_button_width,
-    }
-    local state_indent = self.state and self.state.indent or ""
+    local state_button = self.state or HorizontalSpan:new{}
+    local state_indent = self.table.indent or 0
+    local state_width = state_indent + self.state_w
     local state_container = LeftContainer:new{
         dimen = Geom:new{w = math.floor(self.content_width / 2), h = self.dimen.h},
         HorizontalGroup:new{
-            TextWidget:new{
-                text = state_indent,
-                face = Font:getFace(self.font, self.font_size),
+            HorizontalSpan:new{
+                width = state_indent,
             },
             state_button,
         }
@@ -207,7 +204,7 @@ function MenuItem:init()
     }
     local mandatory_w = mandatory_widget:getWidth()
 
-    local available_width = self.content_width - state_button_width - text_mandatory_padding - mandatory_w
+    local available_width = self.content_width - state_width - text_mandatory_padding - mandatory_w
     local item_name
 
     -- Whether we show text on a single or multiple lines, we don't want it shortened
@@ -370,7 +367,7 @@ function MenuItem:init()
         dimen = Geom:new{w = self.content_width, h = self.dimen.h},
         HorizontalGroup:new{
             HorizontalSpan:new{
-                width = self.state_size.w,
+                width = state_width,
             },
             item_name,
         }
@@ -1074,7 +1071,7 @@ function Menu:updateItems(select_number)
             local item_tmp = MenuItem:new{
                 show_parent = self.show_parent,
                 state = self.item_table[i].state,
-                state_size = self.state_size or {},
+                state_w = self.state_w or 0,
                 text = Menu.getMenuText(self.item_table[i]),
                 bidi_wrap_func = self.item_table[i].bidi_wrap_func,
                 mandatory = self.item_table[i].mandatory,

--- a/frontend/ui/widget/overlapgroup.lua
+++ b/frontend/ui/widget/overlapgroup.lua
@@ -15,7 +15,6 @@ local OverlapGroup = WidgetContainer:new{
     -- It's usually safer to set it to false on the OverlapGroup,
     -- but some thinking is needed when many of them are nested.
     allow_mirroring = true,
-    _mirroredUI = BD.mirroredUILayout(),
     _size = nil,
 }
 
@@ -58,7 +57,7 @@ function OverlapGroup:paintTo(bb, x, y)
     for i, wget in ipairs(self) do
         local wget_size = wget:getSize()
         local overlap_align = wget.overlap_align
-        if self._mirroredUI and self.allow_mirroring then
+        if BD.mirroredUILayout() and self.allow_mirroring then
             -- Checks in the same order as how they are checked below
             if overlap_align == "right" then
                 overlap_align = "left"

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -36,8 +36,6 @@ local PageBrowserWidget = InputContainer:new{
     focus_page = nil,
     -- Should only be nil on the first launch via ReaderThumbnail
     launcher = nil,
-
-    _mirroredUI = BD.mirroredUILayout(),
 }
 
 function PageBrowserWidget:init()
@@ -253,7 +251,7 @@ function PageBrowserWidget:updateLayout()
     for idx = 1, self.nb_grid_items do
         local row = math.floor((idx-1)/self.nb_cols) -- start from 0
         local col = (idx-1) % self.nb_cols
-        if self._mirroredUI then
+        if BD.mirroredUILayout() then
             col = self.nb_cols - col - 1
         end
         local offset_x = self.grid_item_margin*(col+1) + self.grid_item_width*col
@@ -475,7 +473,7 @@ function PageBrowserWidget:update()
     }
     self.row[1] = row
 
-    if self._mirroredUI then
+    if BD.mirroredUILayout() then
         self.view_finder_x = row:getPageX(grid_page_end)
         self.view_finder_w = row:getPageX(grid_page_start, true) - self.view_finder_x
         if blank_page_slots_after_end > 0 then

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -39,6 +39,10 @@ local PageBrowserWidget = InputContainer:new{
 }
 
 function PageBrowserWidget:init()
+    if self.ui.view.inverse_reading_order then
+        BD.invert()
+    end
+
     -- Compute non-settings-dependant sizes and options
     self.dimen = Geom:new{
         w = Screen:getWidth(),
@@ -641,6 +645,7 @@ function PageBrowserWidget:onClose(close_all_parents)
             UIManager:setDirty(self.launcher, "ui")
         end
     else
+        BD.resetInvert()
         -- Remove all thumbnails generated for a different target size than
         -- the last one used (no need to keep old sizes if the user played
         -- with nb_cols/nb_rows, as on next opening, we just need the ones

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -52,7 +52,6 @@ local ProgressWidget = Widget:new{
     fill_from_right = false,
     allow_mirroring = true,
     alt = nil, -- table with alternate pages to mark with different color (in the form {{ini1, len1}, {ini2, len2}, ...})
-    _mirroredUI = BD.mirroredUILayout(),
     _orig_margin_v = nil,
     _orig_bordersize = nil,
 }
@@ -70,6 +69,7 @@ function ProgressWidget:paintTo(bb, x, y)
     }
     if self.dimen.w == 0 or self.dimen.h == 0 then return end
 
+    local _mirroredUI = BD.mirroredUILayout()
     -- We'll draw every bar element in order, bottom to top.
     local fill_width = my_size.w - 2*(self.margin_h + self.bordersize)
     local fill_y = y + self.margin_v + self.bordersize
@@ -100,7 +100,7 @@ function ProgressWidget:paintTo(bb, x, y)
         for i=1, #self.alt do
             local tick_x = fill_width * ((self.alt[i][1] - 1) / self.last)
             local width = fill_width * (self.alt[i][2] / self.last)
-            if self._mirroredUI then
+            if _mirroredUI then
                 tick_x = fill_width - tick_x - width
             end
             tick_x = math.floor(tick_x)
@@ -117,7 +117,7 @@ function ProgressWidget:paintTo(bb, x, y)
     -- Main fill bar for the specified percentage.
     if self.percentage >= 0 and self.percentage <= 1 then
         local fill_x = x + self.margin_h + self.bordersize
-        if self.fill_from_right or (self._mirroredUI and not self.fill_from_right) then
+        if self.fill_from_right or (_mirroredUI and not self.fill_from_right) then
             fill_x = fill_x + (fill_width * (1 - self.percentage))
             fill_x = math.floor(fill_x)
         end
@@ -133,7 +133,7 @@ function ProgressWidget:paintTo(bb, x, y)
     if self.ticks and self.last and self.last > 0 then
         for i, tick in ipairs(self.ticks) do
             local tick_x = fill_width * (tick / self.last)
-            if self._mirroredUI then
+            if _mirroredUI then
                 tick_x = fill_width - tick_x
             end
             tick_x = math.floor(tick_x)

--- a/frontend/ui/widget/verticalgroup.lua
+++ b/frontend/ui/widget/verticalgroup.lua
@@ -8,7 +8,6 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local VerticalGroup = WidgetContainer:new{
     align = "center",
     allow_mirroring = true,
-    _mirroredUI = BD.mirroredUILayout(),
     _size = nil,
     _offsets = {},
 }
@@ -35,7 +34,7 @@ end
 function VerticalGroup:paintTo(bb, x, y)
     local size = self:getSize()
     local align = self.align
-    if self._mirroredUI and self.allow_mirroring then
+    if BD.mirroredUILayout() and self.allow_mirroring then
         if align == "left" then
             align = "right"
         elseif align == "right" then


### PR DESCRIPTION
This PR allows changing the TOC BookMap PageBrowser & ~~SkimTo~~ UI direction based on the tap direction of the book even if it is not the same as the general UI.

This can be useful when for example reading an english book with a RTL hebrew UI

see previous discussion in https://github.com/koreader/koreader/issues/5359#issuecomment-568810654 https://github.com/koreader/koreader/pull/8613#issuecomment-1006717032

`_mirroredUI inherit from widgetcontainer`
This allows `_mirroredUI` to be set on init not require.

The first 3 commits are ready the last one needs some work.

The Toc works great with this (It is also easy to gate with one entry/exit point) however bookmap does not work, some of the elements are off and i could not figure out why. @poire-z Do you have any clue why? Also is there a way to debug which widgets are being painted where? (to we which parent widget is misaligned)
![toc](https://user-images.githubusercontent.com/38916402/149643423-8f583acb-84b8-4ca3-b706-9508079aa8e5.png)
![bookmap](https://user-images.githubusercontent.com/38916402/149643424-454e083d-f75e-4500-a3bd-e23dda29482d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8673)
<!-- Reviewable:end -->
