### PR TITLE
vocabbuilder.koplugin: adding copy button and word context

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -402,7 +402,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
     end
 end
 
-function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tweak_buttons_func, pos)
+function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tweak_buttons_func)
     logger.dbg("dict lookup word:", word, boxes)
     -- escape quotes and other funny characters in word
     word = self:cleanSelection(word, is_sane)
@@ -412,7 +412,7 @@ function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tw
 
     -- Wrapped through Trapper, as we may be using Trapper:dismissablePopen() in it
     Trapper:wrap(function()
-        self:stardictLookup(word, self.enabled_dict_names, not self.disable_fuzzy_search, boxes, link, tweak_buttons_func, pos)
+        self:stardictLookup(word, self.enabled_dict_names, not self.disable_fuzzy_search, boxes, link, tweak_buttons_func)
     end)
     return true
 end
@@ -883,7 +883,7 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     return results
 end
 
-function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, link, tweak_buttons_func, pos)
+function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, link, tweak_buttons_func)
     if word == "" then
         return
     end
@@ -897,7 +897,7 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, 
         end
 
     -- Event for plugin to catch lookup with book title
-    self.ui:handleEvent(Event:new("WordLookedUp", word, book_title, pos))
+    self.ui:handleEvent(Event:new("WordLookedUp", word, book_title))
     if not self.disable_lookup_history then
         lookup_history:addTableItem("lookup_history", {
             book_title = book_title,

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -402,7 +402,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
     end
 end
 
-function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tweak_buttons_func)
+function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tweak_buttons_func, pos)
     logger.dbg("dict lookup word:", word, boxes)
     -- escape quotes and other funny characters in word
     word = self:cleanSelection(word, is_sane)
@@ -412,7 +412,7 @@ function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tw
 
     -- Wrapped through Trapper, as we may be using Trapper:dismissablePopen() in it
     Trapper:wrap(function()
-        self:stardictLookup(word, self.enabled_dict_names, not self.disable_fuzzy_search, boxes, link, tweak_buttons_func)
+        self:stardictLookup(word, self.enabled_dict_names, not self.disable_fuzzy_search, boxes, link, tweak_buttons_func, pos)
     end)
     return true
 end
@@ -883,7 +883,7 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     return results
 end
 
-function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, link, tweak_buttons_func)
+function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, link, tweak_buttons_func, pos)
     if word == "" then
         return
     end
@@ -897,7 +897,7 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, 
         end
 
     -- Event for plugin to catch lookup with book title
-    self.ui:handleEvent(Event:new("WordLookedUp", word, book_title))
+    self.ui:handleEvent(Event:new("WordLookedUp", word, book_title, pos))
     if not self.disable_lookup_history then
         lookup_history:addTableItem("lookup_history", {
             book_title = book_title,

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -888,13 +888,13 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, 
         return
     end
 
-        local book_title = self.ui.doc_settings and self.ui.doc_settings:readSetting("doc_props").title or _("Dictionary lookup")
-        if book_title == "" then -- no or empty metadata title
-            if self.ui.document and self.ui.document.file then
-                local directory, filename = util.splitFilePathName(self.ui.document.file) -- luacheck: no unused
-                book_title = util.splitFileNameSuffix(filename)
-            end
+    local book_title = self.ui.doc_settings and self.ui.doc_settings:readSetting("doc_props").title or _("Dictionary lookup")
+    if book_title == "" then -- no or empty metadata title
+        if self.ui.document and self.ui.document.file then
+            local directory, filename = util.splitFilePathName(self.ui.document.file) -- luacheck: no unused
+            book_title = util.splitFileNameSuffix(filename)
         end
+    end
 
     -- Event for plugin to catch lookup with book title
     self.ui:handleEvent(Event:new("WordLookedUp", word, book_title))

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1196,7 +1196,7 @@ function ReaderHighlight:lookup(selected_text, selected_link)
 
     -- if we extracted text directly
     if selected_text.text and self.hold_pos then
-        self.ui:handleEvent(Event:new("LookupWord", selected_text.text, false, word_boxes, self, selected_link))
+        self.ui:handleEvent(Event:new("LookupWord", selected_text.text, false, word_boxes, self, selected_link, nil, {selected_text.pos0, selected_text.pos1}))
     -- or we will do OCR
     elseif selected_text.sboxes and self.hold_pos then
         local text = self.ui.document:getOCRText(self.hold_pos.page, selected_text.sboxes)

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -140,7 +140,7 @@ local order = {
     search = {
         "dictionary_lookup",
         "dictionary_lookup_history",
-        "vocabulary_builder",
+        "vocabbuilder",
         "dictionary_settings",
         "----------------------------",
         "wikipedia_lookup",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -188,7 +188,7 @@ local order = {
     search = {
         "dictionary_lookup",
         "dictionary_lookup_history",
-        "vocabulary_builder",
+        "vocabbuilder",
         "dictionary_settings",
         "----------------------------",
         "wikipedia_lookup",

--- a/plugins/vocabbuilder.koplugin/_meta.lua
+++ b/plugins/vocabbuilder.koplugin/_meta.lua
@@ -1,6 +1,6 @@
 local _ = require("gettext")
 return {
-    name = "vocabulary_builder",
+    name = "vocabbuilder",
     fullname = _("Vocabulary builder"),
     description = _([[This plugin processes dictionary word lookups and uses spaced repetition to help you remember new words.]]),
 }

--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -5,19 +5,27 @@ local LuaData = require("luadata")
 
 local db_location = DataStorage:getSettingsDir() .. "/vocabulary_builder.sqlite3"
 
-local DB_SCHEMA_VERSION = 20220522
+local DB_SCHEMA_VERSION = 20220608
 local VOCABULARY_DB_SCHEMA = [[
     -- To store looked up words
     CREATE TABLE IF NOT EXISTS "vocabulary" (
         "word"          TEXT NOT NULL UNIQUE,
-        "book_title"    TEXT DEFAULT '',
+        "title_id"      INTEGER,
         "create_time"   INTEGER NOT NULL,
         "review_time"   INTEGER,
         "due_time"      INTEGER NOT NULL,
         "review_count"  INTEGER NOT NULL DEFAULT 0,
+        "prev_context"  TEXT,
+        "next_context"  TEXT,
         PRIMARY KEY("word")
     );
+    CREATE TABLE IF NOT EXISTS "title" (
+        "id"            INTEGER NOT NULL UNIQUE,
+        "name"          TEXT UNIQUE,
+        PRIMARY KEY("id" AUTOINCREMENT)
+    );
     CREATE INDEX IF NOT EXISTS due_time_index ON vocabulary(due_time);
+    CREATE INDEX IF NOT EXISTS title_name_index ON title(name);
 ]]
 
 local VocabularyBuilder = {
@@ -62,7 +70,22 @@ function VocabularyBuilder:createDB()
     if db_version < DB_SCHEMA_VERSION then
         if db_version == 0 then
             self:insertLookupData(db_conn)
+        elseif db_version < 20220608 then
+            db_conn:exec([[ ALTER TABLE vocabulary ADD prev_context TEXT;
+                            ALTER TABLE vocabulary ADD next_context TEXT;
+                            ALTER TABLE vocabulary ADD title_id INTEGER;
+
+                            INSERT INTO title (name)
+                            SELECT DISTINCT book_title FROM vocabulary;
+
+                            UPDATE vocabulary SET title_id = (
+                               SELECT id FROM title WHERE name = book_title
+                            );
+
+                            ALTER TABLE vocabulary DROP book_title;]])
         end
+
+        db_conn:exec("CREATE INDEX IF NOT EXISTS title_id_index ON vocabulary(title_id);")
         -- Update version
         db_conn:exec(string.format("PRAGMA user_version=%d;", DB_SCHEMA_VERSION))
 
@@ -76,21 +99,29 @@ function VocabularyBuilder:insertLookupData(db_conn)
     local lookup_history = LuaData:open(file_path, { name = "LookupHistory" })
     if lookup_history:has("lookup_history") then
         local lookup_history_table = lookup_history:readSetting("lookup_history")
-        local words = {}
+        local book_titles = {}
+        local stmt = db_conn:prepare("INSERT INTO title (name) values (?);")
+        for i = #lookup_history_table, 1, -1 do
+            local book_title = lookup_history_table[i].book_title or ""
+            if not book_titles[book_title] then
+                stmt:bind(book_title)
+                stmt:step()
+                stmt:clearbind():reset()
+                book_titles[book_title] = true
+            end
+        end
 
+        local words = {}
+        local insert_sql = [[INSERT OR REPLACE INTO vocabulary
+                            (word, title_id, create_time, due_time) values
+                            (?, (SELECT id FROM title WHERE name = ?), ?, ?);]]
+        stmt = db_conn:prepare(insert_sql)
         for i = #lookup_history_table, 1, -1 do
             local value = lookup_history_table[i]
             if not words[value.word] then
-                local insert_sql = [[INSERT OR REPLACE INTO vocabulary
-                            (word, book_title, create_time, due_time) values
-                            (?, ?, ?, ?);
-                            ]]
-                local stmt = db_conn:prepare(insert_sql)
-
                 stmt:bind(value.word, value.book_title or "", value.time, value.time + 5*60)
                 stmt:step()
                 stmt:clearbind():reset()
-
                 words[value.word] = true
             end
         end
@@ -100,7 +131,7 @@ end
 
 function VocabularyBuilder:_select_items(items, start_idx)
     local conn = SQ3.open(db_location)
-    local sql = string.format("SELECT * FROM vocabulary ORDER BY due_time limit %d OFFSET %d;", 32, start_idx-1)
+    local sql = string.format("SELECT * FROM vocabulary LEFT JOIN title ON title_id = title.id ORDER BY due_time limit %d OFFSET %d;", 32, start_idx-1)
 
     local results = conn:exec(sql)
     conn:close()
@@ -113,11 +144,13 @@ function VocabularyBuilder:_select_items(items, start_idx)
         if item and not item.word then
             item.word = results.word[i]
             item.review_count = math.max(0, math.min(8, tonumber(results.review_count[i])))
-            item.book_title = results.book_title[i] or ""
+            item.book_title = results.name[i] or ""
             item.create_time = tonumber( results.create_time[i])
             item.review_time = nil --use this field to flag change
             item.due_time = tonumber(results.due_time[i])
             item.is_dim = tonumber(results.due_time[i]) > current_time
+            item.prev_context = results.prev_context[i]
+            item.next_context = results.next_context[i]
             item.got_it_callback = function(item_input)
                 VocabularyBuilder:gotOrForgot(item_input, true)
             end
@@ -198,18 +231,28 @@ function VocabularyBuilder:batchUpdateItems(items)
             stmt:clearbind():reset()
         end
     end
+
+    conn:exec("DELETE FROM title WHERE NOT EXISTS( SELECT title_id FROM vocabulary WHERE id = title_id );")
     conn:close()
 end
 
 function VocabularyBuilder:insertOrUpdate(entry)
     local conn = SQ3.open(db_location)
-    local stmt = conn:prepare([[INSERT INTO vocabulary (word, book_title, create_time, due_time)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(word) DO UPDATE SET book_title = excluded.book_title,
+    local stmt = conn:prepare("INSERT OR IGNORE INTO title (name) VALUES (?);")
+    stmt:bind(entry.book_title)
+    stmt:step()
+    stmt:clearbind():reset()
+
+    stmt = conn:prepare([[INSERT INTO vocabulary (word, title_id, create_time, due_time, prev_context, next_context)
+                        VALUES (?, (SELECT id FROM title WHERE name = ?), ?, ?, ?, ?)
+                        ON CONFLICT(word) DO UPDATE SET title_id = excluded.title_id,
                         create_time = excluded.create_time,
                         review_count = MAX(review_count-1, 0),
-                        due_time = ?;]])
-    stmt:bind(entry.word, entry.book_title, entry.time, entry.time+300, entry.time+300)
+                        due_time = ?,
+                        prev_context = ifnull(excluded.prev_context, prev_context),
+                        next_context = ifnull(excluded.next_context, next_context);]]);
+    stmt:bind(entry.word, entry.book_title, entry.time, entry.time+300,
+              entry.prev_context, entry.next_context, entry.time+300)
     stmt:step()
     stmt:clearbind():reset()
     self.count = tonumber(conn:rowexec("SELECT count(0) from vocabulary;"))
@@ -236,7 +279,7 @@ end
 
 function VocabularyBuilder:purge()
     local conn = SQ3.open(db_location)
-    conn:exec("DELETE FROM vocabulary;")
+    conn:exec("DELETE FROM vocabulary; DELETE FROM title;")
     self.count = 0
     conn:close()
 end

--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -189,7 +189,7 @@ function VocabularyBuilder:gotOrForgot(item, isGot)
 
     local due_time
     local target_count = math.min(math.max(item.review_count + (isGot and 1 or -1), 0), 8)
-    if target_count == 0 then
+    if not isGot or target_count == 0 then
         due_time = current_time + 5 * 60
     elseif target_count == 1 then
         due_time = current_time + 30 * 60

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -377,7 +377,7 @@ function WordInfoDialog:init()
                             VerticalSpan:new{width= Size.padding.default},
                             has_context and
                             TextBoxWidget:new{
-                                text = "..." .. self.prev_context:gsub("\n", " ") .. "~" .. self.next_context:gsub("\n", " ") .. "...",
+                                text = "..." .. self.prev_context:gsub("\n", " ") .. "【" ..self.title.."】" .. self.next_context:gsub("\n", " ") .. "...",
                                 width = width,
                                 face = Font:getFace("smallffont"),
                                 alignment = self.title_align or "left",

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1270,37 +1270,14 @@ function VocabBuilder:addToMainMenu(menu_items)
     }
 end
 
-function VocabBuilder:getWordContext(pos)
-    if not pos then return end
-    local pos_start = pos[1]
-    local pos_end = pos[2]
-    local maximum_span = 15
-    for i=0, maximum_span do
-        local ok, start = pcall(self.ui.document.getPrevVisibleWordStart, self.ui.document, pos_start)
-        if ok then pos_start = start
-        else break end
-    end
-
-    for i=0, maximum_span do
-        local ok, ending = pcall(self.ui.document.getNextVisibleWordEnd, self.ui.document, pos_end)
-        if ok then pos_end = ending
-        else break end
-    end
-
-    local ok_prev, prev = pcall(self.ui.document.getTextFromXPointers, self.ui.document, pos_start, pos[1])
-    local ok_next, next = pcall(self.ui.document.getTextFromXPointers, self.ui.document, pos[2], pos_end)
-
-    return ok_prev and prev, ok_next and next
-end
-
 -- Event sent by readerdictionary "WordLookedUp"
-function VocabBuilder:onWordLookedUp(word, title, pos)
+function VocabBuilder:onWordLookedUp(word, title)
     if not settings.enabled then return end
     if self.builder_widget and self.builder_widget.current_lookup_word == word then return true end
     local prev_context
     local next_context
     if settings.with_context then
-        prev_context, next_context = self:getWordContext(pos)
+        prev_context, next_context = self.ui.highlight:getSelectedWordContext(15)
     end
     DB:insertOrUpdate({
         book_title = title,

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1273,7 +1273,6 @@ end
 function VocabBuilder:addToMainMenu(menu_items)
     menu_items.vocabbuilder = {
         text = _("Vocabulary builder"),
-        keep_menu_open = true,
         callback = function()
             local vocab_items = {}
             for i = 1, DB:selectCount() do

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -295,7 +295,7 @@ local WordInfoDialog = InputContainer:new{
     reset_callback = nil,
     dismissable = true, -- set to false if any button callback is required
 }
-
+local word_info_dialog_width
 function WordInfoDialog:init()
     if self.dismissable then
         if Device:hasKeys() then
@@ -316,7 +316,18 @@ function WordInfoDialog:init()
         end
     end
 
-    local width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.61)
+    if not word_info_dialog_width then
+        local temp_text = TextWidget:new{
+            text = self.dates,
+            padding = Size.padding.fullscreen,
+            face = subtitle_face
+        }
+        local dates_width = temp_text:getSize().w
+        temp_text:free()
+        local screen_width = math.min(Screen:getWidth(), Screen:getHeight())
+        word_info_dialog_width = math.floor(math.max(screen_width * 0.6, math.min(screen_width * 0.8, dates_width)))
+    end
+    local width = word_info_dialog_width
     local reset_button = {
         text = _("Reset progress"),
         callback = function()
@@ -520,6 +531,7 @@ function VocabItemWidget:init()
     self:initItemWidget()
 end
 
+local review_button_width
 function VocabItemWidget:initItemWidget()
     for i = 1, #self.layout do self.layout[i] = nil end
     if not self.show_parent.is_edit_mode and self.item.review_count < 5 then
@@ -549,14 +561,16 @@ function VocabItemWidget:initItemWidget()
     local right_side_width
     local right_widget
     if not self.show_parent.is_edit_mode and self.item.due_time <= os.time() then
-        local temp_button = Button:new{
-            text = _("Got it"),
-            padding_h = Size.padding.large
-        }
-        local review_button_width = temp_button:getSize().w
-        temp_button:setText(_("Forgot"))
-        review_button_width = math.min(math.max(review_button_width, temp_button:getSize().w), Screen:getWidth()/4)
-        temp_button:free()
+        if not review_button_width then
+            local temp_button = Button:new{
+                text = _("Got it"),
+                padding_h = Size.padding.large
+            }
+            review_button_width = temp_button:getSize().w
+            temp_button:setText(_("Forgot"))
+            review_button_width = math.min(math.max(review_button_width, temp_button:getSize().w), Screen:getWidth()/4)
+            temp_button:free()
+        end
         right_side_width = review_button_width * 2 + Size.padding.large * 2 + ellipsis_button_width
         self.forgot_button = Button:new{
             text = _("Forgot"),

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -365,7 +365,7 @@ function WordInfoDialog:init()
                     align = "center",
                     FrameContainer:new{
                         padding = self.padding,
-                        padding_top = Size.padding.small,
+                        padding_top = Size.padding.buttontable,
                         padding_bottom = Size.padding.buttontable,
                         margin = self.margin,
                         bordersize = 0,

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -650,18 +650,23 @@ function VocabItemWidget:initItemWidget()
             padding_bottom = 0,
             allow_flash = false,
         }
+        local button_v_spacer = VerticalSpan:new{width = Screen:scaleBySize(1)}
         right_widget = HorizontalGroup:new{
             dimen = Geom:new{ w = 0, h = self.height },
             self.margin_span,
             VerticalGroup:new{
                 forgot_span_top,
+                button_v_spacer,
                 self.forgot_button,
+                button_v_spacer,
                 forgot_span_bottom,
             },
             self.margin_span,
             VerticalGroup:new{
                 got_it_span_top,
+                button_v_spacer,
                 self.got_it_button,
+                button_v_spacer,
                 got_it_span_bottom,
             },
             self.more_button,

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1071,6 +1071,7 @@ function VocabularyBuilderWidget:setupItemHeight()
     self.items_per_page = math.floor(content_height / line_height)
     self.item_margin = self.item_margin + math.floor((content_height - self.items_per_page * line_height ) / self.items_per_page )
     self.pages = math.ceil(DB:selectCount() / self.items_per_page)
+    self.show_page = math.min(self.pages, self.show_page)
 end
 
 function VocabularyBuilderWidget:nextPage()

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -454,7 +454,6 @@ end
 
 
 -- values useful for item cells
-local review_button_width = math.ceil(math.min(Screen:scaleBySize(95), Screen:getWidth()/6))
 local ellipsis_button_width = Screen:scaleBySize(34)
 local star_width = Screen:scaleBySize(25)
 
@@ -550,8 +549,15 @@ function VocabItemWidget:initItemWidget()
     local right_side_width
     local right_widget
     if not self.show_parent.is_edit_mode and self.item.due_time <= os.time() then
+        local temp_button = Button:new{
+            text = _("Got it"),
+            padding_h = Size.padding.large
+        }
+        local review_button_width = temp_button:getSize().w
+        temp_button:setText(_("Forgot"))
+        review_button_width = math.min(math.max(review_button_width, temp_button:getSize().w), Screen:getWidth()/4)
+        temp_button:free()
         right_side_width = review_button_width * 2 + Size.padding.large * 2 + ellipsis_button_width
-
         self.forgot_button = Button:new{
             text = _("Forgot"),
             width = review_button_width,

--- a/resources/icons/empty.svg
+++ b/resources/icons/empty.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg></svg>

--- a/resources/icons/empty.svg
+++ b/resources/icons/empty.svg
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg></svg>


### PR DESCRIPTION
This PR adds a copy button and word context(off by default) to the three-dot menu of word entries. cf #9180 

Also some db refactoring and minor UI improvements: 
- a dedicated book title table in order to shrink db size by storing references to title names instead of repeated actual strings,
- alignment of different forms of the "more" button and possible clipped words in translations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9195)
<!-- Reviewable:end -->
