### PR TITLE
Calibre plugin - Series/Tag browser updated to show back button.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ i18n
 /.cproject
 /.project
 .gitignore~
+

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ i18n
 /.cproject
 /.project
 .gitignore~
-

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -394,7 +394,6 @@ function CalibreSearch:browse(option, run, chosen)
         }
 
         self.search_menu.onReturn = function ()
-            table.remove(self.search_menu.paths)
             self:browse(option, run, chosen)
         end
 
@@ -420,13 +419,16 @@ function CalibreSearch:browse(option, run, chosen)
             table.insert(menu_entries, entry)
         end
         table.sort(menu_entries, function(v1,v2) return v1.text < v2.text end)
-        self.search_menu:switchItemTable(name, menu_entries)
+
+        -- If browsing after using return button there will be page number in paths table
+        local previous_page = (table.remove(self.search_menu.paths) or 1) * self.search_menu.perpage
+        self.search_menu:switchItemTable(name, menu_entries, previous_page)
 
         UIManager:show(self.search_menu)
     else
         local results
 
-        table.insert(self.search_menu.paths, 1)
+
         if option == "tags" then
             results = getBooksByTag(self.books, chosen)
         elseif option == "series" then
@@ -435,6 +437,9 @@ function CalibreSearch:browse(option, run, chosen)
         if results then
             local catalog = self:bookCatalog(results, option)
             table.sort(catalog, function(v1,v2) return v1.text < v2.text end)
+
+            -- Inserting current page number into paths in case we use return button
+            table.insert(self.search_menu.paths, self.search_menu.page)
             self.search_menu:switchItemTable(chosen, catalog)
 
             UIManager:show(self.search_menu)

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -383,21 +383,21 @@ end
 
 -- browse tags or series
 function CalibreSearch:browse(option, run, chosen)
-    local menu_container = CenterContainer:new{
-        dimen = Screen:getSize(),
-    }
-    self.search_menu = Menu:new{
-        width = Screen:getWidth() - (Size.margin.fullscreen_popout * 2),
-        height = Screen:getHeight() - (Size.margin.fullscreen_popout * 2),
-        show_parent = menu_container,
-        onMenuHold = self.onMenuHold,
-        _manager = self,
-    }
-    table.insert(menu_container, self.search_menu)
-    self.search_menu.close_callback = function()
-        UIManager:close(menu_container)
-    end
     if run == 1 then
+        self.search_menu = self.search_menu or Menu:new{
+            width = Screen:getWidth(),
+            height = Screen:getHeight(),
+            paths = {},
+            parent = nil,
+            is_borderless = true,
+            onMenuHold = self.onMenuHold,
+        }
+
+        self.search_menu.onReturn = function ()
+            table.remove(self.search_menu.paths)
+            self:browse(option, run, chosen)
+        end
+
         local menu_entries = {}
         local search_value
         if self.search_value ~= "" then
@@ -421,9 +421,12 @@ function CalibreSearch:browse(option, run, chosen)
         end
         table.sort(menu_entries, function(v1,v2) return v1.text < v2.text end)
         self.search_menu:switchItemTable(name, menu_entries)
-        UIManager:show(menu_container)
+
+        UIManager:show(self.search_menu)
     else
         local results
+
+        table.insert(self.search_menu.paths, 1)
         if option == "tags" then
             results = getBooksByTag(self.books, chosen)
         elseif option == "series" then
@@ -431,7 +434,10 @@ function CalibreSearch:browse(option, run, chosen)
         end
         if results then
             local catalog = self:bookCatalog(results, option)
-            self:showresults(catalog, chosen)
+            table.sort(catalog, function(v1,v2) return v1.text < v2.text end)
+            self.search_menu:switchItemTable(chosen, catalog)
+
+            UIManager:show(self.search_menu)
         end
     end
 

--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -3,7 +3,6 @@
 --]]
 
 local CalibreMetadata = require("metadata")
-local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -14,7 +13,6 @@ local InputContainer = require("ui/widget/container/inputcontainer")
 local Menu = require("ui/widget/menu")
 local Persist = require("persist")
 local Screen = require("device").screen
-local Size = require("ui/size")
 local TimeVal = require("ui/timeval")
 local UIManager = require("ui/uimanager")
 local lfs = require("libs/libkoreader-lfs")
@@ -381,7 +379,6 @@ function CalibreSearch:browse(option)
     if self.search_value ~= "" then
         search_value = self.search_value
     end
-        
     local name
     local menu_entries = {}
 
@@ -456,7 +453,6 @@ function CalibreSearch:switchResults(t, title, is_child, page)
         path_entry.page = (self.search_menu.perpage or 1) * (self.search_menu.page or 1)
         table.insert(self.search_menu.paths, path_entry)
     end
-    
     self.search_menu:switchItemTable(title, t, page or 1)
 end
 


### PR DESCRIPTION
When browsing tags and series there was no way to go "back" from tag/series results. Figured we can enable return button navigation by pushing entry to paths property of Menu widget.

When return button is enabled it is overlapping with rounded border previously present on browse widget so I made it borderless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8869)
<!-- Reviewable:end -->
