### PR TITLE
[fix, plugin] Terminal emulator: Fix elinks -> 'q' crash

### DIFF
--- a/plugins/terminal.koplugin/terminputtext.lua
+++ b/plugins/terminal.koplugin/terminputtext.lua
@@ -122,6 +122,7 @@ function TermInputText:saveBuffer(buffer)
         {
             self.charlist,
             self.charpos,
+            self.store_pos_dec,
             self.store_pos_sco,
             self.store_position,
             self.scroll_region_bottom,
@@ -145,6 +146,7 @@ function TermInputText:restoreBuffer(buffer)
     if type(former_buffer[1]) == "table" then
         self.charlist,
         self.charpos,
+        self.store_pos_dec,
         self.store_pos_sco,
         self.store_position,
         self.scroll_region_bottom,
@@ -544,7 +546,7 @@ function TermInputText:addChars(chars, skip_callback, skip_table_concat)
             if self.charlist[self.charpos] == "\n" then
                 self.charpos = self.charpos - 1
             end
-            while self.charpos >=1 and self.charlist[self.charpos] ~= "\n" do
+            while self.charpos >= 1 and self.charlist[self.charpos] ~= "\n" do
                 self.charpos = self.charpos - 1
             end
             self.charpos = self.charpos + 1
@@ -811,7 +813,7 @@ function TermInputText:goToStartOfLine(skip_callback)
             if self.charlist[self.charpos] == "\n" then
                 self.charpos = self.charpos - 1
             end
-            while self.charpos >=1 and self.charlist[self.charpos] ~= "\n" do
+            while self.charpos >= 1 and self.charlist[self.charpos] ~= "\n" do
                 self.charpos = self.charpos - 1
             end
             self.charpos = self.charpos + 1


### PR DESCRIPTION
This fixes a crash in terminal emulator on exit of elinks.
see: https://github.com/koreader/koreader/pull/8636#issuecomment-1024956177

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8749)
<!-- Reviewable:end -->
