### PR TITLE
Fix #8053: Pocketbook crashes when filename is nil

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -265,7 +265,7 @@ function PocketBook:notifyBookState(title, document)
         fo:write(fn)
         fo:close()
     end
-    inkview.SetSubtaskInfo(inkview.GetCurrentTask(), 0, title and (title .. " - koreader") or "koreader", fn)
+    inkview.SetSubtaskInfo(inkview.GetCurrentTask(), 0, title and (title .. " - koreader") or "koreader", fn or "[nil]")
 end
 
 function PocketBook:setDateTime(year, month, day, hour, min, sec)


### PR DESCRIPTION
Function SetSubtaskInfo takes only chars as a valid book. Since
filename can be `nil` (not a char) the crash would happen. This
Change avoids the crash by using a char type nil value. See:

int SetSubtaskInfo(int task, int subtask, const char *name, const char *book);