### PR TITLE
ReaderFooter: Refresh the footer on frontlight state changes issued by the frontlight widget

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2473,8 +2473,12 @@ function ReaderFooter:maybeUpdateFooter()
 end
 
 function ReaderFooter:onFrontlightStateChanged()
-    if self.settings.frontlight then
-        self:maybeUpdateFooter()
+    -- Custom variant of maybeUpdateFooter that *also* whitelists the FL widget...
+    local top_wg = UIManager:getTopWidget()
+    if top_wg == "ReaderUI" or top_wg == "FrontLightWidget" then
+        self:onUpdateFooter(self.view.footer_visible)
+    else
+        self:onUpdateFooter()
     end
 end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -25,6 +25,7 @@ local _ = require("gettext")
 local Screen = Device.screen
 
 local FrontLightWidget = FocusManager:new{
+    name = "FrontLightWidget",
     width = nil,
     height = nil,
     -- This should stay active during natural light configuration


### PR DESCRIPTION
c.f, https://www.mobileread.com/forums/showpost.php?p=4220159&postcount=7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9084)
<!-- Reviewable:end -->
