### PR TITLE
Wallabag: Add setting for automatically tagging new articles

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -215,6 +215,19 @@ function Wallabag:addToMainMenu(menu_items)
                         separator = true,
                     },
                     {
+                        text_func = function()
+                            if not self.auto_tags or self.auto_tags == "" then
+                                return _("Automatic tags")
+                            end
+                            return T(_("Automatic tags (%1)"), self.auto_tags)
+                        end,
+                        keep_menu_open = true,
+                        callback = function(touchmenu_instance)
+                            self:setAutoTags(touchmenu_instance)
+                        end,
+                        separator = true,
+                    },
+                    {
                         text = _("Article deletion"),
                         separator = true,
                         sub_item_table = {
@@ -964,6 +977,38 @@ function Wallabag:setIgnoreTags(touchmenu_instance)
     }
     UIManager:show(self.ignore_tags_dialog)
     self.ignore_tags_dialog:onShowKeyboard()
+end
+
+function Wallabag:setAutoTags(touchmenu_instance)
+   self.auto_tags_dialog = InputDialog:new {
+        title =  _("Tags to automatically add"),
+        description = _("Enter a comma-separated list of tags to automatically add."),
+        input = self.auto_tags,
+        input_type = "string",
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(self.auto_tags_dialog)
+                    end,
+                },
+                {
+                    text = _("Set tags"),
+                    is_enter_default = true,
+                    callback = function()
+                        self.auto_tags = self.auto_tags_dialog:getInputText()
+                        self:saveSettings()
+                        touchmenu_instance:updateItems()
+                        UIManager:close(self.auto_tags_dialog)
+                    end,
+                }
+            }
+        },
+    }
+    UIManager:show(self.auto_tags_dialog)
+    self.auto_tags_dialog:onShowKeyboard()
 end
 
 function Wallabag:editServerSettings()


### PR DESCRIPTION
This change adds an "Automatic tags" setting in the Wallabag plugin. Any articles saved with the plugin will be tagged with this comma-separated list.

For example, this can be set to "koreader,inbox" to tag saved articles with "koreader", indicating their origin, and "inbox", indicating that I may want to evaluate the article before saving it to my device for reading.

This can be combined with the "Ignore tags" setting (e.g. ignoring the "inbox" tag) if the user wants to evaluate articles on their PC first before downloading them to their reader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9017)
<!-- Reviewable:end -->
