### PR TITLE
non-touch device highlight support

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -13,6 +13,7 @@ local UIManager = require("ui/uimanager")
 local dbg = require("dbg")
 local logger = require("logger")
 local util = require("util")
+local Size = require("ui/size")
 local ffiUtil = require("ffi/util")
 local _ = require("gettext")
 local C_ = _.pgettext
@@ -45,8 +46,28 @@ local function cleanupSelectedText(text)
     return text
 end
 
+local CLEAR_HIGHLIGHT_SELECTION = { true }
+local NOT_CLEAR_HIGHLIGHT_SELECTION = { false }
+
 function ReaderHighlight:init()
     self.select_mode = false -- extended highlighting
+    self._start_indicator_highlight = false
+    self._current_indicator_pos = nil
+    self._previous_indicator_pos = nil
+
+    local QUICK_INDICTOR_MOVE = true
+    self.key_events.StartHighlightIndicator = { {"H"}, doc = "start non-touch highlight" }
+    self.key_events.StopHighlightIndicator = { {Device.input.group.Back}, doc = "Stop non-touch highlight", args = CLEAR_HIGHLIGHT_SELECTION }
+    self.key_events.UpHighlightIndicator = { {"Up"}, doc = "move indicator up", event = "MoveHighlightIndicator", args = {0, -1} }
+    self.key_events.DownHighlightIndicator = { {"Down"}, doc = "move indicator down", event = "MoveHighlightIndicator", args = {0, 1} }
+    -- let FewKeys device can move indicator left
+    self.key_events.LeftHighlightIndicator = { {"Left"}, doc = "move indicator left", event = "MoveHighlightIndicator", args = {-1, 0} }
+    self.key_events.RightHighlightIndicator = { {"Right"}, doc = "move indicator right", event = "MoveHighlightIndicator", args = {1, 0} }
+    self.key_events.QuicklyUpHighlightIndicator = { {"Shift", "Up"}, doc = "quick move indicator up", event = "MoveHighlightIndicator", args = {0, -1, QUICK_INDICTOR_MOVE} }
+    self.key_events.QuicklyDownHighlightIndicator = { {"Shift", "Down"}, doc = "quick move indicator down", event = "MoveHighlightIndicator", args = {0, 1, QUICK_INDICTOR_MOVE} }
+    self.key_events.QuicklyLeftHighlightIndicator = { {"Shift", "Left"}, doc = "quick move indicator left", event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICTOR_MOVE} }
+    self.key_events.QuicklyRightHighlightIndicator = { {"Shift", "Right"}, doc = "quick move indicator right", event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICTOR_MOVE} }
+    self.key_events.HighlightPress = { {"Press"}, doc = "highlight start or end" }
 
     self._highlight_buttons = {
         -- highlight and add_note are for the document itself,
@@ -295,6 +316,14 @@ local long_press_action = {
 
 function ReaderHighlight:addToMainMenu(menu_items)
     -- insert table to main reader menu
+    if Device:hasDPad() then
+        menu_items.start_content_selection = {
+            text = _("Start content selection"),
+            callback = function()
+                self:onStartHighlightIndicator()
+            end,
+        }
+    end
     menu_items.highlight_options = {
         text = _("Highlight style"),
         sub_item_table = {},
@@ -361,11 +390,6 @@ function ReaderHighlight:addToMainMenu(menu_items)
     end
     menu_items.translation_settings = Translator:genSettingsMenu()
 
-    if not Device:isTouchDevice() then
-        -- Menu items below aren't needed.
-        return
-    end
-
     menu_items.long_press = {
         text = _("Long-press on text"),
         sub_item_table = {
@@ -396,6 +420,12 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 self.view.highlight.disabled = v[2] == "nothing"
             end,
         })
+    end
+    -- long_press menu is under taps_and_gestures menu which is not available for non touch device
+    -- Clone long_press menu and change label making much meaning for non touch devices
+    if Device:hasDPad() then
+        menu_items.selection_text = util.tableDeepCopy(menu_items.long_press)
+        menu_items.selection_text.text = _("Select on text")
     end
 end
 
@@ -907,6 +937,7 @@ function ReaderHighlight:onHold(arg, ges)
             fullscreen = true,
         }
         UIManager:show(imgviewer)
+        self:onStopHighlightIndicator(NOT_CLEAR_HIGHLIGHT_SELECTION)
         return true
     end
 
@@ -1364,10 +1395,13 @@ function ReaderHighlight:onHoldRelease()
 
     local long_final_hold = false
     if self.hold_last_tv then
-        local hold_duration = TimeVal:now() - self.hold_last_tv
-        if hold_duration > TimeVal:new{ sec = 3, usec = 0 } then
-            -- We stayed 3 seconds before release without updating selection
-            long_final_hold = true
+        -- do not turn on long hold timeout detection for non-touch device
+        if Device:isTouchDevice() then
+            local hold_duration = TimeVal:now() - self.hold_last_tv
+            if hold_duration > TimeVal:new{ sec = 3, usec = 0 } then
+                -- We stayed 3 seconds before release without updating selection
+                long_final_hold = true
+            end
         end
         self.hold_last_tv = nil
     end
@@ -1805,5 +1839,127 @@ function ReaderHighlight:onClose()
     -- clear highlighted text
     self:clear()
 end
+
+function ReaderHighlight:onHighlightPress()
+    if self._current_indicator_pos then
+        if not self._start_indicator_highlight then
+            -- try tap on current indicator postion to open existed highlight
+            if not self:onTap(nil, self:_createHighlightGesture("tap")) then
+                -- start hold if no existed highlight at current indicator position
+                self._start_indicator_highlight = true
+                self:onHold(nil, self:_createHighlightGesture("hold"))
+                if self.selected_text and self.selected_text.sboxes and #self.selected_text.sboxes then
+                    local pos = self.selected_text.sboxes[1]
+                    -- set hold_pos to start of selected_test to make center selection more stable, not jitted at edge
+                    self.hold_pos = self.view:screenToPageTransform({
+                        x = pos.x + pos.w / 2,
+                        y = pos.y + pos.h / 2
+                    })
+                    -- move indicator to selected text making succeed same row selection much accurate.
+                    UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
+                    self._current_indicator_pos.x = pos.x + pos.w - self._current_indicator_pos.w
+                    self._current_indicator_pos.y = pos.y + pos.h / 2 - self._current_indicator_pos.h / 2
+                    UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
+                end
+            else
+                self:onStopHighlightIndicator(CLEAR_HIGHLIGHT_SELECTION)
+            end
+        else
+            self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+            self:onStopHighlightIndicator(NOT_CLEAR_HIGHLIGHT_SELECTION)
+        end
+        return true
+    end
+    return false
+end
+
+function ReaderHighlight:onStartHighlightIndicator()
+    if self.view.visible_area and not self._current_indicator_pos then
+        -- set start position to centor of page
+        local rect = self._previous_indicator_pos
+        if not rect then
+            rect = Geom:new()
+            rect.x = self.view.visible_area.w / 2
+            rect.y = self.view.visible_area.h / 2
+            rect.w = Size.item.height_default
+            rect.h = rect.w
+        end
+        self._current_indicator_pos = rect
+        self.view.highlight.indicator = rect
+        UIManager:setDirty(self.dialog, "ui", rect)
+        return true
+    end
+    return false
+end
+
+function ReaderHighlight:onStopHighlightIndicator(args)
+    local need_clear = unpack(args)
+    if self._current_indicator_pos then
+        local rect = self._current_indicator_pos
+        self._previous_indicator_pos = rect
+        self._start_indicator_highlight = false
+        self._current_indicator_pos = nil
+        self.view.highlight.indicator = nil
+        UIManager:setDirty(self.dialog, "ui", rect)
+        if need_clear then
+            self:clear()
+        end
+        return true
+    end
+    return false
+end
+
+function ReaderHighlight:onMoveHighlightIndicator(args)
+    if self.view.visible_area and self._current_indicator_pos then
+        local dx, dy, quick_move = unpack(args)
+        local step_distance = self.view.visible_area.w / 5 -- quick move distance: fifth of visible_area
+        local y_step_distance = self.view.visible_area.h / 5
+        if step_distance > y_step_distance then
+            -- take the smaller, make all direction move distance much predictable
+            step_distance = y_step_distance
+        end
+        if not quick_move then
+            step_distance = step_distance / 4 -- twentieth of visible_area
+        end
+        local rect = self._current_indicator_pos:copy()
+        rect.x = rect.x + step_distance * dx
+        rect.y = rect.y + step_distance * dy
+        if rect.x < 0 then
+            rect.x = 0
+        end
+        if rect.x + rect.w > self.view.visible_area.w then
+            rect.x = self.view.visible_area.w - rect.w
+        end
+        if rect.y < 0 then
+            rect.y = 0
+        end
+        if rect.y + rect.h > self.view.visible_area.h then
+            rect.y = self.view.visible_area.h - rect.h
+        end
+        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
+        self._current_indicator_pos = rect
+        self.view.highlight.indicator = rect
+        UIManager:setDirty(self.dialog, "ui", rect)
+        if self._start_indicator_highlight then
+            self:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
+        end
+        return true
+    end
+    return false
+end
+
+function ReaderHighlight:_createHighlightGesture(gesture)
+    local point = self._current_indicator_pos:copy()
+    point.x = point.x + point.w / 2
+    point.y = point.y + point.h / 2
+    point.w = 0
+    point.h = 0
+    return {
+        ges = gesture,
+        pos = point,
+        time = TimeVal:realtime(),
+    }
+end
+
 
 return ReaderHighlight

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -396,12 +396,12 @@ function ReaderHighlight:addToMainMenu(menu_items)
         text = _("Long-press on text"),
         sub_item_table = {
             {
-                text = _("Highlight Long-press interval"),
+                text = _("Highlight long-press interval"),
                 keep_menu_open = true,
                 callback = function()
                     local SpinWidget = require("ui/widget/spinwidget")
                     local items = SpinWidget:new{
-                        title_text = _("Highlight Long-press interval"),
+                        title_text = _("Highlight long-press interval"),
                         info_text = _([[
 If a touch is not released in this interval, it is considered a long-press. On document text, single word selection will not be triggered.
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -405,7 +405,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                         info_text = _([[
 If a touch is not released in this interval, it is considered a long-press. On document text, single word selection will not be triggered.
 
-The interval value is in seconds and can range from 3 seconds to 20 seconds.]]),
+The interval value is in seconds and can range from 3 to 20 seconds.]]),
                         width = math.floor(Screen:getWidth() * 0.75),
                         value = G_reader_settings:readSetting("highlight_long_hold_threshold", 3),
                         value_min = 3,

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -19,6 +19,7 @@ local UIManager = require("ui/uimanager")
 local dbg = require("dbg")
 local logger = require("logger")
 local optionsutil = require("ui/data/optionsutil")
+local Size = require("ui/size")
 local _ = require("gettext")
 local Screen = Device.screen
 local T = require("ffi/util").template
@@ -44,6 +45,7 @@ local ReaderView = OverlapGroup:extend{
         temp = {},
         saved_drawer = "lighten",
         saved = {},
+        indicator = nil, -- geom: non-touch highlight position indicator: {x = 50, y=50}
     },
     highlight_visible = true,
     -- PDF/DjVu continuous paging
@@ -198,6 +200,10 @@ function ReaderView:paintTo(bb, x, y)
     -- draw temporary highlight
     if self.highlight.temp then
         self:drawTempHighlight(bb, x, y)
+    end
+    -- draw highlight position indicator for non-touch
+    if self.highlight.indicator then
+        self:drawHighlightIndicator(bb, x, y)
     end
     -- paint dogear
     if self.dogear_visible then
@@ -452,6 +458,23 @@ function ReaderView:drawScrollView(bb, x, y)
         y + self.state.offset.y,
         self.visible_area,
         self.state.pos)
+end
+
+function ReaderView:drawHighlightIndicator(bb, x, y)
+    local rect = self.highlight.indicator
+    -- paint big cross line +
+    bb:paintRect(
+        rect.x,
+        rect.y + rect.h / 2 - Size.border.thick / 2,
+        rect.w,
+        Size.border.thick
+    )
+    bb:paintRect(
+        rect.x + rect.w / 2 - Size.border.thick / 2,
+        rect.y,
+        Size.border.thick,
+        rect.h
+    )
 end
 
 function ReaderView:drawTempHighlight(bb, x, y)

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -55,8 +55,10 @@ local order = {
         "speed_reading_module_perception_expander",
         "----------------------------",
         "highlight_options",
+        "selection_text", -- if Device:hasDPad()
         "panel_zoom_options",
         "djvu_render_mode",
+        "start_content_selection", -- if Device:hasDPad(), put this the last one to easy to select by press up key
     },
     setting = {
         -- common settings

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -58,7 +58,7 @@ local order = {
         "selection_text", -- if Device:hasDPad()
         "panel_zoom_options",
         "djvu_render_mode",
-        "start_content_selection", -- if Device:hasDPad(), put this the last one to easy to select by press up key
+        "start_content_selection", -- if Device:hasDPad(), put this as last one so it is easy to select with "press" and "up" keys
     },
     setting = {
         -- common settings

--- a/frontend/ui/widget/openwithdialog.lua
+++ b/frontend/ui/widget/openwithdialog.lua
@@ -23,7 +23,6 @@ local OpenWithDialog = InputDialog:extend{}
 function OpenWithDialog:init()
     -- init title and buttons in base class
     InputDialog.init(self)
-
     self.element_width = math.floor(self.width * 0.9)
 
     self.radio_button_table = RadioButtonTable:new{
@@ -42,6 +41,7 @@ function OpenWithDialog:init()
             end
         end
     }
+    self.layout = {self.layout[#self.layout]} -- keep bottom buttons
     self:mergeLayoutInVertical(self.radio_button_table, #self.layout) -- before bottom buttons
     self._input_widget = self.radio_button_table
 
@@ -86,13 +86,11 @@ function OpenWithDialog:init()
         text = _("Always use this engine for this file"),
         parent = self,
     }
-    table.insert(self.layout, #self.layout, {self._check_file_button}) -- before bottom buttons
     self:addWidget(self._check_file_button)
     self._check_global_button = self._check_global_button or CheckButton:new{
         text = _("Always use this engine for file type"),
         parent = self,
     }
-    table.insert(self.layout, #self.layout, {self._check_global_button}) -- before bottom buttons
     self:addWidget(self._check_global_button)
 
     self.dialog_frame = FrameContainer:new{

--- a/frontend/ui/widget/radiobuttonwidget.lua
+++ b/frontend/ui/widget/radiobuttonwidget.lua
@@ -3,10 +3,10 @@ local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
 local FrameContainer = require("ui/widget/container/framecontainer")
+local FocusManager = require("ui/widget/focusmanager")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
-local InputContainer = require("ui/widget/container/inputcontainer")
 local MovableContainer = require("ui/widget/container/movablecontainer")
 local RadioButtonTable = require("ui/widget/radiobuttontable")
 local Size = require("ui/size")
@@ -17,7 +17,7 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 local Screen = Device.screen
 
-local RadioButtonWidget = InputContainer:new{
+local RadioButtonWidget = FocusManager:new{
     title_text = "",
     info_text = nil,
     width = nil,
@@ -49,27 +49,24 @@ function RadioButtonWidget:init()
         self.width = math.floor(math.min(self.screen_width, self.screen_height) * self.width_factor)
     end
     if Device:hasKeys() then
-        self.key_events = {
-            Close = { {Device.input.group.Back}, doc = "close widget" }
-        }
+        self.key_events.Close = { {Device.input.group.Back}, doc = "close widget" }
     end
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapClose = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = Geom:new{
-                        w = self.screen_width,
-                        h = self.screen_height,
-                    }
-                },
+    self.ges_events = {
+        TapClose = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    w = self.screen_width,
+                    h = self.screen_height,
+                }
             },
-         }
-    end
+        },
+        }
     self:update()
 end
 
 function RadioButtonWidget:update()
+    self.layout = {}
     if self.default_provider then
         local row, col = self:getButtonIndex(self.default_provider)
         self.radio_buttons[row][col].text = self.radio_buttons[row][col].text .. "\u{A0}\u{A0}★"
@@ -83,6 +80,7 @@ function RadioButtonWidget:update()
         parent = self,
         face = self.face,
     }
+    self:mergeLayoutInVertical(value_widget)
     local value_group = HorizontalGroup:new{
         align = "center",
         value_widget,
@@ -149,7 +147,7 @@ function RadioButtonWidget:update()
         zero_sep = true,
         show_parent = self,
     }
-
+    self:mergeLayoutInVertical(ok_cancel_buttons)
     local vgroup = VerticalGroup:new{
         align = "left",
         title_bar,


### PR DESCRIPTION
### Background
Relate to #4329, #6562

In my opinion, highlight is the last major gap left for non-touch devices after PR #8712 and #8859 merged.

Enable text selection in non-touch devices can unlock highlight module features. Dictionary lookup, one of highlight module feature, is very useful for me to read technical book offline.

The essential problem is: how to select a range text?
### Selection Workflow
Similar to #4329:
1. Start text selection mode. An indicator to let user move to the start position.
2. Confirm start position.
3. Move indicator to the end position (optional, if only single word wanted)
4. Confirm end position.

For touch devices, step 1 and step 2 are activated by a `hold` event. Step 3 accusers as user moving figure activated by `pan_hold` events. Step 4 is activated by a `hold_release` event.

So the basic solution idea is calling highlight module touch event handlers to simulate touch events to complete text selection operation:
1. Start selection mode via keyboard hotkey(`H`) or main menu selection
2. Shows indicator at center of screen.
3. Moves indicator to start position with arrow keys.
4. `press` key to confirm start position, call `hold` event handler.
5. (Optional) Moves indicator to end position with arrow keys, call `pan_hold` event handler.
6. `press` key to confirm end position, call `hold_release` event handler

`Back` key to stop selection mode.

### Move step distance
Step distance: 20th of smaller side length of reader visible_view
Quick move step distance: 4 times of step distance.

I have no idea whether the distance is reasonable. But it works well for me.

### Preview
#### Movement
![move](https://user-images.githubusercontent.com/13473736/157046036-47fbba70-8b70-45d9-acc7-ddc2a9a17015.gif)
#### Pick Image
![pick-image](https://user-images.githubusercontent.com/13473736/157046058-52f57d62-38c5-488d-8c5c-e6ea69cbb881.gif)
#### Follow Link
![follow-link](https://user-images.githubusercontent.com/13473736/157046102-c8d40e09-ceb2-4a14-9721-d0c77f5eb8b4.gif)
#### Highlight
![highlight](https://user-images.githubusercontent.com/13473736/157046155-6a6a0122-68df-406f-8380-4ae4c52b04b2.gif)

### Other improvements
* focusmanager: fix same type container share same selected field
* radiobuttonwidget: non touch support
* sortwidget: non touch support
* openwithdialog: fix layout contains textinput, checkbox widgets added to layout twice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8877)
<!-- Reviewable:end -->
