### PR TITLE
SDL & Android: Do not set FM banner on resize

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -59,9 +59,6 @@ function FileManager:onSetRotationMode(rotation)
         Screen:setRotationMode(rotation)
         if FileManager.instance then
             self:reinit(self.path, self.focused_file)
-            if self.select_mode then
-                self.title_bar:setRightIcon("check")
-            end
         end
     end
     return true
@@ -810,6 +807,9 @@ function FileManager:reinit(path, focused_file)
     -- looks unnecessary (cheap with classic mode, less cheap with
     -- CoverBrowser plugin's cover image renderings)
     -- self:onRefresh()
+    if self.select_mode then
+        self.title_bar:setRightIcon("check")
+    end
 end
 
 function FileManager:getCurrentDir()

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -160,9 +160,6 @@ function Device:init()
                     if FileManager.instance then
                         FileManager.instance:reinit(FileManager.instance.path,
                             FileManager.instance.focused_file)
-                        UIManager:setDirty(FileManager.instance.banner, function()
-                            return "ui", FileManager.instance.banner.dimen
-                        end)
                     end
                 end
                 -- to-do: keyboard connected, disconnected

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -256,9 +256,6 @@ function Device:init()
                 if FileManager.instance then
                     FileManager.instance:reinit(FileManager.instance.path,
                         FileManager.instance.focused_file)
-                    UIManager:setDirty(FileManager.instance.banner, function()
-                        return "ui", FileManager.instance.banner.dimen
-                    end)
                 end
             elseif ev.code == SDL_WINDOWEVENT_MOVED then
                 self.window.left = ev.value.data1


### PR DESCRIPTION
regression from #8648

FileManager.instance.banner was removed and replaced with TitleBar

Discovered by dragging the emulator by mistake :)

also 

`FM select mode: let the icon survive through reinit not only rotation`
This commit was not tested for every type of reinit but it should work

@hius07

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8678)
<!-- Reviewable:end -->
