### PR TITLE
PocketBook: Don't break synthetic power input events on suspend

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1292,8 +1292,12 @@ function Input:inhibitInput(toggle)
             self.handleTouchEv = self.voidEv
         end
         if not self._msc_ev_handler then
-            self._msc_ev_handler = self.handleMiscEv
-            self.handleMiscEv = self.voidEv
+            if not self.device:isPocketBook() then
+                -- NOTE: PocketBook is a special snowflake, synthetic Power events are sent as EV_MSC.
+                --       Thankfully, that's all that EV_MSC is used for on that platform.
+                self._msc_ev_handler = self.handleMiscEv
+                self.handleMiscEv = self.voidEv
+            end
         end
         if not self._sdl_ev_handler then
             self._sdl_ev_handler = self.handleSdlEv


### PR DESCRIPTION
Regression since #9036
Fix #9095

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9098)
<!-- Reviewable:end -->
