### PR TITLE
getElapsedTimeSinceBoot: Honor times in suspend, too

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -216,7 +216,8 @@ function BasePowerD:getCapacity()
     if UIManager then
         now_btv = UIManager:getElapsedTimeSinceBoot()
     else
-        now_btv = TimeVal:now() + self.device.total_standby_tv -- Add time the device was in standby
+        -- Add time the device was in standby and suspend
+        now_btv = TimeVal:now() + self.device.total_standby_tv + self.device.total_suspend_tv
     end
 
     if (now_btv - self.last_capacity_pull_time):tonumber() >= 60 then
@@ -236,7 +237,8 @@ function BasePowerD:getAuxCapacity()
     if UIManager then
         now_btv = UIManager:getElapsedTimeSinceBoot()
     else
-        now_btv = TimeVal:now() + self.device.total_standby_tv -- Add time the device was in standby
+        -- Add time the device was in standby and suspend
+        now_btv = TimeVal:now() + self.device.total_standby_tv + self.device.total_suspend_tv
     end
 
     if (now_btv - self.last_aux_capacity_pull_time):tonumber() >= 60 then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1242,10 +1242,10 @@ function UIManager:getTime()
 end
 
 --[[--
-Returns a TimeVal object corresponding to the last UI tick plus the time in standby.
+Returns a TimeVal object corresponding to the last UI tick plus the time in standby and suspend.
 ]]
 function UIManager:getElapsedTimeSinceBoot()
-    return self:getTime() + Device.total_standby_tv
+    return self:getTime() + Device.total_standby_tv + Device.total_suspend_tv
 end
 
 -- precedence of refresh modes:


### PR DESCRIPTION
Without this PR the battery capacity is updated at worst one minute after resume. Which might be annoying, if you have charged the device during suspend.
BTW, now getElapsedTimeSinceBoot does more what it's name promises ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8983)
<!-- Reviewable:end -->
