### PR TITLE
AutoSuspend: Alternate take on the suspend delay extension regression

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1012,7 +1012,6 @@ end
 
 function Kobo:toggleGSensor(toggle)
     if self:canToggleGSensor() and self.input then
-        -- Currently only supported on the Forma
         if self.misc_ntx_gsensor_protocol then
             self.input:toggleMiscEvNTX(toggle)
         end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1841,6 +1841,7 @@ Standby is re-enabled only after all issued prevents are paired with allowStandb
 function UIManager:allowStandby()
     assert(self._prevent_standby_count > 0, "allowing standby that isn't prevented; you have an allow/prevent mismatch somewhere")
     self._prevent_standby_count = self._prevent_standby_count - 1
+    logger.dbg("UIManager:allowStandby, count is now", self._prevent_standby_count)
 end
 
 --[[--
@@ -1850,6 +1851,7 @@ i.e., something is happening in background, yet UI may tick.
 ]]
 function UIManager:preventStandby()
     self._prevent_standby_count = self._prevent_standby_count + 1
+    logger.dbg("UIManager:preventStandby, count is now", self._prevent_standby_count)
 end
 
 -- The allow/prevent calls above can interminently allow standbys, but we're not interested until

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1841,7 +1841,7 @@ Standby is re-enabled only after all issued prevents are paired with allowStandb
 function UIManager:allowStandby()
     assert(self._prevent_standby_count > 0, "allowing standby that isn't prevented; you have an allow/prevent mismatch somewhere")
     self._prevent_standby_count = self._prevent_standby_count - 1
-    logger.dbg("UIManager:allowStandby, count is now", self._prevent_standby_count)
+    logger.dbg("UIManager:allowStandby, counter decreased to", self._prevent_standby_count)
 end
 
 --[[--
@@ -1851,7 +1851,7 @@ i.e., something is happening in background, yet UI may tick.
 ]]
 function UIManager:preventStandby()
     self._prevent_standby_count = self._prevent_standby_count + 1
-    logger.dbg("UIManager:preventStandby, count is now", self._prevent_standby_count)
+    logger.dbg("UIManager:preventStandby, counter increased to", self._prevent_standby_count)
 end
 
 -- The allow/prevent calls above can interminently allow standbys, but we're not interested until

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -555,7 +555,7 @@ Upon user input, the device needs a certain amount of time to wake up. Generally
                 self:pickTimeoutValue(touchmenu_instance,
                     _("Timeout for autostandby"), _("Enter time in minutes and seconds."),
                     "auto_standby_timeout_seconds", default_auto_standby_timeout_seconds,
-                    {default_auto_standby_timeout_seconds, 15*60}, 0)
+                    {3, 15*60}, 0)
             end,
         }
     end
@@ -578,7 +578,7 @@ function AutoSuspend:onAllowStandby()
         wake_in = math.floor(scheduler_times[2]:tonumber()) + 1
     end
 
-    if wake_in > 3 then -- don't go into standby, if scheduled wakeup is in less than 3 secs
+    if wake_in >= 3 then -- don't go into standby, if scheduled wakeup is in less than 3 secs
         UIManager:broadcastEvent(Event:new("EnterStandby"))
         logger.dbg("AutoSuspend: entering standby with a wakeup alarm in", wake_in, "s")
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -585,15 +585,14 @@ function AutoSuspend:onAllowStandby()
 
         logger.dbg("AutoSuspend: left standby after", Device.last_standby_tv:tonumber(), "s")
 
-        -- Make sure UIManager will consume the input events that woke us up first (in case we were woken up by user input,
-        -- as opposed to an rtc wake alarm)!
+        -- We delay the LeaveStandby event (our onLeaveStandby handler is responsible for rescheduling everything properly),
+        -- to make sure UIManager will consume the input events that woke us up first
+        -- (in case we were woken up by user input, as opposed to an rtc wake alarm)!
         -- (This ensures we'll use an up to date last_action_tv, and that it only ever gets updated from *user* input).
         -- NOTE: UIManager consumes scheduled tasks before input events, so make sure we delay by a significant amount,
         --       especially given that this delay will likely be used as the next input polling loop timeout...
         UIManager:scheduleIn(1, self.leave_standby_task)
     end
-    -- We don't reschedule standby here, as this will interfere with suspend.
-    -- Leave that to `onLeaveStandby`.
 end
 
 return AutoSuspend

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -50,6 +50,12 @@ function AutoSuspend:_enabledShutdown()
     return Device:canPowerOff() and self.autoshutdown_timeout_seconds > 0
 end
 
+function AutoSuspend:_updateLastAction()
+    logger.dbg("AutoSuspend: _updateLastAction prologue, last action @", self.last_action_tv:tonumber())
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+    logger.dbg("AutoSuspend: _updateLastAction coda, @", self.last_action_tv:tonumber())
+end
+
 function AutoSuspend:_schedule(shutdown_only)
     if not self:_enabled() and Device:canPowerOff() and not self:_enabledShutdown() then
         logger.dbg("AutoSuspend:_schedule is disabled")
@@ -94,7 +100,7 @@ end
 
 function AutoSuspend:_start()
     if self:_enabled() or self:_enabledShutdown() then
-        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+        self:_updateLastAction()
         logger.dbg("AutoSuspend: start (suspend/shutdown) at", self.last_action_tv:tonumber())
         self:_schedule()
     end
@@ -102,7 +108,7 @@ end
 
 function AutoSuspend:_start_standby()
     if self:_enabledStandby() then
-        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+        self:_updateLastAction()
         logger.dbg("AutoSuspend: start (standby) at", self.last_action_tv:tonumber())
         self:_schedule_standby()
     end
@@ -111,7 +117,7 @@ end
 -- Variant that only re-engages the shutdown timer for onUnexpectedWakeupLimit
 function AutoSuspend:_restart()
     if self:_enabledShutdown() then
-        self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+        self:_updateLastAction()
         logger.dbg("AutoSuspend: restart at", self.last_action_tv:tonumber())
         self:_schedule(true)
     end
@@ -166,7 +172,7 @@ end
 
 function AutoSuspend:onInputEvent()
     logger.dbg("AutoSuspend: onInputEvent")
-    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+    self:_updateLastAction()
 end
 
 function AutoSuspend:_unschedule_standby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -176,9 +176,7 @@ end
 function AutoSuspend:_unschedule_standby()
     if self.is_standby_scheduled and self.standby_task then
         logger.dbg("AutoSuspend: unschedule standby timer")
-        if not UIManager:unschedule(self.standby_task) then
-            logger.dbg("AutoSuspend: nothing to unschedule?!")
-        end
+        UIManager:unschedule(self.standby_task)
         -- Restore the UIManager balance, as we run preventStandby right after scheduling this task.
         UIManager:allowStandby()
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -565,7 +565,8 @@ function AutoSuspend:onAllowStandby()
         -- Make sure UIManager will consume the input events that woke us up first (in case we were woken up by user input,
         -- as opposed to an rtc wake alarm)!
         -- (This ensures we'll use an up to date last_action_tv, and that it only ever gets updated from *user* input).
-        UIManager:nextTick(function()
+        -- NOTE: UIManager consumes scheduled tasks before input, so make sure we delay by a significant amount...
+        UIManager:scheduleIn(1, function()
             -- Only if we're not already entering suspend...
             if self.pause_auto_standby then
                 return

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -176,7 +176,9 @@ end
 function AutoSuspend:_unschedule_standby()
     if self.is_standby_scheduled and self.standby_task then
         logger.dbg("AutoSuspend: unschedule standby timer")
-        UIManager:unschedule(self.standby_task)
+        if not UIManager:unschedule(self.standby_task) then
+            logger.dbg("AutoSuspend: nothing to unschedule?!")
+        end
         -- Restore the UIManager balance, as we run preventStandby right after scheduling this task.
         UIManager:allowStandby()
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -241,7 +241,8 @@ function AutoSuspend:_schedule_standby()
         -- If we blow past the deadline on the first call of a scheduling cycle,
         -- make sure we don't go straight to allowStandby, as we haven't called preventStandby yet...
         if not self.is_standby_scheduled and standby_delay <= 0 then
-            -- If this happens, it means we somehow hit LeaveStandby or Resume *before* consuming new input events,
+            -- If this happens, it means we somehow hit LeaveStandby or Resume *before* consuming new input events
+            -- (or before consuming input events that actually trigger an InputEvent event, e.g., rotation events),
             -- meaning self.last_action_tv is further in the past than it ought to.
             -- Delay by the full amount to avoid further bad scheduling interactions.
             standby_delay = self.auto_standby_timeout_seconds

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -63,7 +63,15 @@ function AutoSuspend:_schedule(shutdown_only)
     end
 
     local suspend_delay, shutdown_delay
-    if PluginShare.pause_auto_suspend or Device.powerd:isCharging() then
+    local is_charging
+    -- On devices with an auxiliary battery, we only care about the auxiliary battery being charged...
+    local powerd = Device:getPowerDevice()
+    if Device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
+        is_charging = powerd:isAuxCharging()
+    else
+        is_charging = powerd:isCharging()
+    end
+    if PluginShare.pause_auto_suspend or is_charging then
         suspend_delay = self.auto_suspend_timeout_seconds
         shutdown_delay = self.autoshutdown_timeout_seconds
     else

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -271,10 +271,21 @@ function AutoSuspend:onSuspend()
     if self:_enabledShutdown() and Device.wakeup_mgr then
         Device.wakeup_mgr:addTask(self.autoshutdown_timeout_seconds, UIManager.poweroff_action)
     end
+
+    -- Make sure we won't attempt to standby during suspend...
+    if self:_enabledStandby() then
+        UIManager:preventStandby()
+    end
 end
 
 function AutoSuspend:onResume()
     logger.dbg("AutoSuspend: onResume")
+
+    -- Restore standby balance after onSuspend
+    if self:_enabledStandby() then
+        UIManager:allowStandby()
+    end
+
     if self:_enabledShutdown() and Device.wakeup_mgr then
         Device.wakeup_mgr:removeTask(nil, nil, UIManager.poweroff_action)
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -241,8 +241,9 @@ function AutoSuspend:_schedule_standby()
         -- If we blow past the deadline on the first call of a scheduling cycle,
         -- make sure we don't go straight to allowStandby, as we haven't called preventStandby yet...
         if not self.is_standby_scheduled and standby_delay <= 0 then
-            -- If this happens, it means we somehow hit LeaveStandby or Resume *before* consuming new input events
-            -- (or before consuming input events that actually trigger an InputEvent event, e.g., when woken up by rotation events),
+            -- If this happens, it means we hit LeaveStandby or Resume *before* consuming new input events,
+            -- e.g., if there weren't any input events at all (woken up by an alarm),
+            -- or if the only input events we consumed did not trigger an InputEvent event (woken up by gyro events),
             -- meaning self.last_action_tv is further in the past than it ought to.
             -- Delay by the full amount to avoid further bad scheduling interactions.
             standby_delay = self.auto_standby_timeout_seconds

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -226,8 +226,8 @@ function AutoSuspend:_schedule_standby()
         -- If we blow past the deadline on the first call of a scheduling cycle,
         -- make sure we don't go straight to allowStandby, as we haven't called preventStandby yet...
         if not self.is_standby_scheduled and standby_delay <= 0 then
-            -- If this happens, it means we somehow hit LeaveStandby orResume *before* consuming new input events,
-            -- meaning self.last_action_tv is farther in the past than it ought to.
+            -- If this happens, it means we somehow hit LeaveStandby or Resume *before* consuming new input events,
+            -- meaning self.last_action_tv is further in the past than it ought to.
             -- Delay by the full amount to avoid further bad scheduling interactions.
             standby_delay = self.auto_standby_timeout_seconds
         end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -334,13 +334,16 @@ end
 
 function AutoSuspend:onLeaveStandby()
     logger.dbg("AutoSuspend: onLeaveStandby")
-    -- unschedule suspend and shutdown, as the realtime clock has ticked
+    -- Unschedule suspend and shutdown, as the realtime clock has ticked
     self:_unschedule()
-    -- reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).
+    -- Reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).
     -- i.e., the goal is to behave as if we'd never unscheduled it, making sure we do *NOT* reset the delay to the full timeout.
     self:_start()
-    -- And reschedule standby, too (we're guaranteed that no standby task is currently scheduled, hence the lack of unscheduling).
-    self:_start_standby()
+    -- Assuming _start didn't send us straight to onSuspend (i.e., we were woken from standby by the scheduled suspend task!)...
+    if not self.pause_auto_standby then
+        -- Reschedule standby, too (we're guaranteed that no standby task is currently scheduled, hence the lack of unscheduling).
+        self:_start_standby()
+    end
 end
 
 function AutoSuspend:onUnexpectedWakeupLimit()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -272,7 +272,9 @@ function AutoSuspend:onSuspend()
         Device.wakeup_mgr:addTask(self.autoshutdown_timeout_seconds, UIManager.poweroff_action)
     end
 
-    -- Make sure we won't attempt to standby during suspend...
+    -- Make sure we won't attempt to standby during suspend
+    -- (because _unschedule_standby calls allowStandby,
+    -- so we may trip UIManager's _standbyTransition and end up in AutoSuspend:onAllowStandby)...
     if self:_enabledStandby() then
         UIManager:preventStandby()
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -36,6 +36,7 @@ local AutoSuspend = WidgetContainer:new{
     is_standby_scheduled = false,
     task = nil,
     standby_task = nil,
+    pause_auto_standby = false,
 }
 
 function AutoSuspend:_enabledStandby()
@@ -286,12 +287,17 @@ function AutoSuspend:onSuspend()
     if self:_enabledStandby() then
         UIManager:preventStandby()
     end
+
+    -- And make sure onLeaveStandby, which will come *after* us if we suspended *during* standby,
+    -- won't re-schedule stuff right before entering suspend...
+    self.pause_auto_standby = true
 end
 
 function AutoSuspend:onResume()
     logger.dbg("AutoSuspend: onResume")
 
     -- Restore standby balance after onSuspend
+    self.pause_auto_standby = false
     if self:_enabledStandby() then
         UIManager:allowStandby()
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -254,6 +254,7 @@ function AutoSuspend:allowStandby()
 
     -- We've just run our course.
     self.is_standby_scheduled = false
+    logger.dbg("AutoSuspend: allowStandby coda, self.is_standby_scheduled:", tostring(self.is_standby_scheduled))
 end
 
 function AutoSuspend:onSuspend()
@@ -280,6 +281,7 @@ function AutoSuspend:onResume()
 end
 
 function AutoSuspend:onLeaveStandby()
+    logger.dbg("AutoSuspend: onLeaveStandby, self.is_standby_scheduled:", tostring(self.is_standby_scheduled))
     self:_start_standby()
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -52,12 +52,6 @@ function AutoSuspend:_enabledShutdown()
     return Device:canPowerOff() and self.autoshutdown_timeout_seconds > 0
 end
 
-function AutoSuspend:_updateLastAction()
-    logger.dbg("AutoSuspend: _updateLastAction prologue, last action @", self.last_action_tv:tonumber())
-    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
-    logger.dbg("AutoSuspend: _updateLastAction coda, @", self.last_action_tv:tonumber())
-end
-
 function AutoSuspend:_schedule(shutdown_only)
     if not self:_enabled() and Device:canPowerOff() and not self:_enabledShutdown() then
         logger.dbg("AutoSuspend:_schedule is disabled")
@@ -165,7 +159,7 @@ function AutoSuspend:init()
         UIManager:broadcastEvent(Event:new("LeaveStandby"))
     end
 
-    self:_updateLastAction()
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
     self:_start()
     self:_start_standby()
 
@@ -189,7 +183,7 @@ end
 
 function AutoSuspend:onInputEvent()
     logger.dbg("AutoSuspend: onInputEvent")
-    self:_updateLastAction()
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
 end
 
 function AutoSuspend:_unschedule_standby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -214,6 +214,8 @@ function AutoSuspend:_schedule_standby()
         standby_delay = self.auto_standby_timeout_seconds
     elseif Device.powerd:isCharging() and not Device:canPowerSaveWhileCharging() then
         -- Don't enter standby when charging on devices where charging prevents entering low power states.
+        -- NOTE: Minor simplification here, we currently don't do the hasAuxBattery dance like in _schedule,
+        --       because all the hasAuxBattery devices can currently enter PM states while charging ;).
         --logger.dbg("AutoSuspend: charging, delaying standby")
         standby_delay = self.auto_standby_timeout_seconds
     else

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -110,9 +110,10 @@ end
 function AutoSuspend:_start()
     if self:_enabled() or self:_enabledShutdown() then
         self:_updateLastAction()
-        logger.dbg("AutoSuspend: start (suspend/shutdown) at", self.last_action_tv:tonumber())
         if self.last_task_schedule_tv then
-            logger.dbg("But recomputing previous task delay by starting from", self.last_task_schedule_tv:tonumber())
+            logger.dbg("AutoSuspend: restart previous (suspend/shutdown) timer originally scheduled at", self.last_task_schedule_tv:tonumber())
+        else
+            logger.dbg("AutoSuspend: start (suspend/shutdown) timer at", self.last_action_tv:tonumber())
         end
         self:_schedule()
     end
@@ -121,7 +122,7 @@ end
 function AutoSuspend:_start_standby()
     if self:_enabledStandby() then
         self:_updateLastAction()
-        logger.dbg("AutoSuspend: start (standby) at", self.last_action_tv:tonumber())
+        logger.dbg("AutoSuspend: start (standby) timer at", self.last_action_tv:tonumber())
         self:_schedule_standby()
     end
 end
@@ -130,7 +131,7 @@ end
 function AutoSuspend:_restart()
     if self:_enabledShutdown() then
         self:_updateLastAction()
-        logger.dbg("AutoSuspend: restart at", self.last_action_tv:tonumber())
+        logger.dbg("AutoSuspend: restart (suspend/shutdown) timer at", self.last_action_tv:tonumber())
         self:_schedule(true)
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -556,8 +556,9 @@ function AutoSuspend:onAllowStandby()
 
         logger.dbg("AutoSuspend: left standby after", Device.last_standby_tv:tonumber(), "s")
 
-        -- Make sure UIManager will consume the input events that woke us up first!
-        -- (This ensures we'll use an up to date last_action_tv).
+        -- Make sure UIManager will consume the input events that woke us up first (in case we were woken up by user input,
+        -- as opposed to an rtc wake alarm)!
+        -- (This ensures we'll use an up to date last_action_tv, and that it only ever gets updated from *user* input).
         UIManager:nextTick(function()
             UIManager:broadcastEvent(Event:new("LeaveStandby"))
             self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -560,6 +560,11 @@ function AutoSuspend:onAllowStandby()
         -- as opposed to an rtc wake alarm)!
         -- (This ensures we'll use an up to date last_action_tv, and that it only ever gets updated from *user* input).
         UIManager:nextTick(function()
+            -- Only if we're not already entering suspend...
+            if self.pause_auto_standby then
+                return
+            end
+
             UIManager:broadcastEvent(Event:new("LeaveStandby"))
             self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked
             self:_start()      -- reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -87,12 +87,12 @@ function AutoSuspend:_schedule(shutdown_only)
             logger.dbg("AutoSuspend: scheduling next suspend check in", suspend_delay)
             UIManager:scheduleIn(suspend_delay, self.task)
             -- Remember the original schedule computation to reschedule it properly after standby
-            self.last_task_schedule_tv = self.last_action_tv
+            self.last_task_schedule_tv = self.last_task_schedule_tv or self.last_action_tv
         end
         if self:_enabledShutdown() then
             logger.dbg("AutoSuspend: scheduling next shutdown check in", shutdown_delay)
             UIManager:scheduleIn(shutdown_delay, self.task)
-            self.last_task_schedule_tv = self.last_action_tv
+            self.last_task_schedule_tv = self.last_task_schedule_tv or self.last_action_tv
         end
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -584,7 +584,8 @@ function AutoSuspend:onAllowStandby()
         -- Make sure UIManager will consume the input events that woke us up first (in case we were woken up by user input,
         -- as opposed to an rtc wake alarm)!
         -- (This ensures we'll use an up to date last_action_tv, and that it only ever gets updated from *user* input).
-        -- NOTE: UIManager consumes scheduled tasks before input, so make sure we delay by a significant amount...
+        -- NOTE: UIManager consumes scheduled tasks before input events, so make sure we delay by a significant amount,
+        --       especially given that this delay will likely be used as the next input polling loop timeout...
         UIManager:scheduleIn(1, self.leave_standby_task)
     end
     -- We don't reschedule standby here, as this will interfere with suspend.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -111,6 +111,9 @@ function AutoSuspend:_start()
     if self:_enabled() or self:_enabledShutdown() then
         self:_updateLastAction()
         logger.dbg("AutoSuspend: start (suspend/shutdown) at", self.last_action_tv:tonumber())
+        if self.last_task_schedule_tv then
+            logger.dbg("But recomputing previous task delay by starting from", self.last_task_schedule_tv:tonumber())
+        end
         self:_schedule()
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -93,21 +93,21 @@ end
 
 function AutoSuspend:_unschedule()
     if self.task then
-        logger.dbg("AutoSuspend: unschedule")
+        logger.dbg("AutoSuspend: unschedule suspend/shutdown timer")
         UIManager:unschedule(self.task)
     end
 end
 
 function AutoSuspend:_start()
     if self:_enabled() or self:_enabledShutdown() then
-        logger.dbg("AutoSuspend: start (suspend/shutdown) timer at", self.last_action_tv:tonumber())
+        logger.dbg("AutoSuspend: start suspend/shutdown timer at", self.last_action_tv:tonumber())
         self:_schedule()
     end
 end
 
 function AutoSuspend:_start_standby()
     if self:_enabledStandby() then
-        logger.dbg("AutoSuspend: start (standby) timer at", self.last_action_tv:tonumber())
+        logger.dbg("AutoSuspend: start standby timer at", self.last_action_tv:tonumber())
         self:_schedule_standby()
     end
 end
@@ -115,7 +115,7 @@ end
 -- Variant that only re-engages the shutdown timer for onUnexpectedWakeupLimit
 function AutoSuspend:_restart()
     if self:_enabledShutdown() then
-        logger.dbg("AutoSuspend: restart (shutdown) timer at", self.last_action_tv:tonumber())
+        logger.dbg("AutoSuspend: restart shutdown timer at", self.last_action_tv:tonumber())
         self:_schedule(true)
     end
 end
@@ -175,7 +175,7 @@ end
 
 function AutoSuspend:_unschedule_standby()
     if self.is_standby_scheduled and self.standby_task then
-        logger.dbg("AutoSuspend: unschedule standby")
+        logger.dbg("AutoSuspend: unschedule standby timer")
         UIManager:unschedule(self.standby_task)
         -- Restore the UIManager balance, as we run preventStandby right after scheduling this task.
         UIManager:allowStandby()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -242,7 +242,7 @@ function AutoSuspend:_schedule_standby()
         -- make sure we don't go straight to allowStandby, as we haven't called preventStandby yet...
         if not self.is_standby_scheduled and standby_delay <= 0 then
             -- If this happens, it means we somehow hit LeaveStandby or Resume *before* consuming new input events
-            -- (or before consuming input events that actually trigger an InputEvent event, e.g., rotation events),
+            -- (or before consuming input events that actually trigger an InputEvent event, e.g., when woken up by rotation events),
             -- meaning self.last_action_tv is further in the past than it ought to.
             -- Delay by the full amount to avoid further bad scheduling interactions.
             standby_delay = self.auto_standby_timeout_seconds

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -527,10 +527,13 @@ function AutoSuspend:onAllowStandby()
 
         logger.dbg("AutoSuspend: left standby after", Device.last_standby_tv:tonumber(), "s")
 
-        UIManager:broadcastEvent(Event:new("LeaveStandby"))
-        self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked
-        self:_start()      -- reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).
-                           -- i.e., the goal is to behave as if we'd never unscheduled it, making sure we do *NOT* reset the delay to the full timeout.
+        -- Make sure UIManager will consume the input events that woke us up first!
+        UIManager:nextTick(function()
+            UIManager:broadcastEvent(Event:new("LeaveStandby"))
+            self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked
+            self:_start()      -- reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).
+                               -- i.e., the goal is to behave as if we'd never unscheduled it, making sure we do *NOT* reset the delay to the full timeout.
+        end)
     end
     -- We don't reschedule standby here, as this will interfere with suspend.
     -- Leave that to `onLeaveStandby`.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -528,6 +528,7 @@ function AutoSuspend:onAllowStandby()
         logger.dbg("AutoSuspend: left standby after", Device.last_standby_tv:tonumber(), "s")
 
         -- Make sure UIManager will consume the input events that woke us up first!
+        -- (This ensures we'll use an up to date last_action_tv).
         UIManager:nextTick(function()
             UIManager:broadcastEvent(Event:new("LeaveStandby"))
             self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -547,7 +547,7 @@ function AutoSuspend:onAllowStandby()
         UIManager:broadcastEvent(Event:new("LeaveStandby"))
         self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked
         self:_start()      -- reschedule suspend and shutdown (we'll recompute the delay based on the remaining time of the previously scheduled task, if any).
-                           -- i.e., the goal is to behave is if we'd never unscheduled it, making sure we do *NOT* reset the delay to the full timeout.
+                           -- i.e., the goal is to behave as if we'd never unscheduled it, making sure we do *NOT* reset the delay to the full timeout.
     end
     -- We don't reschedule standby here, as this will interfere with suspend.
     -- Leave that to `onLeaveStandby`.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -315,6 +315,12 @@ end
 
 function AutoSuspend:onLeaveStandby()
     logger.dbg("AutoSuspend: onLeaveStandby")
+    -- unschedule suspend and shutdown, as the realtime clock has ticked
+    self:_unschedule()
+    -- reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).
+    -- i.e., the goal is to behave as if we'd never unscheduled it, making sure we do *NOT* reset the delay to the full timeout.
+    self:_start()
+    -- And reschedule standby, too (we're guaranteed that no standby task is currently scheduled, hence the lack of unscheduling).
     self:_start_standby()
 end
 
@@ -566,9 +572,6 @@ function AutoSuspend:onAllowStandby()
             end
 
             UIManager:broadcastEvent(Event:new("LeaveStandby"))
-            self:_unschedule() -- unschedule suspend and shutdown, as the realtime clock has ticked
-            self:_start()      -- reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).
-                               -- i.e., the goal is to behave as if we'd never unscheduled it, making sure we do *NOT* reset the delay to the full timeout.
         end)
     end
     -- We don't reschedule standby here, as this will interfere with suspend.


### PR DESCRIPTION
c.f., https://github.com/koreader/koreader/pull/9001#issuecomment-1100726585

RFC to @zwim ;).

----

* Make sure AutoStandby cohabitates nicely with AutoSuspend (regression since #8985), specifically:
* Disable standby during suspend.
* Ensure that leaving standby restores the scheduled suspend properly, with the appropriate remaining amount of time based on the last user input.
* Handle devices with an auxiliary battery better when scheduling suspend (assume it's only charging when the aux battery is charging, not the ereader's).
* Tweak debug logging to be able to remote debug corner-cases more easily without requiring code changes.
* Fix erroneous behavior when awoken from standby by something that doesn't trigger an InputEvent Event (e.g., rtc alarm, gyro, or random bullshit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9009)
<!-- Reviewable:end -->
