### PR TITLE
PW5: Page turn animations

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1006,6 +1006,9 @@ function ReaderRolling:_gotoPos(new_pos, do_dim_area)
     else
         self.view.dim_area:clear()
     end
+    if self.current_pos and not UIManager.currently_scrolling then
+        self.ui:handleEvent(Event:new("PageChangeAnimation", new_pos > self.current_pos))
+    end
     self.ui.document:gotoPos(new_pos)
     -- The current page we get in scroll mode may be a bit innacurate,
     -- but we give it anyway to onPosUpdate so footer and statistics can
@@ -1037,6 +1040,9 @@ function ReaderRolling:_gotoPage(new_page, free_first_page, internal)
                 new_page = new_page - 1
             end
         end
+    end
+    if self.current_page then
+        self.ui:handleEvent(Event:new("PageChangeAnimation", new_page > self.current_page))
     end
     self.ui.document:gotoPage(new_page, internal)
     if self.view.view_mode == "page" then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -889,6 +889,14 @@ function ReaderView:onRotationUpdate(rotation)
     self:recalculate()
 end
 
+function ReaderView:onPageChangeAnimation(forward)
+    if Device:canDoSwipeAnimation() and G_reader_settings:isTrue("swipe_animations") then
+        if self.inverse_reading_order then forward = not forward end
+        Screen:setSwipeAnimations(true)
+        Screen:setSwipeDirection(forward)
+    end
+end
+
 function ReaderView:onReaderFooterVisibilityChange()
     -- Don't bother ReaderRolling with this nonsense, the footer's height is NOT handled via visible_area there ;)
     if self.ui.paging and self.state.page then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -54,6 +54,7 @@ local Device = {
     hasExternalSD = no, -- or other storage volume that cannot be accessed using the File Manager
     canHWDither = no,
     canHWInvert = no,
+    canDoSwipeAnimation = no,
     canModifyFBInfo = no, -- some NTX boards do wonky things with the rotate flag after a FBIOPUT_VSCREENINFO ioctl
     canUseCBB = yes, -- The C BB maintains a 1:1 feature parity with the Lua BB, except that is has NO support for BB4, and limited support for BBRGB24
     hasColorScreen = no,

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -473,6 +473,7 @@ local KindlePaperWhite5 = Kindle:new{
     touch_dev = "/dev/input/by-path/platform-1001e000.i2c-event",
     -- NOTE: While hardware dithering (via MDP) should be a thing, it doesn't appear to do anything right now :/.
     canHWDither = no,
+    canDoSwipeAnimation = yes,
 }
 
 function Kindle2:init()

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -141,6 +141,19 @@ When enabled the UI direction for the Table of Contents, Book Map, and Page Brow
     }
 }
 
+if Device:canDoSwipeAnimation() then
+    table.insert(PageTurns.sub_item_table, {
+        text =_("Page Turn Animations"),
+        checked_func = function()
+            return G_reader_settings:isTrue("swipe_animations")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("swipe_animations")
+        end,
+        separator = true,
+    })
+end
+
 if Device:hasKeys() then
     table.insert(PageTurns.sub_item_table, {
         text = _("Invert page turn buttons"),


### PR DESCRIPTION
enable page turn animations on supported platforms (PW5/MTK)

This creates a swipe animation when turning pages in the reader.

(for some reason, I happened to read a few pages in the stock reader and decided i like the effect ;)


Requires: https://github.com/koreader/koreader-base/pull/1477

To Do:

- PDF
- ~~Landscape (we dont rotate the FB so this must be adjusted)~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8974)
<!-- Reviewable:end -->
