### PR TITLE
Tag browser

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -28,6 +28,7 @@ local ReaderDeviceStatus = require("apps/reader/modules/readerdevicestatus")
 local ReaderDictionary = require("apps/reader/modules/readerdictionary")
 local ReaderWikipedia = require("apps/reader/modules/readerwikipedia")
 local Screenshoter = require("ui/widget/screenshoter")
+local TagChooser = require("ui/widget/tagchooser")
 local TitleBar = require("ui/widget/titlebar")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local UIManager = require("ui/uimanager")
@@ -744,6 +745,15 @@ function FileManager:tapPlus()
                         UIManager:close(self.file_dialog)
                     end
                 }
+            },
+            {
+                {
+                    text = _("Browse tags here"),
+                    callback = function()
+                        self:openTagBrowser(self.file_chooser.path)
+                        UIManager:close(self.file_dialog)
+                    end
+                }
             }
         }
 
@@ -926,6 +936,15 @@ function FileManager:openRandomFile(dir)
             text = _("File not found"),
         })
     end
+end
+
+function FileManager:openTagBrowser(path)
+    local tag_chooser = TagChooser:new{
+        path = path,
+        title = _("Tag Browser"),
+        show_hidden = self.file_chooser.show_hidden
+    }
+    UIManager:show(tag_chooser)
 end
 
 function FileManager:copyFile(file)

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -38,7 +38,7 @@ function BookInfo:isSupported(file)
     return lfs.attributes(file, "mode") == "file"
 end
 
-function BookInfo:show(file, book_props)
+function BookInfo:show(file, book_props, extract_and_return)
     local kv_pairs = {}
 
     local directory, filename = util.splitFilePathName(file)
@@ -55,16 +55,6 @@ function BookInfo:show(file, book_props)
             end
         end
     end
-    local file_size = lfs.attributes(file, "size") or 0
-    local file_modification = lfs.attributes(file, "modification") or 0
-    local size_f = util.getFriendlySize(file_size)
-    local size_b = util.getFormattedSize(file_size)
-    local size = string.format("%s (%s bytes)", size_f, size_b)
-    table.insert(kv_pairs, { _("Filename:"), BD.filename(filename) })
-    table.insert(kv_pairs, { _("Format:"), filetype:upper() })
-    table.insert(kv_pairs, { _("Size:"), size })
-    table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", file_modification) })
-    table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(directory)), separator = true })
 
     -- book_props may be provided if caller already has them available
     -- but it may lack "pages", that we may get from sidecar file
@@ -134,6 +124,21 @@ function BookInfo:show(file, book_props)
     if not book_props then
         book_props = {}
     end
+
+    if extract_and_return == true then
+        return book_props
+    end
+
+    local file_size = lfs.attributes(file, "size") or 0
+    local file_modification = lfs.attributes(file, "modification") or 0
+    local size_f = util.getFriendlySize(file_size)
+    local size_b = util.getFormattedSize(file_size)
+    local size = string.format("%s (%s bytes)", size_f, size_b)
+    table.insert(kv_pairs, { _("Filename:"), BD.filename(filename) })
+    table.insert(kv_pairs, { _("Format:"), filetype:upper() })
+    table.insert(kv_pairs, { _("Size:"), size })
+    table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", file_modification) })
+    table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(directory)), separator = true })
 
     local title = book_props.title
     if title == "" or title == nil then title = _("N/A") end

--- a/frontend/ui/widget/tagchooser.lua
+++ b/frontend/ui/widget/tagchooser.lua
@@ -1,0 +1,146 @@
+local BD = require("ui/bidi")
+local BookInfoManager = require("apps/filemanager/filemanagerbookinfo")
+local Device = require("device")
+local Menu = require("ui/widget/menu")
+local FileChooser = require("ui/widget/filechooser")
+local UIManager = require("ui/uimanager")
+local ffi = require("ffi")
+local lfs = require("libs/libkoreader-lfs")
+local ffiUtil = require("ffi/util")
+local T = ffiUtil.template
+local _ = require("gettext")
+local Screen = Device.screen
+local logger = require("logger")
+local util = require("util")
+
+local TagChooser = Menu:extend{
+    no_title = false,
+    path = lfs.currentdir(),
+    show_path = true,
+    has_close_button = true,
+    show_hidden = false, -- set to true to show folders/files starting with "."
+    file_filter = nil, -- function defined in the caller, returns true for files to be shown
+    -- NOTE: Input is *always* a relative entry name
+    goto_letter = true,
+}
+
+function TagChooser:show_file(filename)
+    return self.file_filter == nil or self.file_filter(filename)
+end
+
+function TagChooser:init()
+    self.width = Screen:getWidth()
+    self.list = function(path, tags)
+        -- lfs.dir directory without permission will give error
+        local ok, iter, dir_obj = pcall(lfs.dir, path)
+        if ok then
+            for f in iter, dir_obj do
+                if self.show_hidden or not util.stringStartsWith(f, ".") then
+                    local filename = path.."/"..f
+                    local attributes = lfs.attributes(filename)
+                    if attributes ~= nil then
+                        -- Always ignore macOS resource forks.
+                        if attributes.mode == "file" and not util.stringStartsWith(f, "._") then
+                            if self:show_file(f) then
+                                local extract_data = true
+                                local bookinfo = BookInfoManager:show(filename, nil, extract_data)
+                                if bookinfo then
+                                    if bookinfo.keywords then
+                                        kws = util.splitToArray(bookinfo.keywords, "\n")
+                                        for i=1, #kws do
+                                            kw = BD.auto(kws[i])
+                                            if tags[kw] == nil then
+                                                tags[kw] = {}
+                                            end
+                                            table.insert(tags[kw], f)
+                                        end
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        else -- error, probably "permission denied"
+            logger.warn("Read error:", path)
+        end
+    end
+
+    self.item_table = self:genItemTableFromPath(self.path)
+    Menu.init(self) -- call parent's init()
+end
+
+function TagChooser:genItemTableFromPath(path)
+    local tags = {}
+
+    self.list(path, tags)
+
+    local item_table = {}
+    for tag, books in pairs(tags) do
+        table.insert(item_table, {
+            text = tag,
+            bidi_wrap_func = BD.auto,
+            mandatory = T("%1 \u{F016}", #books),
+            books = books
+        })
+    end
+
+    sorting = function(a, b)
+        return ffiUtil.strcoll(a.text, b.text)
+    end
+    table.sort(item_table, sorting)
+    -- lfs.dir iterated node string may be encoded with some weird codepage on
+    -- Windows we need to encode them to utf-8
+    if ffi.os == "Windows" then
+        for k, v in pairs(item_table) do
+            if v.text then
+                v.text = ffiUtil.multiByteToUTF8(v.text) or ""
+            end
+        end
+    end
+
+    return item_table
+end
+
+function TagChooser:onMenuSelect(item)
+    local file_chooser = FileChooser:new{
+        parent = self,
+        path = self.path,
+        select_directory = false,
+        select_file = true,
+        detailed_file_info = true,
+        no_title = false,
+        title = item.text,
+        file_filter = function(filename)
+            for i, book in ipairs(item.books) do
+                if filename == book then
+                    return true
+                end
+            end
+            return false
+        end,
+    }
+    function file_chooser:show_dir(dirname)
+        return false
+    end
+    function file_chooser:onMenuHold(item)
+        self:onMenuSelect(item)
+    end
+    function file_chooser:onPathChanged(path) -- handle ..
+        UIManager:close(self)
+    end
+    function file_chooser:onFileSelect(file)
+        local ReaderUI = require("apps/reader/readerui")
+        ReaderUI:showReader(file)
+        UIManager:close(self)
+        UIManager:close(self.parent)
+    end
+    UIManager:show(file_chooser)
+    return true
+end
+
+function TagChooser:onMenuHold(item)
+    return self:onMenuSelect(item)
+end
+
+return TagChooser

--- a/frontend/ui/widget/tagchooser.lua
+++ b/frontend/ui/widget/tagchooser.lua
@@ -46,9 +46,9 @@ function TagChooser:init()
                                 local bookinfo = BookInfoManager:show(filename, nil, extract_data)
                                 if bookinfo then
                                     if bookinfo.keywords then
-                                        kws = util.splitToArray(bookinfo.keywords, "\n")
+                                        local kws = util.splitToArray(bookinfo.keywords, "\n")
                                         for i=1, #kws do
-                                            kw = BD.auto(kws[i])
+                                            local kw = BD.auto(kws[i])
                                             if tags[kw] == nil then
                                                 tags[kw] = {}
                                             end
@@ -85,7 +85,7 @@ function TagChooser:genItemTableFromPath(path)
         })
     end
 
-    sorting = function(a, b)
+    local sorting = function(a, b)
         return ffiUtil.strcoll(a.text, b.text)
     end
     table.sort(item_table, sorting)
@@ -102,7 +102,7 @@ function TagChooser:genItemTableFromPath(path)
     return item_table
 end
 
-function TagChooser:onMenuSelect(item)
+function TagChooser:onMenuSelect(tag)
     local file_chooser = FileChooser:new{
         parent = self,
         path = self.path,
@@ -110,9 +110,9 @@ function TagChooser:onMenuSelect(item)
         select_file = true,
         detailed_file_info = true,
         no_title = false,
-        title = item.text,
+        title = tag.text,
         file_filter = function(filename)
-            for i, book in ipairs(item.books) do
+            for i, book in ipairs(tag.books) do
                 if filename == book then
                     return true
                 end


### PR DESCRIPTION
This adds a tag browser feature to the file manager.

It works by reading the book info of every compatible file in the folder from which it is called. For each tag, it assembles a list of books with that tag. The user can select the tag and view the list, then open one of the books (or change their minds and close it).

It was tested in the emulator. The TagChooser widget is based on the FileChooser widget, so shouldn't introduce any unexpected behavior not already present there. There may, however, be issues with the child FileChooser it creates, since that widget seems to have been written with the FileManager in mind, and so other plugins may interact with it incorrectly (for example, there was an error with one of the functions overwritten by the Cover Browser, which I found in testing).

The tag enumeration can be somewhat slow. It uses the FileManager's built-in BookInfo, the class used for the "Book Details" screen, which doesn't seem to do any caching for what it calls "unopened" files, those without SDR info. Instead, it opens the file, enumerates the info, then closes it again, all without generating SDR. This can be sped up by introducing caching of some info much like the Cover Browser plugin seems to have; I consider that outside the scope of this PR. The tag browser itself doesn't save any data, write to a database, etc.; all tags and book lists are generated every time it's opened.

I would have liked to have made this a plugin, so it can be disabled, but wanted to use both the current folder from the file manager and its BookInfo class. Let me know if there's a more appropriate way to implement this.

![tag1](https://user-images.githubusercontent.com/8064135/173452710-2d8e9ac4-6e04-4a9d-831c-c270faa259dc.png)
![tag2](https://user-images.githubusercontent.com/8064135/173452945-49562552-8a10-434b-8418-709f2f3fa6af.png)

Feedback appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9210)
<!-- Reviewable:end -->
