### PR TITLE
[CI] Downgrade macOS Github Action to macOS 10.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ permissions:
 jobs:
   macos_build:
 
+    # macos-11 and macos-12 are broken at this time being.
+    # https://github.com/koreader/koreader/issues/8686,
+    # https://github.com/koreader/koreader/issues/8686#issuecomment-1172950236
+
+    # Please don't update to newer macOS version unless you can test that the new
+    # action produces working binaries.
     runs-on: macos-10.15
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   macos_build:
   
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
       - name: XCode version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ permissions:
 
 jobs:
   macos_build:
-  
-    runs-on: macos-12
+
+    runs-on: macos-10.15
 
     steps:
       - name: XCode version
@@ -29,7 +29,7 @@ jobs:
 
       - name: Building in progress…
         run: |
-          export MACOSX_DEPLOYMENT_TARGET=11;
+          export MACOSX_DEPLOYMENT_TARGET=10.15;
           export PATH="$(brew --prefix)/opt/gettext/bin:$(brew --prefix)/opt/gnu-getopt/bin:$(brew --prefix)/opt/bison/bin:$(brew --prefix)/opt/grep/libexec/gnubin:${PATH}";
           ./kodev release macos
 


### PR DESCRIPTION
Bump to Monterey, since current action produces a broken `crengine.dylib` anyway.

Keep the minimum target in Big Sur.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9279)
<!-- Reviewable:end -->
