### PR TITLE
Kobo powerd: fix frequency in battery's getCapacity with enabled standby

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -231,12 +231,12 @@ function BasePowerD:isCharging()
 end
 
 function BasePowerD:getAuxCapacity()
-    local now_btv = self.device.total_standby_tv -- Add time the device was in standby
+    local now_btv
 
     if UIManager then
-        now_btv = now_btv + UIManager:getTime()
+        now_btv = UIManager:getElapsedTimeSinceBoot()
     else
-        now_btv = now_btv + TimeVal:now()
+        now_btv = TimeVal:now() + self.device.total_standby_tv -- Add time the device was in standby
     end
 
     if (now_btv - self.last_aux_capacity_pull_time):tonumber() >= 60 then

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -212,19 +212,16 @@ end
 function BasePowerD:getCapacity()
     -- BasePowerD is loaded before UIManager.
     -- Nothing *currently* calls this before UIManager is actually loaded, but future-proof this anyway.
-    local now_ts
+    local now_btv = self.device.total_standby_tv -- Add time the device was in standby
     if UIManager then
-        now_ts = UIManager:getTime()
+        now_btv = now_btv + UIManager:getTime()
     else
-        now_ts = TimeVal:now()
+        now_btv = now_btv + TimeVal:now()
     end
 
-    -- Add time the device was in standby
-    now_ts = now_ts + self.device.total_standby_tv
-
-    if (now_ts - self.last_capacity_pull_time):tonumber() >= 60 then
+    if (now_btv - self.last_capacity_pull_time):tonumber() >= 60 then
         self.batt_capacity = self:getCapacityHW()
-        self.last_capacity_pull_time = now_ts
+        self.last_capacity_pull_time = now_btv
     end
     return self.batt_capacity
 end
@@ -234,22 +231,20 @@ function BasePowerD:isCharging()
 end
 
 function BasePowerD:getAuxCapacity()
-    local now_ts
+    local now_btv = self.device.total_standby_tv -- Add time the device was in standby
+
     if UIManager then
-        now_ts = UIManager:getTime()
+        now_btv = now_btv + UIManager:getTime()
     else
-        now_ts = TimeVal:now()
+        now_btv = now_btv + TimeVal:now()
     end
 
-    -- Add time the device was in standby
-    now_ts = now_ts + self.device.total_standby_tv
-
-    if (now_ts - self.last_aux_capacity_pull_time):tonumber() >= 60 then
+    if (now_btv - self.last_aux_capacity_pull_time):tonumber() >= 60 then
         local aux_batt_capa = self:getAuxCapacityHW()
         -- If the read failed, don't update our cache, and retry next time.
         if aux_batt_capa then
             self.aux_batt_capacity = aux_batt_capa
-            self.last_aux_capacity_pull_time = now_ts
+            self.last_aux_capacity_pull_time = now_btv
         end
     end
     return self.aux_batt_capacity

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -212,11 +212,11 @@ end
 function BasePowerD:getCapacity()
     -- BasePowerD is loaded before UIManager.
     -- Nothing *currently* calls this before UIManager is actually loaded, but future-proof this anyway.
-    local now_btv = self.device.total_standby_tv -- Add time the device was in standby
+    local now_btv
     if UIManager then
-        now_btv = now_btv + UIManager:getTime()
+        now_btv = UIManager:getElapsedTimeSinceBoot()
     else
-        now_btv = now_btv + TimeVal:now()
+        now_btv = TimeVal:now() + self.device.total_standby_tv -- Add time the device was in standby
     end
 
     if (now_btv - self.last_capacity_pull_time):tonumber() >= 60 then

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -219,6 +219,9 @@ function BasePowerD:getCapacity()
         now_ts = TimeVal:now()
     end
 
+    -- Add time the device was in standby
+    now_ts = now_ts + self.device.total_standby_tv
+
     if (now_ts - self.last_capacity_pull_time):tonumber() >= 60 then
         self.batt_capacity = self:getCapacityHW()
         self.last_capacity_pull_time = now_ts
@@ -237,6 +240,9 @@ function BasePowerD:getAuxCapacity()
     else
         now_ts = TimeVal:now()
     end
+
+    -- Add time the device was in standby
+    now_ts = now_ts + self.device.total_standby_tv
 
     if (now_ts - self.last_aux_capacity_pull_time):tonumber() >= 60 then
         local aux_batt_capa = self:getAuxCapacityHW()


### PR DESCRIPTION
This corrects the waiting time in `getCapacity` for the times in standby.

Without this - if standby is enabled - the capacity display in the menu and status bar would get updated way too slow.
On devices without standby this PR is mainly a noop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8958)
<!-- Reviewable:end -->
