### PR TITLE
ButtonProgressWidget: Make hold_callback optional

### DIFF
--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -98,11 +98,7 @@ function ButtonProgressWidget:update()
                 self.callback("-")
                 self:update()
             end,
-            hold_callback = self.hold_callback and
-                function()
-                    self.hold_callback("-")
-                end
-                or nil,
+            hold_callback = self.hold_callback and function() self.hold_callback("-") end,
         }
         if self.thin_grey_style then
             button.frame.color = Blitbuffer.COLOR_DARK_GRAY
@@ -149,11 +145,7 @@ function ButtonProgressWidget:update()
                 self:update()
             end,
             no_focus = highlighted,
-            hold_callback = self.hold_callback and
-                function()
-                    self.hold_callback(i)
-                end
-                or nil,
+            hold_callback = self.hold_callback and function() self.hold_callback(i) end,
         }
         if self.thin_grey_style then
             if is_default then
@@ -208,11 +200,7 @@ function ButtonProgressWidget:update()
                 self.callback("+")
                 self:update()
             end,
-            hold_callback = self.hold_callback and
-                function()
-                    self.hold_callback("+")
-                end
-                or nil,
+            hold_callback = self.hold_callback and function() self.hold_callback("+") end,
         }
 
         if self.thin_grey_style then
@@ -247,11 +235,7 @@ function ButtonProgressWidget:update()
                 self.callback("⋮")
                 self:update()
             end,
-            hold_callback = self.hold_callback and
-                function()
-                    self.hold_callback("⋮")
-                end
-                or nil,
+            hold_callback = self.hold_callback and function() self.hold_callback("⋮") end,
         }
         if self.thin_grey_style then
             button.frame.color = Blitbuffer.COLOR_DARK_GRAY

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -98,9 +98,11 @@ function ButtonProgressWidget:update()
                 self.callback("-")
                 self:update()
             end,
-            hold_callback = function()
-                self.hold_callback("-")
-            end,
+            hold_callback = self.hold_callback and
+                function()
+                    self.hold_callback("-")
+                end
+                or nil,
         }
         if self.thin_grey_style then
             button.frame.color = Blitbuffer.COLOR_DARK_GRAY
@@ -147,9 +149,11 @@ function ButtonProgressWidget:update()
                 self:update()
             end,
             no_focus = highlighted,
-            hold_callback = function()
-                self.hold_callback(i)
-            end,
+            hold_callback = self.hold_callback and
+                function()
+                    self.hold_callback(i)
+                end
+                or nil,
         }
         if self.thin_grey_style then
             if is_default then
@@ -204,9 +208,11 @@ function ButtonProgressWidget:update()
                 self.callback("+")
                 self:update()
             end,
-            hold_callback = function()
-                self.hold_callback("+")
-            end,
+            hold_callback = self.hold_callback and
+                function()
+                    self.hold_callback("+")
+                end
+                or nil,
         }
 
         if self.thin_grey_style then
@@ -241,9 +247,11 @@ function ButtonProgressWidget:update()
                 self.callback("⋮")
                 self:update()
             end,
-            hold_callback = function()
-                self.hold_callback("⋮")
-            end,
+            hold_callback = self.hold_callback and
+                function()
+                    self.hold_callback("⋮")
+                end
+                or nil,
         }
         if self.thin_grey_style then
             button.frame.color = Blitbuffer.COLOR_DARK_GRAY


### PR DESCRIPTION
We don't need one in FrontLightWidget ;).

Fix https://github.com/koreader/koreader/issues/8913#issuecomment-1074915143

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8940)
<!-- Reviewable:end -->
