### PR TITLE
Highlight: strikeout style, fix pdf highlight

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1700,7 +1700,7 @@ function ReaderHighlight:editHighlightStyle(page, i)
             UIManager:setDirty(self.dialog, "ui")
             self.ui:handleEvent(Event:new("BookmarkUpdated",
                     self.ui.bookmark:getBookmarkForHighlight({
-                        page = self.ui.paging and item.pos0.page or item.pos0,
+                        page = self.ui.paging and page or item.pos0,
                         datetime = item.datetime,
                     })))
         end,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -278,6 +278,7 @@ end
 local highlight_style = {
     {_("Lighten"), "lighten"},
     {_("Underline"), "underscore"},
+    {_("Strikeout"), "strikeout"},
     {_("Invert"), "invert"},
 }
 
@@ -1670,13 +1671,14 @@ end
 
 function ReaderHighlight:editHighlightStyle(page, i)
     local item = self.view.highlight.saved[page][i]
+    local save_document = self.ui.paging and G_reader_settings:readSetting("save_document") ~= "disable"
     local radio_buttons = {}
     for _, v in ipairs(highlight_style) do
         table.insert(radio_buttons, {
             {
-            text = v[1],
-            checked = item.drawer == v[2],
-            provider = v[2],
+                text = v[1],
+                checked = item.drawer == v[2],
+                provider = v[2],
             },
         })
     end
@@ -1688,7 +1690,13 @@ function ReaderHighlight:editHighlightStyle(page, i)
         default_provider = self.view.highlight.saved_drawer or
             G_reader_settings:readSetting("highlight_drawing_style", "lighten"),
         callback = function(radio)
+            if save_document then
+                self.ui.document:deleteHighlight(page, item)
+            end
             item.drawer = radio.provider
+            if save_document then
+                self.ui.document:saveHighlight(page, item)
+            end
             UIManager:setDirty(self.dialog, "ui")
             self.ui:handleEvent(Event:new("BookmarkUpdated",
                     self.ui.bookmark:getBookmarkForHighlight({

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -542,15 +542,20 @@ end
 
 function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer)
     local x, y, w, h = rect.x, rect.y, rect.w, rect.h
-
-    if drawer == "underscore" then
-        self.highlight.line_width = self.highlight.line_width or 2
-        self.highlight.line_color = self.highlight.line_color or Blitbuffer.COLOR_GRAY
-        bb:paintRect(x, y+h-1, w,
-            self.highlight.line_width,
-            self.highlight.line_color)
-    elseif drawer == "lighten" then
+    if drawer == "lighten" then
         bb:lightenRect(x, y, w, h, self.highlight.lighten_factor)
+    elseif drawer == "underscore" then
+        local line_y = y + h - 1
+        if self.ui.document.info.has_pages then
+            line_y = line_y - 2
+        end
+        bb:paintRect(x, line_y, w, 2, Blitbuffer.COLOR_GRAY)
+    elseif drawer == "strikeout" then
+        local line_y = y + h + 1 - math.ceil(h / 2)
+        if self.ui.document.info.has_pages then
+            line_y = line_y + 2
+        end
+        bb:paintRect(x, line_y, w, 2, Blitbuffer.COLOR_BLACK)
     elseif drawer == "invert" then
         bb:invertRect(x, y, w, h)
     end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -37,7 +37,7 @@ local ReaderView = OverlapGroup:extend{
         bbox = nil,
     },
     outer_page_color = Blitbuffer.gray(DOUTER_PAGE_COLOR / 15),
-    -- highlight with "lighten" or "underscore" or "invert"
+    -- highlight with "lighten" or "underscore" or "strikeout" or "invert"
     highlight = {
         lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor", 0.2),
         temp_drawer = "invert",
@@ -547,7 +547,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer)
     elseif drawer == "underscore" then
         bb:paintRect(x, y + h - 1, w, 2, Blitbuffer.COLOR_GRAY)
     elseif drawer == "strikeout" then
-        local line_y = y + h + 1 - math.ceil(h / 2)
+        local line_y = y + math.floor(h / 2) + 1
         if self.ui.paging then
             line_y = line_y + 2
         end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -545,14 +545,10 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer)
     if drawer == "lighten" then
         bb:lightenRect(x, y, w, h, self.highlight.lighten_factor)
     elseif drawer == "underscore" then
-        local line_y = y + h - 1
-        if self.ui.document.info.has_pages then
-            line_y = line_y - 2
-        end
-        bb:paintRect(x, line_y, w, 2, Blitbuffer.COLOR_GRAY)
+        bb:paintRect(x, y + h - 1, w, 2, Blitbuffer.COLOR_GRAY)
     elseif drawer == "strikeout" then
         local line_y = y + h + 1 - math.ceil(h / 2)
-        if self.ui.document.info.has_pages then
+        if self.ui.paging then
             line_y = line_y + 2
         end
         bb:paintRect(x, line_y, w, 2, Blitbuffer.COLOR_BLACK)

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -239,7 +239,7 @@ function PdfDocument:saveHighlight(pageno, item)
     elseif item.drawer == "underscore" then
         annot_type = C.PDF_ANNOT_UNDERLINE
     elseif item.drawer == "strikeout" then
-        annot_type = C.PDF_ANNOT_STRIKEOUT
+        annot_type = C.PDF_ANNOT_STRIKE_OUT
     end
     page:addMarkupAnnotation(quadpoints, n, annot_type) -- may update/adjust quadpoints
     -- Update pboxes with the possibly adjusted coordinates (this will have it updated


### PR DESCRIPTION
(1) New `strikeout` highlight style.
Requires https://github.com/koreader/koreader-base/pull/1450.

![01](https://user-images.githubusercontent.com/62179190/150979641-ddd47674-0426-470e-9fce-911cca8f11c7.png)

(2) Fix changing highlight style in pdf documents with enabled `save_document`.
Fix ugly combination of mupdf and KOReader highlights. Closes https://github.com/koreader/koreader/issues/8663.

Before
![02](https://user-images.githubusercontent.com/62179190/150979844-4e9491b6-12d0-46cf-8d3b-fcfea0fe7678.png)

After
![03](https://user-images.githubusercontent.com/62179190/150979878-b1490ea5-efb1-4157-af7c-a3133e1aece5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8725)
<!-- Reviewable:end -->
