### PR TITLE
setupkoenv: ffi.load: search rocks

### DIFF
--- a/setupkoenv.lua
+++ b/setupkoenv.lua
@@ -20,7 +20,7 @@ ffi.load = function(lib)
     local loaded, re = pcall(ffi_load, lib)
     if loaded then return re end
 
-    local lib_path = package.searchpath(lib, "./lib?.so;./libs/lib?.so;./libs/lib?.so.1")
+    local lib_path = package.searchpath(lib, "./lib?.so;./libs/lib?.so;./libs/lib?.so.1;./rocks/lib/lua/5.1/lib?.so")
 
     if not lib_path then
         io.write("ffi.load (warning): ", re, "\n")


### PR DESCRIPTION
TLDR 
allow ffi.load from rocks libs

I have plugins that us a C library via the FFI. to make it easily accessible i packaged it in a rock https://luarocks.org/modules/yparitcher/libzmanim but luajit FFI does not follow `package.cpath` rather it only looks in the native linker paths (LD_LIBRARY_PATH).
This PR allow the FFI to load libraries made available in a rock, it should not affect anything else

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8878)
<!-- Reviewable:end -->
