### PR TITLE
Calibre plugin - Fixed hang when book has series but series index is nil

### DIFF
--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -270,7 +270,7 @@ function CalibreSearch:bookCatalog(t, option)
         local entry = {}
         entry.info = getBookInfo(book)
         entry.path = book.rootpath .. "/" .. book.lpath
-        if series then
+        if series and book.series_index then
             local major, minor = string.format("%05.2f", book.series_index):match("([^.]+).([^.]+)")
             if minor ~= "00" then
                 subseries = true


### PR DESCRIPTION
Sometimes Calibre metadata file does not have series_index for whatever reasons. Tapping series name will not open a list of books which are part of the series. Upon inspection it turns out that code execution never goes past line 274, just hanging there when trying to do string.format. This code change allows those books to still be listed but without series index information while avoiding the hang,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8870)
<!-- Reviewable:end -->
