### PR TITLE
Footer: update on network disconnect

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2495,7 +2495,7 @@ end
 
 function ReaderFooter:onNetworkDisconnected()
     if self.settings.wifi_status then
-        self:onUpdateFooter(true, true)
+        self:onUpdateFooter(self.view.footer_visible)
     end
 end
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2495,7 +2495,7 @@ end
 
 function ReaderFooter:onNetworkDisconnected()
     if self.settings.wifi_status then
-        self:maybeUpdateFooter()
+        self:onUpdateFooter(true, true)
     end
 end
 


### PR DESCRIPTION
Enabled Fi-Wi-Status in the footer.
Turn Wi-Fi on in the menu, the footer gets updated (shows the Icon).
Turn Wi-Fi off in the menu, the footer doesn't get updated. You see the correct unchecked menu entry and the old obsolete Wi-Fi icon in the footer. This inconsistency has confused me quite some time.

With this PR, the footer shows the current status, when toggling Wi-Fi from the menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9185)
<!-- Reviewable:end -->
