### PR TITLE
bump crengine: improved typography for Chinese and Japanese

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -145,6 +145,11 @@ function ReaderFont:onReadSettings(config)
                        or 0
     self.ui.document:setWordExpansion(self.word_expansion)
 
+    self.cjk_width_scaling = config:readSetting("cjk_width_scaling")
+                       or G_reader_settings:readSetting("copt_cjk_width_scaling")
+                       or 100
+    self.ui.document:setCJKWidthScaling(self.cjk_width_scaling)
+
     self.line_space_percent = config:readSetting("line_space_percent")
                            or G_reader_settings:readSetting("copt_line_spacing")
                            or DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM
@@ -261,6 +266,14 @@ function ReaderFont:onSetWordExpansion(value)
     return true
 end
 
+function ReaderFont:onSetCJKWidthScaling(value)
+    self.cjk_width_scaling = value
+    self.ui.document:setCJKWidthScaling(value)
+    self.ui:handleEvent(Event:new("UpdatePos"))
+    Notification:notify(T(_("CJK width scaling set to: %1%."), value))
+    return true
+end
+
 function ReaderFont:onSetFontGamma(gamma)
     self.gamma_index = gamma
     self.ui.document:setGammaIndex(self.gamma_index)
@@ -279,6 +292,7 @@ function ReaderFont:onSaveSettings()
     self.ui.doc_settings:saveSetting("font_kerning", self.font_kerning)
     self.ui.doc_settings:saveSetting("word_spacing", self.word_spacing)
     self.ui.doc_settings:saveSetting("word_expansion", self.word_expansion)
+    self.ui.doc_settings:saveSetting("cjk_width_scaling", self.cjk_width_scaling)
     self.ui.doc_settings:saveSetting("line_space_percent", self.line_space_percent)
     self.ui.doc_settings:saveSetting("gamma_index", self.gamma_index)
 end

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -234,8 +234,11 @@ When the book's language tag is not among our presets, no specific features will
                 return text
             end,
             callback = function()
+                -- We use an InfoMessage because the text might be too long for a Notification.
+                -- Use a small timeout (but long enough to read) as this might be bothering.
                 UIManager:show(InfoMessage:new{
                     text = T(_("Changed language for typography rules to %1."), BD.wrap(lang_name)),
+                    timeout = 2,
                 })
                 self.text_lang_tag = lang_tag
                 self.ui.document:setTextMainLang(lang_tag)
@@ -783,6 +786,7 @@ function ReaderTypography:onPreRenderDocument(config)
         callback = function()
             UIManager:show(InfoMessage:new{
                 text = T(_("Changed language for typography rules to book language: %1."), BD.wrap(self.book_lang_tag)),
+                timeout = 2,
             })
             self.text_lang_tag = self.book_lang_tag
             self.ui.doc_settings:saveSetting("text_lang", self.text_lang_tag)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1124,6 +1124,11 @@ function CreDocument:setWordExpansion(value)
     self._document:setIntProperty("crengine.style.max.added.letter.spacing.percent", value or 0)
 end
 
+function CreDocument:setCJKWidthScaling(value)
+    logger.dbg("CreDocument: set cjk width scaling", value)
+    self._document:setIntProperty("crengine.style.cjk.width.scale.percent", value or 100)
+end
+
 function CreDocument:setStyleSheet(new_css_file, appended_css_content )
     logger.dbg("CreDocument: set style sheet:",
         new_css_file and new_css_file or "no file",

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -510,6 +510,10 @@ Note that your selected font size is not affected by this setting.]]),
                     name_text = _("Max word expansion"),
                     info_text = _([[Set max word expansion as a percentage of the font size.]]),
                     event = "SetWordExpansion",
+                    other_button = { -- allow fine tuning the hidden cjk_width_scaling option (defined below)
+                        text = _("CJK scaling"),
+                        other_option = "cjk_width_scaling",
+                    }
                 },
                 toggle = {C_("Word expansion", "none"), C_("Word expansion", "some"), C_("Word expansion", "more")},
                 values = {
@@ -530,6 +534,33 @@ Note that your selected font size is not affected by this setting.]]),
                 show_true_value_func = function(val)
                     return string.format("%d\xE2\x80\xAF%%", val) -- use Narrow No-Break space here
                 end,
+            },
+            {
+                -- This option is not shown in the bottom menu, but its fine tuning is made
+                -- available via the other_button in Word Expansion's fine tuning widget.
+                -- We still need to define it as an option here for it to be known and
+                -- handled as any other one - we just make it hidden.
+                show = false,
+                name = "cjk_width_scaling",
+                default_value = 100,
+                values = { 100, 105, 110 }, -- (not shown)
+                event = "SetCJKWidthScaling",
+                more_options = true,
+                more_options_param = {
+                    value_min = 100,
+                    value_max = 150,
+                    value_step = 1,
+                    value_hold_step = 5,
+                    unit = "%",
+                    name = "cjk_width_scaling",
+                    name_text = _("CJK width scaling"),
+                    info_text = _([[Increase the width of all CJK (Chinese, Japanese, Korean) chararacters by this percentage. This has the effect of adding space between these glyphs, and might make them easier to distinguish to some readers.]]),
+                    event = "SetCJKWidthScaling",
+                    other_button = {
+                        text = _("Word expansion"),
+                        other_option = "word_expansion",
+                    }
+                },
             },
         }
     },

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -430,6 +430,13 @@ p {
     margin-bottom: 1em;
 }
             ]],
+        },
+        {
+            id = "cjk_tailored";
+            title = _("Tailor widths and text-indent for CJK"),
+            description = _([[
+Adjust paragraph width and text-indent to be an integer multiple of the font size, so that lines of Chinese and Japanese characters don't need space added between glyphs for text justification.]]),
+            css = [[ body { -cr-hint: cjk-tailored; }]], -- This hint is inherited
             separator = true,
         },
         {

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -1337,6 +1337,13 @@ function ConfigDialog:onConfigMoreChoose(values, name, event, args, name_text, m
                             end,
                         })
                     end,
+                    option_text =  more_options_param.other_button and more_options_param.other_button.text,
+                    option_callback =  more_options_param.other_button and function()
+                        when_applied_callback = nil -- prevent bottom menu from being shown (before being hidden again)
+                        widget:onClose()
+                        local option = self:findOptionByName(more_options_param.other_button.other_option)
+                        self:onConfigMoreChoose(option.values, option.name, option.event, nil, option.name_text, option.more_options_param)
+                    end,
                 }
             end
             UIManager:show(widget)
@@ -1419,6 +1426,23 @@ function ConfigDialog:onMakeFineTuneDefault(name, name_text, values, labels, dir
             end)
         end,
     })
+end
+
+function ConfigDialog:findOptionByName(name)
+    local option
+    for i=1, #self.config_options do
+        local options = self.config_options[i].options
+        for j=1, #options do
+            if options[j].name == name then
+                option = options[j]
+                break
+            end
+        end
+        if option then
+            break
+        end
+    end
+    return option
 end
 
 function ConfigDialog:closeDialog()


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/482 :
- initTableRendMethods(): fix possible crash
- ldomXPointer::getRect(): skip inline pads
- Ruby: keep any last text wrapped in internal table elements
- Font: fix HarfBuzz localized glyphs with CJK punctuation
- lvtext: store kerning mode as a Formatter property
- CJK: improved typography by tweaking punctuations
  Closes #6078.
- CJK: allow scaling CJK glyphs' widths
- CSS/lvrend: adds "-cr-hint: cjk-tailored"
- CJK: expand last line as previous justified line
  Closes #8929.
- CJK: add 1/4 em of spacing between CJK and western words

Closes #6162 (and hopefully my journey into CJK :).

Add this style tweak:
![image](https://user-images.githubusercontent.com/24273478/172046891-ef1d5b1b-e77e-4a4b-9498-ae4fcfc701e4.png)
(A bit sad to get 6 items in this style tweak menu - I usually try to target at max 5 items - but couldn't think of any other layout. It has to be in "Paragraphs".)

Also add a new setting `CJK width scaling`:
The setting is handled like all other bottom menu options but, as it's really not useful and its target audience is very limited, make it not shown in the bottom menu, but available via another button in the (also quite not useful) Word Expansion fine tuning widget.
This button allows switching between these 2 widgets:
![image](https://user-images.githubusercontent.com/24273478/172047297-81954d60-94e9-4ce5-89c3-2431fd82db15.png) ![image](https://user-images.githubusercontent.com/24273478/172047092-30ba3f42-7e25-45f1-a24d-6a5ce757d5f3.png)
(A bit not pretty, but this setting does not deserve to have its own bottom toggle, and it has no real place in the top menu - and its handling is just done right by leaving it to the bottom ConfidDialog).

Rewording suggestions welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9170)
<!-- Reviewable:end -->
