### PR TITLE
PocketBook: make canAssociateFileExtensions always return true

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -34,6 +34,7 @@ local PocketBook = Generic:new{
     canPowerOff = yes,
     needsScreenRefreshAfterResume = no,
     home_dir = "/mnt/ext1",
+    canAssociateFileExtensions = yes,
 
     -- all devices that have warmth lights use inkview api
     hasNaturalLightApi = yes,
@@ -284,18 +285,6 @@ function PocketBook:setDateTime(year, month, day, hour, min, sec)
     else
         return false
     end
-end
-
--- Predicate, so no self
-function PocketBook.canAssociateFileExtensions()
-    local f = io.open(ext_path, "r")
-    if not f then return true end
-    local l = f:read("*line")
-    f:close()
-    if l and not l:match("^#koreader") then
-        return false
-    end
-    return true
 end
 
 function PocketBook:associateFileExtensions(assoc)


### PR DESCRIPTION
This change drops the #koreader signature check. This check prevents KOReader from modifying associations if something else has changed the file without putting a verbatim `#koreader` string back. While this prevents KOReader from interfering with another application or the system trying to own the file, it also leads to hard to diagnose issues, when the user can inadvertently change associations without realising they’re doing so, and being unable to return back.

One way this can happen if the user temporarily uninstalls KOReader, powers the device back on again, and then installs it back. The system will drop unknown applications from the associations file and remove the signature as well.

Fixes: #8728

See also: http://www.mobileread.mobi/forums/showthread.php?t=339558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8729)
<!-- Reviewable:end -->
