### PR TITLE
Even more PowerD & PowerCover shenanigans

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -215,4 +215,35 @@ function BasePowerD:stateChanged()
     end
 end
 
+-- Silly helper to avoid code duplication ;).
+function BasePowerD:getBatterySymbol(is_charging, capacity)
+    if is_charging then
+        return ""
+    else
+        if capacity >= 100 then
+            return ""
+        elseif capacity >= 90 then
+            return ""
+        elseif capacity >= 80 then
+            return ""
+        elseif capacity >= 70 then
+            return ""
+        elseif capacity >= 60 then
+            return ""
+        elseif capacity >= 50 then
+            return ""
+        elseif capacity >= 40 then
+            return ""
+        elseif capacity >= 30 then
+            return ""
+        elseif capacity >= 20 then
+            return ""
+        elseif capacity >= 10 then
+            return ""
+        else
+            return ""
+        end
+    end
+end
+
 return BasePowerD

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -9,8 +9,8 @@ local BasePowerD = {
     aux_batt_capacity = 0,            -- auxiliary battery capacity
     device = nil,                     -- device object
 
-    last_capacity_pull_time = TimeVal:new{ sec = 0, usec = 0},      -- timestamp of last pull
-    last_aux_capacity_pull_time = TimeVal:new{ sec = 0, usec = 0},  -- timestamp of last pull
+    last_capacity_pull_time = TimeVal:new{ sec = -61, usec = 0},      -- timestamp of last pull
+    last_aux_capacity_pull_time = TimeVal:new{ sec = -61, usec = 0},  -- timestamp of last pull
 
     is_fl_on = false,                 -- whether the frontlight is on
 }
@@ -195,8 +195,8 @@ function BasePowerD:getAuxCapacity()
 end
 
 function BasePowerD:invalidateCapacityCache()
-    self.last_capacity_pull_time = TimeVal:new{ sec = 0, usec = 0}
-    self.last_aux_capacity_pull_time = TimeVal:new{ sec = 0, usec = 0}
+    self.last_capacity_pull_time = TimeVal:new{ sec = -61, usec = 0}
+    self.last_aux_capacity_pull_time = TimeVal:new{ sec = -61, usec = 0}
 end
 
 function BasePowerD:isAuxCharging()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1764,14 +1764,14 @@ end
 -- The common operations that should be performed when the device is plugged to a power source.
 function UIManager:_beforeCharging()
     -- Leave the kernel some time to figure it out ;o).
-    self:scheduleIn(0.5, function() Device:setupChargingLED() end)
+    self:scheduleIn(1, function() Device:setupChargingLED() end)
     self:broadcastEvent(Event:new("Charging"))
 end
 
 -- The common operations that should be performed when the device is unplugged from a power source.
 function UIManager:_afterNotCharging()
     -- Leave the kernel some time to figure it out ;o).
-    self:scheduleIn(0.5, function() Device:setupChargingLED() end)
+    self:scheduleIn(1, function() Device:setupChargingLED() end)
     self:broadcastEvent(Event:new("NotCharging"))
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -636,36 +636,6 @@ function TouchMenu:_recalculatePageLayout()
     self.page_num = math.ceil(#self.item_table / self.perpage)
 end
 
-local function getBatterySymbol(is_charging, capacity)
-    if is_charging then
-        return ""
-    else
-        if capacity >= 100 then
-            return ""
-        elseif capacity >= 90 then
-            return ""
-        elseif capacity >= 80 then
-            return ""
-        elseif capacity >= 70 then
-            return ""
-        elseif capacity >= 60 then
-            return ""
-        elseif capacity >= 50 then
-            return ""
-        elseif capacity >= 40 then
-            return ""
-        elseif capacity >= 30 then
-            return ""
-        elseif capacity >= 20 then
-            return ""
-        elseif capacity >= 10 then
-            return ""
-        else
-            return ""
-        end
-    end
-end
-
 function TouchMenu:updateItems()
     local old_dimen = self.dimen and self.dimen:copy()
     self:_recalculatePageLayout()
@@ -719,12 +689,12 @@ function TouchMenu:updateItems()
     local powerd = Device:getPowerDevice()
     if Device:hasBattery() then
         local batt_lvl = powerd:getCapacity()
-        local batt_symbol = getBatterySymbol(powerd:isCharging(), batt_lvl)
+        local batt_symbol = powerd:getBatterySymbol(powerd:isCharging(), batt_lvl)
         time_info_txt = BD.wrap(time_info_txt) .. " " .. BD.wrap("⌁") .. BD.wrap(batt_symbol) ..  BD.wrap(batt_lvl .. "%")
 
         if Device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
             local aux_batt_lvl = powerd:getAuxCapacity()
-            local aux_batt_symbol = getBatterySymbol(powerd:isAuxCharging(), aux_batt_lvl)
+            local aux_batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharging(), aux_batt_lvl)
             time_info_txt = time_info_txt .. " " .. BD.wrap("+") .. BD.wrap(aux_batt_symbol) ..  BD.wrap(aux_batt_lvl .. "%")
         end
     end


### PR DESCRIPTION
* Fix the battery capacity pulls during early boot issue mentioned in #8711 
* Handle the PowerCover in ReaderFooter's battery gauge widget (re #8741)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8752)
<!-- Reviewable:end -->
