### PR TITLE
Colordict: use generic send intent.

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -49,7 +49,7 @@ local external = require("device/thirdparty"):new{
     dicts = {
         { "Aard2", "Aard2", false, "itkach.aard2", "aard2" },
         { "Alpus", "Alpus", false, "com.ngcomputing.fora.android", "search" },
-        { "ColorDict", "ColorDict", false, "com.socialnmobile.colordict", "colordict" },
+        { "ColorDict", "ColorDict", false, "com.socialnmobile.colordict", "send" },
         { "Eudic", "Eudic", false, "com.eusoft.eudic", "send" },
         { "EudicPlay", "Eudic (Google Play)", false, "com.qianyan.eudic", "send" },
         { "Fora", "Fora Dict", false, "com.ngc.fora", "search" },


### PR DESCRIPTION
Its custom intent was borked on last update and doesn't work anymore.

Fixes https://github.com/koreader/koreader/issues/8718

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8721)
<!-- Reviewable:end -->
