### PR TITLE
Non touch improvements

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -641,6 +641,7 @@ function CloudStorage:createFolder(url)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(input_dialog)
                     end,

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -131,6 +131,7 @@ function DropBox:config(item, callback)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.settings_dialog:onClose()
                         UIManager:close(self.settings_dialog)

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -125,6 +125,7 @@ Username and password are optional.]])
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.settings_dialog:onClose()
                         UIManager:close(self.settings_dialog)

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -110,6 +110,7 @@ The start folder is appended to the server path.]])
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.settings_dialog:onClose()
                         UIManager:close(self.settings_dialog)

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -255,6 +255,7 @@ function FileManager:setupLayout()
                             buttons = {{
                                 {
                                     text = _("Cancel"),
+                                    id = "close",
                                     enabled = true,
                                     callback = function()
                                         UIManager:close(file_manager.rename_dialog)
@@ -1015,6 +1016,7 @@ function FileManager:createFolder()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(input_dialog)
                     end,

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -125,6 +125,7 @@ function FileSearcher:onShowFileSearch(search_string)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.search_dialog)
                     end,

--- a/frontend/apps/filemanager/filemanagersetdefaults.lua
+++ b/frontend/apps/filemanager/filemanagersetdefaults.lua
@@ -112,6 +112,7 @@ function SetDefaults:init()
 
     local cancel_button = {
         text = _("Cancel"),
+        id = "close",
         enabled = true,
         callback = function()
             self:close()

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -82,6 +82,7 @@ function FileManagerShortcuts:addNewFolder()
                     {
                         {
                             text = _("Cancel"),
+                            id = "close",
                             callback = function()
                                 UIManager:close(add_folder_input)
                             end,
@@ -168,6 +169,7 @@ function FileManagerShortcuts:editFolderShortcut(item)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(edit_folder_input)
                     end,

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1055,6 +1055,7 @@ function ReaderBookmark:renameBookmark(item, from_highlight, is_new_note, new_te
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.input)
                         if is_new_note then -- "Add note" cancelled, remove saved highlight
@@ -1121,6 +1122,7 @@ function ReaderBookmark:onSearchBookmark(bm_menu)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(input_dialog)
                     end,

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -689,6 +689,7 @@ function ReaderDictionary:onShowDictionaryLookup()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.dictionary_lookup_dialog)
                     end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -642,6 +642,7 @@ function ReaderFooter:set_custom_text(touchmenu_instance)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(text_dialog)
                     end,

--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -81,6 +81,7 @@ x for an absolute page number
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self:close()
                     end,

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -114,6 +114,7 @@ function ReaderSearch:onShowFulltextSearchInput()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.input_dialog)
                     end,

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -812,15 +812,20 @@ function ReaderToc:onShowToc()
     end
 
     function toc_menu:onMenuHold(item)
-        -- Match the items' width
-        local infomessage = InfoMessage:new{
-            width = Screen:getWidth() - (Size.padding.fullscreen * (can_collapse and 4 or 3)),
-            alignment = "center",
-            show_icon = false,
-            text = item.text,
-            face = Font:getFace("infofont", self.items_font_size),
-        }
-        UIManager:show(infomessage)
+        if not Device:isTouchDevice() and (item.state and item.state.callback) then
+            -- non touch to expand toc
+            item.state.callback()
+        else
+            -- Match the items' width
+            local infomessage = InfoMessage:new{
+                width = Screen:getWidth() - (Size.padding.fullscreen * (can_collapse and 4 or 3)),
+                alignment = "center",
+                show_icon = false,
+                text = item.text,
+                face = Font:getFace("infofont", self.items_font_size),
+            }
+            UIManager:show(infomessage)
+        end
         return true
     end
 

--- a/frontend/apps/reader/modules/readeruserhyph.lua
+++ b/frontend/apps/reader/modules/readeruserhyph.lua
@@ -188,6 +188,7 @@ function ReaderUserHyph:modifyUserEntry(word)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(input_dialog)
                     end,

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -44,6 +44,7 @@ function ReaderWikipedia:lookupInput()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.input_dialog)
                     end,
@@ -153,6 +154,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                             {
                                 {
                                     text = _("Cancel"),
+                                    id = "close",
                                     callback = function()
                                         UIManager:close(wikilang_input)
                                     end,

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -661,6 +661,7 @@ function ReaderUI:unlockDocumentWithPassword(document, try_again)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     enabled = true,
                     callback = function()
                         self:closeDialog()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -167,7 +167,7 @@ function Kindle:setDateTime(year, month, day, hour, min, sec)
     end
     for _, command in ipairs(commands) do
         if os.execute(command) == 0 then
-            os.execute('hwclock -u -w')
+            os.execute("hwclock -u -w")
             return true
         end
     end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -155,18 +155,23 @@ end
 
 function Kindle:setDateTime(year, month, day, hour, min, sec)
     if hour == nil or min == nil then return true end
-    local command
+    local commands = {}
     if year and month and day then
-        command = string.format("date -s '%d-%d-%d %d:%d:%d'", year, month, day, hour, min, sec)
+        table.insert(commands, string.format("date -s '%d-%d-%d %d:%d:%d'", year, month, day, hour, min, sec))
+        --Kindle DX
+        --BusyBox v1.7.2 (2011-01-13 18:01:58 PST) multi-call binary
+        --Usage: date [OPTION]... [MMDDhhmm[[CC]YY][.ss]] [+FORMAT]
+        table.insert(commands, string.format("date -s '%02d%02d%02d%02d%04d.%02d'", month, day, hour, min, year, sec))
     else
-        command = string.format("date -s '%d:%d'",hour, min)
+        table.insert(commands,string.format("date -s '%d:%d'",hour, min))
     end
-    if os.execute(command) == 0 then
-        os.execute('hwclock -u -w')
-        return true
-    else
-        return false
+    for _, command in ipairs(commands) do
+        if os.execute(command) == 0 then
+            os.execute('hwclock -u -w')
+            return true
+        end
     end
+    return false
 end
 
 function Kindle:usbPlugIn()

--- a/frontend/device/sdl/event_map_sdl2.lua
+++ b/frontend/device/sdl/event_map_sdl2.lua
@@ -65,6 +65,7 @@ return {
     [1073742050] = "Alt", -- left alt
     [1073742054] = "AA", -- right alt key
     [1073741925] = "ContextMenu", -- Context menu key
+    [1073741942] = "ContextMenu", -- Context menu key
     [0x400000E0] = "Ctrl", -- Left Ctrl
     [0x400000E4] = "Ctrl", -- Right Ctrl
     [1073742051] = "Win", -- Left Win/Cmd

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -365,6 +365,7 @@ function Screensaver:setMessage()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.input_dialog)
                     end,

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -253,6 +253,7 @@ function ButtonProgressWidget:update()
         table.insert(self.layout[1], button)
     end
 
+    self:refocusWidget()
     UIManager:setDirty(self.show_parrent, function()
         return "ui", self.dimen
     end)

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -24,12 +24,10 @@ local ButtonTable = FocusManager:new{
     zero_sep = false,
     button_font_face = "cfont",
     button_font_size = 20,
-    auto_focus_first_button = true,
 }
 
 function ButtonTable:init()
     self.width = self.width or math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.9)
-    self.selected = { x = 1, y = 1 }
     self.buttons_layout = {}
     self.button_by_id = {}
     self.container = VerticalGroup:new{ width = self.width }
@@ -100,10 +98,7 @@ function ButtonTable:init()
     self:addHorizontalSep(true, false, false)
     if Device:hasDPad() then
         self.layout = self.buttons_layout
-        if self.auto_focus_first_button then
-            self.layout[1][1]:onFocus()
-        end
-        self.key_events.SelectByKeyPress = { {{"Press"}} }
+        self:refocusWidget()
     else
         self.key_events = {}  -- deregister all key press event listeners
     end
@@ -127,15 +122,6 @@ function ButtonTable:addHorizontalSep(vspan_before, add_line, vspan_after, black
         table.insert(self.container,
                      VerticalSpan:new{ width = Size.span.vertical_default })
     end
-end
-
-function ButtonTable:onSelectByKeyPress()
-    local item = self:getFocusItem()
-    if item and item.enabled then
-        item.callback()
-        return true
-    end
-    return false
 end
 
 function ButtonTable:getButtonById(id)

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -16,7 +16,6 @@ Example:
 
 local Blitbuffer = require("ffi/blitbuffer")
 local CheckMark = require("ui/widget/checkmark")
-local Device = require("device")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local GestureRange = require("ui/gesturerange")
@@ -97,32 +96,30 @@ function CheckButton:initCheckButton(checked)
     self.dimen = self._frame:getSize()
     self[1] = self._frame
 
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapCheckButton = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Tap Button",
+    self.ges_events = {
+        TapCheckButton = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldCheckButton = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold Button",
+            doc = "Tap Button",
+        },
+        HoldCheckButton = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-            -- Safe-guard for when used inside a MovableContainer
-            HoldReleaseCheckButton = {
-                GestureRange:new{
-                    ges = "hold_release",
-                    range = self.dimen,
-                },
-                doc = "Hold Release Button",
-            }
+            doc = "Hold Button",
+        },
+        -- Safe-guard for when used inside a MovableContainer
+        HoldReleaseCheckButton = {
+            GestureRange:new{
+                ges = "hold_release",
+                range = self.dimen,
+            },
+            doc = "Hold Release Button",
         }
-    end
+    }
 end
 
 function CheckButton:onTapCheckButton()
@@ -223,6 +220,22 @@ function CheckButton:disable()
     UIManager:setDirty(self.parent, function()
         return "ui", self.dimen
     end)
+end
+
+function CheckButton:onFocus()
+    if not self.enabled then
+        return false
+    end
+    self._frame.invert = true
+    return true
+end
+
+function CheckButton:onUnfocus()
+    if not self.enabled then
+        return false
+    end
+    self._frame.invert = false
+    return true
 end
 
 return CheckButton

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -923,7 +923,7 @@ function ConfigDialog:update()
     self.dialog_frame.dimen = old_dimen
 
     -- Reset the focusmanager cursor
-    self:moveFocusTo(self.panel_index, #self.layout)
+    self:moveFocusTo(self.panel_index, #self.layout, FocusManager.NOT_FOCUS)
 
     self[1] = BottomContainer:new{
         dimen = Screen:getSize(),

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -665,9 +665,7 @@ end
 function ConfigOption:_itemGroupToLayoutLine(option_items_group)
     local layout_line  = {}
     -- Insert items (skpping item_spacing without a .name attribute),
-    -- skipping indices at the beginning of the line in the layout
-    -- to align it with the current selected tab
-    local j = self.config.panel_index
+    local j = 1 -- no nil in row head
     for i, v in ipairs(option_items_group) do
         if v.name then
             if v.layout and v.disableFocusManagement then -- it is a FocusManager
@@ -680,7 +678,7 @@ function ConfigOption:_itemGroupToLayoutLine(option_items_group)
                         j = j + 1
                     end
                 end
-                v:disableFocusManagement()
+                v:disableFocusManagement(self.config)
             else
                 layout_line[j] = v
                 j = j + 1
@@ -883,9 +881,6 @@ function ConfigDialog:init()
         local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
         self.key_events.Close = { { close_keys }, doc = "close config menu" }
     end
-    if Device:hasDPad() then
-        self.key_events.Select = { {"Press"}, doc = "select current menu item" }
-    end
 end
 
 function ConfigDialog:updateConfigPanel(index)
@@ -893,6 +888,7 @@ function ConfigDialog:updateConfigPanel(index)
 end
 
 function ConfigDialog:update()
+    self:moveFocusTo(1, 1) -- reset selected for re-created layout
     self.layout = {}
 
     if self.config_menubar then
@@ -927,8 +923,7 @@ function ConfigDialog:update()
     self.dialog_frame.dimen = old_dimen
 
     -- Reset the focusmanager cursor
-    self.selected.y=#self.layout
-    self.selected.x=self.panel_index
+    self:moveFocusTo(self.panel_index, #self.layout)
 
     self[1] = BottomContainer:new{
         dimen = Screen:getSize(),
@@ -1461,10 +1456,6 @@ end
 function ConfigDialog:onClose()
     self:closeDialog()
     return true
-end
-
-function ConfigDialog:onSelect()
-    return self:sendTapEventToFocusedWidget()
 end
 
 return ConfigDialog

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -35,7 +35,6 @@ local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
-local logger = require("logger")
 local _ = require("gettext")
 local Screen = Device.screen
 
@@ -72,9 +71,7 @@ function ConfirmBox:init()
             }
         end
         if Device:hasKeys() then
-            self.key_events = {
-                Close = { {Device.input.group.Back}, doc = "cancel" }
-            }
+            self.key_events.Close = { {Device.input.group.Back}, doc = "cancel" }
         end
     end
     local text_widget = TextBoxWidget:new{
@@ -211,17 +208,6 @@ function ConfirmBox:onTapClose(arg, ges)
         self:onClose()
     end
     -- Don't let it propagate to underlying widgets
-    return true
-end
-
-function ConfirmBox:onSelect()
-    logger.dbg("selected:", self.selected.x)
-    if self.selected.x == 1 then
-        self:ok_callback()
-    else
-        self:cancel_callback()
-    end
-    UIManager:close(self)
     return true
 end
 

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -62,7 +62,7 @@ end
 
 function FrameContainer:onFocus()
     if not self.focusable then
-        return
+        return false
     end
     self._origin_bordersize = self.bordersize
     self._origin_border_color = self.color
@@ -73,7 +73,7 @@ end
 
 function FrameContainer:onUnfocus()
     if not self.focusable then
-        return
+        return false
     end
     self.bordersize = self._origin_bordersize
     self.color = self._origin_border_color

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -68,6 +68,7 @@ function FrameContainer:onFocus()
     self._origin_border_color = self.color
     self.bordersize = self.focus_border_size
     self.color = self.focus_border_color
+    self._focused = true
     return true
 end
 
@@ -75,8 +76,11 @@ function FrameContainer:onUnfocus()
     if not self.focusable then
         return false
     end
-    self.bordersize = self._origin_bordersize
-    self.color = self._origin_border_color
+    if self._focused then
+        self.bordersize = self._origin_bordersize
+        self.color = self._origin_border_color
+        self._focused = nil
+    end
     return true
 end
 

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -80,8 +80,9 @@ function FrameContainer:onUnfocus()
         self.bordersize = self._origin_bordersize
         self.color = self._origin_border_color
         self._focused = nil
+        return true
     end
-    return true
+    return false
 end
 
 

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -282,6 +282,7 @@ function InputContainer:onInput(input, ignore_first_hold_release)
             {
                 {
                     text = input.cancel_text or _("Cancel"),
+                    id = "close",
                     callback = function()
                         self:closeInputDialog()
                     end,

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1227,6 +1227,7 @@ function DictQuickLookup:lookupInputWord(hint)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self:closeInputDialog()
                     end,

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -66,7 +66,6 @@ function DoubleSpinWidget:init()
     end
     if Device:hasKeys() then
         self.key_events.Close = { {Device.input.group.Back}, doc = "close doublespin widget" }
-        self.key_events.Press = { {"Press"}, doc = "press button" }
     end
     if Device:isTouchDevice() then
         self.ges_events = {
@@ -229,7 +228,6 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         buttons = buttons,
         zero_sep = true,
         show_parent = self,
-        auto_focus_first_button = false,
     }
     self:mergeLayoutInVertical(button_table)
 
@@ -269,7 +267,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         },
         self.movable,
     }
-    self:focusTopLeftWidget()
+    self:refocusWidget()
     UIManager:setDirty(self, function()
         return "ui", self.widget_frame.dimen
     end)
@@ -311,10 +309,6 @@ function DoubleSpinWidget:onClose()
         self.close_callback()
     end
     return true
-end
-
-function DoubleSpinWidget:onPress()
-    return self:sendTapEventToFocusedWidget()
 end
 
 return DoubleSpinWidget

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -30,23 +30,167 @@ local FocusManager = InputContainer:new{
     movement_allowed = { x = true, y = true },
 }
 
+local function tableClone(t)
+    local c = {}
+    for i, v in ipairs(t) do
+        c[i] = v
+    end
+    for k, v in pairs(t) do
+        c[k] = v
+    end
+    return c
+end
+
 function FocusManager:init()
     if not self.selected then
         self.selected = { x = 1, y = 1 }
+    else
+        self.selected = self.selected -- make sure current FocusManager has its own selected field
     end
-
     if Device:hasDPad() then
-        self.key_events = {
-            -- these will all generate the same event, just with different arguments
-            FocusUp =    { {"Up"},    doc = "move focus up",    event = "FocusMove", args = {0, -1} },
-            FocusDown =  { {"Down"},  doc = "move focus down",  event = "FocusMove", args = {0,  1} },
-            FocusLeft =  { {"Left"},  doc = "move focus left",  event = "FocusMove", args = {-1, 0} },
-            FocusRight = { {"Right"}, doc = "move focus right", event = "FocusMove", args = {1,  0} },
-        }
-        if Device:hasFewKeys() then
-            self.key_events.FocusLeft = nil
+        local event_keys = {}
+        -- these will all generate the same event, just with different arguments
+        table.insert(event_keys, {"FocusUp",    { {"Up"},    doc = "move focus up",    event = "FocusMove", args = {0, -1} } })
+        table.insert(event_keys, {"FocusRight", { {"Right"}, doc = "move focus right", event = "FocusMove", args = {1,  0} } })
+        table.insert(event_keys, {"FocusDown",  { {"Down"},  doc = "move focus down",  event = "FocusMove", args = {0,  1} } })
+        table.insert(event_keys, {"Press",      { {"Press"}, doc = "tap the widget",   event="Press" }})
+        local FEW_KEYS_END_INDEX = #event_keys -- Few keys device: only setup up, down, right and press
+
+        table.insert(event_keys, {"FocusLeft",  { {"Left"},  doc = "move focus left",         event = "FocusMove", args = {-1, 0} } })
+        local NORMAL_KEYS_END_INDEX = #event_keys
+
+        -- Advanced Feature: following event handlers can be enabled via settings.reader.lua
+        -- Key combinations (Sym, Alt+Up, Tab, Shift+Tab and so on) are not used but showed as examples here
+        table.insert(event_keys, {"Hold",           { {"Sym", "AA"}, doc = "tap and hold the widget", event="Hold" } })
+        -- half rows/columns move, it is helpful for slow device like Kindle DX to move quickly
+        table.insert(event_keys, {"HalfFocusUp",    { {"Alt", "Up"},    doc = "move focus half columns up",    event = "FocusHalfMove", args = {"up"} } })
+        table.insert(event_keys, {"HalfFocusRight", { {"Alt", "Right"}, doc = "move focus half rows right",    event = "FocusHalfMove", args = {"right"} } })
+        table.insert(event_keys, {"HalfFocusDown",  { {"Alt", "Down"},  doc = "move focus half columns down",  event = "FocusHalfMove", args = {"down"} } })
+        table.insert(event_keys, {"HalfFocusLeft",  { {"Alt", "Left"},  doc = "move focus half rows left",     event = "FocusHalfMove", args = {"left"} } })
+        -- for PC navigation behavior support
+        table.insert(event_keys, {"FocusNext",      { {"Tab"},            doc = "move focus to next widget",     event="FocusNext"} })
+        table.insert(event_keys, {"FocusPrevious",  { {"Shift", "Tab"},   doc = "move focus to previous widget", event="FocusPrevious"} })
+
+        self.key_events = {}
+        self.builtin_key_events = {}
+        self.extra_key_events = {}
+        for i = 1, FEW_KEYS_END_INDEX do
+            local key_name = event_keys[i][1]
+            self.key_events[key_name] = event_keys[i][2]
+            self.builtin_key_events[key_name] = event_keys[i][2]
+        end
+        if not Device:hasFewKeys() then
+            for i = FEW_KEYS_END_INDEX+1, NORMAL_KEYS_END_INDEX do
+                local key_name = event_keys[i][1]
+                self.key_events[key_name] = event_keys[i][2]
+                self.builtin_key_events[key_name] = event_keys[i][2]
+            end
+            local focus_manager_setting = G_reader_settings:child("focus_manager")
+            -- Enable advanced feature, like Hold, FocusNext, FocusPrevious
+            -- Can also add extra arrow keys like using A, W, D, S for Left, Up, Right, Down
+            local alternative_keymaps = focus_manager_setting:readSetting("alternative_keymaps")
+            if type(alternative_keymaps) == "table" then
+                for i = 1, #event_keys do
+                    local key_name = event_keys[i][1]
+                    local alternative_keymap = alternative_keymaps[key_name]
+                    if alternative_keymap then
+                        local handler_defition = tableClone(event_keys[i][2])
+                        handler_defition[1] = alternative_keymap -- replace sample key combinations
+                        local new_event_key = "Alternative" .. key_name
+                        self.key_events[new_event_key] = handler_defition
+                        self.extra_key_events[new_event_key] = handler_defition
+                    end
+                end
+            end
         end
     end
+end
+
+function FocusManager:isAlternativeKey(key)
+    for _, seq in pairs(self.extra_key_events) do
+        for _, oneseq in ipairs(seq) do
+            if key:match(oneseq) then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+function FocusManager:onFocusHalfMove(args)
+    if not self.layout then
+        return false
+    end
+    local direction = unpack(args)
+    local x, y = self.selected.x, self.selected.y
+    local row = self.layout[self.selected.y]
+    local dx, dy = 0, 0
+    if direction == "up" then
+        dy = - math.floor(#self.layout / 2)
+        if dy == 0 then
+            dy = -1
+        elseif dy + y <= 0 then
+            dy = -y + 1 -- first row
+        end
+    elseif direction == "down" then
+        dy = math.floor(#self.layout / 2)
+        if dy == 0 then
+            dy = 1
+        elseif dy + y > #self.layout then
+            dy = #self.layout - y -- last row
+        end
+    elseif direction == "left" then
+        dx = - math.floor(#row / 2)
+        if dx == 0 then
+            dx = -1
+        elseif dx + x <= 0 then
+            dx = -x + 1 -- first column
+        end
+    elseif direction == "right" then
+        dx = math.floor(#row / 2)
+        if dx == 0 then
+            dx = 1
+        elseif dx + x > #row then
+            dx = #row - y -- last column
+        end
+    end
+    return self:onFocusMove({dx, dy})
+end
+
+function FocusManager:onPress()
+    return self:sendTapEventToFocusedWidget()
+end
+
+function FocusManager:onHold()
+    return self:sendHoldEventToFocusedWidget()
+end
+
+-- for tab key
+function FocusManager:onFocusNext()
+    if not self.layout then
+        return false
+    end
+    local x, y = self.selected.x, self.selected.y
+    local row = self.layout[y]
+    local dx, dy = 1, 0
+    if not row[x + dx] then -- beyond end of column, go to next row
+        dx, dy = 0, 1
+    end
+    return self:onFocusMove({dx, dy})
+end
+
+-- for shift tab key
+function FocusManager:onFocusPrevious()
+    if not self.layout then
+        return false
+    end
+    local x, y = self.selected.x, self.selected.y
+    local row = self.layout[y]
+    local dx, dy = -1, 0
+    if not row[x + dx] then -- beyond start of column, go to previous row
+        dx, dy = 0, -1
+    end
+    return self:onFocusMove({dx, dy})
 end
 
 function FocusManager:onFocusMove(args)
@@ -101,11 +245,43 @@ function FocusManager:onFocusMove(args)
     return true
 end
 
+-- constant, no need to send Unfocus event, used to reset focus widget after layout recreation
+FocusManager.NOT_UNFOCUS = true
+--- Move focus to specified widget
+function FocusManager:moveFocusTo(x, y, no_unfocus)
+    if not self.layout then
+        return false
+    end
+    local current_item = nil
+    if self.layout[self.selected.y] then
+        current_item = self.layout[self.selected.y][self.selected.x]
+    end
+    local target_item = nil
+    if self.layout[y] then
+        target_item = self.layout[y][x]
+    end
+    if target_item then
+        logger.dbg("Move focus position to: " .. y .. ", " .. x)
+        self.selected.x = x
+        self.selected.y = y
+        -- widget create new layout on update, previous may be removed from new layout.
+        if Device:hasDPad() then
+            if not no_unfocus and current_item and current_item ~= target_item then
+                current_item:handleEvent(Event:new("Unfocus"))
+            end
+            target_item:handleEvent(Event:new("Focus"))
+            UIManager:setDirty(self.show_parent or self, "fast")
+        end
+        return true
+    end
+    return false
+end
+
 --- Go to the last valid item directly left or right of the current item.
 -- @return false if none could be found
 function FocusManager:_wrapAroundX(dx)
     local x = self.selected.x
-    while self.layout[x - dx] do
+    while self.layout[self.selected.y][x - dx] do
         x = x - dx
     end
     if x ~= self.selected.x then
@@ -168,7 +344,7 @@ function FocusManager:getFocusItem()
     return self.layout[self.selected.y][self.selected.x]
 end
 
-function FocusManager:sendTapEventToFocusedWidget()
+function FocusManager:_sendGestureEventToFocusedWidget(gesture)
     local focused_widget = self:getFocusItem()
     if focused_widget then
         -- center of widget position
@@ -177,8 +353,9 @@ function FocusManager:sendTapEventToFocusedWidget()
         point.y = point.y + point.h / 2
         point.w = 0
         point.h = 0
+        logger.dbg("FocusManager: Send " .. gesture .. " to " .. point.x .. ", " .. point.y)
         UIManager:sendEvent(Event:new("Gesture", {
-            ges = "tap",
+            ges = gesture,
             pos = point,
         }))
         return true
@@ -186,14 +363,26 @@ function FocusManager:sendTapEventToFocusedWidget()
     return false
 end
 
-function FocusManager:mergeLayoutInVertical(child)
+function FocusManager:sendTapEventToFocusedWidget()
+    return self:_sendGestureEventToFocusedWidget("tap")
+end
+
+function FocusManager:sendHoldEventToFocusedWidget()
+    return self:_sendGestureEventToFocusedWidget("hold")
+end
+
+function FocusManager:mergeLayoutInVertical(child, pos)
     if not child.layout then
         return
     end
-    for _, row in ipairs(child.layout) do
-        table.insert(self.layout, row)
+    if not pos then
+        pos = #self.layout + 1 -- end of row
     end
-    child:disableFocusManagement()
+    for _, row in ipairs(child.layout) do
+        table.insert(self.layout, pos, row)
+        pos = pos + 1
+    end
+    child:disableFocusManagement(self)
 end
 
 function FocusManager:mergeLayoutInHorizontal(child)
@@ -210,18 +399,39 @@ function FocusManager:mergeLayoutInHorizontal(child)
             table.insert(prow, widget)
         end
     end
-    child:disableFocusManagement()
+    child:disableFocusManagement(self)
 end
 
-function FocusManager:disableFocusManagement()
+function FocusManager:disableFocusManagement(parent)
+    self._parent = parent
+    -- unfocus current widget in current child container
+    -- parent container will call refocusWidget to focus another one
+    local row = self.layout[self.selected.y]
+    if row and row[self.selected.x] then
+        row[self.selected.x]:handleEvent(Event:new("Unfocus"))
+    end
     self.layout = nil -- turn off focus feature
 end
 
---- Container call this method after init to let first widget render in focus style
-function FocusManager:focusTopLeftWidget()
-    if Device:hasDPad() then
-        -- trigger selected widget in focused style
-        self:onFocusMove({0, 0})
+-- constant for refocusWidget method to easy code reading
+FocusManager.RENDER_IN_NEXT_TICK = true
+
+--- Container call this method to re-set focus widget style
+--- Some container regenrate layout on update and lost focus style
+function FocusManager:refocusWidget(nextTick)
+    if not self._parent then
+        if not nextTick then
+            self:moveFocusTo(self.selected.x, self.selected.y)
+        else
+            -- sometimes refocusWidget called in widget's action callback
+            -- widget may force repaint after callback, like Button with vsync = true
+            -- then focus style will be lost, set focus style to next tick to make sure focus style painted
+            UIManager:nextTick(function()
+                self:moveFocusTo(self.selected.x, self.selected.y)
+            end)
+        end
+    else
+        self._parent:refocusWidget(nextTick)
     end
 end
 

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -3,6 +3,7 @@ local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local logger = require("logger")
 local UIManager = require("ui/uimanager")
+local util = require("util")
 --[[
 Wrapper Widget that manages focus for a whole dialog
 
@@ -30,17 +31,6 @@ local FocusManager = InputContainer:new{
     movement_allowed = { x = true, y = true },
 }
 
-local function tableClone(t)
-    local c = {}
-    for i, v in ipairs(t) do
-        c[i] = v
-    end
-    for k, v in pairs(t) do
-        c[k] = v
-    end
-    return c
-end
-
 function FocusManager:init()
     if not self.selected then
         self.selected = { x = 1, y = 1 }
@@ -60,7 +50,7 @@ function FocusManager:init()
         local NORMAL_KEYS_END_INDEX = #event_keys
 
         -- Advanced Feature: following event handlers can be enabled via settings.reader.lua
-        -- Key combinations (Sym, Alt+Up, Tab, Shift+Tab and so on) are not used but showed as examples here
+        -- Key combinations (Sym, Alt+Up, Tab, Shift+Tab and so on) are not used but shown as examples here
         table.insert(event_keys, {"Hold",           { {"Sym", "AA"}, doc = "tap and hold the widget", event="Hold" } })
         -- half rows/columns move, it is helpful for slow device like Kindle DX to move quickly
         table.insert(event_keys, {"HalfFocusUp",    { {"Alt", "Up"},    doc = "move focus half columns up",    event = "FocusHalfMove", args = {"up"} } })
@@ -94,7 +84,7 @@ function FocusManager:init()
                     local key_name = event_keys[i][1]
                     local alternative_keymap = alternative_keymaps[key_name]
                     if alternative_keymap then
-                        local handler_defition = tableClone(event_keys[i][2])
+                        local handler_defition = util.tableDeepCopy(event_keys[i][2])
                         handler_defition[1] = alternative_keymap -- replace sample key combinations
                         local new_event_key = "Alternative" .. key_name
                         self.key_events[new_event_key] = handler_defition
@@ -179,7 +169,7 @@ function FocusManager:onFocusNext()
     return self:onFocusMove({dx, dy})
 end
 
--- for shift tab key
+-- for backtab key
 function FocusManager:onFocusPrevious()
     if not self.layout then
         return false
@@ -413,11 +403,11 @@ function FocusManager:disableFocusManagement(parent)
     self.layout = nil -- turn off focus feature
 end
 
--- constant for refocusWidget method to easy code reading
+-- constant for refocusWidget method to ease code reading
 FocusManager.RENDER_IN_NEXT_TICK = true
 
---- Container call this method to re-set focus widget style
---- Some container regenrate layout on update and lost focus style
+--- Container calls this method to re-set focus widget style
+--- Some container regenerate layout on update and lose focus style
 function FocusManager:refocusWidget(nextTick)
     if not self._parent then
         if not nextTick then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -122,24 +122,22 @@ function MenuItem:init()
     self.detail = self.text
 
     -- we need this table per-instance, so we declare it here
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Select Menu Item",
+    self.ges_events = {
+        TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelect = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold Menu Item",
+            doc = "Select Menu Item",
+        },
+        HoldSelect = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-        }
-    end
+            doc = "Hold Menu Item",
+        },
+    }
 
     local max_item_height = self.dimen.h - 2 * self.linesize
 
@@ -889,37 +887,35 @@ function Menu:init()
     ------------------------------------------
     -- start to set up input event callback --
     ------------------------------------------
-    if Device:isTouchDevice() then
-        -- watch for outer region if it's a self contained widget
-        if self.is_popout then
-            self.ges_events.TapCloseAllMenus = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = Geom:new{
-                        x = 0, y = 0,
-                        w = Screen:getWidth(),
-                        h = Screen:getHeight(),
-                    }
+    -- watch for outer region if it's a self contained widget
+    if self.is_popout then
+        self.ges_events.TapCloseAllMenus = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    x = 0, y = 0,
+                    w = Screen:getWidth(),
+                    h = Screen:getHeight(),
                 }
             }
-        end
-        -- delegate swipe gesture to GestureManager in filemanager
-        if not self.filemanager then
-            self.ges_events.Swipe = {
-                GestureRange:new{
-                    ges = "swipe",
-                    range = self.dimen,
-                }
-            }
-            self.ges_events.MultiSwipe = {
-                GestureRange:new{
-                    ges = "multiswipe",
-                    range = self.dimen,
-                }
-            }
-        end
-        self.ges_events.Close = self.on_close_ges
+        }
     end
+    -- delegate swipe gesture to GestureManager in filemanager
+    if not self.filemanager then
+        self.ges_events.Swipe = {
+            GestureRange:new{
+                ges = "swipe",
+                range = self.dimen,
+            }
+        }
+        self.ges_events.MultiSwipe = {
+            GestureRange:new{
+                ges = "multiswipe",
+                range = self.dimen,
+            }
+        }
+    end
+    self.ges_events.Close = self.on_close_ges
 
     if not Device:hasKeyboard() then
         -- remove menu item shortcut for K4
@@ -947,9 +943,6 @@ function Menu:init()
         if self.is_enable_shortcut then
             self.key_events.SelectByShortCut = { {self.item_shortcuts} }
         end
-        self.key_events.Select = {
-            {"Press"}, doc = "select current menu item"
-        }
         self.key_events.Right = {
             {"Right"}, doc = "hold  menu item"
         }
@@ -997,7 +990,7 @@ function Menu:updatePageInfo(select_number)
     if self.item_group[1] then
         if Device:hasDPad() then
             -- reset focus manager accordingly
-            self.selected = { x = 1, y = select_number }
+            self:moveFocusTo(1, select_number)
         end
         -- update page information
         self.page_info_text:setText(FFIUtil.template(_("Page %1 of %2"), self.page, self.page_num))
@@ -1299,20 +1292,8 @@ function Menu:onGotoPage(page)
     return true
 end
 
-function Menu:onSelect()
-    local item = self.item_table[(self.page-1)*self.perpage+self.selected.y]
-    if item then
-        self:onMenuSelect(item)
-    end
-    return true
-end
-
 function Menu:onRight()
-    local item = self.item_table[(self.page-1)*self.perpage+self.selected.y]
-    if item then
-        self:onMenuHold(item)
-    end
-    return true
+    return self:sendHoldEventToFocusedWidget()
 end
 
 function Menu:onClose()

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -34,7 +34,6 @@ local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
-local logger = require("logger")
 local _ = require("gettext")
 local Screen = require("device").screen
 
@@ -72,9 +71,7 @@ function MultiConfirmBox:init()
             }
         end
         if Device:hasKeys() then
-            self.key_events = {
-                Close = { {Device.input.group.Back}, doc = "cancel" }
-            }
+            self.key_events.Close = { {Device.input.group.Back}, doc = "cancel" }
         end
     end
     local content = HorizontalGroup:new{
@@ -171,19 +168,6 @@ function MultiConfirmBox:onTapClose(arg, ges)
         return true
     end
     return false
-end
-
-function MultiConfirmBox:onSelect()
-    logger.dbg("selected:", self.selected.x)
-    if self.selected.x == 1 then
-        self:choice1_callback()
-    elseif self.selected.x == 2 then
-        self:choice2_callback()
-    elseif self.selected.x == 0 then
-        self:cancle_callback()
-    end
-    UIManager:close(self)
-    return true
 end
 
 return MultiConfirmBox

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -32,6 +32,7 @@ Example for input of two strings and a number:
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(sample_input)
                     end
@@ -132,10 +133,7 @@ function MultiInputDialog:init()
             auto_para_direction = field.auto_para_direction or self.auto_para_direction,
             alignment_strict = field.alignment_strict or self.alignment_strict,
         }
-        if Device:hasDPad() then
-            -- little hack to piggyback on the layout of the button_table to handle the new InputText
-            table.insert(self.button_table.layout, #self.button_table.layout, {input_field[k]})
-        end
+        table.insert(self.layout, #self.layout, {input_field[k]})
         if field.description then
             input_description[k] = FrameContainer:new{
                 padding = self.description_padding,
@@ -164,10 +162,6 @@ function MultiInputDialog:init()
         })
     end
 
-    if Device:hasDPad() then
-        -- remove the not needed hack in inputdialog
-        table.remove(self.button_table.layout, 1)
-    end
     -- Add same vertical space after than before InputText
     table.insert(VerticalGroupData,CenterContainer:new{
         dimen = Geom:new{

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -294,6 +294,7 @@ function NetworkItem:onEditNetwork()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(password_input)
                     end,
@@ -336,6 +337,7 @@ function NetworkItem:onAddNetwork()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(password_input)
                     end,

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -136,6 +136,7 @@ function NumberPickerWidget:init()
                     {
                         {
                             text = _("Cancel"),
+                            id = "close",
                             callback = function()
                                 UIManager:close(input_dialog)
                             end,
@@ -186,6 +187,9 @@ function NumberPickerWidget:init()
         show_parent = self.show_parent,
         callback = callback_input,
     }
+    if callback_input then
+        table.insert(self.layout, 2, {self.text_value})
+    end
 
     local widget_spinner = VerticalGroup:new{
         align = "center",
@@ -210,9 +214,7 @@ function NumberPickerWidget:init()
     }
     self.dimen = self.frame:getSize()
     self[1] = self.frame
-    if Device:hasDPad() then
-        self.key_events.Press = { {"Press"}, doc = "press button" }
-    end
+    self:refocusWidget()
     UIManager:setDirty(self.show_parent, function()
         return "ui", self.dimen
     end)
@@ -229,6 +231,7 @@ function NumberPickerWidget:update()
 
     self.text_value:setText(tostring(self.formatted_value), self.width)
 
+    self:refocusWidget()
     UIManager:setDirty(self.show_parent, function()
         return "ui", self.dimen
     end)
@@ -287,10 +290,6 @@ Get value.
 --]]
 function NumberPickerWidget:getValue()
     return self.value, self.value_index
-end
-
-function NumberPickerWidget:onPress()
-    return self:sendTapEventToFocusedWidget()
 end
 
 return NumberPickerWidget

--- a/frontend/ui/widget/openwithdialog.lua
+++ b/frontend/ui/widget/openwithdialog.lua
@@ -42,6 +42,7 @@ function OpenWithDialog:init()
             end
         end
     }
+    self:mergeLayoutInVertical(self.radio_button_table, #self.layout) -- before bottom buttons
     self._input_widget = self.radio_button_table
 
     local vertical_span = VerticalSpan:new{
@@ -85,11 +86,13 @@ function OpenWithDialog:init()
         text = _("Always use this engine for this file"),
         parent = self,
     }
+    table.insert(self.layout, #self.layout, {self._check_file_button}) -- before bottom buttons
     self:addWidget(self._check_file_button)
     self._check_global_button = self._check_global_button or CheckButton:new{
         text = _("Always use this engine for file type"),
         parent = self,
     }
+    table.insert(self.layout, #self.layout, {self._check_global_button}) -- before bottom buttons
     self:addWidget(self._check_global_button)
 
     self.dialog_frame = FrameContainer:new{
@@ -110,6 +113,7 @@ function OpenWithDialog:init()
         },
         self.movable,
     }
+    self:refocusWidget()
 end
 
 function OpenWithDialog:onCloseWidget()

--- a/frontend/ui/widget/radiobuttontable.lua
+++ b/frontend/ui/widget/radiobuttontable.lua
@@ -31,7 +31,6 @@ local RadioButtonTable = FocusManager:new{
 }
 
 function RadioButtonTable:init()
-    self.selected = { x = 1, y = 1 }
     self.radio_buttons_layout = {}
     self.container = VerticalGroup:new{ width = self.width }
     table.insert(self, self.container)
@@ -120,7 +119,7 @@ function RadioButtonTable:init()
 
     if Device:hasDPad() or Device:hasKeyboard() then
         self.layout = self.radio_buttons_layout
-        self.key_events.SelectByKeyPress = { {{"Press"}} }
+        self:refocusWidget()
     else
         self.key_events = {}  -- deregister all key press event listeners
     end
@@ -144,15 +143,6 @@ function RadioButtonTable:addHorizontalSep(vspan_before, add_line, vspan_after, 
         table.insert(self.container,
                      VerticalSpan:new{ width = Size.span.vertical_default })
     end
-end
-
-function RadioButtonTable:onSelectByKeyPress()
-    local item = self:getFocusItem()
-    if item then
-        item.callback()
-        return true
-    end
-    return false
 end
 
 function RadioButtonTable:_checkButton(button)

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -45,7 +45,6 @@ function SkimToWidget:init()
     end
 
     self.buttons_layout = {}
-    self.selected = { x = 1, y = 2 }
 
     local frame_width = math.floor(math.min(screen_width, screen_height) * 0.95)
     local frame_border_size = Size.border.window
@@ -296,8 +295,7 @@ function SkimToWidget:init()
             { button_minus_ten, button_minus, self.current_page_text, button_plus, button_plus_ten },
         }
         self.layout = self.buttons_layout
-        self.layout[2][1]:onFocus()
-        self.key_events.SelectByKeyPress = { { "Press" }, doc = "select focused item" }
+        self:moveFocusTo(1, 2)
     end
     if Device:hasKeyboard() then
         self.key_events.QKey = { { "Q" }, event = "FirstRowKeyPress", args =    0 }
@@ -323,6 +321,7 @@ function SkimToWidget:update()
     self.progress_bar.percentage = self.curr_page / self.page_count
     self.current_page_text:setText(self.current_page_text:text_func(), self.current_page_text.width)
     self.button_bookmark_toggle:setText(self.button_bookmark_toggle:text_func(), self.button_bookmark_toggle.width)
+    self:refocusWidget(FocusManager.RENDER_IN_NEXT_TICK)
 end
 
 function SkimToWidget:addOriginToLocationStack(add_current)
@@ -376,15 +375,6 @@ end
 function SkimToWidget:onAnyKeyPressed()
     UIManager:close(self)
     return true
-end
-
-function SkimToWidget:onSelectByKeyPress()
-    local item = self:getFocusItem()
-    if item then
-        item.callback()
-        return true
-    end
-    return false
 end
 
 function SkimToWidget:onFirstRowKeyPress(percent)

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -65,7 +65,6 @@ function SpinWidget:init()
     end
     if Device:hasKeys() then
         self.key_events.Close = { {Device.input.group.Back}, doc = "close spin widget" }
-        self.key_events.Press = { {"Press"}, doc = "press button" }
     end
     if Device:isTouchDevice() then
         self.ges_events = {
@@ -196,7 +195,6 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         buttons = buttons,
         zero_sep = true,
         show_parent = self,
-        auto_focus_first_button = false,
     }
     self:mergeLayoutInVertical(ok_cancel_buttons)
     local vgroup = VerticalGroup:new{
@@ -236,7 +234,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         },
         self.movable,
     }
-    self:focusTopLeftWidget()
+    self:refocusWidget()
     UIManager:setDirty(self, function()
         return "ui", self.spin_frame.dimen
     end)
@@ -278,10 +276,6 @@ function SpinWidget:onClose()
         self.close_callback()
     end
     return true
-end
-
-function SpinWidget:onPress()
-    return self:sendTapEventToFocusedWidget()
 end
 
 return SpinWidget

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -711,7 +711,7 @@ function TouchMenu:updateItems()
     -- recalculate dimen based on new layout
     self.dimen.w = self.width
     self.dimen.h = self.item_group:getSize().h + self.bordersize*2 + self.padding -- (no padding at top)
-    self:moveFocusTo(self.cur_tab, 1) -- reset the position of the focusmanager
+    self:moveFocusTo(self.cur_tab, 1, FocusManager.NOT_FOCUS) -- reset the position of the focusmanager
 
     -- NOTE: We use a slightly ugly hack to detect a brand new menu vs. a tab switch,
     --       in order to optionally flash on initial menu popup...

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -7,7 +7,6 @@ local Button = require("ui/widget/button")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local CheckMark = require("ui/widget/checkmark")
 local Device = require("device")
-local Event = require("ui/event")
 local FocusManager = require("ui/widget/focusmanager")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -490,7 +489,6 @@ function TouchMenu:init()
     end
     self.key_events.NextPage = { {Input.group.PgFwd}, doc = "next page" }
     self.key_events.PrevPage = { {Input.group.PgBack}, doc = "previous page" }
-    self.key_events.Press = { {"Press"}, doc = "chose selected item" }
 
     local icons = {}
     for _, v in ipairs(self.tab_item_table) do
@@ -713,7 +711,7 @@ function TouchMenu:updateItems()
     -- recalculate dimen based on new layout
     self.dimen.w = self.width
     self.dimen.h = self.item_group:getSize().h + self.bordersize*2 + self.padding -- (no padding at top)
-    self.selected = { x = self.cur_tab, y = 1 } -- reset the position of the focusmanager
+    self:moveFocusTo(self.cur_tab, 1) -- reset the position of the focusmanager
 
     -- NOTE: We use a slightly ugly hack to detect a brand new menu vs. a tab switch,
     --       in order to optionally flash on initial menu popup...
@@ -940,15 +938,6 @@ end
 
 function TouchMenu:onBack()
     self:backToUpperMenu()
-end
-
-function TouchMenu:onPress()
-    local item = self:getFocusItem()
-    if item then
-        item:handleEvent(Event:new("TapSelect"))
-        return true
-    end
-    return false
 end
 
 return TouchMenu

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -2,7 +2,6 @@ local Blitbuffer = require("ffi/blitbuffer")
 local BottomContainer = require("ui/widget/container/bottomcontainer")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
-local Event = require("ui/event")
 local FocusManager = require("ui/widget/focusmanager")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -245,40 +244,38 @@ function VirtualKey:init()
         h = self.height,
     }
     --self.dimen = self[1]:getSize()
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
+    self.ges_events = {
+        TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelect = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
+        },
+        HoldSelect = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-            HoldReleaseKey = {
-                GestureRange:new{
-                    ges = "hold_release",
-                    range = self.dimen,
-                },
+        },
+        HoldReleaseKey = {
+            GestureRange:new{
+                ges = "hold_release",
+                range = self.dimen,
             },
-            PanReleaseKey = {
-                GestureRange:new{
-                    ges = "pan_release",
-                    range = self.dimen,
-                },
+        },
+        PanReleaseKey = {
+            GestureRange:new{
+                ges = "pan_release",
+                range = self.dimen,
             },
-            SwipeKey = {
-                GestureRange:new{
-                    ges = "swipe",
-                    range = self.dimen,
-                },
+        },
+        SwipeKey = {
+            GestureRange:new{
+                ges = "swipe",
+                range = self.dimen,
             },
-        }
-    end
+        },
+    }
     if (self.keyboard.shiftmode_keys[self.label] ~= nil  and self.keyboard.shiftmode) or
         (self.keyboard.umlautmode_keys[self.label] ~= nil and self.keyboard.umlautmode) or
         (self.keyboard.symbolmode_keys[self.label] ~= nil and self.keyboard.symbolmode) then
@@ -479,15 +476,6 @@ function VirtualKeyPopup:onCloseWidget()
     end)
 end
 
-function VirtualKeyPopup:onPressKey()
-    local item = self:getFocusItem()
-    if item then
-        item:handleEvent(Event:new("TapSelect"))
-        return true
-    end
-    return false
-end
-
 function VirtualKeyPopup:init()
     local parent_key = self.parent_key
     local key_chars = parent_key.key_chars
@@ -680,9 +668,6 @@ function VirtualKeyPopup:init()
     self.tap_interval_override = G_reader_settings:readSetting("ges_tap_interval_on_keyboard", 0)
     self.tap_interval_override = TimeVal:new{ usec = self.tap_interval_override }
 
-    if Device:hasDPad() then
-        self.key_events.PressKey = { {"Press"}, doc = "select key" }
-    end
     if Device:hasKeys() then
         self.key_events.Close = { {Device.input.group.Back}, doc = "close keyboard" }
     end
@@ -803,16 +788,13 @@ function VirtualKeyboard:init()
     self:initLayer(self.keyboard_layer)
     self.tap_interval_override = G_reader_settings:readSetting("ges_tap_interval_on_keyboard", 0)
     self.tap_interval_override = TimeVal:new{ usec = self.tap_interval_override }
-    if Device:hasDPad() then
-        self.key_events.PressKey = { {"Press"}, doc = "select key" }
-    end
     if Device:hasKeys() then
         self.key_events.Close = { {"Back"}, doc = "close keyboard" }
     end
     if keyboard.wrapInputBox then
         self.uwrap_func = keyboard.wrapInputBox(self.inputbox) or self.uwrap_func
     end
-    if Device:hasDPad() and Device:hasKeyboard() and Device:isTouchDevice() then
+    if Device:hasDPad() then
         -- hadDPad() would have FocusManager handle arrow keys strokes to navigate
         -- and activate this VirtualKeyboard's touch keys (needed on non-touch Kindle).
         -- If we have a keyboard, we'd prefer arrow keys (and Enter, and Del) to be
@@ -820,12 +802,37 @@ function VirtualKeyboard:init()
         -- add newline and delete chars. And if we are a touch device, we don't
         -- need focus manager to help us navigate keys and fields.
         -- So, disable all key_event handled by FocusManager
-        self.key_events.FocusLeft = nil
-        self.key_events.FocusRight = nil
-        self.key_events.FocusUp = nil
-        self.key_events.FocusDown = nil
-        self.key_events.PressKey = nil -- added above
+        if Device:isTouchDevice() then
+            -- remove all key event handler of FocusManager
+            for k, _ in pairs(self.builtin_key_events) do
+                self.key_events[k] = nil
+            end
+            for k, _ in pairs(self.extra_key_events) do
+                self.key_events[k] = nil
+            end
+        elseif Device:hasKeyboard() then
+            -- Use physical keyboard for most of characters
+            -- For special characters not available in physical keyboard
+            -- Use arrow and Press keys to select in VirtualKeyboard
+            for k, seq in pairs(self.extra_key_events) do
+                if self:_isTextKeyWithoutMofidier(seq) then
+                    self.key_events[k] = nil
+                end
+            end
+        end
     end
+end
+
+function VirtualKeyboard:_isTextKeyWithoutMofidier(seq)
+    for _, oneseq in ipairs(seq) do
+        if #oneseq ~= 1 then -- has modifier key combination
+            return false
+        end
+        if #oneseq[1] ~= 1 then -- not simple text key, like Home, End
+            return false
+        end
+    end
+    return true
 end
 
 function VirtualKeyboard:getKeyboardLayout()
@@ -856,16 +863,12 @@ end
 
 function VirtualKeyboard:onClose()
     UIManager:close(self)
-    return true
-end
-
-function VirtualKeyboard:onPressKey()
-    local item = self:getFocusItem()
-    if item then
-        item:handleEvent(Event:new("TapSelect"))
-        return true
+    if self.inputbox and Device:hasDPad() then
+        -- let input text handle Back event to unfocus
+        -- otherwise, another extra Back event needed
+        return false
     end
-    return false
+    return true
 end
 
 function VirtualKeyboard:_refresh(want_flash, fullscreen)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -803,7 +803,7 @@ function VirtualKeyboard:init()
         -- need focus manager to help us navigate keys and fields.
         -- So, disable all key_event handled by FocusManager
         if Device:isTouchDevice() then
-            -- remove all key event handler of FocusManager
+            -- Remove all FocusManager key event handlers.
             for k, _ in pairs(self.builtin_key_events) do
                 self.key_events[k] = nil
             end
@@ -811,11 +811,11 @@ function VirtualKeyboard:init()
                 self.key_events[k] = nil
             end
         elseif Device:hasKeyboard() then
-            -- Use physical keyboard for most of characters
+            -- Use physical keyboard for most characters
             -- For special characters not available in physical keyboard
             -- Use arrow and Press keys to select in VirtualKeyboard
             for k, seq in pairs(self.extra_key_events) do
-                if self:_isTextKeyWithoutMofidier(seq) then
+                if self:_isTextKeyWithoutModifier(seq) then
                     self.key_events[k] = nil
                 end
             end
@@ -823,7 +823,7 @@ function VirtualKeyboard:init()
     end
 end
 
-function VirtualKeyboard:_isTextKeyWithoutMofidier(seq)
+function VirtualKeyboard:_isTextKeyWithoutModifier(seq)
     for _, oneseq in ipairs(seq) do
         if #oneseq ~= 1 then -- has modifier key combination
             return false

--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -124,6 +124,7 @@ function SSH:show_port_dialog(touchmenu_instance)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.port_dialog)
                     end,

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -451,6 +451,7 @@ function AutoWarmth:getLocationMenu()
                     {
                         {
                             text = _("Cancel"),
+                            id = "close",
                             callback = function()
                                 UIManager:close(location_name_dialog)
                             end,

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -307,6 +307,7 @@ function Calibre:getWirelessMenuTable()
                                 {
                                     {
                                         text = _("Cancel"),
+                                        id = "close",
                                         callback = function()
                                             UIManager:close(url_dialog)
                                         end,

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -207,6 +207,7 @@ function CalibreSearch:ShowSearch()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     enabled = true,
                     callback = function()
                         self.search_dialog:onClose()

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -422,6 +422,7 @@ function CalibreWireless:setPassword()
         buttons = {{
             {
                 text = _("Cancel"),
+                id = "close",
                 callback = function()
                     UIManager:close(password_dialog)
                 end,

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -135,24 +135,22 @@ function ListMenuItem:init()
     self.detail = self.text
 
     -- we need this table per-instance, so we declare it here
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Select Menu Item",
+    self.ges_events = {
+        TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelect = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold Menu Item",
+            doc = "Select Menu Item",
+        },
+        HoldSelect = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-        }
-    end
+            doc = "Hold Menu Item",
+        },
+    }
 
     -- We now build the minimal widget container that won't change after udpate()
 

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -350,6 +350,7 @@ function CoverImage:choosePathFile(touchmenu_instance, key, folder_only, new_fil
                     buttons = {{
                         {
                             text = _("Cancel"),
+                            id = "close",
                             callback = function()
                                 UIManager:close(file_input)
                             end,

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -137,6 +137,7 @@ function Exporter:addToMainMenu(menu_items)
                                     {
                                         {
                                             text = _("Cancel"),
+                                            id = "close",
                                             callback = function()
                                                 UIManager:close(url_dialog)
                                             end
@@ -176,6 +177,7 @@ function Exporter:addToMainMenu(menu_items)
                                     {
                                         {
                                             text = _("Cancel"),
+                                            id = "close",
                                             callback = function()
                                                 UIManager:close(auth_dialog)
                                             end
@@ -246,6 +248,7 @@ For more information, please visit https://github.com/koreader/koreader/wiki/Hig
                                     {
                                         {
                                             text = _("Cancel"),
+                                            id = "close",
                                             callback = function()
                                                 UIManager:close(auth_dialog)
                                             end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -329,6 +329,7 @@ function Gestures:multiswipeRecorder(touchmenu_instance)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(multiswipe_recorder)
                     end,

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -597,6 +597,7 @@ function NewsDownloader:editFeedAttribute(id, key, value)
                 {
                     {
                         text = _("Cancel"),
+                        id = "close",
                         callback = function()
                             UIManager:close(input_dialog)
                             UIManager:show(kv)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -154,6 +154,7 @@ function OPDSBrowser:addNewCatalog()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.add_server_dialog:onClose()
                         UIManager:close(self.add_server_dialog)
@@ -204,6 +205,7 @@ function OPDSBrowser:editCalibreServer()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.add_server_dialog:onClose()
                         UIManager:close(self.add_server_dialog)
@@ -740,6 +742,7 @@ function OPDSBrowser:showDownloads(item)
                         {
                             {
                                 text = _("Cancel"),
+                                id = "close",
                                 callback = function()
                                     UIManager:close(input_dialog)
                                 end,
@@ -818,6 +821,7 @@ function OPDSBrowser:browseSearchable(browse_url, username, password)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.search_server_dialog)
                     end,
@@ -912,6 +916,7 @@ function OPDSBrowser:editOPDSServer(item)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.edit_server_dialog:onClose()
                         UIManager:close(self.edit_server_dialog)

--- a/plugins/perceptionexpander.koplugin/main.lua
+++ b/plugins/perceptionexpander.koplugin/main.lua
@@ -136,6 +136,7 @@ function PerceptionExpander:showSettingsDialog()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.settings_dialog:onClose()
                         UIManager:close(self.settings_dialog)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -64,6 +64,7 @@ function Profiles:getSubMenuItems()
                     buttons = {{
                         {
                             text = _("Cancel"),
+                            id = "close",
                             callback = function()
                                 UIManager:close(name_input)
                             end,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -350,6 +350,7 @@ Do you want to proceed?]]),
                         buttons = {{
                             {
                                 text = _("Cancel"),
+                                id = "close",
                                 callback = function()
                                     UIManager:close(file_input)
                                 end,

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -902,6 +902,7 @@ function Wallabag:setFilterTag(touchmenu_instance)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.tag_dialog)
                     end,
@@ -933,6 +934,7 @@ function Wallabag:setIgnoreTags(touchmenu_instance)
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(self.ignore_tags_dialog)
                     end,
@@ -1000,6 +1002,7 @@ Restart KOReader after editing the config file.]]), BD.dirpath(DataStorage:getSe
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.settings_dialog:onClose()
                         UIManager:close(self.settings_dialog)
@@ -1048,6 +1051,7 @@ function Wallabag:editClientSettings()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         self.client_settings_dialog:onClose()
                         UIManager:close(self.client_settings_dialog)

--- a/spec/unit/focusmanager_spec.lua
+++ b/spec/unit/focusmanager_spec.lua
@@ -1,14 +1,24 @@
 describe("FocusManager module", function()
     local FocusManager
-    local layout
-    local Up,Down,Left,Right
-    Up = function(self) self:onFocusMove({0, -1}) end
-    Down = function(self) self:onFocusMove({0, 1}) end
-    Left = function(self) self:onFocusMove({-1, 0}) end
-    Right = function(self) self:onFocusMove({1, 0}) end
+    local layout, big_layout
+    local Key
+    local Input
+    local Up = function(self) self:onFocusMove({0, -1}) end
+    local Down = function(self) self:onFocusMove({0, 1}) end
+    local Left = function(self) self:onFocusMove({-1, 0}) end
+    local Right = function(self) self:onFocusMove({1, 0}) end
+    local Next = function(self) self:onFocusNext() end
+    local Previous = function(self) self:onFocusPrevious() end
+    local HalfMoveUp = function(self) self:onFocusHalfMove({"up"}) end
+    local HalfMoveDown = function(self) self:onFocusHalfMove({"down"}) end
+    local HalfMoveLeft = function(self) self:onFocusHalfMove({"left"}) end
+    local HalfMoveRight = function(self) self:onFocusHalfMove({"right"}) end
+    local MoveTo = function(self, x, y) self:moveFocusTo(x, y) end
     setup(function()
         require("commonrequire")
         FocusManager = require("ui/widget/focusmanager")
+        Key = require("device/key")
+        Input = require("device/input")
         local Widget = require("ui/widget/textwidget")
         local w = Widget:new{}
         layout= {
@@ -16,7 +26,13 @@ describe("FocusManager module", function()
                 {nil,w,nil},
                 {nil,w,nil},
                 }
-
+        big_layout = {
+            {w, w, w, w, w},
+            {w, w, w, w, w},
+            {w, w, w, w, w},
+            {w, w, w, w, w},
+            {w, w, w, w, w},
+        }
     end)
     it("should go right", function()
         local focusmanager = FocusManager:new{}
@@ -87,5 +103,130 @@ describe("FocusManager module", function()
         focusmanager.selected = {y = 2,x = 2}
         Right(focusmanager)
         assert.are.same({y = 2,x = 2}, focusmanager.selected)
+    end)
+    it("should move next right", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.layout = layout
+        focusmanager.selected = {y = 1,x = 2}
+        Next(focusmanager)
+        assert.are.same({y = 1,x = 3}, focusmanager.selected)
+    end)
+    it("should move next row at end of row", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.layout = layout
+        focusmanager.selected = {y = 1,x = 3}
+        Next(focusmanager)
+        assert.are.same({y = 2,x = 2}, focusmanager.selected)
+    end)
+    it("should move next left", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.layout = layout
+        focusmanager.selected = {y = 1,x = 2}
+        Previous(focusmanager)
+        assert.are.same({y = 1,x = 1}, focusmanager.selected)
+    end)
+    it("should move previous at start of row", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.layout = layout
+        focusmanager.selected = {y = 3,x = 2}
+        Previous(focusmanager)
+        assert.are.same({y = 2,x = 2}, focusmanager.selected)
+    end)
+    it("should move half rows or columns", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.layout = big_layout
+        focusmanager.selected = {x = 1, y = 1}
+        HalfMoveRight(focusmanager)
+        assert.are.same({y = 1,x = 3}, focusmanager.selected)
+        HalfMoveDown(focusmanager)
+        assert.are.same({y = 3,x = 3}, focusmanager.selected)
+        HalfMoveLeft(focusmanager)
+        assert.are.same({y = 3,x = 1}, focusmanager.selected)
+        HalfMoveUp(focusmanager)
+        assert.are.same({y = 1,x = 1}, focusmanager.selected)
+    end)
+    it("should move to specified position", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.layout = big_layout
+        focusmanager.selected = {x = 1, y = 1}
+        MoveTo(focusmanager, 3, 4)
+        assert.are.same({y = 4,x = 3}, focusmanager.selected)
+    end)
+    it("should set layout to nil", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.layout = layout
+        focusmanager:disableFocusManagement()
+        assert.is_nil(focusmanager.layout)
+    end)
+    it("should merge into rows", function()
+        local w = layout[1][1]
+        local fm1 = FocusManager:new{}
+        fm1.layout = {
+            {w, w, w}
+        }
+        local fm2 = FocusManager:new{}
+        fm2.layout = {
+            {w, w},
+        }
+        fm1:mergeLayoutInVertical(fm2)
+        local expected = {
+            {w, w, w},
+            {w, w}
+        }
+        assert.are.same(expected, fm1.layout)
+    end)
+    it("should merge into rows at specified position", function()
+        local w = layout[1][1]
+        local fm1 = FocusManager:new{}
+        fm1.layout = {
+            {w, w, w},
+            {w, w, w},
+        }
+        local fm2 = FocusManager:new{}
+        fm2.layout = {
+            {w, w},
+        }
+        fm1:mergeLayoutInVertical(fm2, 2)
+        local expected = {
+            {w, w, w},
+            {w, w},
+            {w, w, w},
+        }
+        assert.are.same(expected, fm1.layout)
+    end)
+    it("should merge into columns", function()
+        local w = layout[1][1]
+        local fm1 = FocusManager:new{}
+        fm1.layout = {
+            {w},
+            {w},
+        }
+        local fm2 = FocusManager:new{}
+        fm2.layout = {
+            {w, w},
+            {w},
+        }
+        fm1:mergeLayoutInHorizontal(fm2, 2)
+        local expected = {
+            {w, w, w},
+            {w, w},
+        }
+        assert.are.same(expected, fm1.layout)
+    end)
+    it("alternative key", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager.extra_key_events = {
+            Hold = { {"Sym", "AA"}, doc = "tap and hold the widget", event="Hold" },
+            HalfFocusUp = { {"Alt", "Up"},    doc = "move focus half columns up",    event = "FocusHalfMove", args = {"up"} },
+        }
+        local m = Input.modifiers;
+        m.Sym = true
+        assert.is_true(focusmanager:isAlternativeKey(Key:new("AA", m)))
+        m.Sym = false
+        m.Alt = true
+        assert.is_true(focusmanager:isAlternativeKey(Key:new("Up", m)))
+        m.Alt = false
+        assert.is_false(focusmanager:isAlternativeKey(Key:new("AA", m)))
+        assert.is_false(focusmanager:isAlternativeKey(Key:new("Up", m)))
     end)
 end)


### PR DESCRIPTION
### FocusManager
#### Trigger `Tap` Event On `Press`
`FocusManager` handles `Press` key event by default. It sends `Tap` gesture event to focused widget on `Press` event. It is not necessarily to add `Press` Key event handler anymore in most cases, making easy to support non-touch devices.
#### New methods to manage `selected` field
Follow new methods are for other container widgets to manage `selected` field. Easy to control widget focus state. Source code are more understanding.

**moveFocusTo(x, y)**
make widget at specified position in focused state

#### Experiment Features
 `FocusManager` defines new event handlers to enhance focus navigation and supporting trigger `Hold` gesture event to focused widget. **These handlers are disabled by default. No default key bindings defined.** User can add key bindings in `settings.reader.lua` file to enable new features.
 
 ##### More Focus Navigation
![small-focus-navigation](https://user-images.githubusercontent.com/13473736/155999916-7955ccfa-26ec-4a43-8858-2c1fbb074c5d.gif)

 Easy to jump to middle of row/column in one key strike, start/end of row/column in two key strikes.
 Low performance device like Kindle DX/DXG take times to move focus. It is worse when moving focus between long list.
 * `HalfFocusUp`: move focus up steps: half of rows count.
 * `HalfFocusRight`: move focus right steps: half of columns count of current row.
 * `HalfFocusDown`: move focus down steps: half of rows count.
 * `HalfFocusLeft`: move focus left steps: half of columns count of current row.
 * `FocusNext`: move focus to next widget. Acts like `Tab` navigation in PC.
 * `FocusPrevious`: move focus to previous widget. Acts like `Shift + Tab` navigation in PC.

##### Hold Gesture Event
![small-hold-gesture](https://user-images.githubusercontent.com/13473736/156000002-d7e17e6e-1fa5-4e43-9bcd-41e739c3a52b.gif)

Relate issues: #8035, #3818
Use can define key binding to `Hold` gesture event handler if device has spare physical keys not used. For example, Kindle 2/DX/DXG has many physical keys left.

After binding, `FocusManager` sends `Hold` gesture event to focused widget. This can unlock many features for non-touch device.

##### Key Binding
User can not only define key bindings to `Hold` and new navigation handlers, but also define extra key bindings to existed array key and `Press` handlers. Key binding added to `settings.reader.lua` to enable features.

Available handler names: `FocusUp`, `FocusDown`, `FocusLeft`, `FocusRight`, `Press`, `Hold`, `HalfFocusUp`, `HalfFocusRight`, `HalfFocusDown`, `HalfFocusLeft`, `FocusNext`, `FocusPrevious`.

Kindle DX example
```lua
    ["focus_manager"] = {
      ["alternative_keymaps"] = {
        -- W, D, X, A act like array keys
        ["FocusUp"] = {"W"},
        ["FocusRight"] = {"D"},
        ["FocusDown"] = {"X"},
        ["FocusLeft"] = {"A"},
        ["Press"] = {"S"}, -- S is centor of A, W, D, X
        ["Hold"] = {"Sym", "AA"},
        ["HalfFocusUp"] = {"Shift", "Up"},
        ["HalfFocusRight"] = {"Shift", "Right"},
        ["HalfFocusDown"] = {"Shift", "Down"},
        ["HalfFocusLeft"] = {"Shift", "Left"},
      },
    },
```
PC Keyboard example
```lua
    ["focus_manager"] = {
      ["alternative_keymaps"] = {
        ["FocusUp"] = {"W"},
        ["FocusRight"] = {"D"},
        ["FocusDown"] = {"S"},
        ["FocusLeft"] = {"A"},
        ["Hold"] = {"Ctrl", "H"},
        ["FocusNext"] = {"Tab"},
        ["FocusPrevious"] = {"Shift", "Tab"},
        ["HalfFocusUp"] = {"Shift", "Up"},
        ["HalfFocusRight"] = {"Shift", "Right"},
        ["HalfFocusDown"] = {"Shift", "Down"},
        ["HalfFocusLeft"] = {"Shift", "Left"},
      },
    },
```
#### Small Changes
* Reassign `self.selected` in `FocusManager:init` to make sure each container widget does not using same `selected` field in `FocusManager` meta table.  Using shared `selected` in meta table may cause focus position corrupted: popup dialog open another popup dialog.
* Fix `_wrapAroundX` using rows instead of columns to calculate rounding.
### InputText
![small-inputtext](https://user-images.githubusercontent.com/13473736/156000073-88864ba8-f9a3-4732-b94b-8f10eeafee26.gif)

* Press `Back` to close virtual keyboard and unfocus, allow moving focus to other widgets.
* Kindle with physical keyboard can enter text directly via keyboard.
* Stop adding text if not in focus state. Fix always adding text to first `InputText` widget on key press if there are multi `InputText` widgets.
### InputDialog
* Fix non-touch device stuck in dialog problem. #8378, #7224
* Call callback of button with `id = "close"` on `Back` press. Easy for non-touch device to close dialog without navigate to `Cancel` or `Close` button.
#### Add `id="close"` to cancel button in `InputDialog:new`
* apps/cloudstorage/cloudstorage.lua
* apps/cloudstorage/dropox.lua
* apps/cloudstorage/ftp.lua
* apps/cloudstorage/webdav.lua
* apps/filemanager/filemanager.lua
* apps/filemanager/filemanagerfilesearcher.lua
* apps/filemanager/filemanagersetdefaults.lua
* apps/filemanager/filemanagershortcuts.lua
* apps/reader/modules/readerbookmark.lua
* apps/reader/modules/readerdictionary.lua
* apps/reader/modules/readerfooter.lua
* apps/reader/modules/readergoto.lua
* apps/reader/modules/readersearch.lua
* apps/reader/modules/readeruserhyph.lua
* apps/reader/modules/readerwikipedia.lua
* apps/reader/readerui.lua
* ui/screensaver.lua
* ui/widget/container/inputcontainer.lua
* ui/widget/dictquicklookup.lua
* ui/widget/inputdialog.lua
* ui/widget/networksetting.lua
* ui/widget/numberpickerwidget.lua
* plugins/SSH.koplugin/main.lua
* plugins/autowarmth.koplugin/main.lua
* plugins/calibre.koplugin/main.lua
* plugins/calibre.koplugin/search.lua
* plugins/calibre.koplugin/wireless.lua
* plugins/coverimage.koplugin/main.lua
* plugins/exporter.koplugin/main.lua
* plugins/gestures.koplugin/main.lua
* plugins/newsdownloader.koplugin/main.lua
* plugins/opds.koplugin/opdsbrowser.lua
* plugins/perceptionexpander.koplugin/main.lua
* plugins/profiles.koplugin/main.lua
* plugins/texteditor.koplugin/main.lua
* plugins/wallabag.koplugin/main.lua

### Minor Changes
**apps/reader/modules/readertoc.lua**
For non-touch device user, expand/collapse TOC on right key, it is much useful than showing section title.
![small-readertoc](https://user-images.githubusercontent.com/13473736/156000138-5e447c19-7e43-4703-8674-269846d9aa22.gif)

**device/kindle/device.lua**
Fix setDateTime failed on Kindle DX which `date` uses different date time format.

**device/sdl/event_map_sdl2.lua**
Add another key code of `ContextMenu`  in ubuntu 20.04

**ui/widget/bookstatuswidget.lua**
Support non-touch devices. Close by `back` instead of any key.
![small-bookstatus](https://user-images.githubusercontent.com/13473736/156000189-3ebee562-d33e-479c-9f11-000e1b76a4cc.gif)

**ui/widget/checkbutton.lua**
Add focus and unfocus style

**ui/widget/configdialog.lua**
Use FocusManager method to reset focus selection instead of handling `.selected` field directly. Remove press key event handler.

**ui/widget/confirmbox.lua**
Support non-touch devices. Remove unused `onSelect` method.

**ui/widget/datetimewidget.lua**
Support non-touch device. Fix month can be set to larger than 12.

**ui/widget/doublespinwidget.lua**
Remove press handler

**ui/widget/frontlightwidget.lua**
Support non-touch devices

**ui/widget/keyboardlayoutdialog.lua**
Supprot non-touch devices. Close dialog by `back` instead of any key.

**ui/widget/menu.lua**
Remove press key handler. Use `FocusManager.sendHoldEventToFocusedWidget` to easy context menu handling.

**ui/widget/multiconfirmbox.lua**
Supprot non-touch devices. Remove unused `onSelect` method.

**ui/widget/multiinputdialog.lua**
Supprot non-touch devices. No need to hack layout anymore.

**ui/widget/numberpickerwidget.lua**
Supprot non-touch devices. Remove press key handler

**ui/widget/openwithdialog.lua:**
Supprot non-touch devices.

**ui/widget/radiobuttontable.lua**
Use FocusManager method to reset focus selection instead of handling `.selected` field directly. Remove press key event handler.

**ui/widget/skimtowidget.lua**
Support non-touch device better. Use FocusManager method to reset focus selection instead of handling `.selected` field directly. Remove press key event handler.

**ui/widget/spinwidget.lua**
Remove press key event handler.

**ui/widget/touchmenu.lua**
Remove press key event handler. Use FocusManager method to reset focus selection instead of handling `.selected` field directly.

**ui/widget/virtualkeyboard.lua**
Remove press key event handler. Continue propagate `Back` event to let `InputText` to unfocus.

**plugins/coverbrowser.koplugin/listmenu.lua**
Support non-touch device.

**ui/widget/keyvaluepage.lua**
Support non-touch device

**plugins/statistics.koplugin/calendarview.lua**
Support non-touch device

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8859)
<!-- Reviewable:end -->
