### PR TITLE
Auto frontlight plugin: Newer Oasis models are also supported

### DIFF
--- a/plugins/autofrontlight.koplugin/main.lua
+++ b/plugins/autofrontlight.koplugin/main.lua
@@ -1,7 +1,10 @@
 local Device = require("device")
 
 if not Device:isKindle() or
-   (Device.model ~= "KindleVoyage" and Device.model ~= "KindleOasis") then
+   (Device.model ~= "KindleVoyage" and
+    Device.model ~= "KindleOasis" and
+    Device.model ~= "KindleOasis2" and
+    Device.model ~= "KindleOasis3") then
     return { disabled = true, }
 end
 


### PR DESCRIPTION
On a Kindle Oasis 2 and 3 the plugin would be disabled due to not
checking for "KindleOasis2" and "KindleOasis3" respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9202)
<!-- Reviewable:end -->
