### PR TITLE
bump crengine: non-linear fragments and list item tweaks

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -834,6 +834,7 @@ This only works with footnotes that have specific attributes set by the publishe
                 css = [[
 ol.references > li {
     -cr-hint: footnote-inpage;
+    list-style-position: -cr-outside;
     margin: 0 !important;
 }
 /* hide backlinks */
@@ -848,6 +849,7 @@ ol.references > li > .mw-cite-backlink { display: none; }
                 css = [[
 ol.references > li {
     -cr-hint: footnote-inpage;
+    list-style-position: -cr-outside;
     margin: 0 !important;
     font-size: 0.8rem !important;
 }

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -956,6 +956,8 @@ body {
 }
 ol.references {
     list-style-type: inherit;
+    /* Allow hiding these pages as their content is available as footnotes */
+    -cr-hint: non-linear;
 }
 
 /* Show a box around image thumbnails */


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/462 :
- LVHashTable::resize(): behave as ::init()
  Fix floating point crash in #8583
- FB2 series: extract series number as string, not int
  Closes #8666
- Non-linear fragments: more generic handling
  Closes #8623
- CSS: list-style-position: correct alignment for "outside"
- List items: fix marker not drawn with position:inside and no content
- (Upstream) Ordered list markers: add a decimal point suffix
- List item markers: more pleasant rendering
  Closes #8668
- renderListItemMarker(): cleanup, minor optimizations

Also: `Wikipedia: tweak EPUB css and footnote styletweaks
`
EPUB: have pages with footnotes marked as non-linear so they can be hidden with "Hide non-linear flows".
In-page footnotes: keep the footnote number near the left margin (the above crengine update renders them now near the text by default, as the Wikipedia websites do).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8700)
<!-- Reviewable:end -->
