### PR TITLE
[AltStatusBar] Don't show [+] in status line when loading from power cover

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -50,14 +50,14 @@ function ReaderCoptListener:onReadSettings(config)
     local status_line = config:readSetting("copt_status_line") or G_reader_settings:readSetting("copt_status_line", 1)
     self.ui:handleEvent(Event:new("SetStatusLine", status_line))
 
-    self.old_battery_level = Device:getPowerDevice():getCapacity()
+    self.old_battery_level = self.ui.rolling:updateBatteryState()
 
     -- Have this ready in case auto-refresh is enabled, now or later
     self.headerRefresh = function()
         -- Only draw it if the header is shown...
         if self.document.configurable.status_line == 0 and self.view.view_mode == "page" then
             -- ...and something has changed
-            local new_battery_level = Device:getPowerDevice():getCapacity()
+            local new_battery_level = self.ui.rolling:updateBatteryState()
             if self.clock == 1 or (self.battery == 1 and new_battery_level ~= self.old_battery_level) then
                 self.old_battery_level = new_battery_level
                 self:updateHeader()
@@ -92,7 +92,6 @@ end
 
 function ReaderCoptListener:updateHeader()
     -- Have crengine display accurate time and battery on its next drawing
-    self.ui.rolling:updateBatteryState()
     self.ui.document:resetBufferCache() -- be sure next repaint is a redrawing
     -- Force a refresh if we're not hidden behind another widget
     if UIManager:getTopWidget() == "ReaderUI" then
@@ -165,6 +164,7 @@ function ReaderCoptListener:setAndSave(setting, property, value)
     self.ui.document._document:setIntProperty(property, value)
     G_reader_settings:saveSetting(setting, value)
     -- Have crengine redraw it (even if hidden by the menu at this time)
+    self.ui.rolling:updateBatteryState()
     self:updateHeader()
     -- And see if we should auto-refresh
     self:rescheduleHeaderRefreshIfNeeded()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1103,10 +1103,18 @@ function ReaderRolling:updateBatteryState()
         local powerd = Device:getPowerDevice()
         -- -1 is CR_BATTERY_STATE_CHARGING @ crengine/crengine/include/lvdocview.h
         local state = powerd:isCharging() and -1 or powerd:getCapacity()
+        if powerd.device:hasAuxBattery() and powerd:isAuxBatteryConnected() and
+            not powerd:isAuxCharging() then
+            -- If aux_battery not charging, but present -> don't show '[ + ]' in header
+            -- but show the average (as both battery have the same maximum capacity).
+            state = math.floor((powerd:getCapacity() + powerd:getAuxCapacity() + 1) / 2)
+        end
         if state then
             self.ui.document:setBatteryState(state)
         end
+        return state
     end
+    return 0
 end
 
 function ReaderRolling:handleEngineCallback(ev, ...)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1101,13 +1101,23 @@ function ReaderRolling:updateBatteryState()
     if self.view.view_mode == "page" and self.cre_top_bar_enabled then
         logger.dbg("update battery state")
         local powerd = Device:getPowerDevice()
+        local main_batt_lvl = powerd:getCapacity()
         -- -1 is CR_BATTERY_STATE_CHARGING @ crengine/crengine/include/lvdocview.h
-        local state = powerd:isCharging() and -1 or powerd:getCapacity()
+        local state = powerd:isCharging() and -1 or main_batt_lvl
         if powerd.device:hasAuxBattery() and powerd:isAuxBatteryConnected() and
             not powerd:isAuxCharging() then
+            -- The first few reads after connecting to the PowerCover may fail, so default to zero
+            local aux_batt_lvl = powerd:getAuxCapacity()
             -- If aux_battery not charging, but present -> don't show '[ + ]' in header
             -- but show the average (as both battery have the same maximum capacity).
-            state = math.floor((powerd:getCapacity() + powerd:getAuxCapacity() + 1) / 2)
+            if G_reader_settings:readSetting("cre_header_battery_percent") ~= 0 then
+                -- if percentage is wanted, show the total capacity of reader plus power-cover
+                state = main_batt_lvl + aux_batt_lvl
+            else
+                -- if icon is wanted, show the total average capacity of reader and power-cover
+                -- (as this is the shows graphically what capacity is left in total)
+                state = math.floor((main_batt_lvl + aux_batt_lvl) / 2)
+            end
         end
         if state then
             self.ui.document:setBatteryState(state)


### PR DESCRIPTION
As a proud new owner of a KOBO Sage + power cover, I realized, that the alternate status bar is showing `[ + ]` (=charging), when the device is connected to the power cover. 
This PR shows fixes the problem `[ + ]` is only shown, when the device or the device+cover combo is plugged in a power source and not when the device is charging from the cover.

A minor drawback remains: When pulling the device out of the cover, or putting it in the cover, the alternate status bar is updated either on a page change or after a minute (and not immediately).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8741)
<!-- Reviewable:end -->
