### PR TITLE
[plugin, statistics] simplify ReaderProgress for better translations

### DIFF
--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -13,6 +13,7 @@ local LineWidget = require("ui/widget/linewidget")
 local ProgressWidget = require("ui/widget/progresswidget")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
+local TextBoxWidget = require("ui/widget/textboxwidget")
 local TitleBar = require("ui/widget/titlebar")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
@@ -391,63 +392,38 @@ function ReaderProgress:genSummaryWeek(width)
         align = "center",
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                padding = Size.padding.default,
-                text = _("Total"),
+            TextBoxWidget:new{
+                alignment = "center",
+                text = _("Total\nPages"),
                 face = self.small_font_face,
+                width = tile_width * 0.95,
             },
         },
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                text = _("Total"),
+            TextBoxWidget:new{
+                alignment = "center",
+                text = _("Total\nTime"),
                 face = self.small_font_face,
+                width = tile_width * 0.95,
             },
         },
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                text = _("Average"),
+            TextBoxWidget:new{
+                alignment = "center",
+                text = _("Average\nPages"),
                 face = self.small_font_face,
+                width = tile_width * 0.95,
             }
         },
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                text = _("Average"),
+            TextBoxWidget:new{
+                alignment = "center",
+                text = _("Average\nTime"),
                 face = self.small_font_face,
-            }
-        }
-    }
-
-    local titles_group = HorizontalGroup:new{
-        align = "center",
-        CenterContainer:new{
-            dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                text = _("Pages"),
-                face = self.small_font_face,
-            },
-        },
-        CenterContainer:new{
-            dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                text = _("Time"),
-                face = self.small_font_face,
-            },
-        },
-        CenterContainer:new{
-            dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                text = _("Pages"),
-                face = self.small_font_face,
-            }
-        },
-        CenterContainer:new{
-            dimen = Geom:new{ w = tile_width, h = tile_height },
-            TextWidget:new{
-                text = _("Time"),
-                face = self.small_font_face,
+                width = tile_width * 0.95,
             }
         }
     }
@@ -493,7 +469,6 @@ function ReaderProgress:genSummaryWeek(width)
         }
     }
     table.insert(statistics_group, total_group)
-    table.insert(statistics_group, titles_group)
     table.insert(statistics_group, span_group)
     table.insert(statistics_group, data_group)
     table.insert(statistics_container, statistics_group)

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -394,7 +394,7 @@ function ReaderProgress:genSummaryWeek(width)
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextBoxWidget:new{
                 alignment = "center",
-                text = _("Total\nPages"),
+                text = _("Total\npages"),
                 face = self.small_font_face,
                 width = tile_width * 0.95,
             },
@@ -403,7 +403,7 @@ function ReaderProgress:genSummaryWeek(width)
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextBoxWidget:new{
                 alignment = "center",
-                text = _("Total\nTime"),
+                text = _("Total\ntime"),
                 face = self.small_font_face,
                 width = tile_width * 0.95,
             },
@@ -412,7 +412,7 @@ function ReaderProgress:genSummaryWeek(width)
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextBoxWidget:new{
                 alignment = "center",
-                text = _("Average\nPages"),
+                text = _("Average\npages"),
                 face = self.small_font_face,
                 width = tile_width * 0.95,
             }
@@ -421,7 +421,7 @@ function ReaderProgress:genSummaryWeek(width)
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextBoxWidget:new{
                 alignment = "center",
-                text = _("Average\nTime"),
+                text = _("Average\ntime"),
                 face = self.small_font_face,
                 width = tile_width * 0.95,
             }


### PR DESCRIPTION
As `readerstatistics` uses some short strings like `Total` and forms some compound information with this, translations will get difficult (at least for German). -> I have learned this week: `Never be clever. ;-)` -> So this PR will be more than clever, it will be smart ;))

![grafik](https://user-images.githubusercontent.com/36999612/169411533-c4773a7f-13b6-4841-a72c-b8d0b8f9e9a5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9113)
<!-- Reviewable:end -->
