### PR TITLE
Use inkview to adjust image colors to look more bright

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -531,6 +531,7 @@ local PocketBook632 = PocketBook:new{
 local PocketBook633 = PocketBook:new{
     model = "PBColor",
     display_dpi = 300,
+    color_vibrance = 2.0,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
@@ -585,6 +586,7 @@ local PocketBook740_2 = PocketBook:new{
 local PocketBook741 = PocketBook:new{
     model = "PBInkPadColor",
     display_dpi = 300,
+    color_vibrance = 2.0,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
@@ -601,6 +603,7 @@ end
 local PocketBookColorLux = PocketBook:new{
     model = "PBColorLux",
     display_dpi = 125,
+    color_vibrance = 2.0,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
 }


### PR DESCRIPTION
Needed for: https://github.com/koreader/koreader-base/pull/1484

Fixes: #8872

Adjust image colors for pocketbook color devices to supply brighter image colors. Make it a config option to we can adjust it to a sensible default for all devices later.