### PR TITLE
UserHyph: Scrub and sort user dict

### DIFF
--- a/frontend/apps/reader/modules/readeruserhyph.lua
+++ b/frontend/apps/reader/modules/readeruserhyph.lua
@@ -267,6 +267,10 @@ function ReaderUserHyph:modifyUserEntry(word)
 
     local suggested_hyphenation = cre.getHyphenationForWord(word)
 
+    -- word may have some strange punctuation marks (as the upper dot),
+    -- so we use crengine to trimm that.
+    word = suggested_hyphenation:gsub("-","")
+
     local input_dialog
     input_dialog = InputDialog:new{
         title = T(_("Hyphenate: %1"), word),

--- a/frontend/apps/reader/modules/readeruserhyph.lua
+++ b/frontend/apps/reader/modules/readeruserhyph.lua
@@ -231,6 +231,8 @@ function ReaderUserHyph:modifyUserEntry(word)
 
     if not self.ui.document then return end
 
+    word = Utf8Proc.normalize_NFC(word)
+
     local suggested_hyphenation = cre.getHyphenationForWord(word)
 
     local input_dialog

--- a/frontend/apps/reader/modules/readeruserhyph.lua
+++ b/frontend/apps/reader/modules/readeruserhyph.lua
@@ -116,6 +116,9 @@ function ReaderUserHyph:checkHyphenation(suggestion, word)
 end
 
 function ReaderUserHyph:updateDictionary(word, hyphenation)
+    if not word then
+        logger.err("UserHyph: called without arguments")
+    end
     local dict_file = self:getDictionaryPath()
     local new_dict_file = dict_file .. ".new"
 
@@ -125,9 +128,7 @@ function ReaderUserHyph:updateDictionary(word, hyphenation)
         return
     end
 
-    if word then
-        word = Utf8Proc.normalize_NFC(word)
-    end
+    word = Utf8Proc.normalize_NFC(word)
 
     local word_lower = Utf8Proc.lowercase(word)
     local line

--- a/frontend/apps/reader/modules/readeruserhyph.lua
+++ b/frontend/apps/reader/modules/readeruserhyph.lua
@@ -11,6 +11,11 @@ local logger = require("logger")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
+-- if sometime in the future crengine is updated to use normalized utf8 for hypenation
+-- this variable can be set to `true`. (see discussion in : https://github.com/koreader/crengine/pull/466),
+-- and some `if NORM then` branches can be simplified.
+local NORM = false
+
 local ReaderUserHyph = WidgetContainer:new{
     -- return values from setUserHyphenationDict (crengine's UserHyphDict::init())
     USER_DICT_RELOAD = 0,
@@ -109,7 +114,7 @@ function ReaderUserHyph:checkHyphenation(suggestion, word)
     end
 
     suggestion = suggestion:gsub("-","")
-    if Utf8Proc.lowercase(suggestion) == Utf8Proc.lowercase(word) then
+    if Utf8Proc.lowercase(suggestion, NORM) == Utf8Proc.lowercase(word, NORM) then
         return true -- characters match (case insensitive)
     end
     return false
@@ -128,26 +133,32 @@ function ReaderUserHyph:updateDictionary(word, hyphenation)
         return
     end
 
-    word = Utf8Proc.normalize_NFC(word)
+    if NORM then
+        word = Utf8Proc.normalize_NFC(word)
+    end
 
-    local word_lower = Utf8Proc.lowercase(word)
+    local word_lower = Utf8Proc.lowercase(word, NORM)
     local line
 
     local dict = io.open(dict_file, "r")
     if dict then
         line = dict:read()
-        line = line and Utf8Proc.normalize_NFC(line)
+        if NORM then
+            line = line and Utf8Proc.normalize_NFC(line)
+        end
         --search entry
-        while line and Utf8Proc.lowercase(line:sub(1, line:find(";") - 1)) < word_lower do
+        while line and Utf8Proc.lowercase(line:sub(1, line:find(";") - 1), NORM) < word_lower do
             new_dict:write(line .. "\n")
             line = dict:read()
-            line = line and Utf8Proc.normalize_NFC(line)
+            if NORM then
+                line = line and Utf8Proc.normalize_NFC(line)
+            end
         end
 
         -- last word = nil if EOF, else last_word=word if found in file, else last_word is word after the new entry
         if line then
-            local last_word = Utf8Proc.lowercase(line:sub(1, line:find(";") - 1))
-            if last_word == Utf8Proc.lowercase(word) then
+            local last_word = Utf8Proc.lowercase(line:sub(1, line:find(";") - 1), NORM)
+            if last_word == word_lower then
                 line = nil -- word found
             end
         else
@@ -168,8 +179,10 @@ function ReaderUserHyph:updateDictionary(word, hyphenation)
     if dict then
         repeat
             line = dict:read()
+            if NORM then
+                line = line and Utf8Proc.normalize_NFC(line)
+            end
             if line then
-                line = Utf8Proc.normalize_NFC(line)
                 new_dict:write(line .. "\n")
             end
         until (not line)
@@ -184,7 +197,7 @@ function ReaderUserHyph:updateDictionary(word, hyphenation)
 end
 
 -- This is called when the file is badly sorted (which should only happen if a user has edited
--- the hyphenation file by hand and messed the order) or if (some) entries are not utf8_normalized.
+-- the hyphenation file by hand and messed the order).
 function ReaderUserHyph:scrubDictionary()
     logger.dbg("UserHyph: scrubbing and sorting user hyphenation dict")
 
@@ -197,17 +210,19 @@ function ReaderUserHyph:scrubDictionary()
     local dict_entries = {}
 
     local line = dict:read()
-    line = line and Utf8Proc.normalize_NFC(line)
+    if NORM then
+        line = line and Utf8Proc.normalize_NFC(line)
+    end
     while line do
         table.insert(dict_entries, line)
         line = dict:read()
-        if line then
-            line = Utf8Proc.normalize_NFC(line)
+        if NORM then
+            line = line and Utf8Proc.normalize_NFC(line)
         end
     end
     dict:close()
 
-    table.sort(dict_entries, function(a,b) return Utf8Proc.lowercase(a) < Utf8Proc.lowercase(b) end)
+    table.sort(dict_entries, function(a,b) return Utf8Proc.lowercase(a, NORM) < Utf8Proc.lowercase(b, NORM) end)
 
     local new_dict_file = dict_file .. ".new"
 
@@ -231,7 +246,9 @@ function ReaderUserHyph:modifyUserEntry(word)
 
     if not self.ui.document then return end
 
-    word = Utf8Proc.normalize_NFC(word)
+    if NORM then
+        word = Utf8Proc.normalize_NFC(word)
+    end
 
     local suggested_hyphenation = cre.getHyphenationForWord(word)
 
@@ -240,7 +257,7 @@ function ReaderUserHyph:modifyUserEntry(word)
         title = T(_("Hyphenate: %1"), word),
         description = _("Add hyphenation positions with hyphens ('-') or spaces (' ')."),
         input = suggested_hyphenation,
-        old_hyph_lowercase = Utf8Proc.lowercase(suggested_hyphenation),
+        old_hyph_lowercase = Utf8Proc.lowercase(suggested_hyphenation, NORM),
         input_type = "string",
         buttons = {
             {
@@ -268,7 +285,7 @@ function ReaderUserHyph:modifyUserEntry(word)
 
                         if self:checkHyphenation(new_suggestion, word) then
                             -- don't save if no changes
-                            if Utf8Proc.lowercase(new_suggestion) ~= input_dialog.old_hyph_lowercase then
+                            if Utf8Proc.lowercase(new_suggestion, NORM) ~= input_dialog.old_hyph_lowercase then
                                 self:updateDictionary(word, new_suggestion)
                             end
                             UIManager:close(input_dialog)


### PR DESCRIPTION
This should fix https://github.com/koreader/koreader/issues/8843

The problem was, that some user dictionary entries were not utf8-normalized.

With this PR, old dicts get normalized on load and if there is a problem with loading the dicts are get sorted again.
This sorting might help, if someone generates his dicts per hand too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8863)
<!-- Reviewable:end -->
