### PR TITLE
OTAManager: Check for update -> immediately show hourglass

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -468,13 +468,15 @@ function OTAManager:getOTAMenuTable()
                         alignment = "center",
                         show_icon = false,
                         text = "⌛",
-                        timeout = 1, -- timeout value is necessary, the message will be deleted by next message
                     }
                     UIManager:show(working_im)
                     UIManager:forceRePaint()
+
                     local connect_callback = function()
                         OTAManager:fetchAndProcessUpdate()
                     end
+
+                    UIManager:close(working_im)
                     NetworkMgr:runWhenOnline(connect_callback)
                 end
             },

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -464,6 +464,14 @@ function OTAManager:getOTAMenuTable()
             {
                 text = _("Check for updates"),
                 callback = function()
+                    local working_im = InfoMessage:new{
+                        alignment = "center",
+                        show_icon = false,
+                        text = "⌛",
+                        timeout = 1, -- timeout value is necessary, the message will be deleted by next message
+                    }
+                    UIManager:show(working_im)
+                    UIManager:forceRePaint()
                     local connect_callback = function()
                         OTAManager:fetchAndProcessUpdate()
                     end


### PR DESCRIPTION
After tapping "Check for update" some time nothing seems to happen. No big deal, but a little bit annoying.
This PR adds an IM with just an hourglass, so that the user knows, something is started.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9083)
<!-- Reviewable:end -->
