### PR TITLE
PocketBook: Handle rendering of interface and books directly with inkview

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -101,7 +101,7 @@ function PocketBook:init()
     local raw_input = self.raw_input
     local touch_rotation = raw_input and raw_input.touch_rotation or 0
 
-    self.screen = require("ffi/framebuffer_mxcfb"):new {
+    self.screen = require("ffi/framebuffer_pocketbook"):new {
         device = self,
         debug = logger.dbg,
         wf_level = G_reader_settings:readSetting("wf_level") or 0,
@@ -595,6 +595,12 @@ local PocketBook741 = PocketBook:new{
     isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
 }
+
+
+function PocketBook741._fb_init(fb, finfo, vinfo)
+    -- Pocketbook Color Lux reports bits_per_pixel = 8, but actually uses an RGB24 framebuffer
+    vinfo.bits_per_pixel = 24
+end
 
 -- PocketBook Color Lux (801)
 local PocketBookColorLux = PocketBook:new{


### PR DESCRIPTION
Needs following PR too: https://github.com/koreader/koreader-base/pull/1451

Fixes: https://github.com/koreader/koreader/issues/7406
Fixes: https://github.com/koreader/koreader/issues/8187
Needs testing for: https://github.com/koreader/koreader/issues/6479

I've been emailing about color support for the pocketbooks directly with Pocketbook. The awesome folks of pocketbook replied with the implementation of rendering with the native inkview library. I've tested this with my Pocketbook 741 and the results are very promising.

This is their answer:

> Support for PB741 (InkPad Color)
> https://github.com/koreader/koreader/issues/7406 
>
> There are two types of color screens used by PocketBook: Kaleido and Kaleido plus. These two types have slightly different color filter patterns. Thus we need to use different algorithms to display colors. All this functionality is already implemented in inkview library which is already used by KoReader. The easiest way to have colors in your application is not to forward the image directly to framebuffer, but to do it through inkview lib.
​
> Please find attached an example how to do it. You need to unpack archive and replace files of KoReader. We checked on version 2022.01.
>
> Best regards,
> Customer Support Team


This PR is their implementation. All the credits go to the awesome PocketBook developer that took the time to write this.

Of course this also needs to be tested on other pocketbook devices. But I hope this will solve some of rendering issues with the pocketbooks.

Some images of the results:

![IMG_20220125_154259](https://user-images.githubusercontent.com/160743/150999402-a9e39318-bcb2-4e88-85a4-38ffc57ea0b5.jpg)
![IMG_20220125_154227](https://user-images.githubusercontent.com/160743/150999421-9334100a-9d5c-412e-920e-a5ff0b2df9e1.jpg)
![IMG_20220125_154315](https://user-images.githubusercontent.com/160743/150999429-f7c5e31d-37c4-42d3-88b4-5b8efe873533.jpg)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8727)
<!-- Reviewable:end -->
