### PR TITLE
Status bar: fix battery display (threshold with aux battery)

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -27,6 +27,8 @@ local _ = require("gettext")
 local C_ = _.pgettext
 local Screen = Device.screen
 
+local  MAX_BATTERY_HIDE_THRESHOLD = 1000
+
 local MODE = {
     off = 0,
     page_progress = 1,
@@ -187,9 +189,9 @@ local footerTextGeneratorMap = {
                 is_charging = powerd:isAuxCharging()
                 -- Sum both batteries for the actual text
                 -- But average 'em to compute the icon...
-                batt_lvl = math.floor((main_batt_lvl + aux_batt_lvl) / 2 + 0.5)
+                batt_lvl = main_batt_lvl + aux_batt_lvl
                 if symbol_type == "icons" or symbol_type == "compact_items" then
-                    prefix = powerd:getBatterySymbol(is_charging, batt_lvl)
+                    prefix = powerd:getBatterySymbol(is_charging, batt_lvl / 2)
                 end
             else
                 is_charging = powerd:isCharging()
@@ -460,7 +462,7 @@ ReaderFooter.default_settings = {
     time = true,
     pages_left = true,
     battery = Device:hasBattery(),
-    battery_hide_threshold = 100,
+    battery_hide_threshold = Device:hasAuxBattery() and 200 or 100,
     percentage = true,
     book_time_to_read = true,
     chapter_time_to_read = true,
@@ -1569,7 +1571,14 @@ With this enabled, the current page is included, so the count goes from n to 1 i
     if Device:hasBattery() then
         table.insert(sub_items[settings_submenu_num].sub_item_table, 4, {
             text_func = function()
-                return T(_("Hide battery status if level higher than: %1%"), self.settings.battery_hide_threshold)
+                if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200) or 100 then
+                    return T(_("Hide battery status if level higher than: %1%"), self.settings.battery_hide_threshold)
+                else
+                    return _("Hide battery status")
+                end
+            end,
+            checked_func = function()
+                return self.settings.battery_hide_threshold < MAX_BATTERY_HIDE_THRESHOLD
             end,
             enabled_func = function()
                 return self.settings.all_at_once == true
@@ -1578,10 +1587,10 @@ With this enabled, the current page is included, so the count goes from n to 1 i
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
                 local battery_threshold = SpinWidget:new{
-                    value = self.settings.battery_hide_threshold,
+                    value = math.min(self.settings.battery_hide_threshold, Device:hasAuxBattery() and 200 or 100),
                     value_min = 0,
                     value_max = Device:hasAuxBattery() and 200 or 100,
-                    default_value = 100,
+                    default_value = Device:hasAuxBattery() and 200 or 100,
                     value_hold_step = 10,
                     title_text =  _("Hide battery threshold"),
                     callback = function(spin)
@@ -1589,6 +1598,12 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                         self:refreshFooter(true, true)
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,
+                    extra_text = _("Disable"),
+                    extra_callback = function()
+                        self.settings.battery_hide_threshold = MAX_BATTERY_HIDE_THRESHOLD
+                        if touchmenu_instance then touchmenu_instance:updateItems() end
+                    end,
+                    ok_always_enabled = true,
                 }
                 UIManager:show(battery_threshold)
             end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1571,7 +1571,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
     if Device:hasBattery() then
         table.insert(sub_items[settings_submenu_num].sub_item_table, 4, {
             text_func = function()
-                if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200) or 100 then
+                if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200 or 100) then
                     return T(_("Hide battery status if level higher than: %1%"), self.settings.battery_hide_threshold)
                 else
                     return _("Hide battery status")

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -186,10 +186,10 @@ local footerTextGeneratorMap = {
                 local aux_batt_lvl = powerd:getAuxCapacity()
                 is_charging = powerd:isAuxCharging()
                 -- Sum both batteries for the actual text
-                batt_lvl = main_batt_lvl + aux_batt_lvl
                 -- But average 'em to compute the icon...
+                batt_lvl = math.floor((main_batt_lvl + aux_batt_lvl) / 2 + 0.5)
                 if symbol_type == "icons" or symbol_type == "compact_items" then
-                    prefix = powerd:getBatterySymbol(is_charging, batt_lvl / 2)
+                    prefix = powerd:getBatterySymbol(is_charging, batt_lvl)
                 end
             else
                 is_charging = powerd:isCharging()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -188,8 +188,8 @@ local footerTextGeneratorMap = {
                 local aux_batt_lvl = powerd:getAuxCapacity()
                 is_charging = powerd:isAuxCharging()
                 -- Sum both batteries for the actual text
-                -- But average 'em to compute the icon...
                 batt_lvl = main_batt_lvl + aux_batt_lvl
+                -- But average 'em to compute the icon...
                 if symbol_type == "icons" or symbol_type == "compact_items" then
                     prefix = powerd:getBatterySymbol(is_charging, batt_lvl / 2)
                 end


### PR DESCRIPTION
If a device (Sage) has an aux battery and the sum of the internal end external capacity exceed the hide battery threshold, the capacity is not shown in the status bar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8959)
<!-- Reviewable:end -->
