### PR TITLE
PocketBook: Check NET_CONNECTED to see if wifi is really connected

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -359,8 +359,7 @@ function PocketBook:initNetworkManager(NetworkMgr)
     end
 
     function NetworkMgr:isWifiOn()
-        local state = inkview.QueryNetwork()
-        return band(state, C.NET_CONNECTED) ~= 0
+        return band(inkview.QueryNetwork(), C.NET_CONNECTED) ~= 0
     end
 end
 


### PR DESCRIPTION
I've emailed with PocketBook about the problem with Wifi on the newer models. They explained the wrong constant was being used:

> Dear Robert,
>
> Thank you for choosing Pocketbook.
​
> Wi-Fi Connection" enabled when no connection:
> https://github.com/koreader/koreader/issues/8617  
> The problem is in incorrect usage of constant. You should use flag NET_CONNECTED with bit AND operation as shown in example below.
>
> function NetworkMgr:isWifiOn()
>     local state = inkview.QueryNetwork()
>     return band(state, C.NET_CONNECTED) ~= 0
> end
>
> Inkpad3 Wifi Standby
> https://github.com/koreader/koreader/issues/4747 
> the same solution for this issue

Related issues:
https://github.com/koreader/koreader/issues/8617
https://github.com/koreader/koreader/issues/4747

Since I made the previous hack and their suggestion seems to work on the PB741 color. I've made this PR to remove my hack.

It might be wise to also test this fix on older models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8730)
<!-- Reviewable:end -->
