### PR TITLE
Allow any multiswipe to close some fullscreen widgets

### DIFF
--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -599,6 +599,9 @@ function BookMapWidget:init()
         title = self.title,
         left_icon = "info",
         left_icon_tap_callback = function() self:showHelp() end,
+        left_icon_hold_callback = function()
+            self:toggleDefaultSettings() -- toggle between user settings and default view
+        end,
         close_callback = function() self:onClose() end,
         close_hold_callback = function() self:onClose(true) end,
         show_parent = self,
@@ -1022,7 +1025,8 @@ Swipe along the bottom screen edge to change the width of page slots.
 Swipe or pan vertically on content to scroll.
 Any multiswipe will close the book map.
 
-On a newly opened book, the book map will start in grid mode showing all chapter levels, fitting on a single screen, to give the best initial overview of the book's content.]]),
+On a newly opened book, the book map will start in grid mode showing all chapter levels, fitting on a single screen, to give the best initial overview of the book's content.
+Long-press on ⓘ to switch between current and initial views.]]),
     })
 end
 
@@ -1143,6 +1147,24 @@ function BookMapWidget:saveSettings(reset)
     self.ui.doc_settings:saveSetting("book_map_flat", self.flat_map)
     self.ui.doc_settings:saveSetting("book_map_toc_depth", self.toc_depth)
     self.ui.doc_settings:saveSetting("book_map_pages_per_row", self.pages_per_row)
+end
+
+function BookMapWidget:toggleDefaultSettings()
+    if not self.flat_map and self.toc_depth == self.max_toc_depth
+            and self.pages_per_row == self.fit_pages_per_row then
+        -- Still in default/initial view: restore previous settings (if any)
+        self.flat_map = self.ui.doc_settings:readSetting("book_map_previous_flat")
+        self.toc_depth = self.ui.doc_settings:readSetting("book_map_previous_toc_depth")
+        self.pages_per_row = self.ui.doc_settings:readSetting("book_map_previous_pages_per_row")
+        self:saveSettings()
+    else
+        -- Save previous settings and switch to defaults
+        self.ui.doc_settings:saveSetting("book_map_previous_flat", self.flat_map)
+        self.ui.doc_settings:saveSetting("book_map_previous_toc_depth", self.toc_depth)
+        self.ui.doc_settings:saveSetting("book_map_previous_pages_per_row", self.pages_per_row)
+        self:saveSettings(true)
+    end
+    self:update()
 end
 
 function BookMapWidget:updateTocDepth(depth, flat)

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -114,6 +114,12 @@ function BookStatusWidget:init()
                 range = function() return self.dimen end,
             }
         }
+        self.ges_events.MultiSwipe = {
+            GestureRange:new{
+                ges = "multiswipe",
+                range = function() return self.dimen end,
+            }
+        }
     end
 
     local screen_size = Screen:getSize()
@@ -600,6 +606,14 @@ function BookStatusWidget:onSwipe(arg, ges_ev)
         -- so let it propagate
         return false
     end
+end
+
+function BookStatusWidget:onMultiSwipe(arg, ges_ev)
+    -- For consistency with other fullscreen widgets where swipe south can't be
+    -- used to close and where we then allow any multiswipe to close, allow any
+    -- multiswipe to close this widget too.
+    self:onClose()
+    return true
 end
 
 function BookStatusWidget:onClose()

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -115,6 +115,8 @@ function ImageViewer:init()
                     scale = {diagonal - Screen:scaleBySize(200), diagonal}, rate = 1.0,
                 }
             },
+            -- Allow closing with any multiswipe
+            MultiSwipe = { GestureRange:new{ ges = "multiswipe", range = range } },
         }
     end
     if self.fullscreen then
@@ -546,6 +548,13 @@ function ImageViewer:onSwipe(_, ges)
     elseif direction == "southwest" then
         self:panBy(sq_distance, -sq_distance)
     end
+    return true
+end
+
+function ImageViewer:onMultiSwipe(_, ges)
+    -- As swipe south to close is only enabled when scaled to fit, but not
+    -- when we are zoomed in/out, allow any multiswipe to close.
+    self:onClose()
     return true
 end
 

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -295,6 +295,12 @@ function KeyValuePage:init()
                 range = self.dimen,
             }
         }
+        self.ges_events.MultiSwipe = {
+            GestureRange:new{
+                ges = "multiswipe",
+                range = self.dimen,
+            }
+        }
     end
 
     -- return button
@@ -632,6 +638,14 @@ function KeyValuePage:onSwipe(arg, ges_ev)
         -- so let it propagate
         return false
     end
+end
+
+function KeyValuePage:onMultiSwipe(arg, ges_ev)
+    -- For consistency with other fullscreen widgets where swipe south can't be
+    -- used to close and where we then allow any multiswipe to close, allow any
+    -- multiswipe to close this widget too.
+    self:onClose()
+    return true
 end
 
 function KeyValuePage:onClose()

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -914,6 +914,12 @@ function Menu:init()
                     range = self.dimen,
                 }
             }
+            self.ges_events.MultiSwipe = {
+                GestureRange:new{
+                    ges = "multiswipe",
+                    range = self.dimen,
+                }
+            }
         end
         self.ges_events.Close = self.on_close_ges
     end
@@ -1348,7 +1354,7 @@ function Menu:onSwipe(arg, ges_ev)
     elseif direction == "south" then
         if self.has_close_button and not self.no_title then
             -- If there is a close button displayed (so, this Menu can be
-            -- closed), allow easier closing with swipe up/down
+            -- closed), allow easier closing with swipe south.
             self:onClose()
         end
         -- If there is no close button, it's a top level Menu and swipe
@@ -1360,6 +1366,18 @@ function Menu:onSwipe(arg, ges_ev)
         -- trigger full refresh
         UIManager:setDirty(nil, "full")
     end
+end
+
+function Menu:onMultiSwipe(arg, ges_ev)
+    -- For consistency with other fullscreen widgets where swipe south can't be
+    -- used to close and where we then allow any multiswipe to close, allow any
+    -- multiswipe to close this widget too.
+    if self.has_close_button and not self.no_title then
+        -- If there is a close button displayed (so, this Menu can be
+        -- closed), allow easier closing with swipe south.
+        self:onClose()
+    end
+    return true
 end
 
 function Menu:setTitleBarLeftIcon(icon)

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -442,6 +442,12 @@ function CalendarView:init()
                 range = self.dimen,
             }
         }
+        self.ges_events.MultiSwipe = {
+            GestureRange:new{
+                ges = "multiswipe",
+                range = self.dimen,
+            }
+        }
     end
 
     self.outer_padding = Size.padding.large
@@ -828,6 +834,14 @@ function CalendarView:onSwipe(arg, ges_ev)
         -- so let it propagate
         return false
     end
+end
+
+function CalendarView:onMultiSwipe(arg, ges_ev)
+    -- For consistency with other fullscreen widgets where swipe south can't be
+    -- used to close and where we then allow any multiswipe to close, allow any
+    -- multiswipe to close this widget too.
+    self:onClose()
+    return true
 end
 
 function CalendarView:onClose()

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -71,6 +71,12 @@ function ReaderProgress:init()
                 range = function() return self.dimen end,
             }
         }
+        self.ges_events.MultiSwipe = {
+            GestureRange:new{
+                ges = "multiswipe",
+                range = function() return self.dimen end,
+            }
+        }
     end
     self.covers_fullscreen = true -- hint for UIManager:_repaint()
     self[1] = FrameContainer:new{
@@ -517,6 +523,14 @@ function ReaderProgress:onSwipe(arg, ges_ev)
         -- so let it propagate
         return false
     end
+end
+
+function ReaderProgress:onMultiSwipe(arg, ges_ev)
+    -- For consistency with other fullscreen widgets where swipe south can't be
+    -- used to close and where we then allow any multiswipe to close, allow any
+    -- multiswipe to close this widget too.
+    self:onClose()
+    return true
 end
 
 function ReaderProgress:onClose()


### PR DESCRIPTION
#### Allow any multiswipe to close some fullscreen widgets

For consistency with BookMap and PageBrowser widgets where swipe south (the usual gesture to quick close) can't be used for closing and we had to use any multiswipe instead, allow any multiswipe to close these other fullscreen widgets too:
Menu (ToC, Bookmarks), KeyValuePage, ImageViewer, BookStatusWidget, ReaderProgress, CalendarView.

See https://github.com/koreader/koreader/pull/8613#issuecomment-1019557277 item **C**.
(Didn't do SortWidget - rarely used and can't be associated to a gesture - and FootnoteWidget - non fullscreen.)

#### BookMap: long-press on (i) to restore initial view

See https://github.com/koreader/koreader/pull/8613#issuecomment-1019583186

Added this line to the info text:
![image](https://user-images.githubusercontent.com/24273478/150995393-9ef1ab70-f1c9-4d37-af2f-529d9ce3c28e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8726)
<!-- Reviewable:end -->
