### PR TITLE
AutoSuspend: Don't send LeaveStandby events from a zombie plugin instance

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -996,7 +996,7 @@ function ReaderDictionary:showDict(word, results, boxes, link)
         if not results.lookup_cancelled and self._lookup_start_time
             and (time.now() - self._lookup_start_time) > self.quick_dismiss_before_delay then
             -- If the search took more than a few seconds to be done, discard
-            -- queued and coming up input events to avoid a voluntary dismissal
+            -- queued and upcoming input events to avoid a voluntary dismissal
             -- (because the user felt the result would not come) to kill the
             -- result that finally came and is about to be displayed
             Input:inhibitInputUntil(true)

--- a/frontend/device/wakeupmgr.lua
+++ b/frontend/device/wakeupmgr.lua
@@ -88,7 +88,7 @@ with anonymous functions.
 @treturn bool (true if one or more tasks were removed; false otherwise; nil if the task queue is empty).
 --]]
 function WakeupMgr:removeTasks(epoch, callback)
-    if #self._task_queue < 1 then return end
+    if #self._task_queue == 0 then return end
 
     local removed = false
     local reschedule = false
@@ -147,7 +147,7 @@ If necessary, the next upcoming task (if any) is scheduled on exit.
 @treturn bool (true if we were truly woken up by the scheduled wakeup; false otherwise; nil if there weren't any tasks scheduled).
 --]]
 function WakeupMgr:wakeupAction(proximity)
-    if #self._task_queue > 0 then
+    if self._task_queue[1] then
         local task = self._task_queue[1]
         if self:validateWakeupAlarmByProximity(task.epoch, proximity) then
             task.callback()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -554,17 +554,12 @@ function UIManager:schedule(sched_time, action, ...)
     end
 
     local level
-    -- Find the actual public cheduling function in the stack (hairier in debug mode because of how debug guards are implemented).
+    -- Find the actual public cheduling function in the stack...
     for l = 10, 2, -1 do
-        local info = debug.getinfo(l, "Sn")
+        local info = debug.getinfo(l, "n")
         if info then
             if info.name == "scheduleIn" or info.name == "nextTick" or info.name == "tickAfterNext" then
-                if info.source == "@frontend/dbg.lua" then
-                    -- Debug guard shenanigans...
-                    level = l + 1
-                else
-                    level = l
-                end
+                level = l + 1
                 break
             end
         end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -581,8 +581,10 @@ function UIManager:schedule(sched_time, action, ...)
         source = caller,
     })
     self._task_queue_dirty = true
-    logger.dbg("UIManager:schedule: Inserted task", tostring(self._task_queue[p]), "at index", p)
-    logger.dbg(self._task_queue[p])
+    logger.dbg("UIManager:schedule: Inserted task", tostring(self._task_queue[p]), "at index", p, "of", #self._task_queue)
+    logger.dbg("source =", self._task_queue[p].source or "nil")
+    logger.dbg("action =", self._task_queue[p].action or "nil")
+    logger.dbg("time =", self._task_queue[p].time or "nil")
 end
 dbg:guard(UIManager, 'schedule',
     function(self, sched_time, action)
@@ -1177,6 +1179,7 @@ end
 
 function UIManager:_checkTasks()
     self._now = time.now()
+    logger.dbg("UIManager:_checkTasks @", self._now)
     local wait_until = nil
 
     -- Tasks due for execution might themselves schedule more tasks (that might also be immediately due for execution ;)).
@@ -1185,7 +1188,9 @@ function UIManager:_checkTasks()
     while self._task_queue[1] do
         local task_time = self._task_queue[1].time
         logger.dbg("UIManager:_checkTasks checking task", tostring(self._task_queue[1]))
-        logger.dbg(self._task_queue[1])
+        logger.dbg("source =", self._task_queue[1].source or "nil")
+        logger.dbg("action =", self._task_queue[1].action or "nil")
+        logger.dbg("time =", self._task_queue[1].time or "nil")
         if task_time <= self._now then
             logger.dbg("It's due, execute it")
             -- Pop the upcoming task, as it is due for execution...

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -521,11 +521,11 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
     end
 end
 
--- schedule an execution task, task queue is in ascendant order
+-- Schedule an execution task, task queue is in ascending order
 function UIManager:schedule(sched_time, action, ...)
     local p, s, e = 1, 1, #self._task_queue
     if e ~= 0 then
-        -- do a binary insert
+        -- Do a binary insert.
         repeat
             p = math.floor((e + s) / 2) -- Not necessary to use (s + (e -s) / 2) here!
             local p_time = self._task_queue[p].time
@@ -544,8 +544,8 @@ function UIManager:schedule(sched_time, action, ...)
                 end
                 e = p
             else
-                -- for fairness, it's better to make p+1 is strictly less than
-                -- p might want to revisit here in the future
+                -- For fairness, it's better to make sure p+1 is strictly less than p.
+                -- Might want to revisit that in the future.
                 break
             end
         until e < s

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -552,7 +552,7 @@ function UIManager:schedule(sched_time, action, ...)
             end
         until e < s
     end
-    local caller = debug.getinfo(2, "S")
+    local caller = debug.getinfo(5, "S")
     table.insert(self._task_queue, p, {
         time = sched_time,
         action = action,

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1142,7 +1142,7 @@ end
 --]]
 
 function UIManager:getNextTaskTime()
-    if #self._task_queue > 0 then
+    if self._task_queue[1] then
         return self._task_queue[1].time - time:now()
     else
         return nil
@@ -1156,10 +1156,12 @@ function UIManager:_checkTasks()
     -- task.action may schedule other events
     self._task_queue_dirty = false
     while true do
-        if #self._task_queue == 0 then
+        if not self._task_queue[1] then
             -- Nothing to do!
             break
         end
+        -- FIXME: Err, the or makes no sense, UIManager:schedule should ensure time & action fields are sane?
+        --        Either check nothing, or check both time *and* action (which should *never* be nil, unless Greminls, c.f., #9112)
         local task_time = self._task_queue[1].time or 0
         if task_time <= self._now then
             -- remove from table

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1160,8 +1160,7 @@ function UIManager:_checkTasks()
             -- Nothing to do!
             break
         end
-        local next_task = self._task_queue[1]
-        local task_time = next_task.time or 0
+        local task_time = self._task_queue[1].time or 0
         if task_time <= self._now then
             -- remove from table
             local task = table.remove(self._task_queue, 1)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1167,8 +1167,8 @@ function UIManager:_checkTasks()
             local task = table.remove(self._task_queue, 1)
             -- ...so do it now.
             -- NOTE: Said task's action might modify _task_queue.
-            --       To avoid race conditions, we only ever check the head of the queue (c.f., #1758).
-            -- FIXME: Switch to a less confusing reverse for #len loop?
+            --       To avoid race conditions and catch new upcoming tasks during this call,
+            --       we repeatedly check the head of the queue (c.f., #1758).
             task.action(unpack(task.args, 1, task.argc))
         else
             -- As the queue is sorted in ascending order, it's safe to assume all items are currently future tasks.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -582,9 +582,9 @@ function UIManager:schedule(sched_time, action, ...)
     })
     self._task_queue_dirty = true
     logger.dbg("UIManager:schedule: Inserted task", tostring(self._task_queue[p]), "at index", p, "of", #self._task_queue)
-    logger.dbg("source =", self._task_queue[p].source or "nil")
-    logger.dbg("action =", self._task_queue[p].action or "nil")
-    logger.dbg("time =", self._task_queue[p].time or "nil")
+    logger.dbg("\tsource =", self._task_queue[p].source or "nil")
+    logger.dbg("\taction =", self._task_queue[p].action or "nil")
+    logger.dbg("\ttime =", self._task_queue[p].time or "nil")
 end
 dbg:guard(UIManager, 'schedule',
     function(self, sched_time, action)
@@ -1188,9 +1188,9 @@ function UIManager:_checkTasks()
     while self._task_queue[1] do
         local task_time = self._task_queue[1].time
         logger.dbg("UIManager:_checkTasks checking task", tostring(self._task_queue[1]))
-        logger.dbg("source =", self._task_queue[1].source or "nil")
-        logger.dbg("action =", self._task_queue[1].action or "nil")
-        logger.dbg("time =", self._task_queue[1].time or "nil")
+        logger.dbg("\tsource =", self._task_queue[1].source or "nil")
+        logger.dbg("\taction =", self._task_queue[1].action or "nil")
+        logger.dbg("\ttime =", self._task_queue[1].time or "nil")
         if task_time <= self._now then
             logger.dbg("It's due, execute it")
             -- Pop the upcoming task, as it is due for execution...

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -556,10 +556,15 @@ function UIManager:schedule(sched_time, action, ...)
     local level
     -- Find the actual public cheduling function in the stack (hairier in debug mode because of how debug guards are implemented).
     for l = 10, 2, -1 do
-        local info = debug.getinfo(l, "n")
+        local info = debug.getinfo(l, "Sn")
         if info then
             if info.name == "scheduleIn" or info.name == "nextTick" or info.name == "tickAfterNext" then
-                level = l
+                if info.source == "@frontend/dbg.lua" then
+                    -- Debug guard shenanigans...
+                    level = l + 1
+                else
+                    level = l
+                end
                 break
             end
         end
@@ -567,8 +572,8 @@ function UIManager:schedule(sched_time, action, ...)
 
     local caller
     if level then
-        local info = debug.getinfo(level, "Sl")
-        caller = string.format("%s:%d:%d", info.source, info.linedefined, info.currentline)
+        local info = debug.getinfo(level, "Sln")
+        caller = string.format("%s %s:%d declared line %d", info.name, info.source, info.currentline, info.linedefined)
     else
         caller = "N/A"
     end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -527,7 +527,7 @@ function UIManager:schedule(sched_time, action, ...)
     if e ~= 0 then
         -- Do a binary insert.
         repeat
-            p = math.floor((e + s) / 2) -- Not necessary to use (s + (e -s) / 2) here!
+            p = bit.rshift(e + s, 1) -- Not necessary to use (s + (e -s) / 2) here!
             local p_time = self._task_queue[p].time
             if sched_time > p_time then
                 if s == e then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -615,12 +615,12 @@ function UIManager:tickAfterNext(action, ...)
     local va = {...}
     -- We need to keep a reference to this anonymous function, as it is *NOT* quite `action` yet,
     -- and the caller might want to unschedule it early...
-    local delayed_action = function()
+    local action_wrapper = function()
         self:nextTick(action, unpack(va, 1, n))
     end
-    self:nextTick(delayed_action)
+    self:nextTick(action_wrapper)
 
-    return delayed_action
+    return action_wrapper
 end
 --[[
 -- NOTE: This appears to work *nearly* just as well, but does sometimes go too fast (might depend on kernel HZ & NO_HZ settings?)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1166,7 +1166,9 @@ function UIManager:_checkTasks()
             -- Pop the upcoming task, as it is due for execution...
             local task = table.remove(self._task_queue, 1)
             -- ...so do it now.
-            -- NOTE: Said task's action might modify _task_queue. Be wary of race conditions. (?)
+            -- NOTE: Said task's action might modify _task_queue.
+            --       To avoid race conditions, we only ever check the head of the queue (c.f., #1758).
+            -- FIXME: Switch to a less confusing reverse for #len loop?
             task.action(unpack(task.args, 1, task.argc))
         else
             -- As the queue is sorted in ascending order, it's safe to assume all items are currently future tasks.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1156,11 +1156,7 @@ function UIManager:_checkTasks()
     -- Tasks due for execution might themselves schedule more tasks (that might also be immediately due for execution ;)).
     -- Flipping this switch ensures we'll consume all such tasks *before* yielding to input polling.
     self._task_queue_dirty = false
-    while true do
-        if not self._task_queue[1] then
-            -- Nothing to do!
-            break
-        end
+    while self._task_queue[1] do
         local task_time = self._task_queue[1].time
         if task_time <= self._now then
             -- Pop the upcoming task, as it is due for execution...

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -661,6 +661,7 @@ UIManager:scheduleIn(10.5, self.anonymousFunction)
 UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
+    logger.dbg("UIManager:unschedule:", tostring(action))
     local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then
@@ -668,6 +669,7 @@ function UIManager:unschedule(action)
             removed = true
         end
     end
+    logger.dbg(removed)
     return removed
 end
 dbg:guard(UIManager, 'unschedule',

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -186,7 +186,7 @@ function ConfirmBox:onShow()
         return "ui", self[1][1].dimen
     end)
     if self.flush_events_on_show then
-        -- Discard queued and coming up input events to avoid accidental dismissal
+        -- Discard queued and upcoming input events to avoid accidental dismissal
         Input:inhibitInputUntil(true)
     end
 end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -234,7 +234,7 @@ function InfoMessage:onShow()
         return "ui", self[1][1].dimen
     end)
     if self.flush_events_on_show then
-        -- Discard queued and coming up input events to avoid accidental dismissal
+        -- Discard queued and upcoming input events to avoid accidental dismissal
         Input:inhibitInputUntil(true)
     end
     -- schedule us to close ourself if timeout provided

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -33,11 +33,11 @@ local AutoSuspend = WidgetContainer:new{
     auto_suspend_timeout_seconds = default_auto_suspend_timeout_seconds,
     auto_standby_timeout_seconds = default_auto_standby_timeout_seconds,
     last_action_time = 0,
-    is_standby_scheduled = false,
+    is_standby_scheduled = nil,
     task = nil,
     standby_task = nil,
     leave_standby_task = nil,
-    going_to_suspend = false,
+    going_to_suspend = nil,
 }
 
 function AutoSuspend:_enabledStandby()
@@ -134,6 +134,10 @@ function AutoSuspend:init()
     self.auto_standby_timeout_seconds = G_reader_settings:readSetting("auto_standby_timeout_seconds", -1)
 
     if Device:isPocketBook() and not Device:canSuspend() then return end
+
+    -- We only want those to exist as *instance* members
+    self.is_standby_scheduled = false
+    self.going_to_suspend = false
 
     UIManager.event_hook:registerWidget("InputEvent", self)
     -- We need an instance-specific function reference to schedule, because in some rare cases,

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -185,7 +185,6 @@ function AutoSuspend:onCloseWidget()
 
     self:_unschedule_standby()
     self.standby_task = nil
-    self.wrapped_leave_standby_task = nil
     self.leave_standby_task = nil
 end
 
@@ -208,6 +207,7 @@ function AutoSuspend:_unschedule_standby()
     if self.wrapped_leave_standby_task then
         logger.dbg("AutoSuspend: unschedule leave standby task wrapper")
         UIManager:unschedule(self.wrapped_leave_standby_task)
+        self.wrapped_leave_standby_task = nil
     end
 
     if self.leave_standby_task then


### PR DESCRIPTION
Long story short: the LeaveStandby event is sent via `tickAfterNext`, so if we tear down the plugin right after calling it (in this case, that means that the very input event that wakes the device up from suspend is one that kills ReaderUI or FileManager), what's in UIManager's task queue isn't the actual function, but the anonymous nextTick wrapper constructed by `tickAfterNext` (c.f., 
https://github.com/koreader/koreader/issues/9112#issuecomment-1133999385).

Tweak `UIManager:tickAfterNext` to return a reference to said wrapper, so that we can store it and unschedule that one, too, in `AutoSuspend:onCloseWidget`.

Fix #9112 (many thanks to [@boredhominid](https://github.com/boredhominid) for his help in finding a repro for this ;)).
Re: #8638, as the extra debugging facilities (i.e., ebb81b98451e2a8f54c46f51e861c19fdfb40499) added during testing might help pinpoint the root issue for that one, too.

Also includes a minor simplification to `UIManager:_checkTasks`, and various other task queue related codepaths (e.g., `WakeupMgr`) ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9124)
<!-- Reviewable:end -->
