### PR TITLE
Bidi: keep invert() generic, handle settings in ReaderView

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -643,7 +643,7 @@ function ReaderToc:expandParentNode(index)
 end
 
 function ReaderToc:onShowToc()
-    if self.view.inverse_reading_order then
+    if self.view:shouldInvertBiDiLayoutMirroring() then
         BD.invert()
     end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -831,6 +831,11 @@ function ReaderView:onReadSettings(config)
                                               or 8)
 end
 
+function ReaderView:shouldInvertBiDiLayoutMirroring()
+    -- A few widgets may temporarily invert UI layout mirroring when both these settings are true
+    return self.inverse_reading_order and G_reader_settings:isTrue("invert_ui_layout_mirroring")
+end
+
 function ReaderView:onPageUpdate(new_page_no)
     self.state.page = new_page_no
     self.state.drawn = false

--- a/frontend/ui/bidi.lua
+++ b/frontend/ui/bidi.lua
@@ -130,7 +130,7 @@ end
 -- This fuction can be used by document widgets to temporarily match a widget
 -- to the document page turn direction instead of the UI layout direction.
 function Bidi.invert()
-    if G_reader_settings:isTrue("invert_ui_layout_mirroring") and not Bidi._inverted then
+    if not Bidi._inverted then
         Bidi._mirrored_ui_layout = not Bidi._mirrored_ui_layout
         Bidi._inverted = true
     end

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -527,7 +527,7 @@ local BookMapWidget = InputContainer:new{
 }
 
 function BookMapWidget:init()
-    if self.ui.view.inverse_reading_order then
+    if self.ui.view:shouldInvertBiDiLayoutMirroring() then
         BD.invert()
     end
 

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -39,7 +39,7 @@ local PageBrowserWidget = InputContainer:new{
 }
 
 function PageBrowserWidget:init()
-    if self.ui.view.inverse_reading_order then
+    if self.ui.view:shouldInvertBiDiLayoutMirroring() then
         BD.invert()
     end
 


### PR DESCRIPTION
Follow up to #8673 / 42dd5aad. Handle settings only in `ReaderView:shouldInvertBiDiLayoutMirroring()`. See https://github.com/koreader/koreader/pull/8673#issuecomment-1046349246.

I haven't changed them, but currently, the settings are named:
```
["inverse_reading_order"] = true
["invert_ui_layout_mirroring"] = true
```
I find the 2nd one a bit too generic, while it depends on the first one.
Should we change the 2nd one to read `inverse_reading_order_also_ui_layout` ?
https://github.com/koreader/koreader/pull/8673/commits/4e45227250da427636db3498b0eabf7dfd9a28c4#r789583906

@yparitcher : in TOC, chapters titles are still rendered LTR:
![image](https://user-images.githubusercontent.com/24273478/157018149-35bb590d-6992-4439-935e-f8851fd2f786.png)
while in Book map and Page browser, they look better:
![image](https://user-images.githubusercontent.com/24273478/157018255-91c33b89-1228-458d-a1ba-8aa6e7a3a9a2.png)
![image](https://user-images.githubusercontent.com/24273478/157018335-c2133ff9-6646-45c3-90f9-e06999661e65.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8876)
<!-- Reviewable:end -->
