### PR TITLE
Autosuspend: Fix regression 

### DIFF
--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -94,7 +94,6 @@ end
 
 function AutoSuspend:_start()
     if self:_enabled() or self:_enabledShutdown() then
-        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
         logger.dbg("AutoSuspend: start (suspend/shutdown) at", self.last_action_tv:tonumber())
         self:_schedule()
     end
@@ -102,7 +101,6 @@ end
 
 function AutoSuspend:_start_standby()
     if self:_enabledStandby() then
-        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
         logger.dbg("AutoSuspend: start (standby) at", self.last_action_tv:tonumber())
         self:_schedule_standby()
     end
@@ -144,6 +142,7 @@ function AutoSuspend:init()
         self:_schedule_standby()
     end
 
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
     self:_start()
     self:_start_standby()
 
@@ -273,6 +272,7 @@ function AutoSuspend:onResume()
         Device.wakeup_mgr:removeTask(nil, nil, UIManager.poweroff_action)
     end
     -- Unschedule in case we tripped onUnexpectedWakeupLimit first...
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
     self:_unschedule()
     self:_start()
     self:_unschedule_standby()
@@ -346,6 +346,8 @@ function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
             end
             self[setting] = Math.clamp(self[setting], range[1], range[2])
             G_reader_settings:saveSetting(setting, self[setting])
+            -- Not necessary to call self.last_action_fts = UIManager:getElapsedTimeSinceBoot_fts() here,
+            -- as there was a onInputEvent before.
             if is_standby then
                 self:_unschedule_standby()
                 self:_start_standby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -346,7 +346,7 @@ function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
             end
             self[setting] = Math.clamp(self[setting], range[1], range[2])
             G_reader_settings:saveSetting(setting, self[setting])
-            -- Not necessary to call self.last_action_fts = UIManager:getElapsedTimeSinceBoot_fts() here,
+            -- Not necessary to call self.last_action_tv = UIManager:getElapsedTimeSinceBoot() here,
             -- as there was a onInputEvent before.
             if is_standby then
                 self:_unschedule_standby()


### PR DESCRIPTION
Fix regression introduced in  #8985, where suspend did not start if standby (without network) is enabled.
This is a backport from #8999 ([1453774](https://github.com/koreader/koreader/pull/8999/commits/1453774843b296043466b33b27af180dd4c88686))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9001)
<!-- Reviewable:end -->
