### PR TITLE
AutoSuspend: Avoid unbalanced prevent/allow Suspend calls

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -805,7 +805,6 @@ function Kobo:suspend()
     -- So, unless that changes, unconditionally disable it.
 
     --[[
-
     local has_wakeup_count = false
     f = io.open("/sys/power/wakeup_count", "re")
     if f ~= nil then
@@ -822,12 +821,11 @@ function Kobo:suspend()
         curr_wakeup_count = "$(cat /sys/power/wakeup_count)"
         logger.info("Kobo suspend: Current WakeUp count:", curr_wakeup_count)
     end
-
     -]]
 
     -- NOTE: Sets gSleep_Mode_Suspend to 1. Used as a flag throughout the
     -- kernel to suspend/resume various subsystems
-    -- cf. kernel/power/main.c @ L#207
+    -- c.f., state_extended_store @ kernel/power/main.c
     local ret = writeToSys("1", "/sys/power/state-extended")
     logger.info("Kobo suspend: asked the kernel to put subsystems to sleep, ret:", ret)
 
@@ -838,7 +836,6 @@ function Kobo:suspend()
     logger.info("Kobo suspend: synced FS")
 
     --[[
-
     if has_wakeup_count then
         f = io.open("/sys/power/wakeup_count", "we")
         if not f then
@@ -854,13 +851,12 @@ function Kobo:suspend()
         end
         f:close()
     end
-
     --]]
 
     logger.info("Kobo suspend: asking for a suspend to RAM . . .")
     f = io.open("/sys/power/state", "we")
     if not f then
-        -- reset state-extend back to 0 since we are giving up
+        -- Reset state-extended back to 0 since we are giving up.
         local ext_fd = io.open("/sys/power/state-extended", "we")
         if not ext_fd then
             logger.err("cannot open /sys/power/state-extended for writing!")

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1226,11 +1226,14 @@ This is essentially a cached TimeVal:now(), computed at the top of every iterati
 (right before checking/running scheduled tasks).
 This is mainly useful to compute/schedule stuff in the same time scale as the UI loop (i.e., MONOTONIC),
 without having to resort to a syscall.
-It should never be significantly stale (i.e., it should be precise enough),
-unless you're blocking the UI for a significant amount of time in the same UI tick.
+It should never be significantly stale, assuming the UI is in use (e.g., there are input events),
+unless you're blocking the UI for a significant amount of time in a single UI frame.
 
-Prefer the appropriate TimeVal method for your needs if you require perfect accuracy
-(e.g., when you're actually working on the event loop *itself* (UIManager, Input, GestureDetector)).
+That is to say, its granularity is an UI frame.
+
+Prefer the appropriate TimeVal method for your needs if you require perfect accuracy or better granularity
+(e.g., when you're actually working on the event loop *itself* (UIManager, Input, GestureDetector),
+or if you're dealing with intra-frame timers).
 
 This is *NOT* wall clock time (REALTIME).
 ]]

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1830,7 +1830,6 @@ Called once we're done with whatever we were doing in the background.
 Standby is re-enabled only after all issued prevents are paired with allowStandby for each one.
 ]]
 function UIManager:allowStandby()
-    logger.dbg("UIManager:allowStandby:", self._prevent_standby_count, ":", debug.traceback())
     assert(self._prevent_standby_count > 0, "allowing standby that isn't prevented; you have an allow/prevent mismatch somewhere")
     self._prevent_standby_count = self._prevent_standby_count - 1
 end
@@ -1841,7 +1840,6 @@ Prevent standby.
 i.e., something is happening in background, yet UI may tick.
 ]]
 function UIManager:preventStandby()
-    logger.dbg("UIManager:preventStandby:", self._prevent_standby_count, ":", debug.traceback())
     self._prevent_standby_count = self._prevent_standby_count + 1
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1830,7 +1830,7 @@ Called once we're done with whatever we were doing in the background.
 Standby is re-enabled only after all issued prevents are paired with allowStandby for each one.
 ]]
 function UIManager:allowStandby()
-    logger.dbg("UIManager:allowStandby: ", self._prevent_standby_count, " :", debug.traceback())
+    logger.dbg("UIManager:allowStandby:", self._prevent_standby_count, ":", debug.traceback())
     assert(self._prevent_standby_count > 0, "allowing standby that isn't prevented; you have an allow/prevent mismatch somewhere")
     self._prevent_standby_count = self._prevent_standby_count - 1
 end
@@ -1841,7 +1841,7 @@ Prevent standby.
 i.e., something is happening in background, yet UI may tick.
 ]]
 function UIManager:preventStandby()
-    logger.dbg("UIManager:preventStandby: ", self._prevent_standby_count, " :", debug.traceback())
+    logger.dbg("UIManager:preventStandby:", self._prevent_standby_count, ":", debug.traceback())
     self._prevent_standby_count = self._prevent_standby_count + 1
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1830,6 +1830,7 @@ Called once we're done with whatever we were doing in the background.
 Standby is re-enabled only after all issued prevents are paired with allowStandby for each one.
 ]]
 function UIManager:allowStandby()
+    logger.dbg("UIManager:allowStandby: ", self._prevent_standby_count, " :", debug.traceback())
     assert(self._prevent_standby_count > 0, "allowing standby that isn't prevented; you have an allow/prevent mismatch somewhere")
     self._prevent_standby_count = self._prevent_standby_count - 1
 end
@@ -1840,6 +1841,7 @@ Prevent standby.
 i.e., something is happening in background, yet UI may tick.
 ]]
 function UIManager:preventStandby()
+    logger.dbg("UIManager:preventStandby: ", self._prevent_standby_count, " :", debug.traceback())
     self._prevent_standby_count = self._prevent_standby_count + 1
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -432,11 +432,18 @@ end
 -- UI signals us that standby is allowed at this very moment because nothing else goes on in the background.
 function AutoSuspend:onAllowStandby()
     logger.dbg("AutoSuspend: onAllowStandby")
+
     -- In case the OS frontend itself doesn't manage power state, we can do it on our own here.
     -- One should also configure wake-up pins and perhaps wake alarm,
     -- if we want to enter deeper sleep states later on from within standby.
 
-    -- Don't enter standby if wifi is on, as this my break reconnecting (at least on Kobo-Sage)
+    -- Don't enter standby if we haven't set a proper timeout yet.
+    if not self:_enabledStandby() then
+        logger.dbg("AutoSuspend: No timeout set, no standby")
+        return
+    end
+
+    -- Don't enter standby if wifi is on, as this will break in fun and interesting ways (from Wi-Fi issues to kernel deadlocks).
     if NetworkMgr:isWifiOn() then
         logger.dbg("AutoSuspend: WiFi is on, no standby")
         return

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -161,6 +161,8 @@ function AutoSuspend:onInputEvent()
     logger.dbg("AutoSuspend: onInputEvent")
     self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
 
+    -- NOTE: The fact that we run this on *this* event ensures we don't have to handle the standby scheduling
+    --       at all in setSuspendShutdownTimes ;).
     self:_reschedule_standby()
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -146,6 +146,7 @@ function AutoSuspend:onCloseWidget()
     if not Device:canStandby() then return end
     -- allowStandby may be necessary, as we do a preventStandby on plugin start
     while self.prevent_standby_count > 0 do
+        logger.debug("AutoSuspend: prevent_standby_count is", self.prevent_standby_count)
         UIManager:allowStandby()
         self.prevent_standby_count = self.prevent_standby_count - 1
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -181,14 +181,14 @@ function AutoSuspend:_reschedule_standby()
 end
 
 function AutoSuspend:preventStandby()
-    logger.dbg("AutoSuspend:preventStandby:", self.is_standby_scheduled)
+    logger.dbg("AutoSuspend:preventStandby")
     -- Tell UIManager that we want to prevent standby until our allowStandby scheduled task runs.
     UIManager:preventStandby()
 end
 
 -- NOTE: This is the scheduled task that should trip the UIManager state to standby
 function AutoSuspend:allowStandby()
-    logger.dbg("AutoSuspend:allowStandby:", self.is_standby_scheduled)
+    logger.dbg("AutoSuspend:allowStandby")
     -- Tell UIManager that we now allow standby.
     UIManager:allowStandby()
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -34,7 +34,6 @@ local AutoSuspend = WidgetContainer:new{
     auto_standby_timeout_seconds = default_auto_standby_timeout_seconds,
     last_action_tv = TimeVal.zero,
     is_standby_scheduled = false,
-    prevent_standby_count = 0,
     task = nil,
 }
 
@@ -159,7 +158,7 @@ function AutoSuspend:_unschedule_standby()
         logger.dbg("AutoSuspend: unschedule standby")
         UIManager:unschedule(AutoSuspend.allowStandby)
         -- Restore the UIManager balance, as we run preventStandby right after scheduling this task.
-        self:_allowStandby()
+        UIManager:allowStandby()
 
         self.is_standby_scheduled = false
     end
@@ -181,29 +180,17 @@ function AutoSuspend:_reschedule_standby()
     self:preventStandby()
 end
 
-function AutoSuspend:_preventStandby()
-    UIManager:preventStandby()
-    self.prevent_standby_count = self.prevent_standby_count + 1
-    logger.dbg("Increasing prevent_standby_count to", self.prevent_standby_count)
-end
-
 function AutoSuspend:preventStandby()
     logger.dbg("AutoSuspend:preventStandby:", self.is_standby_scheduled)
     -- Tell UIManager that we want to prevent standby until our allowStandby scheduled task runs.
-    self:_preventStandby()
-end
-
-function AutoSuspend:_allowStandby()
-    UIManager:allowStandby()
-    self.prevent_standby_count = self.prevent_standby_count - 1
-    logger.dbg("Decreasing prevent_standby_count to", self.prevent_standby_count)
+    UIManager:preventStandby()
 end
 
 -- NOTE: This is the scheduled task that should trip the UIManager state to standby
 function AutoSuspend:allowStandby()
     logger.dbg("AutoSuspend:allowStandby:", self.is_standby_scheduled)
     -- Tell UIManager that we now allow standby.
-    self:_allowStandby()
+    UIManager:allowStandby()
 
     -- This is necessary for wakeup from standby, as the deadline for receiving input events
     -- is calculated from the time to the next scheduled function.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -477,8 +477,8 @@ function AutoSuspend:onAllowStandby()
     -- Wake up before the second next scheduled function executes (e.g. footer update, suspend ...)
     local scheduler_times = UIManager:getNextTaskTimes(2)
     if #scheduler_times == 2 then
-        -- Wake up slightly after the formerly scheduled event, to avoid resheduling the same function
-        -- after a fraction of a second again (e.g. don't draw footer twice).
+        -- Wake up slightly after the formerly scheduled event,
+        -- to avoid resheduling the same function after a fraction of a second again (e.g. don't draw footer twice).
         wake_in = math.floor(scheduler_times[2]:tonumber()) + 1
     end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -194,7 +194,6 @@ function AutoSuspend:_reschedule_standby()
 end
 
 function AutoSuspend:preventStandby()
-    logger.dbg("AutoSuspend:preventStandby")
     -- Tell UIManager that we want to prevent standby until our allowStandby scheduled task runs.
     UIManager:preventStandby()
 end
@@ -436,7 +435,7 @@ Upon user input, the device needs a certain amount of time to wake up. With some
                 self:setSuspendShutdownTimes(touchmenu_instance,
                     _("Timeout for autostandby"), _("Enter time in minutes and seconds."),
                     "auto_standby_timeout_seconds", default_auto_standby_timeout_seconds,
-                    {4, 15*60}, 0)
+                    {default_auto_standby_timeout_seconds, 15*60}, 0)
             end,
         }
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -429,14 +429,14 @@ Upon user input, the device needs a certain amount of time to wake up. With some
             help_text = standby_help,
             keep_menu_open = true,
             callback = function(touchmenu_instance)
-                -- 3 sec is the minimum and 15*60 sec (15min) is the maximum standby time.
+                -- 4 sec is the minimum and 15*60 sec (15min) is the maximum standby time.
                 -- We need a minimum time, so that scheduled function have a chance to execute.
                 -- A standby time of 15 min seem excessive.
                 -- But or battery testing it might give some sense.
                 self:setSuspendShutdownTimes(touchmenu_instance,
                     _("Timeout for autostandby"), _("Enter time in minutes and seconds."),
                     "auto_standby_timeout_seconds", default_auto_standby_timeout_seconds,
-                    {3, 15*60}, 0)
+                    {4, 15*60}, 0)
             end,
         }
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -470,30 +470,29 @@ function AutoSuspend:onAllowStandby()
     if Device:canStandby() then
         local wake_in = math.huge
         -- The next scheduled function should be the deadline_guard
-        -- Wake before the second next scheduled function executes (e.g. footer update, suspend ...)
+        -- Wake up before the second next scheduled function executes (e.g. footer update, suspend ...)
         local scheduler_times = UIManager:getNextTaskTimes(2)
         if #scheduler_times == 2 then
             -- Wake up slightly after the formerly scheduled event, to avoid resheduling the same function
-            -- after a fraction of a second again (e.g. don't draw footer twice)
+            -- after a fraction of a second again (e.g. don't draw footer twice).
             wake_in = math.floor(scheduler_times[2]:tonumber()) + 1
         end
 
-        if wake_in > 3 then -- don't go into standby, if scheduled wake is in less than 3 secs
+        if wake_in > 3 then -- don't go into standby, if scheduled wakeup is in less than 3 secs
             UIManager:broadcastEvent(Event:new("EnterStandby"))
             logger.dbg("AutoSuspend: going to standby and wake in " .. wake_in .. "s zZzzZzZzzzzZZZzZZZz")
 
-            -- This is for the Kobo Sage/Elipsa for now, as these are the only with useStandby.
-            -- Other devices may be added
+            -- This obviously needs a matching implementation in Device, the canonical one being Kobo.
             Device:standby(wake_in)
 
             logger.dbg("AutoSuspend: leaving standby after " .. Device.last_standby_tv:tonumber() .. " s")
 
             UIManager:broadcastEvent(Event:new("LeaveStandby"))
-            self:_unschedule() -- unschedule suspend and shutdown as the realtime clock has ticked
+            self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked
             self:_schedule()   -- reschedule suspend and shutdown with the new time
         end
         -- Don't do a `self:_reschedule_standby()` here, as this will interfere with suspend.
-        -- Better to to it in onLeaveStandby.
+        -- Leave that to onLeaveStandby.
     end
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -409,7 +409,7 @@ function AutoSuspend:addToMainMenu(menu_items)
 
 Standby can not be entered if Wi-Fi is on.
 
-Upon user input, the device needs a certain amount of time to wake up. With some devices this period of time is not noticeable, with other devices it can be annoying.]])
+Upon user input, the device needs a certain amount of time to wake up. Generally, the newer the device, the less noticeable this delay will be, but it can be fairly aggravating on slower devices.]])
 
         menu_items.autostandby = {
             sorting_hint = "device",

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -173,9 +173,11 @@ function AutoSuspend:_reschedule_standby()
 
     if not self:_enabledStandby() then return end
 
-    self:preventStandby()
     logger.dbg("AutoSuspend: schedule autoStandby in", self.auto_standby_timeout_seconds)
+    self.is_standby_scheduled = true
     UIManager:scheduleIn(self.auto_standby_timeout_seconds, self.allowStandby, self)
+
+    self:preventStandby()
 end
 
 function AutoSuspend:preventStandby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -144,6 +144,7 @@ function AutoSuspend:onCloseWidget()
 
     self:_unschedule_standby()
     if not Device:canStandby() then return end
+
     -- allowStandby may be necessary, as we do a preventStandby on plugin start
     while self.prevent_standby_count > 0 do
         logger.debug("AutoSuspend: prevent_standby_count is", self.prevent_standby_count)
@@ -163,17 +164,15 @@ function AutoSuspend:_unschedule_standby()
     UIManager:unschedule(AutoSuspend.allowStandby)
 end
 
-function AutoSuspend:_reschedule_standby(standby_timeout)
+function AutoSuspend:_reschedule_standby()
     if not Device:canStandby() then return end
-    standby_timeout = standby_timeout or self.auto_standby_timeout_seconds
+
     self:_unschedule_standby()
-    if standby_timeout < 1 then
-        return
-    end
+    if not self:_enabledStandby() then return end
 
     self:preventStandby()
-    logger.dbg("AutoSuspend: schedule autoStandby in", standby_timeout) -- xxx may be deleted later
-    UIManager:scheduleIn(standby_timeout, self.allowStandby, self)
+    logger.dbg("AutoSuspend: schedule autoStandby in", self.auto_standby_timeout_seconds)
+    UIManager:scheduleIn(self.auto_standby_timeout_seconds, self.allowStandby, self)
 end
 
 function AutoSuspend:preventStandby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -142,8 +142,9 @@ function AutoSuspend:onCloseWidget()
     self:_unschedule()
     self.task = nil
 
-    self:_unschedule_standby()
     if not Device:canStandby() then return end
+
+    self:_unschedule_standby()
 
     -- allowStandby may be necessary, as we do a preventStandby on plugin start
     while self.prevent_standby_count > 0 do
@@ -167,7 +168,9 @@ end
 function AutoSuspend:_reschedule_standby()
     if not Device:canStandby() then return end
 
+    -- We may have just disabled the feature, so unschedule before checking it.
     self:_unschedule_standby()
+
     if not self:_enabledStandby() then return end
 
     self:preventStandby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -432,10 +432,8 @@ end
 -- UI signals us that standby is allowed at this very moment because nothing else goes on in the background.
 function AutoSuspend:onAllowStandby()
     logger.dbg("AutoSuspend: onAllowStandby")
-
-    -- In case the OS frontend itself doesn't manage power state, we can do it on our own here.
-    -- One should also configure wake-up pins and perhaps wake alarm,
-    -- if we want to enter deeper sleep states later on from within standby.
+    -- This piggy-backs minimally on the UI framework implemented for the PocketBook autostandby plugin,
+    -- see its own AllowStandby handlers for more details.
 
     -- Don't enter standby if we haven't set a proper timeout yet.
     if not self:_enabledStandby() then

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -156,6 +156,7 @@ end
 
 function AutoSuspend:_unschedule_standby()
     if self.is_standby_scheduled then
+        logger.dbg("AutoSuspend: unschedule standby")
         UIManager:unschedule(AutoSuspend.allowStandby)
         -- Restore the UIManager balance, as we run preventStandby right after scheduling this task.
         self:_allowStandby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -449,7 +449,7 @@ function AutoSuspend:onAllowStandby()
         return
     end
 
-    -- Don't enter standby if device is charging and it is a non sunxi kobo
+    -- Don't enter standby when charging on devices where charging prevents entering low power states.
     if Device.powerd:isCharging() and not Device:canPowerSaveWhileCharging() then
         logger.dbg("AutoSuspend: charging, no standby")
         return

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -176,18 +176,22 @@ function AutoSuspend:_reschedule_standby(standby_timeout)
 end
 
 function AutoSuspend:preventStandby()
+    logger.dbg("AutoSuspend:preventStandby:", self.is_standby_scheduled)
     if self.is_standby_scheduled ~= false then
         self.is_standby_scheduled = false
         UIManager:preventStandby()
         self.prevent_standby_count = self.prevent_standby_count + 1
+        logger.dbg("Increasing prevent_standby_count to", self.prevent_standby_count)
     end
 end
 
 function AutoSuspend:allowStandby()
+    logger.dbg("AutoSuspend:allowStandby:", self.is_standby_scheduled)
     if not self.is_standby_scheduled then
         self.is_standby_scheduled = true
         UIManager:allowStandby()
         self.prevent_standby_count = self.prevent_standby_count - 1
+        logger.dbg("Decreasing prevent_standby_count to", self.prevent_standby_count)
 
         -- This is necessary for wakeup from standby, as the deadline for receiving input events
         -- is calculated from the time to the next scheduled function.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -418,7 +418,7 @@ Upon user input, the device needs a certain amount of time to wake up. With some
             help_text = standby_help,
             keep_menu_open = true,
             callback = function(touchmenu_instance)
-                -- 5 sec is the minimum and 60*60 sec (15min) is the maximum standby time.
+                -- 3 sec is the minimum and 15*60 sec (15min) is the maximum standby time.
                 -- We need a minimum time, so that scheduled function have a chance to execute.
                 -- A standby time of 15 min seem excessive.
                 -- But or battery testing it might give some sense.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -62,7 +62,7 @@ function AutoSuspend:_schedule(shutdown_only)
         delay_suspend = self.auto_suspend_timeout_seconds
         delay_shutdown = self.autoshutdown_timeout_seconds
     else
-        local now_tv = UIManager:getTime() + Device.total_standby_tv
+        local now_tv = UIManager:getElapsedTimeSinceBoot()
         delay_suspend = (self.last_action_tv - now_tv):tonumber() + self.auto_suspend_timeout_seconds
         delay_shutdown = (self.last_action_tv - now_tv):tonumber() + self.autoshutdown_timeout_seconds
     end
@@ -95,7 +95,7 @@ end
 
 function AutoSuspend:_start()
     if self:_enabled() or self:_enabledShutdown() then
-        self.last_action_tv = UIManager:getTime() + Device.total_standby_tv
+        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
         logger.dbg("AutoSuspend: start at", self.last_action_tv:tonumber())
         self:_schedule()
     end
@@ -104,7 +104,7 @@ end
 -- Variant that only re-engages the shutdown timer for onUnexpectedWakeupLimit
 function AutoSuspend:_restart()
     if self:_enabledShutdown() then
-        self.last_action_tv = UIManager:getTime() + Device.total_standby_tv
+        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
         logger.dbg("AutoSuspend: restart at", self.last_action_tv:tonumber())
         self:_schedule(true)
     end
@@ -155,7 +155,7 @@ end
 
 function AutoSuspend:onInputEvent()
     logger.dbg("AutoSuspend: onInputEvent")
-    self.last_action_tv = UIManager:getTime() + Device.total_standby_tv
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
 
     self:_reschedule_standby()
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -433,7 +433,7 @@ end
 function AutoSuspend:onAllowStandby()
     logger.dbg("AutoSuspend: onAllowStandby")
     -- This piggy-backs minimally on the UI framework implemented for the PocketBook autostandby plugin,
-    -- see its own AllowStandby handlers for more details.
+    -- see its own AllowStandby handler for more details.
 
     -- Don't enter standby if we haven't set a proper timeout yet.
     if not self:_enabledStandby() then

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -33,7 +33,7 @@ local AutoSuspend = WidgetContainer:new{
     auto_suspend_timeout_seconds = default_auto_suspend_timeout_seconds,
     auto_standby_timeout_seconds = default_auto_standby_timeout_seconds,
     last_action_tv = TimeVal.zero,
-    is_standby_scheduled = nil,
+    is_standby_scheduled = false,
     prevent_standby_count = 0,
     task = nil,
 }
@@ -180,7 +180,7 @@ end
 
 function AutoSuspend:preventStandby()
     logger.dbg("AutoSuspend:preventStandby:", self.is_standby_scheduled)
-    if self.is_standby_scheduled ~= false then
+    if self.is_standby_scheduled then
         self.is_standby_scheduled = false
         UIManager:preventStandby()
         self.prevent_standby_count = self.prevent_standby_count + 1


### PR DESCRIPTION
This fixes the issue mentioned in https://www.mobileread.com/forums/showthread.php?t=345985, which you can easily reproduce by having autostandby disabled, long-pressing on a book to refresh its metadata, and opening it after the thumbnail has been refreshed.

It would cash a few seconds after, once the metadata processes get reaped.

This also cleans up a few minor things, and one not so minor thing: don't actually suspend if the timeout is unset ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8970)
<!-- Reviewable:end -->
