### PR TITLE
exporter plugin: fix history dir

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -1,3 +1,4 @@
+local DataStorage = require("datastorage")
 local DocumentRegistry = require("document/documentregistry")
 local DocSettings = require("docsettings")
 local ReadHistory = require("readhistory")
@@ -9,7 +10,7 @@ local T = require("ffi/util").template
 
 local MyClipping = {
     my_clippings = "/mnt/us/documents/My Clippings.txt",
-    history_dir = "./history",
+    history_dir = string.format("%s%s", DataStorage:getDataDir(), "/history"),
 }
 
 function MyClipping:new(o)

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -10,7 +10,7 @@ local T = require("ffi/util").template
 
 local MyClipping = {
     my_clippings = "/mnt/us/documents/My Clippings.txt",
-    history_dir = string.format("%s%s", DataStorage:getDataDir(), "/history"),
+    history_dir = DataStorage:getDataDir() .. "/history",
 }
 
 function MyClipping:new(o)


### PR DESCRIPTION
for platforms where history dir don't match installation path.

Fixes https://github.com/koreader/koreader/issues/8675

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8685)
<!-- Reviewable:end -->
