### PR TITLE
Unify RenderImage API & usage

### DIFF
--- a/frontend/ui/renderimage.lua
+++ b/frontend/ui/renderimage.lua
@@ -303,4 +303,35 @@ function RenderImage:renderSVGImageFileWithMupdf(filename, width, height, zoom)
     return bb -- pre-multiplied alpha: no is_straight_alpha=true
 end
 
+--- Renders a checkerboard pattern (useful as a fallback after a decoding failure)
+function RenderImage:renderCheckerboard(width, height, bb_type)
+    width = width or 800
+    height = height or 800
+    local bb = Blitbuffer.new(width, height, bb_type or Blitbuffer.TYPE_BB8)
+    local checker_size = bit.rshift(math.min(width, height), 4)
+    local pen_color = Blitbuffer.COLOR_BLACK
+    local row_start
+    for y = 0, height - 1, checker_size do
+        row_start = pen_color
+        for x = 0, width - 1, checker_size do
+            -- BBs are zero-initialized (i.e., black)
+            if pen_color == Blitbuffer.COLOR_WHITE then
+                bb:paintRect(x, y, checker_size, checker_size, Blitbuffer.COLOR_WHITE)
+                -- Alternate pen color every "column"
+                pen_color = Blitbuffer.COLOR_BLACK
+            else
+                pen_color = Blitbuffer.COLOR_WHITE
+            end
+        end
+        -- Alternate initial pen color every "row"
+        if row_start == Blitbuffer.COLOR_WHITE then
+            pen_color = Blitbuffer.COLOR_BLACK
+        else
+            pen_color = Blitbuffer.COLOR_WHITE
+        end
+    end
+
+    return bb
+end
+
 return RenderImage

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -3,7 +3,6 @@ local Blitbuffer = require("ffi/blitbuffer")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
 local BottomContainer = require("ui/widget/container/bottomcontainer")
-local DataStorage = require("datastorage")
 local Device = require("device")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
@@ -94,6 +93,7 @@ function Screensaver:_getRandomImage(dir)
     else
         return nil
     end
+
     return dir .. pics[math.random(i)]
 end
 
@@ -262,7 +262,7 @@ function Screensaver:chooseFolder()
         }
     })
     local screensaver_dir = G_reader_settings:readSetting("screensaver_dir")
-                         or DataStorage:getDataDir() .. "/screenshots/"
+                         or _("N/A")
     self.choose_dialog = ButtonDialogTitle:new{
         title = T(_("Current screensaver image folder:\n%1"), BD.dirpath(screensaver_dir)),
         buttons = buttons
@@ -321,8 +321,9 @@ function Screensaver:chooseFile(document_cover)
         }
     })
     local screensaver_image = G_reader_settings:readSetting("screensaver_image")
-                           or DataStorage:getDataDir() .. "/resources/koreader.png"
+                           or _("N/A")
     local screensaver_document_cover = G_reader_settings:readSetting("screensaver_document_cover")
+                                    or _("N/A")
     local title = document_cover and T(_("Current screensaver document cover:\n%1"), BD.filepath(screensaver_document_cover))
         or T(_("Current screensaver image:\n%1"), BD.filepath(screensaver_image))
     self.choose_dialog = ButtonDialogTitle:new{

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -170,8 +170,22 @@ function ImageWidget:_loadfile()
                 -- and paintTo() must use alphablitFrom() instead of pmulalphablitFrom() (which is
                 -- fine for everything MuPDF renders out)
                 self._bb, self._is_straight_alpha = RenderImage:renderSVGImageFile(self.file, width, height, zoom)
+
+                -- Ensure we always return a BB, even on failure
+                if not self._bb then
+                    logger.warn("ImageWidget: Failed to render SVG image file:", self.file)
+                    self._bb = RenderImage:renderCheckerboard(width, height, Screen.bb:getType())
+                    self._is_straight_alpha = false
+                end
             else
                 self._bb = RenderImage:renderImageFile(self.file, false, width, height)
+
+                if not self._bb then
+                    logger.warn("ImageWidget: Failed to render image file:", self.file)
+                    self._bb = RenderImage:renderCheckerboard(width, height, Screen.bb:getType())
+                    self._is_straight_alpha = false
+                end
+
                 if scale_for_dpi_here then
                     local bb_w, bb_h = self._bb:getWidth(), self._bb:getHeight()
                     self._bb = RenderImage:scaleBlitBuffer(self._bb, math.floor(bb_w * DPI_SCALE), math.floor(bb_h * DPI_SCALE))

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -722,6 +722,7 @@ function OPDSBrowser:streamPages(item, remote_url, count)
 
             if code == 200 then
                 local page_bb = RenderImage:renderImageData(data, #data, false)
+                             or RenderImage:renderImageFile("resources/koreader.png", false)
                 return page_bb
             else
                 local error_bb = RenderImage:renderImageFile("resources/koreader.png", false)

--- a/spec/unit/imagewidget_spec.lua
+++ b/spec/unit/imagewidget_spec.lua
@@ -12,7 +12,12 @@ describe("ImageWidget module", function()
         imgw:_render()
         assert(imgw._bb)
     end)
-    it("should error out on none exist image", function()
+    --[[
+    -- NOTE: There was never actually sane error handling in there,
+    --       it would just crash later because of a lack of BB object.
+    --       We now return a checkerboard pattern on image decoding failure,
+    --       which also happens to make the caller's life easier.
+    it("should error out on missing or invalid images", function()
         local imgw = ImageWidget:new{
             file = "wtf.png"
         }
@@ -20,4 +25,5 @@ describe("ImageWidget module", function()
             imgw:_render()
         end)
     end)
+    --]]
 end)


### PR DESCRIPTION
* RenderImage: Always pcall C/FFI stuff, and always return nil on error
* OPDSBrowser: Handle renderImageData failure in streamPages
* ImageWidget: Always return a bb, even on decoding failures (in which case, a checkerboard pattern is returned).
* ScreenSaver: Make sure the choose image/folder/document settings report what the code *actually* does (especially on empty settings).

This is all a bunch of cleanup spurred by #5469 ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9206)
<!-- Reviewable:end -->
