### PR TITLE
AutoSuspend: Make sure we send a LeaveStandby event ASAP

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -145,12 +145,10 @@ function ReaderCoptListener:onResume()
     end
 
     self:headerRefresh()
-    self:rescheduleHeaderRefreshIfNeeded()
 end
 
 function ReaderCoptListener:onLeaveStandby()
     self:headerRefresh()
-    self:rescheduleHeaderRefreshIfNeeded()
 end
 
 function ReaderCoptListener:onOutOfScreenSaver()
@@ -160,7 +158,6 @@ function ReaderCoptListener:onOutOfScreenSaver()
 
     self._delayed_screensaver = nil
     self:headerRefresh()
-    self:rescheduleHeaderRefreshIfNeeded()
 end
 
 -- Unschedule on these events

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -766,8 +766,9 @@ end
 
 function ReaderFooter:unscheduleFooterAutoRefresh()
     if not self.autoRefreshFooter then return end -- not yet set up
+    -- Slightly different wording than in rescheduleFooterAutoRefreshIfNeeded because it might not actually be scheduled at all
+    logger.dbg("ReaderFooter: unschedule autoRefreshFooter")
     UIManager:unschedule(self.autoRefreshFooter)
-    logger.dbg("ReaderFooter.autoRefreshFooter unscheduled")
 end
 
 function ReaderFooter:rescheduleFooterAutoRefreshIfNeeded()
@@ -808,12 +809,12 @@ function ReaderFooter:rescheduleFooterAutoRefreshIfNeeded()
     if schedule then
         UIManager:scheduleIn(61 - tonumber(os.date("%S")), self.autoRefreshFooter)
         if not unscheduled then
-            logger.dbg("ReaderFooter.autoRefreshFooter scheduled")
+            logger.dbg("ReaderFooter: scheduled autoRefreshFooter")
         else
-            logger.dbg("ReaderFooter.autoRefreshFooter rescheduled")
+            logger.dbg("ReaderFooter: rescheduled autoRefreshFooter")
         end
     elseif unscheduled then
-        logger.dbg("ReaderFooter.autoRefreshFooter unscheduled")
+        logger.dbg("ReaderFooter: unscheduled autoRefreshFooter")
     end
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -523,6 +523,8 @@ end
 
 -- Schedule an execution task; task queue is in ascending order
 function UIManager:schedule(sched_time, action, ...)
+    logger.dbg("UIManager:schedule:", sched_time, action)
+    logger.dbg(debug.traceback())
     local p, s, e = 1, 1, #self._task_queue
     if e ~= 0 then
         -- Do a binary insert.
@@ -551,13 +553,38 @@ function UIManager:schedule(sched_time, action, ...)
         until e < s
     end
 
+    local level
+    -- Find the actual public cheduling function in the stack...
+    for l = 10, 2, -1 do
+        local info = debug.getinfo(l, "n")
+        if info then
+            if info.name == "scheduleIn" or info.name == "nextTick" or info.name == "tickAfterNext" then
+                level = l + 1
+                break
+            end
+        end
+    end
+
+    local caller
+    if level then
+        local info = debug.getinfo(level, "Sln")
+        caller = string.format("%s %s:%d declared line %d", info.name, info.source, info.currentline, info.linedefined)
+    else
+        caller = "N/A"
+    end
+
     table.insert(self._task_queue, p, {
         time = sched_time,
         action = action,
         argc = select('#', ...),
         args = {...},
+        source = caller,
     })
     self._task_queue_dirty = true
+    logger.dbg("UIManager:schedule: Inserted task", tostring(self._task_queue[p]), "at index", p, "of", #self._task_queue)
+    logger.dbg("\tsource =", self._task_queue[p].source or "nil")
+    logger.dbg("\taction =", self._task_queue[p].action or "nil")
+    logger.dbg("\ttime =", self._task_queue[p].time or "nil")
 end
 dbg:guard(UIManager, 'schedule',
     function(self, sched_time, action)
@@ -644,6 +671,7 @@ UIManager:scheduleIn(10.5, self.anonymousFunction)
 UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
+    logger.dbg("UIManager:unschedule:", tostring(action))
     local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then
@@ -651,6 +679,7 @@ function UIManager:unschedule(action)
             removed = true
         end
     end
+    logger.dbg(removed)
     return removed
 end
 dbg:guard(UIManager, 'unschedule',
@@ -1162,6 +1191,7 @@ end
 
 function UIManager:_checkTasks()
     self._now = time.now()
+    logger.dbg("UIManager:_checkTasks @", self._now)
     local wait_until = nil
 
     -- Tasks due for execution might themselves schedule more tasks (that might also be immediately due for execution ;)).
@@ -1169,7 +1199,12 @@ function UIManager:_checkTasks()
     self._task_queue_dirty = false
     while self._task_queue[1] do
         local task_time = self._task_queue[1].time
+        logger.dbg("UIManager:_checkTasks checking task", tostring(self._task_queue[1]))
+        logger.dbg("\tsource =", self._task_queue[1].source or "nil")
+        logger.dbg("\taction =", self._task_queue[1].action or "nil")
+        logger.dbg("\ttime =", self._task_queue[1].time or "nil")
         if task_time <= self._now then
+            logger.dbg("It's due, execute it")
             -- Pop the upcoming task, as it is due for execution...
             local task = table.remove(self._task_queue, 1)
             -- ...so do it now.
@@ -1184,6 +1219,7 @@ function UIManager:_checkTasks()
         end
     end
 
+    logger.dbg("UIManager:_checkTasks @", self._now, "asked input polling to wait until", wait_until)
     return wait_until, self._now
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1698,7 +1698,7 @@ function UIManager:handleInput()
     if self.PM_INPUT_TIMEOUT then
         -- If the PM state transition requires an early return from input polling, honor that.
         -- c.f., UIManager:setPMInputTimeout (and AutoSuspend:AllowStandbyHandler).
-        deadline = now + time.us(self.PM_INPUT_TIMEOUT)
+        deadline = now + time.s(self.PM_INPUT_TIMEOUT)
         self.PM_INPUT_TIMEOUT = nil
     end
 
@@ -1883,7 +1883,7 @@ function UIManager:_standbyTransition()
     self._prev_prevent_standby_count = self._prevent_standby_count
 end
 
--- Used by a PM transition event handler to request an early return from input polling (value in µs).
+-- Used by a PM transition event handler to request an early return from input polling (value in s).
 -- NOTE: We can't re-use setInputTimeout to avoid interactions with ZMQ...
 function UIManager:setPMInputTimeout(timeout)
     self.PM_INPUT_TIMEOUT = timeout

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -672,6 +672,7 @@ UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
     logger.dbg("UIManager:unschedule:", tostring(action))
+    logger.dbg(debug.traceback())
     local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -523,8 +523,6 @@ end
 
 -- Schedule an execution task; task queue is in ascending order
 function UIManager:schedule(sched_time, action, ...)
-    logger.dbg("UIManager:schedule:", sched_time, action)
-    logger.dbg(debug.traceback())
     local p, s, e = 1, 1, #self._task_queue
     if e ~= 0 then
         -- Do a binary insert.
@@ -553,38 +551,13 @@ function UIManager:schedule(sched_time, action, ...)
         until e < s
     end
 
-    local level
-    -- Find the actual public cheduling function in the stack...
-    for l = 10, 2, -1 do
-        local info = debug.getinfo(l, "n")
-        if info then
-            if info.name == "scheduleIn" or info.name == "nextTick" or info.name == "tickAfterNext" then
-                level = l + 1
-                break
-            end
-        end
-    end
-
-    local caller
-    if level then
-        local info = debug.getinfo(level, "Sln")
-        caller = string.format("%s %s:%d declared line %d", info.name, info.source, info.currentline, info.linedefined)
-    else
-        caller = "N/A"
-    end
-
     table.insert(self._task_queue, p, {
         time = sched_time,
         action = action,
         argc = select('#', ...),
         args = {...},
-        source = caller,
     })
     self._task_queue_dirty = true
-    logger.dbg("UIManager:schedule: Inserted task", tostring(self._task_queue[p]), "at index", p, "of", #self._task_queue)
-    logger.dbg("\tsource =", self._task_queue[p].source or "nil")
-    logger.dbg("\taction =", self._task_queue[p].action or "nil")
-    logger.dbg("\ttime =", self._task_queue[p].time or "nil")
 end
 dbg:guard(UIManager, 'schedule',
     function(self, sched_time, action)
@@ -671,8 +644,6 @@ UIManager:scheduleIn(10.5, self.anonymousFunction)
 UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
-    logger.dbg("UIManager:unschedule:", tostring(action))
-    logger.dbg(debug.traceback())
     local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then
@@ -680,7 +651,6 @@ function UIManager:unschedule(action)
             removed = true
         end
     end
-    logger.dbg(removed)
     return removed
 end
 dbg:guard(UIManager, 'unschedule',
@@ -1192,7 +1162,6 @@ end
 
 function UIManager:_checkTasks()
     self._now = time.now()
-    logger.dbg("UIManager:_checkTasks @", self._now)
     local wait_until = nil
 
     -- Tasks due for execution might themselves schedule more tasks (that might also be immediately due for execution ;)).
@@ -1200,12 +1169,7 @@ function UIManager:_checkTasks()
     self._task_queue_dirty = false
     while self._task_queue[1] do
         local task_time = self._task_queue[1].time
-        logger.dbg("UIManager:_checkTasks checking task", tostring(self._task_queue[1]))
-        logger.dbg("\tsource =", self._task_queue[1].source or "nil")
-        logger.dbg("\taction =", self._task_queue[1].action or "nil")
-        logger.dbg("\ttime =", self._task_queue[1].time or "nil")
         if task_time <= self._now then
-            logger.dbg("It's due, execute it")
             -- Pop the upcoming task, as it is due for execution...
             local task = table.remove(self._task_queue, 1)
             -- ...so do it now.
@@ -1220,7 +1184,6 @@ function UIManager:_checkTasks()
         end
     end
 
-    logger.dbg("UIManager:_checkTasks @", self._now, "asked input polling to wait until", wait_until)
     return wait_until, self._now
 end
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1694,7 +1694,7 @@ function UIManager:handleInput()
     -- If allowed, entering standby (from which we can wake by input) must trigger in response to event
     -- this function emits (plugin), or within waitEvent() right after (hardware).
     -- Anywhere else breaks preventStandby/allowStandby invariants used by background jobs while UI is left running.
-    self:_standbyTransition(deadline)
+    self:_standbyTransition()
     if self.PM_INPUT_TIMEOUT then
         -- If the PM state transition requires an early return from input polling, honor that.
         -- c.f., UIManager:setPMInputTimeout (and AutoSuspend:AllowStandbyHandler).
@@ -1868,17 +1868,17 @@ end
 
 -- The allow/prevent calls above can interminently allow standbys, but we're not interested until
 -- the state change crosses UI tick boundary, which is what self._prev_prevent_standby_count is tracking.
-function UIManager:_standbyTransition(input_deadline)
+function UIManager:_standbyTransition()
     if self._prevent_standby_count == 0 and self._prev_prevent_standby_count > 0 then
         -- edge prevent->allow
         logger.dbg("allow standby")
         Device:setAutoStandby(true)
-        self:broadcastEvent(Event:new("AllowStandby", input_deadline))
+        self:broadcastEvent(Event:new("AllowStandby"))
     elseif self._prevent_standby_count > 0 and self._prev_prevent_standby_count == 0 then
         -- edge allow->prevent
         logger.dbg("prevent standby")
         Device:setAutoStandby(false)
-        self:broadcastEvent(Event:new("PreventStandby", input_deadline))
+        self:broadcastEvent(Event:new("PreventStandby"))
     end
     self._prev_prevent_standby_count = self._prevent_standby_count
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1695,6 +1695,12 @@ function UIManager:handleInput()
     -- this function emits (plugin), or within waitEvent() right after (hardware).
     -- Anywhere else breaks preventStandby/allowStandby invariants used by background jobs while UI is left running.
     self:_standbyTransition()
+    if self.PM_INPUT_TIMEOUT then
+        -- If the PM state transition requires an early return from input polling, honor that.
+        -- c.f., UIManager:setPMInputTimeout (and AutoSuspend:AllowStandbyHandler).
+        deadline = now + time.us(self.PM_INPUT_TIMEOUT)
+        self.PM_INPUT_TIMEOUT = nil
+    end
 
     -- wait for next batch of events
     local input_events = Input:waitEvent(now, deadline)
@@ -1875,6 +1881,12 @@ function UIManager:_standbyTransition()
         self:broadcastEvent(Event:new("PreventStandby"))
     end
     self._prev_prevent_standby_count = self._prevent_standby_count
+end
+
+-- Used by a PM transition event handler to request an early return from input polling (value in µs).
+-- NOTE: We can't re-use setInputTimeout to avoid interactions with ZMQ...
+function UIManager:setPMInputTimeout(timeout)
+    self.PM_INPUT_TIMEOUT = timeout
 end
 
 --- Broadcasts a `FlushSettings` Event to *all* widgets.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -607,6 +607,8 @@ function AutoSuspend:AllowStandbyHandler()
             -- NOTE: Warning: magic number, YMMV!
             UIManager:setPMInputTimeout(2)
         end
+
+        -- FIXME: Just recompute input timeout based on standby time :?
     end
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -609,6 +609,9 @@ function AutoSuspend:AllowStandbyHandler()
         end
 
         -- FIXME: Just recompute input timeout based on Device.last_standby_time :?
+        --        I was going to say now is also outdated after suspend, but, err, no,
+        --        MONOTONIC doesn't tick during low power states, you dummy.
+        --        TL;DR: I need a working brain, see you in three days.
     end
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -602,8 +602,11 @@ function AutoSuspend:AllowStandbyHandler()
         -- input polling deadline (because MONOTONIC doesn't tick during standby/suspend),
         -- tweak said deadline to make sure poll will return immediately, so we get a chance to run through the task queue ASAP.
         -- This ensures we get a LeaveStandby event in a timely fashion,
-        -- even when there isn't actually any user input happening.
-        -- This should, hopefully, not prevent us from actually consuming any pending input events first, though...
+        -- even when there isn't actually any user input happening (e.g., woken up by the rtc alarm).
+        -- This shouldn't prevent us from actually consuming any pending input events first,
+        -- because if we were woken up by user input, those events should already be in the evdev queue
+        -- (i.e., select will return immediately, sure,
+        -- but it'll have flagged the proper input device's fd as needing to be read).
         UIManager:setPMInputTimeout(0)
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -204,12 +204,6 @@ function AutoSuspend:_unschedule_standby()
     end
 
     -- Make sure we don't trigger a ghost LeaveStandby event...
-    if self.wrapped_leave_standby_task then
-        logger.dbg("AutoSuspend: unschedule leave standby task wrapper")
-        UIManager:unschedule(self.wrapped_leave_standby_task)
-        self.wrapped_leave_standby_task = nil
-    end
-
     if self.leave_standby_task then
         logger.dbg("AutoSuspend: unschedule leave standby task")
         UIManager:unschedule(self.leave_standby_task)
@@ -338,8 +332,6 @@ end
 
 function AutoSuspend:onLeaveStandby()
     logger.dbg("AutoSuspend: onLeaveStandby")
-    -- If the Event got through, tickAfterNext did its thing, clear the reference to the initial nextTick wrapper...
-    self.wrapped_leave_standby_task = nil
     -- Unschedule suspend and shutdown, as the realtime clock has ticked
     self:_unschedule()
     -- Reschedule suspend and shutdown (we'll recompute the delay based on the last user input, *not* the current time).
@@ -599,15 +591,22 @@ function AutoSuspend:AllowStandbyHandler()
         -- to make sure UIManager will consume the input events that woke us up first
         -- (in case we were woken up by user input, as opposed to an rtc wake alarm)!
         -- (This ensures we'll use an up to date last_action_time, and that it only ever gets updated from *user* input).
-        -- NOTE: UIManager consumes scheduled tasks before input events, which is why we can't use nextTick.
-        self.wrapped_leave_standby_task = UIManager:tickAfterNext(self.leave_standby_task)
+        -- NOTE: While UIManager consumes scheduled tasks before input events, we do *NOT* have to rely on tickAfterNext,
+        --       solely because of where we run inside an UI frame (via UIManager:_standbyTransition):
+        --       we're neither a scheduled task nor an input event, we run *between* scheduled tasks and input polling.
+        --       That means we go straight to input polling when returning, *without* a trip through the task queue
+        --       (c.f., UIManager:_checkTasks in UIManager:handleInput).
+        UIManager:nextTick(self.leave_standby_task)
 
-        -- If we don't have a scheduled task soon, we may not actually get two UI frames,
-        -- we might just go to a potentially long wait on input polling right away.
-        -- To ensure we do get a LeaveStandby in those edge-cases,
-        -- make sure we'll actually return from input polling in the next second by inserting a NOP in the task queue.
+        -- Since we go straight to input polling, with the timeout already computed,
+        -- if we don't have a scheduled task soon, we might just be waiting on input polling for a while.
+        -- To ensure we get a LeaveStandby event in a timely fashion, even when there isn't actually any user input happening,
+        -- tell UIManager to return early from input polling, so we get a chance to run through the task queue soon.
+        -- FIXME: Without a real input event, self.last_action_time will *not* have been updated!
+        --        Double-check how bad this might be ;).
         if not next_task_time or next_task_time > 1 then
-            UIManager:scheduleIn(1, function() end)
+            -- 1s shouldn't skew things too much ;).
+            UIManager:setPMInputTimeout(1000)
         end
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -606,7 +606,7 @@ function AutoSuspend:AllowStandbyHandler()
         --        Double-check how bad this might be ;).
         if not next_task_time or next_task_time > 1 then
             -- 1s shouldn't skew things too much ;).
-            UIManager:setPMInputTimeout(1000)
+            UIManager:setPMInputTimeout(1000000)
         end
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -602,10 +602,10 @@ function AutoSuspend:AllowStandbyHandler()
         -- if we don't have a scheduled task soon, we might just be waiting on input polling for a while.
         -- To ensure we get a LeaveStandby event in a timely fashion, even when there isn't actually any user input happening,
         -- tell UIManager to return early from input polling, so we get a chance to run through the task queue soon.
-        if not next_task_time or next_task_time > 1 then
-            -- 1s shouldn't skew things too much ;).
-            -- FIXME: But it might actually be slightly too early in some cases?
-            UIManager:setPMInputTimeout(1)
+        if not next_task_time or next_task_time > 2 then
+            -- 2s shouldn't skew things too much, while ensuring we still have time to consume late input events ;).
+            -- NOTE: Warning: magic number, YMMV!
+            UIManager:setPMInputTimeout(2)
         end
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -604,6 +604,7 @@ function AutoSuspend:AllowStandbyHandler()
         -- tell UIManager to return early from input polling, so we get a chance to run through the task queue soon.
         if not next_task_time or next_task_time > 1 then
             -- 1s shouldn't skew things too much ;).
+            -- FIXME: But it might actually be slightly too early in some cases?
             UIManager:setPMInputTimeout(1000000)
         end
     end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -601,6 +601,14 @@ function AutoSuspend:AllowStandbyHandler()
         -- (This ensures we'll use an up to date last_action_time, and that it only ever gets updated from *user* input).
         -- NOTE: UIManager consumes scheduled tasks before input events, which is why we can't use nextTick.
         self.wrapped_leave_standby_task = UIManager:tickAfterNext(self.leave_standby_task)
+
+        -- If we don't have a scheduled task soon, we may not actually get two UI frames,
+        -- we might just go to a potentially long wait on input polling right away.
+        -- To ensure we do get a LeaveStandby in those edge-cases,
+        -- make sure we'll actually return from input polling in the next second by inserting a NOP in the task queue.
+        if not next_task_time or next_task_time > 1 then
+            UIManager:scheduleIn(1, function() end)
+        end
     end
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -605,7 +605,7 @@ function AutoSuspend:AllowStandbyHandler()
         if not next_task_time or next_task_time > 1 then
             -- 1s shouldn't skew things too much ;).
             -- FIXME: But it might actually be slightly too early in some cases?
-            UIManager:setPMInputTimeout(1000000)
+            UIManager:setPMInputTimeout(1)
         end
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -604,9 +604,7 @@ function AutoSuspend:AllowStandbyHandler()
         -- This ensures we get a LeaveStandby event in a timely fashion,
         -- even when there isn't actually any user input happening (e.g., woken up by the rtc alarm).
         -- This shouldn't prevent us from actually consuming any pending input events first,
-        -- because if we were woken up by user input, those events should already be in the evdev queue
-        -- (i.e., select will return immediately, sure,
-        -- but it'll have flagged the proper input device's fd as needing to be read).
+        -- because if we were woken up by user input, those events should already be in the evdev queue...
         UIManager:setPMInputTimeout(0)
     end
 end

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -608,7 +608,7 @@ function AutoSuspend:AllowStandbyHandler()
             UIManager:setPMInputTimeout(2)
         end
 
-        -- FIXME: Just recompute input timeout based on standby time :?
+        -- FIXME: Just recompute input timeout based on Device.last_standby_time :?
     end
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -602,8 +602,6 @@ function AutoSuspend:AllowStandbyHandler()
         -- if we don't have a scheduled task soon, we might just be waiting on input polling for a while.
         -- To ensure we get a LeaveStandby event in a timely fashion, even when there isn't actually any user input happening,
         -- tell UIManager to return early from input polling, so we get a chance to run through the task queue soon.
-        -- FIXME: Without a real input event, self.last_action_time will *not* have been updated!
-        --        Double-check how bad this might be ;).
         if not next_task_time or next_task_time > 1 then
             -- 1s shouldn't skew things too much ;).
             UIManager:setPMInputTimeout(1000000)


### PR DESCRIPTION
Even in corner cases where we're woken up *without* user input (e.g., rtc alarm).

Fix #9157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9173)
<!-- Reviewable:end -->
