### PR TITLE
Initial Kindle PW5 support

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -160,7 +160,7 @@ local footerTextGeneratorMap = {
         local prefix = symbol_prefix[symbol_type].frontlight_warmth
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
-            local warmth = powerd:getWarmth()
+            local warmth = powerd:frontlightWarmth()
             if warmth then
                 return (prefix .. " %d%%"):format(warmth)
             end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -438,7 +438,7 @@ function Device:_showLightDialog()
         self.powerd.fl_intensity = self.powerd:frontlightIntensityHW()
         logger.dbg("Dialog OK, brightness: " .. self.powerd.fl_intensity)
         if android.isWarmthDevice() then
-            self.powerd.fl_warmth = self.powerd:getWarmth()
+            self.powerd.fl_warmth = self.powerd:frontlightWarmthHW()
             logger.dbg("Dialog OK, warmth: " .. self.powerd.fl_warmth)
         end
         local Event = require("ui/event")

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -42,18 +42,14 @@ function AndroidPowerD:init()
         self.fl_warmth_min = android.getScreenMinWarmth()
         self.fl_warmth_max = android.getScreenMaxWarmth()
         self.warm_diff = self.fl_warmth_max - self.fl_warmth_min
-        self.fl_warmth = self:getWarmth()
     end
 end
 
-function AndroidPowerD:setWarmth(warmth)
-    self.fl_warmth = warmth
-    local new_warmth = math.floor(warmth * self.fl_warmth_max / 100)
-    android.setScreenWarmth(new_warmth)
-    self:stateChanged()
+function AndroidPowerD:setWarmthHW(warmth)
+    android.setScreenWarmth(self:toNativeWarmth(warmth))
 end
 
-function AndroidPowerD:getWarmth()
+function AndroidPowerD:frontlightWarmthHW()
     return android.getScreenWarmth() * self.warm_diff
 end
 

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -46,7 +46,7 @@ function AndroidPowerD:init()
 end
 
 function AndroidPowerD:setWarmthHW(warmth)
-    android.setScreenWarmth(self:toNativeWarmth(warmth))
+    android.setScreenWarmth(warmth)
 end
 
 function AndroidPowerD:frontlightWarmthHW()

--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -14,8 +14,8 @@ local CervantesPowerD = BasePowerD:new{
     status_file = battery_sysfs .. 'status'
 }
 
--- We can't read value from the OS or hardware.
--- Use last values stored in koreader settings.
+-- We can't read back the current state from the OS or hardware.
+-- Use the last value stored in KOReader settings instead.
 function CervantesPowerD:frontlightWarmthHW()
     return G_reader_settings:readSetting("frontlight_warmth") or 0
 end

--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -5,7 +5,6 @@ local battery_sysfs = "/sys/devices/platform/pmic_battery.1/power_supply/mc13892
 
 local CervantesPowerD = BasePowerD:new{
     fl = nil,
-    fl_warmth = nil,
 
     fl_min = 0,
     fl_max = 100,
@@ -15,16 +14,16 @@ local CervantesPowerD = BasePowerD:new{
     status_file = battery_sysfs .. 'status'
 }
 
+-- We can't read value from the OS or hardware.
+-- Use last values stored in koreader settings.
+function CervantesPowerD:frontlightWarmthHW()
+    return G_reader_settings:readSetting("frontlight_warmth") or 0
+end
+
 function CervantesPowerD:_syncLightOnStart()
-    -- We can't read value from the OS or hardware.
-    -- Use last values stored in koreader settings.
+
     local new_intensity = G_reader_settings:readSetting("frontlight_intensity") or nil
     local is_frontlight_on = G_reader_settings:readSetting("is_frontlight_on") or nil
-    local new_warmth = nil
-
-    if self.fl_warmth ~= nil then
-        new_warmth = G_reader_settings:readSetting("frontlight_warmth") or nil
-    end
 
     if new_intensity ~= nil then
         self.hw_intensity = new_intensity
@@ -34,9 +33,7 @@ function CervantesPowerD:_syncLightOnStart()
         self.initial_is_fl_on = is_frontlight_on
     end
 
-    if new_warmth ~= nil then
-        self.fl_warmth = new_warmth
-    end
+    self.fl_warmth = self:frontlightWarmthHW()
 
     if self.initial_is_fl_on == false and self.hw_intensity == 0 then
         self.hw_intensity = 1
@@ -67,7 +64,6 @@ function CervantesPowerD:init()
                 end
             end
             self.fl = SysfsLight:new(self.device.frontlight_settings)
-            self.fl_warmth = 0
             self:_syncLightOnStart()
         else
             local kobolight = require("ffi/kobolight")
@@ -122,16 +118,9 @@ function CervantesPowerD:setIntensityHW(intensity)
     self:_decideFrontlightState()
 end
 
-function CervantesPowerD:setWarmth(warmth)
+function CervantesPowerD:setWarmthHW(warmth)
     if self.fl == nil then return end
-    self.fl_warmth = warmth
-    self.fl:setWarmth(self.fl_warmth)
-    self:stateChanged()
-end
-
-function CervantesPowerD:getWarmth()
-    if self.fl == nil then return end
-    return self.fl_warmth
+    self.fl:setWarmth(warmth)
 end
 
 function CervantesPowerD:getCapacityHW()
@@ -151,7 +140,7 @@ end
 function CervantesPowerD:afterResume()
     if self.fl == nil then return end
     -- just re-set it to self.hw_intensity that we haven't change on Suspend
-    if self.fl_warmth == nil then
+    if not self.device:hasNaturalLight() then
         self.fl:setBrightness(self.hw_intensity)
     else
         self.fl:setNaturalBrightness(self.hw_intensity, self.fl_warmth)

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -60,11 +60,11 @@ function BasePowerD:isFrontlightOnHW() return self.fl_intensity > self.fl_min en
 function BasePowerD:turnOffFrontlightHW() self:setIntensityHW(self.fl_min) end
 function BasePowerD:turnOnFrontlightHW() self:setIntensityHW(self.fl_intensity) end --- @fixme: what if fl_intensity == fl_min (c.f., kindle)?
 function BasePowerD:frontlightWarmthHW() return 0 end
--- Anything needs to be done before do a real hardware suspend. Such as turn off
--- front light.
+-- Anything that needs to be done before do a real hardware suspend.
+-- (Such as turning the front light off).
 function BasePowerD:beforeSuspend() end
--- Anything needs to be done after do a real hardware resume. Such as resume
--- front light state.
+-- Anything that needs to be done after do a real hardware resume.
+-- (Such as restoring front light state).
 function BasePowerD:afterResume() end
 
 function BasePowerD:isFrontlightOn()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -60,10 +60,10 @@ function BasePowerD:isFrontlightOnHW() return self.fl_intensity > self.fl_min en
 function BasePowerD:turnOffFrontlightHW() self:setIntensityHW(self.fl_min) end
 function BasePowerD:turnOnFrontlightHW() self:setIntensityHW(self.fl_intensity) end --- @fixme: what if fl_intensity == fl_min (c.f., kindle)?
 function BasePowerD:frontlightWarmthHW() return 0 end
--- Anything that needs to be done before do a real hardware suspend.
+-- Anything that needs to be done before doing a real hardware suspend.
 -- (Such as turning the front light off).
 function BasePowerD:beforeSuspend() end
--- Anything that needs to be done after do a real hardware resume.
+-- Anything that needs to be done after doing a real hardware resume.
 -- (Such as restoring front light state).
 function BasePowerD:afterResume() end
 
@@ -166,7 +166,7 @@ function BasePowerD:normalizeIntensity(intensity)
     return intensity > self.fl_max and self.fl_max or intensity
 end
 
--- NOTE: Takes an intensity in the native scale (i.e., [self.fl_min, self.fl_max])
+--- @note: Takes an intensity in the native scale (i.e., [self.fl_min, self.fl_max])
 function BasePowerD:setIntensity(intensity)
     if not self.device:hasFrontlight() then return false end
     if intensity == self:frontlightIntensity() then return false end
@@ -191,7 +191,7 @@ function BasePowerD:fromNativeWarmth(nat_warmth)
     return Math.round(nat_warmth * self.warmth_scale)
 end
 
--- NOTE: Takes a warmth in the *KOReader* scale (i.e., [0, 100], *sic*)
+--- @note: Takes a warmth in the *KOReader* scale (i.e., [0, 100], *sic*)
 function BasePowerD:setWarmth(warmth)
     if not self.device:hasNaturalLight() then return false end
     if warmth == self:frontlightWarmth() then return false end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -87,6 +87,9 @@ function BasePowerD:frontlightIntensity()
     assert(self ~= nil)
     if not self.device:hasFrontlight() then return 0 end
     if self:isFrontlightOff() then return 0 end
+    --- @note: We assume that nothing other than us will set the frontlight level,
+    ---        so we only actually query the HW during initialization.
+    ---        (Also, some platforms do not actually have any way of querying the HW).
     return self.fl_intensity
 end
 
@@ -126,6 +129,7 @@ function BasePowerD:frontlightWarmth()
     if not self.device:hasNaturalLight() then
         return 0
     end
+    --- @note: No live query, much like frontlightIntensity
     return self.fl_warmth
 end
 

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -32,7 +32,7 @@ function BasePowerD:new(o)
     --- @note: Post-init, as the min/max values may be computed at runtime on some platforms
     assert(o.fl_warmth_min < o.fl_warmth_max)
     -- For historical reasons, the PowerD API always expects warmth to be in the [0...100] range...
-    self.warmth_scale = 100 / self.fl_warmth_max
+    self.warmth_scale = 100 / o.fl_warmth_max
     --- @note: Some platforms cannot actually read fl/warmth level from the HW,
     --         in which case the implementation should just return self.fl_warmth (c.f., kobo).
     if o.device and o.device:hasNaturalLight() then

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -24,14 +24,15 @@ function BasePowerD:new(o)
     setmetatable(o, self)
     self.__index = self
     assert(o.fl_min < o.fl_max)
-    assert(o.fl_warmth_min < o.fl_warmth_max)
-    -- For historical reasons, the PowerD API always expects warmth to be in the [0...100] range...
-    self.warmth_scale = 100 / self.fl_warmth_max
     if o.init then o:init() end
     if o.device and o.device:hasFrontlight() then
         o.fl_intensity = o:frontlightIntensityHW()
         o:_decideFrontlightState()
     end
+    -- NOTE: Post-init, as the min/max values may be computed at runtime on some platforms
+    assert(o.fl_warmth_min < o.fl_warmth_max)
+    -- For historical reasons, the PowerD API always expects warmth to be in the [0...100] range...
+    self.warmth_scale = 100 / self.fl_warmth_max
     -- FIXME: Might be better left to imp inits... (e.g., it's a gigantic mess on kobo)
     if o.device and o.device:hasNaturalLight() then
         o.fl_warmth = o:frontlightWarmthHW()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -29,11 +29,12 @@ function BasePowerD:new(o)
         o.fl_intensity = o:frontlightIntensityHW()
         o:_decideFrontlightState()
     end
-    -- NOTE: Post-init, as the min/max values may be computed at runtime on some platforms
+    --- @note: Post-init, as the min/max values may be computed at runtime on some platforms
     assert(o.fl_warmth_min < o.fl_warmth_max)
     -- For historical reasons, the PowerD API always expects warmth to be in the [0...100] range...
     self.warmth_scale = 100 / self.fl_warmth_max
-    -- FIXME: Might be better left to imp inits... (e.g., it's a gigantic mess on kobo)
+    --- @note: Some platforms cannot actually read fl/warmth level from the HW,
+    --         in which case the implementation should just return self.fl_warmth (c.f., kobo).
     if o.device and o.device:hasNaturalLight() then
         o.fl_warmth = o:frontlightWarmthHW()
     end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -31,7 +31,7 @@ function BasePowerD:new(o)
     end
     --- @note: Post-init, as the min/max values may be computed at runtime on some platforms
     assert(o.fl_warmth_min < o.fl_warmth_max)
-    -- For historical reasons, the PowerD API always expects warmth to be in the [0...100] range...
+    -- For historical reasons, the *public* PowerD warmth API always expects warmth to be in the [0...100] range...
     self.warmth_scale = 100 / o.fl_warmth_max
     --- @note: Some platforms cannot actually read fl/warmth level from the HW,
     --         in which case the implementation should just return self.fl_warmth (c.f., kobo).

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -47,6 +47,7 @@ end
 
 function BasePowerD:init() end
 function BasePowerD:setIntensityHW(intensity) end
+--- @note: Unlike the "public" setWarmth, this one takes a value in the *native* scale!
 function BasePowerD:setWarmthHW(warmth) end
 function BasePowerD:getCapacityHW() return 0 end
 function BasePowerD:getAuxCapacityHW() return 0 end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,10 +1,14 @@
 local UIManager -- will be updated when available
+local Math = require("optmath")
 local TimeVal = require("ui/timeval")
 local logger = require("logger")
 local BasePowerD = {
     fl_min = 0,                       -- min frontlight intensity
     fl_max = 10,                      -- max frontlight intensity
     fl_intensity = nil,               -- frontlight intensity
+    fl_warmth_min = 0,                -- min warmth level
+    fl_warmth_max = 100,              -- max warmth level
+    fl_warmth = nil,                  -- warmth level
     batt_capacity = 0,                -- battery capacity
     aux_batt_capacity = 0,            -- auxiliary battery capacity
     device = nil,                     -- device object
@@ -20,10 +24,17 @@ function BasePowerD:new(o)
     setmetatable(o, self)
     self.__index = self
     assert(o.fl_min < o.fl_max)
+    assert(o.fl_warmth_min < o.fl_warmth_max)
+    -- For historical reasons, the PowerD API always expects warmth to be in the [0...100] range...
+    self.warmth_scale = 100 / self.fl_warmth_max
     if o.init then o:init() end
     if o.device and o.device:hasFrontlight() then
         o.fl_intensity = o:frontlightIntensityHW()
         o:_decideFrontlightState()
+    end
+    -- FIXME: Might be better left to imp inits... (e.g., it's a gigantic mess on kobo)
+    if o.device and o.device:hasNaturalLight() then
+        o.fl_warmth = o:frontlightWarmthHW()
     end
     return o
 end
@@ -34,6 +45,7 @@ end
 
 function BasePowerD:init() end
 function BasePowerD:setIntensityHW(intensity) end
+function BasePowerD:setWarmthHW(warmth) end
 function BasePowerD:getCapacityHW() return 0 end
 function BasePowerD:getAuxCapacityHW() return 0 end
 function BasePowerD:isAuxBatteryConnectedHW() return false end
@@ -45,6 +57,7 @@ function BasePowerD:frontlightIntensityHW() return 0 end
 function BasePowerD:isFrontlightOnHW() return self.fl_intensity > self.fl_min end
 function BasePowerD:turnOffFrontlightHW() self:setIntensityHW(self.fl_min) end
 function BasePowerD:turnOnFrontlightHW() self:setIntensityHW(self.fl_intensity) end --- @fixme: what if fl_intensity == fl_min (c.f., kindle)?
+function BasePowerD:frontlightWarmthHW() return 0 end
 -- Anything needs to be done before do a real hardware suspend. Such as turn off
 -- front light.
 function BasePowerD:beforeSuspend() end
@@ -105,6 +118,14 @@ function BasePowerD:turnOnFrontlight()
     return true
 end
 
+function BasePowerD:frontlightWarmth()
+    assert(self ~= nil)
+    if not self.device:hasNaturalLight() then
+        return 0
+    end
+    return self.fl_warmth
+end
+
 function BasePowerD:read_int_file(file)
     local fd = io.open(file, "r")
     if fd then
@@ -143,6 +164,7 @@ function BasePowerD:normalizeIntensity(intensity)
     return intensity > self.fl_max and self.fl_max or intensity
 end
 
+-- NOTE: Takes an intensity in the native scale (i.e., [self.fl_min, self.fl_max])
 function BasePowerD:setIntensity(intensity)
     if not self.device:hasFrontlight() then return false end
     if intensity == self:frontlightIntensity() then return false end
@@ -150,6 +172,32 @@ function BasePowerD:setIntensity(intensity)
     self:_decideFrontlightState()
     logger.dbg("set light intensity", self.fl_intensity)
     self:setIntensityHW(self.fl_intensity)
+    self:stateChanged()
+    return true
+end
+
+function BasePowerD:normalizeWarmth(warmth)
+    warmth = warmth < 0 and 0 or warmth
+    return warmth > 100 and 100 or warmth
+end
+
+function BasePowerD:toNativeWarmth(ko_warmth)
+    return Math.round(ko_warmth / self.warmth_scale)
+end
+
+function BasePowerD:fromNativeWarmth(nat_warmth)
+    return Math.round(nat_warmth * self.warmth_scale)
+end
+
+-- NOTE: Takes a warmth in the *KOReader* scale (i.e., [0, 100], *sic*)
+function BasePowerD:setWarmth(warmth)
+    if not self.device:hasNaturalLight() then return false end
+    if warmth == self:frontlightWarmth() then return false end
+    -- Which means that fl_warmth is *also* in the KOReader scale (unlike fl_intensity)
+    self.fl_warmth = self:normalizeWarmth(warmth)
+    local nat_warmth = self:toNativeWarmth(self.fl_warmth)
+    logger.dbg("set light warmth", self.fl_warmth, "->", nat_warmth)
+    self:setWarmthHW(nat_warmth)
     self:stateChanged()
     return true
 end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -488,6 +488,7 @@ local KindlePaperWhite5 = Kindle:new{
     isMTK = yes,
     isTouchDevice = yes,
     hasFrontlight = yes,
+    hasNaturalLight = yes,
     display_dpi = 300,
     touch_dev = "/dev/input/by-path/platform-1001e000.i2c-event",
     -- NOTE: While hardware dithering (via MDP) should be a thing, it doesn't appear to do anything right now :/.
@@ -902,6 +903,22 @@ function KindleBasic3:init()
     self.input.open("fake_events")
 end
 
+function KindlePaperWhite5:init()
+    self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
+    self.powerd = require("device/kindle/powerd"):new{
+        device = self,
+        fl_intensity_file = "/sys/class/backlight/fp9966-bl1/brightness",
+        warmth_intensity_file = "/sys/class/backlight/fp9966-bl0/brightness",
+        batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
+        is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
+    }
+
+    Kindle.init(self)
+
+    self.input.open(self.touch_dev)
+    self.input.open("fake_events")
+end
+
 function KindleTouch:exit()
     Generic.exit(self)
     if self.isSpecialOffers then
@@ -930,6 +947,7 @@ KindleBasic2.exit = KindleTouch.exit
 KindlePaperWhite4.exit = KindleTouch.exit
 KindleBasic3.exit = KindleTouch.exit
 KindleOasis3.exit = KindleTouch.exit
+KindlePaperWhite5.exit = KindleTouch.exit
 
 function Kindle3:exit()
     -- send double menu key press events to trigger screen refresh

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -928,12 +928,12 @@ function KindlePaperWhite5:init()
 end
 
 function KindleTouch:exit()
-    Generic.exit(self)
-
     if self:isMTK() then
         -- Disable the so-called "fast" mode
         self.screen:_MTK_ToggleFastMode(false)
     end
+
+    Generic.exit(self)
 
     if self.isSpecialOffers then
         -- Wakey wakey...

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -61,8 +61,9 @@ end
 --]]
 
 -- Faster lipc-less variant ;).
-local function isConnected()
+local function isWifiUp()
     -- Read carrier state from sysfs (so far, all Kindles appear to use wlan0)
+    -- NOTE: We can afford to use CLOEXEC, as devices too old for it don't support Wi-Fi anyway ;).
     local file = io.open("/sys/class/net/wlan0/carrier", "re")
 
     -- File only exists while Wi-Fi module is loaded.
@@ -164,7 +165,7 @@ function Kindle:initNetworkManager(NetworkMgr)
         end
     end
 
-    NetworkMgr.isWifiOn = isConnected
+    NetworkMgr.isWifiOn = isWifiUp
 end
 
 function Kindle:supportsScreensaver()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -918,6 +918,9 @@ function KindlePaperWhite5:init()
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
     }
 
+    -- Enable the so-called "fast" mode, so as to prevent the driver from silently promoting refreshes to REAGL.
+    self.screen:_MTK_ToggleFastMode(true)
+
     Kindle.init(self)
 
     self.input.open(self.touch_dev)
@@ -926,6 +929,12 @@ end
 
 function KindleTouch:exit()
     Generic.exit(self)
+
+    if self:isMTK() then
+        -- Disable the so-called "fast" mode
+        self.screen:_MTK_ToggleFastMode(false)
+    end
+
     if self.isSpecialOffers then
         -- Wakey wakey...
         if os.getenv("AWESOME_STOPPED") == "yes" then

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -454,8 +454,7 @@ local KindlePaperWhite5 = Kindle:new{
     isTouchDevice = yes,
     hasFrontlight = yes,
     display_dpi = 300,
-    -- FIXME!
-    touch_dev = "/dev/input/event2",
+    touch_dev = "/dev/input/by-path/platform-1001e000.i2c-event",
 }
 
 function Kindle2:init()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -449,6 +449,11 @@ local KindleOasis3 = Kindle:new{
     isZelda = yes,
     isTouchDevice = yes,
     hasFrontlight = yes,
+    --- @fixme: Requires a proper KindleOasis3.init, notably with the right warmth_intensity_file entry.
+    --[[
+    hasNaturalLight = yes,
+    hasNaturalLightMixer = yes,
+    --]]
     hasKeys = yes,
     hasGSensor = yes,
     display_dpi = 300,

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -471,6 +471,8 @@ local KindlePaperWhite5 = Kindle:new{
     hasFrontlight = yes,
     display_dpi = 300,
     touch_dev = "/dev/input/by-path/platform-1001e000.i2c-event",
+    -- NOTE: While hardware dithering (via MDP) should be a thing, it doesn't appear to do anything right now :/.
+    canHWDither = no,
 }
 
 function Kindle2:init()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -489,6 +489,10 @@ local KindlePaperWhite5 = Kindle:new{
     isTouchDevice = yes,
     hasFrontlight = yes,
     hasNaturalLight = yes,
+    -- NOTE: We *can* technically control both LEDs independently,
+    --       but the mix is device-specific, we don't have access to the LUT for the mix powerd is using,
+    --       and the widget is designed for the Kobo Aura One anyway, so, hahaha, nope.
+    hasNaturalLightMixer = yes,
     display_dpi = 300,
     touch_dev = "/dev/input/by-path/platform-1001e000.i2c-event",
     -- NOTE: While hardware dithering (via MDP) should be a thing, it doesn't appear to do anything right now :/.

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -195,9 +195,9 @@ function Kindle:setDateTime(year, month, day, hour, min, sec)
     else
         local command
         if year and month and day then
-            command = string.format("date -s '%d-%d-%d %d:%d:%d'", year, month, day, hour, min, sec)
+            command = string.format("date -s '%d-%d-%d %d:%d:%d' '+%Y-%m-%d %H:%M:%S'", year, month, day, hour, min, sec)
         else
-            command = string.format("date -s '%d:%d'", hour, min)
+            command = string.format("date -s '%d:%d' '+%H:%M'", hour, min)
         end
         if os.execute(command) == 0 then
             os.execute("hwclock -u -w")

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -28,7 +28,7 @@ function KindlePowerD:init()
             self.fl_warmth = self.lipc_handle:get_int_property("com.lab126.powerd", "currentAmberLevel")
             if self.fl_warmth then
                 -- [0...24] -> [0...100]
-                self.fl_warmth = math.floor(self.fl_warmth * self.warmth_scale)
+                self.fl_warmth = math.floor(self.fl_warmth * self.warmth_scale + 0.5)
             end
         end
     end
@@ -125,7 +125,7 @@ function KindlePowerD:setWarmth(warmth)
 
     if self.lipc_handle ~= nil then
         -- [0...100] -> [0...24]
-        local warmth_level = math.floor(self.fl_warmth / self.warmth_scale)
+        local warmth_level = math.floor(self.fl_warmth / self.warmth_scale + 0.5)
 
         self.lipc_handle:set_int_property("com.lab126.powerd", "currentAmberLevel", warmth_level)
     end

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -104,10 +104,6 @@ function KindlePowerD:setIntensityHW(intensity)
 end
 
 function KindlePowerD:frontlightWarmthHW()
-    if not self.device:hasNaturalLight() then
-        return 0
-    end
-
     if self.lipc_handle ~= nil then
         local nat_warmth = self.lipc_handle:get_int_property("com.lab126.powerd", "currentAmberLevel")
         if nat_warmth then
@@ -120,10 +116,6 @@ function KindlePowerD:frontlightWarmthHW()
 end
 
 function KindlePowerD:setWarmthHW(warmth)
-    if not self.device:hasNaturalLight() then
-        return
-    end
-
     if self.lipc_handle ~= nil then
         self.lipc_handle:set_int_property("com.lab126.powerd", "currentAmberLevel", warmth)
     end

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -22,8 +22,14 @@ function KindlePowerD:init()
 
     -- The FL widget expects this to be set if available...
     if self.device:hasNaturalLight() then
+        -- The PowerD API always expects warmth to be in the [0...100] range...
+        self.warmth_scale = 100 / self.fl_warmth_max
         if self.lipc_handle ~= nil then
             self.fl_warmth = self.lipc_handle:get_int_property("com.lab126.powerd", "currentAmberLevel")
+            if self.fl_warmth then
+                -- [0...24] -> [0...100]
+                self.fl_warmth = math.floor(self.fl_warmth * self.warmth_scale)
+            end
         end
     end
 end
@@ -118,8 +124,10 @@ function KindlePowerD:setWarmth(warmth)
     self.fl_warmth = warmth or self.fl_warmth
 
     if self.lipc_handle ~= nil then
-        self.lipc_handle:set_int_property(
-            "com.lab126.powerd", "currentAmberLevel", warmth)
+        -- [0...100] -> [0...24]
+        local warmth_level = math.floor(self.fl_warmth / self.warmth_scale)
+
+        self.lipc_handle:set_int_property("com.lab126.powerd", "currentAmberLevel", warmth_level)
     end
 
     self:stateChanged()

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -96,7 +96,7 @@ function KindlePowerD:setIntensityHW(intensity)
         -- We do *both* to make the fl restore on resume less jarring on devices where lipc 0 != off.
         os.execute("printf '%s' ".. intensity .." > " .. self.fl_intensity_file)
 
-        -- And in case there are two LEDs...
+        -- And in case there are two LED groups...
         if self.warmth_intensity_file then
             os.execute("printf '%s' ".. intensity .." > " .. self.warmth_intensity_file)
         end

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -19,6 +19,13 @@ function KindlePowerD:init()
     if not self.device:canTurnFrontlightOff() then
         self.fl_max = self.fl_max + 1
     end
+
+    -- The FL widget expects this to be set if available...
+    if self.device:hasNaturalLight() then
+        if self.lipc_handle ~= nil then
+            self.fl_warmth = self.lipc_handle:get_int_property("com.lab126.powerd", "currentAmberLevel")
+        end
+    end
 end
 
 -- If we start with the light off (fl_intensity is fl_min), ensure a toggle will set it to the lowest "on" step,
@@ -88,8 +95,7 @@ function KindlePowerD:setIntensityHW(intensity)
     --       it knows what the UI values should map to for the specific hardware much better than us.
     if self.lipc_handle ~= nil then
         -- NOTE: We want to bypass setIntensity's shenanigans and simply restore the light as-is
-        self.lipc_handle:set_int_property(
-            "com.lab126.powerd", "flIntensity", intensity)
+        self.lipc_handle:set_int_property("com.lab126.powerd", "flIntensity", intensity)
     end
     if turn_it_off then
         -- NOTE: when intensity is 0, we want to *really* kill the light, so do it manually

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -1,4 +1,5 @@
 local BasePowerD = require("device/generic/powerd")
+local Math = require("optmath")
 local NickelConf = require("device/kobo/nickel_conf")
 local SysfsLight = require ("device/sysfs_light")
 local ffiUtil = require("ffi/util")
@@ -41,7 +42,7 @@ function KoboPowerD:_syncKoboLightOnStart()
                     -- ColorSetting is stored as a color temperature scale in Kelvin,
                     -- from 1500 to 6400
                     -- so normalize this to [0, 100] on our end.
-                    new_warmth = (100 - math.floor((new_color - 1500) / 49 + 0.5))
+                    new_warmth = (100 - Math.round((new_color - 1500) / 49))
                 end
             end
             if is_frontlight_on == nil then

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -41,7 +41,7 @@ function KoboPowerD:_syncKoboLightOnStart()
                 if new_color ~= nil then
                     -- ColorSetting is stored as a color temperature scale in Kelvin,
                     -- from 1500 to 6400
-                    -- so normalize this to [0,100] on our end.
+                    -- so normalize this to [0, 100] on our end.
                     new_warmth = (100 - math.floor((new_color - 1500) / 49))
                 end
             end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -132,7 +132,7 @@ function KoboPowerD:init()
         if self.device:hasNaturalLight() then
             local nl_config = G_reader_settings:readSetting("natural_light_config")
             if nl_config then
-                for key,val in pairs(nl_config) do
+                for key, val in pairs(nl_config) do
                     self.device.frontlight_settings[key] = val
                 end
             end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -16,7 +16,6 @@ local KoboPowerD = BasePowerD:new{
     battery_sysfs = nil,
     aux_battery_sysfs = nil,
     fl_warmth_min = 0, fl_warmth_max = 100,
-    fl_warmth = nil,
     fl_was_on = nil,
 }
 
@@ -250,22 +249,19 @@ function KoboPowerD:setIntensityHW(intensity)
     self:_decideFrontlightState()
 end
 
-function KoboPowerD:setWarmth(warmth)
+-- NOTE: We *can* actually read this from the system (as well as frontlight level, since Mk. 7),
+--       but this is already a huge mess, so, keep ignoring it...
+function KoboPowerD:frontlightWarmthHW()
+    return self.fl_warmth
+end
+
+function KoboPowerD:setWarmthHW(warmth)
     if self.fl == nil then return end
-    self.fl_warmth = warmth or self.fl_warmth
     -- Don't turn the light back on on legacy NaturalLight devices just for the sake of setting the warmth!
     -- That's because we can only set warmth independently of brightness on devices with a mixer.
     -- On older ones, calling setWarmth *will* actually set the brightness, too!
     if self.device:hasNaturalLightMixer() or self:isFrontlightOnHW() then
-        self.fl:setWarmth(self.fl_warmth)
-        self:stateChanged()
-    end
-end
-
-function KoboPowerD:getWarmth()
-    if self.fl == nil then return end
-    if self.device:hasNaturalLight() then
-        return self.fl_warmth
+        self.fl:setWarmth(warmth)
     end
 end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -42,7 +42,7 @@ function KoboPowerD:_syncKoboLightOnStart()
                     -- ColorSetting is stored as a color temperature scale in Kelvin,
                     -- from 1500 to 6400
                     -- so normalize this to [0, 100] on our end.
-                    new_warmth = (100 - math.floor((new_color - 1500) / 49))
+                    new_warmth = (100 - math.floor((new_color - 1500) / 49 + 0.5))
                 end
             end
             if is_frontlight_on == nil then

--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -12,10 +12,10 @@ local PocketBookPowerD = BasePowerD:new{
 }
 
 function PocketBookPowerD:frontlightIntensityHW()
-    -- Always update fl_intensity (and perhaps fl_warmth) from the OS value whenever queried (its fast).
-    -- This way koreader setting can stay in sync even if the value is changed behind its back.
+    -- Always update fl_intensity (and perhaps fl_warmth) from the OS value whenever queried (it's fast).
+    -- This way koreader settings can stay in sync even if the value is changed behind its back.
     self.fl_intensity = math.max(0, inkview.GetFrontlightState())
-    if self.fl_warmth then
+    if self.device:hasNaturalLight() then
         self.fl_warmth = math.max(0, inkview.GetFrontlightColor())
     end
     return self.fl_intensity
@@ -24,6 +24,8 @@ end
 function PocketBookPowerD:frontlightIntensity()
     if not self.device:hasFrontlight() then return 0 end
     if self:isFrontlightOff() then return 0 end
+    --- @note: We actually have a working frontlightIntensityHW implementation,
+    ---        use it instead of returning a cached self.fl_intensity like BasePowerD.
     return self:frontlightIntensityHW()
 end
 
@@ -52,7 +54,7 @@ function PocketBookPowerD:isFrontlightOn()
 end
 
 function PocketBookPowerD:setWarmthHW(level)
-    return inkview.SetFrontlightColor(self.fl_warmth)
+    return inkview.SetFrontlightColor(level)
 end
 
 function PocketBookPowerD:frontlightWarmthHW()

--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -4,21 +4,12 @@ local inkview = ffi.load("inkview")
 
 local PocketBookPowerD = BasePowerD:new{
     is_charging = nil,
-    fl_warmth = nil,
 
     fl_min = 0,
     fl_max = 100,
     fl_warmth_min = 0,
     fl_warmth_max = 100,
 }
-
-function PocketBookPowerD:init()
-    -- needed for SetFrontlightState / GetFrontlightState
-    if self.device:hasNaturalLight() then
-        local color = inkview.GetFrontlightColor()
-        self.fl_warmth = color >= 0 and color or 0
-    end
-end
 
 function PocketBookPowerD:frontlightIntensityHW()
     -- Always update fl_intensity (and perhaps fl_warmth) from the OS value whenever queried (its fast).
@@ -60,18 +51,12 @@ function PocketBookPowerD:isFrontlightOn()
     return enabled
 end
 
-function PocketBookPowerD:setWarmth(level)
-    if self.fl_warmth then
-        self.fl_warmth = level or self.fl_warmth
-        inkview.SetFrontlightColor(self.fl_warmth)
-        self:stateChanged()
-    end
+function PocketBookPowerD:setWarmthHW(level)
+    return inkview.SetFrontlightColor(self.fl_warmth)
 end
 
-function PocketBookPowerD:getWarmth()
-    if self.fl_warmth then
-        return self.fl_warmth
-    end
+function PocketBookPowerD:frontlightWarmthHW()
+    return inkview.GetFrontlightColor()
 end
 
 function PocketBookPowerD:getCapacityHW()

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -20,15 +20,7 @@ function SDLPowerD:setIntensityHW(intensity)
     self.hw_intensity = intensity or self.hw_intensity
 end
 
-
-function SDLPowerD:setWarmth(level)
-    require("logger").info("set warmth to", level)
-    self.fl_warmth = level or self.fl_warmth
-    self:stateChanged()
-end
-
-function SDLPowerD:getWarmth()
-    if self.hw_intensity == 0 then return end
+function SDLPowerD:frontlightWarmthHW()
     return self.fl_warmth
 end
 

--- a/frontend/device/sysfs_light.lua
+++ b/frontend/device/sysfs_light.lua
@@ -68,7 +68,7 @@ function SysfsLight:setNaturalBrightness(brightness, warmth)
     -- Newer devices use a mixer instead of writting values per color.
     if self.frontlight_mixer then
         -- Honor the device's scale, which may not be [0...100] (e.g., it's [0...10] on the Forma) ;).
-        warmth = math.floor(warmth / self.nl_max)
+        warmth = math.floor(warmth / (100 / self.nl_max))
         if set_brightness then
             -- Prefer the ioctl, as it's much lower latency.
             if self.frontlight_ioctl then

--- a/frontend/device/sysfs_light.lua
+++ b/frontend/device/sysfs_light.lua
@@ -68,7 +68,7 @@ function SysfsLight:setNaturalBrightness(brightness, warmth)
     -- Newer devices use a mixer instead of writting values per color.
     if self.frontlight_mixer then
         -- Honor the device's scale, which may not be [0...100] (e.g., it's [0...10] on the Forma) ;).
-        warmth = math.floor(warmth / (100 / self.nl_max))
+        warmth = math.floor(warmth / (100 / self.nl_max) + 0.5)
         if set_brightness then
             -- Prefer the ioctl, as it's much lower latency.
             if self.frontlight_ioctl then

--- a/frontend/device/sysfs_light.lua
+++ b/frontend/device/sysfs_light.lua
@@ -53,6 +53,7 @@ dbg:guard(SysfsLight, 'setWarmth',
                      "Wrong warmth value given!")
           end)
 
+--- @note: warmth is already in the *native* scale!
 function SysfsLight:setNaturalBrightness(brightness, warmth)
     local set_brightness = true
     local set_warmth = true
@@ -67,8 +68,6 @@ function SysfsLight:setNaturalBrightness(brightness, warmth)
 
     -- Newer devices use a mixer instead of writting values per color.
     if self.frontlight_mixer then
-        -- Honor the device's scale, which may not be [0...100] (e.g., it's [0...10] on the Forma) ;).
-        warmth = math.floor(warmth / (100 / self.nl_max) + 0.5)
         if set_brightness then
             -- Prefer the ioctl, as it's much lower latency.
             if self.frontlight_ioctl then
@@ -77,7 +76,7 @@ function SysfsLight:setNaturalBrightness(brightness, warmth)
                 self:_write_value(self.frontlight_white, brightness)
             end
         end
-        -- And it may be inverted... (cold is nl_max, warm is nl_min)
+        -- The mixer might be using inverted values... (cold is nl_max, warm is nl_min)
         if set_warmth then
             if self.nl_inverted then
                 self:_write_value(self.frontlight_mixer, self.nl_max - warmth)

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -655,7 +655,7 @@ end
 
 function BookStatusWidget:closeInputDialog()
     UIManager:close(self.note_dialog)
-    self.input_note:onUnfocus();
+    self.input_note:onUnfocus()
 end
 
 return BookStatusWidget

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -96,7 +96,7 @@ function Button:init()
                 local new_size = self.label_widget.face.orig_size - 1
                 if new_size < font_size_2_lines then
                     -- Switch to a 2-lines TextBoxWidget
-                    self.label_widget:free()
+                    self.label_widget:free(true)
                     self.label_widget = TextBoxWidget:new{
                         text = self.text,
                         line_height = 0,
@@ -118,7 +118,7 @@ function Button:init()
                 if new_size < 8 then -- don't go too small
                     break
                 end
-                self.label_widget:free()
+                self.label_widget:free(true)
                 self.label_widget = TextWidget:new{
                     text = self.text,
                     max_width = max_width,

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -254,7 +254,7 @@ function ButtonProgressWidget:update()
     end
 
     self:refocusWidget()
-    UIManager:setDirty(self.show_parrent, function()
+    UIManager:setDirty(self.show_parent, function()
         return "ui", self.dimen
     end)
 end

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -637,7 +637,7 @@ function ConfigOption:init()
                                 self.options[c].labels or self.options[c].args, arg)
                         end
                     end,
-                    show_parrent = self.config,
+                    show_parent = self.config,
                     enabled = enabled,
                     fine_tune = self.options[c].fine_tune,
                     fine_tune_param = self.options[c].fine_tune_param,

--- a/frontend/ui/widget/container/widgetcontainer.lua
+++ b/frontend/ui/widget/container/widgetcontainer.lua
@@ -118,11 +118,12 @@ function WidgetContainer:handleEvent(event)
     end
 end
 
-function WidgetContainer:free()
+-- Honor full for TextBoxWidget's benefit...
+function WidgetContainer:free(full)
     for _, widget in ipairs(self) do
         if widget.free then
             --print("WidgetContainer: Calling free for widget", debug.getinfo(widget.free, "S").short_src, widget, "from", debug.getinfo(self.free, "S").short_src, self)
-            widget:free()
+            widget:free(full)
         end
     end
 end

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -559,7 +559,7 @@ function DictQuickLookup:init()
             for_measurement_only = true, -- flag it as a dummy, so it won't trigger any bogus repaint/refresh...
         }
         self.definition_line_height = test_widget:getLineHeight()
-        test_widget:free()
+        test_widget:free(true)
     end
 
     if is_large_window then

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -137,7 +137,7 @@ function FrontLightWidget:layout()
         }
     end
 
-    self.main_container = CenterContainer:new{
+    local main_container = CenterContainer:new{
         dimen = Geom:new{
             w = self.width,
             h = math.floor(self.screen_height * 0.2),
@@ -148,7 +148,7 @@ function FrontLightWidget:layout()
     local padding_span = VerticalSpan:new{ width = self.span }
     local fl_group_above = HorizontalGroup:new{ align = "center" }
     local fl_group_below = HorizontalGroup:new{ align = "center" }
-    self.main_group = VerticalGroup:new{ align = "center" }
+    local main_group = VerticalGroup:new{ align = "center" }
 
     local ticks = {}
     for i = 1, self.fl.steps - 2 do
@@ -254,17 +254,17 @@ function FrontLightWidget:layout()
 
     if self.has_nl then
         -- Only insert 'Brightness' caption if we also add 'warmth' widgets below.
-        table.insert(self.main_group, fl_header)
+        table.insert(main_group, fl_header)
     end
     table.insert(fl_group_above, fl_buttons_above)
     table.insert(fl_group_below, fl_buttons_below)
-    table.insert(self.main_group, padding_span)
-    table.insert(self.main_group, fl_group_above)
-    table.insert(self.main_group, padding_span)
-    table.insert(self.main_group, self.fl_progress)
-    table.insert(self.main_group, padding_span)
-    table.insert(self.main_group, fl_group_below)
-    table.insert(self.main_group, padding_span)
+    table.insert(main_group, padding_span)
+    table.insert(main_group, fl_group_above)
+    table.insert(main_group, padding_span)
+    table.insert(main_group, self.fl_progress)
+    table.insert(main_group, padding_span)
+    table.insert(main_group, fl_group_below)
+    table.insert(main_group, padding_span)
 
     -- Warmth
     if self.has_nl then
@@ -347,17 +347,17 @@ function FrontLightWidget:layout()
         }
         self.layout[4] = {nl_min, nl_max}
 
-        table.insert(self.main_group, nl_header)
+        table.insert(main_group, nl_header)
         table.insert(nl_group_above, nl_buttons_above)
         table.insert(nl_group_below, nl_buttons_below)
 
-        table.insert(self.main_group, padding_span)
-        table.insert(self.main_group, nl_group_above)
-        table.insert(self.main_group, padding_span)
-        table.insert(self.main_group, self.nl_group)
-        table.insert(self.main_group, padding_span)
-        table.insert(self.main_group, nl_group_below)
-        table.insert(self.main_group, padding_span)
+        table.insert(main_group, padding_span)
+        table.insert(main_group, nl_group_above)
+        table.insert(main_group, padding_span)
+        table.insert(main_group, self.nl_group)
+        table.insert(main_group, padding_span)
+        table.insert(main_group, nl_group_below)
+        table.insert(main_group, padding_span)
 
         -- Aura One R/G/B widget
         if not self.has_nl_mixer and not self.has_nl_api then
@@ -371,14 +371,14 @@ function FrontLightWidget:layout()
                     UIManager:show(NaturalLight:new{fl_widget = self})
                 end,
             }
-            table.insert(self.main_group, nl_setup)
+            table.insert(main_group, nl_setup)
             self.layout[5] = {nl_setup}
         end
     end
 
-    table.insert(self.main_container, self.main_group)
+    table.insert(main_container, main_group)
     -- Reset container height to what it actually contains
-    self.main_container.dimen.h = self.main_group:getSize().h
+    main_container.dimen.h = main_group:getSize().h
 
     -- Common
     local title_bar = TitleBar:new{
@@ -392,18 +392,18 @@ function FrontLightWidget:layout()
         end,
         show_parent = self,
     }
-    self.inner_frame = FrameContainer:new{
+    local inner_frame = FrameContainer:new{
         padding = Size.padding.button,
         margin = Size.margin.small,
         bordersize = 0,
-        self.main_container,
+        main_container,
     }
-    self.center_container = CenterContainer:new{
+    local center_container = CenterContainer:new{
         dimen = Geom:new{
             w = self.width,
-            h = self.inner_frame:getSize().h,
+            h = inner_frame:getSize().h,
         },
-        self.inner_frame,
+        inner_frame,
     }
     self.frame = FrameContainer:new{
         radius = Size.radius.window,
@@ -414,7 +414,7 @@ function FrontLightWidget:layout()
         VerticalGroup:new{
             align = "left",
             title_bar,
-            self.center_container,
+            center_container,
         }
     }
     self[1] = WidgetContainer:new{
@@ -429,28 +429,10 @@ function FrontLightWidget:layout()
             self.frame,
         },
     }
-
-    logger.dbg("FrontLightWidget:layout self.center_container:getSize", self.center_container:getSize())
-    logger.dbg("FrontLightWidget:layout self.inner_frame:getSize", self.inner_frame:getSize())
-    logger.dbg("FrontLightWidget:layout self.frame:getSize", self.frame:getSize())
-    logger.dbg("FrontLightWidget:layout self.main_container.dimen", self.main_container.dimen, self.main_container:getSize())
-    logger.dbg("FrontLightWidget:layout self.main_group.dimen", self.main_group:getSize())
 end
 
 function FrontLightWidget:update()
-    --self.main_group:resetLayout() -- invalidate getSize's cache
-    --self.center_container.dimen.h = self.inner_frame:getSize().h
-    logger.dbg("FrontLightWidget:update self.main_container.dimen", self.main_container.dimen, self.main_container:getSize())
-    logger.dbg("FrontLightWidget:update self.main_group.dimen", self.main_group:getSize())
-
-    -- Reset container height to what it actually contains
-    --self.main_container.dimen.h = self.main_group:getSize().h
     self:refocusWidget()
-
-    -- Ditto for the frames
-    logger.dbg("FrontLightWidget:layout self.center_container:getSize", self.center_container:getSize())
-    logger.dbg("FrontLightWidget:layout self.inner_frame:getSize", self.inner_frame:getSize())
-    logger.dbg("FrontLightWidget:update self.frame.dimen", self.frame.dimen, self.frame:getSize())
 
     UIManager:setDirty(self, function()
         return "ui", self.frame.dimen

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -175,7 +175,7 @@ function FrontLightWidget:setProgress(num, step, step_nl, num_warmth)
         enabled = enable_button_minus,
         width = math.floor(self.screen_width * 0.2),
         show_parent = self,
-        callback = function()  self:setProgress(self.fl_cur - 1, step, step_nl) end,
+        callback = function() self:setProgress(self.fl_cur - 1, step, step_nl) end,
     }
     local button_plus = Button:new{
         text = "+1",

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -259,6 +259,7 @@ function FrontLightWidget:layout()
             thin_grey_style = false,
             num_buttons = self.nl.steps - 1, -- no button for step 0
             position = math.floor(self.nl.cur / self.nl.stride),
+            default_position = math.floor(self.nl.cur / self.nl.stride),
             callback = function(i)
                 self:setWarmth(i, false)
             end,
@@ -474,6 +475,7 @@ function FrontLightWidget:setBrightness(intensity)
 end
 
 function FrontLightWidget:setWarmth(warmth, update_position)
+    logger.dbg("FrontLightWidget:setWarmth", warmth, update_position)
     if warmth == self.nl.cur then
         return
     end
@@ -485,7 +487,7 @@ function FrontLightWidget:setWarmth(warmth, update_position)
     -- Update the progress bar, if we were called from outside ButtonProgressWidget
     -- (as it already handles that internally ;)).
     if update_position then
-        self.nl_progress:setPosition(warmth)
+        self.nl_progress:setPosition(warmth, self.nl_progress.default_position)
     end
 
     self.nl_level:setText(tostring(self.nl.cur))

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -377,6 +377,8 @@ function FrontLightWidget:layout()
     end
 
     table.insert(self.main_container, self.main_group)
+    -- Reset container height to what it actually contains
+    self.main_container.dimen.h = self.main_group:getSize().h
 
     -- Common
     local title_bar = TitleBar:new{
@@ -390,11 +392,18 @@ function FrontLightWidget:layout()
         end,
         show_parent = self,
     }
-    local inner_frame = FrameContainer:new{
+    self.inner_frame = FrameContainer:new{
         padding = Size.padding.button,
         margin = Size.margin.small,
         bordersize = 0,
         self.main_container,
+    }
+    self.center_container = CenterContainer:new{
+        dimen = Geom:new{
+            w = self.width,
+            h = self.inner_frame:getSize().h,
+        },
+        self.inner_frame,
     }
     self.frame = FrameContainer:new{
         radius = Size.radius.window,
@@ -405,13 +414,7 @@ function FrontLightWidget:layout()
         VerticalGroup:new{
             align = "left",
             title_bar,
-            CenterContainer:new{
-                dimen = Geom:new{
-                    w = self.width,
-                    h = inner_frame:getSize().h,
-                },
-                inner_frame,
-            },
+            self.center_container,
         }
     }
     self[1] = WidgetContainer:new{
@@ -427,17 +430,27 @@ function FrontLightWidget:layout()
         },
     }
 
+    logger.dbg("FrontLightWidget:layout self.center_container:getSize", self.center_container:getSize())
+    logger.dbg("FrontLightWidget:layout self.inner_frame:getSize", self.inner_frame:getSize())
+    logger.dbg("FrontLightWidget:layout self.frame:getSize", self.frame:getSize())
     logger.dbg("FrontLightWidget:layout self.main_container.dimen", self.main_container.dimen, self.main_container:getSize())
-    logger.dbg("FrontLightWidget:layout self.main_group.dimen", self.main_group.dimen, self.main_group:getSize())
+    logger.dbg("FrontLightWidget:layout self.main_group.dimen", self.main_group:getSize())
 end
 
 function FrontLightWidget:update()
+    --self.main_group:resetLayout() -- invalidate getSize's cache
+    --self.center_container.dimen.h = self.inner_frame:getSize().h
     logger.dbg("FrontLightWidget:update self.main_container.dimen", self.main_container.dimen, self.main_container:getSize())
-    logger.dbg("FrontLightWidget:update self.main_group.dimen", self.main_group.dimen, self.main_group:getSize())
+    logger.dbg("FrontLightWidget:update self.main_group.dimen", self.main_group:getSize())
 
     -- Reset container height to what it actually contains
-    self.main_container.dimen.h = self.main_group:getSize().h
+    --self.main_container.dimen.h = self.main_group:getSize().h
     self:refocusWidget()
+
+    -- Ditto for the frames
+    logger.dbg("FrontLightWidget:layout self.center_container:getSize", self.center_container:getSize())
+    logger.dbg("FrontLightWidget:layout self.inner_frame:getSize", self.inner_frame:getSize())
+    logger.dbg("FrontLightWidget:update self.frame.dimen", self.frame.dimen, self.frame:getSize())
 
     UIManager:setDirty(self, function()
         return "ui", self.frame.dimen
@@ -470,6 +483,8 @@ function FrontLightWidget:rebuildWarmthProgress()
                         end
         })
     end
+
+    logger.dbg("FrontLightWidget:rebuildWarmthProgress self.nl_group.dimen", self.nl_group.dimen, self.nl_group:getSize())
 end
 
 function FrontLightWidget:setBrightness(intensity)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -22,7 +22,6 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
-local logger = require("logger")
 local Screen = Device.screen
 
 local FrontLightWidget = FocusManager:new{
@@ -75,8 +74,6 @@ function FrontLightWidget:init()
             self.nl.steps = self.nl.steps + 1
         end
         self.nl.steps = math.min(self.nl.steps, nl_steps)
-
-        logger.dbg("self.nl:", self.nl)
     end
 
     -- Input
@@ -480,7 +477,6 @@ function FrontLightWidget:setBrightness(intensity)
 end
 
 function FrontLightWidget:setWarmth(warmth, update_position)
-    logger.dbg("FrontLightWidget:setWarmth", warmth, update_position)
     if warmth == self.nl.cur then
         return
     end

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -13,7 +13,7 @@ local Math = require("optmath")
 local NaturalLight = require("ui/widget/naturallightwidget")
 local ProgressWidget = require("ui/widget/progresswidget")
 local Size = require("ui/size")
-local TextBoxWidget = require("ui/widget/textboxwidget")
+local TextWidget = require("ui/widget/textwidget")
 local TimeVal = require("ui/timeval")
 local TitleBar = require("ui/widget/titlebar")
 local UIManager = require("ui/uimanager")
@@ -163,13 +163,11 @@ function FrontLightWidget:layout()
         tick_width = Screen:scaleBySize(0.5),
         last = self.fl.max,
     }
-    -- FIXME: Switch to TextWidget and leave the alignment to a CenterContainer?
-    local fl_header = TextBoxWidget:new{
+    local fl_header = TextWidget:new{
         text = _("Brightness"),
         face = self.medium_font_face,
         bold = true,
-        alignment = "center",
-        width = math.floor(self.screen_width * 0.95),
+        max_width = math.floor(self.screen_width * 0.95),
     }
     self.fl_minus = Button:new{
         text = "−",
@@ -193,11 +191,17 @@ function FrontLightWidget:layout()
             self:setBrightness(self.fl.cur + 1)
         end,
     }
-    self.fl_level = TextBoxWidget:new{
-        text = self.fl.cur,
+    self.fl_level = TextWidget:new{
+        text = tostring(self.fl.cur),
         face = self.medium_font_face,
-        alignment = "center",
-        width = math.floor(self.screen_width * 0.95 - 1.275 * self.fl_minus.width - 1.275 * self.fl_plus.width),
+        max_width = math.floor(self.screen_width * 0.95 - 1.275 * self.fl_minus.width - 1.275 * self.fl_plus.width),
+    }
+    local fl_level_container = CenterContainer:new{
+        dimen = Geom:new{
+            w = self.fl_level.max_width,
+            h = self.fl_level:getSize().h
+        },
+        self.fl_level,
     }
     local fl_min = Button:new{
         text = _("Min"),
@@ -238,7 +242,7 @@ function FrontLightWidget:layout()
     local fl_buttons_above = HorizontalGroup:new{
         align = "center",
         self.fl_minus,
-        self.fl_level,
+        fl_level_container,
         self.fl_plus,
     }
     self.layout[1] = {self.fl_minus, self.fl_plus}
@@ -274,12 +278,12 @@ function FrontLightWidget:layout()
 
         self:rebuildWarmthProgress()
 
-        local nl_header = TextBoxWidget:new{
-            text = "\n" .. _("Warmth"),
+        local nl_span = VerticalSpan:new{ width = Size.span.vertical_large * 4 }
+        local nl_header = TextWidget:new{
+            text = _("Warmth"),
             face = self.medium_font_face,
             bold = true,
-            alignment = "center",
-            width = math.floor(self.screen_width * 0.95),
+            max_width = math.floor(self.screen_width * 0.95),
         }
         self.nl_minus = Button:new{
             text = "−",
@@ -301,11 +305,17 @@ function FrontLightWidget:layout()
             callback = function()
                 self:setWarmth(self.nl.cur + 1) end,
         }
-        self.nl_level = TextBoxWidget:new{
-            text = self.nl.cur,
+        self.nl_level = TextWidget:new{
+            text = tostring(self.nl.cur),
             face = self.medium_font_face,
-            alignment = "center",
-            width = math.floor(self.screen_width * 0.95 - 1.275 * self.nl_minus.width - 1.275 * self.nl_plus.width),
+            max_width = math.floor(self.screen_width * 0.95 - 1.275 * self.nl_minus.width - 1.275 * self.nl_plus.width),
+        }
+        local nl_level_container = CenterContainer:new{
+            dimen = Geom:new{
+                w = self.nl_level.max_width,
+                h = self.nl_level:getSize().h
+            },
+            self.nl_level,
         }
         local nl_min = Button:new{
             text = _("Min"),
@@ -335,7 +345,7 @@ function FrontLightWidget:layout()
         local nl_buttons_above = HorizontalGroup:new{
             align = "center",
             self.nl_minus,
-            self.nl_level,
+            nl_level_container,
             self.nl_plus,
         }
         self.layout[3] = {self.nl_minus, self.nl_plus}
@@ -347,6 +357,7 @@ function FrontLightWidget:layout()
         }
         self.layout[4] = {nl_min, nl_max}
 
+        table.insert(main_group, nl_span)
         table.insert(main_group, nl_header)
         table.insert(nl_group_above, nl_buttons_above)
         table.insert(nl_group_below, nl_buttons_below)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -578,7 +578,7 @@ function FrontLightWidget:onTapProgress(arg, ges_ev)
 
     if ges_ev.pos:intersectWith(self.fl_progress.dimen) then
         -- Unschedule any pending updates.
-        UIManager:unschedule(self.update)
+        UIManager:unschedule(self.refreshBrightnessWidgets)
 
         local perc = self.fl_progress:getPercentageFromPosition(ges_ev.pos)
         if not perc then

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -470,7 +470,7 @@ function FrontLightWidget:rebuildWarmthProgress()
 end
 
 function FrontLightWidget:setBrightness(intensity)
-    if intensity == self.fl.cur then
+    if intensity ~= self.fl.min and intensity == self.fl.cur then
         return
     end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -21,6 +21,7 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
+local logger = require("logger")
 local Screen = Device.screen
 
 local FrontLightWidget = FocusManager:new{
@@ -424,13 +425,13 @@ function FrontLightWidget:layout()
         },
     }
 
-    logger.dbg("FrontLightWidget:layout self.main_container.dimen", self.main_container.dimen)
-    logger.dbg("FrontLightWidget:layout self.main_group.dimen", self.main_group.dimen)
+    logger.dbg("FrontLightWidget:layout self.main_container.dimen", self.main_container.dimen, self.main_container:getSize())
+    logger.dbg("FrontLightWidget:layout self.main_group.dimen", self.main_group.dimen, self.main_group:getSize())
 end
 
 function FrontLightWidget:update()
-    logger.dbg("FrontLightWidget:update self.main_container.dimen", self.main_container.dimen)
-    logger.dbg("FrontLightWidget:update self.main_group.dimen", self.main_group.dimen)
+    logger.dbg("FrontLightWidget:update self.main_container.dimen", self.main_container.dimen, self.main_container:getSize())
+    logger.dbg("FrontLightWidget:update self.main_group.dimen", self.main_group.dimen, self.main_group:getSize())
 
     -- Reset container height to what it actually contains
     self.main_container.dimen.h = self.main_group:getSize().h
@@ -478,8 +479,7 @@ function FrontLightWidget:setBrightness(intensity)
 
     -- Update the progress bar
     self.fl_progress:setPercentage(self.fl.cur / self.fl.max)
-    self.fl_level.text = self.fl.cur
-    self.fl_level:update()
+    self.fl_level:setText(tostring(self.fl.cur))
     if self.fl.cur == self.fl.min then
         self.fl_minus:disable()
     else
@@ -506,8 +506,7 @@ function FrontLightWidget:setWarmth(warmth)
 
     -- Update the progress bar
     self:rebuildWarmthProgress()
-    self.nl_level.text = self.nl.cur
-    self.nl_level:update()
+    self.nl_level:setText(tostring(self.nl.cur))
     if self.nl.cur == self.nl.min then
         self.nl_minus:disable()
     else

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -258,6 +258,7 @@ function FrontLightWidget:layout()
 
         self.nl_progress = ButtonProgressWidget:new{
             width = math.floor(self.screen_width * 0.9),
+            font_size = 20, -- match Button's default
             padding = 0,
             thin_grey_style = false,
             num_buttons = self.nl.steps - 1, -- no button for step 0

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -65,7 +65,7 @@ function FrontLightWidget:init()
         self.nl = {}
         self.nl.min = self.powerd.fl_warmth_min
         self.nl.max = self.powerd.fl_warmth_max
-        self.nl.cur = self.powerd:frontlightWarmth()
+        self.nl.cur = self.powerd:toNativeWarmth(self.powerd:frontlightWarmth())
 
         local nl_steps = self.nl.max - self.nl.min + 1
         self.nl.stride = math.ceil(nl_steps / 25)
@@ -74,6 +74,8 @@ function FrontLightWidget:init()
             self.nl.steps = self.nl.steps + 1
         end
         self.nl.steps = math.min(self.nl.steps, nl_steps)
+
+        logger.dbg("self.nl:", self.nl)
     end
 
     -- Input
@@ -447,6 +449,7 @@ function FrontLightWidget:rebuildWarmthProgress()
     self.nl_group:clear()
 
     local curr_warmth_step = math.floor(self.nl.cur / self.nl.stride)
+    logger.dbg("curr_warmth_step:", curr_warmth_step)
     if curr_warmth_step > 0 then
         for i = 1, curr_warmth_step do
             table.insert(self.nl_group, self.nl_prog_button:new{

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -463,6 +463,7 @@ function FrontLightWidget:refreshBrightnessWidgets()
 end
 
 function FrontLightWidget:setBrightness(intensity)
+    -- Let fl.min through, as that's what we use for the Toggle button ;).
     if intensity ~= self.fl.min and intensity == self.fl.cur then
         return
     end

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -49,7 +49,7 @@ function FrontLightWidget:init()
     self.fl.max = self.powerd.fl_max
     self.fl.cur = self.powerd:frontlightIntensity()
     local fl_steps = self.fl.max - self.fl.min + 1
-    slef.fl.stride = math.ceil(fl_steps / 25)
+    self.fl.stride = math.ceil(fl_steps / 25)
     self.fl.steps = math.ceil(fl_steps / self.fl.stride)
     if (self.fl.steps - 1) * self.fl.stride < self.fl.max - self.fl.min then
         self.fl.steps = self.fl.steps + 1
@@ -136,7 +136,10 @@ function FrontLightWidget:layout()
     end
 
     self.main_container = CenterContainer:new{
-        dimen = Geom:new{ w = width, h = height },
+        dimen = Geom:new{
+            w = self.width,
+            h = math.floor(self.screen_height * 0.2),
+        },
     }
 
     -- Frontlight
@@ -239,7 +242,7 @@ function FrontLightWidget:layout()
         align = "center",
         fl_min,
         fl_spacer,
-        button_toggle,
+        fl_toggle,
         fl_spacer,
         fl_max,
     }
@@ -448,7 +451,7 @@ function FrontLightWidget:rebuildWarmthProgress()
         table.insert(self.nl_group, self.nl_prog_button:new{
                         text = "",
                         callback = function()
-                            self:setWarmth(i * sself.nl.stride)
+                            self:setWarmth(i * self.nl.stride)
                         end
         })
     end
@@ -511,7 +514,7 @@ function FrontLightWidget:setFrontLightIntensity(intensity)
     self.fl.cur = intensity
 
     -- min (which is always 0) means toggle
-    if set.fl == self.fl.min then
+    if self.fl.cur == self.fl.min then
         self.powerd:toggleFrontlight()
     else
         self.powerd:setIntensity(self.fl.cur)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -57,6 +57,10 @@ function FrontLightWidget:init()
         self.nl_min = self.powerd.fl_warmth_min
         self.nl_max = self.powerd.fl_warmth_max
 
+        -- NOTE: fl_warmth is always [0...100] even when internal scale is [0...10],
+        --       but we want the UI to reflect the *internal* scale.
+        self.nl_scale = (100 / self.nl_max)
+
         local steps_nl = self.nl_max - self.nl_min + 1
         self.one_step_nl = math.ceil(steps_nl / 25)
         self.steps_nl = math.ceil(steps_nl / self.one_step_nl)
@@ -130,7 +134,7 @@ function FrontLightWidget:setProgress(num, step, num_warmth)
     local enable_button_plus = true
     local enable_button_minus = true
     if self.natural_light then
-        num_warmth = num_warmth or self.powerd.fl_warmth
+        num_warmth = num_warmth or math.floor(self.powerd.fl_warmth / self.nl_scale)
     end
     if num then
         --- @note Don't set the same value twice, to play nice with the update() sent by the swipe handler on the FL bar
@@ -194,7 +198,7 @@ function FrontLightWidget:setProgress(num, step, num_warmth)
         enabled = true,
         width = math.floor(self.screen_width * 0.2),
         show_parent = self,
-        callback = function() self:setProgress(self.fl_min+1, step) end, -- min is 1 (use toggle for 0)
+        callback = function() self:setProgress(self.fl_min + 1, step) end, -- min is 1 (use toggle for 0)
     }
     local button_max = Button:new{
         text = _("Max"),
@@ -289,8 +293,8 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
 
     if self[1] then
         --- @note Don't set the same value twice, to play nice with the update() sent by the swipe handler on the FL bar
-        if num_warmth ~= self.powerd.fl_warmth then
-            self.powerd:setWarmth(num_warmth)
+        if num_warmth ~= math.floor(self.powerd.fl_warmth / self.nl_scale) then
+            self.powerd:setWarmth(math.floor(num_warmth * self.nl_scale))
         end
     end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -469,15 +469,7 @@ function FrontLightWidget:rebuildWarmthProgress()
     logger.dbg("FrontLightWidget:rebuildWarmthProgress self.nl_group.dimen", self.nl_group.dimen, self.nl_group:getSize())
 end
 
-function FrontLightWidget:setBrightness(intensity)
-    if intensity ~= self.fl.min and intensity == self.fl.cur then
-        return
-    end
-
-    -- Set brightness
-    self:setFrontLightIntensity(intensity)
-
-    -- Update the progress bar
+function FrontLightWidget:updateBrightnessWidgets()
     self.fl_progress:setPercentage(self.fl.cur / self.fl.max)
     self.fl_level:setText(tostring(self.fl.cur))
     if self.fl.cur == self.fl.min then
@@ -490,6 +482,23 @@ function FrontLightWidget:setBrightness(intensity)
     else
         self.fl_plus:enable()
     end
+end
+
+function FrontLightWidget:refreshBrightnessWidgets()
+    self:updateBrightnessWidgets()
+    self:update()
+end
+
+function FrontLightWidget:setBrightness(intensity)
+    if intensity ~= self.fl.min and intensity == self.fl.cur then
+        return
+    end
+
+    -- Set brightness
+    self:setFrontLightIntensity(intensity)
+
+    -- Update the progress bar
+    self:updateBrightnessWidgets()
 
     -- Refresh widget
     self:update()
@@ -588,12 +597,12 @@ function FrontLightWidget:onTapProgress(arg, ges_ev)
                 self.last_time = current_time
             else
                 -- Schedule a final update after we stop panning.
-                UIManager:scheduleIn(0.075, self.update, self)
+                UIManager:scheduleIn(0.075, self.refreshBrightnessWidgets, self)
                 return true
             end
         end
 
-        self:update()
+        self:refreshBrightnessWidgets()
     elseif not ges_ev.pos:intersectWith(self.frame.dimen) and ges_ev.ges == "tap" then
         -- close if tap outside
         self:onClose()

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -134,7 +134,7 @@ function FrontLightWidget:setProgress(num, step, num_warmth)
     local enable_button_plus = true
     local enable_button_minus = true
     if self.natural_light then
-        num_warmth = num_warmth or math.floor(self.powerd.fl_warmth / self.nl_scale)
+        num_warmth = num_warmth or math.floor(self.powerd.fl_warmth / self.nl_scale + 0.5)
     end
     if num then
         --- @note Don't set the same value twice, to play nice with the update() sent by the swipe handler on the FL bar
@@ -293,8 +293,8 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
 
     if self[1] then
         --- @note Don't set the same value twice, to play nice with the update() sent by the swipe handler on the FL bar
-        if num_warmth ~= math.floor(self.powerd.fl_warmth / self.nl_scale) then
-            self.powerd:setWarmth(math.floor(num_warmth * self.nl_scale))
+        if num_warmth ~= math.floor(self.powerd.fl_warmth / self.nl_scale + 0.5) then
+            self.powerd:setWarmth(math.floor(num_warmth * self.nl_scale + 0.5))
         end
     end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -188,7 +188,7 @@ function FrontLightWidget:layout()
         show_parent = self,
         callback = function()
             self:setBrightness(self.fl.min + 1)
-        end, -- min is 1 (use toggle for 0)
+        end, -- min is 1 (We use 0 to mean "toggle")
     }
     local fl_max = Button:new{
         text = _("Max"),
@@ -233,7 +233,8 @@ function FrontLightWidget:layout()
     self.layout[2] = {fl_min, fl_toggle, fl_max}
 
     if self.has_nl then
-        -- Only insert 'Brightness' caption if we also add 'warmth' widgets below.
+        -- Only insert a "Brightness" caption if we also add the full set of warmth widgets below,
+        -- otherwise, it's implied by the title bar ;).
         table.insert(main_group, fl_header)
     end
     table.insert(fl_group_above, fl_buttons_above)
@@ -267,6 +268,7 @@ function FrontLightWidget:layout()
             show_parent = self,
             enabled = true,
         }
+        -- We want a wider gap between the two sets of widgets
         local nl_span = VerticalSpan:new{ width = Size.span.vertical_large * 4 }
         local nl_header = TextWidget:new{
             text = _("Warmth"),
@@ -517,7 +519,7 @@ function FrontLightWidget:setFrontLightIntensity(intensity)
         self.powerd:setIntensity(self.fl.cur)
     end
 
-    -- Retrieve the real level (different from set_fl on toggle)
+    -- Retrieve the real level (different from intensity on toggle)
     self.fl.cur = self.powerd:frontlightIntensity()
 end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -296,14 +296,16 @@ function FrontLightWidget:addWarmthWidgets(num_warmth, step, vertical_group)
 
     if self.natural_light and num_warmth then
         local curr_warmth_step = math.floor(num_warmth / step)
-        for i = 0, curr_warmth_step do
-            table.insert(warmth_group, self.fl_prog_button:new{
-                             text = "",
-                             preselect = curr_warmth_step > 0 and true or false,
-                             callback = function()
-                                 self:setProgress(self.fl_cur, step, i * step)
-                             end
-            })
+        if curr_warmth_step > 0 then
+            for i = 1, curr_warmth_step do
+                table.insert(warmth_group, self.fl_prog_button:new{
+                                text = "",
+                                preselect = curr_warmth_step > 0 and true or false,
+                                callback = function()
+                                    self:setProgress(self.fl_cur, step, i * step)
+                                end
+                })
+            end
         end
 
         for i = curr_warmth_step + 1, self.steps_nl - 1 do

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -163,7 +163,7 @@ function FrontLightWidget:layout()
         tick_width = Screen:scaleBySize(0.5),
         last = self.fl.max,
     }
-    -- FIXME: Switch to TextWidget and leave the alignment to an HorizontalSpan?
+    -- FIXME: Switch to TextWidget and leave the alignment to a CenterContainer?
     local fl_header = TextBoxWidget:new{
         text = _("Brightness"),
         face = self.medium_font_face,
@@ -172,7 +172,7 @@ function FrontLightWidget:layout()
         width = math.floor(self.screen_width * 0.95),
     }
     self.fl_minus = Button:new{
-        text = "-1",
+        text = "−",
         margin = Size.margin.small,
         radius = 0,
         enabled = self.fl.cur ~= self.fl.min,
@@ -183,7 +183,7 @@ function FrontLightWidget:layout()
         end,
     }
     self.fl_plus = Button:new{
-        text = "+1",
+        text = "＋",
         margin = Size.margin.small,
         radius = 0,
         enabled = self.fl.cur ~= self.fl.max,
@@ -282,7 +282,7 @@ function FrontLightWidget:layout()
             width = math.floor(self.screen_width * 0.95),
         }
         self.nl_minus = Button:new{
-            text = "-1",
+            text = "−",
             margin = Size.margin.small,
             radius = 0,
             enabled = self.nl.cur ~= self.nl.min,
@@ -292,7 +292,7 @@ function FrontLightWidget:layout()
                 self:setWarmth(self.nl.cur - 1) end,
         }
         self.nl_plus = Button:new{
-            text = "+1",
+            text = "＋",
             margin = Size.margin.small,
             radius = 0,
             enabled = self.nl.cur ~= self.nl.max,

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -39,7 +39,7 @@ function FrontLightWidget:init()
     self.medium_font_face = Font:getFace("ffont")
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
-    self.span = math.ceil(self.screen_height * 0.01)
+    self.span = Math.round(self.screen_height * 0.01)
     self.width = math.floor(self.screen_width * 0.95)
 
     -- State constants
@@ -123,7 +123,8 @@ function FrontLightWidget:layout()
     }
 
     -- Frontlight
-    local padding_span = VerticalSpan:new{ width = self.span }
+    -- Bigger spans, as ProgressWidget appears to be ever so slightly smaller than ButtonProgressWidget ;).
+    local fl_padding_span = VerticalSpan:new{ width = Math.round(self.span * 1.5) }
     local fl_group_above = HorizontalGroup:new{ align = "center" }
     local fl_group_below = HorizontalGroup:new{ align = "center" }
     local main_group = VerticalGroup:new{ align = "center" }
@@ -240,16 +241,18 @@ function FrontLightWidget:layout()
     end
     table.insert(fl_group_above, fl_buttons_above)
     table.insert(fl_group_below, fl_buttons_below)
-    table.insert(main_group, padding_span)
+    table.insert(main_group, fl_padding_span)
     table.insert(main_group, fl_group_above)
-    table.insert(main_group, padding_span)
+    table.insert(main_group, fl_padding_span)
     table.insert(main_group, self.fl_progress)
-    table.insert(main_group, padding_span)
+    table.insert(main_group, fl_padding_span)
     table.insert(main_group, fl_group_below)
-    table.insert(main_group, padding_span)
+    table.insert(main_group, fl_padding_span)
 
     -- Warmth
     if self.has_nl then
+        -- Smaller spans, as ButtonProgressWidget appears to be ever so slightly taller than ProgressWidget ;).
+        local nl_padding_span = VerticalSpan:new{ width = self.span }
         local nl_group_above = HorizontalGroup:new{ align = "center" }
         local nl_group_below = HorizontalGroup:new{ align = "center" }
 
@@ -350,13 +353,13 @@ function FrontLightWidget:layout()
         table.insert(nl_group_above, nl_buttons_above)
         table.insert(nl_group_below, nl_buttons_below)
 
-        table.insert(main_group, padding_span)
+        table.insert(main_group, nl_padding_span)
         table.insert(main_group, nl_group_above)
-        table.insert(main_group, padding_span)
+        table.insert(main_group, nl_padding_span)
         table.insert(main_group, self.nl_progress)
-        table.insert(main_group, padding_span)
+        table.insert(main_group, nl_padding_span)
         table.insert(main_group, nl_group_below)
-        table.insert(main_group, padding_span)
+        table.insert(main_group, nl_padding_span)
 
         -- Aura One R/G/B widget
         if not self.has_nl_mixer and not self.has_nl_api then

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -517,6 +517,11 @@ function InputText:initTextBox(text, char_added)
         self.edit_callback(self.is_text_edited)
     end
 end
+dbg:guard(InputText, "initTextBox",
+    function(self, text, char_added)
+        assert(type(text) == "string",
+            "Wrong text type (expected string)")
+    end)
 
 function InputText:initKeyboard()
     local keyboard_layer = 2
@@ -634,6 +639,11 @@ function InputText:onTextInput(text)
     end
     return false
 end
+dbg:guard(InputText, "onTextInput",
+    function(self, text)
+        assert(type(text) == "string",
+            "Wrong text type (expected string)")
+    end)
 
 function InputText:onShowKeyboard(ignore_first_hold_release)
     Device:startTextInput()
@@ -932,5 +942,10 @@ function InputText:setText(text, keep_edited_state)
         self:checkTextEditability()
     end
 end
+dbg:guard(InputText, "setText",
+    function(self, text, keep_edited_state)
+        assert(type(text) == "string",
+            "Wrong text type (expected string)")
+    end)
 
 return InputText

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -360,7 +360,7 @@ end
 -- lines than before
 function InputText:initTextBox(text, char_added)
     if self.text_widget then
-        self.text_widget:free()
+        self.text_widget:free(true)
     end
     self.text = text
     local fgcolor
@@ -438,7 +438,7 @@ function InputText:initTextBox(text, char_added)
         }
         self.height = text_widget:getTextHeight()
         self.scroll = true
-        text_widget:free()
+        text_widget:free(true)
     end
     if self.scroll then
         self.text_widget = ScrollTextWidget:new{

--- a/frontend/ui/widget/naturallightwidget.lua
+++ b/frontend/ui/widget/naturallightwidget.lua
@@ -347,7 +347,7 @@ end
 
 function NaturalLightWidget:setValueTextBox(widget, val)
     widget:focus()
-    widget:setText(val)
+    widget:setText(tostring(val))
     widget:unfocus()
 end
 
@@ -360,7 +360,7 @@ end
 
 function NaturalLightWidget:onShow()
     UIManager:setDirty(self, function()
-                           return "ui", self.nl_frame.dimen
+        return "ui", self.nl_frame.dimen
     end)
     -- Store values in case user cancels
     self.old_values = self:getCurrentValues()

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1180,9 +1180,7 @@ function TextBoxWidget:setText(text)
     end
 
     self.text = text
-
     self:_computeTextDimensions()
-
     self:update()
 
     -- Don't break the reference

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -28,6 +28,7 @@ local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
 local Math = require("optmath")
 local logger = require("logger")
+local dbg = require("dbg")
 local util = require("util")
 local Screen = require("device").screen
 
@@ -1167,6 +1168,28 @@ function TextBoxWidget:update(scheduled_update)
     self:_updateLayout()
     self.scheduled_update = nil
 end
+
+function TextBoxWidget:setText(text)
+    if text == self.text then
+        return
+    end
+
+    self.text = text
+
+    if self.use_xtext then
+        self:_measureWithXText()
+    else
+        self:_evalCharWidthList()
+    end
+    self:_splitToLines()
+
+    self:update()
+end
+dbg:guard(TextBoxWidget, "setText",
+    function(self, text)
+        assert(type(text) == "string",
+            "Wrong text type (expected string)")
+    end)
 
 function TextBoxWidget:onTapImage(arg, ges)
     if self.line_num_to_image and self.line_num_to_image[self.virtual_line_num] then

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1185,7 +1185,10 @@ function TextBoxWidget:setText(text)
 
     self:update()
 
-    self.dimen = Geom:new(self:getSize())
+    -- Don't break the reference
+    local new_size = self:getSize()
+    self.dimen.w = new_size.w
+    self.dimen.h = new_size.h
 end
 dbg:guard(TextBoxWidget, "setText",
     function(self, text)

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -152,6 +152,26 @@ function TextBoxWidget:init()
         self.text_height = self.lines_per_page * self.line_height_px
     end
 
+    self:_computeDimensions()
+    self:_updateLayout()
+    if self.editable then
+        self:moveCursorToCharPos(self.charpos or 1)
+    end
+    self.dimen = Geom:new(self:getSize())
+
+    if Device:isTouchDevice() then
+        self.ges_events = {
+            TapImage = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = function() return self.dimen end,
+                },
+            },
+        }
+    end
+end
+
+function TextBoxWidget:_computeDimensions()
     if self.use_xtext then
         self:_measureWithXText()
     else
@@ -185,21 +205,6 @@ function TextBoxWidget:init()
         if self.editable and self.charpos then
             self:scrollViewToCharPos()
         end
-    end
-    self:_updateLayout()
-    if self.editable then
-        self:moveCursorToCharPos(self.charpos or 1)
-    end
-    self.dimen = Geom:new(self:getSize())
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapImage = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = function() return self.dimen end,
-                },
-            },
-        }
     end
 end
 
@@ -1176,12 +1181,7 @@ function TextBoxWidget:setText(text)
 
     self.text = text
 
-    if self.use_xtext then
-        self:_measureWithXText()
-    else
-        self:_evalCharWidthList()
-    end
-    self:_splitToLines()
+    self:_computeDimensions()
 
     self:update()
 end

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -152,7 +152,7 @@ function TextBoxWidget:init()
         self.text_height = self.lines_per_page * self.line_height_px
     end
 
-    self:_computeDimensions()
+    self:_computeTextDimensions()
     self:_updateLayout()
     if self.editable then
         self:moveCursorToCharPos(self.charpos or 1)
@@ -171,7 +171,7 @@ function TextBoxWidget:init()
     end
 end
 
-function TextBoxWidget:_computeDimensions()
+function TextBoxWidget:_computeTextDimensions()
     if self.use_xtext then
         self:_measureWithXText()
     else
@@ -1181,9 +1181,11 @@ function TextBoxWidget:setText(text)
 
     self.text = text
 
-    self:_computeDimensions()
+    self:_computeTextDimensions()
 
     self:update()
+
+    self.dimen = Geom:new(self:getSize())
 end
 dbg:guard(TextBoxWidget, "setText",
     function(self, text)

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -312,10 +312,12 @@ function TextWidget:getBaseline()
 end
 
 function TextWidget:setText(text)
-    if text ~= self.text then
-        self.text = text
-        self:free()
+    if text == self.text then
+        return
     end
+
+    self.text = text
+    self:free()
 end
 dbg:guard(TextWidget, "setText",
     function(self, text)

--- a/frontend/ui/widget/titlebar.lua
+++ b/frontend/ui/widget/titlebar.lua
@@ -162,7 +162,7 @@ function TitleBar:init()
                 -- gathered, we'll re :init() ourselves with the original title,
                 -- using the metrics we're computing now (self._initial*).
                 self._initial_re_init_needed = true
-                self.title_widget:free(full)
+                self.title_widget:free(true)
                 self.title_widget = TextWidget:new{
                     text = "",
                     face = title_face,
@@ -171,7 +171,7 @@ function TitleBar:init()
                 break
             end
             -- otherwise, loop and do the same with a smaller font size
-            self.title_widget:free(full)
+            self.title_widget:free(true)
             title_face = Font:getFace(title_face.orig_font, title_face.orig_size - 1)
         end
     end

--- a/frontend/ui/widget/titlebar.lua
+++ b/frontend/ui/widget/titlebar.lua
@@ -162,7 +162,7 @@ function TitleBar:init()
                 -- gathered, we'll re :init() ourselves with the original title,
                 -- using the metrics we're computing now (self._initial*).
                 self._initial_re_init_needed = true
-                self.title_widget:free()
+                self.title_widget:free(full)
                 self.title_widget = TextWidget:new{
                     text = "",
                     face = title_face,
@@ -171,7 +171,7 @@ function TitleBar:init()
                 break
             end
             -- otherwise, loop and do the same with a smaller font size
-            self.title_widget:free()
+            self.title_widget:free(full)
             title_face = Font:getFace(title_face.orig_font, title_face.orig_size - 1)
         end
     end

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -582,7 +582,6 @@ function ListMenuItem:update()
                 -- Free previously made widgets to avoid memory leaks
                 if wtitle then
                     wtitle:free(true)
-                    wtitle = nil
                 end
                 if wauthors then
                     wauthors:free(true)

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -581,10 +581,11 @@ function ListMenuItem:update()
             while true do
                 -- Free previously made widgets to avoid memory leaks
                 if wtitle then
-                    wtitle:free()
+                    wtitle:free(true)
+                    wtitle = nil
                 end
                 if wauthors then
-                    wauthors:free()
+                    wauthors:free(true)
                     wauthors = nil
                 end
                 -- BookInfoManager:extractBookInfo() made sure
@@ -730,7 +731,7 @@ function ListMenuItem:update()
             local fontsize_no_bookinfo = _fontSize(18, 22)
             repeat
                 if text_widget then
-                    text_widget:free()
+                    text_widget:free(true)
                 end
                 text_widget = TextBoxWidget:new{
                     text = text .. hint,

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -211,15 +211,15 @@ function FakeCover:init()
     while true do
         -- Free previously made widgets to avoid memory leaks
         if authors_wg then
-            authors_wg:free()
+            authors_wg:free(true)
             authors_wg = nil
         end
         if title_wg then
-            title_wg:free()
+            title_wg:free(true)
             title_wg = nil
         end
         if filename_wg then
-            filename_wg:free()
+            filename_wg:free(true)
             filename_wg = nil
         end
         -- Build new widgets
@@ -485,7 +485,7 @@ function MosaicMenuItem:update()
         local directory
         while true do
             if directory then
-                directory:free()
+                directory:free(true)
             end
             directory = TextBoxWidget:new{
                 text = text,

--- a/reader.lua
+++ b/reader.lua
@@ -146,6 +146,7 @@ if dpi_override ~= nil then
     Device:setScreenDPI(dpi_override)
 end
 -- Night mode
+local hw_nightmode = Device.screen:getHWNightmode()
 if G_reader_settings:isTrue("night_mode") then
     Device.screen:toggleNightMode()
 end
@@ -346,6 +347,9 @@ local function exitReader()
 
     -- Close lipc handles
     ReaderActivityIndicator:coda()
+
+    -- Restore initial inversion state
+    Device.screen:setHWNightmode(hw_nightmode)
 
     -- shutdown hardware abstraction
     Device:exit()


### PR DESCRIPTION
Requires https://github.com/koreader/koreader-base/pull/1457

(Oh, hello there, "mystery" device ;p).

----

* Rejig frontlight warmth API to more closely match the existing API, and, hopefully, clarify some of its quirks, and reduce boilerplate and duplicate code in platform implementations.
* Tweak Kindle:setDateTime to prefer using the platform's custom script, as in interacts better with the stock UI. And make the fallbacks handle old busybox versions better.
* Add Kindle PW5 support ;).
* Add warmth support to the Kindle platform.
* Random TextBoxWidget cleanups: make sure we immediately free destroyed instances.
* FrontLightWidget: Refactor to make it slightly less obnoxious to grok and update; i.e., separate layout from update, and properly separate brightness from warmth handling. Move to simpler widgets instead of reinventing the wheel.
* TextBoxWidgets: Implement `setText` to match TextWidget's API, as some callers may be using the two interchangeably (i.e., Button).
* NaturalLightWidget: Make sure we pass a string to InputText
* InputText: Add debug guards to catch bad callers not passing strings ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8856)
<!-- Reviewable:end -->
