### PR TITLE
[plugin] batteryCare: Tune charge characteristics

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -77,6 +77,7 @@ local Device = {
     last_suspend_time = 0,
     canReboot = no,
     canPowerOff = no,
+    canControlCharge = no,
     canAssociateFileExtensions = no,
 
     -- Start and stop text input mode (e.g. open soft keyboard, etc)

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -385,6 +385,12 @@ function Device:suspend() end
 -- Hardware specific method to resume the device
 function Device:resume() end
 
+-- Hardware specific method to suspend subsytems of the device
+function Device:suspendSubsystems() end
+
+-- Hardware specific method to resume subsystems of the device
+function Device:resumeSubsystems() end
+
 -- Hardware specific method to power off the device
 function Device:powerOff() end
 

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -244,8 +244,8 @@ end
 --- Enables or disables charging of batteries
 -- @param bool batt enables charging of the main battery
 -- @param bool aux_batt enables charging of an auxilliary battery
-function BasePowerD:charge(batt, aux_batt)
-    return self:chargeHW(batt, aux_batt)
+function BasePowerD:charge(batt, aux_batt, balance)
+    return self:chargeHW(batt, aux_batt, balance)
 end
 
 function BasePowerD:getAuxCapacity()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -139,14 +139,14 @@ function BasePowerD:frontlightWarmth()
     return self.fl_warmth
 end
 
-function BasePowerD:read_int_file(file)
+function BasePowerD:read_int_file(file, error_val)
     local fd = io.open(file, "r")
     if fd then
         local int = fd:read("*number")
         fd:close()
         return int or 0
     else
-        return 0
+        return error_val or 0
     end
 end
 

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -52,12 +52,14 @@ function BasePowerD:setWarmthHW(warmth) end
 function BasePowerD:getCapacityHW() return 0 end
 function BasePowerD:getAuxCapacityHW() return 0 end
 function BasePowerD:isAuxBatteryConnectedHW() return false end
+function BasePowerD:isChargerPresentHW() return false end
 function BasePowerD:getDismissBatteryStatus() return self.battery_warning end
 function BasePowerD:setDismissBatteryStatus(status) self.battery_warning = status end
 --- @note: Should ideally return true as long as the device is plugged in, even once the battery is full...
 function BasePowerD:isChargingHW() return false end
 --- @note: ...at which point this should start returning true (i.e., plugged in & fully charged).
 function BasePowerD:isChargedHW() return false end
+function BasePowerD:chargeHW(batt, aux_batt) return "" end
 function BasePowerD:isAuxChargingHW() return false end
 function BasePowerD:isAuxChargedHW() return false end
 function BasePowerD:frontlightIntensityHW() return 0 end
@@ -239,6 +241,13 @@ function BasePowerD:isCharged()
     return self:isChargedHW()
 end
 
+--- Enables or disables charging of batteries
+-- @param bool batt enables charging of the main battery
+-- @param bool aux_batt enables charging of an auxilliary battery
+function BasePowerD:charge(batt, aux_batt)
+    return self:chargeHW(batt, aux_batt)
+end
+
 function BasePowerD:getAuxCapacity()
     local now
 
@@ -275,6 +284,10 @@ end
 
 function BasePowerD:isAuxBatteryConnected()
     return self:isAuxBatteryConnectedHW()
+end
+
+function BasePowerD:isChargerPresent()
+    return self:isChargerPresentHW()
 end
 
 function BasePowerD:stateChanged()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -15,6 +15,7 @@ local BasePowerD = {
 
     last_capacity_pull_time = time.s(-61),      -- timestamp of last pull
     last_aux_capacity_pull_time = time.s(-61),  -- timestamp of last pull
+    capacity_pull_intervall = time.s(60),       -- default intervall between two capacity reads
 
     is_fl_on = false,                 -- whether the frontlight is on
 }
@@ -226,7 +227,7 @@ function BasePowerD:getCapacity()
         now = time.now() + self.device.total_standby_time + self.device.total_suspend_time
     end
 
-    if now - self.last_capacity_pull_time >= time.s(60) then
+    if now - self.last_capacity_pull_time >= self.capacity_pull_intervall then
         self.batt_capacity = self:getCapacityHW()
         self.last_capacity_pull_time = now
     end
@@ -258,7 +259,7 @@ function BasePowerD:getAuxCapacity()
         now = time.now() + self.device.total_standby_time + self.device.total_suspend_time
     end
 
-    if now - self.last_aux_capacity_pull_time >= time.s(60) then
+    if now - self.last_aux_capacity_pull_time >= self.capacity_pull_intervall then
         local aux_batt_capa = self:getAuxCapacityHW()
         -- If the read failed, don't update our cache, and retry next time.
         if aux_batt_capa then

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -59,7 +59,7 @@ function BasePowerD:setDismissBatteryStatus(status) self.battery_warning = statu
 function BasePowerD:isChargingHW() return false end
 --- @note: ...at which point this should start returning true (i.e., plugged in & fully charged).
 function BasePowerD:isChargedHW() return false end
-function BasePowerD:chargeHW(batt, aux_batt) return "" end
+function BasePowerD:chargeHW(batt, aux_batt, balance) return "" end
 function BasePowerD:isAuxChargingHW() return false end
 function BasePowerD:isAuxChargedHW() return false end
 function BasePowerD:frontlightIntensityHW() return 0 end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -401,6 +401,7 @@ local KoboCadmus = Kobo:new{
     ntx_dev = "/dev/input/by-path/platform-ntx_event0-event",
     touch_dev = "/dev/input/by-path/platform-0-0010-event",
     isSMP = yes,
+    canControlCharge = yes,
 }
 
 -- Kobo Libra 2:

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -941,7 +941,7 @@ function Kobo:suspendSubsystems()
     end
 end
 
-function Kobo:resumeSubsystems(settle_time)
+function Kobo:resumeSubsystems()
     -- Now that we're up, unflag subsystems for suspend...
     -- NOTE: Sets gSleep_Mode_Suspend to 0. Used as a flag throughout the
     --       kernel to suspend/resume various subsystems
@@ -955,8 +955,7 @@ function Kobo:resumeSubsystems(settle_time)
     end
 
     -- HACK: wait at least 0.1 sec for the kernel to catch up
-    settle_time = settle_time or 0
-    ffiUtil.usleep(math.max(settle_time or 100000))
+    ffiUtil.usleep(100000)
 end
 
 
@@ -994,6 +993,9 @@ function Kobo:suspend()
         logger.info("Kobo suspend: Current WakeUp count:", curr_wakeup_count)
     end
     -]]
+
+    local Event = require("ui/event")
+    UIManager:broadcastEvent(Event:new("SuspendSubsystems"))
 
     self:suspendSubsystems()
 
@@ -1037,7 +1039,6 @@ function Kobo:suspend()
     else
         logger.warn("Kobo suspend: the kernel refused to enter suspend!")
         -- Reset state-extended back to 0 since we are giving up.
-        -- Todo: Ask @NiLuJe: Why is are the subsystems are not always enabled here? Isn't this the right point to do, right after leaving sleep mode. Why is this delayed to resume?
         self:resumeSubsystems()
     end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -126,7 +126,7 @@ function KoboPowerD:init()
         -- Enable/disable charging of batteries,
         -- and return a string about what's happening.
         function KoboPowerD:chargeHW(batt, aux_batt, balance)
-            logger.dbg("Charger: batt", tostring(batt), "aux_batt", tostring(aux_batt))
+            logger.dbg("Charger: batt", tostring(batt), "aux_batt", tostring(aux_batt), "balance", tostring(balance))
 
             if batt == nil and aux_batt == nil then
                 return "Charger: nothing to do"
@@ -154,7 +154,7 @@ function KoboPowerD:init()
                         writeToSys("1", self.battery_sysfs_charge_enable)
                         writeToSys("0", self.aux_battery_sysfs_charge_enable)
                     else -- if aux_batt == nil
-                        info = info .. "battery: no,  aux: xx"
+                        info = info .. "battery: yes,  aux: xx"
                         writeToSys("1", self.battery_sysfs_charge_enable)
                     end
                 elseif batt == false then
@@ -242,11 +242,11 @@ function KoboPowerD:init()
             -- 0 when discharging
             -- 3 when full
             -- 2 when charging via DCP
-            return this:read_int_file(this.aux_batt_charging_file) ~= 0
+            return this:read_int_file(this.aux_batt_charging_file, -1) ~= 0
         end
 
         self.isAuxChargedHW = function(this)
-            return this:read_int_file(this.aux_batt_charging_file) == 3
+            return this:read_int_file(this.aux_batt_charging_file, -1) == 3
         end
     end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -96,7 +96,6 @@ function KoboPowerD:init()
     self.is_charging_file = self.battery_sysfs .. "/status"
 
     if self.device:canControlCharge() then
-        -- self.aux_batt_charger = "/sys/class/misc/cilix/pin_ce" -- xxx not needed anymore
         self.battery_sysfs_charge_enable = "/sys/class/misc/cilix/glf72120_enable"
         self.aux_battery_sysfs_charge_enable = "/sys/class/misc/cilix/sy6974b/charge_enable"
         self.is_charger_present_file = "/sys/class/power_supply/battery/device/charger_type"

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -80,6 +80,7 @@ local Device = Generic:new{
     startTextInput = SDL.startTextInput,
     stopTextInput = SDL.stopTextInput,
     canOpenLink = getLinkOpener,
+    canControlCharge = yes, -- development of batteryCare
     openLink = function(self, link)
         local enabled, tool = getLinkOpener()
         if not enabled or not tool or not link or type(link) ~= "string" then return end

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -80,7 +80,6 @@ local Device = Generic:new{
     startTextInput = SDL.startTextInput,
     stopTextInput = SDL.stopTextInput,
     canOpenLink = getLinkOpener,
-    canControlCharge = yes, -- development of batteryCare
     openLink = function(self, link)
         local enabled, tool = getLinkOpener()
         if not enabled or not tool or not link or type(link) ~= "string" then return end
@@ -135,7 +134,7 @@ local Emulator = Device:new{
     canReboot = yes,
     -- NOTE: Via simulateSuspend
     canSuspend = yes,
-    canStandby = no,
+    canControlCharge = yes, -- for development of batteryCare
 }
 
 local UbuntuTouch = Device:new{

--- a/plugins/batterycare.koplugin/_meta.lua
+++ b/plugins/batterycare.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = "batterycare",
+    fullname = _("Battery care"),
+    description = _([[This plugin allows to set thresholds for battery charging. Smart settings extend battery life.]]),
+}

--- a/plugins/batterycare.koplugin/main.lua
+++ b/plugins/batterycare.koplugin/main.lua
@@ -217,6 +217,8 @@ function BatteryCare:onCharging()
 end
 
 BatteryCare.onNotCharging = BatteryCare.onCharging
+BatteryCare.onUsbPlugIn = BatteryCare.onCharging
+BatteryCare.onUsbPlugOut = BatteryCare.onCharging
 
 function BatteryCare:setThresholds(touchmenu_instance, title, info, lower, upper, lower_default, upper_default, value_min)
     local threshold_spinner = DoubleSpinWidget:new {

--- a/plugins/batterycare.koplugin/main.lua
+++ b/plugins/batterycare.koplugin/main.lua
@@ -228,11 +228,13 @@ function BatteryCare:setThresholds(touchmenu_instance, title, info, lower, upper
         left_max = 100,
         right_text = _("Stop"),
         right_value = self[upper] or upper_default,
-        left_upper = upper_default,
+        right_default = upper_default,
         right_min = value_min or 50,
         right_max = 100,
         unit = "%",
         ok_always_enabled = true,
+        default_values = true,
+        is_range = true,
         callback = function(left_value, right_value)
             if left_value > right_value then
                 left_value = right_value
@@ -264,7 +266,7 @@ function BatteryCare:setAuxMin(touchmenu_instance, title, info, setting, value_d
         title_text = title,
         info_text = info,
         value = self[setting] or value_default,
-        default = value_default,
+        default_value = value_default,
         value_min = value_min,
         value_max = value_max,
         value_hold_step = 5,

--- a/plugins/batterycare.koplugin/main.lua
+++ b/plugins/batterycare.koplugin/main.lua
@@ -1,0 +1,526 @@
+--[[--
+@module koplugin.batterycare
+
+Plugin for tuning the threshold for battery charging.
+]]
+local Device = require("device")
+
+if not Device:canControlCharge() then
+    return { disabled = true }
+end
+
+local Dispatcher = require("dispatcher")
+local DoubleSpinWidget = require("ui/widget/doublespinwidget")
+local InfoMessage = require("ui/widget/infomessage")
+local SpinWidget = require("ui/widget/spinwidget")
+local UIManager = require("ui/uimanager")
+local WakeupManager = require("device/wakeupmgr")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local logger = require("logger")
+local _ = require("gettext")
+local T = require("ffi/util").template
+
+local powerd = Device:getPowerDevice()
+
+-- xxx 15*60
+local WAKEUP_TIMER_SECONDS = 5*60 -- time for a scheduled wakeup, when a charger is connected
+
+local default_stop_threshold = 95
+local default_start_threshold = 80
+local default_aux_stop_threshold = 99
+local default_aux_start_threshold = 95
+local default_balance_thr = 10
+
+local BatteryCare = WidgetContainer:new{
+    name = "batterycare",
+    is_doc_only = false,
+}
+
+function BatteryCare:init()
+    if not Device:canControlCharge() then return end
+
+    self.enabled = G_reader_settings:isTrue("battery_care")
+    self.battery_care_stop_threshold = G_reader_settings:readSetting("battery_care_stop_threshold",
+        default_stop_threshold)
+    self.battery_care_start_threshold = G_reader_settings:readSetting("battery_care_start_threshold",
+        default_start_threshold)
+
+    self.battery_care_aux_stop_threshold = G_reader_settings:readSetting("battery_care_aux_stop_threshold",
+        default_aux_stop_threshold)
+    self.battery_care_aux_start_threshold = G_reader_settings:readSetting("battery_care_aux_start_threshold",
+        default_aux_start_threshold)
+    self.battery_care_balance_thr = G_reader_settings:readSetting("battery_care_balance_thr",
+        default_balance_thr)
+
+    self:task() -- Schedules itself, if BatteryCare is enabled.
+
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function BatteryCare:onDispatcherRegisterActions()
+    Dispatcher:registerAction("Charge Battery: disable",
+        {category="none", event="BatteryCareEnable", title=_("Battery care enable"), device=true})
+    Dispatcher:registerAction("Charge Battery: enable",
+        {category="none", event="BatteryCareDisable", title=_("Battery care disable "), device=true})
+    Dispatcher:registerAction("Charge Battery: toggle",
+        {category="none", event="BatteryCareToggle", title=_("Battery care toggle"), device=true})
+    Dispatcher:registerAction("Charge Battery: once on",
+        {category="none", event="BatteryCareOnceOn", title=_("Battery care charge once on"), device=true})
+    Dispatcher:registerAction("Charge Battery: once off",
+        {category="none", event="BatteryCareOnceOff", title=_("Battery care charge once off"), device=true})
+    Dispatcher:registerAction("Charge Battery: once toggle",
+        {category="none", event="BatteryCareOnceToggle", title=_("Battery care once toggle"), device=true})
+end
+
+function BatteryCare:onBatteryCareEnable()
+    self.enabled = true
+    G_reader_settings:saveSetting("battery_care", true)
+    -- don't save this setting!!!
+    self.charge_once = false
+    self:_unschedule()
+    self:task()
+end
+
+function BatteryCare:onBatteryCareDisable()
+    self.enabled = false
+    G_reader_settings:saveSetting("battery_care", false)
+    self.charge_once = false
+    self:_unschedule()
+end
+
+function BatteryCare:onBatteryCareToggle()
+    self.enabled = not G_reader_settings:isTrue("battery_care")
+    G_reader_settings:saveSetting("battery_care", self.enabled)
+    self.charge_once = false
+    self:_unschedule()
+    self:task()
+end
+
+function BatteryCare:onBatteryCareOnceOn()
+    -- don't save this setting!!!
+    self.charge_once = true
+    self:_unschedule()
+    self:task()
+end
+
+function BatteryCare:onBatteryCareOnceOff()
+    -- don't save this setting!!!
+    self.charge_once = false
+    self:_unschedule()
+    self:task()
+end
+
+function BatteryCare:onBatteryCareOnceToggle()
+    -- don't save this setting!!!
+    self.charge_once = not self.charge_once
+    self:_unschedule()
+    self:task()
+end
+
+function BatteryCare:_schedule()
+    -- schedule the same time as footer update, to reduce wake ups.
+    UIManager:scheduleIn(61 - tonumber(os.date("%S")), self.task, self)
+--        UIManager:scheduleIn(5, self.task, self) -- for testing xxx
+end
+
+function BatteryCare:_unschedule()
+    UIManager:unschedule(self.task)
+end
+
+function BatteryCare:scheduleWakeupCall(enabled)
+    -- We will do wakeup from suspend every WAKEUP_TIMER_SECONDS if connected to an external charger or
+    -- if the internal battery is charged from the aux battery. Then we can check and set the new
+    -- charging state.
+    local function wakeupCall()
+        logger.dbg("BatteryCare: wakeup to check state reached")
+        if Device:canSuspend() then
+            self:_unschedule() -- and unschedule, as we are going to suspend anyway
+            self:task() -- check state on scheduled wakeup
+            self:_unschedule() -- and unschedule, as we are going to suspend anyway
+            UIManager:scheduleIn(5, UIManager.suspend, UIManager) -- and go back to sleep
+        end
+    end
+
+    logger.dbg("BatteryCare: wakeup to check state deleted")
+    WakeupManager:removeTask(nil, nil, wakeupCall)
+    if not enabled then
+        logger.dbg("BatteryCare: don't schedule wakeup call")
+        return
+    end
+
+    -- Schedule a wakeup if necessary, when going to suspend.
+    local wakeup_timer_seconds
+    if powerd:isCharging() then
+        -- If charging from an external charger or aux battery
+        wakeup_timer_seconds = WAKEUP_TIMER_SECONDS
+    else
+        -- If _not_ charging ...
+        if powerd.device:hasAuxBattery() and powerd:isAuxBatteryConnected() and powerd:getAuxCapacityHW() then
+            -- ... and with an aux battery for a _long_ sleeping period: It is desireable to load
+            -- the internal battery (from the aux batt) if its capacity drops.
+            wakeup_timer_seconds = 6 * 3600 -- four times a day
+        else
+            -- ... an no aux battery present:  Don't wake.
+            wakeup_timer_seconds = nil
+        end
+    end
+
+    if wakeup_timer_seconds then
+        logger.dbg("BatteryCare: scheduling a wakeup in", wakeup_timer_seconds)
+        WakeupManager:addTask(wakeup_timer_seconds, wakeupCall)
+    else
+        logger.dbg("BatteryCare: scheduling a wakeup skipped")
+    end
+end
+
+function BatteryCare:onExit()
+    logger.dbg("BatteryCare: onExit/onRestart/onReboot")
+    self:_unschedule()
+    self:scheduleWakeupCall(false)
+    powerd:charge(true, true) -- restore default behaviour
+end
+
+BatteryCare.onRestart = BatteryCare.onExit
+BatteryCare.onReboot = BatteryCare.onExit
+-- no BatteryCare.onPowerOff as we don't want the cover to be succed
+
+function BatteryCare:onEnterStandby()
+    self:_unschedule()
+end
+
+function BatteryCare:onLeaveStandby()
+    self:task() -- is not scheduled here
+end
+
+function BatteryCare:onSuspend()
+    logger.dbg("BatteryCare: onSuspend")
+    self:task() -- check current state
+    self:_unschedule()
+    self:scheduleWakeupCall(true)
+end
+
+function BatteryCare:onResume()
+    logger.dbg("BatteryCare: onResume/onLeaveStandby")
+    logger.dbg("BatteryCare: isCharging", tostring(powerd:isCharging()), "isAuxCharging", tostring(powerd:isAuxCharging()))
+    self:scheduleWakeupCall(false)
+    self:task() -- is not scheduled here
+    -- .. and give the firmware some time (at least less than standby time) to calculate the new state
+--    UIManager:scheduleIn(0.5, self.task, self) -- task gets called in 0.5s and then schedules itself on a full minute
+end
+
+
+function BatteryCare:onCharging()
+    logger.dbg("BatteryCare: onCharging/onNotCharging")
+    -- Give the firmware some time (at least less than standby time) to calculate the new state
+    UIManager:scheduleIn(1.5, self.task, self) -- task gets called in 1.5s and then schedules itself on a full minute
+end
+
+BatteryCare.onNotCharging = BatteryCare.onCharging
+
+function BatteryCare:setThresholds(touchmenu_instance, title, info, lower, upper, lower_default, upper_default)
+    local threshold_spinner = DoubleSpinWidget:new {
+        title_text = title,
+        info_text = info,
+        left_text = _("Start"),
+        left_value = self[lower] or lower_default,
+        left_default = lower_default,
+        left_min = 10,
+        left_max = 100,
+        right_text = _("Stop"),
+        right_value = self[upper] or upper_default,
+        left_upper = upper_default,
+        right_min = 50,
+        right_max = 100,
+        unit = "%",
+        ok_always_enabled = true,
+        callback = function(left_value, right_value)
+            if left_value > right_value then
+                left_value = right_value
+            end
+            self[lower] = left_value
+            G_reader_settings:saveSetting(lower, left_value)
+            self[upper] = right_value
+            G_reader_settings:saveSetting(upper, right_value)
+            self:_unschedule()
+            self:task()
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+        extra_text = _("Disable"),
+        extra_callback = function()
+            self[lower] = false
+            self[upper] = false
+            G_reader_settings:saveSetting(lower, false)
+            G_reader_settings:saveSetting(upper, false)
+            self:_unschedule()
+            self:task()
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+    }
+    UIManager:show(threshold_spinner)
+end
+
+function BatteryCare:setAuxMin(touchmenu_instance, title, info, setting, value_default)
+    local threshold_spinner = SpinWidget:new{
+        title_text = title,
+        info_text = info,
+        value = self[setting] or value_default,
+        default = value_default,
+        value_min = 1,
+        value_max = 100,
+        value_hold_step = 5,
+        unit = "%",
+        ok_always_enabled = true,
+        callback = function(spin)
+            if spin.value >= 0 and spin.value <=100 then
+                self[setting] = spin.value
+                G_reader_settings:saveSetting(setting, spin.value)
+                self:_unschedule()
+                self:task()
+            end
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+        extra_text = _("Disable"),
+        extra_callback = function()
+            self[setting] = false
+            G_reader_settings:delSetting(setting)
+            self:_unschedule()
+            self:task()
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+    }
+    UIManager:show(threshold_spinner)
+end
+
+local about_text = _([[Allows to set thresholds to start and stop charging.
+
+Depending on the hardware, an attempt is made to adhere to the specified thresholds as precisely as possible.
+
+On some devices an auxilliary battery can be managed, too.]])
+
+function BatteryCare:addToMainMenu(menu_items)
+    local batt_item = {
+        text_func = function()
+            if self.battery_care_start_threshold and  self.battery_care_stop_threshold then
+                return T(_("Primary battery charge hysteresis: %1 % — %2 %"),
+                    self.battery_care_start_threshold, self.battery_care_stop_threshold)
+            else
+                return _("Primary battery charge hysteresis")
+            end
+        end,
+        enabled_func = function()
+            return self.enabled
+        end,
+        checked_func = function()
+            return self.battery_care_start_threshold and self.battery_care_stop_threshold
+        end,
+        keep_menu_open = true,
+        callback = function(touchmenu_instance)
+            self:setThresholds(touchmenu_instance, _("Charge hysteresis thresholds"),
+                _("Enter lower threshold to start and upper threshold to stop start charging.\nCharging will starts if the capacity is below the lower and stops if the capacity is higher than the upper threshold."),
+                "battery_care_start_threshold", "battery_care_stop_threshold",
+                default_start_threshold, default_stop_threshold)
+        end,
+        separator = true,
+    }
+
+    local aux_batt_item, aux_batt_ballance
+    if Device:isKobo() and Device:hasAuxBattery() or Device:isEmulator() then
+        aux_batt_item = {
+            text_func = function()
+                if self.battery_care_aux_start_threshold and self.battery_care_aux_stop_threshold then
+                    return T(_("Auxilliary battery charge hysteresis: %1 % — %2 %"),
+                        self.battery_care_aux_start_threshold, self.battery_care_aux_stop_threshold)
+                else
+                    return _("Auxilliary battery charge hysteresis")
+                end
+            end,
+            enabled_func = function()
+                return self.enabled
+            end,
+            checked_func = function()
+                return self.battery_care_aux_start_threshold and self.battery_care_aux_stop_threshold
+            end,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                self:setThresholds(touchmenu_instance, _("Charge hysteresis thresholds"),
+                    _("Enter lower threshold to start and upper threshold to stop start charging.\nCharging starts if the capacity is below the lower and stops if the capacity is higher than the upper threshold."),
+                    "battery_care_aux_start_threshold", "battery_care_aux_stop_threshold",
+                    default_aux_start_threshold, default_aux_stop_threshold)
+            end,
+        }
+        aux_batt_ballance = {
+            text_func = function()
+                if self.battery_care_balance_thr then
+                    return T(_("Balance threshold: %1 %"), self.battery_care_balance_thr)
+                else
+                    return _("Balance threshold")
+                end
+            end,
+            enabled_func = function()
+                return self.enabled
+            end,
+            checked_func = function()
+                return self.battery_care_balance_thr
+            end,
+            help_text = _("Keep batteries ballanced, if aux battery's capacity drops below this threshold."),
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                self:setAuxMin(touchmenu_instance,
+                    _("Charge equalize thresholds"),
+                    _("Enter threshold to equalize batteries."),
+                    "battery_care_balance_thr", default_balance_thr)
+            end,
+        }
+    end
+
+    menu_items.BatteryCare = {
+        sorting_hint = "device",
+        checked_func = function()
+            return self.enabled
+        end,
+        text = _("Battery care"),
+        sub_item_table = {
+            {
+                text = _("About battery care"),
+                callback = function(touchmenu_instance)
+                    UIManager:show(InfoMessage:new{
+                        text = about_text,
+                    })
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end,
+                keep_menu_open = true,
+                separator = true,
+            },
+            {
+                text = _("Battery care"),
+                checked_func = function()
+                    return self.enabled
+                end,
+                callback = function(touchmenu_instance)
+                    self.enabled = not G_reader_settings:isTrue("battery_care")
+                    G_reader_settings:saveSetting("battery_care", self.enabled)
+                    -- don't save this setting!!!
+                    self.charge_once = false
+                    self:_unschedule()
+                    self:task()
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end,
+            },
+            {
+                text = _("Charge once"),
+                enabled_func = function()
+                    return self.enabled
+                end,
+                checked_func = function()
+                    return self.charge_once
+                end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    self.charge_once = not self.charge_once
+                    -- don't save this setting!!!
+                    self:_unschedule()
+                    self:task()
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end,
+            },
+            batt_item,
+            aux_batt_item,
+            aux_batt_ballance,
+        },
+    }
+end
+
+--- Calculate the charging conditions for an internal and an external battery, and schedules its next call.
+-- The actual action has to be done in powerd:charge().
+-- For a new device an appropriate powerd:charge() has to be implemented.
+function BatteryCare:task() -- the brain of batteryCare
+    local info
+    if self.enabled then
+        if self:_unschedule() then
+            -- delete the next line, after testing -xxxx
+            logger.err("BatteryCare: XXX: THIS SHOULD NOT HAPPEN; BUGBUGUBUGUBUGUBUGUBUG")
+        end
+
+        self:_schedule()
+    else
+        self:_unschedule()
+        info = powerd:charge(true, true) -- restore default behavior
+        logger.dbg("BatteryCare disabled:", info)
+        return
+    end
+
+    logger.dbg("BatteryCare: isCharging", tostring(powerd:isChargingHW()), "isAuxCharging",
+        tostring(powerd:isAuxChargingHW()))
+
+    local curr_capacity = powerd:getCapacityHW()
+
+    local curr_aux_capacity
+    if powerd.device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
+        curr_aux_capacity = powerd:getAuxCapacityHW() -- might give us nil, even if aux batt is present
+    end
+
+    if self.charge_once then
+        if curr_capacity > 99 and (curr_aux_capacity == nil or curr_aux_capacity > 99) then
+            logger.dbg("BatteryCare: charge once off")
+            self.charge_once = false
+            info = powerd:charge(false, false)
+        else
+            logger.dbg("BatteryCare: charge once running")
+            info = powerd:charge(true, true) -- turn on default behaviour
+        end
+        logger.dbg("BatteryCare:", info)
+        return
+    end
+
+    logger.dbg("BatteryCare: battery", curr_capacity, " - ",
+        self.battery_care_start_threshold, self.battery_care_stop_threshold)
+
+    local charge_batt, charge_aux -- nil means, don't change state
+
+    if self.battery_care_stop_threshold and self.battery_care_start_threshold then
+        if curr_capacity > self.battery_care_stop_threshold then
+            logger.dbg("BatteryCare: disable batt charge")
+            charge_batt = false
+        elseif curr_capacity < self.battery_care_start_threshold then
+            logger.dbg("BatteryCare: enable batt charge")
+            charge_batt = true
+        else
+            logger.dbg("BatteryCare: nochange batt charge")
+        end
+    end
+
+    if curr_aux_capacity and self.battery_care_aux_stop_threshold and self.battery_care_aux_start_threshold then
+        logger.dbg("BatteryCare: aux battery", curr_aux_capacity, " - ",
+            self.battery_care_aux_start_threshold, self.battery_care_aux_stop_threshold)
+
+        if curr_aux_capacity > self.battery_care_aux_stop_threshold then
+            logger.dbg("BatteryCare: disable aux batt charge")
+            charge_aux = false
+        elseif curr_aux_capacity < self.battery_care_aux_start_threshold then
+            logger.dbg("BatteryCare: enable aux batt charge")
+            charge_aux = true
+        else
+            logger.dbg("BatteryCare: nochange aux batt charge")
+        end
+        if self.battery_care_balance_thr then
+            if curr_capacity <= curr_aux_capacity then
+                logger.dbg("BatteryCare: batt lower or equal aux, enable charging")
+                charge_batt = true
+                charge_aux = true
+            else
+                if powerd:isChargerPresent() then
+                    logger.dbg("BatteryCare: enable batt charge (charger present)")
+                    charge_batt = true
+                else
+                    logger.dbg("BatteryCare: batt higher than aux, disable charging")
+                    charge_batt = false
+                end
+            end
+        end
+    end
+
+    info = powerd:charge(charge_batt, charge_aux)
+    logger.dbg("BatteryCare:", info)
+end
+
+return BatteryCare


### PR DESCRIPTION
Not connected to any power-saving strategies, but can improve lifetime of batteries.


Currently, quite common sense for Lithium (anything) is, that for battery health it is important not to overcharge and not to undercharge it.

A sane strategy is not to charge it to 100% and not to suck it out (0%). On Laptops and electric vehicles this should be done by the intelligent charger. 

On our devices, we don't really know what the vendor has implemented.

This PR allows to set a `start_charging_threshold` and a `stop_charging_threshold` for the battery (on a Sage with power cover the batteries).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8934)
<!-- Reviewable:end -->
