### PR TITLE
Bump android-luajit-launcher

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -172,14 +172,15 @@ function ReaderHighlight:init()
 
     -- Android devices
     if Device:canShareText() then
+        local action = _("Share Text")
         self:addToHighlightDialog("08_share_text", function(_self)
             return {
-                text = _("Share Text"),
+                text = action,
                 callback = function()
                     local text = cleanupSelectedText(_self.selected_text.text)
                     -- call self:onClose() before calling the android framework
                     _self:onClose()
-                    Device.doShareText(text)
+                    Device:doShareText(text, action)
                 end,
             }
         end)

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -97,7 +97,9 @@ local Device = Generic:new{
     hasExternalSD = function() return android.getExternalSdPath() end,
     importFile = function(path) android.importFile(path) end,
     canShareText = yes,
-    doShareText = function(text) android.sendText(text) end,
+    doShareText = function(self, text, reason, title, mimetype)
+        android.sendText(text, reason, title, mimetype)
+    end,
 
     canExternalDictLookup = yes,
     getExternalDictLookupList = function() return external.dicts end,


### PR DESCRIPTION
* Decouples dict lookup from generic text share.
    * Fixes #9178

* New devices:
    * Added: Onyx Note
    * Fixed: Onyx Nova 3 (this time for real :))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9193)
<!-- Reviewable:end -->
