### PR TITLE
Reading statistics: various fixes and tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -921,6 +921,11 @@ function ReaderRolling:onChangeViewMode()
     self.current_header_height = self.view.view_mode == "page" and self.ui.document:getHeaderHeight() or 0
     -- Restore current position when switching page/scroll mode
     if self.xpointer then
+        if self.visible_pages == 2 then
+            -- Switching from 2-pages page mode to scroll mode has crengine switch to 1-page,
+            -- and we need to notice this re-rendering and keep things sane
+            self.ui:handleEvent(Event:new("UpdatePos"))
+        end
         self:_gotoXPointer(self.xpointer)
         -- Ensure a whole screen refresh is always enqueued
         UIManager:setDirty(self.view.dialog, "partial")

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -755,7 +755,16 @@ function CalendarView:_populateItems()
                     title = day_text,
                     value_align = "right",
                     kv_pairs = self.reader_statistics:getBooksFromPeriod(day_ts, day_ts + 86400),
-                    callback_return = function() end -- to just have that return button shown
+                    close_callback = function()
+                        -- Refresh calendar in case some day stats were reset for some books
+                        -- (we don't know if some reset were done... so we refresh the current
+                        -- display always - at tickAfterNext so there is no noticable slowness
+                        -- when closing, and the re-painting happening after is not noticable;
+                        -- but if some stat reset were done, this will make a nice noticable
+                        -- repainting showing dynamically reset books disappearing :)
+                        UIManager:tickAfterNext(function() self:_populateItems() end)
+                    end,
+                    callback_return = function() end, -- to just have that return button shown
                 })
             end
         })

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1122,7 +1122,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end, -- clean stack
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1138,7 +1139,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1154,7 +1156,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1171,7 +1174,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1187,7 +1191,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1203,7 +1208,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1219,7 +1225,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1235,7 +1242,8 @@ function ReaderStatistics:statMenu()
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                     UIManager:show(self.kv)
                 end,
@@ -1395,7 +1403,8 @@ function ReaderStatistics:getCurrentStat()
                     callback_return = function()
                         UIManager:show(kv)
                         self.kv = kv
-                    end
+                    end,
+                    close_callback = function() self.kv = nil end,
                 }
                 UIManager:show(self.kv)
             end,
@@ -1496,7 +1505,8 @@ function ReaderStatistics:getBookStat(id_book)
                     callback_return = function()
                         UIManager:show(kv)
                         self.kv = kv
-                    end
+                    end,
+                    close_callback = function() self.kv = nil end,
                 }
                 UIManager:show(self.kv)
             end,
@@ -1575,7 +1585,8 @@ function ReaderStatistics:callbackMonthly(begin, finish, date_text, book_mode)
             callback_return = function()
                 UIManager:show(kv)
                 self.kv = kv
-            end
+            end,
+            close_callback = function() self.kv = nil end,
         }
     else
         self.kv = KeyValuePage:new{
@@ -1585,7 +1596,8 @@ function ReaderStatistics:callbackMonthly(begin, finish, date_text, book_mode)
             callback_return = function()
                 UIManager:show(kv)
                 self.kv = kv
-            end
+            end,
+            close_callback = function() self.kv = nil end,
         }
     end
     UIManager:show(self.kv)
@@ -1602,7 +1614,8 @@ function ReaderStatistics:callbackWeekly(begin, finish, date_text, book_mode)
             callback_return = function()
                 UIManager:show(kv)
                 self.kv = kv
-            end
+            end,
+            close_callback = function() self.kv = nil end,
         }
     else
         self.kv = KeyValuePage:new{
@@ -1612,7 +1625,8 @@ function ReaderStatistics:callbackWeekly(begin, finish, date_text, book_mode)
             callback_return = function()
                 UIManager:show(kv)
                 self.kv = kv
-            end
+            end,
+            close_callback = function() self.kv = nil end,
         }
     end
     UIManager:show(self.kv)
@@ -1628,7 +1642,8 @@ function ReaderStatistics:callbackDaily(begin, finish, date_text)
         callback_return = function()
             UIManager:show(kv)
             self.kv = kv
-        end
+        end,
+        close_callback = function() self.kv = nil end,
     }
     UIManager:show(self.kv)
 end
@@ -1775,7 +1790,8 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
                     callback_return = function()
                         UIManager:show(kv)
                         self.kv = kv
-                    end
+                    end,
+                    close_callback = function() self.kv = nil end,
                 }
                 UIManager:show(self.kv)
             end,
@@ -1819,7 +1835,8 @@ function ReaderStatistics:getBooksFromPeriod(period_begin, period_end, callback_
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                 else
                     self.kv = KeyValuePage:new{
@@ -1829,7 +1846,8 @@ function ReaderStatistics:getBooksFromPeriod(period_begin, period_end, callback_
                         callback_return = function()
                             UIManager:show(kv)
                             self.kv = kv
-                        end
+                        end,
+                        close_callback = function() self.kv = nil end,
                     }
                 end
                 UIManager:show(self.kv)
@@ -2022,7 +2040,8 @@ function ReaderStatistics:getTotalStats()
                     callback_return = function()
                         UIManager:show(kv)
                         self.kv = kv
-                    end
+                    end,
+                    close_callback = function() self.kv = nil end,
                 }
                 UIManager:show(self.kv)
             end,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1056,10 +1056,11 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                 text = _("Current book"),
                 keep_menu_open = true,
                 callback = function()
-                    UIManager:show(KeyValuePage:new{
+                    self.kv = KeyValuePage:new{
                         title = _("Current statistics"),
                         kv_pairs = self:getCurrentStat()
-                    })
+                    }
+                    UIManager:show(self.kv)
                 end,
                 enabled_func = function() return not self:isDocless() and self.settings.is_enabled end,
             },
@@ -2448,6 +2449,7 @@ end
 
 function ReaderStatistics:onShowCalendarView()
     self:insertDB()
+    self.kv = nil -- clean left over stack link
     local CalendarView = require("calendarview")
     UIManager:show(CalendarView:new{
         reader_statistics = self,
@@ -2569,11 +2571,11 @@ end
 
 function ReaderStatistics:onShowBookStats()
     if self:isDocless() or not self.settings.is_enabled then return end
-    local stats = KeyValuePage:new{
+    self.kv = KeyValuePage:new{
         title = _("Current statistics"),
         kv_pairs = self:getCurrentStat()
     }
-    UIManager:show(stats)
+    UIManager:show(self.kv)
 end
 
 function ReaderStatistics:getCurrentBookReadPages()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2055,7 +2055,7 @@ function ReaderStatistics:resetPerBook()
                 book_title,
                 util.secondsToClockDuration(user_duration_format, total_time_book, false),
                 id_book,
-                callback = function()
+                callback = function(kv_page, kv_item)
                     UIManager:show(ConfirmBox:new{
                         text = T(_("Do you want to reset statistics for book:\n%1"), book_title),
                         cancel_text = _("Cancel"),
@@ -2064,15 +2064,8 @@ function ReaderStatistics:resetPerBook()
                         end,
                         ok_text = _("Reset"),
                         ok_callback = function()
-                            for j=1, #total_stats do
-                                if total_stats[j][3] == id_book then
-                                    self:deleteBook(id_book)
-                                    table.remove(total_stats, j)
-                                    break
-                                end
-                            end
-                            -- refresh window after delete item
-                            kv_reset_book:_populateItems()
+                            self:deleteBook(id_book)
+                            kv_page:removeKeyValueItem(kv_item) -- Reset, refresh what's displayed
                         end,
                     })
                 end,


### PR DESCRIPTION
Please review by looking at each individual commmits - as some of them are just chores repeating the same changes.

`ReaderStatistics: remove id_book parameter to insertDB()`

As it should always just work on the current book.
Also remove uneeded getCalendarView().

`ReaderStatistics: fix current page stats on close/suspend`

Fixes current page statistics (duration) ignored when document closed, or when suspending and resuming.
On suspend/resume, update the page start ts by the time spent sleeping, so its duration will be the time spent on it not sleeping.
This fixes in a more generic approach the issue noticed at https://github.com/koreader/koreader/pull/6778#issuecomment-982779673 , which became more noticable now that we have Book map.

I made `onReadingPaused()` and `onReadingResumed()` generic event handlers (instead of hardcoding what they do in `onResume()/onSuspend()` because I will be using them in my own patch (for some standby/resume without insertDB and less radical that suspend/resume) instead of some previous hacks.
These could also be used if we ever want to _not_ account (possibly optionally via a setting) time spent on a page while playing with some other widget above it, like Dict, Wiki, viewing stats, playing with menus... I personally don't think it's a super idea, as showing pages with a big black bar means it had some words or thematic you felt the need to go querying about :) (Cross-ref: https://github.com/koreader/koreader/issues/6461#issuecomment-667707227)

`KeyValuePage: allow for more fancy callbacks`

Add support for hold_callback.
Provides kv_page and kv_item to callbacks.
Allow for item removal and refresh.

`ReaderStatistics: allow reset statistics per period per book`

Closes #6784.
Wording for the 2 different contexts this is available in:
![image](https://user-images.githubusercontent.com/24273478/151660010-69301b76-22b0-4a7a-82e3-e12a5899c2c0.png)

![image](https://user-images.githubusercontent.com/24273478/151660047-4bfc7c29-724e-4fa6-bddb-fe35feec8db0.png)


`ReaderStatistics: reset stack/link on showing first widget`

Reset self.kv stack/link on showing first widget.
This avoids return arrow to possibly show previously displayed old and unrelated KeyValuePage. See https://github.com/koreader/koreader/pull/8726#issuecomment-1023634523.
Note: when closing a leaf KeyValuePage, the previous one will leak as self.kv.

`ReaderStatistics: avoid self.kv leaking after close`

Fixes previous commit "Note:".
Keeping these 2 commits appart in case one of them was a bad idea :) and we would need to revert them. I'm not a statistics menu super user, so may be there is some kind of navigation that this may break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8745)
<!-- Reviewable:end -->
