### PR TITLE
[Terminal] fix crash on clear screen

### DIFF
--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -350,9 +350,7 @@ function Terminal:generateInputDialog()
             {
             text = "⎚", --clear
             callback = function()
-                self.history = ""
-                self.input = {}
-                self.input_dialog:setInputText("$ ")
+                self:transmit("clear\n") -- this could happen during a running program (e.g. top)
             end,
             },
             {

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -348,12 +348,6 @@ function Terminal:generateInputDialog()
                 end,
             },
             {
-            text = "⎚", --clear
-            callback = function()
-                self:transmit("clear\n") -- this could happen during a running program (e.g. top)
-            end,
-            },
-            {
             text = "⇧",
             callback = function()
                 self.input_widget:upLine()


### PR DESCRIPTION
This fixes https://github.com/koreader/koreader/issues/9108#issuecomment-1132243061

Tapping on clear screen during a running program like top, let's KOReader crash.

Some programs use ansi-sequences to implement a TUI. When messing with the input buffer, there would need to adjust at least some saved char positions (and maybe more). So I decided to implement the `clear screen` just as a shurtcut to send the shell command `clear`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9119)
<!-- Reviewable:end -->
