### PR TITLE
wallabag : fixes synchronization when "send review as tags" is checked

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -807,30 +807,31 @@ function Wallabag:addTags(path)
     if id then
         local docinfo = DocSettings:open(path)
 
-        local tags = docinfo.data.summary.note
+        if docinfo.data and docinfo.data.summary and docinfo.data.summary.note then
+          local tags = docinfo.data.summary.note
 
-        if tags ~= "" and tags ~= nil then
+          if tags ~= "" and tags ~= nil then
 
-            logger.dbg("Wallabag: sending tags ", tags, " for ", path)
+              logger.dbg("Wallabag: sending tags ", tags, " for ", path)
 
-            local body = {
-                tags = tags
-            }
+              local body = {
+                  tags = tags,
+              }
 
-            local bodyJSON = JSON.encode(body)
+              local bodyJSON = JSON.encode(body)
 
-            local headers = {
-                ["Content-type"] = "application/json",
-                ["Accept"] = "application/json, */*",
-                ["Content-Length"] = tostring(#bodyJSON),
-                ["Authorization"] = "Bearer " .. self.access_token,
-            }
+              local headers = {
+                  ["Content-type"] = "application/json",
+                  ["Accept"] = "application/json, */*",
+                  ["Content-Length"] = tostring(#bodyJSON),
+                  ["Authorization"] = "Bearer " .. self.access_token,
+              }
 
-            self:callAPI("POST", "/api/entries/" .. id .. "/tags.json", headers, bodyJSON, "")
-        else
-            logger.dbg("Wallabag: no tags to send for ", path)
-        end
-
+              self:callAPI("POST", "/api/entries/" .. id .. "/tags.json", headers, bodyJSON, "")
+          else
+              logger.dbg("Wallabag: no tags to send for ", path)
+          end
+       end
     end
 end
 


### PR DESCRIPTION
In this PR https://github.com/koreader/koreader/pull/8637
It worked on my sev environnement, but when updating my device, there
were synchronization errors.

Apparently sometimes documents do not have a summary.
To avoid an error during the synchronisation this change adds checks
when getting tags for the document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8733)
<!-- Reviewable:end -->
