### PR TITLE
Translations: Don't make brand names translatable

### DIFF
--- a/plugins/calibre.koplugin/_meta.lua
+++ b/plugins/calibre.koplugin/_meta.lua
@@ -1,6 +1,6 @@
 local _ = require("gettext")
 return {
     name = "calibre",
-    fullname = _("Calibre"),
+    fullname = "Calibre", -- don't translate
     description = _([[Integration with calibre. Send documents from calibre library via Wi-Fi and search calibre metadata.]]),
 }

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -75,7 +75,7 @@ end
 function Calibre:addToMainMenu(menu_items)
     menu_items.calibre = {
         -- its name is "calibre", but all our top menu items are uppercase.
-        text = _("Calibre"),
+        text = "Calibre", -- don't translate
         sub_item_table = {
             {
                 text_func = function()

--- a/plugins/exporter.koplugin/target/joplin.lua
+++ b/plugins/exporter.koplugin/target/joplin.lua
@@ -212,7 +212,7 @@ end
 
 function JoplinExporter:getMenuTable()
     return {
-        text = _("Joplin"),
+        text = "Joplin", --don't translate
         checked_func = function() return self:isEnabled() end,
         sub_item_table = {
             {

--- a/plugins/exporter.koplugin/target/readwise.lua
+++ b/plugins/exporter.koplugin/target/readwise.lua
@@ -49,7 +49,7 @@ end
 
 function ReadwiseExporter:getMenuTable()
     return {
-        text = _("Readwise"),
+        text = "Readwise", -- don't translate
         checked_func = function() return self:isEnabled() end,
         sub_item_table = {
             {

--- a/plugins/wallabag.koplugin/_meta.lua
+++ b/plugins/wallabag.koplugin/_meta.lua
@@ -1,6 +1,6 @@
 local _ = require("gettext")
 return {
     name = "wallabag",
-    fullname = _("Wallabag"),
+    fullname = "Wallabag", -- don't translate
     description = _([[Synchronises articles with a Wallabag server.]]),
 }

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -116,7 +116,7 @@ end
 
 function Wallabag:addToMainMenu(menu_items)
     menu_items.wallabag = {
-        text = _("Wallabag"),
+        text = "Wallabag", -- don't translate
         sub_item_table = {
             {
                 text = _("Retrieve new articles from server"),


### PR DESCRIPTION
I realized during translation, that brand names are translatable, but that makes not much sense.

This PR is to ease translators work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9092)
<!-- Reviewable:end -->
