### PR TITLE
Kobo: Disable key repeat during suspend

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -448,6 +448,14 @@ function Device:setupChargingLED() end
 -- (Should only be implemented on embedded platforms where we can afford to control that without screwing with the system).
 function Device:enableCPUCores(amount) end
 
+-- NOTE: For this to work, all three must be implemented, and getKeyRepeat must be run on init (c.f., Kobo)!
+-- Device specific method to get the current key repeat setup
+function Device:getKeyRepeat() end
+-- Device specific method to disable key repeat
+function Device:disableKeyRepeat() end
+-- Device specific method to restore key repeat
+function Device:restoreKeyRepeat() end
+
 --[[
 prepare for application shutdown
 --]]

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -263,7 +263,7 @@ Note that we adhere to the "." syntax here for compatibility.
 @todo Clean up separation FFI/this.
 --]]
 function Input.open(device, is_emu_events)
-    input.open(device, is_emu_events and 1 or 0)
+    return input.open(device, is_emu_events and 1 or 0)
 end
 
 --[[--

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -119,6 +119,11 @@ local linux_evdev_abs_code_map = {
 local linux_evdev_msc_code_map = {
     [C.MSC_RAW] = "MSC_RAW",
 }
+
+local linux_evdev_rep_code_map = {
+    [C.REP_DELAY] = "REP_DELAY",
+    [C.REP_PERIOD] = "REP_PERIOD",
+}
 -- luacheck: pop
 
 local _internal_clipboard_text = nil -- holds the last copied text
@@ -1157,6 +1162,11 @@ function Input:waitEvent(now, deadline)
                     logger.dbg(string.format(
                         "input event => type: %d (%s), code: %d (%s), value: %s, time: %d.%06d",
                         event.type, linux_evdev_type_map[event.type], event.code, linux_evdev_msc_code_map[event.code], event.value,
+                        event.time.sec, event.time.usec))
+                elseif event.type == C.EV_REP then
+                    logger.dbg(string.format(
+                        "input event => type: %d (%s), code: %d (%s), value: %s, time: %d.%06d",
+                        event.type, linux_evdev_type_map[event.type], event.code, linux_evdev_rep_code_map[event.code], event.value,
                         event.time.sec, event.time.usec))
                 else
                     logger.dbg(string.format(

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -439,7 +439,7 @@ function Kobo:getKeyRepeat()
         self.hasKeyRepeat = false
     else
         self.hasKeyRepeat = true
-        logger.dbg("Key repeat is setup to repeat every", self.key_repeat[C.REP_PERIOD], "after a delay of", self.key_repeat[C.REP_DELAY])
+        logger.dbg("Key repeat is setup to repeat every", self.key_repeat[C.REP_PERIOD], "ms after a delay of", self.key_repeat[C.REP_DELAY], "ms")
     end
 
     return self.hasKeyRepeat

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -432,7 +432,7 @@ function Kobo:setupChargingLED()
 end
 
 function Kobo:getKeyRepeat()
-    self.key_repeat = ffi.new("int[?]", C.REP_CNT)
+    self.key_repeat = ffi.new("unsigned int[?]", C.REP_CNT)
     if C.ioctl(self.ntx_fd, C.EVIOCGREP, self.key_repeat) < 0 then
         local err = ffi.errno()
         logger.warn("Device:getKeyRepeat: EVIOCGREP ioctl failed:", ffi.string(C.strerror(err)))
@@ -450,7 +450,7 @@ function Kobo:disableKeyRepeat()
         return
     end
 
-    local key_repeat = ffi.new("int[?]", C.REP_CNT)
+    local key_repeat = ffi.new("unsigned int[?]", C.REP_CNT)
     if C.ioctl(self.ntx_fd, C.EVIOCSREP, key_repeat) < 0 then
         local err = ffi.errno()
         logger.warn("Device:disableKeyRepeat: EVIOCSREP ioctl failed:", ffi.string(C.strerror(err)))

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -450,6 +450,7 @@ function Kobo:disableKeyRepeat()
         return
     end
 
+    -- NOTE: LuaJIT zero inits, and PERIOD == 0 with DELAY == 0 disables repeats ;).
     local key_repeat = ffi.new("unsigned int[?]", C.REP_CNT)
     if C.ioctl(self.ntx_fd, C.EVIOCSREP, key_repeat) < 0 then
         local err = ffi.errno()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -433,7 +433,7 @@ end
 
 function Kobo:getKeyRepeat()
     self.key_repeat = ffi.new("int[?]", C.REP_CNT)
-    if C.ioctl(self.ntx_dev, C.EVIOCGREP, self.key_repeat) < 0 then
+    if C.ioctl(self.ntx_fd, C.EVIOCGREP, self.key_repeat) < 0 then
         local err = ffi.errno()
         logger.warn("Device:getKeyRepeat: EVIOCGREP ioctl failed:", ffi.string(C.strerror(err)))
         self.hasKeyRepeat = false
@@ -450,7 +450,7 @@ function Kobo:disableKeyRepeat()
     end
 
     local key_repeat = ffi.new("int[?]", C.REP_CNT)
-    if C.ioctl(self.ntx_dev, C.EVIOCSREP, key_repeat) < 0 then
+    if C.ioctl(self.ntx_fd, C.EVIOCSREP, key_repeat) < 0 then
         local err = ffi.errno()
         logger.warn("Device:disableKeyRepeat: EVIOCSREP ioctl failed:", ffi.string(C.strerror(err)))
     end
@@ -461,7 +461,7 @@ function Kobo:restoreKeyRepeat()
         return
     end
 
-    if C.ioctl(self.ntx_dev, C.EVIOCSREP, self.key_repeat) < 0 then
+    if C.ioctl(self.ntx_fd, C.EVIOCSREP, self.key_repeat) < 0 then
         local err = ffi.errno()
         logger.warn("Device:restoreKeyRepeat: EVIOCSREP ioctl failed:", ffi.string(C.strerror(err)))
     end
@@ -551,7 +551,7 @@ function Kobo:init()
     Generic.init(self)
 
     -- When present, event2 is the raw accelerometer data (3-Axis Orientation/Motion Detection)
-    self.input.open(self.ntx_dev) -- Various HW Buttons, Switches & Synthetic NTX events
+    self.ntx_fd = self.input.open(self.ntx_dev) -- Various HW Buttons, Switches & Synthetic NTX events
     self.input.open(self.touch_dev)
     -- fake_events is only used for usb plug event so far
     -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status (... but only when Nickel is running ;p)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -439,6 +439,7 @@ function Kobo:getKeyRepeat()
         self.hasKeyRepeat = false
     else
         self.hasKeyRepeat = true
+        logger.dbg("Key repeat is setup to repeat every", self.key_repeat[C.REP_PERIOD], "after a delay of", self.key_repeat[C.REP_DELAY])
     end
 
     return self.hasKeyRepeat

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -432,6 +432,12 @@ function Kobo:setupChargingLED()
 end
 
 function Kobo:getKeyRepeat()
+    -- Sanity check (mostly for the testsuite's benefit...)
+    if not self.ntx_fd then
+        self.hasKeyRepeat = false
+        return false
+    end
+
     self.key_repeat = ffi.new("unsigned int[?]", C.REP_CNT)
     if C.ioctl(self.ntx_fd, C.EVIOCGREP, self.key_repeat) < 0 then
         local err = ffi.errno()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -439,7 +439,7 @@ function Kobo:getKeyRepeat()
         self.hasKeyRepeat = false
     else
         self.hasKeyRepeat = true
-        logger.dbg("Key repeat is setup to repeat every", self.key_repeat[C.REP_PERIOD], "ms after a delay of", self.key_repeat[C.REP_DELAY], "ms")
+        logger.dbg("Key repeat is set up to repeat every", self.key_repeat[C.REP_PERIOD], "ms after a delay of", self.key_repeat[C.REP_DELAY], "ms")
     end
 
     return self.hasKeyRepeat

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1771,12 +1771,18 @@ function UIManager:_beforeSuspend()
     self:flushSettings()
     self:broadcastEvent(Event:new("Suspend"))
 
+    -- Disable key repeat to avoid useless chatter (especially where Sleep Covers are concerned...)
+    Device:disableKeyRepeat()
+
     -- Reset gesture detection state to a blank slate (anything power-management related emits KEY events, which don't need gesture detection).
     Input:resetState()
 end
 
 -- The common operations that should be performed after resuming the device.
 function UIManager:_afterResume()
+    -- Restore key repeating
+    Device:restoreKeyRepeat()
+
     self:broadcastEvent(Event:new("Resume"))
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1780,7 +1780,7 @@ end
 
 -- The common operations that should be performed after resuming the device.
 function UIManager:_afterResume()
-    -- Restore key repeating
+    -- Restore key repeat
     Device:restoreKeyRepeat()
 
     self:broadcastEvent(Event:new("Resume"))


### PR DESCRIPTION
Might help avoiding evdev queue overflow on misbehaving covers (#8964).

At the very least shaves a fair bit of stupid from debug logs ;o).

Requires https://github.com/koreader/koreader-base/pull/1478

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8987)
<!-- Reviewable:end -->
