### PR TITLE
Power-savings in readerdevicestatus: Schedule on full minute and fix multiple scheduling.

### DIFF
--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -19,7 +19,8 @@ function ReaderDeviceStatus:init()
         self.battery_interval_m = G_reader_settings:readSetting("device_status_battery_interval_minutes", 10)
         self.battery_threshold = G_reader_settings:readSetting("device_status_battery_threshold", 20)
         self.battery_threshold_high = G_reader_settings:readSetting("device_status_battery_threshold_high", 100)
-        -- If sync is true, schedule on a full minute (to reduce wakeups from suspend).
+        -- `checkLowBatteryLevel` and `checkHighMemoryUsage` are each supposed to start one second past the top of the minute,
+        -- as some other periodic activities do (e.g. footer). This means that the processor is woken up less often from standby.
         self.checkLowBatteryLevel = function(sync)
             local is_charging = powerd:isCharging()
             local battery_capacity = powerd:getCapacity()
@@ -55,7 +56,8 @@ function ReaderDeviceStatus:init()
     if not Device:isAndroid() then
         self.memory_interval_m = G_reader_settings:readSetting("device_status_memory_interval_minutes", 5)
         self.memory_threshold = G_reader_settings:readSetting("device_status_memory_threshold", 100)
-        -- If sync is true, schedule on a full minute (to reduce wakeups from suspend).
+        -- `checkLowBatteryLevel` and `checkHighMemoryUsage` are each supposed to start one second past the top of the minute,
+        -- as some other periodic activities do (e.g. footer). This means that the processor is woken up less often from standby.
         self.checkHighMemoryUsage = function(sync)
             local statm = io.open("/proc/self/statm", "r")
             if statm then
@@ -303,7 +305,8 @@ High level threshold is checked when the device is charging.]]),
     end
 end
 
--- If sync is true, the next schedule will be on a full minute (rounded down) to reduce wakeups from standby.
+-- `checkLowBatteryLevel` and `checkHighMemoryUsage` are each supposed to start one second past the top of the minute,
+-- as some other periodic activities do (e.g. footer). This means that the processor is woken up less often from standby.
 function ReaderDeviceStatus:startBatteryChecker(sync)
     if G_reader_settings:isTrue("device_status_battery_alarm") then
         self.checkLowBatteryLevel(sync)
@@ -316,7 +319,8 @@ function ReaderDeviceStatus:stopBatteryChecker()
     end
 end
 
--- If sync is true, the next schedule will be on a full minute (rounded down) to reduce wakeups from standby.
+-- `checkLowBatteryLevel` and `checkHighMemoryUsage` are each supposed to start one second past the top of the minute,
+-- as some other periodic activities do (e.g. footer). This means that the processor is woken up less often from standby.
 function ReaderDeviceStatus:startMemoryChecker(sync)
     if G_reader_settings:isTrue("device_status_memory_alarm") then
         self.checkHighMemoryUsage(sync)

--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -19,7 +19,7 @@ function ReaderDeviceStatus:init()
         self.battery_interval_m = G_reader_settings:readSetting("device_status_battery_interval_minutes", 10)
         self.battery_threshold = G_reader_settings:readSetting("device_status_battery_threshold", 20)
         self.battery_threshold_high = G_reader_settings:readSetting("device_status_battery_threshold_high", 100)
-        -- if sync is true, schedule on a full minute (to reduce wakeups from suspend)
+        -- If sync is true, schedule on a full minute (to reduce wakeups from suspend).
         self.checkLowBatteryLevel = function(sync)
             local is_charging = powerd:isCharging()
             local battery_capacity = powerd:getCapacity()
@@ -55,7 +55,7 @@ function ReaderDeviceStatus:init()
     if not Device:isAndroid() then
         self.memory_interval_m = G_reader_settings:readSetting("device_status_memory_interval_minutes", 5)
         self.memory_threshold = G_reader_settings:readSetting("device_status_memory_threshold", 100)
-        -- if sync is true, schedule on a full minute (to reduce wakeups from suspend)
+        -- If sync is true, schedule on a full minute (to reduce wakeups from suspend).
         self.checkHighMemoryUsage = function(sync)
             local statm = io.open("/proc/self/statm", "r")
             if statm then
@@ -226,7 +226,7 @@ High level threshold is checked when the device is charging.]]),
                 callback = function()
                     G_reader_settings:flipNilOrFalse("device_status_memory_alarm")
                     if G_reader_settings:isTrue("device_status_memory_alarm") then
-                        self:startMemoryChecker(start)
+                        self:startMemoryChecker(true)
                     else
                         self:stopMemoryChecker()
                     end
@@ -303,7 +303,7 @@ High level threshold is checked when the device is charging.]]),
     end
 end
 
--- if sync is true, the next schedule will be on a full minute (rounded down) to reduce wakeups from standby
+-- If sync is true, the next schedule will be on a full minute (rounded down) to reduce wakeups from standby.
 function ReaderDeviceStatus:startBatteryChecker(sync)
     if G_reader_settings:isTrue("device_status_battery_alarm") then
         self.checkLowBatteryLevel(sync)
@@ -316,7 +316,7 @@ function ReaderDeviceStatus:stopBatteryChecker()
     end
 end
 
--- if sync is true, the next schedule will be on a full minute (rounded down) to reduce wakeups from standby
+-- If sync is true, the next schedule will be on a full minute (rounded down) to reduce wakeups from standby.
 function ReaderDeviceStatus:startMemoryChecker(sync)
     if G_reader_settings:isTrue("device_status_memory_alarm") then
         self.checkHighMemoryUsage(sync)

--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -46,7 +46,7 @@ function ReaderDeviceStatus:init()
                     UIManager:show(self.battery_confirm_box)
                 end
             end
-            local offset = sync and os.date("%S") or 0
+            local offset = sync and (os.date("%S") - 1) or 0
             UIManager:scheduleIn(self.battery_interval_m * 60 - offset, self.checkLowBatteryLevel)
         end
         self:startBatteryChecker()
@@ -106,7 +106,7 @@ function ReaderDeviceStatus:init()
                     end
                 end
             end
-            local offset = sync and os.date("%S") or 0
+            local offset = sync and (os.date("%S") - 1) or 0
             UIManager:scheduleIn(self.memory_interval_m * 60 - offset, self.checkHighMemoryUsage)
         end
         self:startMemoryChecker()
@@ -161,7 +161,7 @@ function ReaderDeviceStatus:addToMainMenu(menu_items)
                             powerd:setDismissBatteryStatus(false)
                             self:stopBatteryChecker()
                             -- schedule first check on a full minute to reduce wakeups from standby)
-                            UIManager:scheduleIn(self.battery_interval_m * 60 - os.date("%S"),
+                            UIManager:scheduleIn(self.battery_interval_m * 60 - os.date("%S") + 1,
                                 self.checkLowBatteryLevel)
                         end,
                     })
@@ -255,7 +255,7 @@ High level threshold is checked when the device is charging.]]),
                             touchmenu_instance:updateItems()
                             self:stopMemoryChecker()
                             -- schedule first check on a full minute to reduce wakeups from standby)
-                            UIManager:scheduleIn(self.memory_interval_m * 60 - os.date("%S"),
+                            UIManager:scheduleIn(self.memory_interval_m * 60 - os.date("%S") + 1,
                                 self.checkHighMemoryUsage)
                         end,
                     })


### PR DESCRIPTION
Shift the first scheduling of the checkers to a full minute (rounded down to the previous minute), the consecutive schedule are multiples of minutes. This is to reduce wakeups from standby.

Fix the missing unschedule of the checkers, when the checker intervals are changed from the menu (to avoid multiple scheduled checkers).



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9032)
<!-- Reviewable:end -->
