### PR TITLE
FocusManager: only trigger selected widged in focused style with DPad support device

### DIFF
--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -219,7 +219,10 @@ end
 
 --- Container call this method after init to let first widget render in focus style
 function FocusManager:focusTopLeftWidget()
-    self:onFocusMove({0, 0})
+    if Device:hasDPad() then
+        -- trigger selected widget in focused style
+        self:onFocusMove({0, 0})
+    end
 end
 
 return FocusManager


### PR DESCRIPTION
Fix https://github.com/koreader/koreader/pull/8712#issuecomment-1023134610

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8737)
<!-- Reviewable:end -->
