### PR TITLE
bump crengine: support for inline margin/border/padding

### DIFF
--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -137,12 +137,17 @@ function ReaderPageMap:updateVisibleLabels()
     local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()
     local max_y = Screen:getHeight() - footer_height
     local last_label_bottom_y = 0
+    local on_second_page = false
     for _, page in ipairs(page_labels) do
         local in_left_margin = BD.mirroredUILayout()
         if self.ui.document:getVisiblePageCount() > 1 then
             -- Pages in 2-page mode are not mirrored, so we'll
             -- have to handle any mirroring tweak ourselves
             in_left_margin = page.screen_page == 1
+            if not on_second_page and page.screen_page == 2 then
+                on_second_page = true
+                last_label_bottom_y = 0 -- reset this
+            end
         end
         local max_label_width = in_left_margin and self.max_left_label_width or self.max_right_label_width
         if max_label_width < self.min_label_width then

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1287,6 +1287,14 @@ function CreDocument:buildAlternativeToc()
     self._document:buildAlternativeToc()
 end
 
+function CreDocument:buildSyntheticPageMapIfNoneDocumentProvided(chars_per_synthetic_page)
+    self._document:buildSyntheticPageMapIfNoneDocumentProvided(chars_per_synthetic_page or 1024)
+end
+
+function CreDocument:isPageMapSynthetic()
+    return self._document:isPageMapSynthetic()
+end
+
 function CreDocument:hasPageMap()
     return self._document:hasPageMap()
 end


### PR DESCRIPTION
Includes:
- https://github.com/koreader/crengine/pull/477
  - lvtext: tweak object flags implementation
  - lvtext: rename LTEXT_WORD_IS_OBJECT to LTEXT_WORD_IS_IMAGE
  - lvtext: add LTEXT_OBJECT_IS_EMBEDDED_BLOCK
  - Text: support for inline margin/border/padding.
  Closes #8156.
- https://github.com/koreader/crengine/pull/478
  - PageMap: allow building synthetic pages numbers

cre: add synthetic page map functions. These are not yet used, it will need some thinking to address #9020 (if we really want to) - but the functions are there so we can experiment.

Also:
`ReaderPageMap: fix page labels in 2-columns mode`
Page labels on the right page could have some bad y position (they were never above the last page label on the left page).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9072)
<!-- Reviewable:end -->
