### PR TITLE
BookShortcuts plugin: fix folders handling

### DIFF
--- a/plugins/bookshortcuts.koplugin/main.lua
+++ b/plugins/bookshortcuts.koplugin/main.lua
@@ -36,16 +36,27 @@ function BookShortcuts:onBookShortcut(path)
         local file
         if lfs.attributes(path, "mode") ~= "file" then
             if G_reader_settings:readSetting("BookShortcuts_directory_action") == "FM" then
-                local FileManager = require("apps/filemanager/filemanager")
-                FileManager:showFiles(path)
+                if self.ui.file_chooser then
+                    self.ui.file_chooser:changeToPath(path)
+                else -- called from Reader
+                    self.ui:onClose()
+                    local FileManager = require("apps/filemanager/filemanager")
+                    if FileManager.instance then
+                        FileManager.instance:reinit(path)
+                    else
+                        FileManager:showFiles(path)
+                    end
+                end
             else
                 file = ReadHistory:getFileByDirectory(path)
             end
         else
             file = path
         end
-        local ReaderUI = require("apps/reader/readerui")
-        ReaderUI:showReader(file)
+        if file then
+            local ReaderUI = require("apps/reader/readerui")
+            ReaderUI:showReader(file)
+        end
     end
 end
 
@@ -96,7 +107,7 @@ function BookShortcuts:getSubMenuItems()
             end,
         },
         {
-            text_func = function() return T(_("Directory action: %1"), G_reader_settings:readSetting("BookShortcuts_directory_action", "FM") == "FM" and FM_text or last_text) end,
+            text_func = function() return T(_("Folder action: %1"), G_reader_settings:readSetting("BookShortcuts_directory_action", "FM") == "FM" and FM_text or last_text) end,
             keep_menu_open = true,
             sub_item_table = {
                 {


### PR DESCRIPTION
Fixes:

(1)
`02/09/22-16:06:51 WARN  FileManager instance mismatch! Tried to spin up a new instance, while we still have an existing one: table: 0x42d62bb8
`

(2)
`02/09/22-16:06:51 ERROR failed to call event handler onBookShortcut frontend/apps/reader/readerui.lua:545: bad argument #1 to 'attributes' (string expected, got nil)
`

(3) `Directory` to `Folder`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8795)
<!-- Reviewable:end -->
