### PR TITLE
frontend/device/kindle: KOA3: allow rotation-lock

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -441,6 +441,7 @@ local KindlePaperWhite4 = Kindle:new{
     isRex = yes,
     isTouchDevice = yes,
     hasFrontlight = yes,
+    hasGSensor = yes,
     display_dpi = 300,
     -- NOTE: LTE devices once again have a mysterious extra SX9310 proximity sensor...
     --       Except this time, we can't rely on by-path, because there's no entry for the TS :/.


### PR DESCRIPTION
I have not tested this yet.  Still need to figure out how to build
koreader locally, and test things without bricking my
has-no-serial-console KOA3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9138)
<!-- Reviewable:end -->
