### PR TITLE
bump crengine: text selection and embedded fonts tweaks

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -258,8 +258,6 @@ function ReaderView:screenToPageTransform(pos)
         end
     else
         pos.page = self.document:getCurrentPage()
-        -- local last_y = self.document:getCurrentPos()
-        logger.dbg("document has no pages at", pos)
         return pos
     end
 end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -835,6 +835,10 @@ function CreDocument:getTextFromXPointers(pos0, pos1, draw_selection)
     return self._document:getTextFromXPointers(pos0, pos1, draw_selection, draw_segmented_selection)
 end
 
+function CreDocument:extendXPointersToSentenceSegment(pos0, pos1)
+    return self._document:extendXPointersToSentenceSegment(pos0, pos1)
+end
+
 function CreDocument:getHTMLFromXPointer(xp, flags, from_final_parent)
     if xp then
         return self._document:getHTMLFromXPointer(xp, flags, from_final_parent)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -797,6 +797,10 @@ function CreDocument:getFontFace()
     return self._document:getFontFace()
 end
 
+function CreDocument:getEmbeddedFontList()
+    return self._document:getEmbeddedFontList()
+end
+
 function CreDocument:getCurrentPos()
     return self._document:getCurrentPos()
 end

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -1,9 +1,10 @@
 local Device = require("device")
 local Screen = Device.screen
+local ffiUtil = require("ffi/util")
 local optionsutil = require("ui/data/optionsutil")
 local _ = require("gettext")
 local C_ = _.pgettext
-local T = require("ffi/util").template
+local T = ffiUtil.template
 
 -- Get font size numbers as a table of strings
 local tableOfNumbersToTableOfStrings = function(numbers)
@@ -700,12 +701,24 @@ Whether enabled or disabled, KOReader's own status bar at the bottom of the scre
                 args = {false, true},
                 default_arg = nil,
                 event = "ToggleEmbeddedFonts",
-                enabled_func = function(configurable)
+                enabled_func = function(configurable, document)
                     return optionsutil.enableIfEquals(configurable, "embedded_css", 1)
+                            and next(document:getEmbeddedFontList()) ~= nil
                 end,
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Enable or disable the use of the fonts embedded in the book.
 (Disabling the fonts specified in the publisher stylesheets can also be achieved via Style Tweaks in the main menu.)]]),
+                help_text_func = function(configurable, document)
+                    local font_list = document:getEmbeddedFontList()
+                    if next(font_list) then
+                        local font_details = {}
+                        table.insert(font_details, _("Embedded fonts provided by the current book:"))
+                        for name in ffiUtil.orderedPairs(font_list) do
+                            table.insert(font_details, name .. (font_list[name] and "" or T("  (%1)", _("not used"))))
+                        end
+                        return table.concat(font_details, "\n")
+                    end
+                end,
             },
             {
                 name = "smooth_scaling",

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -101,7 +101,10 @@ function optionsutil.showValues(configurable, option, prefix, document)
     end
     if option.help_text_func then
         -- Allow for concatenating a dynamic help_text_func to a static help_text
-        help_text = T("%1\n%2\n", help_text, option.help_text_func(configurable, document))
+        local more_text = option.help_text_func(configurable, document)
+        if more_text and more_text ~= "" then
+            help_text = T("%1\n%2\n", help_text, more_text)
+        end
     end
     local text
     local name_text = option.name_text_func


### PR DESCRIPTION
#### bump crengine: text selection tweaks and helpers

Includes https://github.com/koreader/crengine/pull/484 : 
- lvtext: fix `m_kerning_mode` type
- XML: let '`gb2312`' (Chinese) encoding be known
- Add `ldomXPointer::getChar()`
- `LVDocView::getNodeByPoint()`: tweak for text selection
- Fonts: allow fetching the list of embedded fonts

cre.cpp https://github.com/koreader/koreader-base/pull/1490 : 
- `getTextFromPositions()`: use `getNodeByPoint(forTextSelection=true)` to allow panning in margins and get the nearest text instead of nothing.
Closes #9169.
- add `extendXPointersToSentenceSegment()` to allow extending some xpointer range to include punctuations at start or end (with for now a quite rudimentary implementation).
- add `getEmbeddedFontList()` to allow fetching the list of embedded fonts in the current EPUB book.

Also includes https://github.com/koreader/koreader-base/pull/1489 `Make luacheck >= 0.26 happy`.

#### Text highlighting: extend to include punctuations

When selected text seems to be a "sentence segment" (that is, when there are punctuations around start AND end), extend the selection to include the relevant punctuation.
Do this only when saving highlights and for translation (but not when dict or wikipedia lookups, or search).
See https://github.com/koreader/koreader/issues/8857#issuecomment-1151198923 for some screenshots showing what good (and bad) this does. Might need further refinements.
Closes #6217. Closes #8857.

#### Embedded fonts toggle: disabled if no embedded font

Have the enabled/disabled state of the toggle show the presence or not of embedded fonts in the current book.
Also show the names of the embedded fonts in the help_text InfoMessage.
See https://github.com/koreader/koreader/issues/9190#issuecomment-1152503765 for some screenshots. Any rewording suggestion ?
Closes #9190.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9198)
<!-- Reviewable:end -->
