### PR TITLE
TitleBar left and right buttons navigation on non-touch devices

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -146,7 +146,7 @@ function FileManager:setupLayout()
         return_arrow_propagation = true,
         -- allow Menu widget to delegate handling of some gestures to GestureManager
         filemanager = self,
-        -- let Menu widget to merge TitleBar's FocusManager layout
+        -- let Menu widget merge our title_bar into its own TitleBar's FocusManager layout
         outer_title_bar = self.title_bar,
     }
     self.file_chooser = file_chooser

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -146,6 +146,8 @@ function FileManager:setupLayout()
         return_arrow_propagation = true,
         -- allow Menu widget to delegate handling of some gestures to GestureManager
         filemanager = self,
+        -- let Menu widget to merge TitleBar's FocusManager layout
+        outer_title_bar = self.title_bar,
     }
     self.file_chooser = file_chooser
     self.focused_file = nil -- use it only once

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -359,7 +359,7 @@ end
 
 function FileChooser:updateItems(select_number)
     Menu.updateItems(self, select_number) -- call parent's updateItems()
-    self:addTitleBarLayout()
+    self:mergeTitleBarLayout()
     self.path_items[self.path] = (self.page - 1) * self.perpage + (select_number or 1)
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -359,7 +359,7 @@ end
 
 function FileChooser:updateItems(select_number)
     Menu.updateItems(self, select_number) -- call parent's updateItems()
-    self:mergeTitleBarLayout()
+    self:mergeTitleBarIntoLayout()
     self.path_items[self.path] = (self.page - 1) * self.perpage + (select_number or 1)
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -359,6 +359,7 @@ end
 
 function FileChooser:updateItems(select_number)
     Menu.updateItems(self, select_number) -- call parent's updateItems()
+    self:addTitleBarLayout()
     self.path_items[self.path] = (self.page - 1) * self.perpage + (select_number or 1)
 end
 

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -208,6 +208,7 @@ function FocusManager:onFocusMove(args)
     end
 
     if not self.layout[self.selected.y] or not self.layout[self.selected.y][self.selected.x] then
+        logger.dbg("FocusManager: Not found current selected widget")
         return true
     end
     local current_item = self.layout[self.selected.y][self.selected.x]
@@ -269,7 +270,7 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
         target_item = self.layout[y][x]
     end
     if target_item then
-        logger.dbg("FocusManager: Move focus position to:", y, ",", x)
+        logger.dbg("FocusManager: Move focus position to:", x, ",", y)
         self.selected.x = x
         self.selected.y = y
         -- widget create new layout on update, previous may be removed from new layout.

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -208,7 +208,7 @@ function FocusManager:onFocusMove(args)
     end
 
     if not self.layout[self.selected.y] or not self.layout[self.selected.y][self.selected.x] then
-        logger.dbg("FocusManager: Not found current selected widget")
+        logger.dbg("FocusManager: no currently selected widget found")
         return true
     end
     local current_item = self.layout[self.selected.y][self.selected.x]

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -337,9 +337,16 @@ function InputText:isTextEdited()
 end
 
 function InputText:init()
-    if self.text_type == "password" then
-        -- text_type changes from "password" to "text" when we toggle password
-        self.is_password_type = true
+    if Device:isTouchDevice() then
+        if self.text_type == "password" then
+            -- text_type changes from "password" to "text" when we toggle password
+            self.is_password_type = true
+        end
+    else
+        -- focus move does not work with textbox and show password checkbox
+        -- force show password for non-touch device
+        self.text_type = "text"
+        self.is_password_type = false
     end
     -- Beware other cases where implicit conversion to text may be done
     -- at some point, but checkTextEditability() would say "not editable".

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1098,7 +1098,7 @@ function Menu:updateItems(select_number)
     if self.show_path then
         self.title_bar:setSubTitle(BD.directory(filemanagerutil.abbreviate(self.path)))
     end
-    self:addTitleBarLayout()
+    self:mergeTitleBarLayout()
 
     UIManager:setDirty(self.show_parent, function()
         local refresh_dimen =
@@ -1109,12 +1109,12 @@ function Menu:updateItems(select_number)
 end
 
 -- merge TitleBar layout into self FocusManager layout
-function Menu:addTitleBarLayout()
+function Menu:mergeTitleBarLayout()
     local menu_item_layout_start_row = 1
     local titlebars = {self.title_bar, self.outer_title_bar}
     for _, v in ipairs(titlebars) do
-        -- Menu use right key for context menu trigger, there is no chances to move focus in horizontal directions
-        -- Add title bar buttons to layout in vertical directions
+        -- Menu uses the right key to trigger the context menu: we can't use it to move focus in horizontal directions.
+        -- So, add title bar buttons to FocusManager's layout in a vertical-only layout
         local title_bar_layout = v:generateVerticalLayout()
         for _, row in ipairs(title_bar_layout) do
             table.insert(self.layout, menu_item_layout_start_row, row)
@@ -1122,7 +1122,7 @@ function Menu:addTitleBarLayout()
         end
     end
     if menu_item_layout_start_row > #self.layout then -- no menu items
-        menu_item_layout_start_row = #self.layout -- void index overflow
+        menu_item_layout_start_row = #self.layout -- avoid index overflow
     end
     self:moveFocusTo(1, menu_item_layout_start_row) -- move focus to first menu item if any, keep original behavior
 end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1098,7 +1098,7 @@ function Menu:updateItems(select_number)
     if self.show_path then
         self.title_bar:setSubTitle(BD.directory(filemanagerutil.abbreviate(self.path)))
     end
-    self:mergeTitleBarLayout()
+    self:mergeTitleBarIntoLayout()
 
     UIManager:setDirty(self.show_parent, function()
         local refresh_dimen =
@@ -1109,7 +1109,7 @@ function Menu:updateItems(select_number)
 end
 
 -- merge TitleBar layout into self FocusManager layout
-function Menu:mergeTitleBarLayout()
+function Menu:mergeTitleBarIntoLayout()
     local menu_item_layout_start_row = 1
     local titlebars = {self.title_bar, self.outer_title_bar}
     for _, v in ipairs(titlebars) do

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1098,6 +1098,7 @@ function Menu:updateItems(select_number)
     if self.show_path then
         self.title_bar:setSubTitle(BD.directory(filemanagerutil.abbreviate(self.path)))
     end
+    self:addTitleBarLayout()
 
     UIManager:setDirty(self.show_parent, function()
         local refresh_dimen =
@@ -1106,6 +1107,26 @@ function Menu:updateItems(select_number)
         return "ui", refresh_dimen
     end)
 end
+
+-- merge TitleBar layout into self FocusManager layout
+function Menu:addTitleBarLayout()
+    local menu_item_layout_start_row = 1
+    local titlebars = {self.title_bar, self.outer_title_bar}
+    for _, v in ipairs(titlebars) do
+        -- Menu use right key for context menu trigger, there is no chances to move focus in horizontal directions
+        -- Add title bar buttons to layout in vertical directions
+        local title_bar_layout = v:generateVerticalLayout()
+        for _, row in ipairs(title_bar_layout) do
+            table.insert(self.layout, menu_item_layout_start_row, row)
+            menu_item_layout_start_row = menu_item_layout_start_row + 1
+        end
+    end
+    if menu_item_layout_start_row > #self.layout then -- no menu items
+        menu_item_layout_start_row = #self.layout -- void index overflow
+    end
+    self:moveFocusTo(1, menu_item_layout_start_row) -- move focus to first menu item if any, keep original behavior
+end
+
 
 --[[
     the itemnumber paramter determines menu page number after switching item table
@@ -1146,6 +1167,9 @@ function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch)
     local max_pages = math.ceil(#new_item_table / self.perpage)
     if self.page > max_pages then
         self.page = max_pages
+    end
+    if self.page <= 0 then
+        self.page = 1
     end
 
     self.item_table = new_item_table

--- a/frontend/ui/widget/titlebar.lua
+++ b/frontend/ui/widget/titlebar.lua
@@ -101,15 +101,13 @@ function TitleBar:init()
     -- No button on non-touch device
     local left_icon_reserved_width = 0
     local right_icon_reserved_width = 0
-    if Device:isTouchDevice() then
-        if self.left_icon then
-            self.has_left_icon = true
-            left_icon_reserved_width = left_icon_size + self.button_padding
-        end
-        if self.right_icon then
-            self.has_right_icon = true
-            right_icon_reserved_width = right_icon_size + self.button_padding
-        end
+    if self.left_icon then
+        self.has_left_icon = true
+        left_icon_reserved_width = left_icon_size + self.button_padding
+    end
+    if self.right_icon then
+        self.has_right_icon = true
+        right_icon_reserved_width = right_icon_size + self.button_padding
     end
 
     if self.align == "center" then
@@ -456,5 +454,32 @@ function TitleBar:setRightIcon(icon)
         self.right_button:setIcon(icon)
         UIManager:setDirty(self.show_parent, "ui", self.dimen)
     end
+end
+
+-- layout for FocusManager
+function TitleBar:generateHorizontalLayout()
+    local row = {}
+    if self.left_button then
+        table.insert(row, self.left_button)
+    end
+    if self.right_button then
+        table.insert(row, self.right_button)
+    end
+    local layout = {}
+    if #row > 0 then
+        table.insert(layout, row)
+    end
+    return layout
+end
+
+function TitleBar:generateVerticalLayout()
+    local layout = {}
+    if self.left_button then
+        table.insert(layout, {self.left_button})
+    end
+    if self.right_button then
+        table.insert(layout, {self.right_button})
+    end
+    return layout
 end
 return TitleBar

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -409,6 +409,7 @@ function CoverMenu:updateItems(select_number)
             self.onFileHold_ours = self.onFileHold
         end)
     end
+    Menu.addTitleBarLayout(self)
 end
 
 -- Similar to onFileHold setup just above, but for History,

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -409,7 +409,7 @@ function CoverMenu:updateItems(select_number)
             self.onFileHold_ours = self.onFileHold
         end)
     end
-    Menu.addTitleBarLayout(self)
+    Menu.mergeTitleBarLayout(self)
 end
 
 -- Similar to onFileHold setup just above, but for History,

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -409,7 +409,7 @@ function CoverMenu:updateItems(select_number)
             self.onFileHold_ours = self.onFileHold
         end)
     end
-    Menu.mergeTitleBarLayout(self)
+    Menu.mergeTitleBarIntoLayout(self)
 end
 
 -- Similar to onFileHold setup just above, but for History,

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -385,24 +385,22 @@ function MosaicMenuItem:init()
     self.percent_finished = nil
 
     -- we need this table per-instance, so we declare it here
-    if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                },
-                doc = "Select Menu Item",
+    self.ges_events = {
+        TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             },
-            HoldSelect = {
-                GestureRange:new{
-                    ges = "hold",
-                    range = self.dimen,
-                },
-                doc = "Hold Menu Item",
+            doc = "Select Menu Item",
+        },
+        HoldSelect = {
+            GestureRange:new{
+                ges = "hold",
+                range = self.dimen,
             },
-        }
-    end
+            doc = "Hold Menu Item",
+        },
+    }
 
     -- We now build the minimal widget container that won't change after udpate()
 


### PR DESCRIPTION
## Preview
![output](https://user-images.githubusercontent.com/13473736/165757179-a75b955c-3f74-48d1-a9c3-7037f4c06566.gif)

## Design
Fix #9027 

There are 22 `TitleBar:new` in source code. Only few of them have buttons other than just right `close` button (`PageBrowserWidget` has TitleBar with buttons while it is disabled for non-touch device.):
* File Manager
* History
* Folder Shortcuts
* Favorites
* Cloud Storage

All these pages are based on `Menu` widget. `Menu` widget replaces `FocusManager` move focus right key listener as menu item `Hold` event listener. It also turn off move focus left key listener on `hasFewKey()` device. It is hard to support horizontal focus movement between `TitleBar` buttons in `Menu` widget.

After several failure solutions, making `TitleBar` buttons layout in vertical is a simple and safe solution so far.

![layout](https://user-images.githubusercontent.com/13473736/165767392-06b12f67-98fd-4c6b-92da-6ea5b660bf80.png)

## Code Changes
**frontend/ui/widget/titlebar.lua**
Show left and right on non-touch devices
Methods to generate FocusManager layout for parent widget to merge

**frontend/ui/widget/titlebar.lua**
`addTitleBarLayout` method to merge TitleBars' buttons layout
call `addTitleBarLayout` in `updateItems` method

**plugins/coverbrowser.koplugin/covermenu.lua**
call `Menu.addTitleBarLayout` in `updateItems` method

**frontend/ui/widget/filechooser.lua**
call `Menu.addTitleBarLayout` in `updateItems` method

**frontend/apps/filemanager/filemanager.lua**
pass TitleBar to FileChooser to merge layout

**frontend/ui/widget/inputtext.lua**
Hide `Show password` checkbox, it does not work with FocusManager

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9041)
<!-- Reviewable:end -->
