### PR TITLE
Font scale in pt or koscale

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -120,6 +120,7 @@ DKOPTREADER_CONFIG_DOC_DEFAULT_LANG_CODE = "eng"          -- that have filenames
 -- crereader font sizes
 -- feel free to add more entries in this list
 DCREREADER_CONFIG_FONT_SIZES = {12, 16, 20, 22, 24, 26, 28, 30, 34, 38, 44}  -- option range from 12 to 44
+DCREREADER_CONFIG_FONT_SIZES_PT = {4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 20, 22}  -- alternate option range for sizes in pt
 DCREREADER_CONFIG_DEFAULT_FONT_SIZE = 22    -- default font size
 
 -- crereader margin sizes

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -408,23 +408,33 @@ Note that your selected font size is not affected by this setting.]]),
             {
                 name = "font_size",
                 alt_name_text = _("Font Size"),
-                item_text = tableOfNumbersToTableOfStrings(DCREREADER_CONFIG_FONT_SIZES),
                 item_align_center = 1.0,
                 spacing = 15,
+                item_use_alt_func = function() return G_reader_settings:isTrue("current_font_scale_in_pt") end,
+                item_text = tableOfNumbersToTableOfStrings(DCREREADER_CONFIG_FONT_SIZES),
+                item_text_alt = tableOfNumbersToTableOfStrings(DCREREADER_CONFIG_FONT_SIZES_PT),
                 item_font_size = DCREREADER_CONFIG_FONT_SIZES,
+                item_font_size_alt = DCREREADER_CONFIG_FONT_SIZES_PT,
+                item_font_scale_func = function()
+                    return G_reader_settings:isTrue("current_font_scale_in_pt") and Screen.scaleByPt or Screen.scaleBySize
+                end,
                 values = DCREREADER_CONFIG_FONT_SIZES,
-                default_value = DCREREADER_CONFIG_DEFAULT_FONT_SIZE,
+                values_alt = DCREREADER_CONFIG_FONT_SIZES_PT,
                 args = DCREREADER_CONFIG_FONT_SIZES,
+                args_alt = DCREREADER_CONFIG_FONT_SIZES_PT,
+                default_value = DCREREADER_CONFIG_DEFAULT_FONT_SIZE,
                 event = "SetFontSize",
             },
             {
                 name = "font_fine_tune",
-                name_text = _("Font Size"),
+                name_text_func = function()
+                    return G_reader_settings:isTrue("current_font_scale_in_pt") and _("Font Size: pt") or _("Font Size")
+                end,
                 toggle = Device:isTouchDevice() and {_("decrease"), _("increase")} or nil,
                 item_text = not Device:isTouchDevice() and {_("decrease"), _("increase")} or nil,
                 more_options = true,
                 more_options_param = {
-                    value_min = 12,
+                    value_min = 4,
                     value_max = 255,
                     value_step = 0.5,
                     precision = "%.1f",

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -232,15 +232,19 @@ end
 -- @string font
 -- @int size optional size
 -- @int faceindex optional index of font face in font file
+-- @bool don't scale size
 -- @treturn table @{FontFaceObj}
-function Font:getFace(font, size, faceindex)
+function Font:getFace(font, size, faceindex, dont_scale)
     -- default to content font
     if not font then font = self.cfont end
 
     if not size then size = self.sizemap[font] end
     -- original size before scaling by screen DPI
     local orig_size = size
-    size = Screen:scaleBySize(size)
+
+    if not dont_scale then
+        size = Screen:scaleBySize(size)
+    end
 
     local realname = self.fontmap[font]
     if not realname then


### PR DESCRIPTION
This PR allows to set the font size of an epub to an absolute value in pt -> The goal is, that the font size is the same on any device.

If you use different devices, the font size of the book should be the same, despite the size of the device. (Except you use a tiny device like a mobile. On a Tolino and a Sage it is preferable to have the same font size.)

The size calulations of KOReaders menus et al is unchanged.

Draft, as I need some time to test and check on my three devices.
Most of the changes are in the bottom menu (unfunny), the epub font thing is tiny.


![grafik](https://user-images.githubusercontent.com/36999612/171509903-fe813734-e35c-43a4-93d9-359cec271610.png)

![grafik](https://user-images.githubusercontent.com/36999612/171509660-bede4dfa-5453-4e44-87f7-7cb6dea283ad.png)



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9159)
<!-- Reviewable:end -->
