### PR TITLE
Fix menu entry, when no keyboard is activated

### DIFF
--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -47,7 +47,8 @@ local sub_item_table = {
     {
         text_func = function()
             local activated_keyboards, nb_keyboards = getActivatedKeyboards()
-            local item_text = T(_("Keyboard layouts: %1"), activated_keyboards)
+            local item_text = activated_keyboards and T(_("Keyboard layouts: %1"), activated_keyboards)
+                or _("Keyboard layouts")
 
             -- get width of text
             local tmp = TextWidget:new{


### PR DESCRIPTION
In the device menu -> Keyboard -> Keyboard layout show "Keyboard layouts: %1" if no keyboard is selected.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9008)
<!-- Reviewable:end -->
