### PR TITLE
Various UX fixes

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -49,12 +49,6 @@ function FileManagerShortcuts:updateItemTable()
     table.sort(item_table, function(l, r)
         return l.text < r.text
     end)
-    table.insert(item_table, 1, {
-        text = _("Add new folder shortcut"),
-        callback = function()
-            self:addNewFolder()
-        end,
-    })
 
     -- try to stay on current page
     local select_number
@@ -77,9 +71,8 @@ function FileManagerShortcuts:addNewFolder()
             local add_folder_input
             local friendly_name = util.basename(path) or _("my folder")
             add_folder_input = InputDialog:new{
-                title = self.title,
+                title = _("Enter friendly name"),
                 input = friendly_name,
-                input_type = "text",
                 description = T(_("Title for selected folder:\n%1"), BD.dirpath(path)),
                 buttons = {
                     {
@@ -166,7 +159,6 @@ function FileManagerShortcuts:editFolderShortcut(item)
     edit_folder_input = InputDialog:new {
         title = _("Edit friendly name"),
         input = item.friendly_name,
-        input_type = "text",
         description = T(_("Rename title for selected folder:\n%1"), BD.dirpath(item.folder)),
         buttons = {
             {
@@ -243,6 +235,8 @@ function FileManagerShortcuts:onShowFolderShortcutsDialog()
         curr_path = self.ui.file_chooser and self.ui.file_chooser.path or self.ui:getLastDirFile(),
         onMenuHold = self.onMenuHold,
         onSetRotationMode = self.MenuSetRotationModeHandler,
+        title_bar_left_icon = "plus",
+        onLeftButtonTap = function() self:addNewFolder() end,
         _manager = self,
     }
 

--- a/frontend/ui/data/keyboardlayouts/ja_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ja_keyboard.lua
@@ -141,12 +141,10 @@ local function genMenuItems(self)
                 local Screen = require("device").screen
                 local items = SpinWidget:new{
                     title_text = _("Keitai tap interval"),
-                    info_text = T(_([[
+                    info_text = _([[
 How long to wait (in seconds) for the next tap when in keitai input mode before committing to the current character. During this window, tapping a single key will loop through candidates for the current character being input. Any other input will cause you to leave keitai mode.
 
-If set to 0, keitai input is disabled entirely and only flick input can be used.
-
-Default value: %1]]), DEFAULT_KEITAI_TAP_INTERVAL),
+If set to 0, keitai input is disabled entirely and only flick input can be used.]]),
                     width = math.floor(Screen:getWidth() * 0.75),
                     value = getKeitaiTapInterval(),
                     value_min = 0,

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -237,11 +237,10 @@ if Device:isTouchDevice() or Device:hasDPad() then
                             },
                             {
                                 text = _("Paste"),
+                                enabled = not is_clipboard_empty,
                                 callback = function()
-                                    if not is_clipboard_empty then
-                                        UIManager:close(clipboard_dialog)
-                                        self:addChars(clipboard_value)
-                                    end
+                                    UIManager:close(clipboard_dialog)
+                                    self:addChars(clipboard_value)
                                 end,
                             },
                         },

--- a/frontend/ui/widget/openwithdialog.lua
+++ b/frontend/ui/widget/openwithdialog.lua
@@ -5,12 +5,11 @@ This widget displays an open with dialog.
 local Blitbuffer = require("ffi/blitbuffer")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local CheckButton = require("ui/widget/checkbutton")
-local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local InputDialog = require("ui/widget/inputdialog")
-local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
+local MovableContainer = require("ui/widget/container/movablecontainer")
 local RadioButtonTable = require("ui/widget/radiobuttontable")
 local Size = require("ui/size")
 local UIManager = require("ui/uimanager")
@@ -25,7 +24,6 @@ function OpenWithDialog:init()
     -- init title and buttons in base class
     InputDialog.init(self)
 
-    self.face = Font:getFace("cfont", 22)
     self.element_width = math.floor(self.width * 0.9)
 
     self.radio_button_table = RadioButtonTable:new{
@@ -34,7 +32,6 @@ function OpenWithDialog:init()
         focused = true,
         scroll = false,
         parent = self,
-        face = self.face,
         button_select_callback = function(btn)
             if btn.provider.one_time_provider then
                 self._check_file_button:disable()
@@ -45,36 +42,55 @@ function OpenWithDialog:init()
             end
         end
     }
+    self._input_widget = self.radio_button_table
+
+    local vertical_span = VerticalSpan:new{
+        width = Size.padding.large,
+    }
+    self.vgroup = VerticalGroup:new{
+        align = "left",
+        self.title_bar,
+        vertical_span,
+        CenterContainer:new{
+            dimen = Geom:new{
+                w = self.width,
+                h = self.radio_button_table:getSize().h,
+            },
+            self.radio_button_table,
+        },
+        CenterContainer:new{
+            dimen = Geom:new{
+                w = self.width,
+                h = Size.padding.large,
+            },
+            LineWidget:new{
+                background = Blitbuffer.COLOR_DARK_GRAY,
+                dimen = Geom:new{
+                    w = self.element_width,
+                    h = Size.line.medium,
+                }
+            },
+        },
+        vertical_span,
+        CenterContainer:new{
+            dimen = Geom:new{
+                w = self.title_bar:getSize().w,
+                h = self.button_table:getSize().h,
+            },
+            self.button_table,
+        }
+    }
 
     self._check_file_button = self._check_file_button or CheckButton:new{
         text = _("Always use this engine for this file"),
-        width = self.element_width,
-        face = self.face,
         parent = self,
     }
-    self._always_file_toggle = LeftContainer:new{
-        bordersize = 0,
-        dimen = Geom:new{
-            w = self.element_width,
-            h = self._check_file_button:getSize().h,
-        },
-        self._check_file_button,
-    }
-
+    self:addWidget(self._check_file_button)
     self._check_global_button = self._check_global_button or CheckButton:new{
         text = _("Always use this engine for file type"),
-        width = self.element_width,
-        face = self.face,
         parent = self,
     }
-    self._always_global_toggle = LeftContainer:new{
-        bordersize = 0,
-        dimen = Geom:new{
-            w = self.element_width,
-            h = self._check_global_button:getSize().h,
-        },
-        self._check_global_button,
-    }
+    self:addWidget(self._check_global_button)
 
     self.dialog_frame = FrameContainer:new{
         radius = Size.radius.window,
@@ -82,68 +98,17 @@ function OpenWithDialog:init()
         padding = 0,
         margin = 0,
         background = Blitbuffer.COLOR_WHITE,
-        VerticalGroup:new{
-            align = "left",
-            self.title_bar,
-            VerticalSpan:new{
-                width = Size.span.vertical_large*2,
-            },
-            CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.title_bar:getSize().w,
-                    h = self.radio_button_table:getSize().h,
-                },
-                self.radio_button_table,
-            },
-            CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.title_bar:getSize().w,
-                    h = Size.span.vertical_large*2,
-                },
-                LineWidget:new{
-                    background = Blitbuffer.COLOR_DARK_GRAY,
-                    dimen = Geom:new{
-                        w = self.element_width,
-                        h = Size.line.medium,
-                    }
-                },
-            },
-            CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.title_bar:getSize().w,
-                    h = self._always_file_toggle:getSize().h,
-                },
-                self._always_file_toggle,
-            },
-            CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.title_bar:getSize().w,
-                    h = self._always_global_toggle:getSize().h,
-                },
-                self._always_global_toggle,
-            },
-            VerticalSpan:new{
-                width = Size.span.vertical_large*2,
-            },
-            -- buttons
-            CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.title_bar:getSize().w,
-                    h = self.button_table:getSize().h,
-                },
-                self.button_table,
-            }
-        }
+        self.vgroup,
     }
-
-    self._input_widget = self.radio_button_table
-
+    self.movable = MovableContainer:new{
+        self.dialog_frame,
+    }
     self[1] = CenterContainer:new{
         dimen = Geom:new{
             w = Screen:getWidth(),
             h = Screen:getHeight(),
         },
-        self.dialog_frame,
+        self.movable,
     }
 end
 

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -782,6 +782,7 @@ function OPDSBrowser:showDownloads(item)
                 local TextViewer = require("ui/widget/textviewer")
                 UIManager:show(TextViewer:new{
                     title = item.text,
+                    title_multilines = true,
                     text = util.htmlToPlainTextIfHtml(item.content),
                     text_face = Font:getFace("x_smallinfofont", G_reader_settings:readSetting("items_font_size")),
                 })


### PR DESCRIPTION
Minor UX fixes and standardization
(1) OpenWithDialog: movable; checkbuttons added via standard `addWidget`
(2) KeyboardLayoutDialog: insert TitleBar
(3) Clipboard: disable Paste button on empty clipboard
(4) OPDS book info: multiline title (book author and title)
(5) Folder shortcuts: standard "plus" button to add a shortcut
(6) ja_keyboard Keitai tap interval: no default value in description (shown in default spinwidget button)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8720)
<!-- Reviewable:end -->
