### PR TITLE
kosync: send progress as a string to the server

### DIFF
--- a/plugins/kosync.koplugin/KOSyncClient.lua
+++ b/plugins/kosync.koplugin/KOSyncClient.lua
@@ -114,7 +114,7 @@ function KOSyncClient:update_progress(
         local ok, res = pcall(function()
             return self.client:update_progress({
                 document = document,
-                progress = progress,
+                progress = tostring(progress),
                 percentage = percentage,
                 device = device,
                 device_id = device_id,


### PR DESCRIPTION
Currently the progress sent to the server can be either a string or an int (depending on whetther the document has pages).

The following are both payload sent from koreader to the server.

```
{"percentage":0.005,"device":"device_name","device_id":"B78EA04ACC3A453DBA220D720C0BE102","document":"348e34463a44ba68659fc6fe814a6778","progress":3}
```
where document `348e34463a44ba68659fc6fe814a6778` is a pdf file.

```
{"percentage":1,"device":"device_name","device_id":"B78EA04ACC3A453DBA220D720C0BE102","document":"4eb484b229696cb39cd8fe5495aa1bbe","progress":"\/body\/DocFragment[30]\/body\/p\/img.0"}
```
where document `4eb484b229696cb39cd8fe5495aa1bbe` is an epub file.

This may add extra work to the backend server. A few commits were added to my personal fork of [kosyncsrv](https://github.com/yeeac/kosyncsrv) (a kosync backend server). kosyncsrv initially tries to decode progress as a string. It then failed on document with pages (in which, progress is just integer page number). I then change the field's type, only to [revert it later](https://github.com/contrun/kosyncsrv/commit/8a642e31a0bcb061a04ececd4af57a27836b7928).

I believe it is more appropriate for us to fix the progress type to string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8758)
<!-- Reviewable:end -->
