### PR TITLE
Use hw keys for page turning when ImageViewer.image is a table

### DIFF
--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -80,11 +80,21 @@ local ImageViewer = InputContainer:new{
 
 function ImageViewer:init()
     if Device:hasKeys() then
-        self.key_events = {
-            Close = { {Device.input.group.Back}, doc = "close viewer" },
-            ZoomIn = { {Device.input.group.PgBack}, doc = "Zoom In" },
-            ZoomOut = { {Device.input.group.PgFwd}, doc = "Zoom out" },
-        }
+        if type(self.image) == "table" then
+            -- if self.image is a table, then use hardware keys to change page
+            self.key_events = {
+                Close = { {Device.input.group.Back}, doc = "close viewer" },
+                PageBack = { {Device.input.group.PgBack}, doc = "Page back" },
+                PageForward = { {Device.input.group.PgFwd}, doc = "Page forward" },
+            }
+        else
+            -- otherwise, use hardware keys to zoom in/out
+            self.key_events = {
+                Close = { {Device.input.group.Back}, doc = "close viewer" },
+                ZoomIn = { {Device.input.group.PgBack}, doc = "Zoom In" },
+                ZoomOut = { {Device.input.group.PgFwd}, doc = "Zoom out" },
+            }
+        end
     end
     if Device:isTouchDevice() then
         local range = Geom:new{
@@ -449,6 +459,19 @@ function ImageViewer:switchToImageNum(image_num)
     self:update()
 end
 
+-- Page events
+function ImageViewer:onPageForward()
+    if self._images_list_cur < self._images_list_nb then
+        self:switchToImageNum(self._images_list_cur + 1)
+    end
+end
+
+function ImageViewer:onPageBack()
+    if self._images_list_cur > 1 then
+        self:switchToImageNum(self._images_list_cur - 1)
+    end
+end
+
 function ImageViewer:onTap(_, ges)
     if ges.pos:notIntersectWith(self.main_frame.dimen) then
         self:onClose()
@@ -479,13 +502,9 @@ function ImageViewer:onTap(_, ges)
             show_next_image = not BD.mirroredUILayout()
         end
         if show_prev_image then
-            if self._images_list_cur > 1 then
-                self:switchToImageNum(self._images_list_cur - 1)
-            end
+            self:onPageBack()
         elseif show_next_image then
-            if self._images_list_cur < self._images_list_nb then
-                self:switchToImageNum(self._images_list_cur + 1)
-            end
+            self:onPageForward()
         else -- toggle buttons when tap on middle 1/3 of screen width
             self.buttons_visible = not self.buttons_visible
             self:update()

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -81,11 +81,11 @@ local ImageViewer = InputContainer:new{
 function ImageViewer:init()
     if Device:hasKeys() then
         if type(self.image) == "table" then
-            -- if self.image is a table, then use hardware keys to change page
+            -- if self.image is a table, then use hardware keys to change image
             self.key_events = {
                 Close = { {Device.input.group.Back}, doc = "close viewer" },
-                PageBack = { {Device.input.group.PgBack}, doc = "Page back" },
-                PageForward = { {Device.input.group.PgFwd}, doc = "Page forward" },
+                ShowPrevImage = { {Device.input.group.PgBack}, doc = "Previous image" },
+                ShowNextImage = { {Device.input.group.PgFwd}, doc = "Next image" },
             }
         else
             -- otherwise, use hardware keys to zoom in/out
@@ -459,14 +459,14 @@ function ImageViewer:switchToImageNum(image_num)
     self:update()
 end
 
--- Page events
-function ImageViewer:onPageForward()
+-- Image switching events
+function ImageViewer:onShowNextImage()
     if self._images_list_cur < self._images_list_nb then
         self:switchToImageNum(self._images_list_cur + 1)
     end
 end
 
-function ImageViewer:onPageBack()
+function ImageViewer:onShowPrevImage()
     if self._images_list_cur > 1 then
         self:switchToImageNum(self._images_list_cur - 1)
     end
@@ -502,9 +502,9 @@ function ImageViewer:onTap(_, ges)
             show_next_image = not BD.mirroredUILayout()
         end
         if show_prev_image then
-            self:onPageBack()
+            self:onShowPrevImage()
         elseif show_next_image then
-            self:onPageForward()
+            self:onShowNextImage()
         else -- toggle buttons when tap on middle 1/3 of screen width
             self.buttons_visible = not self.buttons_visible
             self:update()


### PR DESCRIPTION
Makes ImageViewer more ergonomic on devices with hardware keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8927)
<!-- Reviewable:end -->
