### PR TITLE
File searcher: fix show folders, include subfolders checkbutton

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -20,7 +20,7 @@ local FileSearcher = InputContainer:new{
     dirs = {},
     files = {},
     results = {},
-    
+
     case_sensitive = false,
     include_subfolders = true,
 }

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -35,14 +35,8 @@ function FileManagerShortcuts:updateItemTable(select_callback)
                         if self.ui.file_chooser then
                             self.ui.file_chooser:changeToPath(folder)
                         else -- called from Reader
-                            local FileManager = require("apps/filemanager/filemanager")
-
                             self.ui:onClose()
-                            if FileManager.instance then
-                                FileManager.instance:reinit(folder)
-                            else
-                                FileManager:showFiles(folder)
-                            end
+                            self.ui:showFileManager(folder .. "/")
                         end
                     end
                 end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -509,8 +509,9 @@ function ReaderUI:showFileManager(file)
 
     local last_dir, last_file
     if file then
-        last_dir, last_file = util.splitFilePathName(file)
+        last_dir = util.splitFilePathName(file)
         last_dir = last_dir:match("(.*)/")
+        last_file = file
     else
         last_dir, last_file = self:getLastDirFile(true)
     end


### PR DESCRIPTION
(1) Correct show folders
(2) `Include subfolders` checkbutton (default true)
(3) Show file size in search results

![01](https://user-images.githubusercontent.com/62179190/154045330-8f525ff4-0c66-4356-a9f8-f6539fdb9e37.png)

![02](https://user-images.githubusercontent.com/62179190/154045346-62ce300e-28d5-4e77-a6c5-6d7dc846f290.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8807)
<!-- Reviewable:end -->
