### PR TITLE
fix exception on expand TOC on non-touch device: table index is nil

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -815,7 +815,7 @@ function ReaderToc:onShowToc()
     function toc_menu:onMenuHold(item)
         if not Device:isTouchDevice() and (item.state and item.state.callback) then
             -- non touch to expand toc
-            item.state.callback()
+            item.state.callback(item.index)
         else
             -- Match the items' width
             local infomessage = InfoMessage:new{


### PR DESCRIPTION
Introduced by #8859.

Non touch support is implemented before commit d8087b37e3e7c5e21fc3f3320bd3d435b26c4b56, which adds `index` parameter to `callback` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8892)
<!-- Reviewable:end -->
