### PR TITLE
readerfooter: make setDirty happy, reduce log

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2214,7 +2214,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
             -- c.f., ReaderView:paintTo()
             UIManager:widgetRepaint(self.view.footer, 0, 0)
             -- We've painted it first to ensure self.footer_content.dimen is sane
-            UIManager:setDirty(self.view.footer, function()
+            UIManager:setDirty(nil, function()
                 return self.view.currently_scrolling and "fast" or "ui", self.footer_content.dimen
             end)
         else


### PR DESCRIPTION
Not quite sure if I did this right @NiLuJe (esp. `setDirty` is not familiar to me)

Without this PR I get in the log on each footer update (every minute):
```
04/14/22-14:50:01 DEBUG refresh on physical rectangle 0 0 540 31
04/14/22-14:50:01 DEBUG Explicit widgetRepaint: table: 0x7f02dcf46fd8 @ ( 0 , 0 )
04/14/22-14:50:01 DEBUG setDirty via a func from widget table: 0x7f02dcf46fd8
# 04/14/22-14:50:01  INFO: invalid widget for setDirty() stack traceback:
	frontend/ui/uimanager.lua:880: in function 'post_guard'
	frontend/dbg.lua:68: in function 'setDirty'
	frontend/apps/reader/modules/readerfooter.lua:2217: in function 'updateFooterText'
	frontend/apps/reader/modules/readerfooter.lua:2114: in function 'updateFooterPage'
	frontend/apps/reader/modules/readerfooter.lua:2098: in function 'onUpdateFooter'
	frontend/apps/reader/modules/readerfooter.lua:782: in function 'action'
	frontend/ui/uimanager.lua:1210: in function '_checkTasks'
	frontend/ui/uimanager.lua:1641: in function 'handleInput'
	frontend/ui/uimanager.lua:1753: in function 'run'
	./reader.lua:291: in main chunk
	[C]: at 0x560a091c0792
04/14/22-14:50:01 DEBUG ReaderFooter.autoRefreshFooter scheduled
04/14/22-14:50:01 DEBUG _refresh: Enqueued ui update for region 0 706 540 14 
# 04/14/22-14:50:01  triggering refresh {
    ["mode"] = "ui",
    ["region"] = {
        ["h"] = 14,
        ["y"] = 706,
        ["x"] = 0,
        ["w"] = 540,
    },
}
```

With this the log is cleaner:
```
04/14/22-14:51:01 DEBUG refresh on physical rectangle 0 0 540 31
04/14/22-14:51:01 DEBUG Explicit widgetRepaint: table: 0x7f2c6d4560a0 @ ( 0 , 0 )
04/14/22-14:51:01 DEBUG setDirty via a func from widget nil
04/14/22-14:51:01 DEBUG ReaderFooter.autoRefreshFooter scheduled
04/14/22-14:51:01 DEBUG _refresh: Enqueued ui update for region 0 706 540 14 
# 04/14/22-14:51:01  triggering refresh {
    ["region"] = {
        ["w"] = 540,
        ["h"] = 14,
        ["x"] = 0,
        ["y"] = 706,
    },
    ["mode"] = "ui",
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9005)
<!-- Reviewable:end -->
