### PR TITLE
AutoSuspend: Handle standby scheduling in the same manner as suspend/shutdown

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -776,12 +776,13 @@ function Kobo:standby(max_duration)
     local TimeVal = require("ui/timeval")
     local standby_time_tv = TimeVal:boottime_or_realtime_coarse()
 
+    logger.info("Kobo suspend: asking to enter standby . . .")
     local ret = writeToSys("standby", "/sys/power/state")
 
     self.last_standby_tv = TimeVal:boottime_or_realtime_coarse() - standby_time_tv
     self.total_standby_tv = self.total_standby_tv + self.last_standby_tv
 
-    logger.info("Kobo suspend: asked the kernel to put subsystems to standby, ret:", ret)
+    logger.info("Kobo suspend: zZz zZz zZz zZz? Write syscall returned: ", ret)
 
     if max_duration then
         self.wakeup_mgr:removeTask(nil, nil, dummy)

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -300,7 +300,7 @@ function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
 
     local setting_val = self[setting] > 0 and self[setting] or default_value
 
-    -- Standby uses a different scheduled task that suspend/shutdown
+    -- Standby uses a different scheduled task than suspend/shutdown
     local is_standby = setting == "auto_standby_timeout_seconds"
 
     local left_val

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -96,8 +96,16 @@ end
 function AutoSuspend:_start()
     if self:_enabled() or self:_enabledShutdown() then
         self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
-        logger.dbg("AutoSuspend: start at", self.last_action_tv:tonumber())
+        logger.dbg("AutoSuspend: start (suspend/shutdown) at", self.last_action_tv:tonumber())
         self:_schedule()
+    end
+end
+
+function AutoSuspend:_start_standby()
+    if self:_enabledStandby() then
+        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+        logger.dbg("AutoSuspend: start (standby) at", self.last_action_tv:tonumber())
+        self:_schedule_standby()
     end
 end
 
@@ -113,6 +121,7 @@ end
 function AutoSuspend:init()
     logger.dbg("AutoSuspend: init")
     if Device:isPocketBook() and not Device:canSuspend() then return end
+
     self.autoshutdown_timeout_seconds = G_reader_settings:readSetting("autoshutdown_timeout_seconds",
         default_autoshutdown_timeout_seconds)
     self.auto_suspend_timeout_seconds = G_reader_settings:readSetting("auto_suspend_timeout_seconds",
@@ -133,11 +142,11 @@ function AutoSuspend:init()
         self:_schedule(shutdown_only)
     end
     self.standby_task = function()
-        self:allowStandby()
+        self:_schedule_standby()
     end
 
     self:_start()
-    self:_reschedule_standby()
+    self:_start_standby()
 
     -- self.ui is nil in the testsuite
     if not self.ui or not self.ui.menu then return end
@@ -148,10 +157,9 @@ end
 function AutoSuspend:onCloseWidget()
     logger.dbg("AutoSuspend: onCloseWidget")
     if Device:isPocketBook() and not Device:canSuspend() then return end
+
     self:_unschedule()
     self.task = nil
-
-    if not Device:canStandby() then return end
 
     self:_unschedule_standby()
     self.standby_task = nil
@@ -160,10 +168,6 @@ end
 function AutoSuspend:onInputEvent()
     logger.dbg("AutoSuspend: onInputEvent")
     self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
-
-    -- NOTE: The fact that we run this on *this* event ensures we don't have to handle the standby scheduling
-    --       at all in setSuspendShutdownTimes ;).
-    self:_reschedule_standby()
 end
 
 function AutoSuspend:_unschedule_standby()
@@ -177,20 +181,49 @@ function AutoSuspend:_unschedule_standby()
     end
 end
 
-function AutoSuspend:_reschedule_standby()
-    if not Device:canStandby() then return end
+function AutoSuspend:_schedule_standby()
+    -- Start the long list of conditions in which we do *NOT* want to go into standby ;).
+    if not Device:canStandby() then
+        -- NOTE: This partly duplicates what `_enabledStandby` does,
+        --       but it's here to avoid logging noise on devices that can't even standby ;).
+        return
+    end
 
-    -- We may have just disabled the feature, so unschedule before checking it.
-    self:_unschedule_standby()
+    -- Don't even schedule standby if we haven't set a proper timeout yet.
+    if not self:_enabledStandby() then
+        logger.dbg("AutoSuspend: No timeout set, no standby")
+        return
+    end
 
-    if not self:_enabledStandby() then return end
+    local delay_standby
+    if NetworkMgr:isWifiOn() then
+        -- Don't enter standby if wifi is on, as this will break in fun and interesting ways (from Wi-Fi issues to kernel deadlocks).
+        logger.dbg("AutoSuspend: WiFi is on, delaying standby")
+        delay_standby = self.auto_standby_timeout_seconds
+    elseif Device.powerd:isCharging() and not Device:canPowerSaveWhileCharging() then
+        -- Don't enter standby when charging on devices where charging prevents entering low power states.
+        logger.dbg("AutoSuspend: charging, delaying standby")
+        delay_standby = self.auto_standby_timeout_seconds
+    else
+        local now_tv = UIManager:getElapsedTimeSinceBoot()
+        delay_standby = (self.last_action_tv - now_tv):tonumber() + self.auto_standby_timeout_seconds
+    end
 
-    logger.dbg("AutoSuspend: schedule autoStandby in", self.auto_standby_timeout_seconds)
-    UIManager:scheduleIn(self.auto_standby_timeout_seconds, self.standby_task)
-    self.is_standby_scheduled = true
+    if delay_standby <= 0 then
+        -- We blew the deadline, tell UIManager we're ready to enter standby
+        self:allowStandby()
+    else
+        -- Reschedule standby
+        logger.dbg("AutoSuspend: scheduling next standby check in", delay_standby)
+        UIManager:scheduleIn(delay_standby, self.standby_task)
 
-    -- Prevent standby until our scheduled allowStandby
-    self:preventStandby()
+        -- Prevent standby until our scheduled allowStandby
+        if not self.is_standby_scheduled then
+            self:preventStandby()
+        end
+
+        self.is_standby_scheduled = true
+    end
 end
 
 function AutoSuspend:preventStandby()
@@ -198,7 +231,7 @@ function AutoSuspend:preventStandby()
     UIManager:preventStandby()
 end
 
--- NOTE: This is the scheduled task that should trip the UIManager state to standby
+-- NOTE: This is what our scheduled task runs to trip the UIManager state to standby
 function AutoSuspend:allowStandby()
     logger.dbg("AutoSuspend:allowStandby")
     -- Tell UIManager that we now allow standby.
@@ -207,7 +240,7 @@ function AutoSuspend:allowStandby()
     -- This is necessary for wakeup from standby, as the deadline for receiving input events
     -- is calculated from the time to the next scheduled function.
     -- Make sure this function comes soon, as the time for going to standby after a scheduled wakeup
-    -- is prolonged by the given time. Any time between 0.500 and 0.001 seconds would go.
+    -- is prolonged by the given time. Any time between 0.500 and 0.001 seconds should do.
     -- Let's call it deadline_guard.
     UIManager:scheduleIn(0.100, function() end)
 
@@ -234,11 +267,12 @@ function AutoSuspend:onResume()
     -- Unschedule in case we tripped onUnexpectedWakeupLimit first...
     self:_unschedule()
     self:_start()
-    self:_reschedule_standby()
+    self:_unschedule_standby()
+    self:_start_standby()
 end
 
 function AutoSuspend:onLeaveStandby()
-    self:_reschedule_standby()
+    self:_schedule_standby()
 end
 
 function AutoSuspend:onUnexpectedWakeupLimit()
@@ -251,14 +285,17 @@ end
 -- 2 ... display day:hour
 -- 1 ... display hour:min
 -- else ... display min:sec
-function AutoSuspend:setSuspendShutdownTimes(touchmenu_instance, title, info, setting,
+function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
         default_value, range, time_scale)
-    -- Attention if is_day_hour then time.hour stands for days and time.min for hours
+    -- NOTE: if is_day_hour then time.hour stands for days and time.min for hours
 
     local InfoMessage = require("ui/widget/infomessage")
     local DateTimeWidget = require("ui/widget/datetimewidget")
 
     local setting_val = self[setting] > 0 and self[setting] or default_value
+
+    -- Standby uses a different scheduled task that suspend/shutdown
+    local is_standby = setting == "auto_standby_timeout_seconds"
 
     local left_val
     if time_scale == 2 then
@@ -301,8 +338,13 @@ function AutoSuspend:setSuspendShutdownTimes(touchmenu_instance, title, info, se
             end
             self[setting] = Math.clamp(self[setting], range[1], range[2])
             G_reader_settings:saveSetting(setting, self[setting])
-            self:_unschedule()
-            self:_start()
+            if is_standby then
+                self:_unschedule_standby()
+                self:_start_standby()
+            else
+                self:_unschedule()
+                self:_start()
+            end
             if touchmenu_instance then touchmenu_instance:updateItems() end
             local time_string = util.secondsToClockDuration("modern", self[setting],
                 time_scale == 2 or time_scale == 1, true, true)
@@ -337,7 +379,11 @@ function AutoSuspend:setSuspendShutdownTimes(touchmenu_instance, title, info, se
         extra_callback = function(this)
             self[setting] = -1 -- disable with a negative time/number
             G_reader_settings:saveSetting(setting, -1)
-            self:_unschedule()
+            if is_standby then
+                self:_unschedule_standby()
+            else
+                self:_unschedule()
+            end
             if touchmenu_instance then touchmenu_instance:updateItems() end
             UIManager:show(InfoMessage:new{
                 text = T(_("%1: disabled"), title),
@@ -370,7 +416,7 @@ function AutoSuspend:addToMainMenu(menu_items)
             -- 60 sec (1') is the minimum and 24*3600 sec (1day) is the maximum suspend time.
             -- A suspend time of one day seems to be excessive.
             -- But or battery testing it might give some sense.
-            self:setSuspendShutdownTimes(touchmenu_instance,
+            self:pickTimeoutValue(touchmenu_instance,
                 _("Timeout for autosuspend"), _("Enter time in hours and minutes."),
                 "auto_suspend_timeout_seconds", default_auto_suspend_timeout_seconds,
                 {60, 24*3600}, 1)
@@ -397,7 +443,7 @@ function AutoSuspend:addToMainMenu(menu_items)
                 -- Minimum time has to be big enough, to avoid start-stop death scenarious.
                 -- Maximum more than four weeks seems a bit excessive if you want to enable authoshutdown,
                 -- even if the battery can last up to three months.
-                self:setSuspendShutdownTimes(touchmenu_instance,
+                self:pickTimeoutValue(touchmenu_instance,
                     _("Timeout for autoshutdown"),  _("Enter time in days and hours."),
                     "autoshutdown_timeout_seconds", default_autoshutdown_timeout_seconds,
                     {5*60, 28*24*3600}, 2)
@@ -432,7 +478,7 @@ Upon user input, the device needs a certain amount of time to wake up. Generally
                 -- We need a minimum time, so that scheduled function have a chance to execute.
                 -- A standby time of 15 min seem excessive.
                 -- But or battery testing it might give some sense.
-                self:setSuspendShutdownTimes(touchmenu_instance,
+                self:pickTimeoutValue(touchmenu_instance,
                     _("Timeout for autostandby"), _("Enter time in minutes and seconds."),
                     "auto_standby_timeout_seconds", default_auto_standby_timeout_seconds,
                     {default_auto_standby_timeout_seconds, 15*60}, 0)
@@ -448,30 +494,6 @@ function AutoSuspend:onAllowStandby()
     -- This piggy-backs minimally on the UI framework implemented for the PocketBook autostandby plugin,
     -- see its own AllowStandby handler for more details.
 
-    -- Start the long list of conditions in which we do *NOT* want to go into standby ;).
-    if not Device:canStandby() then
-        return
-    end
-
-    -- Don't enter standby if we haven't set a proper timeout yet.
-    if not self:_enabledStandby() then
-        logger.dbg("AutoSuspend: No timeout set, no standby")
-        return
-    end
-
-    -- Don't enter standby if wifi is on, as this will break in fun and interesting ways (from Wi-Fi issues to kernel deadlocks).
-    if NetworkMgr:isWifiOn() then
-        logger.dbg("AutoSuspend: WiFi is on, no standby")
-        return
-    end
-
-    -- Don't enter standby when charging on devices where charging prevents entering low power states.
-    if Device.powerd:isCharging() and not Device:canPowerSaveWhileCharging() then
-        logger.dbg("AutoSuspend: charging, no standby")
-        return
-    end
-
-    -- Do the thing!
     local wake_in = math.huge
     -- The next scheduled function should be our deadline_guard (c.f., `AutoSuspend:allowStandby`).
     -- Wake up before the second next scheduled function executes (e.g. footer update, suspend ...)
@@ -493,9 +515,9 @@ function AutoSuspend:onAllowStandby()
 
         UIManager:broadcastEvent(Event:new("LeaveStandby"))
         self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked
-        self:_schedule()   -- reschedule suspend and shutdown with the new time
+        self:_start()      -- reschedule suspend and shutdown with the new time
     end
-    -- Don't do a `self:_reschedule_standby()` here, as this will interfere with suspend.
+    -- We don't reschedule standby here, as this will interfere with suspend.
     -- Leave that to `onLeaveStandby`.
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -195,15 +195,13 @@ function AutoSuspend:_schedule_standby()
         return
     end
 
-    local delay_standby
+    local delay_standby = self.auto_standby_timeout_seconds
     if NetworkMgr:isWifiOn() then
         -- Don't enter standby if wifi is on, as this will break in fun and interesting ways (from Wi-Fi issues to kernel deadlocks).
         logger.dbg("AutoSuspend: WiFi is on, delaying standby")
-        delay_standby = self.auto_standby_timeout_seconds
     elseif Device.powerd:isCharging() and not Device:canPowerSaveWhileCharging() then
         -- Don't enter standby when charging on devices where charging prevents entering low power states.
         logger.dbg("AutoSuspend: charging, delaying standby")
-        delay_standby = self.auto_standby_timeout_seconds
     else
         local now_tv = UIManager:getElapsedTimeSinceBoot()
         delay_standby = (self.last_action_tv - now_tv):tonumber() + self.auto_standby_timeout_seconds

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -271,7 +271,7 @@ function AutoSuspend:onResume()
 end
 
 function AutoSuspend:onLeaveStandby()
-    self:_schedule_standby()
+    self:_start_standby()
 end
 
 function AutoSuspend:onUnexpectedWakeupLimit()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -198,10 +198,10 @@ function AutoSuspend:_schedule_standby()
     local standby_delay = self.auto_standby_timeout_seconds
     if NetworkMgr:isWifiOn() then
         -- Don't enter standby if wifi is on, as this will break in fun and interesting ways (from Wi-Fi issues to kernel deadlocks).
-        logger.dbg("AutoSuspend: WiFi is on, delaying standby")
+        --logger.dbg("AutoSuspend: WiFi is on, delaying standby")
     elseif Device.powerd:isCharging() and not Device:canPowerSaveWhileCharging() then
         -- Don't enter standby when charging on devices where charging prevents entering low power states.
-        logger.dbg("AutoSuspend: charging, delaying standby")
+        --logger.dbg("AutoSuspend: charging, delaying standby")
     else
         local now_tv = UIManager:getElapsedTimeSinceBoot()
         standby_delay = self.auto_standby_timeout_seconds - (now_tv - self.last_action_tv):tonumber()
@@ -219,6 +219,7 @@ function AutoSuspend:_schedule_standby()
         self:allowStandby()
     else
         -- Reschedule standby for the full or remaining delay
+        -- NOTE: This is fairly chatty, given the low delays, but really helpful nonetheless... :/
         logger.dbg("AutoSuspend: scheduling next standby check in", standby_delay)
         UIManager:scheduleIn(standby_delay, self.standby_task)
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -207,7 +207,8 @@ function AutoSuspend:_schedule_standby()
         standby_delay = self.auto_standby_timeout_seconds - (now_tv - self.last_action_tv):tonumber()
     end
 
-    if standby_delay <= 0 then
+    -- We need to actually have been scheduled once (i.e., we need a deadline to be able to blow past it ;)).
+    if self.is_standby_scheduled and standby_delay <= 0 then
         -- We blew the deadline, tell UIManager we're ready to enter standby
         self:allowStandby()
     else


### PR DESCRIPTION
Specifically, don't forcibly unschedule/schedule on every input event, instead, let the scheduled task figure out if the deadline came to pass or not ;).

c.f., https://github.com/koreader/koreader/pull/8970#issuecomment-1092775830

Besides getting rid of some overhead, this allows proper scheduling after a task that would have blocked for longer than the standby timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8985)
<!-- Reviewable:end -->
