### PR TITLE
Handle LPLEG LUA dependency on Fedora

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -34,6 +34,15 @@ Install the prerequisites using DNF:
 sudo dnf install libstdc++-static SDL SDL-devel patch wget unzip git cmake luarocks autoconf nasm ragel gcc
 ```
 
+Install LUA LPEG and set symbolic link for KOReader to find it:
+
+```
+sudo dnf install lua5.1-lpeg
+sudo mkdir /usr/local/lib/lua
+sudo mkdir /usr/local/lib/lua/5.1
+sudo ln -s /usr/lib64/lua/5.1/lpeg.so /usr/local/lib/lua/5.1/lpeg.so
+```
+
 ### macOS
 
 Install the prerequisites using [Homebrew](https://brew.sh/):


### PR DESCRIPTION
When calling `./kodev run`, KOReader looks for LPEG, and looks for it in
the wrong path.
This will tell the user to install LPEG and make a symbolic link for
KOReader to find it.