### PR TITLE
RadioMark: down shift

### DIFF
--- a/frontend/ui/widget/radiomark.lua
+++ b/frontend/ui/widget/radiomark.lua
@@ -3,8 +3,6 @@ local Blitbuffer = require("ffi/blitbuffer")
 local Font = require("ui/font")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local TextWidget = require("ui/widget/textwidget")
-local VerticalGroup = require("ui/widget/verticalgroup")
-local VerticalSpan = require("ui/widget/verticalspan")
 
 local RadioMark = InputContainer:new{
     checkable = true, -- empty space when false
@@ -15,23 +13,18 @@ local RadioMark = InputContainer:new{
     _mirroredUI = BD.mirroredUILayout(),
     -- round radio mark looks a little bit upper than the button/menu text
     -- default vertical down shift ratio (to the text height) looks good in touchmenu
-    v_shift_ratio = 0.05,
+    v_shift_ratio = 0.03,
 }
 
 function RadioMark:init()
-    local text_widget = TextWidget:new{
+    local widget = TextWidget:new{
         text = self.checkable and (self.checked and "◉ " or "◯ ") or "",
         face = self.face,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
         para_direction_rtl = self._mirroredUI,
     }
-    self.baseline = text_widget:getBaseline()
-    local pad = math.floor(text_widget:getSize().h * self.v_shift_ratio)
-    local widget = VerticalGroup:new{
-        align = "left",
-        VerticalSpan:new{ width = pad },
-        text_widget,
-    }
+    self.baseline = widget:getBaseline()
+    widget.forced_baseline = self.baseline + math.floor(widget:getSize().h * self.v_shift_ratio)
     self[1] = widget
     self.dimen = widget:getSize()
 end

--- a/frontend/ui/widget/radiomark.lua
+++ b/frontend/ui/widget/radiomark.lua
@@ -11,7 +11,7 @@ local RadioMark = InputContainer:new{
     face = Font:getFace("smallinfofont"),
     baseline = 0,
     _mirroredUI = BD.mirroredUILayout(),
-    -- round radio mark looks a little bit upper than the button/menu text
+    -- round radio mark looks a little bit higher than the button/menu text
     -- default vertical down shift ratio (to the text height) looks good in touchmenu
     v_shift_ratio = 0.03,
 }

--- a/frontend/ui/widget/radiomark.lua
+++ b/frontend/ui/widget/radiomark.lua
@@ -3,6 +3,8 @@ local Blitbuffer = require("ffi/blitbuffer")
 local Font = require("ui/font")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local TextWidget = require("ui/widget/textwidget")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
 
 local RadioMark = InputContainer:new{
     checkable = true, -- empty space when false
@@ -11,16 +13,25 @@ local RadioMark = InputContainer:new{
     face = Font:getFace("smallinfofont"),
     baseline = 0,
     _mirroredUI = BD.mirroredUILayout(),
+    -- round radio mark looks a little bit upper than the button/menu text
+    -- default vertical down shift ratio (to the text height) looks good in touchmenu
+    v_shift_ratio = 0.05,
 }
 
 function RadioMark:init()
-    local widget = TextWidget:new{
+    local text_widget = TextWidget:new{
         text = self.checkable and (self.checked and "◉ " or "◯ ") or "",
         face = self.face,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
         para_direction_rtl = self._mirroredUI,
     }
-    self.baseline = widget:getBaseline()
+    self.baseline = text_widget:getBaseline()
+    local pad = math.floor(text_widget:getSize().h * self.v_shift_ratio)
+    local widget = VerticalGroup:new{
+        align = "left",
+        VerticalSpan:new{ width = pad },
+        text_widget,
+    }
     self[1] = widget
     self.dimen = widget:getSize()
 end


### PR DESCRIPTION
A small down shifting of the radio mark to eliminate visual effect of round mark being upper than the text.

Before
![51](https://user-images.githubusercontent.com/62179190/152384793-95ce4bf3-0f96-46e9-9fd1-a4c4347ac901.png)

After
![52](https://user-images.githubusercontent.com/62179190/152384823-36308497-ea6c-4213-922e-350a9c7145f9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8771)
<!-- Reviewable:end -->
