### PR TITLE
NetworkManager: Make sure we show an IM at the *start* of a Wi-Fi toggle action

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -277,7 +277,7 @@ function KoboPowerD:getCapacityHW()
     return self:read_int_file(self.batt_capacity_file)
 end
 
--- NOTE: Match the behavior of the NXP ntx_io _Is_USB_plugged ioctl!
+-- NOTE: Match the behavior of the ntx_io _Is_USB_plugged ioctl!
 --       (Otherwise, a device that is fully charged, but still plugged in will no longer be flagged as charging).
 function KoboPowerD:isChargingHW()
     return self:read_str_file(self.is_charging_file) ~= "Discharging"

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -70,7 +70,8 @@ local settingsList = {
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:canToggleGSensor()},
     wifi_on = {category="none", event="InfoWifiOn", title=_("Turn on Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     wifi_off = {category="none", event="InfoWifiOff", title=_("Turn off Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
-    toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle(), separator=true},
+    toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
+    show_network_info = {category="none", event="ShowNetworkInfo", title=_("Show network info"), device=true, separator=true},
     suspend = {category="none", event="SuspendEvent", title=_("Suspend"), device=true},
     exit = {category="none", event="Exit", title=_("Exit KOReader"), device=true},
     restart = {category="none", event="Restart", title=_("Restart KOReader"), device=true, condition=Device:canRestart()},
@@ -234,6 +235,7 @@ local dispatcher_menu_order = {
     "wifi_on",
     "wifi_off",
     "toggle_wifi",
+    "show_network_info",
 
     "show_frontlight_dialog",
     "toggle_frontlight",

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -113,16 +113,32 @@ function NetworkMgr:restoreWifiAsync() end
 -- End of device specific methods
 
 function NetworkMgr:toggleWifiOn(complete_callback, long_press)
+    local toggle_im = InfoMessage:new{
+        text = _("Turning on Wi-Fi…"),
+    }
+    UIManager:show(toggle_im)
+    UIManager:forceRePaint()
+
     self.wifi_was_on = true
     G_reader_settings:makeTrue("wifi_was_on")
     self.wifi_toggle_long_press = long_press
     self:turnOnWifi(complete_callback)
+
+    UIManager:close(toggle_im)
 end
 
 function NetworkMgr:toggleWifiOff(complete_callback)
+    local toggle_im = InfoMessage:new{
+        text = _("Turning off Wi-Fi…"),
+    }
+    UIManager:show(toggle_im)
+    UIManager:forceRePaint()
+
     self.wifi_was_on = false
     G_reader_settings:makeFalse("wifi_was_on")
     self:turnOffWifi(complete_callback)
+
+    UIManager:close(toggle_im)
 end
 
 function NetworkMgr:promptWifiOn(complete_callback, long_press)
@@ -481,16 +497,7 @@ function NetworkMgr:getInfoMenuTable()
         keep_menu_open = true,
         enabled_func = function() return self:isNetworkInfoAvailable() end,
         callback = function()
-            if Device.retrieveNetworkInfo then
-                UIManager:show(InfoMessage:new{
-                    text = Device:retrieveNetworkInfo(),
-                })
-            else
-                UIManager:show(InfoMessage:new{
-                    text = _("Could not retrieve network info."),
-                    timeout = 3,
-                })
-            end
+            UIManager:broadcastEvent(Event:new("ShowNetworkInfo"))
         end
     }
 end

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -53,8 +53,15 @@ function NetworkListener:onInfoWifiOff()
     local complete_callback = function()
         UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
     end
+    local toggle_im = InfoMessage:new{
+        text = _("Turning off Wi-Fi…"),
+    }
+    UIManager:show(toggle_im)
+    UIManager:forceRePaint()
+
     NetworkMgr:turnOffWifi(complete_callback)
 
+    UIManager:close(toggle_im)
     UIManager:show(InfoMessage:new{
         text = _("Wi-Fi off."),
         timeout = 1,

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -13,10 +13,11 @@ local NetworkListener = InputContainer:new{}
 
 function NetworkListener:onToggleWifi()
     if not NetworkMgr:isWifiOn() then
-        UIManager:show(InfoMessage:new{
+        local toggle_im = InfoMessage:new{
             text = _("Turning on Wi-Fi…"),
-            timeout = 1,
-        })
+        }
+        UIManager:show(toggle_im)
+        UIManager:forceRePaint()
 
         -- NB Normal widgets should use NetworkMgr:promptWifiOn()
         -- (or, better yet, the NetworkMgr:beforeWifiAction wrappers: NetworkMgr:runWhenOnline() & co.)
@@ -25,12 +26,21 @@ function NetworkListener:onToggleWifi()
             UIManager:broadcastEvent(Event:new("NetworkConnected"))
         end
         NetworkMgr:turnOnWifi(complete_callback)
+
+        UIManager:close(toggle_im)
     else
         local complete_callback = function()
             UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         end
+        local toggle_im = InfoMessage:new{
+            text = _("Turning off Wi-Fi…"),
+        }
+        UIManager:show(toggle_im)
+        UIManager:forceRePaint()
+
         NetworkMgr:turnOffWifi(complete_callback)
 
+        UIManager:close(toggle_im)
         UIManager:show(InfoMessage:new{
             text = _("Wi-Fi off."),
             timeout = 1,
@@ -53,10 +63,11 @@ end
 
 function NetworkListener:onInfoWifiOn()
     if not NetworkMgr:isOnline() then
-        UIManager:show(InfoMessage:new{
-            text = _("Enabling wifi…"),
-            timeout = 1,
-        })
+        local toggle_im = InfoMessage:new{
+            text = _("Enabling Wi-Fi…"),
+        }
+        UIManager:show(toggle_im)
+        UIManager:forceRePaint()
 
         -- NB Normal widgets should use NetworkMgr:promptWifiOn()
         -- (or, better yet, the NetworkMgr:beforeWifiAction wrappers: NetworkMgr:runWhenOnline() & co.)
@@ -65,6 +76,8 @@ function NetworkListener:onInfoWifiOn()
             UIManager:broadcastEvent(Event:new("NetworkConnected"))
         end
         NetworkMgr:turnOnWifi(complete_callback)
+
+        UIManager:close(toggle_im)
     else
         local info_text
         local current_network = NetworkMgr:getCurrentNetwork()
@@ -209,6 +222,19 @@ end
 -- Also unschedule on suspend (and we happen to also kill Wi-Fi to do so, so resetting the stats is also relevant here)
 function NetworkListener:onSuspend()
     self:onNetworkDisconnected()
+end
+
+function NetworkListener:onShowNetworkInfo()
+    if Device.retrieveNetworkInfo then
+        UIManager:show(InfoMessage:new{
+            text = Device:retrieveNetworkInfo(),
+        })
+    else
+        UIManager:show(InfoMessage:new{
+            text = _("Could not retrieve network info."),
+            timeout = 3,
+        })
+    end
 end
 
 return NetworkListener


### PR DESCRIPTION
There's possibly a weird behavioral quirk on Kobo depending on whether there are system-level saved networks or not, c.f., #8667,
so this ensures that the worst-case scenario gets a hint that something is indeed actually happening ;).

Heavily based on @zwim's implementation in #8667, just took a more defensive approach to refresh races to avoid glitches on mxcfb ;).

(First commit is a random comment cleanup I missed in #9036 ;)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9064)
<!-- Reviewable:end -->
