### PR TITLE
Readerview: Fix save_settings calculation with standby

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1030,13 +1030,13 @@ end
 
 function ReaderView:onReaderReady()
     self.ui.doc_settings:delSetting("docsettings_reset_done")
-    self.settings_last_save_btv = UIManager:getTime() + Device.total_standby_tv
+    self.settings_last_save_btv = UIManager:getElapsedTimeSinceBoot()
 end
 
 function ReaderView:onResume()
     -- As settings were saved on suspend, reset this on resume,
     -- as there's no need for a possibly immediate save.
-    self.settings_last_save_btv = UIManager:getTime() + Device.total_standby_tv
+    self.settings_last_save_btv = UIManager:getElapsedTimeSinceBoot()
 end
 
 function ReaderView:checkAutoSaveSettings()
@@ -1050,7 +1050,7 @@ function ReaderView:checkAutoSaveSettings()
 
     local interval = G_reader_settings:readSetting("auto_save_settings_interval_minutes")
     interval = TimeVal:new{ sec = interval*60, usec = 0 }
-    local now_btv = UIManager:getTime() + Device.total_standby_tv
+    local now_btv = UIManager:getElapsedTimeSinceBoot()
     if now_btv - self.settings_last_save_btv >= interval then
         self.settings_last_save_btv = now_btv
         -- I/O, delay until after the pageturn

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1238,6 +1238,13 @@ function UIManager:getTime()
     return self._now
 end
 
+--[[--
+Returns a TimeVal object corresponding to the last UI tick plus the time in standby.
+]]
+function UIManager:getElapsedTimeSinceBoot()
+    return self:getTime() + Device.total_standby_tv
+end
+
 -- precedence of refresh modes:
 local refresh_modes = { fast = 1, ui = 2, partial = 3, flashui = 4, flashpartial = 5, full = 6 }
 -- NOTE: We might want to introduce a "force_fast" that points to fast, but has the highest priority,


### PR DESCRIPTION
Also, the save_settings calculation has to be educated to honor the times in standby.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8961)
<!-- Reviewable:end -->
