### PR TITLE
Fix reMarkable crash bug v2022.05: event overwrite with new time module

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -95,7 +95,13 @@ function Remarkable2:adjustTouchEvent(ev, by)
     -- Inject CLOCK_MONOTONIC timestamps at the end of every input frame in order to have consistent gesture detection across input devices.
     -- c.f., #7536
     if ev.type == C.EV_SYN and ev.code == C.SYN_REPORT then
-       ev.time = time.now()
+        now = time.now()
+        sec = math.floor(time.to_s(now))
+        usec = now - time.s(sec)
+        ev.time = {
+            sec = sec,
+            usec = usec
+        }
     end
 end
 

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -95,9 +95,7 @@ function Remarkable2:adjustTouchEvent(ev, by)
     -- Inject CLOCK_MONOTONIC timestamps at the end of every input frame in order to have consistent gesture detection across input devices.
     -- c.f., #7536
     if ev.type == C.EV_SYN and ev.code == C.SYN_REPORT then
-        now = time.now()
-        sec = math.floor(time.to_s(now))
-        usec = now - time.s(sec)
+        local sec, usec = time.split_s_us(time.now())
         ev.time = {
             sec = sec,
             usec = usec


### PR DESCRIPTION
The change from `timeval` to `time` completely broke reMarkable.
`frontend/device/remarkable/device.lua` was using `TimeVal:now()` to manually overwrite event `time` values, as noted in the code comments.
`Input:handleTouchEv` is expecting those event `time` values to be timevals, not integer times.
So as soon as the user touches the screen,
```
./luajit: frontend/ui/time.lua:130: attempt to index local 'tv' (a number value)
stack traceback:
        frontend/ui/time.lua:130: in function 'timeval'
        frontend/device/input.lua:714: in function 'handleTouchEv'
        frontend/device/input.lua:1240: in function 'waitEvent'
        frontend/ui/uimanager.lua:1698: in function 'handleInput'
        frontend/ui/uimanager.lua:1754: in function 'run'
        ./reader.lua:324: in main chunk
        [C]: at 0x000140f1
!!!!
Uh oh, something went awry...
```

I didn't see an existing function in `frontend/ui/time.lua` to directly generate an old-school timeval for the current time, so I used the existing functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9121)
<!-- Reviewable:end -->

Fixes #9122 