### PR TITLE
Pocketbook: Keep wifi alive as long as wifi is enabled

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -354,6 +354,24 @@ function PocketBook:initNetworkManager(NetworkMgr)
     function NetworkMgr:isWifiOn()
         return band(inkview.QueryNetwork(), C.NET_CONNECTED) ~= 0
     end
+
+    local UIManager = require("ui/uimanager");
+
+    local function wifiKeepAlive()
+        logger.dbg('check keep alive')
+
+        if (NetworkMgr:isWifiOn()) then
+            logger.dbg('ping wifi keep alive')
+
+            inkview.NetMgrPing();
+        end
+
+        -- Make sure only one wifiKeepAlive is scheduled
+        UIManager:unschedule(wifiKeepAlive)
+        UIManager:scheduleIn(30, wifiKeepAlive);
+    end
+
+    wifiKeepAlive();
 end
 
 function PocketBook:getSoftwareVersion()


### PR DESCRIPTION
This will keep the PocketBook wifi alive by telling to the PocketBook to keep it alive. This is the first time I used the scheduleIn function so feel free to nitpick.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9208)
<!-- Reviewable:end -->
