### PR TITLE
BottomMenu: show real sizes for margins and font size

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -238,6 +238,10 @@ function Device:setScreenDPI(dpi_override)
     self.input.gesture_detector:init()
 end
 
+function Device:getDisplayDPI()
+    return self.display_dpi
+end
+
 function Device:getPowerDevice()
     return self.powerd
 end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -238,7 +238,7 @@ function Device:setScreenDPI(dpi_override)
     self.input.gesture_detector:init()
 end
 
-function Device:getDisplayDPI()
+function Device:getDeviceScreenDPI()
     return self.display_dpi
 end
 

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -224,7 +224,7 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                 },
                 hide_on_apply = true,
                 name_text_hold_callback = function(configurable, opt, prefix)
-                    optionsutil.showValues(configurable, opt, prefix, nil, true)
+                    optionsutil.showValues(configurable, opt, prefix, nil, 1)
                 end,
                 more_options = true,
                 more_options_param = {
@@ -278,7 +278,7 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                 },
                 hide_on_apply = true,
                 name_text_hold_callback = function(configurable, opt, prefix)
-                    optionsutil.showValues(configurable, opt, prefix, nil, true)
+                    optionsutil.showValues(configurable, opt, prefix, nil, 1)
                 end,
                 help_text = _([[In the top menu → Settings → Status bar, you can choose whether the bottom margin applies from the bottom of the screen, or from above the status bar.]]),
                 more_options = true,
@@ -455,7 +455,7 @@ Note that your selected font size is not affected by this setting.]]),
                         name = "font_size",
                         name_text = _("Font Size"),
                     }
-                    optionsutil.showValues(configurable, opt, prefix, nil, true)
+                    optionsutil.showValues(configurable, opt, prefix, nil, 2)
                 end,
             },
             {

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -223,7 +223,9 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                     DCREREADER_CONFIG_T_MARGIN_SIZES_XX_HUGE,
                 },
                 hide_on_apply = true,
-                name_text_hold_callback = optionsutil.showValues,
+                name_text_hold_callback = function(configurable, opt, prefix)
+                    optionsutil.showValues(configurable, opt, prefix, nil, true)
+                end,
                 more_options = true,
                 more_options_param = {
                     -- Allow this to tune both top and bottom margins, handling
@@ -275,7 +277,9 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                     DCREREADER_CONFIG_B_MARGIN_SIZES_XX_HUGE,
                 },
                 hide_on_apply = true,
-                name_text_hold_callback = optionsutil.showValues,
+                name_text_hold_callback = function(configurable, opt, prefix)
+                    optionsutil.showValues(configurable, opt, prefix, nil, true)
+                end,
                 help_text = _([[In the top menu → Settings → Status bar, you can choose whether the bottom margin applies from the bottom of the screen, or from above the status bar.]]),
                 more_options = true,
                 more_options_param = {
@@ -451,7 +455,7 @@ Note that your selected font size is not affected by this setting.]]),
                         name = "font_size",
                         name_text = _("Font Size"),
                     }
-                    optionsutil.showValues(configurable, opt, prefix)
+                    optionsutil.showValues(configurable, opt, prefix, nil, true)
                 end,
             },
             {

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -224,7 +224,7 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                 },
                 hide_on_apply = true,
                 name_text_hold_callback = function(configurable, opt, prefix)
-                    optionsutil.showValues(configurable, opt, prefix, nil, 1)
+                    optionsutil.showValues(configurable, opt, prefix, nil, "mm")
                 end,
                 more_options = true,
                 more_options_param = {
@@ -278,7 +278,7 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                 },
                 hide_on_apply = true,
                 name_text_hold_callback = function(configurable, opt, prefix)
-                    optionsutil.showValues(configurable, opt, prefix, nil, 1)
+                    optionsutil.showValues(configurable, opt, prefix, nil, "mm")
                 end,
                 help_text = _([[In the top menu → Settings → Status bar, you can choose whether the bottom margin applies from the bottom of the screen, or from above the status bar.]]),
                 more_options = true,
@@ -455,7 +455,7 @@ Note that your selected font size is not affected by this setting.]]),
                         name = "font_size",
                         name_text = _("Font Size"),
                     }
-                    optionsutil.showValues(configurable, opt, prefix, nil, 2)
+                    optionsutil.showValues(configurable, opt, prefix, nil, "pt")
                 end,
             },
             {

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -29,7 +29,7 @@ local function convertSizeTo(px, format)
         format_factor = 1 / 25.4
     end
 
-    local display_dpi = Device:getDisplayDPI() or Screen:getDPI() -- use device hardcoded dpi if available
+    local display_dpi = Device:getDeviceScreenDPI() or Screen:getDPI() -- use device hardcoded dpi if available
     return Screen:scaleBySize(px) / display_dpi * 25.4 * format_factor
 end
 

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -39,7 +39,7 @@ local function real_size_string(ko_size, unit)
     ko_size = tonumber(ko_size)
     local shown_unit
     if unit == "pt" then
-        shown_unit = C_("FontSize", "pt")
+        shown_unit = C_("Font size", "pt")
     elseif unit == "mm" then
         shown_unit = C_("Length", "mm")
     elseif unit == "in" then

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -6,6 +6,7 @@ local Device = require("device")
 local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
+local C_ = _.pgettext
 local T = require("ffi/util").template
 local logger = require("logger")
 local Screen = Device.screen
@@ -25,7 +26,7 @@ local function convertSizeTo(px, format)
 
     if format == "pt" then
         format_factor =  format_factor * 2660 / 1000 -- see https://www.wikiwand.com/en/Metric_typographic_units
-    elseif format == "\"" then
+    elseif format == "in" then
         format_factor = 1 / 25.4
     end
 
@@ -153,10 +154,10 @@ function optionsutil.showValues(configurable, option, prefix, document, is_size)
         end
     else
         local unit
-        if is_size == 1 then
-            unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "\""
-        else
+        if is_size == "pt" then
             unit = "pt"
+        else
+            unit = G_reader_settings:nilOrTrue("metric_length") and C_("Length", "mm") or C_("Length", "in")
         end
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
                                             current, real_size_string(current, unit),
@@ -168,7 +169,7 @@ end
 function optionsutil.showValuesHMargins(configurable, option)
     local default = G_reader_settings:readSetting("copt_"..option.name)
     local current = configurable[option.name]
-    local unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "\""
+    local unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
     if not default then
         UIManager:show(InfoMessage:new{
             text = T(_([[

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -17,8 +17,8 @@ function optionsutil.enableIfEquals(configurable, option, value)
 end
 
 -- Converts px size to mm, inch or pt
--- if the `metric_system`-setting is not set or true -> mm
--- if the `metric_sytem`-setting is false -> inch
+-- if the `metric_length`-setting is not set or true -> mm
+-- if the `metric_length`-setting is false -> inch
 -- if format == "pt" -> pt
 local function convertSizeTo(px, format)
     local format_factor = 1 -- we are defaulting on mm
@@ -151,7 +151,7 @@ function optionsutil.showValues(configurable, option, prefix, document, is_size)
                                             current, value_current, default)
         end
     else
-        local unit = G_reader_settings:nilOrTrue("metric_system") and _("mm") or _("\"")
+        local unit = G_reader_settings:nilOrTrue("metric_length") and _("mm") or _("\"")
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
                                             current, real_size_string(current, unit),
                                             default, real_size_string(default, unit))
@@ -162,7 +162,7 @@ end
 function optionsutil.showValuesHMargins(configurable, option)
     local default = G_reader_settings:readSetting("copt_"..option.name)
     local current = configurable[option.name]
-    local unit = G_reader_settings:nilOrTrue("metric_system") and _("mm") or _("\"")
+    local unit = G_reader_settings:nilOrTrue("metric_length") and _("mm") or _("\"")
     if not default then
         UIManager:show(InfoMessage:new{
             text = T(_([[

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -2,11 +2,13 @@
 This module contains miscellaneous helper functions for the creoptions and koptoptions.
 ]]
 
+local Device = require("device")
 local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 local T = require("ffi/util").template
 local logger = require("logger")
+local Screen = Device.screen
 
 local optionsutil = {}
 
@@ -14,7 +16,17 @@ function optionsutil.enableIfEquals(configurable, option, value)
     return configurable[option] == value
 end
 
-function optionsutil.showValues(configurable, option, prefix, document)
+local function real_size_string(ko_size, is_size)
+    if not ko_size or not is_size then return "" end
+    ko_size = tonumber(ko_size)
+    if ko_size then
+        return string.format(" (%.2f pt)", ko_size * Screen:getSize2PtFactor())
+    else
+        return ""
+    end
+end
+
+function optionsutil.showValues(configurable, option, prefix, document, is_size)
     local default = G_reader_settings:readSetting(prefix.."_"..option.name)
     local current = configurable[option.name]
     local value_default, value_current
@@ -123,7 +135,9 @@ function optionsutil.showValues(configurable, option, prefix, document)
                                             current, value_current, default)
         end
     else
-        text = T(_("%1\n%2\nCurrent value: %3\nDefault value: %4"), name_text, help_text, current, default)
+        text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
+                                            current, real_size_string(current, is_size),
+                                            default, real_size_string(default, is_size))
     end
     UIManager:show(InfoMessage:new{ text=text })
 end
@@ -135,22 +149,25 @@ function optionsutil.showValuesHMargins(configurable, option)
         UIManager:show(InfoMessage:new{
             text = T(_([[
 Current margins:
-  left:  %1
-  right: %2
+  left:  %1%2
+  right: %3%4
 Default margins: not set]]),
-                current[1], current[2])
+                current[1], real_size_string(current[1], true),
+                current[2], real_size_string(current[2], true))
         })
     else
         UIManager:show(InfoMessage:new{
             text = T(_([[
 Current margins:
-  left:  %1
-  right: %2
+  left:  %1%2
+  right: %3%4
 Default margins:
-  left:  %3
-  right: %4]]),
-                current[1], current[2],
-                default[1], default[2])
+  left:  %5%6
+  right: %7%8]]),
+                current[1], real_size_string(current[1], true),
+                current[2], real_size_string(current[2], true),
+                default[1], real_size_string(default[1], true),
+                default[2], real_size_string(default[2], true))
         })
     end
 end

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -54,7 +54,7 @@ local function real_size_string(ko_size, unit)
     end
 end
 
-function optionsutil.showValues(configurable, option, prefix, document, is_size)
+function optionsutil.showValues(configurable, option, prefix, document, unit)
     local default = G_reader_settings:readSetting(prefix.."_"..option.name)
     local current = configurable[option.name]
     local value_default, value_current
@@ -163,10 +163,7 @@ function optionsutil.showValues(configurable, option, prefix, document, is_size)
                                             current, value_current, default)
         end
     else
-        local unit
-        if is_size == "pt" then
-            unit = "pt"
-        else
+        if unit ~= "pt" then
             unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
         end
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -151,9 +151,10 @@ function optionsutil.showValues(configurable, option, prefix, document, is_size)
                                             current, value_current, default)
         end
     else
+        local unit = G_reader_settings:nilOrTrue("metric_system") and _("mm") or _("\"")
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
-                                            current, real_size_string(current, "pt"),
-                                            default, real_size_string(default, "pt"))
+                                            current, real_size_string(current, unit),
+                                            default, real_size_string(default, unit))
     end
     UIManager:show(InfoMessage:new{ text=text })
 end

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -37,8 +37,18 @@ end
 local function real_size_string(ko_size, unit)
     if not ko_size or not unit then return "" end
     ko_size = tonumber(ko_size)
+    local shown_unit
+    if unit == "pt" then
+        shown_unit = C_("FontSize", "pt")
+    elseif unit == "mm" then
+        shown_unit = C_("Length", "mm")
+    elseif unit == "in" then
+        shown_unit = C_("Length", "in")
+    else
+        shown_unit = unit -- for future units
+    end
     if ko_size then
-        return string.format(" (%.2f %s)", convertSizeTo(ko_size, unit), unit)
+        return string.format(" (%.2f %s)", convertSizeTo(ko_size, unit), shown_unit)
     else
         return ""
     end
@@ -157,7 +167,7 @@ function optionsutil.showValues(configurable, option, prefix, document, is_size)
         if is_size == "pt" then
             unit = "pt"
         else
-            unit = G_reader_settings:nilOrTrue("metric_length") and C_("Length", "mm") or C_("Length", "in")
+            unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
         end
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
                                             current, real_size_string(current, unit),

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -29,7 +29,8 @@ local function convertSizeTo(px, format)
         format_factor = 1 / 25.4
     end
 
-    return Screen:scaleBySize(px) / Screen:getDPI() * 25.4 * format_factor
+    local display_dpi = Device:getDisplayDPI() or Screen:getDPI() -- use device hardcoded dpi if available
+    return Screen:scaleBySize(px) / display_dpi * 25.4 * format_factor
 end
 
 local function real_size_string(ko_size, unit)

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -151,7 +151,12 @@ function optionsutil.showValues(configurable, option, prefix, document, is_size)
                                             current, value_current, default)
         end
     else
-        local unit = G_reader_settings:nilOrTrue("metric_length") and _("mm") or _("\"")
+        local unit
+        if is_size == 1 then
+            unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "\""
+        else
+            unit = "pt"
+        end
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
                                             current, real_size_string(current, unit),
                                             default, real_size_string(default, unit))
@@ -162,7 +167,7 @@ end
 function optionsutil.showValuesHMargins(configurable, option)
     local default = G_reader_settings:readSetting("copt_"..option.name)
     local current = configurable[option.name]
-    local unit = G_reader_settings:nilOrTrue("metric_length") and _("mm") or _("\"")
+    local unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "\""
     if not default then
         UIManager:show(InfoMessage:new{
             text = T(_([[

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -594,4 +594,15 @@ common_settings.screenshot = {
     keep_menu_open = true,
 }
 
+common_settings.metric_system = {
+    text = _("Metric system"),
+    checked_func = function()
+        return G_reader_settings:readSetting("metric_system", true)
+    end,
+    callback = function(touchmenu_instance)
+        G_reader_settings:toggle("metric_system")
+        if touchmenu_instance then touchmenu_instance:updateItems() end
+    end,
+}
+
 return common_settings

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -594,15 +594,21 @@ common_settings.screenshot = {
     keep_menu_open = true,
 }
 
-common_settings.metric_system = {
-    text = _("Metric system"),
-    checked_func = function()
-        return G_reader_settings:readSetting("metric_system", true)
-    end,
-    callback = function(touchmenu_instance)
-        G_reader_settings:toggle("metric_system")
-        if touchmenu_instance then touchmenu_instance:updateItems() end
-    end,
+common_settings.units = {
+    text = _("Units"),
+    sub_item_table = {
+        {
+            text = _("Metric length"),
+            checked_func = function()
+                return G_reader_settings:readSetting("metric_length", true)
+            end,
+            callback = function(touchmenu_instance)
+                G_reader_settings:toggle("metric_length")
+                if touchmenu_instance then touchmenu_instance:updateItems() end
+            end,
+            keep_menu_open = true,
+        },
+    },
 }
 
 return common_settings

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -46,6 +46,7 @@ local order = {
         "font_ui_fallbacks",
         "----------------------------",
         "time",
+        "units",
         "device_status_alarm",
         "charging_led", -- if Device:canToggleChargingLED()
         "autostandby",
@@ -57,7 +58,6 @@ local order = {
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",
         "screenshot",
-        "metric_system",
     },
     navigation = {
         "back_to_exit",

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -57,6 +57,7 @@ local order = {
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",
         "screenshot",
+        "metric_system",
     },
     navigation = {
         "back_to_exit",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -100,6 +100,7 @@ local order = {
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",
         "screenshot",
+        "metric_system",
     },
     navigation = {
         "back_to_exit",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -89,6 +89,7 @@ local order = {
         "font_ui_fallbacks",
         "----------------------------",
         "time",
+        "units",
         "device_status_alarm",
         "charging_led", -- if Device:canToggleChargingLED()
         "autostandby",
@@ -100,7 +101,6 @@ local order = {
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",
         "screenshot",
-        "metric_system",
     },
     navigation = {
         "back_to_exit",


### PR DESCRIPTION
Pictures say more than words:

![grafik](https://user-images.githubusercontent.com/36999612/173244853-bd816ccc-cabe-4b69-a6e2-48bcd44fc1c0.png)

![grafik](https://user-images.githubusercontent.com/36999612/173626183-577bca00-b639-4a1f-a2ac-2d5b60f33162.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9205)
<!-- Reviewable:end -->
