### PR TITLE
Doc settings reset: fixes

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -42,6 +42,7 @@ function filemanagerutil.resetDocumentSettings(file)
     local settings_to_keep = {
         bookmarks = true,
         bookmarks_sorted = true,
+        bookmarks_sorted_20220106 = true,
         bookmarks_version = true,
         cre_dom_version = true,
         highlight = true,
@@ -57,6 +58,7 @@ function filemanagerutil.resetDocumentSettings(file)
                 doc_settings:delSetting(k)
             end
         end
+        doc_settings:makeTrue("docsettings_reset_done") -- for readertypeset block_rendering_mode
         doc_settings:close()
     end
 end

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -72,7 +72,6 @@ function ReaderTypeset:onReadSettings(config)
         else
             self.block_rendering_mode = G_reader_settings:readSetting("copt_block_rendering_mode")
                                      or 3 -- default to 'web' mode
-            config:delSetting("docsettings_reset_done")
         end
         -- Let ConfigDialog know so it can update it on screen and have it saved on quit
         self.ui.document.configurable.block_rendering_mode = self.block_rendering_mode

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -66,12 +66,13 @@ function ReaderTypeset:onReadSettings(config)
     if config:has("copt_block_rendering_mode") then
         self.block_rendering_mode = config:readSetting("copt_block_rendering_mode")
     else
-        if config:has("last_xpointer") then
+        if config:has("last_xpointer") and not config:has("docsettings_reset_done") then
             -- We have a last_xpointer: this book was previously opened
             self.block_rendering_mode = 0
         else
             self.block_rendering_mode = G_reader_settings:readSetting("copt_block_rendering_mode")
                                      or 3 -- default to 'web' mode
+            config:delSetting("docsettings_reset_done")
         end
         -- Let ConfigDialog know so it can update it on screen and have it saved on quit
         self.ui.document.configurable.block_rendering_mode = self.block_rendering_mode

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1001,6 +1001,7 @@ function ReaderView:onCloseDocument()
 end
 
 function ReaderView:onReaderReady()
+    self.ui.doc_settings:delSetting("docsettings_reset_done")
     self.settings_last_save_tv = UIManager:getTime()
 end
 


### PR DESCRIPTION
(1) Fix default `block_rendering_mode` in readertypeset, see https://github.com/koreader/koreader/pull/8412#issuecomment-1029531114.
(2) Keep `bookmarks_sorted_20220106`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8792)
<!-- Reviewable:end -->
