### PR TITLE
Exporter highlight sort

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -287,7 +287,8 @@ function MyClipping:parseHighlight(highlights, bookmarks, book)
         end
     end
     -- A table to map bookmarks timestamp to index in the bookmarks table
-    -- to facilitate sorting clippings by their position in the book.
+    -- to facilitate sorting clippings by their position in the book
+    -- since highlights are not sorted by position while bookmarks are.
     local bookmark_indexes = {}
     for i, bookmark in ipairs(bookmarks) do
         bookmark_indexes[self:getTime(bookmark.datetime)] = i

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -286,7 +286,14 @@ function MyClipping:parseHighlight(highlights, bookmarks, book)
             end
         end
     end
-    table.sort(book, function(v1, v2) return v1[1].page < v2[1].page end)
+    -- A table to map bookmarks timestamp to index in the bookmarks table
+    -- to facilitate sorting clippings by their position in the book.
+    local bookmark_indexes = {}
+    for i, bookmark in ipairs(bookmarks) do
+        bookmark_indexes[self:getTime(bookmark.datetime)] = i
+    end
+    -- Sort clippings by their position in the book.
+    table.sort(book, function(v1, v2) return bookmark_indexes[v1[1].time] > bookmark_indexes[v2[1].time] end)
 end
 
 function MyClipping:parseHistoryFile(clippings, history_file, doc_file)


### PR DESCRIPTION
This is a lightweight solution (in terms of coding) for the exporter's highlight ordering problem reported in #8982

It just uses bookmarks to sort highlights.

Since #8996 might go unmerged, I propose this as an intermediate solution. 😄

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9021)
<!-- Reviewable:end -->
