### PR TITLE
Network: ToggleWiFi: check `isWifiOn` instead of `isConnected`

### DIFF
--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -12,7 +12,7 @@ local T = require("ffi/util").template
 local NetworkListener = InputContainer:new{}
 
 function NetworkListener:onToggleWifi()
-    if not NetworkMgr:isConnected() then
+    if not NetworkMgr:isWifiOn() then
         UIManager:show(InfoMessage:new{
             text = _("Turning on Wi-Fi…"),
             timeout = 1,


### PR DESCRIPTION
Rationale from: https://github.com/koreader/koreader/pull/9064#issuecomment-1116485065

>While we are dealing with WiFi, a slight hijack, on my kindle when the WiFi is on but not connected the ToggleWiFi gesture tries to connect so i have no way of turning it off. For eample I use the gesture to turn it on, then leave the range I can't use it to turn off. I think the more direct approach would be to toggle On -> Off states so if i am disconnected and want to reconnect i can always go Off then On, but I am able to turn it off.

>TLDR: the tooglewifi gesture should check for iswififup not isconnected

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9067)
<!-- Reviewable:end -->
