### PR TITLE
FilemanagerShortcuts: fix crash on adding the first shortcut

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -51,7 +51,7 @@ function FileManagerShortcuts:updateItemTable(select_callback)
     -- try to stay on current page
     local select_number
 
-    if self.fm_bookmark.page and self.fm_bookmark.perpage then
+    if self.fm_bookmark.page and self.fm_bookmark.perpage and self.fm_bookmark.page > 0 then
         select_number = (self.fm_bookmark.page - 1) * self.fm_bookmark.perpage + 1
     end
 


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/9105.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9107)
<!-- Reviewable:end -->
