### PR TITLE
[fix, plugin] Wallabag: avoid crash when setDownloadDirectory doesn't have a touchmenu_instance

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -1077,12 +1077,14 @@ end
 
 function Wallabag:setDownloadDirectory(touchmenu_instance)
     require("ui/downloadmgr"):new{
-       onConfirm = function(path)
-           logger.dbg("Wallabag: set download directory to: ", path)
-           self.directory = path
-           self:saveSettings()
-           touchmenu_instance:updateItems()
-       end,
+        onConfirm = function(path)
+            logger.dbg("Wallabag: set download directory to: ", path)
+            self.directory = path
+            self:saveSettings()
+            if touchmenu_instance then
+                touchmenu_instance:updateItems()
+            end
+        end,
     }:chooseDir()
 end
 


### PR DESCRIPTION
Fixes #8930.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8933)
<!-- Reviewable:end -->
