### PR TITLE
FrontLightWidget: Unbreak warmth on full-granularity devices

### DIFF
--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -263,7 +263,7 @@ function FrontLightWidget:layout()
             position = math.floor(self.nl.cur / self.nl.stride),
             default_position = math.floor(self.nl.cur / self.nl.stride),
             callback = function(i)
-                self:setWarmth(i, false)
+                self:setWarmth(Math.round(i * self.nl.stride), false)
             end,
             show_parent = self,
             enabled = true,
@@ -479,23 +479,19 @@ function FrontLightWidget:setBrightness(intensity)
 end
 
 function FrontLightWidget:setWarmth(warmth, update_position)
-    -- `warmth` is currently not an actual warmth level, but a position inside the ButtonProgressWidget, rescale it appropriately.
-    local warmth_lvl = Math.round(warmth * self.nl.stride)
-
-    if warmth_lvl == self.nl.cur then
+    if warmth == self.nl.cur then
         return
     end
 
     -- Set warmth
-    self.powerd:setWarmth(self.powerd:fromNativeWarmth(warmth_lvl))
+    self.powerd:setWarmth(self.powerd:fromNativeWarmth(warmth))
     -- Retrieve the value PowerD actually set, in case there were rounding shenanigans and we blew the range...
     self.nl.cur = self.powerd:toNativeWarmth(self.powerd:frontlightWarmth())
 
     -- Update the progress bar, if we were called from outside ButtonProgressWidget
     -- (as it already handles that internally ;)).
     if update_position then
-        -- We do want to use the position here, not the actual warmth level ;).
-        self.nl_progress:setPosition(warmth, self.nl_progress.default_position)
+        self.nl_progress:setPosition(math.floor(self.nl.cur / self.nl.stride), self.nl_progress.default_position)
     end
 
     self.nl_level:setText(tostring(self.nl.cur))

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -479,17 +479,22 @@ function FrontLightWidget:setBrightness(intensity)
 end
 
 function FrontLightWidget:setWarmth(warmth, update_position)
-    if warmth == self.nl.cur then
+    -- `warmth` is currently not an actual warmth level, but a position inside the ButtonProgressWidget, rescale it appropriately.
+    local warmth_lvl = Math.round(warmth * self.nl.stride)
+
+    if warmth_lvl == self.nl.cur then
         return
     end
 
     -- Set warmth
-    self.nl.cur = warmth
-    self.powerd:setWarmth(self.powerd:fromNativeWarmth(self.nl.cur))
+    self.powerd:setWarmth(self.powerd:fromNativeWarmth(warmth_lvl))
+    -- Retrieve the value PowerD actually set, in case there were rounding shenanigans and we blew the range...
+    self.nl.cur = self.powerd:toNativeWarmth(self.powerd:frontlightWarmth())
 
     -- Update the progress bar, if we were called from outside ButtonProgressWidget
     -- (as it already handles that internally ;)).
     if update_position then
+        -- We do want to use the position here, not the actual warmth level ;).
         self.nl_progress:setPosition(warmth, self.nl_progress.default_position)
     end
 
@@ -519,7 +524,7 @@ function FrontLightWidget:setFrontLightIntensity(intensity)
         self.powerd:setIntensity(self.fl.cur)
     end
 
-    -- Retrieve the real level (different from intensity on toggle)
+    -- Retrieve the real level set by PowerD (will be different from intensity on toggle)
     self.fl.cur = self.powerd:frontlightIntensity()
 end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -519,7 +519,7 @@ function FrontLightWidget:setFrontLightIntensity(intensity)
         self.powerd:setIntensity(self.fl.cur)
     end
 
-    -- Retrieve the real level set by PowerD (will be different from intensity on toggle)
+    -- Retrieve the real level set by PowerD (will be different from `intensity` on toggle)
     self.fl.cur = self.powerd:frontlightIntensity()
 end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -488,8 +488,7 @@ function FrontLightWidget:setWarmth(warmth, update_position)
     -- Retrieve the value PowerD actually set, in case there were rounding shenanigans and we blew the range...
     self.nl.cur = self.powerd:toNativeWarmth(self.powerd:frontlightWarmth())
 
-    -- Update the progress bar, if we were called from outside ButtonProgressWidget
-    -- (as it already handles that internally ;)).
+    -- If we were not called by ButtonProgressWidget's callback, we'll have to update its progress bar ourselves.
     if update_position then
         self.nl_progress:setPosition(math.floor(self.nl.cur / self.nl.stride), self.nl_progress.default_position)
     end


### PR DESCRIPTION
Fix #8913

Unlike previous iterations of the widget (I think?), this leaves the full granularity accessible via the +/- buttons.
In case that's unwanted, the first commit honored the scaling for those ;p.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8935)
<!-- Reviewable:end -->
