### PR TITLE
Add OPDS PSE 1.0 support

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -701,7 +701,7 @@ function OPDSBrowser:streamPages(item, remote_url, count)
             local code
             if parsed.scheme == "http" or parsed.scheme == "https" then
                 socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
-                code, _ = socket.skip(1, http.request {
+                code = socket.skip(1, http.request {
                     url         = page_url,
                     headers     = {
                         ["Accept-Encoding"] = "identity",

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -5,14 +5,14 @@ local Cache = require("cache")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DocumentRegistry = require("document/documentregistry")
 local Font = require("ui/font")
+local ImageViewer = require("ui/widget/imageviewer")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local Menu = require("ui/widget/menu")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
-local RenderImage = require("ui/renderimage")
-local ImageViewer = require("ui/widget/imageviewer")
 local NetworkMgr = require("ui/network/manager")
 local OPDSParser = require("opdsparser")
+local RenderImage = require("ui/renderimage")
 local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local http = require("socket.http")
@@ -762,7 +762,7 @@ function OPDSBrowser:showDownloads(item)
         if acquisition.stream then
             -- this is an OPDS PSE stream
             table.insert(type_buttons, {
-                text = _("Page Stream") .. "\u{2B0C}", -- append LEFT RIGHT BLACK ARROW
+                text = _("Page stream") .. "\u{2B0C}", -- append LEFT RIGHT BLACK ARROW
                 callback = function()
                     self:streamPages(item, acquisition.href, acquisition.count)
                     UIManager:close(self.download_dialog)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -685,7 +685,7 @@ end
 
 function OPDSBrowser:streamPages(item, remote_url, count)
     local page_table = {image_disposable = true}
-    setmetatable(page_table, {__index = function (t, key)
+    setmetatable(page_table, {__index = function (_, key)
         if type(key) ~= "number" then
             local error_bb = RenderImage:renderImageFile("resources/koreader.png", false)
             return error_bb
@@ -694,14 +694,14 @@ function OPDSBrowser:streamPages(item, remote_url, count)
             local page_url = remote_url:gsub("{pageNumber}", tostring(index))
             page_url = page_url:gsub("{maxWidth}", tostring(Screen:getWidth()))
             local page_data = {}
-            
+
             logger.dbg("Streaming page from", page_url)
             local parsed = url.parse(page_url)
 
-            local code, headers
+            local code
             if parsed.scheme == "http" or parsed.scheme == "https" then
                 socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
-                code, headers = socket.skip(1, http.request {
+                code, _ = socket.skip(1, http.request {
                     url         = page_url,
                     headers     = {
                         ["Accept-Encoding"] = "identity",
@@ -717,9 +717,9 @@ function OPDSBrowser:streamPages(item, remote_url, count)
                     timeout = 3,
                 })
             end
-            
+
             local data = table.concat(page_data)
-        
+
             if code == 200 then
                 local page_bb = RenderImage:renderImageData(data, #data, false)
                 return page_bb
@@ -758,7 +758,7 @@ function OPDSBrowser:showDownloads(item)
     local type_buttons = {} -- file type download buttons
     for i = 1, #acquisitions do -- filter out unsupported file types
         local acquisition = acquisitions[i]
-        
+
         if acquisition.stream then
             -- this is an OPDS PSE stream
             table.insert(type_buttons, {


### PR DESCRIPTION
This PR adds support for the unofficial page streaming extension for OPDS. See: https://anansi-project.github.io/docs/opds-pse/specs/v1.0. This is useful for streaming comics from a remote server.

Addresses #7500.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8919)
<!-- Reviewable:end -->
