### PR TITLE
vocabulary builder bug fix: resetting changes when reviewing backwards

### DIFF
--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -110,7 +110,7 @@ function VocabularyBuilder:_select_items(items, start_idx)
 
     for i = 1, #results.word do
         local item = items[start_idx+i-1]
-        if item then
+        if item and not item.word then
             item.word = results.word[i]
             item.review_count = math.max(0, math.min(8, tonumber(results.review_count[i])))
             item.book_title = results.book_title[i] or ""


### PR DESCRIPTION
Fix the bug that when reviewing backwards, changes made earlier could be reset by loading more from database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9161)
<!-- Reviewable:end -->
