### PR TITLE
AutoWarmth: force setWarmth after resume

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -201,9 +201,9 @@ function BasePowerD:fromNativeWarmth(nat_warmth)
 end
 
 --- @note: Takes a warmth in the *KOReader* scale (i.e., [0, 100], *sic*)
-function BasePowerD:setWarmth(warmth)
+function BasePowerD:setWarmth(warmth, force_setting)
     if not self.device:hasNaturalLight() then return false end
-    if warmth == self:frontlightWarmth() then return false end
+    if not force_setting and warmth == self:frontlightWarmth() then return false end
     -- Which means that fl_warmth is *also* in the KOReader scale (unlike fl_intensity)
     self.fl_warmth = self:normalizeWarmth(warmth)
     local nat_warmth = self:toNativeWarmth(self.fl_warmth)

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -136,7 +136,7 @@ end
 AutoWarmth.onLeaveStandby = AutoWarmth.onResume
 
 -- wrapper for unscheduling, so that only our setWarmth gets unscheduled
-function AutoWarmth.setWarmth(val)
+function AutoWarmth.setWarmth(val, force)
     if val then
         if val > 100 then
             DeviceListener:onSetNightMode(true)
@@ -145,7 +145,7 @@ function AutoWarmth.setWarmth(val)
         end
         if Device:hasNaturalLight() then
             val = math.min(val, 100)
-            Device.powerd:setWarmth(val)
+            Device.powerd:setWarmth(val, force)
         end
     end
 end
@@ -300,7 +300,7 @@ function AutoWarmth:scheduleWarmthChanges(time)
     -- schedule setting of another valid warmth (=`next_warmth`) again (one time).
     -- On sane devices this schedule does no harm.
     -- see https://github.com/koreader/koreader/issues/8363
-    UIManager:scheduleIn(delay_time, self.setWarmth, next_warmth)
+    UIManager:scheduleIn(delay_time, self.setWarmth, next_warmth, true)
 end
 
 function AutoWarmth:hoursToClock(hours)


### PR DESCRIPTION
This should fix #9274.
I made for a dedicated PR for this, for testing (as I don't have a KA1).

The additional overhead of setting warmth twice in scheduling warmth changes will disappear in #9252 (where the whole scheduling gets optimized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9289)
<!-- Reviewable:end -->
