### PR TITLE
Only toggle nightmode via the grayscale fb info flag on Kindle

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -53,6 +53,7 @@ local Device = {
     hasExternalSD = no, -- or other storage volume that cannot be accessed using the File Manager
     canHWDither = no,
     canHWInvert = no,
+    canModifyFBInfo = no, -- some NTX boards do wonky things with the rotate flag after a FBIOPUT_VSCREENINFO ioctl
     canUseCBB = yes, -- The C BB maintains a 1:1 feature parity with the Lua BB, except that is has NO support for BB4, and limited support for BBRGB24
     hasColorScreen = no,
     hasBGRFrameBuffer = no,

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -129,6 +129,8 @@ local Kindle = Generic:new{
     hasFastWifiStatusQuery = yes,
     -- NOTE: HW inversion is generally safe on mxcfb Kindles
     canHWInvert = yes,
+    -- NOTE: And the fb driver is generally sane on those, too
+    canModifyFBInfo = yes,
     -- NOTE: Newer devices will turn the frontlight off at 0
     canTurnFrontlightOff = yes,
     home_dir = "/mnt/us",
@@ -326,6 +328,7 @@ local Kindle2 = Kindle:new{
     hasKeys = yes,
     hasDPad = yes,
     canHWInvert = no,
+    canModifyFBInfo = no,
     canUseCBB = no, -- 4bpp
     canUseWAL = no, -- Kernel too old to support mmap'ed I/O on /mnt/us
     supportsScreensaver = yes, -- The first ad-supported device was the K3
@@ -338,6 +341,7 @@ local KindleDXG = Kindle:new{
     hasKeys = yes,
     hasDPad = yes,
     canHWInvert = no,
+    canModifyFBInfo = no,
     canUseCBB = no, -- 4bpp
     canUseWAL = no, -- Kernel too old to support mmap'ed I/O on /mnt/us
     supportsScreensaver = yes, -- The first ad-supported device was the K3
@@ -350,6 +354,7 @@ local Kindle3 = Kindle:new{
     hasKeys = yes,
     hasDPad = yes,
     canHWInvert = no,
+    canModifyFBInfo = no,
     canUseCBB = no, -- 4bpp
     isSpecialOffers = hasSpecialOffers(),
 }
@@ -360,6 +365,7 @@ local Kindle4 = Kindle:new{
     hasKeys = yes,
     hasDPad = yes,
     canHWInvert = no,
+    canModifyFBInfo = no,
     -- NOTE: It could *technically* use the C BB, as it's running @ 8bpp, but it's expecting an inverted palette...
     canUseCBB = no,
     isSpecialOffers = hasSpecialOffers(),


### PR DESCRIPTION
Most NTX boards require elaborate trickery (see fbdepth) to actually
send a vput ioctl without the driver screwing with the rotation behind
your back.

This was causing spurious hardware rotations on exit on most Kobo
devices, something which might have gone mostly unnoticed, as current
Nickel versions will sanitize it on startup.
A simple repro was instead to start an USBMS session, as that exits
KOReader and restarts it without going through fbdepth again ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8931)
<!-- Reviewable:end -->
