### PR TITLE
[CI] Also use Ubuntu 20.04 Docker image for docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           path: koreader-emulator-x86_64-linux-gnu/koreader/junit-test-results.xml
   docs:
     docker:
-      - image: koreader/koappimage:0.2.2
+      - image: koreader/kobase:0.3.0
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD


### PR DESCRIPTION
Overlooked in <https://github.com/koreader/koreader/pull/9007>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9209)
<!-- Reviewable:end -->
