### PR TITLE
Frontlight/Naturallight widgets: insert TitleBar, movable

### DIFF
--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -1,7 +1,6 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CloseButton = require("ui/widget/closebutton")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
@@ -10,15 +9,14 @@ local Font = require("ui/font")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local LineWidget = require("ui/widget/linewidget")
 local Math = require("optmath")
+local MovableContainer = require("ui/widget/container/movablecontainer")
 local NaturalLight = require("ui/widget/naturallightwidget")
-local OverlapGroup = require("ui/widget/overlapgroup")
 local ProgressWidget = require("ui/widget/progresswidget")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
-local TextWidget = require("ui/widget/textwidget")
 local TimeVal = require("ui/timeval")
+local TitleBar = require("ui/widget/titlebar")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
@@ -27,7 +25,6 @@ local _ = require("gettext")
 local Screen = Device.screen
 
 local FrontLightWidget = InputContainer:new{
-    title_face = Font:getFace("x_smalltfont"),
     width = nil,
     height = nil,
     -- This should stay active during natural light configuration
@@ -38,7 +35,6 @@ local FrontLightWidget = InputContainer:new{
 
 function FrontLightWidget:init()
     self.medium_font_face = Font:getFace("ffont")
-    self.light_bar = {}
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
     self.span = math.ceil(self.screen_height * 0.01)
@@ -258,7 +254,6 @@ function FrontLightWidget:setProgress(num, step, num_warmth)
                 margin = Size.margin.small,
                 radius = 0,
                 width = math.floor(self.screen_width * 0.2),
-                enabled = not self.nl_configure_open,
                 show_parent = self,
                 callback = function()
                     UIManager:show(NaturalLight:new{fl_widget = self})
@@ -415,38 +410,21 @@ function FrontLightWidget:setFrontLightIntensity(num)
 end
 
 function FrontLightWidget:update()
-    -- header
-    self.light_title = FrameContainer:new{
-        padding = Size.padding.default,
-        margin = Size.margin.title,
-        bordersize = 0,
-        TextWidget:new{
-            text = _("Frontlight"),
-            face = self.title_face,
-            bold = true,
-            width = math.floor(self.screen_width * 0.95),
-        },
+    local title_bar = TitleBar:new{
+        title = _("Frontlight"),
+        width = self.width,
+        align = "left",
+        with_bottom_line = true,
+        bottom_v_padding = 0,
+        close_callback = function() self:onClose() end,
+        show_parent = self,
     }
     local light_level = FrameContainer:new{
         padding = Size.padding.button,
         margin = Size.margin.small,
         bordersize = 0,
-        self:generateProgressGroup(math.floor(self.screen_width * 0.95), math.floor(self.screen_height * 0.2),
+        self:generateProgressGroup(self.width, math.floor(self.screen_height * 0.2),
             self.fl_cur, self.one_step)
-    }
-    local light_line = LineWidget:new{
-        dimen = Geom:new{
-            w = self.width,
-            h = Size.line.thick,
-        }
-    }
-    self.light_bar = OverlapGroup:new{
-        dimen = {
-            w = self.width,
-            h = self.light_title:getSize().h
-        },
-        self.light_title,
-        CloseButton:new{ window = self, padding_top = Size.margin.title, },
     }
     self.light_frame = FrameContainer:new{
         radius = Size.radius.window,
@@ -456,16 +434,18 @@ function FrontLightWidget:update()
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
             align = "left",
-            self.light_bar,
-            light_line,
+            title_bar,
             CenterContainer:new{
                 dimen = Geom:new{
-                    w = light_line:getSize().w,
+                    w = self.width,
                     h = light_level:getSize().h,
                 },
                 light_level,
             },
         }
+    }
+    self.movable = MovableContainer:new{
+        self.light_frame,
     }
     self[1] = WidgetContainer:new{
         align = "center",
@@ -474,10 +454,7 @@ function FrontLightWidget:update()
             w = self.screen_width,
             h = self.screen_height,
         },
-        FrameContainer:new{
-            bordersize = 0,
-            self.light_frame,
-        }
+        self.movable,
     }
 end
 
@@ -503,28 +480,6 @@ end
 function FrontLightWidget:onClose()
     UIManager:close(self)
     return true
-end
-
--- This is called when natural light configuration is shown
-function FrontLightWidget:naturalLightConfigOpen()
-    -- Remove the close button
-    table.remove(self.light_bar)
-    -- Disable the 'configure' button
-    self.configure_button:disable()
-    self.nl_configure_open = true
-    -- Move to the bottom to make place for the new widget
-    self[1].align="bottom"
-    UIManager:setDirty(self, "ui")
-end
-
-function FrontLightWidget:naturalLightConfigClose()
-    table.insert(self.light_bar,
-                 CloseButton:new{window = self,
-                                 padding_top = Size.margin.title})
-    self.configure_button:enable()
-    self.nl_configure_open = false
-    self[1].align="center"
-    UIManager:setDirty(self, "ui")
 end
 
 function FrontLightWidget:onTapProgress(arg, ges_ev)

--- a/frontend/ui/widget/naturallightwidget.lua
+++ b/frontend/ui/widget/naturallightwidget.lua
@@ -9,11 +9,10 @@ local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputText = require("ui/widget/inputtext")
-local LineWidget = require("ui/widget/linewidget")
-local OverlapGroup = require("ui/widget/overlapgroup")
+local MovableContainer = require("ui/widget/container/movablecontainer")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
-local TextWidget = require("ui/widget/textwidget")
+local TitleBar = require("ui/widget/titlebar")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
@@ -23,7 +22,6 @@ local Screen = Device.screen
 
 local NaturalLightWidget = InputContainer:new{
     is_always_active = true,
-    title_face = Font:getFace("x_smalltfont"),
     width = nil,
     height = nil,
     textbox_width = 0.1,
@@ -51,7 +49,7 @@ function NaturalLightWidget:init()
     self.textbox_width = 0.1 * self.width
     self.text_width = 0.2 * self.width
     self.powerd = Device:getPowerDevice()
-    self:createFrame()
+    self:update()
 end
 
 function NaturalLightWidget:applyValues()
@@ -140,37 +138,24 @@ function NaturalLightWidget:getCurrentValues()
                 self.powerd.fl.exponent}
 end
 
-function NaturalLightWidget:createFrame()
-    self.nl_title = FrameContainer:new{
-        padding = Size.padding.default,
-        margin = Size.margin.title,
-        bordersize = 0,
-        TextWidget:new{
-            text = _("Natural light configuration"),
-            face = self.title_face,
-            bold = true,
-            width = math.floor(self.screen_width * 0.95),
-        },
+function NaturalLightWidget:update()
+    local title_bar = TitleBar:new{
+        title = _("Natural light configuration"),
+        width = self.width,
+        align = "left",
+        with_bottom_line = true,
+        bottom_v_padding = 0,
+        close_callback = function()
+            self:setAllValues(self.old_values)
+            self:onClose()
+        end,
+        show_parent = self,
     }
     local main_content = FrameContainer:new{
         padding = Size.padding.button,
         margin = Size.margin.small,
         bordersize = 0,
-        self:createMainContent(math.floor(self.screen_width * 0.95),
-                               math.floor(self.screen_height * 0.2))
-    }
-    local nl_line = LineWidget:new{
-        dimen = Geom:new{
-            w = self.width,
-            h = Size.line.thick,
-        }
-    }
-    self.nl_bar = OverlapGroup:new{
-        dimen = {
-            w = self.width,
-            h = self.nl_title:getSize().h
-        },
-        self.nl_title,
+        self:createMainContent(self.width, math.floor(self.screen_height * 0.2))
     }
     self.nl_frame = FrameContainer:new{
         radius = Size.radius.window,
@@ -180,16 +165,18 @@ function NaturalLightWidget:createFrame()
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
             align = "left",
-            self.nl_bar,
-            nl_line,
+            title_bar,
             CenterContainer:new{
                 dimen = Geom:new{
-                    w = nl_line:getSize().w,
+                    w = self.width,
                     h = main_content:getSize().h,
                 },
                 main_content,
             },
         }
+    }
+    self.movable = MovableContainer:new{
+        self.nl_frame,
     }
     self[1] = WidgetContainer:new{
         align = "top",
@@ -198,10 +185,7 @@ function NaturalLightWidget:createFrame()
             w = self.screen_width,
             h = self.screen_height,
         },
-        FrameContainer:new{
-            bordersize = 0,
-            self.nl_frame,
-        }
+        self.movable,
     }
 end
 
@@ -230,42 +214,36 @@ function NaturalLightWidget:createMainContent(width, height)
         text = _("Amplification"),
         face = self.medium_font_face,
         bold = true,
-        alignment = "left",
         width = self.textbox_width + 2 * self.button_width
     }
     local text_offset = TextBoxWidget:new{
         text = _("Offset"),
         face = self.medium_font_face,
         bold = true,
-        alignment = "left",
         width = self.textbox_width + self.button_width
     }
     local text_white = TextBoxWidget:new{
         text = _("White"),
         face = self.medium_font_face,
         bold = true,
-        alignment = "left",
         width = self.text_width
     }
     local text_red = TextBoxWidget:new{
         text = _("Red"),
         face = self.medium_font_face,
         bold = true,
-        alignment = "left",
         width = self.text_width
     }
     local text_green = TextBoxWidget:new{
         text = _("Green"),
         face = self.medium_font_face,
         bold = true,
-        alignment = "left",
         width = self.text_width
     }
     local text_exponent = TextBoxWidget:new{
         text = _("Exponent"),
         face = self.medium_font_face,
         bold = true,
-        alignment = "left",
         width = self.text_width
     }
     local button_defaults = Button:new{
@@ -379,16 +357,12 @@ function NaturalLightWidget:onCloseWidget()
     UIManager:setDirty(nil, function()
         return "flashui", self.nl_frame.dimen
     end)
-    -- Tell frontlight widget that we're closed
-    self.fl_widget:naturalLightConfigClose()
 end
 
 function NaturalLightWidget:onShow()
     UIManager:setDirty(self, function()
                            return "ui", self.nl_frame.dimen
     end)
-    -- Tell the frontlight widget that we're open
-    self.fl_widget:naturalLightConfigOpen()
     -- Store values in case user cancels
     self.old_values = self:getCurrentValues()
     return true


### PR DESCRIPTION
Removed the last old close button.
Both widgets are now movable, so removed jumping down/up of the Frontlight dialog when opening Naturallight configuration.

Before
![01](https://user-images.githubusercontent.com/62179190/152331269-20ad9453-3d9c-4a08-be44-c7a4995e63e6.png)

After
![02](https://user-images.githubusercontent.com/62179190/152331290-0779d38d-7812-4a3b-9e51-a9cedbd19ee2.png)

I have no device with warmlight, so made it blindly, looking at the picture in https://github.com/koreader/koreader/pull/3744#issuecomment-372471223.
Need testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8769)
<!-- Reviewable:end -->
