### PR TITLE
Don't use KOReader suspend/screensaver/autosuspend when launched from Oxide

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -1,5 +1,6 @@
 local Generic = require("device/generic/device") -- <= look at this file!
 local TimeVal = require("ui/timeval")
+local PluginShare = require("pluginshare")
 local logger = require("logger")
 local ffi = require("ffi")
 local C = ffi.C
@@ -139,6 +140,9 @@ function Remarkable:init()
     local rotation_mode = self.screen.ORIENTATION_PORTRAIT
     self.screen.native_rotation_mode = rotation_mode
     self.screen.cur_rotation_mode = rotation_mode
+    
+    -- Disable autosuspend on this device
+    PluginShare.pause_auto_suspend = true
 
     Generic.init(self)
 end

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -113,8 +113,6 @@ end
 
 
 function Remarkable:init()
-    -- Check if we were launched from Oxide launcher
-    --- @fixme this could be changed to check parent process of KOReader instead
     local oxide_running = os.execute("systemctl is-active --quiet tarnish") == 0
     logger.info(string.format("Oxide running?: %s", oxide_running))
 

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -131,7 +131,7 @@ function Remarkable:init()
         status_file = self.status_path,
     }
 
-    event_map = require("device/remarkable/event_map")
+    local event_map = require("device/remarkable/event_map")
     -- If we were launched from Oxide, remove Power from the event map
     if oxide_running then
         event_map[116] = "noop"

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -114,7 +114,7 @@ end
 
 function Remarkable:init()
     -- Check if we were launched from Oxide launcher
-    -- FIXME this could be changed to check parent process of KOReader instead
+    --- @fixme this could be changed to check parent process of KOReader instead
     local oxide_running = os.execute("systemctl is-active --quiet tarnish") == 0
     logger.info(string.format("Oxide running?: %s", oxide_running))
 

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -134,7 +134,7 @@ function Remarkable:init()
     local event_map = require("device/remarkable/event_map")
     -- If we were launched from Oxide, remove Power from the event map
     if oxide_running then
-        event_map[116] = "noop"
+        event_map[116] = nil
     end
 
     self.input = require("device/input"):new{

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -130,7 +130,7 @@ function Remarkable:init()
     }
 
     local event_map = require("device/remarkable/event_map")
-    -- If we were launched from Oxide, remove Power from the event map
+    -- If we are launched while Oxide is running, remove Power from the event map
     if oxide_running then
         event_map[116] = nil
     end

--- a/frontend/device/remarkable/event_map.lua
+++ b/frontend/device/remarkable/event_map.lua
@@ -2,6 +2,6 @@ return {
     [102] = "Home",
     [105] = "LPgBack",
     [106] = "RPgFwd",
-    [116] = "Power",
+    [116] = "noop",
 }
 -- TODO libremarkable has 143 as "wakeup" - don't know what that corresponds to?

--- a/frontend/device/remarkable/event_map.lua
+++ b/frontend/device/remarkable/event_map.lua
@@ -2,6 +2,6 @@ return {
     [102] = "Home",
     [105] = "LPgBack",
     [106] = "RPgFwd",
-    [116] = "noop",
+    [116] = "Power",
 }
 -- TODO libremarkable has 143 as "wakeup" - don't know what that corresponds to?


### PR DESCRIPTION
When running KOReader with a launcher, having the power button trigger the Power event conflicts with the launcher's built-in screensaver (see https://github.com/koreader/koreader/issues/8891).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8900)
<!-- Reviewable:end -->
