### PR TITLE
Fix invert for pocketbooks by disabling hardware invert

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -42,7 +42,11 @@ local PocketBook = Generic:new{
     -- NOTE: Apparently, HW inversion is a pipedream on PB (#6669), ... well, on sunxi chipsets anyway.
     -- For which we now probe in fbinfoOverride() and tweak the flag to "no".
     -- NTX chipsets *should* work (PB631), but in case it doesn't on your device, set this to "no" in here.
-    canHWInvert = yes,
+    -- 
+    -- The above comment applied to rendering without inkview. With the inkview library inverting the screen
+    -- seems possible but needs some discussion with the developers of Pocketbook. For now disable HWInvert
+    -- so this feature is not broken while we figure out how to change the invert with inkview.
+    canHWInvert = no,
 
     -- If we can access the necessary devices, input events can be handled directly.
     -- This improves latency (~40ms), as well as power usage - we can spend more time asleep,

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -43,9 +43,8 @@ local PocketBook = Generic:new{
     -- For which we now probe in fbinfoOverride() and tweak the flag to "no".
     -- NTX chipsets *should* work (PB631), but in case it doesn't on your device, set this to "no" in here.
     --
-    -- The above comment applied to rendering without inkview. With the inkview library inverting the screen
-    -- seems possible but needs some discussion with the developers of Pocketbook. For now disable HWInvert
-    -- so this feature is not broken while we figure out how to change the invert with inkview.
+    -- The above comment applied to rendering without inkview. With the inkview library HW inverting the
+    -- screen is not possible. For now disable HWInvert for all devices.
     canHWInvert = no,
 
     -- If we can access the necessary devices, input events can be handled directly.

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -42,7 +42,7 @@ local PocketBook = Generic:new{
     -- NOTE: Apparently, HW inversion is a pipedream on PB (#6669), ... well, on sunxi chipsets anyway.
     -- For which we now probe in fbinfoOverride() and tweak the flag to "no".
     -- NTX chipsets *should* work (PB631), but in case it doesn't on your device, set this to "no" in here.
-    -- 
+    --
     -- The above comment applied to rendering without inkview. With the inkview library inverting the screen
     -- seems possible but needs some discussion with the developers of Pocketbook. For now disable HWInvert
     -- so this feature is not broken while we figure out how to change the invert with inkview.


### PR DESCRIPTION
With the inkview library inverting the screen seems possible but needs some 
discussion with the developers of Pocketbook. For now disable HWInvert so 
this feature is not broken while we figure out how to change the invert with inkview.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8803)
<!-- Reviewable:end -->
