### PR TITLE
SpinWidget, DoubleSpinWidget: add units to bottom menu

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -335,19 +335,25 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                 more_options = true,
                 more_options_param = {
                     value_hold_step = 20,
+                    unit = C_("Resolution", "dpi"),
                 },
                 toggle = {_("off"), "48", "96¹’¹", "167", "212", "300"},
                 values = {0, 48, 96, 167, 212, 300},
                 default_value = 96,
                 args = {0, 48, 96, 167, 212, 300},
                 event = "SetRenderDPI",
-                name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Sets the DPI used to scale absolute CSS units and images:
 - off: ignore absolute units (old engine behavior).
 - 96¹’¹: at 96 DPI, 1 CSS pixel = 1 screen pixel and images are rendered at their original dimensions.
 - other values scale CSS absolute units and images by a factor (300 DPI = x3, 48 DPI = x0.5)
 Using your device's actual DPI will ensure 1 cm in CSS actually translates to 1 cm on screen.
 Note that your selected font size is not affected by this setting.]]),
+                name_text_hold_callback = optionsutil.showValues,
+                name_text_true_values = true,
+                show_true_value_func = function(val) -- add "dpi"
+                    return val ~= 0 and string.format("%d dpi", val) or _("off")
+                end,
+
             },
             {
                 name = "line_spacing",
@@ -376,6 +382,7 @@ Note that your selected font size is not affected by this setting.]]),
                   value_max = 300,
                   value_step = 1,
                   value_hold_step = 5,
+                  unit = "%",
                 },
                 event = "SetLineSpace",
                 args = {
@@ -394,10 +401,8 @@ Note that your selected font size is not affected by this setting.]]),
                     DCREREADER_CONFIG_LINE_SPACE_PERCENT_XX_LARGE,
                 },
                 name_text_hold_callback = optionsutil.showValues,
-                -- used by showValues
-                name_text_true_values = true,
                 show_true_value_func = function(val) -- add "%"
-                    return string.format("%d%%", val)
+                    return string.format("%d\xE2\x80\xAF%%", val) -- use Narrow No-Break space here
                 end,
             },
         }
@@ -424,7 +429,7 @@ Note that your selected font size is not affected by this setting.]]),
                 item_text = not Device:isTouchDevice() and {_("decrease"), _("increase")} or nil,
                 more_options = true,
                 more_options_param = {
-                    value_min = 12,
+                    value_min = 7,
                     value_max = 255,
                     value_step = 0.5,
                     precision = "%.1f",
@@ -455,16 +460,17 @@ Note that your selected font size is not affected by this setting.]]),
                     info_text = _([[Set word spacing percentages:
 - how much to scale the width of each space character from its regular width,
 - by how much some of them can then be reduced to make more words fit on a line.]]),
-                    left_text = _("Scaling %"),
+                    left_text = _("Scaling"),
                     left_min = 10,
                     left_max = 500,
                     left_step = 1,
                     left_hold_step = 10,
-                    right_text = _("Reduction %"),
+                    right_text = _("Reduction"),
                     right_min = 25,
                     right_max = 100,
                     right_step = 1,
                     right_hold_step = 10,
+                    unit = "%",
                     event = "SetWordSpacing",
                 },
                 toggle = {C_("Word spacing", "small"), C_("Word spacing", "medium"), C_("Word spacing", "large")},
@@ -484,7 +490,7 @@ Note that your selected font size is not affected by this setting.]]),
                 name_text_hold_callback = optionsutil.showValues,
                 name_text_true_values = true,
                 show_true_value_func = function(val)
-                    return string.format("%d%%, %d%%", val[1], val[2])
+                    return string.format("%d\xE2\x80\xAF%%, %d\xE2\x80\xAF%%", val[1], val[2]) -- use Narrow Now-Break space here
                 end,
             },
             {
@@ -496,9 +502,10 @@ Note that your selected font size is not affected by this setting.]]),
                     value_max = 20,
                     value_step = 1,
                     value_hold_step = 4,
+                    unit = "%",
                     name = "word_expansion",
                     name_text = _("Max word expansion"),
-                    info_text = _([[Set max word expansion as a % of the font size.]]),
+                    info_text = _([[Set max word expansion as a percentage of the font size.]]),
                     event = "SetWordExpansion",
                 },
                 toggle = {C_("Word expansion", "none"), C_("Word expansion", "some"), C_("Word expansion", "more")},
@@ -518,7 +525,7 @@ Note that your selected font size is not affected by this setting.]]),
                 name_text_hold_callback = optionsutil.showValues,
                 name_text_true_values = true,
                 show_true_value_func = function(val)
-                    return string.format("%d%%", val)
+                    return string.format("%d\xE2\x80\xAF%%", val) -- use Narrow No-Break space here
                 end,
             },
         }

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -351,7 +351,10 @@ Note that your selected font size is not affected by this setting.]]),
                 name_text_hold_callback = optionsutil.showValues,
                 name_text_true_values = true,
                 show_true_value_func = function(val) -- add "dpi"
-                    return val ~= 0 and string.format("%d dpi", val) or _("off")
+                    if val == 96 then
+                        val = "96¹’¹"
+                    end
+                    return val ~= 0 and string.format("%s dpi", val) or _("off")
                 end,
 
             },

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -106,9 +106,13 @@ function optionsutil.showValues(configurable, option, prefix, document)
     local text
     local name_text = option.name_text_func
                       and option.name_text_func(configurable)
-                       or option.name_text
+                      or option.name_text
     if option.name_text_true_values and option.toggle and option.values then
-        if value_default then
+        local nb_current, nb_default = tonumber(current), tonumber(default)
+        if nb_current == nil or nb_default == nil then
+            text = T(_("%1\n%2\nCurrent value: %3\nDefault value: %4"), name_text, help_text,
+                                            value_current or current, value_default or default)
+        elseif value_default then
             text = T(_("%1\n%2\nCurrent value: %3 (%4)\nDefault value: %5 (%6)"), name_text, help_text,
                                             current, value_current, default, value_default)
         else

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1171,6 +1171,8 @@ function ConfigDialog:onConfigMoreChoose(values, name, event, args, name_text, m
                     right_step = more_options_param.right_step,
                     right_hold_step = more_options_param.right_hold_step,
                     keep_shown_on_apply = true,
+                    unit = more_options_param.unit,
+                    precision = more_options_param.precision,
                     close_callback = function()
                         if when_applied_callback then
                             when_applied_callback()
@@ -1264,7 +1266,8 @@ function ConfigDialog:onConfigMoreChoose(values, name, event, args, name_text, m
                     value_step = more_options_param.value_step or 1,
                     value_hold_step = value_hold_step,
                     value_max = more_options_param.value_max or values[#values],
-                    precision = more_options_param.precision or "%02d",
+                    unit = more_options_param.unit,
+                    precision = more_options_param.precision,
                     keep_shown_on_apply = true,
                     close_callback = function()
                         if when_applied_callback then


### PR DESCRIPTION
A follow up to #9046 to add some units to the bottom menu.

Don't worry, after this PR regarding units there will only be one follow up with the font size. (But it's a little bigger. It will allow to switch the text scaling from `pt` (aka dpt) to `KOScale™`)

For that  future PR, I have to fiddle out what the `name_text_true_values` option does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9126)
<!-- Reviewable:end -->
