### PR TITLE
NumberPickerWidget: add method to avoid min-max checks and input math expressions.

### DIFF
--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -165,7 +165,7 @@ function NumberPickerWidget:init()
                                     local function run_lua_protected_string(code)
                                         -- make environment
                                         local env = {math = math}
-                                        local func, message = loadstring(code)
+                                        local func, dummy = loadstring(code)
                                         if func then
                                             setfenv(func, env)
                                             return pcall(func)

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -150,18 +150,18 @@ function NumberPickerWidget:init()
                                 local input_value = tonumber(input_text)
                                 local turn_off_checks = false
 
-                                -- if the first character of the input string is ":" turn of min-max checks
+                                -- if the first character of the input string is ":" turn off min-max checks
                                 if input_text:match("^:") and G_reader_settings:isTrue("debug_verbose") then
                                     turn_off_checks = true -- turn off checks
                                     input_text = input_text:gsub("^:", "") -- shorten input
                                     input_value = tonumber(input_text) -- try to get value
                                 end
 
-                                -- if the input text starts with `=` try to evaluate the expression
+                                -- if the input text starts with `=`, try to evaluate the expression
                                 -- only allow `math.*` and no other functions to be safe here.
                                 if input_text:match("^=") then
                                     local function evaluate_string(code)
-                                        -- only execute if there a no chars (except math.xxx) and {[]} in the user input
+                                        -- only execute if there are no chars (except math.xxx) and no {[]} in the user input
                                         local check_code = code:gsub("math%.%a*", "")
                                         if check_code:find("[%a%[%]%{%}]") then
                                             return nil
@@ -182,7 +182,7 @@ function NumberPickerWidget:init()
                                     if not input_value then return end
                                     if input_value < self.value_min or input_value > self.value_max then
                                         UIManager:show(InfoMessage:new{
-                                            text = T(_("ATTENTION:\nYou turned of sanity checks!\nThis value should be in the range %1 - %2\nUndefined behavior is possible.\n"), self.value_min, self.value_max),
+                                            text = T(_("ATTENTION:\nSanity checks are disabled, by prefixing the input with ':'!\nThis value should be in the range %1 - %2.\nUndefined behavior may occur.\n"), self.value_min, self.value_max),
                                         })
                                     end
                                     self.value = input_value

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -182,7 +182,7 @@ function NumberPickerWidget:init()
                                     if not input_value then return end
                                     if input_value < self.value_min or input_value > self.value_max then
                                         UIManager:show(InfoMessage:new{
-                                            text = T(_("ATTENTION:\nSanity checks are disabled, by prefixing the input with ':'!\nThis value should be in the range %1 - %2.\nUndefined behavior may occur.\n"), self.value_min, self.value_max),
+                                            text = T(_("ATTENTION:\nPrefixing the input with ':' disables sanity checks!\nThis value should be in the range of %1 - %2.\nUndefined behavior may occur.\n"), self.value_min, self.value_max),
                                         })
                                     end
                                     self.value = input_value


### PR DESCRIPTION
If the input of a numberpickerwidget starts with `=` evaluate that expression. Might be useful if you want to enter for example `=12+10` or `=12*1.2` (not so usefull, but for free `=math.sqrt(144)`).

If the input of a numberpickerwidget starts with `:` avoid the min-max checks: Useful for testing (or exagerate some value like the max autoturn time see #9051). This is only enabled if `verbose debug` is on. 

To be combined in `:=1+2`, math plus suppressed checks.

A possible use case (independend of testing purposes) could be to allow autoturn in 7 days (=60 x 24 x 7)
Here I exagerate the max value and calculate the value.

![grafik](https://user-images.githubusercontent.com/36999612/172484616-d95f87d1-4e8f-4498-9768-83b2ae69b6e2.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9182)
<!-- Reviewable:end -->
