### PR TITLE
CheckButton: insert RadioMark

### DIFF
--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -22,6 +22,7 @@ local FrameContainer = require("ui/widget/container/framecontainer")
 local GestureRange = require("ui/gesturerange")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local RadioMark = require("ui/widget/radiomark")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
@@ -30,8 +31,10 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local CheckButton = InputContainer:new{
     callback = nil,
     hold_callback = nil,
+    checkable = true, -- empty space when false
     checked = false,
     enabled = true,
+    radio = false, -- radio mark when true
     face = Font:getFace("smallinfofont"),
     background = Blitbuffer.COLOR_WHITE,
     text = nil,
@@ -46,13 +49,25 @@ end
 
 function CheckButton:initCheckButton(checked)
     self.checked = checked
-    self._checkmark = CheckMark:new{
-        checked = self.checked,
-        enabled = self.enabled,
-        face = self.face,
-        parent = self.parent or self,
-        show_parent = self.show_parent or self,
-    }
+    if self.radio then
+        self._checkmark = RadioMark:new{
+            checkable = self.checkable,
+            checked = self.checked,
+            enabled = self.enabled,
+            face = self.face,
+            parent = self.parent or self,
+            show_parent = self.show_parent or self,
+        }
+    else
+        self._checkmark = CheckMark:new{
+            checkable = self.checkable,
+            checked = self.checked,
+            enabled = self.enabled,
+            face = self.face,
+            parent = self.parent or self,
+            show_parent = self.show_parent or self,
+        }
+    end
     self._textwidget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
@@ -118,7 +133,9 @@ function CheckButton:onTapCheckButton()
         self:onInput(self.tap_input_func())
     else
         if G_reader_settings:isFalse("flash_ui") then
-            self:toggleCheck()
+            if not self.radio then
+                self:toggleCheck()
+            end
             if self.callback then
                 self.callback()
             end
@@ -144,7 +161,9 @@ function CheckButton:onTapCheckButton()
 
             -- Callback
             --
-            self:toggleCheck()
+            if not self.radio then
+                self:toggleCheck()
+            end
             if self.callback then
                 self.callback()
             end

--- a/frontend/ui/widget/radiobuttontable.lua
+++ b/frontend/ui/widget/radiobuttontable.lua
@@ -1,11 +1,11 @@
 local Blitbuffer = require("ffi/blitbuffer")
+local CheckButton = require("ui/widget/checkbutton")
 local Device = require("device")
 local FocusManager = require("ui/widget/focusmanager")
 local Font = require("ui/font")
 local Geom = require("ui/geometry")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local LineWidget = require("ui/widget/linewidget")
-local RadioButton = require("ui/widget/radiobutton")
 local Size = require("ui/size")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
@@ -52,17 +52,18 @@ function RadioButtonTable:init()
         local horizontal_group = HorizontalGroup:new{}
         local row = self.radio_buttons[i]
         local column_cnt = #row
-        local sizer_space = self.sep_width * (column_cnt - 1) + 2
+        local sizer_space = (self.sep_width + 2 * self.padding) * (column_cnt - 1)
         for j = 1, column_cnt do
             local btn_entry = row[j]
-            local button = RadioButton:new{
+            local button = CheckButton:new{
                 text = btn_entry.text,
-                enabled = btn_entry.enabled,
+                checkable = btn_entry.checkable,
                 checked = btn_entry.checked,
+                enabled = btn_entry.enabled,
+                radio = true,
                 provider = btn_entry.provider,
 
-                width = (self.width - sizer_space)/column_cnt,
-                max_width = (self.width - sizer_space)/column_cnt - 2*self.sep_width - 2*self.padding,
+                width = (self.width - sizer_space) / column_cnt,
                 bordersize = 0,
                 margin = 0,
                 padding = 0,
@@ -113,7 +114,7 @@ function RadioButtonTable:init()
 
     -- check first entry unless otherwise specified
     if not self.checked_button then
-        self._first_button:check()
+        self._first_button:toggleCheck()
         self.checked_button = self._first_button
     end
 
@@ -159,8 +160,8 @@ function RadioButtonTable:_checkButton(button)
     -- nothing to do
     if button.checked then return end
 
-    self.checked_button:unCheck()
-    button:check()
+    self.checked_button:toggleCheck()
+    button:toggleCheck()
     self.checked_button = button
 end
 


### PR DESCRIPTION
CheckButton now can have CheckMark or RadioMark.
RadioButton widget is not used anymore and can be deleted.

![01](https://user-images.githubusercontent.com/62179190/152636124-042c7318-dd31-430c-b3c3-07069f68409c.png)

(Minor visual change: previous radiobuttons were shorter than checkbuttons by 2 points. Now they are equal.
Hard to observe, only with flash_ui enabled).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8774)
<!-- Reviewable:end -->
