### PR TITLE
TOC: replace "Table of Contents" with book title

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -753,8 +753,14 @@ function ReaderToc:onShowToc()
     --       because we inflate the state Button's width on the left, mainly to give it a larger tap zone.
     --       This yields *slightly* better alignment between state & mandatory (in terms of effective margins).
     local button_size = self.expand_button:getSize()
+
+    -- Get book title if available, else use generic "Table of Contents"
+    local doc_info = self.ui.document:getProps()
+    local title = doc_info and doc_info.title ~= "" and doc_info.title or _("Table of Contents")
+    title = title:gsub(" ", "\xC2\xA0") -- replace space with no-break-space
+
     local toc_menu = Menu:new{
-        title = _("Table of Contents"),
+        title = title,
         item_table = self.collapsed_toc,
         state_w = can_collapse and button_size.w or 0,
         ui = self.ui,

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -754,7 +754,7 @@ function ReaderToc:onShowToc()
     --       This yields *slightly* better alignment between state & mandatory (in terms of effective margins).
     local button_size = self.expand_button:getSize()
 
-    -- Get book title if available, else use generic "Table of Contents"
+    -- Get book title if available and the setting `toc_show_book_title` is true, else use generic "Table of Contents"
     local doc_info = self.ui.document:getProps()
     local show_book_title = G_reader_settings:isTrue("toc_show_book_title")
     local title = show_book_title and doc_info and doc_info.title ~= "" and doc_info.title or _("Table of Contents")
@@ -785,7 +785,7 @@ function ReaderToc:onShowToc()
                 },
                 direction = BD.flipDirectionIfMirroredUILayout("west")
             }
-        }
+        },
     }
 
     local menu_container = CenterContainer:new{

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -756,8 +756,8 @@ function ReaderToc:onShowToc()
 
     -- Get book title if available, else use generic "Table of Contents"
     local doc_info = self.ui.document:getProps()
-    local title = doc_info and doc_info.title ~= "" and doc_info.title or _("Table of Contents")
-    title = title:gsub(" ", "\xC2\xA0") -- replace space with no-break-space
+    local show_book_title = G_reader_settings:isTrue("toc_show_book_title")
+    local title = show_book_title and doc_info and doc_info.title ~= "" and doc_info.title or _("Table of Contents")
 
     local toc_menu = Menu:new{
         title = title,
@@ -1000,6 +1000,15 @@ See Style tweaks → Miscellaneous → Alternative ToC hints.]]),
             end,
         }
     end
+    menu_items.toc_show_book_title = {
+        text = _("Show book title in table of contents"),
+        checked_func = function()
+            return G_reader_settings:isTrue("toc_show_book_title")
+        end,
+        callback = function()
+            G_reader_settings:toggle("toc_show_book_title")
+        end,
+    }
     -- Allow to have getTocTicksFlattened() get rid of all items at some depths, which
     -- might be useful to have the footer and SkimTo progress bar less crowded.
     -- This also affects the footer current chapter title, but leave the ToC itself unchanged.

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -31,6 +31,7 @@ local order = {
     },
     navi_settings = {
         "toc_alt_toc",
+        "toc_show_book_title",
         "----------------------------",
         "toc_ticks_level_ignore",
         "----------------------------",


### PR DESCRIPTION
If a boot title is available replace the generic "Table of Contents" with the book title. (Is shortened, when too title is to long).

In the following image is a collage of three books. The first has not title, the scond one a very long title and the last is shown as it is.

This PR could fix #9042.


![grafik](https://user-images.githubusercontent.com/36999612/166249211-cbb52ef9-061c-41b4-8e39-ccd42690c27d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9058)
<!-- Reviewable:end -->
