### PR TITLE
PageBrowser: allow changing nb of chapter levels shown

### DIFF
--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -104,6 +104,12 @@ function PageBrowserWidget:init()
         title = self.title,
         left_icon = "info",
         left_icon_tap_callback = function() self:showHelp() end,
+        left_icon_hold_callback = function()
+            -- Cycle nb of toc span levels shown in bottom row
+            if self:updateNbTocSpans(-1, true) then
+                self:updateLayout()
+            end
+        end,
         close_callback = function() self:onClose() end,
         close_hold_callback = function() self:onClose(true) end,
         show_parent = self,
@@ -128,65 +134,9 @@ function PageBrowserWidget:init()
     self.min_nb_cols = 1
     self.max_nb_cols = 6
 
+    -- Get some info that shouldn't change across calls to update() and updateLayout()
     self.ui.toc:fillToc()
     self.max_toc_depth = self.ui.toc.toc_depth
-    -- We show the toc depth chosen in BookMapWidget, or all of it if not set
-    -- (nothing in this PageBrowserWidget to allow changing it)
-    self.nb_toc_spans = self.ui.doc_settings:readSetting("book_map_toc_depth", self.max_toc_depth)
-
-    -- Row will contain: nb_toc_spans + page slots + spacing (+ some borders)
-    self.statistics_enabled = self.ui.statistics and self.ui.statistics:isEnabled()
-    local page_slots_height_ratio = 1 -- default to 1 * span_height
-    if not self.statistics_enabled and self.nb_toc_spans > 0 then
-        -- Just enough to show page separators below toc spans
-        page_slots_height_ratio = 0.2
-    end
-    self.row_height = math.ceil((self.nb_toc_spans + page_slots_height_ratio + 1) * self.span_height + 2*BookMapRow.pages_frame_border)
-
-    self.grid_width = self.dimen.w
-    self.grid_height = self.dimen.h - self.title_bar_h - self.row_height
-
-    -- We'll draw some kind of static transparent glass over the BookMapRow,
-    -- which should span over the page slots that get their thumbnails shown.
-    self.view_finder_r = Size.radius.window
-    self.view_finder_bw = Size.border.default
-    -- Have its top border noticable above the BookMapRow top border
-    self.view_finder_y = self.dimen.h - self.row_height - 2*self.view_finder_bw
-    -- And put its bottom rounded corner outside of screen
-    self.view_finder_h = self.row_height + 2*self.view_finder_bw + Size.radius.window
-
-    self.grid = OverlapGroup:new{
-        dimen = Geom:new{
-            w = self.grid_width,
-            h = self.grid_height,
-        },
-        allow_mirroring = false,
-    }
-    self.row = CenterContainer:new{
-        dimen = Geom:new{
-            w = self.dimen.w,
-            h = self.row_height,
-        },
-        -- Will contain a BookMapRow wider, with l/r borders outside screen
-    }
-
-    self[1] = FrameContainer:new{
-        width = self.dimen.w,
-        height = self.dimen.h,
-        padding = 0,
-        margin = 0,
-        bordersize = 0,
-        background = Blitbuffer.COLOR_WHITE,
-        VerticalGroup:new{
-            align = "center",
-            self.title_bar,
-            self.grid,
-            self.row,
-        }
-    }
-
-
-    -- Get some info that shouldn't change across calls to update() and updateLayout()
     self.nb_pages = self.ui.document:getPageCount()
     self.cur_page = self.ui.toc.pageno
     -- Get bookmarks and highlights from ReaderBookmark
@@ -218,6 +168,67 @@ function PageBrowserWidget:init()
 end
 
 function PageBrowserWidget:updateLayout()
+    -- We start with showing all toc levels (we could use book_map_toc_depth,
+    -- but we might want to have it different here).
+    self.nb_toc_spans = self.ui.doc_settings:readSetting("page_browser_toc_depth") or self.max_toc_depth
+
+    -- Row will contain: nb_toc_spans + page slots + spacing (+ some borders)
+    local statistics_enabled = self.ui.statistics and self.ui.statistics:isEnabled()
+    local page_slots_height_ratio = 1 -- default to 1 * span_height
+    if not statistics_enabled and self.nb_toc_spans > 0 then
+        -- Just enough to show page separators below toc spans
+        page_slots_height_ratio = 0.2
+    end
+    self.row_height = math.ceil((self.nb_toc_spans + page_slots_height_ratio + 1) * self.span_height + 2*BookMapRow.pages_frame_border)
+
+    self.grid_width = self.dimen.w
+    self.grid_height = self.dimen.h - self.title_bar_h - self.row_height
+
+    -- We'll draw some kind of static transparent glass over the BookMapRow,
+    -- which should span over the page slots that get their thumbnails shown.
+    self.view_finder_r = Size.radius.window
+    self.view_finder_bw = Size.border.default
+    -- Have its top border noticable above the BookMapRow top border
+    self.view_finder_y = self.dimen.h - self.row_height - 2*self.view_finder_bw
+    -- And put its bottom rounded corner outside of screen
+    self.view_finder_h = self.row_height + 2*self.view_finder_bw + Size.radius.window
+
+    if self.grid then
+        self.grid:free()
+    end
+    self.grid = OverlapGroup:new{
+        dimen = Geom:new{
+            w = self.grid_width,
+            h = self.grid_height,
+        },
+        allow_mirroring = false,
+    }
+    if self.row then
+        self.row:free()
+    end
+    self.row = CenterContainer:new{
+        dimen = Geom:new{
+            w = self.dimen.w,
+            h = self.row_height,
+        },
+        -- Will contain a BookMapRow wider, with l/r borders outside screen
+    }
+
+    self[1] = FrameContainer:new{
+        width = self.dimen.w,
+        height = self.dimen.h,
+        padding = 0,
+        margin = 0,
+        bordersize = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        VerticalGroup:new{
+            align = "center",
+            self.title_bar,
+            self.grid,
+            self.row,
+        }
+    }
+
     self.nb_rows = self.ui.doc_settings:readSetting("page_browser_nb_rows")
                    or G_reader_settings:readSetting("page_browser_nb_rows")
     self.nb_cols = self.ui.doc_settings:readSetting("page_browser_nb_cols")
@@ -609,7 +620,8 @@ Swipe along the top or left screen edge to change the number of columns or rows 
 Swipe vertically to move one row, horizontally to move one page.
 Swipe horizontally in the bottom ribbon to move by the full stripe.
 Tap in the bottom ribbon on a page to focus thumbnails on this page.
-Tap on a thumbnail to go read this page.
+Tap on a thumbnail to read this page.
+Long-press on ⓘ to decrease or reset the number of chapter levels shown in the bottom ribbon.
 Any multiswipe will close the page browser.]]),
     })
 end
@@ -651,15 +663,39 @@ end
 
 function PageBrowserWidget:saveSettings(reset)
     if reset then
+        self.nb_toc_spans = nil
         self.nb_rows = nil
         self.nb_cols = nil
     end
+    self.ui.doc_settings:saveSetting("page_browser_toc_depth", self.nb_toc_spans)
     self.ui.doc_settings:saveSetting("page_browser_nb_rows", self.nb_rows)
     self.ui.doc_settings:saveSetting("page_browser_nb_cols", self.nb_cols)
-    -- We also save them as global settings, so they will apply on other books
+    -- We also save nb_rows/nb_cols as global settings, so they will apply on other books
     -- where they were not already set
     G_reader_settings:saveSetting("page_browser_nb_rows", self.nb_rows)
     G_reader_settings:saveSetting("page_browser_nb_cols", self.nb_cols)
+end
+
+function PageBrowserWidget:updateNbTocSpans(value, relative)
+    local new_nb_toc_spans
+    if relative then
+        new_nb_toc_spans = self.nb_toc_spans + value
+    else
+        new_nb_toc_spans = value
+    end
+    -- We don't cap, we cycle
+    if new_nb_toc_spans < 0 then
+        new_nb_toc_spans = self.max_toc_depth
+    end
+    if new_nb_toc_spans > self.max_toc_depth then
+        new_nb_toc_spans = 0
+    end
+    if new_nb_toc_spans == self.nb_toc_spans then
+        return false
+    end
+    self.nb_toc_spans = new_nb_toc_spans
+    self:saveSettings()
+    return true
 end
 
 function PageBrowserWidget:updateNbCols(value, relative)


### PR DESCRIPTION
Instead of using the depth configured in Book map, start with max depth, and allow decreasing (and reseting when at 0) with long-press on the (i) top left icon.
See https://github.com/koreader/koreader/pull/8613#issuecomment-1025716574

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8772)
<!-- Reviewable:end -->
