### PR TITLE
AutoStandby: fix (re)scheduling

### DIFF
--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -607,7 +607,9 @@ function AutoSuspend:AllowStandbyHandler()
         -- because if we were woken up by user input, those events should already be in the evdev queue...
         UIManager:consumeInputEarlyAfterPM(true)
     else
-        self:_start_standby()
+        if not self.going_to_suspend then
+            self:_start_standby()
+        end
     end
 end
 

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -606,6 +606,8 @@ function AutoSuspend:AllowStandbyHandler()
         -- This shouldn't prevent us from actually consuming any pending input events first,
         -- because if we were woken up by user input, those events should already be in the evdev queue...
         UIManager:consumeInputEarlyAfterPM(true)
+    else
+        self:_start_standby()
     end
 end
 


### PR DESCRIPTION
I had the feeling that `autostandby` has Alzheimer. Sometimes my Sage forgot to standby. 

@NiLuJe : It's not the metal table, it's the time of the day. When reading at night I have more time and sometimes `autodim` or `autowarmth` knock in. If they knock in within the `wake_in >=3` is false, autostandby looses its scheduling. (Autodim is a real stress-test.)

On normal reading (with no autodim starting, during the day when warmth does not change) you can sometimes provoke the failure if you tap right before an automatic footer update (around second 57, 58).

This PR should fix the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9258)
<!-- Reviewable:end -->
