### PR TITLE
Fix docs after Exporter plugin refactor

### DIFF
--- a/doc/config.ld
+++ b/doc/config.ld
@@ -25,7 +25,7 @@ file = {
     '../platform/android/luajit-launcher/assets',
     exclude = {'../base/ffi/sha2.lua',
         '../base/ffi/qrencode.lua',
-        '../plugins/exporter.koplugin/slt2.lua',
+        '../plugins/exporter.koplugin/template/slt2.lua',
         '../plugins/newsdownloader.koplugin/lib/handler.lua',
         '../plugins/newsdownloader.koplugin/lib/xml.lua',
     },


### PR DESCRIPTION
The file was moved in <https://github.com/koreader/koreader/pull/8944> but not changed in the docs config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9075)
<!-- Reviewable:end -->
