### PR TITLE
Wikipedia: rework wiki languages internal handling

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -947,7 +947,7 @@ end
 
 function ReaderDictionary:showDict(word, results, boxes, link)
     if results and results[1] then
-        logger.dbg("showing quick lookup window", word, results)
+        logger.dbg("showing quick lookup window", #self.dict_window_list+1, ":", word, results)
         self.dict_window = DictQuickLookup:new{
             window_list = self.dict_window_list,
             ui = self.ui,
@@ -962,7 +962,6 @@ function ReaderDictionary:showDict(word, results, boxes, link)
             preferred_dictionaries = self.preferred_dictionaries,
             -- differentiate between dict and wiki
             is_wiki = self.is_wiki,
-            wiki_languages = self.wiki_languages,
             refresh_callback = function()
                 if self.view then
                     -- update info in footer (time, battery, etc)

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -9,6 +9,7 @@ local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Mupdf = require("ffi/mupdf")
 local Screen = Device.screen
+local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local util  = require("util")
@@ -229,7 +230,7 @@ function HtmlBoxWidget:onHoldReleaseText(callback, ges)
         return false
     end
 
-    local hold_duration = UIManager:getTime() - self.hold_start_tv
+    local hold_duration = TimeVal.now() - self.hold_start_tv
 
     local page = self.document:openPage(self.page_number)
     local lines = page:getPageText()

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -24,6 +24,7 @@ local RenderText = require("ui/rendertext")
 local RightContainer = require("ui/widget/container/rightcontainer")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
+local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
 local Math = require("optmath")
 local logger = require("logger")
@@ -1858,7 +1859,7 @@ function TextBoxWidget:onHoldReleaseText(callback, ges)
         return false
     end
 
-    local hold_duration = UIManager:getTime() - self.hold_start_tv
+    local hold_duration = TimeVal.now() - self.hold_start_tv
 
     -- If page contains an image, check if Hold is on this image and deal
     -- with it directly

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -114,6 +114,18 @@ local BOOKINFO_SELECT_SQL = "SELECT " .. table.concat(BOOKINFO_COLS_SET, ",") ..
                             "WHERE directory=? AND filename=? AND in_progress=0;"
 local BOOKINFO_IN_PROGRESS_SQL = "SELECT in_progress, filename, unsupported FROM bookinfo WHERE directory=? AND filename=?;"
 
+-- We need these _ litterals for them to be made available to translators. the english "string" is
+-- what is inserted in the DB, and it will be translated only when read from the DB and displayed.
+local UNSUPPORTED_REASONS = {
+    not_readable_by_engine = {
+               string = "not readable by engine",
+        translation = _("not readable by engine")
+    },
+    too_many_interruptions_or_crashes = {
+               string = "too many interruptions or crashes",
+        translation = _("too many interruptions or crashes")
+    }
+}
 
 local BookInfoManager = {}
 
@@ -439,7 +451,7 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
         logger.info("Seen", prev_tries, "previous attempts at info extraction", filepath, ", too many, ignoring it.")
         tried_enough = true
         dbrow.in_progress = 0     -- row will exist, we'll never be called again
-        dbrow.unsupported = _("too many interruptions or crashes") -- but caller will now it failed
+        dbrow.unsupported = UNSUPPORTED_REASONS.too_many_interruptions_or_crashes.string
         dbrow.cover_fetched = 'Y' -- so we don't try again if we're called later with cover_specs
     end
     -- Insert the temporary "in progress" record (or the definitive "unsupported" record)
@@ -548,7 +560,7 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
         loaded = false
     end
     if not loaded then
-        dbrow.unsupported = _("not readable by engine")
+        dbrow.unsupported = UNSUPPORTED_REASONS.not_readable_by_engine.string
         dbrow.cover_fetched = 'Y' -- so we don't try again if we're called later if cover_specs
     end
     dbrow.in_progress = 0 -- extraction completed (successful or definitive failure)

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -576,7 +576,7 @@ function ListMenuItem:update()
             end
             if bookinfo.unsupported then
                 -- Let's show this fact in place of the anyway empty authors slot
-                authors = T(_("(no book information: %1)"), bookinfo.unsupported)
+                authors = T(_("(no book information: %1)"), _(bookinfo.unsupported))
             end
             -- Build title and authors texts with decreasing font size
             -- till it fits in the space available


### PR DESCRIPTION
`CoverBrowser: use translations for error messages`
Closes #8594.

`Fix hold duration in text/html box widgets`

Fix very-long-press in DictQuickLookup that should allow doing the query to the other domain (dict <> wiki) instead of the current one.
Similar to 7dea979.

`Wikipedia: rework wiki languages internal handling`

Fix various issues with stacked Wikipedia lookup results, and follow up lookups when invoked from Wikipedia lookup history (where going to a search for language LL would not use language LL when hitting "Full wikipedia").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8677)
<!-- Reviewable:end -->
