### PR TITLE
[fix, i18n] Add gettext() to info text about UI fallback fonts

### DIFF
--- a/frontend/ui/elements/font_ui_fallbacks.lua
+++ b/frontend/ui/elements/font_ui_fallbacks.lua
@@ -48,13 +48,13 @@ local genFallbackCandidates = function()
     end
 end
 
-local more_info_text = [[
+local more_info_text = _([[
 If some book titles, dictionary entries and such are not displayed well but shown as ￾￾ or ��, it may be necessary to download the required fonts for those languages. They can then be enabled as additional UI fallback fonts.
 Fonts for many languages can be downloaded at:
 
 https://fonts.google.com/noto
 
-Only fonts named "Noto Sans xyz" or "Noto Sans xyz UI" (regular, not bold nor italic, not Serif) will be available in this menu.]]
+Only fonts named "Noto Sans xyz" or "Noto Sans xyz UI" (regular, not bold nor italic, not Serif) will be available in this menu.]])
 
 local getSubMenuItems = function()
     genFallbackCandidates()


### PR DESCRIPTION
Fixes #8810.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8849)
<!-- Reviewable:end -->
