### PR TITLE
AutoDim: reschedule on every tap

### DIFF
--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -173,6 +173,9 @@ end
 
 function AutoDim:onInputEvent()
     self.last_action_time = UIManager:getElapsedTimeSinceBoot()
+    -- Make sure the next scheduled autodim check is as much in the future
+    -- as possible, to reduce wakes from standby.
+    self:_schedule_autodim_task()
 end
 
 function AutoDim:_unschedule_autodim_task()


### PR DESCRIPTION
This is a maintenance PR.
With scheduling the next autodim_check on every tap, we can keep the device longer in standby mode. So we have more power savings.

The long story: The current version works like that:
Let's say I set the idle-time to 3 min and I need 2.5 min to read a page.
Start at 0 min (next scheduled check is at/in 3 min)
Read and tap to turn page after 2.5 min (next scheduled check is at 3 min - in 0.5 min)
At 3 min there is a scheduled_check (wakeup) -> reschedule check in 3 min.
Read and tap to turn page after 2.5 min (no wakeup)
Then after 1 min there is a wakeup -> reschedule.
---> So I get an additional wakeup on every second page.

This PR solves the problem: During normal reading I don't get _any_ wakeup during reading. (The only drawback is, that one function is unscheduled/scheduled on every tap, but that is no big deal).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9243)
<!-- Reviewable:end -->
