### PR TITLE
Dropbox: Add support for refresh tokens

### DIFF
--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -92,17 +92,18 @@ function DropBox:createFolder(url, password, folder_name, callback_close)
 end
 
 function DropBox:config(item, callback)
-    local text_info = "How to generate Access Token:\n"..
+    local text_info = "How to link your Dropbox account:\n"..
         "1. Open the following URL in your Browser, and log in using your account: https://www.dropbox.com/developers/apps.\n"..
         "2. Click on >>Create App<<, then select >>Dropbox API app<<.\n"..
         "3. Now go on with the configuration, choosing the app permissions and access restrictions to your DropBox folder.\n"..
         "4. Enter the >>App Name<< that you prefer (e.g. KOReader).\n"..
         "5. Now, click on the >>Create App<< button.\n" ..
-        "6. When your new App is successfully created, please click on the Generate button.\n"..
-        "7. Under the 'Generated access token' section, then enter code in Dropbox token field."
+        "6. Generate a refresh token by following the instructions in https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens\n"..
+        "7. Enter the refresh token in the Dropbox refresh token field.\n" ..
+        "8. On a new line, enter the app's key, a colon and the app's secret encoded with base64 in the Dropbox refresh token field."
     local hint_top = _("Your Dropbox name")
     local text_top = ""
-    local hint_bottom = _("Dropbox token\n\n\n\n")
+    local hint_bottom = _("Dropbox refresh token \\n\nApp Key:App Secret in base64 encoding\n\n\n\n")
     local text_bottom = ""
     local title
     local text_button_right = _("Add")

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -92,15 +92,15 @@ function DropBox:createFolder(url, password, folder_name, callback_close)
 end
 
 function DropBox:config(item, callback)
-    local text_info = "How to link your Dropbox account:\n"..
-        "1. Open the following URL in your Browser, and log in using your account: https://www.dropbox.com/developers/apps.\n"..
-        "2. Click on >>Create App<<, then select >>Dropbox API app<<.\n"..
-        "3. Now go on with the configuration, choosing the app permissions and access restrictions to your DropBox folder.\n"..
-        "4. Enter the >>App Name<< that you prefer (e.g. KOReader).\n"..
-        "5. Now, click on the >>Create App<< button.\n" ..
-        "6. Generate a refresh token by following the instructions in https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens\n"..
-        "7. Enter the refresh token in the Dropbox refresh token field.\n" ..
-        "8. On a new line, enter the app's key, a colon and the app's secret encoded with base64 in the Dropbox refresh token field."
+    local text_info = _([[How to link your Dropbox account:
+1. Open the following URL in your Browser, and log in using your account: https://www.dropbox.com/developers/apps.
+2. Click on >>Create App<<, then select >>Dropbox API app<<.
+3. Now go on with the configuration, choosing the app permissions and access restrictions to your DropBox folder.
+4. Enter the >>App Name<< that you prefer (e.g. KOReader).
+5. Now, click on the >>Create App<< button.
+6. Generate a refresh token by following the instructions in https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens.
+7. Enter the refresh token in the Dropbox refresh token field.
+8. On a new line, enter the app's key, a colon and the app's secret encoded with base64 in the Dropbox refresh token field.]])
     local hint_top = _("Your Dropbox name")
     local text_top = ""
     local hint_bottom = _("Dropbox refresh token \\n\nApp Key:App Secret in base64 encoding\n\n\n\n")


### PR DESCRIPTION
Dropbox dropped support for long-lived access tokens, keeping only
short-lived ones when you use the "Generate token" method, meaning that
the token only works for a few hours.

This commit introduces support for refresh tokens which allow for
generating short-lived tokens dynamically, essentially having the same
functionality as a long-lived token.

The downside is that in the "Dropbox token" field in the settings you
now have to both add a refresh token (which isn't trivial to generate https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens),
as well as the app's key, a colon and the app's secret (all this in
base64 encoding).

In the future the refresh-token support would probably be better if it
didnt generate a new short-lived token for each request (which this
implementation does), and instead cached them and just generated new
ones when they expired.

Fixes #8571

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9131)
<!-- Reviewable:end -->
