### PR TITLE
DateTimeWidget: don't make ":" and "/" translatable

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -788,7 +788,7 @@ function ReaderHighlight:onShowHighlightDialog(page, index, is_auto_text)
                 end,
             },
             {
-                text = _("…"),
+                text = "…",
                 callback = function()
                     self.selected_text = self.view.highlight.saved[page][index]
                     self:onShowHighlightMenu(page, index)

--- a/frontend/ui/widget/datetimewidget.lua
+++ b/frontend/ui/widget/datetimewidget.lua
@@ -245,12 +245,12 @@ function DateTimeWidget:createLayout()
         bold = true,
     }
     separator_time = TextWidget:new{
-        text = _(":"),
+        text = ":",
         face = self.title_face,
         bold = true,
     }
     separator_date_time = TextWidget:new{
-        text =  _("/"),
+        text =  "/",
         face = self.title_face,
         bold = true,
     }


### PR DESCRIPTION
Follow up to #9070.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9145)
<!-- Reviewable:end -->
