### PR TITLE
Kobo, Sage: better power cover detection

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -106,7 +106,10 @@ function KoboPowerD:init()
         end
 
         self.isAuxBatteryConnectedHW = function(this)
-            return this:read_int_file(this.aux_batt_connected_file) == 1
+            -- aux_batt_connected_file shows us:
+            -- 0 if power cover is not connected
+            -- and 1 (or sometimes -1) if the power cover is connected (without a charger)
+            return this:read_int_file(this.aux_batt_connected_file) ~= 0
         end
 
         self.isAuxChargingHW = function(this)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -108,7 +108,8 @@ function KoboPowerD:init()
         self.isAuxBatteryConnectedHW = function(this)
             -- aux_batt_connected_file shows us:
             -- 0 if power cover is not connected
-            -- and 1 (or sometimes -1) if the power cover is connected (without a charger)
+            -- 1 if the power cover is connected
+            -- 1 or sometimes -1 if the power cover is connected without a charger
             return this:read_int_file(this.aux_batt_connected_file) ~= 0
         end
 


### PR DESCRIPTION
I am doing some prework on a batterycare.koplugin, which will allow to keep the charge of the internal battery as well as the charge of the power cover in sane regions (aka no over charge, no deep charge).

This PR minimizes the unsuccessful detection of the power cover, which is good for all Sages with a power cover.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8894)
<!-- Reviewable:end -->
