### PR TITLE
Clear screen before zsync update starts

### DIFF
--- a/platform/common/spinning_zsync
+++ b/platform/common/spinning_zsync
@@ -19,6 +19,7 @@ else
     ZSYNC_MESSAGE="Computing zsync delta"
 fi
 
+./fbink --clear
 # Small zsync wrapper so we can print its output while it works...
 ./fbink -q -y -7 -pmh "${ZSYNC_MESSAGE} . . ."
 # Clear any potential leftover from the local OTA tarball creation.


### PR DESCRIPTION
Can not test atm. But showing a current book title, while gradually overwriting the page with zsync messages look primitive.
Better to clear the page and only show the progress.

Draft by now, as I am not able to test it atm. 

@NiLuJe : Any expectable problems with that aproach?