### PR TITLE
Improve reader config dialog for Non-Touch devices

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -26,9 +26,7 @@ function ReaderConfig:init()
             ShowConfigMenu = { {{"Press","AA"}}, doc = "show config dialog" },
         }
     end
-    if Device:isTouchDevice() then
-        self:initGesListener()
-    end
+    self:initGesListener()
     if G_reader_settings:has("activate_menu") then
         self.activation_menu = G_reader_settings:readSetting("activate_menu")
     else

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -165,31 +165,29 @@ function Button:init()
     end
     self.dimen = self.frame:getSize()
     self[1] = self.frame
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelectButton = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Tap Button",
+    self.ges_events = {
+        TapSelectButton = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelectButton = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold Button",
+            doc = "Tap Button",
+        },
+        HoldSelectButton = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-            -- Safe-guard for when used inside a MovableContainer
-            HoldReleaseSelectButton = {
-                GestureRange:new{
-                    ges = "hold_release",
-                    range = self.dimen,
-                },
-            }
+            doc = "Hold Button",
+        },
+        -- Safe-guard for when used inside a MovableContainer
+        HoldReleaseSelectButton = {
+            GestureRange:new{
+                ges = "hold_release",
+                range = self.dimen,
+            },
         }
-    end
+    }
 end
 
 function Button:setText(text, width)

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -1,17 +1,17 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local Device = require("device")
+local FocusManager = require("ui/widget/focusmanager")
 local Geom = require("ui/geometry")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
-local InputContainer = require("ui/widget/container/inputcontainer")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Size = require("ui/size")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 local Screen = Device.screen
 
-local ButtonProgressWidget = InputContainer:new{
+local ButtonProgressWidget = FocusManager:new{
     width = Screen:scaleBySize(216),
     height = Size.item.height_default,
     padding = Size.padding.small,
@@ -27,6 +27,8 @@ local ButtonProgressWidget = InputContainer:new{
 }
 
 function ButtonProgressWidget:init()
+    self.current_button_index = self.position
+
     self.buttonprogress_frame = FrameContainer:new{
         background = Blitbuffer.COLOR_WHITE,
         color = Blitbuffer.COLOR_DARK_GRAY,
@@ -46,12 +48,17 @@ function ButtonProgressWidget:init()
         self.horizontal_span_width = self.horizontal_span.width
     end
     self:update()
+    if self.fine_tune then
+        self.current_button_index = self.current_button_index + 1
+    end
     self.buttonprogress_frame[1] = self.buttonprogress_content
     self[1] = self.buttonprogress_frame
     self.dimen = Geom:new(self.buttonprogress_frame:getSize())
 end
 
 function ButtonProgressWidget:update()
+    self.layout = {{}}
+
     self.buttonprogress_content:clear()
     local button_margin = Size.margin.tiny
     local button_padding = Size.padding.button
@@ -91,7 +98,6 @@ function ButtonProgressWidget:update()
                 self.callback("-")
                 self:update()
             end,
-            no_focus = true,
             hold_callback = function()
                 self.hold_callback("-")
             end,
@@ -100,6 +106,7 @@ function ButtonProgressWidget:update()
             button.frame.color = Blitbuffer.COLOR_DARK_GRAY
         end
         table.insert(self.buttonprogress_content, button)
+        table.insert(self.layout[1], button)
         table.insert(self.buttonprogress_content, self.horizontal_span)
     end
 
@@ -139,7 +146,7 @@ function ButtonProgressWidget:update()
                 self.position = i
                 self:update()
             end,
-            no_focus = true,
+            no_focus = highlighted,
             hold_callback = function()
                 self.hold_callback(i)
             end,
@@ -161,11 +168,15 @@ function ButtonProgressWidget:update()
                     margin = button_margin,
                     padding = 0,
                     bordersize = 0,
+                    focusable = true,
+                    color = Blitbuffer.COLOR_BLACK,
+                    focus_border_size = Size.border.thin,
                     button,
                 }
             end
         end
         table.insert(self.buttonprogress_content, button)
+        table.insert(self.layout[1], button)
     end
 
     -- Plus button on the right
@@ -194,16 +205,17 @@ function ButtonProgressWidget:update()
                 self.callback("+")
                 self:update()
             end,
-            no_focus = true,
             hold_callback = function()
                 self.hold_callback("+")
             end,
         }
+
         if self.thin_grey_style then
             button.frame.color = Blitbuffer.COLOR_DARK_GRAY
         end
         table.insert(self.buttonprogress_content, self.horizontal_span)
         table.insert(self.buttonprogress_content, button)
+        table.insert(self.layout[1], button)
     end
     -- More option button on the right
     if self.more_options then
@@ -230,7 +242,6 @@ function ButtonProgressWidget:update()
                 self.callback("⋮")
                 self:update()
             end,
-            no_focus = true,
             hold_callback = function()
                 self.hold_callback("⋮")
             end,
@@ -240,6 +251,7 @@ function ButtonProgressWidget:update()
         end
         table.insert(self.buttonprogress_content, self.horizontal_span)
         table.insert(self.buttonprogress_content, button)
+        table.insert(self.layout[1], button)
     end
 
     UIManager:setDirty(self.show_parrent, function()
@@ -251,16 +263,6 @@ function ButtonProgressWidget:setPosition(position, default_position)
     self.position = position
     self.default_position = default_position
     self:update()
-end
-
-function ButtonProgressWidget:onFocus()
-    self.buttonprogress_frame.background = Blitbuffer.COLOR_BLACK
-    return true
-end
-
-function ButtonProgressWidget:onUnfocus()
-    self.buttonprogress_frame.background = Blitbuffer.COLOR_WHITE
-    return true
 end
 
 function ButtonProgressWidget:onTapSelect(arg, gev)

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -169,7 +169,6 @@ function ButtonProgressWidget:update()
                     padding = 0,
                     bordersize = 0,
                     focusable = true,
-                    color = Blitbuffer.COLOR_BLACK,
                     focus_border_size = Size.border.thin,
                     button,
                 }

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -24,6 +24,7 @@ local ButtonTable = FocusManager:new{
     zero_sep = false,
     button_font_face = "cfont",
     button_font_size = 20,
+    auto_focus_first_button = true,
 }
 
 function ButtonTable:init()
@@ -99,7 +100,9 @@ function ButtonTable:init()
     self:addHorizontalSep(true, false, false)
     if Device:hasDPad() then
         self.layout = self.buttons_layout
-        self.layout[1][1]:onFocus()
+        if self.auto_focus_first_button then
+            self.layout[1][1]:onFocus()
+        end
         self.key_events.SelectByKeyPress = { {{"Press"}} }
     else
         self.key_events = {}  -- deregister all key press event listeners
@@ -128,9 +131,10 @@ end
 
 function ButtonTable:onSelectByKeyPress()
     local item = self:getFocusItem()
-    if item.enabled then
+    if item and item.enabled then
         item.callback()
     end
+    return item
 end
 
 function ButtonTable:getButtonById(id)

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -133,8 +133,9 @@ function ButtonTable:onSelectByKeyPress()
     local item = self:getFocusItem()
     if item and item.enabled then
         item.callback()
+        return true
     end
-    return item
+    return false
 end
 
 function ButtonTable:getButtonById(id)

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -670,10 +670,15 @@ function ConfigOption:_itemGroupToLayoutLine(option_items_group)
     local j = self.config.panel_index
     for i, v in ipairs(option_items_group) do
         if v.name then
-            if type(v.layout) == "table" and type(v.disableFocusManagement) == "function" then
-                for _, widget in ipairs(v.layout[1]) do
-                    layout_line[j] = widget
-                    j = j + 1
+            if v.layout and v.disableFocusManagement then -- it is a FocusManager
+                -- merge child layout to one row layout
+                -- currently child widgets are all one row
+                -- need improved if two or more rows widget existed
+                for _, row in ipairs(v.layout) do
+                    for _, widget in ipairs(row) do
+                        layout_line[j] = widget
+                        j = j + 1
+                    end
                 end
                 v:disableFocusManagement()
             else
@@ -1460,13 +1465,6 @@ end
 
 function ConfigDialog:onSelect()
     return self:sendTapEventToFocusedWidget()
-    --[[
-    local item = self:getFocusItem()
-    if item then
-        item:handleEvent(Event:new("TapSelect"))
-    end
-    return item
-    ]]
 end
 
 return ConfigDialog

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -52,24 +52,22 @@ function OptionTextItem:init()
     }
     self.dimen = self[1]:getSize()
     -- we need this table per-instance, so we declare it here
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Select Option Item",
+    self.ges_events = {
+        TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelect = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold Option Item",
+            doc = "Select Option Item",
+        },
+        HoldSelect = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-        }
-    end
+            doc = "Hold Option Item",
+        },
+    }
 end
 
 function OptionTextItem:onFocus()
@@ -128,25 +126,23 @@ function OptionIconItem:init()
     }
     self.dimen = self[1]:getSize()
     -- we need this table per-instance, so we declare it here
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Select Option Item",
+    self.ges_events = {
+        TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelect = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold Option Item",
+            doc = "Select Option Item",
+        },
+        HoldSelect = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
+            doc = "Hold Option Item",
+        },
 
-        }
-    end
+    }
 end
 
 function OptionIconItem:onFocus()
@@ -674,8 +670,16 @@ function ConfigOption:_itemGroupToLayoutLine(option_items_group)
     local j = self.config.panel_index
     for i, v in ipairs(option_items_group) do
         if v.name then
-            layout_line[j] = v
-            j = j + 1
+            if type(v.layout) == "table" and type(v.disableFocusManagement) == "function" then
+                for _, widget in ipairs(v.layout[1]) do
+                    layout_line[j] = widget
+                    j = j + 1
+                end
+                v:disableFocusManagement()
+            else
+                layout_line[j] = v
+                j = j + 1
+            end
         end
     end
     return layout_line
@@ -849,28 +853,26 @@ function ConfigDialog:init()
     ------------------------------------------
     -- start to set up input event callback --
     ------------------------------------------
-    if Device:isTouchDevice() then
-        self.ges_events.TapCloseMenu = {
-            GestureRange:new{
-                ges = "tap",
-                range = Geom:new{
-                    x = 0, y = 0,
-                    w = Screen:getWidth(),
-                    h = Screen:getHeight(),
-                }
+    self.ges_events.TapCloseMenu = {
+        GestureRange:new{
+            ges = "tap",
+            range = Geom:new{
+                x = 0, y = 0,
+                w = Screen:getWidth(),
+                h = Screen:getHeight(),
             }
         }
-        self.ges_events.SwipeCloseMenu = {
-            GestureRange:new{
-                ges = "swipe",
-                range = Geom:new{
-                    x = 0, y = 0,
-                    w = Screen:getWidth(),
-                    h = Screen:getHeight(),
-                }
+    }
+    self.ges_events.SwipeCloseMenu = {
+        GestureRange:new{
+            ges = "swipe",
+            range = Geom:new{
+                x = 0, y = 0,
+                w = Screen:getWidth(),
+                h = Screen:getHeight(),
             }
         }
-    end
+    }
     if Device:hasKeys() then
         -- set up keyboard events
         local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
@@ -1457,8 +1459,14 @@ function ConfigDialog:onClose()
 end
 
 function ConfigDialog:onSelect()
-    self:getFocusItem():handleEvent(Event:new("TapSelect"))
-    return true
+    return self:sendTapEventToFocusedWidget()
+    --[[
+    local item = self:getFocusItem()
+    if item then
+        item:handleEvent(Event:new("TapSelect"))
+    end
+    return item
+    ]]
 end
 
 return ConfigDialog

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -41,7 +41,15 @@ local FrameContainer = WidgetContainer:new{
     invert = false,
     allow_mirroring = true,
     _mirroredUI = BD.mirroredUILayout(),
+    focusable = false,
+    focus_border_size = Size.border.window * 2,
+    focus_border_color = Blitbuffer.COLOR_BLACK,
 }
+
+function FrameContainer:init()
+    self.origin_bordersize = nil
+    self.origin_border_color = nil
+end
 
 function FrameContainer:getSize()
     local content_size = self[1]:getSize()
@@ -57,6 +65,27 @@ function FrameContainer:getSize()
         h = content_size.h + ( self.margin + self.bordersize ) * 2 + self._padding_top + self._padding_bottom
     }
 end
+
+function FrameContainer:onFocus()
+    if not self.focusable then
+        return
+    end
+    self.origin_bordersize = self.bordersize
+    self.origin_border_color = self.color
+    self.bordersize = self.focus_border_size
+    self.color = self.focus_border_color
+    return true
+end
+
+function FrameContainer:onUnfocus()
+    if not self.focusable then
+        return
+    end
+    self.bordersize = self.origin_bordersize
+    self.color = self.origin_border_color
+    return true
+end
+
 
 function FrameContainer:paintTo(bb, x, y)
     local my_size = self:getSize()

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -47,6 +47,7 @@ local FrameContainer = WidgetContainer:new{
 }
 
 function FrameContainer:init()
+    WidgetContainer.init(self)
     self.origin_bordersize = nil
     self.origin_border_color = nil
 end

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -46,12 +46,6 @@ local FrameContainer = WidgetContainer:new{
     focus_border_color = Blitbuffer.COLOR_BLACK,
 }
 
-function FrameContainer:init()
-    WidgetContainer.init(self)
-    self.origin_bordersize = nil
-    self.origin_border_color = nil
-end
-
 function FrameContainer:getSize()
     local content_size = self[1]:getSize()
     self._padding_top = self.padding_top or self.padding

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -65,8 +65,8 @@ function FrameContainer:onFocus()
     if not self.focusable then
         return
     end
-    self.origin_bordersize = self.bordersize
-    self.origin_border_color = self.color
+    self._origin_bordersize = self.bordersize
+    self._origin_border_color = self.color
     self.bordersize = self.focus_border_size
     self.color = self.focus_border_color
     return true
@@ -76,8 +76,8 @@ function FrameContainer:onUnfocus()
     if not self.focusable then
         return
     end
-    self.bordersize = self.origin_bordersize
-    self.color = self.origin_border_color
+    self.bordersize = self._origin_bordersize
+    self.color = self._origin_border_color
     return true
 end
 

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -181,8 +181,9 @@ function FocusManager:sendTapEventToFocusedWidget()
             ges = "tap",
             pos = point,
         }))
+        return true
     end
-    return focused_widget
+    return false
 end
 
 function FocusManager:mergeLayoutInVertical(child)
@@ -213,7 +214,7 @@ function FocusManager:mergeLayoutInHorizontal(child)
 end
 
 function FocusManager:disableFocusManagement()
-    self.layout = nil -- turn off child focus feature
+    self.layout = nil -- turn off focus feature
 end
 
 --- Container call this method after init to let first widget render in focus style

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -27,7 +27,7 @@ it rather defines an abstract layout.
 local FocusManager = InputContainer:new{
     selected = nil, -- defaults to x=1, y=1
     layout = nil, -- mandatory
-    movement_allowed = { x = true, y = true }
+    movement_allowed = { x = true, y = true },
 }
 
 function FocusManager:init()
@@ -50,6 +50,9 @@ function FocusManager:init()
 end
 
 function FocusManager:onFocusMove(args)
+    if not self.layout then -- allow parent focus manger to handle the event
+        return false
+    end
     local dx, dy = unpack(args)
 
     if (dx ~= 0 and not self.movement_allowed.x)
@@ -57,7 +60,7 @@ function FocusManager:onFocusMove(args)
         return true
     end
 
-    if not self.layout or not self.layout[self.selected.y] or not self.layout[self.selected.y][self.selected.x] then
+    if not self.layout[self.selected.y] or not self.layout[self.selected.y][self.selected.x] then
         return true
     end
     local current_item = self.layout[self.selected.y][self.selected.x]
@@ -159,7 +162,63 @@ function FocusManager:_verticalStep(dy)
 end
 
 function FocusManager:getFocusItem()
+    if not self.layout then
+        return nil
+    end
     return self.layout[self.selected.y][self.selected.x]
+end
+
+function FocusManager:sendTapEventToFocusedWidget()
+    local focused_widget = self:getFocusItem()
+    if focused_widget then
+        -- center of widget position
+        local point = focused_widget.dimen:copy()
+        point.x = point.x + point.w / 2
+        point.y = point.y + point.h / 2
+        point.w = 0
+        point.h = 0
+        UIManager:sendEvent(Event:new("Gesture", {
+            ges = "tap",
+            pos = point,
+        }))
+    end
+    return focused_widget
+end
+
+function FocusManager:mergeLayoutInVertical(child)
+    if not child.layout then
+        return
+    end
+    for _, row in ipairs(child.layout) do
+        table.insert(self.layout, row)
+    end
+    child:disableFocusManagement()
+end
+
+function FocusManager:mergeLayoutInHorizontal(child)
+    if not child.layout then
+        return
+    end
+    for i, row in ipairs(child.layout) do
+        local prow = self.layout[i]
+        if not prow then
+            prow = {}
+            self.layout[i] = prow
+        end
+        for _, widget in ipairs(row) do
+            table.insert(prow, widget)
+        end
+    end
+    child:disableFocusManagement()
+end
+
+function FocusManager:disableFocusManagement()
+    self.layout = nil -- turn off child focus feature
+end
+
+--- Container call this method after init to let first widget render in focus style
+function FocusManager:focusTopLeftWidget()
+    self:onFocusMove({0, 0})
 end
 
 return FocusManager

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -73,31 +73,29 @@ function IconButton:update()
 end
 
 function IconButton:initGesListener()
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapIconButton = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Tap IconButton",
+    self.ges_events = {
+        TapIconButton = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldIconButton = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold IconButton",
+            doc = "Tap IconButton",
+        },
+        HoldIconButton = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-            HoldReleaseIconButton = {
-                GestureRange:new{
-                    ges = "hold_release",
-                    range = self.dimen,
-                },
-                doc = "Hold Release IconButton",
-            }
+            doc = "Hold IconButton",
+        },
+        HoldReleaseIconButton = {
+            GestureRange:new{
+                ges = "hold_release",
+                range = self.dimen,
+            },
+            doc = "Hold Release IconButton",
         }
-    end
+    }
 end
 
 function IconButton:onTapIconButton()

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -18,11 +18,11 @@ Example:
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
+local FocusManager = require("ui/widget/focusmanager")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local Font = require("ui/font")
 local InfoMessage = require("ui/widget/infomessage")
-local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local Size = require("ui/size")
 local UIManager = require("ui/uimanager")
@@ -32,7 +32,7 @@ local _ = require("gettext")
 local T = require("ffi/util").template
 local Screen = Device.screen
 
-local NumberPickerWidget = InputContainer:new{
+local NumberPickerWidget = FocusManager:new{
     spinner_face = Font:getFace("smalltfont"),
     precision = "%02d",
     width = nil,
@@ -60,6 +60,7 @@ function NumberPickerWidget:init()
         self.value_index = self.value_index or 1
         self.value = self.value_table[self.value_index]
     end
+    self.layout = {}
 
     -- Widget layout
     local bordersize = Size.border.default
@@ -87,6 +88,7 @@ function NumberPickerWidget:init()
             self:update()
         end
     }
+    table.insert(self.layout, {button_up})
     local button_down = Button:new{
         text = "▼",
         bordersize = bordersize,
@@ -110,6 +112,7 @@ function NumberPickerWidget:init()
             self:update()
         end
     }
+    table.insert(self.layout, {button_down})
 
     local empty_space = VerticalSpan:new{ width = Size.padding.large }
 
@@ -207,6 +210,9 @@ function NumberPickerWidget:init()
     }
     self.dimen = self.frame:getSize()
     self[1] = self.frame
+    if Device:hasDPad() then
+        self.key_events.Press = { {"Press"}, doc = "press button" }
+    end
     UIManager:setDirty(self.show_parent, function()
         return "ui", self.dimen
     end)
@@ -281,6 +287,10 @@ Get value.
 --]]
 function NumberPickerWidget:getValue()
     return self.value, self.value_index
+end
+
+function NumberPickerWidget:onPress()
+    return self:sendTapEventToFocusedWidget()
 end
 
 return NumberPickerWidget

--- a/frontend/ui/widget/radiobuttontable.lua
+++ b/frontend/ui/widget/radiobuttontable.lua
@@ -147,7 +147,11 @@ function RadioButtonTable:addHorizontalSep(vspan_before, add_line, vspan_after, 
 end
 
 function RadioButtonTable:onSelectByKeyPress()
-    self:getFocusItem().callback()
+    local item = self:getFocusItem()
+    if item then
+        item.callback()
+    end
+    return item
 end
 
 function RadioButtonTable:_checkButton(button)

--- a/frontend/ui/widget/radiobuttontable.lua
+++ b/frontend/ui/widget/radiobuttontable.lua
@@ -150,8 +150,9 @@ function RadioButtonTable:onSelectByKeyPress()
     local item = self:getFocusItem()
     if item then
         item.callback()
+        return true
     end
-    return item
+    return false
 end
 
 function RadioButtonTable:_checkButton(button)

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -380,7 +380,11 @@ end
 
 function SkimToWidget:onSelectByKeyPress()
     local item = self:getFocusItem()
-    item.callback()
+    if item then
+        item.callback()
+        return true
+    end
+    return false
 end
 
 function SkimToWidget:onFirstRowKeyPress(percent)

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -9,11 +9,11 @@ local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
+local FocusManager = require("ui/widget/focusmanager")
 local Font = require("ui/font")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
-local InputContainer = require("ui/widget/container/inputcontainer")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Notification = require("ui/widget/notification")
 local Size = require("ui/size")
@@ -29,7 +29,7 @@ local ToggleLabel = TextWidget:new{
     fgcolor = Blitbuffer.COLOR_BLACK,
 }
 
-local ToggleSwitch = InputContainer:new{
+local ToggleSwitch = FocusManager:new{
     width = Screen:scaleBySize(216),
     height = Size.item.height_default,
     bgcolor = Blitbuffer.COLOR_WHITE, -- unfocused item color
@@ -41,6 +41,7 @@ local ToggleSwitch = InputContainer:new{
 }
 
 function ToggleSwitch:init()
+    self.layout = {{}}
     -- Item count per row
     self.n_pos = math.ceil(#self.toggle / self.row_count)
     self.position = nil
@@ -100,31 +101,33 @@ function ToggleSwitch:init()
             radius = Size.radius.window,
             bordersize = item_border_size,
             padding = 0,
+            focusable = true,
+            focus_border_size = item_border_size,
+            focus_border_color = Blitbuffer.COLOR_BLACK,
             content,
         }
         table.insert(self.toggle_content[math.ceil(i / self.n_pos)], button)
+        table.insert(self.layout[1], button)
     end
     self.toggle_frame[1] = self.toggle_content
     self[1] = self.toggle_frame
     self.dimen = Geom:new(self.toggle_frame:getSize())
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Toggle switch",
+    self.ges_events = {
+        TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelect = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold switch",
+            doc = "Toggle switch",
+        },
+        HoldSelect = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-        }
-    end
+            doc = "Hold switch",
+        },
+    }
 end
 
 function ToggleSwitch:update()
@@ -183,6 +186,8 @@ function ToggleSwitch:calculatePosition(gev)
 end
 
 function ToggleSwitch:onTapSelect(arg, gev)
+    local logger = require("logger")
+    logger.dbg("ToggleSwitch:onTapSelect", arg, gev)
     if not self.enabled then
         if self.readonly ~= true then
             return true
@@ -247,16 +252,6 @@ function ToggleSwitch:onHoldSelect(arg, gev)
         self.config:onMakeDefault(self.name, self.name_text,
                         self.values or self.args, self.toggle, position)
     end
-    return true
-end
-
-function ToggleSwitch:onFocus()
-    self.toggle_frame.background = Blitbuffer.COLOR_BLACK
-    return true
-end
-
-function ToggleSwitch:onUnfocus()
-    self.toggle_frame.background = Blitbuffer.COLOR_WHITE
     return true
 end
 

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -186,8 +186,6 @@ function ToggleSwitch:calculatePosition(gev)
 end
 
 function ToggleSwitch:onTapSelect(arg, gev)
-    local logger = require("logger")
-    logger.dbg("ToggleSwitch:onTapSelect", arg, gev)
     if not self.enabled then
         if self.readonly ~= true then
             return true

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -966,8 +966,9 @@ function TouchMenu:onPress()
     local item = self:getFocusItem()
     if item then
         item:handleEvent(Event:new("TapSelect"))
+        return true
     end
-    return item
+    return false
 end
 
 return TouchMenu

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -963,7 +963,11 @@ function TouchMenu:onBack()
 end
 
 function TouchMenu:onPress()
-    self:getFocusItem():handleEvent(Event:new("TapSelect"))
+    local item = self:getFocusItem()
+    if item then
+        item:handleEvent(Event:new("TapSelect"))
+    end
+    return item
 end
 
 return TouchMenu

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -475,8 +475,9 @@ function VirtualKeyPopup:onPressKey()
     local item = self:getFocusItem()
     if item then
         item:handleEvent(Event:new("TapSelect"))
+        return true
     end
-    return item
+    return false
 end
 
 function VirtualKeyPopup:init()
@@ -854,8 +855,9 @@ function VirtualKeyboard:onPressKey()
     local item = self:getFocusItem()
     if item then
         item:handleEvent(Event:new("TapSelect"))
+        return true
     end
-    return item
+    return false
 end
 
 function VirtualKeyboard:_refresh(want_flash, fullscreen)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -472,8 +472,11 @@ function VirtualKeyPopup:onCloseWidget()
 end
 
 function VirtualKeyPopup:onPressKey()
-    self:getFocusItem():handleEvent(Event:new("TapSelect"))
-    return true
+    local item = self:getFocusItem()
+    if item then
+        item:handleEvent(Event:new("TapSelect"))
+    end
+    return item
 end
 
 function VirtualKeyPopup:init()
@@ -848,8 +851,11 @@ function VirtualKeyboard:onClose()
 end
 
 function VirtualKeyboard:onPressKey()
-    self:getFocusItem():handleEvent(Event:new("TapSelect"))
-    return true
+    local item = self:getFocusItem()
+    if item then
+        item:handleEvent(Event:new("TapSelect"))
+    end
+    return item
 end
 
 function VirtualKeyboard:_refresh(want_flash, fullscreen)

--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -41,7 +41,6 @@ local DEBUG = require("dbg")
 local Screen = require("device").screen
 local Blitbuffer = require("ffi/blitbuffer")
 local InputText = require("ui/widget/inputtext")
-local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 
 DEBUG:turnOn()
 
@@ -261,7 +260,7 @@ readerwindow = CenterContainer:new{
 reader = ReaderUI:new{
     dialog = readerwindow,
     dimen = Geom:new{ w = Screen:getWidth() - 100, h = Screen:getHeight() - 100 },
-    document = DocumentRegistry:openDocument("test/sample.pdf")
+    document = DocumentRegistry:openDocument("spec/front/unit/data/2col.pdf")
     --document = DocumentRegistry:openDocument("spec/front/unit/data/djvu3spec.djvu")
 }
 readerwindow[1][1] = reader
@@ -449,9 +448,9 @@ end
 -----------------------------------------------------------------------
 --UIManager:show(Background:new())
 --UIManager:show(TestGrid)
---UIManager:show(TestVisible)
---UIManager:show(Clock:new())
---UIManager:show(M)
+UIManager:show(TestVisible)
+UIManager:show(Clock:new())
+-- UIManager:show(M)
 --UIManager:show(Quiz)
 --UIManager:show(readerwindow)
 --UIManager:show(touch_menu)
@@ -461,6 +460,5 @@ end
 -- testKeyValuePage()
 -- testTouchProbe()
 -- testBookStatus()
---testNetworkSetting()
-UIManager:show(DoubleSpinWidget:new{})
+testNetworkSetting()
 UIManager:run()

--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -41,6 +41,7 @@ local DEBUG = require("dbg")
 local Screen = require("device").screen
 local Blitbuffer = require("ffi/blitbuffer")
 local InputText = require("ui/widget/inputtext")
+local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 
 DEBUG:turnOn()
 
@@ -260,7 +261,7 @@ readerwindow = CenterContainer:new{
 reader = ReaderUI:new{
     dialog = readerwindow,
     dimen = Geom:new{ w = Screen:getWidth() - 100, h = Screen:getHeight() - 100 },
-    document = DocumentRegistry:openDocument("spec/front/unit/data/2col.pdf")
+    document = DocumentRegistry:openDocument("test/sample.pdf")
     --document = DocumentRegistry:openDocument("spec/front/unit/data/djvu3spec.djvu")
 }
 readerwindow[1][1] = reader
@@ -448,9 +449,9 @@ end
 -----------------------------------------------------------------------
 --UIManager:show(Background:new())
 --UIManager:show(TestGrid)
-UIManager:show(TestVisible)
-UIManager:show(Clock:new())
--- UIManager:show(M)
+--UIManager:show(TestVisible)
+--UIManager:show(Clock:new())
+--UIManager:show(M)
 --UIManager:show(Quiz)
 --UIManager:show(readerwindow)
 --UIManager:show(touch_menu)
@@ -460,5 +461,6 @@ UIManager:show(Clock:new())
 -- testKeyValuePage()
 -- testTouchProbe()
 -- testBookStatus()
-testNetworkSetting()
+--testNetworkSetting()
+UIManager:show(DoubleSpinWidget:new{})
 UIManager:run()


### PR DESCRIPTION
# Non-Touch Devices: Improve reader configuration
## Background
There are many difficulties for non-touch to use reader configuration panel.
* Cannot select specified value, only cycle toggle one by one: `toggleswitch` and `ButtonProgressWidget`
* Cannot select `⋮` button: `toggleswitch` and `ButtonProgressWidget`
* Dialog opened by `⋮`  cannot focus button in dialog content.
## Preview
![improvement screen recorder](https://user-images.githubusercontent.com/13473736/150658197-60c2d7d6-f5d9-40f3-b68c-f72ff3c95da8.gif)

## FocusManager
### How FocusManager works?
`FocusManager` is a based on `InputContainer`. It maintains a 2D table layout which contains focus-able widgets. `FocusManager` handles `left`, `up`, `right`, `down` press events. On those keys pressed, it send `unfocus` event to current focused widget and `focus` event to next widget.

Widget updates its style on receiving  `unfocus`and `focus`event.

A container widget(like dialog), extend `FocusManager`, add focus-able widget to `layout` field on `init`. Then the container has focus navigation support.

On `press` event(`enter` key pressed), `FocusManager` do nothing. Container widget needs to setup `press` event listener. In listener callback, get current focused widget from `FocusManager:getFocusItem`, and call the widget's action handler.

### Improvement: FocusManager hierarchy
Relate issues: #8378 and #7224

Dialog like `SpinWidget`or `DoubleSpinWidget`, make these widget based on `FocusManager` and add buttons to `layout` field. One of child widget is `ButtonTable`, it is also a `FocusManager`.  Current `FocusManager` has no hierarchy support.

#### function  FocusManager:mergeLayoutInVertical(child)
Merge child's `layout` in vertically and turn off child's focus management(return `false` in `onFocusMove`, let event propagates to parent `FocusManager`)
![vertical-merge](https://user-images.githubusercontent.com/13473736/150661713-c6c4593f-1cdc-43cf-9d28-c909fca417de.png)
#### function  FocusManager:mergeLayoutInHorizontal(child)
Merge child's `layout` in horizontally and turn off child's focus management(return `false` in `onFocusMove`, let event propagates to parent `FocusManager`)
![horizontal-merge](https://user-images.githubusercontent.com/13473736/150660691-2c2ff6e2-2e9d-49c9-a9cd-ba11c1ecd6c2.png)
### Improvement: Fake Tap Event
On `press` event, container needs to call focused widget's action handler. Each container may use different ways:
* Call its children's `callback` function: `ButtonTable`, `RadioButtonTable`, `SkimToWidget`
* Send `TapSelect` event: `item:handleEvent(Event:new("TapSelect"))`: `ConfigDialog`, `TouchMenu`, `VirtualKeyPopup`

It has disadvantages
* Widget container need to figure out which way each child widget supports.
* Atomic widget developer also need support both touch and non-touch event listeners.

Many widgets can work with `tap` event only. So thing can be much simple. On press:
1. Container widget can get focused widget position and size (`dimen` field), 
2. Container send fake tap event with position of center of widget via `UIManager`
3. `UIManager` propagates event like normal tap event.

In this way, widget container handle `press` event easily. Atomic widget developer no need to setup non-touch event listeners.

## Improvement: FrameContainer focusable
Adding focusable style support to `FrameContainer` due to `toggleswitch` and `ButtonProgressWidget` using `FrameContainer` as children. 

## Tested Environment
* Linux AppImage
* Kindle DX

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8712)
<!-- Reviewable:end -->
