### PR TITLE
[i18n] Add context for calibre configuration type

### DIFF
--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -268,7 +268,7 @@ function Calibre:getWirelessMenuTable()
             enabled_func = isEnabled,
             sub_item_table = {
                 {
-                    text = _("Configuration type", "Automatic"),
+                    text = C_("Configuration type", "Automatic"),
                     checked_func = function()
                         return G_reader_settings:hasNot("calibre_wireless_url")
                     end,

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -17,6 +17,7 @@ local LuaSettings = require("luasettings")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
+local C_ = _.pgettext
 local T = require("ffi/util").template
 
 local Calibre = WidgetContainer:new{
@@ -267,7 +268,7 @@ function Calibre:getWirelessMenuTable()
             enabled_func = isEnabled,
             sub_item_table = {
                 {
-                    text = _("Automatic"),
+                    text = _("Configuration type", "Automatic"),
                     checked_func = function()
                         return G_reader_settings:hasNot("calibre_wireless_url")
                     end,
@@ -276,7 +277,7 @@ function Calibre:getWirelessMenuTable()
                     end,
                 },
                 {
-                    text = _("Manual"),
+                    text = C_("Configuration type", "Manual"),
                     checked_func = function()
                         return G_reader_settings:has("calibre_wireless_url")
                     end,


### PR DESCRIPTION
`Manual` could mean several things, most notably some kind of documentation and something you do by hand.

The added context is partially to aid translators and partially to preclude potential collisions in the future.

Cf. <https://github.com/koreader/koreader-translations/pull/138>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8909)
<!-- Reviewable:end -->
