### PR TITLE
SpinWidgets and discardEvents() fixes

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -884,7 +884,9 @@ function ReaderRolling:onUpdatePos()
     self:updatePos()
 
     Device:setIgnoreInput(false) -- Allow processing of events (on Android).
-    UIManager:discardEvents(true) -- Discard events, which might have occured (double tap).
+    UIManager:discardEvents(0.2) -- Discard events, which might have occurred (double tap).
+    -- We can use a smaller duration than the default (quite large to avoid accidental dismissals),
+    -- to allow for quicker setting changes and rendering comparisons.
 end
 
 function ReaderRolling:updatePos()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1081,7 +1081,7 @@ function UIManager:discardEvents(set_or_seconds)
     else -- we expect a number
         delay = TimeVal:new{ sec = set_or_seconds, usec = 0 }
     end
-    self._discard_events_till = self._now + delay
+    self._discard_events_till = TimeVal:now() + delay
 end
 
 --[[--

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -86,6 +86,8 @@ function DoubleSpinWidget:init()
 end
 
 function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_value)
+    local prev_movable_offset = self.movable and self.movable:getMovedOffset()
+    local prev_movable_alpha = self.movable and self.movable.alpha
     self.layout = {}
     local left_widget = NumberPickerWidget:new{
         show_parent = self,
@@ -256,6 +258,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         }
     }
     self.movable = MovableContainer:new{
+        alpha = prev_movable_alpha,
         self.widget_frame,
     }
     self[1] = WidgetContainer:new{
@@ -267,6 +270,9 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         },
         self.movable,
     }
+    if prev_movable_offset then
+        self.movable:setMovedOffset(prev_movable_offset)
+    end
     self:refocusWidget()
     UIManager:setDirty(self, function()
         return "ui", self.widget_frame.dimen

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -85,6 +85,8 @@ function SpinWidget:init()
 end
 
 function SpinWidget:update(numberpicker_value, numberpicker_value_index)
+    local prev_movable_offset = self.movable and self.movable:getMovedOffset()
+    local prev_movable_alpha = self.movable and self.movable.alpha
     self.layout = {}
     local value_widget = NumberPickerWidget:new{
         show_parent = self,
@@ -223,6 +225,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         vgroup,
     }
     self.movable = MovableContainer:new{
+        alpha = prev_movable_alpha,
         self.spin_frame,
     }
     self[1] = WidgetContainer:new{
@@ -234,6 +237,9 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         },
         self.movable,
     }
+    if prev_movable_offset then
+        self.movable:setMovedOffset(prev_movable_offset)
+    end
     self:refocusWidget()
     UIManager:setDirty(self, function()
         return "ui", self.spin_frame.dimen


### PR DESCRIPTION
#### UIManager:discardEvents(): use accurate "now"

Instead of UIManager possibly staled _now, which could have no effect after a long ReaderRolling re-rendering.
Also lower the delay after such ReaderRolling re-renderings, so we can change settings quicker when comparing renderings.
See https://github.com/koreader/koreader/pull/8501#issuecomment-1086628431 and followups.

#### SpinWidgets: keep movable position/alpha after Apply

Since eda8379e8c #8495, on Apply, the widget is fully rebuild, and was repositionned at its initial position (centered) and fully opaque.
See https://github.com/koreader/koreader/pull/8490#issuecomment-1094276472

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/8993)
<!-- Reviewable:end -->
