### PR TITLE
Try route from net-tools if ip from iproute2 is not available

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -21,7 +21,7 @@ local function isUrl(s)
 end
 
 local function isCommand(s)
-    return os.execute("which "..s.." >/dev/null 2>&1") == 0
+    return os.execute("command -v "..s.." >/dev/null") == 0
 end
 
 local function runCommand(command)
@@ -378,13 +378,13 @@ function Device:initNetworkManager(NetworkMgr)
         end
 
         if std_out then
-            default_gw = std_out:read("*all")
+            default_gw = std_out:read("*l")
             std_out:close()
             if not default_gw or default_gw == "" then
                 return false
             end
         end
-        return 0 == os.execute("ping -c1 -w2 " .. default_gw)
+        return 0 == os.execute("ping -c1 -w2 " .. default_gw .. " > /dev/null")
     end
 end
 


### PR DESCRIPTION
Some Pocketbook devices (e.g. Lux 4) lack iproute2 binaries, but have net-tools installed instead. Instead of running `ip r` multiple times, try running it and parsing its output directly, falling back to `route -n` if `ip` is not available.

Unfortunately, I can’t pinging itself because apparently on my device `ping` is not suid-root, but having added some debug print to this function I was able to determine that the parsing code works correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8739)
<!-- Reviewable:end -->
