### PR TITLE
Cloudstorage WebDAV: more fix slash in server address

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -122,7 +122,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path)
             local is_not_collection = item:find("<[^:]*:resourcetype/>") or
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
 
-            local item_path = path == "" and item_name or path .. "/" .. item_name
+            local item_path = (path == "" and has_trailing_slash) and item_name or path .. "/" .. item_name
             if item:find("<[^:]*:collection/>") then
                 item_name = item_name .. "/"
                 if not is_current_dir then


### PR DESCRIPTION
Honor server addresses with or without trailing slash.
Regression since https://github.com/koreader/koreader/pull/9061. Closes https://github.com/koreader/koreader/issues/9125.