### PR TITLE
AutoDimm: Allow to dimm the frontlight on idle

### DIFF
--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -90,6 +90,7 @@ local order = {
         "----------------------------",
         "screen_dpi",
         "screen_eink_opt",
+        "autodim",
         "autowarmth",
         "color_rendering",
         "----------------------------",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -135,6 +135,7 @@ local order = {
         "----------------------------",
         "screen_dpi",
         "screen_eink_opt",
+        "autodim",
         "autowarmth",
         "color_rendering",
         "----------------------------",

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -633,7 +633,7 @@ Unschedules a previously scheduled task.
 In order to unschedule anonymous functions, store a reference.
 
 @func action
-@see scheduleIn
+@see scheduleIn, unscheduleSoonestN, unscheduleLatestN
 
 @usage
 
@@ -647,6 +647,65 @@ function UIManager:unschedule(action)
         if self._task_queue[i].action == action then
             table.remove(self._task_queue, i)
             removed = true
+        end
+    end
+    return removed
+end
+dbg:guard(UIManager, 'unschedule',
+    function(self, action) assert(action ~= nil) end)
+
+--[[--
+Unschedules the soonest N previously scheduled tasks.
+
+This function is faster than `self:unschedule`, if only a well known number of tasks have to be removed
+(and that number is not to big compared to the total number of scheduled tasks).
+
+@func action
+@see unschedule, unscheduleLatestN
+
+@return number of removed tasks
+]]
+function UIManager:unscheduleSoonestN(action, N)
+    logger.dbg("UIManager: unscheduleSoonestN", N) -- to be removed xxx
+    print("xxx unscheduleFirstN", N) -- to be removed xxx
+    local removed = 0
+    N = N or 1
+    for i = 1, #self._task_queue do
+        if self._task_queue[i].action == action then
+            table.remove(self._task_queue, i)
+            removed = removed + 1
+            if removed >= N then
+                return N
+            end
+        end
+    end
+    return removed
+end
+dbg:guard(UIManager, 'unschedule',
+    function(self, action) assert(action ~= nil) end)
+
+--[[--
+Unschedules the latest N previously scheduled tasks.
+
+This function is faster than `self:unschedule`, if only a well known number of tasks have to be removed.
+
+@func action
+@see unschedule, unscheduleSoonestN
+
+@return number of removed tasks
+]]
+function UIManager:unscheduleLatestN(action, N)
+    logger.dbg("UIManager: unscheduleLatestN", N) -- to be removed xxx
+    print("xxx unscheduleLatestN", N) -- to be removed xxx
+    local removed = 0
+    N = N or 1
+    for i = #self._task_queue, 1, -1 do
+        if self._task_queue[i].action == action then
+            table.remove(self._task_queue, i)
+            removed = removed + 1
+            if removed >= N then
+                return N
+            end
         end
     end
     return removed

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -177,7 +177,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
                     right_widget.value = self.right_default
                     left_widget:update()
                     right_widget:update()
-                    self.callback(nil, nil)
+                    self.callback(self.left_default, self.right_default)
                 end,
             }
         })

--- a/plugins/autowarmth.koplugin/_meta.lua
+++ b/plugins/autowarmth.koplugin/_meta.lua
@@ -2,5 +2,6 @@ local _ = require("gettext")
 return {
     name = "autowarmth",
     fullname = require("device"):hasNaturalLight() and _("Auto warmth and night mode") or _("Auto night mode"),
-    description = _([[This plugin allows set the frontlight warmth automagically.]]),
+    description = _([[This plugin allows to set the frontlight warmth automagically
+        and to dim the frontlight after an idle period.]]),
 }

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -1,5 +1,6 @@
 --[[--
 Plugin for setting screen warmth based on the sun position and/or a time schedule
+and for automatic dimming the frontlight after an idle period.
 
 @module koplugin.autowarmth
 --]]--
@@ -25,6 +26,10 @@ local _ = require("gettext")
 local T = FFIUtil.template
 local Screen = require("device").screen
 local util = require("util")
+
+local DEFAULT_AUTODIM_STARTTIME_M = 5
+local DEFAULT_AUTODIM_DURATION_M = 2
+local DEFAULT_AUTODIM_ENDPERCENTAGE = 20
 
 local activate_sun = 1
 local activate_schedule = 2
@@ -64,13 +69,15 @@ function AutoWarmth:init()
     self.longitude = G_reader_settings:readSetting("autowarmth_longitude") or -20.30
     self.altitude = G_reader_settings:readSetting("autowarmth_altitude") or 200
     self.timezone = G_reader_settings:readSetting("autowarmth_timezone") or 0
-    self.scheduler_times = G_reader_settings:readSetting("autowarmth_scheduler_times") or
-        {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
+    self.scheduler_times = G_reader_settings:readSetting("autowarmth_scheduler_times")
+        or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth =   G_reader_settings:readSetting("autowarmth_warmth")
         or { 90, 90, 80, 60, 20, 20, 20, 60, 80, 90, 90}
 
     -- schedule recalculation shortly afer midnight
     self:scheduleMidnightUpdate()
+
+    self:initAutoDim()
 end
 
 function AutoWarmth:onDispatcherRegisterActions()
@@ -318,6 +325,7 @@ function AutoWarmth:addToMainMenu(menu_items)
             return self:getSubMenuItems()
         end,
     }
+    menu_items.autodim = self:getAutodimMenu()
 end
 
 local function tidy_menu(menu, request)
@@ -353,7 +361,7 @@ function AutoWarmth:getSubMenuItems()
             callback = function()
                 UIManager:show(InfoMessage:new{
                     text = about_text,
-                     width = math.floor(Screen:getWidth() * 0.9),
+                    width = math.floor(Screen:getWidth() * 0.9),
                 })
             end,
             keep_menu_open = true,
@@ -474,8 +482,9 @@ function AutoWarmth:getLocationMenu()
                                 if touchmenu_instance then touchmenu_instance:updateItems() end
                             end,
                         },
-                    }}
-                }
+                    }
+                },
+            }
             UIManager:show(location_name_dialog)
             location_name_dialog:onShowKeyboard()
         end,
@@ -557,8 +566,7 @@ function AutoWarmth:getScheduleMenu()
         self.scheduler_times[num] = new_time
         if num == 1 then
             if new_time then
-                self.scheduler_times[midnight_index]
-                    = new_time + 24 -- next day
+                self.scheduler_times[midnight_index] = new_time + 24 -- next day
             else
                 self.scheduler_times[midnight_index] = nil
             end
@@ -741,7 +749,6 @@ function AutoWarmth:getWarmthMenu()
                                 text = _("Cancel"),
                             }
                         }},
-
                     })
                 end
             end,
@@ -856,7 +863,7 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
     UIManager:show(InfoMessage:new{
         face = face,
         width = math.floor(Screen:getWidth() * (self.easy_mode and 0.75 or 0.90)),
-            text = title .. location_string .. ":\n\n" ..
+        text = title .. location_string .. ":\n\n" ..
             info_line(0, _("Solar midnight:"), times, 1, face, request_easy) ..
             add_line(_("Dawn"), request_easy) ..
             info_line(4, _("Astronomic:"), times, 2, face, request_easy) ..
@@ -909,6 +916,197 @@ function AutoWarmth:getLocationString()
         return self.location
     else
         return "(" .. self.latitude .. "," .. self.longitude .. ")"
+    end
+end
+
+------------------------------------ autodim ----------------------------------
+
+function AutoWarmth:initAutoDim()
+    self.autodim_starttime_m = G_reader_settings:readSetting("autodim_starttime_minutes", -1)
+    self.autodim_duration_m = G_reader_settings:readSetting("autodim_duration_minutes", DEFAULT_AUTODIM_DURATION_M)
+    self.autodim_endpercentage = G_reader_settings:readSetting("autodim_endpercentage", DEFAULT_AUTODIM_ENDPERCENTAGE)
+
+    self.autodim_save_fl = Device.powerd:frontlightIntensity()
+
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+    UIManager.event_hook:registerWidget("InputEvent", self)
+
+    self:_schedule_autodim_task()
+    self.isCurrentlyDimming = false
+
+end
+
+function AutoWarmth:getAutodimMenu()
+    return {
+        text = _("Automatic dimmer"),
+        checked_func = function() return self.autodim_starttime_m > 0 end,
+        sub_item_table = {
+            {
+                text_func = function()
+                    return self.autodim_starttime_m <= 0 and _("Automatic dimmer") or
+                    T(_("Automatic dimmer (%1 / %2 minutes)"), self.autodim_starttime_m, self.autodim_duration_m)
+                end,
+                checked_func = function() return self.autodim_starttime_m > 0 end,
+                callback = function(touchmenu_instance)
+                    local frontlight_dialog = DoubleSpinWidget:new{
+                        title_text = _("Automatic dimmer"),
+                        info_text = _("Times are in minutes."),
+                        left_text = _("Start after idle"),
+                        left_value = self.autodim_starttime_m,
+                        left_default = DEFAULT_AUTODIM_STARTTIME_M,
+                        left_min = 0.1, -- xxx
+                        left_max = 60,
+                        left_step = 0.5,
+                        left_hold_step = 5,
+                        left_precision = "%0.1f",
+                        right_text = _("Duration"),
+                        right_value = self.autodim_duration_m,
+                        right_default = DEFAULT_AUTODIM_DURATION_M,
+                        right_min = 0,
+                        right_max = 10,
+                        right_step = 0.5,
+                        right_hold_step = 5,
+                        right_precision = "%0.1f",
+                        callback = function(starttime_m, duration_m)
+                            self.autodim_starttime_m = starttime_m
+                            self.autodim_duration_m = duration_m
+                            G_reader_settings:saveSetting("autodim_starttime_minutes", starttime_m)
+                            G_reader_settings:saveSetting("autodim_duration_minutes", duration_m)
+                            self:_schedule_autodim_task()
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                        default_values = true,
+                        extra_text = _("Disable"),
+                        extra_callback = function()
+                            self.autodim_starttime_m = -1
+                            self.autodim_duration_m = -1
+                            G_reader_settings:saveSetting("autodim_starttime_minutes", -1)
+                            G_reader_settings:saveSetting("autodim_duration_minutes", -1)
+                            self:_schedule_autodim_task()
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                    }
+                    UIManager:show(frontlight_dialog)
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end,
+                keep_menu_open = true,
+            },
+            {
+                text_func = function()
+                    return T(_("Dimming percentage: %1%"), self.autodim_endpercentage)
+                end,
+                checked_func = function() return self.autodim_starttime_m > 0 end,
+                callback = function(touchmenu_instance)
+                    local percentage_dialog = SpinWidget:new{
+                        title_text = _("Percentage"),
+                        info_text = _("Enter the percentage of you want the frontlight to dim to. 50% means half of your normal intensity."),
+                        value = self.autodim_endpercentage,
+                        value_default = DEFAULT_AUTODIM_ENDPERCENTAGE,
+                        value_min = 0,
+                        value_max = 100,
+                        value_hold_step = 10,
+                        callback = function(spin)
+                            self.autodim_endpercentage = spin.value
+                            G_reader_settings:saveSetting("autodim_endpercentage", spin.value)
+                            self:_schedule_autodim_task()
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                    }
+                    UIManager:show(percentage_dialog)
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end,
+                keep_menu_open = true,
+            },
+        }
+    }
+end
+
+function AutoWarmth:_schedule_autodim_task(seconds)
+    UIManager:unscheduleSoonestN(self.autodim_task, 1)
+    if not seconds then
+        -- if starttime is lower or equal to 1 minute, use the exact time
+        if self.autodim_starttime_m <= 1 then
+            seconds = self.autodim_starttime_m * 60
+        else -- use the next full minute (to minimize wakeups from standby)
+            seconds = self.autodim_starttime_m * 60 + (61 - tonumber(os.date("%S")))
+        end
+    end
+    UIManager:scheduleIn(seconds, self.autodim_task, self)
+    print("xxx secondes", seconds)
+end
+
+function AutoWarmth:onInputEvent()
+    self.last_action_tv = UIManager:getElapsedTimeSinceBoot()
+    print("xxx default input event!!! is in ramp", self.isCurrentlyDimming)
+
+    if self.isCurrentlyDimming then
+        Device.powerd:setIntensity(self.autodim_save_fl)
+
+        self:_unschedule_ramp_task()
+        self:_schedule_autodim_task()
+
+        UIManager:discardEvents(1) -- discard events for 1 sec after dimming
+    end
+end
+
+function AutoWarmth:onResume()
+    if self.isCurrentlyDimming then
+        Device.powerd:setIntensity(self.autodim_save_fl)
+        self:_schedule_autodim_task()
+        UIManager:discardEvents(0) -- stop discarding events
+    end
+end
+
+function AutoWarmth:onSuspend()
+    if self.isCurrentlyDimming then
+        self:_unschedule_ramp_task()
+        self.isCurrentlyDimming = true
+    end
+end
+
+function AutoWarmth:autodim_task()
+    if self.isCurrentlyDimming then return end
+
+    local TimeVal = require("ui/timeval")
+    local now = UIManager:getElapsedTimeSinceBoot()
+    local idle_duration =  now - self.last_action_tv
+    local check_delay = TimeVal:new{ sec = self.autodim_starttime_m * 60} - idle_duration
+    print("xxx idlee", idle_duration:tonumber())
+    print("xxx delay", check_delay:tonumber())
+    if check_delay:tonumber() <= 0 then
+        self.autodim_save_fl = Device.powerd:frontlightIntensity()
+        self.autodim_end_fl = math.floor(self.autodim_save_fl * self.autodim_endpercentage / 100 + 0.5)
+        local fl_diff = self.autodim_save_fl - self.autodim_end_fl
+        -- calculate time until the next decrease step
+        self.autodim_step_time_s = (self.autodim_duration_m * 60) / fl_diff
+
+        UIManager:discardEvents(math.huge)
+        self:ramp_task() -- which schedules itself
+        -- Don't schedule `autodim_task` here, as this is done on the next `onInputEvent`
+    else
+        self:_schedule_autodim_task(check_delay:tonumber())
+    end
+end
+
+function AutoWarmth:ramp_task()
+    self.isCurrentlyDimming = true
+    local new_fl_level = Device.powerd:frontlightIntensity() - 1
+    if new_fl_level <= self.autodim_end_fl then
+        new_fl_level = self.autodim_end_fl
+    else
+        self:_schedule_ramp_task()
+    end
+    Device.powerd:setIntensity(new_fl_level)
+end
+
+function AutoWarmth:_schedule_ramp_task()
+    UIManager:scheduleIn(self.autodim_step_time_s, self.ramp_task, self)
+end
+
+function AutoWarmth:_unschedule_ramp_task()
+    if self.isCurrentlyDimming then
+        UIManager:unscheduleSoonestN(self.ramp_task, 1)
+        self.isCurrentlyDimming = false
     end
 end
 


### PR DESCRIPTION
This PR allows to set an idle time after that the frontlight will start dimming and a duration for that. (Duration can be zero, so there is an immediate off possible).

For testing it is possible to set the minimal idle time to 0.1 minutes (6s), this will be changed to 0.5 minutes.


