### PR TITLE
[feat] vocabulary builder

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -208,7 +208,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
     menu_items.dictionary_lookup_history = {
         text = _("Vocabulary Builder"),
         enabled_func = function()
-            return VocabularyBuilder.has_items
+            return VocabularyBuilder:hasItems()
         end,
         callback = function()
             VocabularyBuilder:showUI(function(item) self:onVocabularyBuilderLookupWord(item) end)
@@ -266,7 +266,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
             {
                 text = _("Clean dictionary lookup history"),
                 enabled_func = function()
-                    return VocabularyBuilder.has_items
+                    return VocabularyBuilder:hasItems()
                 end,
                 keep_menu_open = true,
                 callback = function(touchmenu_instance)

--- a/frontend/apps/reader/modules/readervocabularybuilder.lua
+++ b/frontend/apps/reader/modules/readervocabularybuilder.lua
@@ -145,7 +145,7 @@ function VocabularyBuilder:showUI(onSelect)
     conn:close()
     
 
-    local vocab_widget = VocabBuilderWidget:new{
+    self.vocab_widget = VocabBuilderWidget:new{
         title = _("Vocabulary Builder"),
         item_table = vocab_items,
         callback = function()
@@ -153,7 +153,7 @@ function VocabularyBuilder:showUI(onSelect)
             changed_callback()
         end
     }
-    UIManager:show(vocab_widget)
+    UIManager:show(self.vocab_widget)
 end
 
 
@@ -221,6 +221,14 @@ end
 function VocabularyBuilder:reset()
     local conn = SQ3.open(db_location)
     conn:exec("DELETE * FROM vocabulary;")
+end
+
+function VocabularyBuilder:gotItFromDict(word)
+    self.vocab_widget:gotItFromDict(word)
+end
+
+function VocabularyBuilder:forgotFromDict(word)
+    self.vocab_widget:forgotFromDict(word)
 end
 
 VocabularyBuilder:init()

--- a/frontend/apps/reader/modules/readervocabularybuilder.lua
+++ b/frontend/apps/reader/modules/readervocabularybuilder.lua
@@ -140,11 +140,9 @@ function VocabularyBuilder:_select_items(items, start_idx)
     local current_time = os.time()
 
     for i = 1, #results.word do
-        local reviewable = results.due_time[i] < current_time
         item = items[start_idx+i-1]
         if item then
             item.word = results.word[i]
-            item.reviewable = reviewable
             item.review_count = tonumber(results.review_count[i])
             item.book_title = results.book_title[i]
             item.create_time = tonumber( results.create_time[i])
@@ -251,7 +249,8 @@ end
 
 function VocabularyBuilder:reset()
     local conn = SQ3.open(db_location)
-    conn:exec("DELETE * FROM vocabulary;")
+    conn:exec("DELETE FROM vocabulary;")
+    self.count = 0
 end
 
 function VocabularyBuilder:gotItFromDict(word)

--- a/frontend/apps/reader/modules/readervocabularybuilder.lua
+++ b/frontend/apps/reader/modules/readervocabularybuilder.lua
@@ -1,0 +1,228 @@
+
+local DataStorage = require("datastorage")
+local Device = require("device")
+-- local ReaderDictionary = require("apps/reader/modules/readerdictionary")
+local SQ3 = require("lua-ljsqlite3/init")
+local logger = require("logger")
+local LuaData = require("luadata")
+local VocabBuilderWidget = require("frontend/ui/widget/vocabularybuilderwidget")
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+
+
+local db_location = DataStorage:getSettingsDir() .. "/vocabulary_builder.sqlite3"
+
+local DB_SCHEMA_VERSION = 20220522
+local VOCABULARY_DB_SCHEMA = [[
+    -- To store looked up words
+    CREATE TABLE IF NOT EXISTS "vocabulary" (
+        "word"	        TEXT NOT NULL UNIQUE,
+        "book_title"	TEXT,
+        "create_time"	REAL NOT NULL,
+        "review_time"	REAL,
+        "due_time"      REAL NOT NULL,
+        "review_count"	REAL NOT NULL DEFAULT 0,
+        PRIMARY KEY("word")
+    );
+    
+    CREATE INDEX IF NOT EXISTS due_time_index ON vocabulary(due_time);
+]]
+-- CREATE INDEX IF NOT EXISTS create_time_index ON vocabulary(create_time);
+-- CREATE INDEX IF NOT EXISTS review_time_index ON vocabulary(review_time);
+
+local VocabularyBuilder = {}
+
+function VocabularyBuilder:init()
+    VocabularyBuilder:createDB()
+    local conn = SQ3.open(db_location)
+    local count = conn:rowexec("SELECT count(0) FROM vocabulary;")
+    self["has_items"] = count > 0
+end
+
+function VocabularyBuilder:createDB()
+    local db_conn = SQ3.open(db_location)
+    -- Make it WAL, if possible
+    if Device:canUseWAL() then
+        db_conn:exec("PRAGMA journal_mode=WAL;")
+    else
+        db_conn:exec("PRAGMA journal_mode=TRUNCATE;")
+    end
+    -- Create db
+    db_conn:exec(VOCABULARY_DB_SCHEMA)
+    -- Check version
+    local db_version = tonumber(db_conn:rowexec("PRAGMA user_version;"))        
+    if db_version < DB_SCHEMA_VERSION then
+        if db_version == 0 then
+            self:insertLookupData(db_conn)
+        end
+        -- Update version
+        db_conn:exec(string.format("PRAGMA user_version=%d;", DB_SCHEMA_VERSION))
+
+    end
+    db_conn:close()
+end
+
+function VocabularyBuilder:insertLookupData(db_conn)
+    local file_path = DataStorage:getSettingsDir() .. "/lookup_history.lua"
+
+    local lookup_history = LuaData:open(file_path, { name = "LookupHistory" })
+    if lookup_history:has("lookup_history") then
+        local lookup_history_table = lookup_history:readSetting("lookup_history")
+        local words = {}
+        -- if not lookup_history_table return
+        for i = #lookup_history_table, 1, -1 do
+            local value = lookup_history_table[i]
+            if not words[value.word] then
+                local insert_sql = [[INSERT OR REPLACE INTO vocabulary
+                            (word, book_title, create_time, due_time) values
+                            (?, ?, ?, ?);
+                            ]]
+                local stmt = db_conn:prepare(insert_sql)
+
+                stmt:bind(value.word, value.book_title, value.time, value.time + 5*60)
+                stmt:step()
+                stmt:clearbind():reset()
+
+                words[value.word] = true
+            end
+        end
+        
+
+        -- os.remove(file_path)
+    end
+end
+
+function VocabularyBuilder:getDuration(seconds)
+    local abs = math.abs(seconds)
+    local readable_time
+    if abs < 60 then
+        readable_time = "0m"
+    elseif abs < 3600 then
+        readable_time = string.format("%dm", abs/60)
+    elseif abs < 3600 * 24 then
+        readable_time = string.format("%dh", abs/3600)
+    else
+        readable_time = string.format("%dd", abs/3600/24)
+    end
+
+    if seconds < 0 then
+        return " " .. readable_time
+    else
+        return readable_time
+    end
+end
+
+function VocabularyBuilder:showUI(onSelect)
+    local conn = SQ3.open(db_location)
+
+    local results = conn:exec("SELECT * FROM vocabulary ORDER BY due_time;")
+    local current_time = os.time()
+
+    local vocab_items = {}
+    for i = 1, #results.word, 1 do
+        local reviewable = results.due_time[i] < current_time
+
+        table.insert(vocab_items, {
+            word = results.word[i],
+            reviewable = reviewable,
+            review_count = results.review_count[i],
+            book_title = results.book_title[i],
+            create_time = results.create_time[i],
+            review_time = results.review_time[i],
+            elapse_time = results.review_count[i] < 8 and self:getDuration(current_time - results.due_time[i]) .. " | " or "",
+            got_it_callback = function(item)
+                VocabularyBuilder:gotOrForgot(item, true)
+            end,
+            forgot_callback = function(item)
+                VocabularyBuilder:gotOrForgot(item, false)
+            end,
+            remove_callback = function(item)
+                VocabularyBuilder:remove(item)
+            end,
+            callback = onSelect
+        })
+    end
+    conn:close()
+    
+
+    local vocab_widget = VocabBuilderWidget:new{
+        title = _("Vocabulary Builder"),
+        item_table = vocab_items,
+        callback = function()
+            UIManager:setDirty(nil, "ui")
+            changed_callback()
+        end
+    }
+    UIManager:show(vocab_widget)
+end
+
+
+function VocabularyBuilder:gotOrForgot(item, isGot) 
+    local conn = SQ3.open(db_location)
+    local current_time = os.time()
+
+    local due_time
+    local target_count = math.min(math.max(item.review_count + (isGot and 1 or -1), 0), 8)
+    if target_count == 0 then
+        due_time = current_time + 5 * 60
+    elseif target_count == 1 then
+        due_time = current_time + 30 * 60
+    elseif target_count == 2 then
+        due_time = current_time + 12 * 3600
+    elseif target_count == 3 then
+        due_time = current_time + 24 * 3600
+    elseif target_count == 4 then
+        due_time = current_time + 48 * 3600
+    elseif target_count == 5 then
+        due_time = current_time + 96 * 3600
+    elseif target_count == 6 then
+        due_time = current_time + 24 * 7 * 3600
+    elseif target_count == 7 then
+        due_time = current_time + 24 * 15 * 3600
+    else
+        due_time = current_time + 25 * 30 * 3600
+    end
+    
+    local sql = string.format([[UPDATE vocabulary 
+    SET review_count = %d,
+        review_time = %d,
+        due_time = %d
+    WHERE word = '%s';]], target_count, current_time, due_time, item.word)
+
+    local x = conn:exec(sql)
+
+    if x == nil then
+        item.review_count = target_count
+        item.reviewable = false
+        item.elapse_time = target_count < 8 and self:getDuration(current_time - due_time) .. " | " or ""
+    end
+    conn:close()
+end
+
+function VocabularyBuilder:insertOrUpdate(entry) 
+    local conn = SQ3.open(db_location)
+    local current_time = os.time()
+
+    conn:exec(string.format([[INSERT INTO vocabulary (word, book_title, create_time, due_time) 
+                    VALUES ('%s', '%s', %d, %d)
+                    ON CONFLICT(word) DO UPDATE SET book_title = excluded.book_title,
+                        create_time = excluded.create_time,
+                        review_count = MAX(review_count-1, 0),
+                        due_time = %d;
+              ]], entry.word, entry.book_title, entry.time, entry.time+300, entry.time+300))
+    conn:close()
+end
+
+function VocabularyBuilder:remove(item)
+    local conn = SQ3.open(db_location)
+    conn:exec(string.format("DELETE FROM vocabulary WHERE word = '%s' ;", item.word))
+end
+
+function VocabularyBuilder:reset()
+    local conn = SQ3.open(db_location)
+    conn:exec("DELETE * FROM vocabulary;")
+end
+
+VocabularyBuilder:init()
+
+return VocabularyBuilder

--- a/frontend/apps/reader/modules/readervocabularybuilder.lua
+++ b/frontend/apps/reader/modules/readervocabularybuilder.lua
@@ -98,8 +98,6 @@ function VocabularyBuilder:insertLookupData(db_conn)
             end
         end
         
-
-        -- os.remove(file_path)
     end
 end
 
@@ -251,6 +249,8 @@ function VocabularyBuilder:reset()
     local conn = SQ3.open(db_location)
     conn:exec("DELETE FROM vocabulary;")
     self.count = 0
+
+    os.remove(DataStorage:getSettingsDir() .. "/lookup_history.lua")
 end
 
 function VocabularyBuilder:gotItFromDict(word)

--- a/frontend/ui/widget/vocabularybuilderwidget.lua
+++ b/frontend/ui/widget/vocabularybuilderwidget.lua
@@ -27,7 +27,6 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local HorizontalSpan = require("ui/widget/horizontalspan")
 local MovableContainer = require("ui/widget/container/movablecontainer")
 local Screen = Device.screen
-local logger = require("logger")
 local util = require("util")
 local T = require("ffi/util").template
 local _ = require("gettext")
@@ -39,6 +38,7 @@ local subtitle_face = Font:getFace("cfont", 12)
 local subtitle_italic_face = Font:getFace("NotoSans-Italic.ttf", 12)
 local nerd_face = Font:getFace("smallinfofont")
 local subtitle_color = Blitbuffer.Color8(0x88)
+local dim_color = Blitbuffer.Color8(0x55)
 -- More Info
 
 function getDialogWidth()
@@ -204,7 +204,7 @@ local point_widget = TextWidget:new{
     text = " • ",
     bold = true,
     face = Font:getFace("cfont", 24),
-    fgcolor = Blitbuffer.Color8(0x66)
+    fgcolor = dim_color
 }
 
 local point_widget_height = point_widget:getSize().h
@@ -269,28 +269,19 @@ function VocabItemWidget:initItemWidget()
 
         local forgot_button = Button:new{
             text = _("Forgot"),
-            callback = nil,
-            background = Blitbuffer.COLOR_DARK_GRAY,
-            radius = 5,
             width = review_button_width,
-            bordersize = 0,
             callback = function() 
                 self:onForgot()
             end,
         }
-        forgot_button.label_widget.fgcolor = Blitbuffer.COLOR_WHITE
     
         local got_it_button = Button:new{
             text = _("Got it"),
             callback = function() 
                 self:onGotIt()
             end,
-            background = Blitbuffer.COLOR_DARK_GRAY,
-            radius = 5,
             width = review_button_width,
-            bordersize = 0
         }
-        got_it_button.label_widget.fgcolor = Blitbuffer.COLOR_WHITE
 
         right_widget = HorizontalGroup:new{
             dimen = Geom:new{ w = 0, h = self.height },
@@ -371,7 +362,7 @@ function VocabItemWidget:initItemWidget()
                             text = self .item.word,
                             face = word_face,
                             bold = true,
-                            fgcolor = self .item.is_dim and Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_BLACK
+                            fgcolor = self .item.is_dim and dim_color or Blitbuffer.COLOR_BLACK
                         }
                     },
                     LeftContainer:new{
@@ -648,21 +639,19 @@ function VocabularyBuilderWidget:init()
         close_callback = function() self:onClose() end,
         show_parent = self,
     }
-    -- self.title_bar.title_widget.fgcolor = Blitbuffer.COLOR_DARK_GRAY
+
     -- setup main content
     self.item_margin = math.floor(self.item_height / 8)
     local line_height = self.item_height + self.item_margin
     local content_height = self.dimen.h - self.title_bar:getHeight() - vertical_footer:getSize().h - padding
     self.items_per_page = math.floor(content_height / line_height)
+    self.item_margin = self.item_margin + math.floor((content_height - self.items_per_page * line_height ) / self.items_per_page)
+    line_height = self.item_height + self.item_margin
     self.pages = math.ceil(#self.item_table / self.items_per_page)
     self.main_content = VerticalGroup:new{}
 
     self:_populateItems()
 
-    local padding_below_title = 0
-    if self.pages > 1 then -- center content vertically
-        padding_below_title = (content_height - self.items_per_page * line_height) / 2
-    end
     local frame_content = FrameContainer:new{
         height = self.dimen.h,
         padding = 0,
@@ -670,7 +659,6 @@ function VocabularyBuilderWidget:init()
         background = Blitbuffer.COLOR_WHITE,
         VerticalGroup:new{
             self.title_bar,
-            VerticalSpan:new{ width = padding_below_title },
             self.main_content,
         },
     }
@@ -725,7 +713,7 @@ function VocabularyBuilderWidget:moveItem(diff)
         self.marked = move_to
         self:_populateItems()
     end
-end
+end 
 
 function VocabularyBuilderWidget:removeAt(index)
     if index > #self.item_table then return end

--- a/frontend/ui/widget/vocabularybuilderwidget.lua
+++ b/frontend/ui/widget/vocabularybuilderwidget.lua
@@ -254,7 +254,7 @@ function VocabItemWidget:init()
     }
 
     self.v_spacer = VerticalSpan:new{width = (self.height - word_height - subtitle_height)/2}
-    self.point_v_spacer = VerticalSpan:new{width = (self.v_spacer.width + word_height/2) - point_widget_height/2 + Screen:scaleBySize(1) }
+    self.point_v_spacer = VerticalSpan:new{width = (self.v_spacer.width + word_height/2) - point_widget_height/2 }
     self.margin_span = HorizontalSpan:new{ width = Size.padding.large }
     self:initItemWidget()
 end
@@ -771,7 +771,7 @@ function VocabularyBuilderWidget:_populateItems()
     end
 
     for idx = idx_offset + 1, page_last do
-        table.insert(self.main_content, VerticalSpan:new{ width = self.item_margin })
+        table.insert(self.main_content, VerticalSpan:new{ width = self.item_margin / (idx == idx_offset+1 and 2 or 1) })
         local invert_status = false
         if idx == self.marked then
             invert_status = true

--- a/frontend/ui/widget/vocabularybuilderwidget.lua
+++ b/frontend/ui/widget/vocabularybuilderwidget.lua
@@ -320,7 +320,7 @@ function VocabItemWidget:initItemWidget()
                 table.insert(right_widget, star)
             end
         else
-            star:close()
+            star:free()
             right_widget = HorizontalGroup:new{
                 dimen = Geom:new{w=0, h = self.height},
                  HorizontalSpan:new {width = Size.padding.default }
@@ -728,7 +728,6 @@ function VocabularyBuilderWidget:moveItem(diff)
 end
 
 function VocabularyBuilderWidget:removeAt(index)
-    logger.err("------------- index", index, self.item_table)
     if index > #self.item_table then return end
     table.remove(self.item_table, index)
     self.show_page = math.ceil(math.min(index, #self.item_table) / self.items_per_page)

--- a/frontend/ui/widget/vocabularybuilderwidget.lua
+++ b/frontend/ui/widget/vocabularybuilderwidget.lua
@@ -1,0 +1,862 @@
+local BD = require("ui/bidi")
+local Blitbuffer = require("ffi/blitbuffer")
+local BottomContainer = require("ui/widget/container/bottomcontainer")
+local Button = require("ui/widget/button")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local CheckMark = require("ui/widget/checkmark")
+local Device = require("device")
+local Font = require("ui/font")
+local FocusManager = require("ui/widget/focusmanager")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local LeftContainer = require("ui/widget/container/leftcontainer")
+local LineWidget = require("ui/widget/linewidget")
+local RightContainer = require("ui/widget/container/rightcontainer")
+local LineWidget = require("ui/widget/linewidget")
+local OverlapGroup = require("ui/widget/overlapgroup")
+local Size = require("ui/size")
+local TextWidget = require("ui/widget/textwidget")
+local TextBoxWidget = require("ui/widget/textboxwidget")
+local TitleBar = require("ui/widget/titlebar")
+local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
+local HorizontalSpan = require("ui/widget/horizontalspan")
+local MovableContainer = require("ui/widget/container/movablecontainer")
+local Screen = Device.screen
+local logger = require("logger")
+local util = require("util")
+local T = require("ffi/util").template
+local _ = require("gettext")
+
+--------
+
+local word_face = Font:getFace("cfont", 20)
+local subtitle_face = Font:getFace("cfont", 12)
+local nerd_face = Font:getFace("smallinfofont")
+
+-- More Info
+
+
+local WordInfoDialog = InputContainer:new{
+    title = nil,
+    book_title = nil,
+    dates = nil,
+    padding = Size.padding.large,
+    margin = Size.margin.title,
+    button = nil,
+    tap_close_callback = nil,
+    dismissable = true, -- set to false if any button callback is required
+}
+
+function WordInfoDialog:init()
+    if self.dismissable then
+        if Device:hasKeys() then
+            local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
+            self.key_events = {
+                Close = { { close_keys }, doc = "close button dialog" }
+            }
+        end
+        if Device:isTouchDevice() then
+            self.ges_events.TapClose = {
+                GestureRange:new {
+                    ges = "tap",
+                    range = Geom:new {
+                        x = 0,
+                        y = 0,
+                        w = Screen:getWidth(),
+                        h = Screen:getHeight(),
+                    }
+                }
+            }
+        end
+    end
+    local width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.8)
+    self[1] = CenterContainer:new{
+        dimen = Screen:getSize(),
+        MovableContainer:new{
+            FrameContainer:new{
+                VerticalGroup:new{
+                    align = "center",
+                    FrameContainer:new{
+                        padding =self.padding,
+                        margin = self.margin,
+                        bordersize = 0,
+                        VerticalGroup:new {
+                            align = "left",
+                            TextWidget:new{
+                                text = self.title,
+                                width = width,
+                                face = word_face,
+                                bold = true,
+                                alignment = self.title_align or "left",
+                            },
+                            TextBoxWidget:new{
+                                text = self.book_title,
+                                width = width,
+                                face = subtitle_face,
+                                fgcolor = Blitbuffer.Color8(0x88),
+                                alignment = self.title_align or "left",
+                            },
+                            VerticalSpan:new{width= Size.padding.default},
+                            TextBoxWidget:new{
+                                text = self.dates,
+                                width = width,
+                                face = subtitle_face,
+                                alignment = self.title_align or "left",
+                            },
+                        }
+                        
+                    },
+                    VerticalSpan:new{ width = Size.span.vertical_default },
+                    -- ButtonTable:new{
+                    --     buttons = self.buttons,
+                    --     zero_sep = true,
+                    --     show_parent = self,
+                    -- },
+                    LineWidget:new{
+                        background = Blitbuffer.COLOR_GRAY,
+                        dimen = Geom:new{
+                            w = width + self.padding + self.margin,
+                            h = Screen:scaleBySize(2),
+                        }
+                    },
+                    self.button,
+                },
+                background = Blitbuffer.COLOR_WHITE,
+                bordersize = Size.border.window,
+                radius = Size.radius.window,
+                padding = Size.padding.button,
+                padding_bottom = 0, -- no padding below buttontable
+            }
+        }
+    }
+end
+
+function WordInfoDialog:setTitle(title)
+    self.title = title
+    self:free()
+    self:init()
+    UIManager:setDirty("all", "ui")
+end
+
+function WordInfoDialog:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self[1][1].dimen
+    end)
+end
+
+function WordInfoDialog:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "ui", self[1][1].dimen
+    end)
+end
+
+function WordInfoDialog:onTapClose()
+    UIManager:close(self)
+    if self.tap_close_callback then
+        self.tap_close_callback()
+    end
+    return true
+end
+
+function WordInfoDialog:onClose()
+    self:onTapClose()
+    return true
+end
+
+function WordInfoDialog:paintTo(...)
+    InputContainer.paintTo(self, ...)
+    self.dimen = self[1][1].dimen -- FrameContainer
+end
+
+
+local review_button_width = Screen:scaleBySize(95)
+local ellipsis_button_width = Screen:scaleBySize(22)
+local star_width = Screen:scaleBySize(24)
+
+local VocabItemWidget = InputContainer:new{
+    item = nil,
+    face = Font:getFace("smallinfofont"),
+    width = nil,
+    height = nil,
+    show_parent = nil,
+}
+
+-- [[
+    -- item: {
+    --     reviewable: BOOL,
+    --     checked_func: Block,
+    --     review_count: interger,
+    --     word: Text
+    --     book_title: TEXT
+    --     create_time: Integer
+    --     review_time: Integer
+    --     elapse_time: TEXT,
+    --     got_it_callback: function
+    --     remove_callback: function
+    -- } 
+--]]
+
+local point_widget = TextWidget:new{
+    text = " • ",
+    bold = true,
+    face = Font:getFace("cfont", 24),
+    fgcolor = Blitbuffer.Color8(0x6f)
+}
+
+local point_widget_height = point_widget:getSize().h
+local point_widget_width = point_widget:getSize().w
+local word_height = TextWidget:new{text = " ", face = word_face}:getSize().h
+local subtitle_height = TextWidget:new{text = " ", face = subtitle_face}:getSize().h
+
+
+function VocabItemWidget:init()
+    self.dimen = Geom:new{w = self.width, h = self.height}
+    self.ges_events.Tap = {
+        GestureRange:new{
+            ges = "tap",
+            range = self.dimen,
+        }
+    }
+    self.ges_events.Hold = {
+        GestureRange:new{
+            ges = "hold",
+            range = self.dimen,
+        }
+    }
+
+    -- local item_checkable = not self.item.checked
+    -- if self.item.checked_func then
+    --     item_checkable = true
+    --     item_checked = self.item.checked_func()
+    -- end
+    -- self.checkmark_widget = CheckMark:new{
+    --     checkable = item_checkable,
+    --     checked = item_checked,
+    -- }
+    self.v_spacer = VerticalSpan:new{width = (self.height - word_height - subtitle_height)/2}
+    self.point_v_spacer = VerticalSpan:new{width = (self.v_spacer.width + word_height/2) - point_widget_height/2 + Screen:scaleBySize(2) }
+    self.margin_span = HorizontalSpan:new{ width = Size.padding.large }
+    self:initItemWidget()
+end
+
+function VocabItemWidget:initItemWidget()
+
+    local more_button
+    if self.item.review_count < 5 then
+        more_button = Button:new{
+            text = "···",--"", --ellipsis nerd font
+            face = nerd_face,
+            callback = function() self:showMore() end,
+            width = ellipsis_button_width,
+            bordersize = 0
+        } 
+        more_button.label_widget.fgcolor = Blitbuffer.Color8(0x6D)
+    else 
+        more_button = Button:new{
+            icon = "exit",
+            icon_width = star_width,
+            icon_height = star_width,
+            bordersize = 0,
+            radius = 0,
+            margin = 0,
+            callback = function() 
+                self:remove()
+            end
+        }
+        more_button.label_widget.alpha = true
+    end
+    
+    
+    local right_side_width
+    local right_widget
+    if self.item.reviewable then
+        right_side_width = review_button_width * 2 + Size.padding.large * 4 + ellipsis_button_width
+        
+        local forgot_button = Button:new{
+            text = _("Forgot"),
+            callback = nil,
+            background = Blitbuffer.Color8(0xF7),
+            radius = 5,
+            width = review_button_width,
+            bordersize = 0,
+            callback = function() 
+                self.item.forgot_callback(self.item)
+                self:initItemWidget()
+                UIManager:setDirty(self.show_parent, function()
+                    return "ui", self[1].dimen end) 
+                if self.item.callback then
+                    self.item.callback(self.item.word) 
+                end
+            end,
+        }
+        forgot_button.label_widget.fgcolor = Blitbuffer.Color8(0x6D)
+    
+        local got_it_button = Button:new{
+            text = _("Got it"),
+            callback = function() 
+                self.item.got_it_callback(self.item)
+                self:initItemWidget()
+                UIManager:setDirty(self.show_parent, function()
+                    return "ui", self[1].dimen end) 
+            end,
+            background = Blitbuffer.Color8(0xF7),
+            radius = 5,
+            width = review_button_width,
+            bordersize = 0
+        }
+        got_it_button.label_widget.fgcolor = Blitbuffer.Color8(0x6D)
+
+        right_widget = HorizontalGroup:new{
+            dimen = Geom:new{ w = 0, h = self.height },
+            self.margin_span,
+            forgot_button,
+            self.margin_span,
+            got_it_button,
+            self.margin_span,
+            more_button,
+        }
+    else
+        right_side_width =  Size.padding.large * 3 + self.item.review_count * star_width
+
+        if self.item.review_count > 0 then
+            local star = Button:new{
+                icon = "star.full",
+                icon_width = star_width,
+                icon_height = star_width,
+                bordersize = 0,
+                radius = 0,
+                margin = 0,
+                enabled = false,
+            }
+            
+
+            right_widget = HorizontalGroup:new {
+                dimen = Geom:new{w=0, h = self.height},
+            }
+            for i=1, self.item.review_count, 1 do
+                table.insert(right_widget, star)
+            end
+        else
+            right_widget = HorizontalGroup:new{
+                dimen = Geom:new{w=0, h = self.height},
+                 HorizontalSpan:new {width = Size.padding.default }
+            }
+        end
+        table.insert(right_widget, self.margin_span)
+        table.insert(right_widget, more_button)
+    end
+
+    local text_max_width = self.width - Size.padding.default - point_widget_width - right_side_width
+
+    logger.err("rstarstarst", self.item)
+
+    self[1] = FrameContainer:new{
+        padding = 0,
+        bordersize = 0,
+        focusable = true,
+        focus_border_size = Size.border.thin,
+        HorizontalGroup:new{
+            dimen = Geom:new{
+                w = self.width,
+                h = self.height,
+            },
+            HorizontalGroup:new{
+                dimen = Geom:new{
+                    w = self.width - Size.padding.default - right_side_width,
+                    h = self.height,
+                },
+                VerticalGroup:new{
+                    dimen = Geom:new{w = point_widget_width, h = self.height},
+                    self.point_v_spacer,
+                    point_widget,
+                    VerticalSpan:new { width = self.height - point_widget_height - self.point_v_spacer.width}
+                },
+                VerticalGroup:new{
+                    dimen = Geom:new{
+                        w = text_max_width,
+                        h = self.height,
+                    },
+                    self.v_spacer,
+                    LeftContainer:new{
+                        dimen = Geom:new{w = text_max_width, h = word_height},
+                        TextWidget:new{
+                            text = self.item.word,
+                            face = word_face,
+                            bold = true
+                        }
+                    },
+                    LeftContainer:new{
+                        dimen = Geom:new{w = text_max_width, h = self.height - word_height - self.v_spacer.width*2.2},
+                        TextWidget:new{
+                            text = self.item.elapse_time .. "From " .. self.item.book_title,
+                            face = subtitle_face,
+                            max_width = text_max_width,
+                            fgcolor = Blitbuffer.Color8(0x88)
+                        }
+                    },
+                    self.v_spacer
+                }
+
+            },
+            RightContainer:new{
+                dimen = Geom:new{ w = right_side_width, h = self.height},
+                right_widget
+            }
+        },
+    }
+    self[1].invert = self.invert
+end
+
+function VocabItemWidget:remove()
+    self.item.remove_callback(self.item)
+    self.show_parent:removeAt(self.index)
+end
+
+function VocabItemWidget:showMore()
+    self.dialogue = WordInfoDialog:new{
+        title = self.item.word,
+        book_title = 
+        "From " .. self.item.book_title,
+        dates =
+        "Lookup date: " .. os.date("%Y-%m-%d", self.item.create_time) .. " | " ..
+        "Review date: " .. os.date("%Y-%m-%d", self.item.review_time),
+        button = Button:new {
+            text = _("Remove Word"),
+            callback = function() 
+                UIManager:close(self.dialogue)
+                self:remove() 
+            end,
+            bordersize = 0
+        }
+    }
+
+    UIManager:show(self.dialogue)
+end
+
+function VocabItemWidget:onTap(_, ges)
+    if self.item.callback then
+        self.item.callback(self.item.word)
+    elseif self.show_parent.marked == self.index then
+        self.show_parent.marked = 0
+    else
+        self.show_parent.marked = self.index
+    end
+    -- self.show_parent:_populateItems()
+    return true
+end
+
+function VocabItemWidget:onHold()
+    if self.item.callback then
+        self.item.callback(self.item.word)
+        -- self.show_parent:_populateItems()
+    end
+    return true
+end
+
+------- 
+
+
+local VocabularyBuilderWidget = FocusManager:new{
+    title = "",
+    width = nil,
+    height = nil,
+    -- index for the first item to show
+    show_page = 1,
+    -- table of items to sort
+    item_table = nil, -- mandatory (array)
+    callback = nil,
+}
+
+function VocabularyBuilderWidget:init()
+    self.layout = {}
+    -- no item is selected on start
+    self.marked = 0
+    self.orig_item_table = nil
+
+    self.dimen = Geom:new{
+        w = self.width or Screen:getWidth(),
+        h = self.height or Screen:getHeight(),
+    }
+    if Device:hasKeys() then
+        self.key_events.Close = { { Device.input.group.Back }, doc = "close dialog" }
+        self.key_events.NextPage = { { Device.input.group.PgFwd}, doc = "next page"}
+        self.key_events.PrevPage = { { Device.input.group.PgBack}, doc = "prev page"}
+    end
+    if Device:isTouchDevice() then
+        self.ges_events.Swipe = {
+            GestureRange:new{
+                ges = "swipe",
+                range = self.dimen,
+            }
+        }
+    end
+    local padding = Size.padding.large
+    self.width_widget = self.dimen.w - 2 * padding
+    self.item_width = self.dimen.w - 2 * padding
+    self.footer_center_width = math.floor(self.width_widget * 32 / 100)
+    self.footer_button_width = math.floor(self.width_widget * 12 / 100)
+    self.item_height = Screen:scaleBySize(80)
+    -- group for footer
+    local chevron_left = "chevron.left"
+    local chevron_right = "chevron.right"
+    local chevron_first = "chevron.first"
+    local chevron_last = "chevron.last"
+    if BD.mirroredUILayout() then
+        chevron_left, chevron_right = chevron_right, chevron_left
+        chevron_first, chevron_last = chevron_last, chevron_first
+    end
+    self.footer_left = Button:new{
+        icon = chevron_left,
+        width = self.footer_button_width,
+        callback = function() self:prevPage() end,
+        bordersize = 0,
+        radius = 0,
+        show_parent = self,
+    }
+    self.footer_right = Button:new{
+        icon = chevron_right,
+        width = self.footer_button_width,
+        callback = function() self:nextPage() end,
+        bordersize = 0,
+        radius = 0,
+        show_parent = self,
+    }
+    self.footer_first_up = Button:new{
+        icon = chevron_first,
+        width = self.footer_button_width,
+        callback = function()
+            if self.marked > 0 then
+                self:moveItem(-1)
+            else
+                self:goToPage(1)
+            end
+        end,
+        bordersize = 0,
+        radius = 0,
+        show_parent = self,
+    }
+    self.footer_last_down = Button:new{
+        icon = chevron_last,
+        width = self.footer_button_width,
+        callback = function()
+            if self.marked > 0 then
+                self:moveItem(1)
+            else
+                self:goToPage(self.pages)
+            end
+        end,
+        bordersize = 0,
+        radius = 0,
+        show_parent = self,
+    }
+    -- self.footer_cancel = Button:new{
+    --     icon = "exit",
+    --     width = self.footer_button_width,
+    --     callback = function() self:onClose() end,
+    --     bordersize = 0,
+    --     radius = 0,
+    --     show_parent = self,
+    -- }
+    -- self.footer_ok = Button:new{
+    --     icon = "check",
+    --     width = self.footer_button_width,
+    --     callback = function() self:onReturn() end,
+    --     bordersize = 0,
+    --     radius = 0,
+    --     show_parent = self,
+    -- }
+    self.footer_page = Button:new{
+        text = "",
+        hold_input = {
+            title = _("Enter page number"),
+            hint_func = function()
+                return "(" .. "1 - " .. self.pages .. ")"
+            end,
+            type = "number",
+            deny_blank_input = true,
+            callback = function(input)
+                local page = tonumber(input)
+                if page and page >= 1 and page <= self.pages then
+                    self:goToPage(page)
+                end
+            end,
+            ok_text = _("Go to page"),
+        },
+        call_hold_input_on_tap = true,
+        bordersize = 0,
+        margin = 0,
+        text_font_face = "pgfont",
+        text_font_bold = false,
+        width = self.footer_center_width,
+        show_parent = self,
+    }
+    self.page_info = HorizontalGroup:new{
+        -- self.footer_cancel,
+        self.footer_first_up,
+        self.footer_left,
+        self.footer_page,
+        self.footer_right,
+        self.footer_last_down,
+        -- self.footer_ok,
+    }
+    -- table.insert(self.layout, {
+    --     self.footer_cancel,
+    --     self.footer_ok,
+    -- })
+    local bottom_line = LineWidget:new{
+        dimen = Geom:new{ w = self.item_width, h = Size.line.thick },
+        background = Blitbuffer.COLOR_LIGHT_GRAY,
+    }
+    local vertical_footer = VerticalGroup:new{
+        bottom_line,
+        self.page_info,
+    }
+    local footer = BottomContainer:new{
+        dimen = self.dimen:copy(),
+        vertical_footer,
+    }
+    -- setup title bar
+    self.title_bar = TitleBar:new{
+        width = self.dimen.w,
+        align = "center",
+        title_face = Font:getFace("x_smalltfont"),
+        bottom_line_color = Blitbuffer.COLOR_LIGHT_GRAY,
+        with_bottom_line = true,
+        bottom_line_h_padding = padding,
+        title = self.title,
+        close_callback = function() self:onClose() end,
+        show_parent = self,
+    }
+    self.title_bar.title_widget.fgcolor = Blitbuffer.Color8(0x61)
+    -- setup main content
+    self.item_margin = math.floor(self.item_height / 8)
+    local line_height = self.item_height + self.item_margin
+    local content_height = self.dimen.h - self.title_bar:getHeight() - vertical_footer:getSize().h - padding
+    self.items_per_page = math.floor(content_height / line_height)
+    self.pages = math.ceil(#self.item_table / self.items_per_page)
+    self.main_content = VerticalGroup:new{}
+
+    self:_populateItems()
+
+    local padding_below_title = 0
+    if self.pages > 1 then -- center content vertically
+        padding_below_title = (content_height - self.items_per_page * line_height) / 2
+    end
+    local frame_content = FrameContainer:new{
+        height = self.dimen.h,
+        padding = 0,
+        bordersize = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        VerticalGroup:new{
+            self.title_bar,
+            VerticalSpan:new{ width = padding_below_title },
+            self.main_content,
+        },
+    }
+    local content = OverlapGroup:new{
+        dimen = self.dimen:copy(),
+        frame_content,
+        footer,
+    }
+    -- assemble page
+    self[1] = FrameContainer:new{
+        height = self.dimen.h,
+        padding = 0,
+        bordersize = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        content
+    }
+end
+
+function VocabularyBuilderWidget:nextPage()
+    local new_page = math.min(self.show_page+1, self.pages)
+    if new_page > self.show_page then
+        self.show_page = new_page
+        if self.marked > 0 then
+            self:moveItem(self.items_per_page * (self.show_page - 1) + 1 - self.marked)
+        end
+        self:_populateItems()
+    end
+end
+
+function VocabularyBuilderWidget:prevPage()
+    local new_page = math.max(self.show_page-1, 1)
+    if new_page < self.show_page then
+        self.show_page = new_page
+        if self.marked > 0 then
+            self:moveItem(self.items_per_page * (self.show_page - 1) + 1 - self.marked)
+        end
+        self:_populateItems()
+    end
+end
+
+function VocabularyBuilderWidget:goToPage(page)
+    self.show_page = page
+    self:_populateItems()
+end
+
+function VocabularyBuilderWidget:moveItem(diff)
+    local move_to = self.marked + diff
+    if move_to > 0 and move_to <= #self.item_table then
+        -- Remember the original state to support Cancel
+        if not self.orig_item_table then
+            self.orig_item_table = util.tableDeepCopy(self.item_table)
+        end
+        table.insert(self.item_table, move_to, table.remove(self.item_table, self.marked))
+        self.show_page = math.ceil(move_to / self.items_per_page)
+        self.marked = move_to
+        self:_populateItems()
+    end
+end
+
+function VocabularyBuilderWidget:removeAt(index)
+    if index > #self.item_table then return end
+    table.remove(self.item_table, index)
+    self.show_page = math.ceil(math.min(index, #self.item_table) / self.items_per_page)
+    self:_populateItems()
+end
+
+-- make sure self.item_margin and self.item_height are set before calling this
+function VocabularyBuilderWidget:_populateItems()
+    self.main_content:clear()
+    self.layout = { self.layout[#self.layout] } -- keep footer
+    local idx_offset = (self.show_page - 1) * self.items_per_page
+    local page_last
+    if idx_offset + self.items_per_page <= #self.item_table then
+        page_last = idx_offset + self.items_per_page
+    else
+        page_last = #self.item_table
+    end
+    for idx = idx_offset + 1, page_last do
+        table.insert(self.main_content, VerticalSpan:new{ width = self.item_margin })
+        local invert_status = false
+        if idx == self.marked then
+            invert_status = true
+        end
+        local item = VocabItemWidget:new{
+            height = self.item_height,
+            width = self.item_width,
+            item = self.item_table[idx],
+            invert = invert_status,
+            index = idx,
+            show_parent = self,
+        }
+        table.insert(self.layout, #self.layout, {item})
+        table.insert(
+            self.main_content,
+            item
+        )
+    end
+    self.footer_page:setText(T(_("Page %1 of %2"), self.show_page, self.pages), self.footer_center_width)
+    if self.pages > 1 then
+        self.footer_page:enable()
+    else
+        self.footer_page:disableWithoutDimming()
+    end
+    local chevron_first = "chevron.first"
+    local chevron_last = "chevron.last"
+    if BD.mirroredUILayout() then
+        chevron_first, chevron_last = chevron_last, chevron_first
+    end
+    if self.marked > 0 then
+        -- self.footer_cancel:setIcon("cancel", self.footer_button_width)
+        -- self.footer_cancel.callback = function() self:onCancel() end
+        self.footer_first_up:setIcon("move.up", self.footer_button_width)
+        self.footer_last_down:setIcon("move.down", self.footer_button_width)
+    else
+        -- self.footer_cancel:setIcon("exit", self.footer_button_width)
+        -- self.footer_cancel.callback = function() self:onClose() end
+        self.footer_first_up:setIcon(chevron_first, self.footer_button_width)
+        self.footer_last_down:setIcon(chevron_last, self.footer_button_width)
+    end
+    self.footer_left:enableDisable(self.show_page > 1)
+    self.footer_right:enableDisable(self.show_page < self.pages)
+    self.footer_first_up:enableDisable(self.show_page > 1 or (self.marked > 0 and self.marked > 1))
+    self.footer_last_down:enableDisable(self.show_page < self.pages or (self.marked > 0 and self.marked < #self.item_table))
+    UIManager:setDirty(self, function()
+        return "ui", self.dimen
+    end)
+end
+
+function VocabularyBuilderWidget:onNextPage()
+    self:nextPage()
+    return true
+end
+
+function VocabularyBuilderWidget:onPrevPage()
+    self:prevPage()
+    return true
+end
+
+function VocabularyBuilderWidget:onSwipe(arg, ges_ev)
+    local direction = BD.flipDirectionIfMirroredUILayout(ges_ev.direction)
+    if direction == "west" then
+        self:onNextPage()
+    elseif direction == "east" then
+        self:onPrevPage()
+    elseif direction == "south" then
+        -- Allow easier closing with swipe down
+        self:onClose()
+    elseif direction == "north" then
+        -- no use for now
+        do end -- luacheck: ignore 541
+    else -- diagonal swipe
+        -- trigger full refresh
+        UIManager:setDirty(nil, "full")
+        -- a long diagonal swipe may also be used for taking a screenshot,
+        -- so let it propagate
+        return false
+    end
+end
+
+function VocabularyBuilderWidget:onClose()
+    UIManager:close(self)
+    UIManager:setDirty(nil, "ui")
+    return true
+end
+
+function VocabularyBuilderWidget:onCancel()
+    self.marked = 0
+    if self.orig_item_table then
+        -- We can't break the reference to self.item_table, as that's what the callback uses to update the original data...
+        -- So, do this in two passes: empty it, then re-fill it from the copy.
+        for i = #self.item_table, 1, -1 do
+            self.item_table[i] = nil
+        end
+
+        for __, item in ipairs(self.orig_item_table) do
+            table.insert(self.item_table, item)
+        end
+
+        self.orig_item_table = nil
+    end
+
+    self:goToPage(self.show_page)
+    return true
+end
+
+function VocabularyBuilderWidget:onReturn()
+    -- The callback we were passed is usually responsible for passing along the re-ordered table itself,
+    -- as well as items' enabled flag, if any, meaning we have to honor it even if nothing was moved.
+    if self.callback then
+        self:callback()
+    end
+
+    -- If we're not in the middle of moving stuff around, just exit.
+    if self.marked == 0 then
+        return self:onClose()
+    end
+
+    self.marked = 0
+    self.orig_item_table = nil
+    self:goToPage(self.show_page)
+    return true
+end
+
+return VocabularyBuilderWidget
+

--- a/frontend/ui/widget/vocabularybuilderwidget.lua
+++ b/frontend/ui/widget/vocabularybuilderwidget.lua
@@ -38,6 +38,7 @@ local word_face = Font:getFace("x_smallinfofont")
 local subtitle_face = Font:getFace("cfont", 12)
 local subtitle_italic_face = Font:getFace("NotoSans-Italic.ttf", 12)
 local nerd_face = Font:getFace("smallinfofont")
+local subtitle_color = Blitbuffer.Color8(0x88)
 -- More Info
 
 function getDialogWidth()
@@ -100,7 +101,7 @@ function WordInfoDialog:init()
                                 text = self.book_title,
                                 width = width,
                                 face = subtitle_italic_face,
-                                fgcolor = Blitbuffer.Color8(0x88),
+                                fgcolor = subtitle_color,
                                 alignment = self.title_align or "left",
                             },
                             VerticalSpan:new{width= Size.padding.default},
@@ -265,7 +266,7 @@ function VocabItemWidget:initItemWidget()
     local right_widget
     if self .item.reviewable then
         right_side_width = review_button_width * 2 + Size.padding.large * 2 + ellipsis_button_width
-        
+
         local forgot_button = Button:new{
             text = _("Forgot"),
             callback = nil,
@@ -300,20 +301,18 @@ function VocabItemWidget:initItemWidget()
             more_button,
         }
     else
-        right_side_width =  Size.padding.large * 3 + self .item.review_count * star_width
+        local star = Button:new{
+            icon = "check",
+            icon_width = star_width,
+            icon_height = star_width,
+            bordersize = 0,
+            radius = 0,
+            margin = 0,
+            enabled = false,
+        }
+        right_side_width =  Size.padding.large * 3 + self .item.review_count * (star:getSize().w)
 
         if self .item.review_count > 0 then
-            local star = Button:new{
-                icon = "check",
-                icon_width = star_width,
-                icon_height = star_width,
-                bordersize = 0,
-                radius = 0,
-                margin = 0,
-                enabled = false,
-            }
-            
-
             right_widget = HorizontalGroup:new {
                 dimen = Geom:new{w=0, h = self.height}
             }
@@ -321,6 +320,7 @@ function VocabItemWidget:initItemWidget()
                 table.insert(right_widget, star)
             end
         else
+            star:close()
             right_widget = HorizontalGroup:new{
                 dimen = Geom:new{w=0, h = self.height},
                  HorizontalSpan:new {width = Size.padding.default }
@@ -331,6 +331,12 @@ function VocabItemWidget:initItemWidget()
     end
 
     local text_max_width = self.width - point_widget_width - right_side_width
+
+    local subtitle_prefix = TextWidget:new{
+        text = self:getTimeSinceDue() .. "From " ,
+        face = subtitle_face,
+        fgcolor = subtitle_color
+    }
 
     self[1] = FrameContainer:new{
         padding = 0,
@@ -371,17 +377,12 @@ function VocabItemWidget:initItemWidget()
                     LeftContainer:new{
                         dimen = Geom:new{w = text_max_width, h = self.height - word_height - self.v_spacer.width*2.2},
                         HorizontalGroup:new{
-                            TextWidget:new{
-                                text = self:getTimeSinceDue() .. "From " ,
-                                face = subtitle_face,
-                                max_width = text_max_width,
-                                fgcolor = Blitbuffer.Color8(0x88)
-                            },
+                            subtitle_prefix,
                             TextWidget:new{
                                 text = self .item.book_title,
                                 face = subtitle_italic_face,
-                                max_width = text_max_width,
-                                fgcolor = Blitbuffer.Color8(0x88)
+                                max_width = text_max_width - subtitle_prefix:getSize().w - Size.padding.fullscreen,
+                                fgcolor = subtitle_color
                             }
                         }
                     },


### PR DESCRIPTION
Made the old dictionary lookup history into a flashcard-ish vocabulary builder.

No duplicate entries.
Auto schedule reviewable time and sort by it.
Individual word deletable.
Works when lookup history enabled.

Uses a new sqlite db instead of lookup_history.lua as data source.

A bit intrusive change to be honest, though I thought it'll be a nice built-in feature. Or maybe this can live in a plugin and leave the old lookup history intact?