### PR TITLE
Handle arrow keys and enter in emulator text fields

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -434,7 +434,7 @@ function FileManager:setupLayout()
     if Device:hasKeys() then
         self.key_events.Home = { {"Home"}, doc = "go home" }
         -- Override the menu.lua way of handling the back key
-        self.file_chooser.key_events.Back = { {"Back"}, doc = "go back" }
+        self.file_chooser.key_events.Back = { {Device.input.group.Back}, doc = "go back" }
         if not Device:hasFewKeys() then
             -- Also remove the handler assigned to the "Back" key by menu.lua
             self.file_chooser.key_events.Close = nil

--- a/frontend/apps/reader/modules/readerback.lua
+++ b/frontend/apps/reader/modules/readerback.lua
@@ -21,7 +21,7 @@ local ReaderBack = EventListener:new{
 
 function ReaderBack:init()
     if Device:hasKeys() then
-        self.ui.key_events.Back = { {"Back"}, doc = "Reader back" }
+        self.ui.key_events.Back = { {Device.input.group.Back}, doc = "Reader back" }
     end
     -- Regular function wrapping our method, to avoid re-creating
     -- an anonymous function at each page turn

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -51,7 +51,7 @@ function TweakInfoWidget:init()
     end
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "cancel" }
+            Close = { {Device.input.group.Back}, doc = "cancel" }
         }
     end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -137,6 +137,7 @@ local Input = {
         Cursor = { "Up", "Down", "Left", "Right" },
         PgFwd = { "RPgFwd", "LPgFwd" },
         PgBack = { "RPgBack", "LPgBack" },
+        Back = { "Back" },
         Alphabet = {
             "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
             "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
@@ -247,6 +248,10 @@ function Input:init()
             self.event_map[key] = value
         end
         logger.info("loaded custom event map", custom_event_map)
+    end
+
+    if G_reader_settings:isTrue("backspace_as_back") then
+        table.insert(self.group.Back, "Backspace")
     end
 end
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -434,6 +434,21 @@ common_settings.back_in_reader = {
         genGenericMenuEntry(_("Go to previous read page"), "back_in_reader", "previous_read_page"),
     },
 }
+if Device:hasKeyboard() then
+    common_settings.backspace_as_back = {
+        text = _("Backspace works as back button"),
+        checked_func = function()
+            return G_reader_settings:isTrue("backspace_as_back")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("backspace_as_back")
+            UIManager:show(InfoMessage:new{
+                text = _("This will take effect on next restart."),
+            })
+        end,
+    }
+end
+
 common_settings.opening_page_location_stack = {
         text = _("Add opening page to location history"),
         checked_func = function()

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -60,6 +60,8 @@ local order = {
         "back_to_exit",
         "back_in_filemanager",
         "back_in_reader",
+        "backspace_as_back",
+        "----------------------------",
         "android_volume_keys",
         "android_camera_key",
         "android_haptic_feedback",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -101,6 +101,7 @@ local order = {
         "back_to_exit",
         "back_in_filemanager",
         "back_in_reader",
+        "backspace_as_back",
         "----------------------------",
         "page_turns_non_touch",
         "android_volume_keys",

--- a/frontend/ui/widget/bboxwidget.lua
+++ b/frontend/ui/widget/bboxwidget.lua
@@ -50,7 +50,7 @@ function BBoxWidget:init()
         }
     end
     if Device:hasKeys() then
-        self.key_events.Close = { {"Back"}, doc = "close windows" }
+        self.key_events.Close = { {Device.input.group.Back}, doc = "close windows" }
         self.key_events.Select = { {"Press"}, doc = "confirm adjust" }
     end
 end

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -538,7 +538,7 @@ function BookMapWidget:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close page" },
+            Close = { {Input.group.Back}, doc = "close page" },
             ScrollRowUp = {{"Up"}, doc = "scroll up"},
             ScrollRowDown = {{"Down"}, doc = "scrol down"},
             ScrollPageUp = {{Input.group.PgBack}, doc = "prev page"},

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -20,7 +20,7 @@ local ButtonDialog = InputContainer:new{
 
 function ButtonDialog:init()
     if Device:hasKeys() then
-        local close_keys = Device:hasFewKeys() and { "Back", "Left" } or "Back"
+        local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
         self.key_events = {
             Close = { { close_keys }, doc = "close button dialog" }
         }

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -34,7 +34,7 @@ local ButtonDialogTitle = InputContainer:new{
 function ButtonDialogTitle:init()
     if self.dismissable then
         if Device:hasKeys() then
-            local close_keys = Device:hasFewKeys() and { "Back", "Left" } or "Back"
+            local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
             self.key_events = {
                 Close = { { close_keys }, doc = "close button dialog" }
             }

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -873,7 +873,7 @@ function ConfigDialog:init()
     end
     if Device:hasKeys() then
         -- set up keyboard events
-        local close_keys = Device:hasFewKeys() and { "Back", "Left" } or "Back"
+        local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
         self.key_events.Close = { { close_keys }, doc = "close config menu" }
     end
     if Device:hasDPad() then

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -73,7 +73,7 @@ function ConfirmBox:init()
         end
         if Device:hasKeys() then
             self.key_events = {
-                Close = { {"Back"}, doc = "cancel" }
+                Close = { {Device.input.group.Back}, doc = "cancel" }
             }
         end
     end

--- a/frontend/ui/widget/datetimewidget.lua
+++ b/frontend/ui/widget/datetimewidget.lua
@@ -82,7 +82,7 @@ function DateTimeWidget:init()
         (self.is_date and 0.8 or 0.6))
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close date widget" }
+            Close = { {Device.input.group.Back}, doc = "close date widget" }
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -93,7 +93,7 @@ function DictQuickLookup:init()
         self.key_events = {
             ReadPrevResult = {{Input.group.PgBack}, doc = "read prev result"},
             ReadNextResult = {{Input.group.PgFwd}, doc = "read next result"},
-            Close = { {"Back"}, doc = "close quick lookup" }
+            Close = { {Input.group.Back}, doc = "close quick lookup" }
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -66,7 +66,7 @@ function DoubleSpinWidget:init()
     end
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close doublespin widget" }
+            Close = { {Device.input.group.Back}, doc = "close doublespin widget" }
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -206,7 +206,7 @@ function FootnoteWidget:init()
     end
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "cancel" },
+            Close = { {Device.input.group.Back}, doc = "cancel" },
             Follow = { {"Press"}, doc = "follow link" },
         }
     end

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -84,7 +84,7 @@ function FrontLightWidget:init()
     }
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close frontlight" }
+            Close = { {Device.input.group.Back}, doc = "close frontlight" }
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -81,7 +81,7 @@ local ImageViewer = InputContainer:new{
 function ImageViewer:init()
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close viewer" },
+            Close = { {Device.input.group.Back}, doc = "close viewer" },
             ZoomIn = { {Device.input.group.PgBack}, doc = "Zoom In" },
             ZoomOut = { {Device.input.group.PgFwd}, doc = "Zoom out" },
         }

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -543,30 +543,47 @@ end
 -- is shown. Mostly likely to be in the emulator, but could be Android + BT
 -- keyboard, or a "coder's keyboard" Android input method.
 function InputText:onKeyPress(key)
-    if key["Backspace"] then
-        self:delChar()
-    elseif key["Del"] then
-        self:rightChar()
-        self:delChar()
-    elseif key["Left"] then
-        self:leftChar()
-    elseif key["Right"] then
-        self:rightChar()
-    elseif key["End"] then
-        self:goToEnd()
-    elseif key["Home"] then
-        self:goToHome()
+
+    local handled = true
+
+    if not key["Ctrl"] and not key["Shift"] and not key["Alt"] then
+        if key["Backspace"] then
+            self:delChar()
+        elseif key["Del"] then
+            self:rightChar()
+            self:delChar()
+        elseif key["Left"] then
+            self:leftChar()
+        elseif key["Right"] then
+            self:rightChar()
+        elseif key["Up"] then
+            self:upLine()
+        elseif key["Down"] then
+            self:downLine()
+        elseif key["End"] then
+            self:goToEnd()
+        elseif key["Home"] then
+            self:goToHome()
+        elseif key["Press"] then
+            self:addChars("\n")
+        elseif key["Tab"] then
+            self:addChars("    ")
+        else
+            handled = false
+        end
     elseif key["Ctrl"] and not key["Shift"] and not key["Alt"] then
         if key["U"] then
             self:delToStartOfLine()
         elseif key["H"] then
             self:delChar()
+        else
+            handled = false
         end
     else
-        return false
+        handled = false
     end
 
-    return true
+    return handled
 end
 
 -- Handle text coming directly as text from the Device layer (eg. soft keyboard

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -283,7 +283,7 @@ function KeyValuePage:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close page" },
+            Close = { {Input.group.Back}, doc = "close page" },
             NextPage = {{Input.group.PgFwd}, doc = "next page"},
             PrevPage = {{Input.group.PgBack}, doc = "prev page"},
         }

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -925,7 +925,7 @@ function Menu:init()
 
     if Device:hasKeys() then
         -- set up keyboard events
-        self.key_events.Close = { {"Back"}, doc = "close menu" }
+        self.key_events.Close = { {Input.group.Back}, doc = "close menu" }
         if Device:hasFewKeys() then
             self.key_events.Close = { {"Left"}, doc = "close menu" }
         end

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -73,7 +73,7 @@ function MultiConfirmBox:init()
         end
         if Device:hasKeys() then
             self.key_events = {
-                Close = { {"Back"}, doc = "cancel" }
+                Close = { {Device.input.group.Back}, doc = "cancel" }
             }
         end
     end

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -50,7 +50,7 @@ function PageBrowserWidget:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close page" },
+            Close = { {Device.input.group.Back}, doc = "close page" },
             ScrollRowUp = {{"Up"}, doc = "scroll up"},
             ScrollRowDown = {{"Down"}, doc = "scrol down"},
             ScrollPageUp = {{Input.group.PgBack}, doc = "prev page"},

--- a/frontend/ui/widget/radiobuttonwidget.lua
+++ b/frontend/ui/widget/radiobuttonwidget.lua
@@ -50,7 +50,7 @@ function RadioButtonWidget:init()
     end
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close widget" }
+            Close = { {Device.input.group.Back}, doc = "close widget" }
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -15,7 +15,7 @@ local ScreenSaverWidget = InputContainer:new{
 function ScreenSaverWidget:init()
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close widget" },
+            Close = { {Device.input.group.Back}, doc = "close widget" },
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -27,7 +27,7 @@ function SkimToWidget:init()
     local screen_height = Screen:getHeight()
 
     if Device:hasKeys() then
-        self.key_events.Close = { { "Back" }, doc = "close skimto page" }
+        self.key_events.Close = { {Device.input.group.Back}, doc = "close skimto page" }
     end
     if Device:isTouchDevice() then
         self.ges_events = {

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -65,7 +65,7 @@ function SpinWidget:init()
     end
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close spin widget" }
+            Close = { {Device.input.group.Back}, doc = "close spin widget" }
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -71,7 +71,7 @@ function TextViewer:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close text viewer" }
+            Close = { {Device.input.group.Back}, doc = "close text viewer" }
         }
     end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -474,7 +474,7 @@ function TouchMenu:init()
         }
     }
 
-    self.key_events.Back = { {"Back"}, doc = "back to upper menu or close touchmenu" }
+    self.key_events.Back = { {Input.group.Back}, doc = "back to upper menu or close touchmenu" }
     if Device:hasFewKeys() then
         self.key_events.Back = { {"Left"}, doc = "back to upper menu or close touchmenu" }
     end

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -672,7 +672,7 @@ function VirtualKeyPopup:init()
         self.key_events.PressKey = { {"Press"}, doc = "select key" }
     end
     if Device:hasKeys() then
-        self.key_events.Close = { {"Back"}, doc = "close keyboard" }
+        self.key_events.Close = { {Device.input.group.Back}, doc = "close keyboard" }
     end
 
     local offset_x = 2*keyboard_frame.bordersize + keyboard_frame.padding + parent_key.keyboard.key_padding

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -800,6 +800,20 @@ function VirtualKeyboard:init()
     if keyboard.wrapInputBox then
         self.uwrap_func = keyboard.wrapInputBox(self.inputbox) or self.uwrap_func
     end
+    if Device:hasDPad() and Device:hasKeyboard() and Device:isTouchDevice() then
+        -- hadDPad() would have FocusManager handle arrow keys strokes to navigate
+        -- and activate this VirtualKeyboard's touch keys (needed on non-touch Kindle).
+        -- If we have a keyboard, we'd prefer arrow keys (and Enter, and Del) to be
+        -- handled by InputText to navigate the cursor inside the text box, and to
+        -- add newline and delete chars. And if we are a touch device, we don't
+        -- need focus manager to help us navigate keys and fields.
+        -- So, disable all key_event handled by FocusManager
+        self.key_events.FocusLeft = nil
+        self.key_events.FocusRight = nil
+        self.key_events.FocusUp = nil
+        self.key_events.FocusDown = nil
+        self.key_events.PressKey = nil -- added above
+    end
 end
 
 function VirtualKeyboard:getKeyboardLayout()

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -430,7 +430,7 @@ function CalendarView:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {"Back"}, doc = "close page" },
+            Close = { {Input.group.Back}, doc = "close page" },
             NextMonth = {{Input.group.PgFwd}, doc = "next page"},
             PrevMonth = {{Input.group.PgBack}, doc = "prev page"},
         }


### PR DESCRIPTION
Refresh of #7183 (too old to be merged) by @johnbeard .
Also add an option to allow Backspace to work as Back.
Discussion at the bottom of #7183.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8716)
<!-- Reviewable:end -->
