### PR TITLE
Support non-touch device to choose file or folder

### DIFF
--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -51,6 +51,9 @@ end
 function PathChooser:onMenuSelect(item)
     local path = item.path
     if path:sub(-2, -1) == "/." then -- with show_current_dir_for_hold
+        if self.select_directory then -- let non-touch device can select the folder
+            return self:onMenuHold(item)
+        end
         -- Don't navigate to same directory
         return true
     end
@@ -68,6 +71,9 @@ function PathChooser:onMenuSelect(item)
         return true
     end
     if attr.mode ~= "directory" then
+        if self.select_file then -- let non-touch device can select the file
+            return self:onMenuHold(item)
+        end
         -- Do nothing if Tap on other than directories
         return true
     end

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+local Device = require("device")
 local FileChooser = require("ui/widget/filechooser")
 local UIManager = require("ui/uimanager")
 local ffiutil = require("ffi/util")
@@ -51,7 +52,7 @@ end
 function PathChooser:onMenuSelect(item)
     local path = item.path
     if path:sub(-2, -1) == "/." then -- with show_current_dir_for_hold
-        if self.select_directory then -- let non-touch device can select the folder
+        if not Device:isTouchDevice() and self.select_directory then -- let non-touch device can select the folder
             return self:onMenuHold(item)
         end
         -- Don't navigate to same directory
@@ -71,7 +72,7 @@ function PathChooser:onMenuSelect(item)
         return true
     end
     if attr.mode ~= "directory" then
-        if self.select_file then -- let non-touch device can select the file
+        if not Device:isTouchDevice() and self.select_file then -- let non-touch device can select the file
             return self:onMenuHold(item)
         end
         -- Do nothing if Tap on other than directories


### PR DESCRIPTION
## Background
`pathchooser.lua` does not support non-touch device to choose file or folder due to those device cannot generate long press event.

## Choose File
Non-touch device can select file in list, it is good enough to choose file without long press to confirm.

## Choose Folder
`pathchooser.lua` changes the label of current directory `.` to `Long-press to choose a folder`. It is user friendly, while for non-device, it is a very good place to let user tell the system I want the current folder to be chosen without extra long press.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8696)
<!-- Reviewable:end -->
