### PR TITLE
Style tweaks: reorganize menu, add in-page footnotes helper tweaks

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -427,10 +427,19 @@ Further small adjustments can be done with 'Line Spacing' in the bottom menu.]])
             },
             {
                 id = "font_size_all_inherit",
+                conflicts_with = "font_size_most_reset",
                 title = _("Ignore publisher font sizes"),
                 description = _("Disable font-size specified in embedded styles."),
                 priority = -1, -- so in-page footnotes smaller can override this
                 css = [[* { font-size: inherit !important; }]],
+            },
+            {
+                id = "font_size_most_reset",
+                conflicts_with = "font_size_all_inherit",
+                title = _("Reset main text font size"),
+                description = _("Disable font-size set on the main text (keeping possibly larger headings untouched), so that KOReader's font size is used."),
+                priority = -1, -- so in-page footnotes smaller can override this
+                css = [[body, p, li, div, blockquote { font-size: 1rem !important; }]],
             },
         },
         {

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -21,59 +21,79 @@ DEFAULT_GLOBAL_STYLE_TWEAKS["footnote-inpage_fb2"] = true
 local CssTweaks = {
     DEFAULT_GLOBAL_STYLE_TWEAKS = DEFAULT_GLOBAL_STYLE_TWEAKS,
     {
-        title = C_("Style tweaks category", "Pages"),
+        title = C_("Style tweaks category", "Pages and margins"),
         {
-            id = "margin_body_0";
+            id = "margin_body_0",
             title = _("Ignore publisher page margins"),
             description = _("Force page margins to be 0, and may allow KOReader's margin settings to work on books where they would not."),
             css = [[body { margin: 0 !important; }]],
         },
         {
-            title = _("Ignore margin and padding"),
+            title = _("Horizontal margins"),
             {
-                id = "margin_horizontal_all_0";
-                title = _("Ignore horizontal margins"),
-                priority = 2,
+                id = "margin_horizontal_all_0",
+                title = _("Ignore all horizontal margins"),
                 css = [[* { margin-left: 0 !important; margin-right: 0 !important; }]],
             },
             {
-                id = "margin_vertical_all_0";
-                title = _("Ignore vertical margins"),
-                priority = 2,
-                css = [[* { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+                id = "padding_horizontal_all_0",
+                title = _("Ignore all horizontal padding"),
+                css = [[* { padding-left: 0 !important; padding-right: 0 !important; }]],
                 separator = true,
             },
             {
-                id = "padding_horizontal_all_0";
-                title = _("Ignore horizontal padding"),
-                priority = 2,
-                css = [[* { padding-left: 0 !important; padding-right: 0 !important; }]],
+                id = "paragraph_no_horizontal_margin",
+                title = _("Ignore horizontal paragraph margins"),
+                css = [[p, li { margin-left: 0 !important; margin-right: 0 !important; }]],
             },
             {
-                id = "padding_vertical_all_0";
-                title = _("Ignore vertical padding"),
-                priority = 2,
+                id = "paragraph_no_horizontal_padding",
+                title = _("Ignore horizontal paragraph padding"),
+                css = [[p, li { padding-left: 0 !important; padding-right: 0 !important; }]],
+            },
+        },
+        {
+            title = _("Vertical margins"),
+            {
+                id = "margin_vertical_all_0",
+                title = _("Ignore all vertical margins"),
+                css = [[* { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+            },
+            {
+                id = "padding_vertical_all_0",
+                title = _("Ignore all vertical padding"),
                 css = [[* { padding-top: 0 !important; padding-bottom: 0 !important; }]],
+                separator = true,
+            },
+            {
+                id = "paragraph_no_vertical_margin",
+                title = _("Ignore vertical paragraph margins"),
+                css = [[p, li { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+            },
+            {
+                id = "paragraph_no_vertical_padding",
+                title = _("Ignore vertical paragraph padding"),
+                css = [[p, li { padding-top: 0 !important; padding-bottom: 0 !important; }]],
             },
             separator = true,
         },
         {
             title = _("Page breaks and blank pages"),
             {
-                id = "titles_page-break-before_avoid ";
+                id = "titles_page-break-before_avoid ",
                 title = _("Avoid blank page on chapter start"),
                 priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
                 css = [[h1, h2, h3 { page-break-before: auto !important; }]],
 
             },
             {
-                id = "docfragment_page-break-before_avoid ";
+                id = "docfragment_page-break-before_avoid ",
                 title = _("Avoid blank page on chapter end"),
                 priority = 2, -- so it can override the one put back by publisher_page-break-before_avoid
                 css = [[DocFragment { page-break-before: auto !important; }]],
             },
             {
-                id = "publisher_page-breaks_avoid ";
+                id = "publisher_page-breaks_avoid ",
                 title = _("Avoid publisher page breaks"),
                 description = _("Disable all publisher page breaks, keeping only KOReader's epub.css ones.\nWhen combined with the two previous tweaks, all page-breaks are disabled."),
                 css = [[
@@ -89,12 +109,12 @@ h1, h2, h3, h4, h5, h6 { page-break-after: avoid !important; }
             {
                 title = _("New page on headings"),
                 {
-                    id = "h1_page-break-before_always";
+                    id = "h1_page-break-before_always",
                     title = _("New page on <H1>"),
                     css = [[h1 { page-break-before: always !important; }]],
                 },
                 {
-                    id = "h2_page-break-before_always";
+                    id = "h2_page-break-before_always",
                     title = _("New page on <H2>"),
                     css = [[
 h2 { page-break-before: always !important; }
@@ -102,7 +122,7 @@ h1 + h2 { page-break-before: avoid !important; }
                     ]],
                 },
                 {
-                    id = "h3_page-break-before_always";
+                    id = "h3_page-break-before_always",
                     title = _("New page on <H3>"),
                     css = [[
 h3 { page-break-before: always !important; }
@@ -110,7 +130,7 @@ h1 + h3, h2 + h3 { page-break-before: avoid !important; }
                     ]],
                 },
                 {
-                    id = "h4_page-break-before_always";
+                    id = "h4_page-break-before_always",
                     title = _("New page on <H4>"),
                     css = [[
 h4 { page-break-before: always !important; }
@@ -118,7 +138,7 @@ h1 + h4, h2 + h4, h3 + h4 { page-break-before: avoid !important; }
                     ]],
                 },
                 {
-                    id = "h5_page-break-before_always";
+                    id = "h5_page-break-before_always",
                     title = _("New page on <H5>"),
                     css = [[
 h5 { page-break-before: always !important; }
@@ -126,13 +146,76 @@ h1 + h5, h2 + h5, h3 + h5, h4 + h5 { page-break-before: avoid !important; }
                     ]],
                 },
                 {
-                    id = "h6_page-break-before_always";
+                    id = "h6_page-break-before_always",
                     title = _("New page on <H6>"),
                     css = [[
 h6 { page-break-before: always !important; }
 h1 + h6, h2 + h6, h3 + h6, h4 + h6, h5 + h6 { page-break-before: avoid !important; }
                     ]],
                 },
+            },
+        },
+        {
+            title = _("Widows and orphans"),
+            {
+                title = _("About widow and orphan lines"),
+                info_text = _([[
+Widows and orphans are lines at the beginning or end of a paragraph, which are left dangling at the top or bottom of a page, separated from the rest of the paragraph.
+The first line of a paragraph alone at the bottom of a page is called an orphan line.
+The last line of a paragraph alone at the top of a page is called a widow line.
+
+Some people (and publishers) don't like widows and orphans, and can avoid them with CSS rules.
+To avoid widows and orphans, some lines have to be pushed to the next page to accompany what would otherwise be widows and orphans. This may leave some blank space at the bottom of the previous page, which might be more disturbing to others.
+
+The default is to allow widows and orphans.
+These tweaks allow you to change this behavior, and to override publisher rules.]]),
+                separator = true,
+            },
+            -- To avoid duplicating these 2 tweaks into 2 others for ignoring publisher rules,
+            -- we apply the rules to BODY without !important (so they can still be overriden
+            -- by publisher rules applied to BODY), and to DocFragment with !important (so
+            -- that with "* {widows/orphans: inherit !important}", all elements will inherit
+            -- from the DocFragment rules.
+            -- This trick will work with EPUB, but not with single file HTML.
+            {
+                id = "widows_orphans_avoid",
+                title = _("Avoid widows and orphans"),
+                description = _("Avoid widow and orphan lines, allowing for some possible blank space at the bottom of pages."),
+                css = [[
+body { orphans: 2; widows: 2; }
+DocFragment {
+    orphans: 2 !important;
+    widows:  2 !important;
+}
+                ]],
+                priority = 2, -- so it overrides the * inherit below for DocFragment
+            },
+            {
+                id = "widows_avoid_orphans_allow",
+                title = _("Avoid widows but allow orphans"),
+                description = _([[
+Avoid widow lines, but allow orphan lines, allowing for some possible blank space at the bottom of pages.
+Allowing orphans avoids ambiguous blank space at the bottom of a page, which could otherwise be confused with real spacing between paragraphs.]]),
+                css = [[
+body { orphans: 1; widows: 2; }
+DocFragment {
+    orphans: 1 !important;
+    widows:  2 !important;
+}
+                ]],
+                priority = 2, -- so it overrides the * inherit below for DocFragment
+                separator = true,
+            },
+            {
+                id = "widows_orphans_all_inherit",
+                title = _("Ignore publisher orphan and widow rules"),
+                description = _("Disable orphan and widow rules specified in embedded styles."),
+                css = [[
+* {
+    orphans: inherit !important;
+    widows:  inherit !important;
+}
+                ]],
             },
         },
     },
@@ -231,72 +314,9 @@ You may also want to enable, in the top menu → Gear → Taps and gestures → 
             separator = true,
         },
         {
-            title = _("Widows and orphans"),
-            {
-                title = _("About widow and orphan lines"),
-                info_text = _([[
-Widows and orphans are lines at the beginning or end of a paragraph, which are left dangling at the top or bottom of a page, separated from the rest of the paragraph.
-The first line of a paragraph alone at the bottom of a page is called an orphan line.
-The last line of a paragraph alone at the top of a page is called a widow line.
-
-Some people (and publishers) don't like widows and orphans, and can avoid them with CSS rules.
-To avoid widows and orphans, some lines have to be pushed to the next page to accompany what would otherwise be widows and orphans. This may leave some blank space at the bottom of the previous page, which might be more disturbing to others.
-
-The default is to allow widows and orphans.
-These tweaks allow you to change this behavior, and to override publisher rules.]]),
-                separator = true,
-            },
-            -- To avoid duplicating these 2 tweaks into 2 others for ignoring publisher rules,
-            -- we apply the rules to BODY without !important (so they can still be overriden
-            -- by publisher rules applied to BODY), and to DocFragment with !important (so
-            -- that with "* {widows/orphans: inherit !important}", all elements will inherit
-            -- from the DocFragment rules.
-            -- This trick will work with EPUB, but not with single file HTML.
-            {
-                id = "widows_orphans_avoid";
-                title = _("Avoid widows and orphans"),
-                description = _("Avoid widow and orphan lines, allowing for some possible blank space at the bottom of pages."),
-                css = [[
-body { orphans: 2; widows: 2; }
-DocFragment {
-    orphans: 2 !important;
-    widows:  2 !important;
-}
-                ]],
-                priority = 2, -- so it overrides the * inherit below for DocFragment
-            },
-            {
-                id = "widows_avoid_orphans_allow";
-                title = _("Avoid widows but allow orphans"),
-                description = _([[
-Avoid widow lines, but allow orphan lines, allowing for some possible blank space at the bottom of pages.
-Allowing orphans avoids ambiguous blank space at the bottom of a page, which could otherwise be confused with real spacing between paragraphs.]]),
-                css = [[
-body { orphans: 1; widows: 2; }
-DocFragment {
-    orphans: 1 !important;
-    widows:  2 !important;
-}
-                ]],
-                priority = 2, -- so it overrides the * inherit below for DocFragment
-                separator = true,
-            },
-            {
-                id = "widows_orphans_all_inherit";
-                title = _("Ignore publisher orphan and widow rules"),
-                description = _("Disable orphan and widow rules specified in embedded styles."),
-                css = [[
-* {
-    orphans: inherit !important;
-    widows:  inherit !important;
-}
-                ]],
-            },
-        },
-        {
             title = _("Hyphenation, ligatures, ruby"),
             {
-                id = "hyphenate_all_auto";
+                id = "hyphenate_all_auto",
                 title = _("Allow hyphenation on all text"),
                 description = _("Allow hyphenation on all text (except headings), in case the publisher has disabled it."),
                 css = [[
@@ -305,7 +325,7 @@ h1, h2, h3, h4, h5, h6 { hyphens: none !important; }
                 ]],
             },
             {
-                id = "line_break_cre_loose";
+                id = "line_break_cre_loose",
                 title = _("Ignore publisher line-break restrictions"),
                 description = _([[
 A publisher might use non-breaking spaces and hyphens to avoid line breaking between some words, which is not always necessary and may have been added to make reading easier. This can cause large word spacing on some lines.
@@ -313,7 +333,7 @@ Ignoring them will only use KOReader's own typography rules for line breaking.]]
                 css = [[* { line-break: -cr-loose; }]],
             },
             {
-                id = "ligature_all_no_common_ligature";
+                id = "ligature_all_no_common_ligature",
                 title = _("Disable common ligatures"),
                 description = _("Disable common ligatures, which are enabled by default in 'best' kerning mode."),
                 -- We don't use !important, as this would stop other font-variant properties
@@ -333,7 +353,7 @@ These tweaks can help make ruby easier to read or ignore.]]),
                     separator = true,
                 },
                 {
-                    id = "ruby_font_sans_serif";
+                    id = "ruby_font_sans_serif",
                     title = _("Sans-serif font for ruby"),
                     description = _([[
 Use a sans serif font to display all ruby text for a more 'book-like' feeling.
@@ -346,14 +366,14 @@ rt, rubyBox[T=rt] {
                     ]],
                 },
                 {
-                    id = "ruby_font_size_larger";
+                    id = "ruby_font_size_larger",
                     title = _("Larger ruby text size"),
                     description = _("Increase ruby text size."),
                     css = [[rt, rubyBox[T=rt] { font-size: 50% !important; }]],
                     separator = true,
                 },
                 {
-                    id = "ruby_most_line_height_larger";
+                    id = "ruby_most_line_height_larger",
                     title = _("Larger spacing between ruby lines"),
                     description = _([[
 Increase line spacing of most text, so that lines keep an even spacing whether or not they include ruby.
@@ -362,7 +382,7 @@ Further small adjustments can be done with 'Line Spacing' in the bottom menu.]])
                     -- no need for priority, this has higher specificity than lineheight_all_inherit below
                 },
                 {
-                    id = "ruby_inline";
+                    id = "ruby_inline",
                     title = _("Render ruby content inline"),
                     description = _("Disable handling of <ruby> tags and render them inline."),
                     css = [[ruby { display: inline !important; }]],
@@ -371,28 +391,32 @@ Further small adjustments can be done with 'Line Spacing' in the bottom menu.]])
             separator = true,
         },
         {
-            title = _("Fonts and line heights"),
+            title = _("Font size and families"),
             {
-                id = "font_family_all_inherit";
+                id = "font_family_all_inherit",
                 title = _("Ignore publisher font families"),
                 description = _("Disable font-family specified in embedded styles."),
                 css = [[* { font-family: inherit !important; }]],
-            },
-            {
-                id = "font_size_all_inherit";
-                title = _("Ignore publisher font sizes"),
-                description = _("Disable font-size specified in embedded styles."),
-                css = [[* { font-size: inherit !important; }]],
                 separator = true,
             },
             {
-                id = "lineheight_all_inherit";
+                id = "font_size_all_inherit",
+                title = _("Ignore publisher font sizes"),
+                description = _("Disable font-size specified in embedded styles."),
+                priority = -1, -- so in-page footnotes smaller can override this
+                css = [[* { font-size: inherit !important; }]],
+            },
+        },
+        {
+            title = _("Line heights"),
+            {
+                id = "lineheight_all_inherit",
                 title = _("Ignore publisher line heights"),
                 description = _("Disable line-height specified in embedded styles, and may allow KOReader's line spacing settings to work on books where they would not."),
                 css = [[* { line-height: inherit !important; }]],
             },
             {
-                id = "lineheight_all_normal_strut_confined";
+                id = "lineheight_all_normal_strut_confined",
                 title = _("Enforce steady line heights"),
                 description = _("Prevent inline content like sub- and superscript from changing their paragraph line height."),
                 -- strut-confined is among the few cr-hints that are inherited
@@ -400,7 +424,7 @@ Further small adjustments can be done with 'Line Spacing' in the bottom menu.]])
                 separator = true,
             },
             {
-                id = "sub_sup_smaller";
+                id = "sub_sup_smaller",
                 title = _("Smaller sub- and superscript"),
                 description = _("Prevent sub- and superscript from affecting line-height."),
                 priority = 5, -- so we can override "font_size_all_inherit"
@@ -416,7 +440,7 @@ sub { font-size: 50% !important; vertical-align: sub !important; }
     {
         title = _("Paragraphs"),
         {
-            id = "paragraph_web_browser_style";
+            id = "paragraph_web_browser_style",
             title = _("Generic web browser paragraph style"),
             description = _([[
 Display paragraphs as browsers do, in full-block style without indentation or justification, discarding KOReader's book paragraph style.
@@ -432,7 +456,7 @@ p {
             ]],
         },
         {
-            id = "cjk_tailored";
+            id = "cjk_tailored",
             title = _("Tailor widths and text-indent for CJK"),
             description = _([[
 Adjust paragraph width and text-indent to be an integer multiple of the font size, so that lines of Chinese and Japanese characters don't need space added between glyphs for text justification.]]),
@@ -442,14 +466,14 @@ Adjust paragraph width and text-indent to be an integer multiple of the font siz
         {
             title = _("Paragraph first-line indentation"),
             {
-                id = "paragraph_no_indent";
+                id = "paragraph_no_indent",
                 title = _("No indentation on first paragraph line"),
                 description = _("Do not indent the first line of paragraphs."),
                 css = [[p { text-indent: 0 !important; }]],
                 separator = true,
             },
             {
-                id = "paragraph_indent";
+                id = "paragraph_indent",
                 title = _("Indentation on first paragraph line"),
                 description = _("Indentation on the first line of a paragraph is the default, but it may be overridden by publisher styles. This will force KOReader's defaults on common elements."),
                 css = [[
@@ -458,14 +482,14 @@ body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
                 ]],
             },
             {
-                id = "paragraph_first_no_indent";
+                id = "paragraph_first_no_indent",
                 title = _("No indentation on first paragraph"),
                 description = _("Do not indent the first line of the first paragraph of its container. This might be needed to correctly display drop caps, while still having indentation on following paragraphs."),
                 priority = 2, -- so it can override 'paragraph_indent'
                 css = [[p:first-child { text-indent: 0 !important; }]],
             },
             {
-                id = "paragraph_following_no_indent";
+                id = "paragraph_following_no_indent",
                 title = _("No indentation on following paragraphs"),
                 description = _("Do not indent the first line of following paragraphs, but leave the first paragraph of its container untouched."),
                 priority = 2, -- so it can override 'paragraph_indent'
@@ -475,178 +499,145 @@ body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
         {
             title = _("Spacing between paragraphs"),
             {
-                id = "paragraph_whitespace";
+                id = "paragraph_whitespace",
                 title = _("Spacing between paragraphs"),
                 description = _("Add a line of whitespace between paragraphs."),
-                priority = 5, -- Override "Ignore margins and paddings" below
+                priority = 5, -- Override "Ignore margins and paddings" above
                 css = [[p + p { margin-top: 1em !important; }]],
             },
             {
-                id = "paragraph_whitespace_half";
+                id = "paragraph_whitespace_half",
                 title = _("Spacing between paragraphs (half)"),
                 description = _("Add half a line of whitespace between paragraphs."),
                 priority = 5,
                 css = [[p + p { margin-top: .5em !important; }]],
             },
             {
-                id = "paragraph_no_whitespace";
+                id = "paragraph_no_whitespace",
                 title = _("No spacing between paragraphs"),
                 description = _("No whitespace between paragraphs is the default, but it may be overridden by publisher styles. This will re-enable it for paragraphs and list items."),
                 priority = 5,
-                css = [[p, li { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+                css = [[p { margin-top: 0 !important; margin-bottom: 0 !important; }]],
+            },
+        },
+    },
+    {
+        title = _("Tables, links, images"),
+        {
+            title = _("Tables"),
+            {
+                id = "table_full_width",
+                title = _("Full-width tables"),
+                description = _("Make table expand to the full width of the page. (Tables with small content now use only the width needed to display that content. This restores the previous behavior.)"),
+                css = [[table { width: 100% !important; }]],
+                priority = 2, -- Override next one
+            },
+            {
+                id = "table_td_width_auto",
+                title = _("Ignore publisher table and cell widths"),
+                description = _("Ignore table and cells widths specified by the publisher, and let the engine decide the most appropriate widths."),
+                css = [[table, td, th { width: auto !important; }]],
+            },
+            {
+                id = "table_margin_left_right_auto",
+                title = _("Center small tables"),
+                description = _("Horizontally center tables that do not use the full page width."),
+                css = [[table { margin-left: auto !important; margin-right: auto !important; }]],
+                priority = 3, -- Override "Pages > Ignore margin and padding"
                 separator = true,
             },
             {
-                id = "paragraph_no_vertical_padding";
-                title = _("Ignore vertical paragraph padding"),
-                priority = 3, -- Override "Pages > Ignore margin and padding"
-                css = [[p, li { padding-top: 0 !important; padding-bottom: 0 !important; }]],
-            },
-        },
-        {
-            title = _("Horizontal paragraph margins"),
-            {
-                id = "paragraph_no_horizontal_margin";
-                title = _("Ignore horizontal paragraph margins"),
-                priority = 3, -- Override "Pages > Ignore margin and padding"
-                css = [[p, li { margin-left: 0 !important; margin-right: 0 !important; }]],
+                id = "td_vertical_align_none",
+                title = _("Ignore publisher vertical alignment in tables"),
+                -- Using "vertical-align: top" would vertical-align children text nodes to top.
+                -- "vertical-align: baseline" has no meaning in table rendering, and is as fine
+                css = [[td { vertical-align: baseline !important; }]],
             },
             {
-                id = "paragraph_no_horizontal_padding";
-                title = _("Ignore horizontal paragraph padding"),
-                priority = 3,
-                css = [[p, li { padding-left: 0 !important; padding-right: 0 !important; }]],
-            },
-            separator = true,
-        },
-        {
-            title = _("List items"),
-            {
-                id = "ul_li_type_disc";
-                title = _("Force bullets with unordered lists"),
-                css = [[ul > li { list-style-type: disc !important; }]],
-            },
-            {
-                id = "ol_li_type_decimal";
-                title = _("Force decimal numbers with ordered lists"),
-                css = [[ol > li { list-style-type: decimal !important; }]],
-            },
-        },
-    },
-    {
-        title = _("Tables"),
-        {
-            id = "table_full_width";
-            title = _("Full-width tables"),
-            description = _("Make table expand to the full width of the page. (Tables with small content now use only the width needed to display that content. This restores the previous behavior.)"),
-            css = [[table { width: 100% !important; }]],
-            priority = 2, -- Override next one
-        },
-        {
-            id = "table_td_width_auto";
-            title = _("Ignore publisher table and cell widths"),
-            description = _("Ignore table and cells widths specified by the publisher, and let the engine decide the most appropriate widths."),
-            css = [[table, td, th { width: auto !important; }]],
-        },
-        {
-            id = "table_margin_left_right_auto";
-            title = _("Center small tables"),
-            description = _("Horizontally center tables that do not use the full page width."),
-            css = [[table { margin-left: auto !important; margin-right: auto !important; }]],
-            priority = 3, -- Override "Pages > Ignore margin and padding"
-            separator = true,
-        },
-        {
-            id = "td_vertical_align_none";
-            title = _("Ignore publisher vertical alignment in tables"),
-            -- Using "vertical-align: top" would vertical-align children text nodes to top.
-            -- "vertical-align: baseline" has no meaning in table rendering, and is as fine
-            css = [[td { vertical-align: baseline !important; }]],
-        },
-        {
-            id = "table_row_odd_even";
-            title = _("Alternate background color of table rows"),
-            css = [[
+                id = "table_row_odd_even",
+                title = _("Alternate background color of table rows"),
+                css = [[
 tr:nth-child(odd)  { background-color: #EEE !important; }
 tr:nth-child(even) { background-color: #CCC !important; }
-            ]],
-        },
-        {
-            id = "table_force_border";
-            title = _("Show borders on all tables"),
-            css = [[
+                ]],
+            },
+            {
+                id = "table_force_border",
+                title = _("Show borders on all tables"),
+                css = [[
 table, tcaption, tr, th, td { border: black solid 1px; border-collapse: collapse; }
-            ]],
-        },
-    },
-    {
-        title = _("Links"),
-        {
-            id = "a_black";
-            title = _("Links always black"),
-            css = [[a, a * { color: black !important; }]],
+                ]],
+            },
         },
         {
-            id = "a_blue";
-            title = _("Links always blue"),
-            css = [[a, a * { color: blue !important; }]],
-            separator = true,
+            title = _("Links"),
+            {
+                id = "a_black",
+                title = _("Links always black"),
+                css = [[a, a * { color: black !important; }]],
+            },
+            {
+                id = "a_blue",
+                title = _("Links always blue"),
+                css = [[a, a * { color: blue !important; }]],
+                separator = true,
+            },
+            {
+                id = "a_bold",
+                title = _("Links always bold"),
+                css = [[a, a * { font-weight: bold !important; }]],
+            },
+            {
+                id = "a_not_bold",
+                title = _("Links never bold"),
+                css = [[a, a * { font-weight: normal !important; }]],
+                separator = true,
+            },
+            {
+                id = "a_italic",
+                title = _("Links always italic"),
+                css = [[a, a * { font-style: italic !important; }]],
+            },
+            {
+                id = "a_not_italic",
+                title = _("Links never italic"),
+                css = [[a, a * { font-style: normal !important; }]],
+                separator = true,
+            },
+            {
+                id = "a_underline",
+                title = _("Links always underlined"),
+                css = [[a[href], a[href] * { text-decoration: underline !important; }]],
+                -- Have it apply only on real links with a href=, not on anchors
+            },
+            {
+                id = "a_not_underline",
+                title = _("Links never underlined"),
+                css = [[a, a * { text-decoration: none !important; }]],
+            },
         },
         {
-            id = "a_bold";
-            title = _("Links always bold"),
-            css = [[a, a * { font-weight: bold !important; }]],
-        },
-        {
-            id = "a_not_bold";
-            title = _("Links never bold"),
-            css = [[a, a * { font-weight: normal !important; }]],
-            separator = true,
-        },
-        {
-            id = "a_italic";
-            title = _("Links always italic"),
-            css = [[a, a * { font-style: italic !important; }]],
-        },
-        {
-            id = "a_not_italic";
-            title = _("Links never italic"),
-            css = [[a, a * { font-style: normal !important; }]],
-            separator = true,
-        },
-        {
-            id = "a_underline";
-            title = _("Links always underlined"),
-            css = [[a[href], a[href] * { text-decoration: underline !important; }]],
-            -- Have it apply only on real links with a href=, not on anchors
-        },
-        {
-            id = "a_not_underline";
-            title = _("Links never underlined"),
-            css = [[a, a * { text-decoration: none !important; }]],
-        },
-    },
-    {
-        title = _("Images"),
-        {
-            id = "image_full_width";
-            title = _("Full-width images"),
-            description = _("Useful for books containing only images, when they are smaller than your screen. May stretch images in some cases."),
-            -- This helped me once with a book. Will mess with aspect ratio
-            -- when images have a style="width: NNpx; heigh: NNpx"
-            css = [[
+            title = _("Images"),
+            {
+                id = "image_full_width",
+                title = _("Full-width images"),
+                description = _("Useful for books containing only images, when they are smaller than your screen. May stretch images in some cases."),
+                -- This helped me once with a book. Will mess with aspect ratio
+                -- when images have a style="width: NNpx; heigh: NNpx"
+                css = [[
 img {
 text-align: center !important;
 text-indent: 0px !important;
 display: block !important;
 width: 100% !important;
 }
-            ]],
-        },
-        {
-            id = "image_valign_middle";
-            title = _("Vertically center-align images relative to text"),
-            css = [[img { vertical-align: middle; }]],
+                ]],
+            },
+            {
+                id = "image_valign_middle",
+                title = _("Vertically center-align images relative to text"),
+                css = [[img { vertical-align: middle; }]],
+            },
         },
     },
     {
@@ -667,43 +658,43 @@ After applying these tweaks, the alternative ToC needs to be rebuilt by toggling
                 separator = true,
             },
             {
-                id = "alt_toc_ignore_h_all";
+                id = "alt_toc_ignore_h_all",
                 title = _("Ignore all <H1> to <H6>"),
                 css = [[h1, h2, h3, h4, h5, h6 { -cr-hint: toc-ignore; }]],
             },
             {
-                id = "alt_toc_ignore_h1";
+                id = "alt_toc_ignore_h1",
                 title = _("Ignore <H1>"),
                 css = [[h1 { -cr-hint: toc-ignore; }]],
             },
             {
-                id = "alt_toc_ignore_h2";
+                id = "alt_toc_ignore_h2",
                 title = _("Ignore <H2>"),
                 css = [[h2 { -cr-hint: toc-ignore; }]],
             },
             {
-                id = "alt_toc_ignore_h3";
+                id = "alt_toc_ignore_h3",
                 title = _("Ignore <H3>"),
                 css = [[h3 { -cr-hint: toc-ignore; }]],
             },
             {
-                id = "alt_toc_ignore_h4";
+                id = "alt_toc_ignore_h4",
                 title = _("Ignore <H4>"),
                 css = [[h4 { -cr-hint: toc-ignore; }]],
             },
             {
-                id = "alt_toc_ignore_h5";
+                id = "alt_toc_ignore_h5",
                 title = _("Ignore <H5>"),
                 css = [[h5 { -cr-hint: toc-ignore; }]],
             },
             {
-                id = "alt_toc_ignore_h6";
+                id = "alt_toc_ignore_h6",
                 title = _("Ignore <H6>"),
                 css = [[h6 { -cr-hint: toc-ignore; }]],
                 separator = true,
             },
             {
-                id = "alt_toc_level_example";
+                id = "alt_toc_level_example",
                 title = _("Example of book specific ToC hints"),
                 description = _([[
 If headings or document fragments do not result in a usable ToC, you can inspect the HTML and look for elements that contain chapter titles. Then you can set hints to their class names.
@@ -715,21 +706,59 @@ This is just an example, that will need to be adapted into a user style tweak.]]
 .chap_tit1 { -cr-hint: toc-level3; }
                 ]],
             },
+            separator = true,
         },
         {
-            title = _("In-page footnotes"),
+            title = _("List items"),
             {
+                id = "ul_li_type_disc",
+                title = _("Force bullets with unordered lists"),
+                css = [[ul > li { list-style-type: disc !important; }]],
+            },
+            {
+                id = "ol_li_type_decimal",
+                title = _("Force decimal numbers with ordered lists"),
+                css = [[ol > li { list-style-type: decimal !important; }]],
+            },
+        },
+        {
+            id = "no_pseudo_element_before_after",
+            title = _("Disable before/after pseudo elements"),
+            description = _([[Disable generated text from ::before and ::after pseudo elements, usually used to add cosmetic text around some content.]]),
+            css = [[
+*::before { display: none !important; }
+*::after  { display: none !important; }
+            ]],
+            separator = true,
+        },
+        {
+            id = "pure_black_and_white",
+            title = _("Pure black and white"),
+            description = _([[Enforce black text and borders, and remove backgrounds.]]),
+            css = [[
+* {
+    color: black !important;
+    border-color: black !important;
+    background-color: transparent !important;
+    background-image: !important;
+}
+            ]], -- (This last empty background-image: works for cancelling any previous one
+        },
+    },
+    {
+        title = _("In-page footnotes"),
+        {
+            title = _("In-page FB2 footnotes"),
+            {
+                id = "footnote-inpage_fb2",
                 title = _("In-page FB2 footnotes"),
-                {
-                    id = "footnote-inpage_fb2";
-                    title = _("In-page FB2 footnotes"),
-                    description = _([[
+                description = _([[
 Show FB2 footnote text at the bottom of pages that contain links to them.]]),
-                    -- Restrict this to FB2 documents, even if we won't probably
-                    -- match in any other kind of document
-                    -- (Last selector avoids title bottom margin from collapsing
-                    -- into the first footnote by substituting it with padding.)
-                    css = [[
+                -- Restrict this to FB2 documents, even if we won't probably
+                -- match in any other kind of document
+                -- (Last selector avoids title bottom margin from collapsing
+                -- into the first footnote by substituting it with padding.)
+                css = [[
 body[name="notes"] section {
     -cr-only-if: fb2-document;
         -cr-hint: footnote-inpage;
@@ -744,14 +773,14 @@ body[name="notes"] > title {
         margin-bottom: 0;
         padding-bottom: 0.5em;
 }
-                    ]],
-                },
-                {
-                    id = "footnote-inpage_fb2_comments";
-                    title = _("In-page FB2 endnotes"),
-                    description = _([[
+                ]],
+            },
+            {
+                id = "footnote-inpage_fb2_comments",
+                title = _("In-page FB2 endnotes"),
+                description = _([[
 Show FB2 endnote text at the bottom of pages that contain links to them.]]),
-                    css = [[
+                css = [[
 body[name="comments"] section {
     -cr-only-if: fb2-document;
         -cr-hint: footnote-inpage;
@@ -766,33 +795,33 @@ body[name="comments"] > title {
         margin-bottom: 0;
         padding-bottom: 0.5em;
 }
-                    ]],
-                    separator = true,
-                },
-                {
-                    id = "fb2_footnotes_regular_font_size";
-                    title = _("Keep regular font size"),
-                    description = _([[
+                ]],
+                separator = true,
+            },
+            {
+                id = "fb2_footnotes_regular_font_size",
+                title = _("Keep regular font size"),
+                description = _([[
 FB2 footnotes and endnotes get a smaller font size when displayed in-page. This allows them to be shown with the normal font size.]]),
-                    css = [[
+                css = [[
 body[name="notes"] > section,
 body[name="comments"] > section
 {
     -cr-only-if: fb2-document;
         font-size: 1rem !important;
 }
-                    ]],
-                },
-                separator = true,
+                ]],
             },
-            {
-                id = "footnote-inpage_epub";
-                title = _("In-page EPUB footnotes"),
-                description = _([[
+            separator = true,
+        },
+        {
+            id = "footnote-inpage_epub",
+            title = _("In-page EPUB footnotes"),
+            description = _([[
 Show EPUB footnote text at the bottom of pages that contain links to them.
 This only works with footnotes that have specific attributes set by the publisher.]]),
-                -- Restrict this to non-FB2 documents, as FB2 can have <a type="note">
-                css = [[
+            -- Restrict this to non-FB2 documents, as FB2 can have <a type="note">
+            css = [[
 *[type~="note"],
 *[type~="endnote"],
 *[type~="footnote"],
@@ -806,17 +835,17 @@ This only works with footnotes that have specific attributes set by the publishe
         -cr-hint: footnote-inpage;
         margin: 0 !important;
 }
-                ]],
-            },
-            {
-                id = "footnote-inpage_epub_smaller";
-                title = _("In-page EPUB footnotes (smaller)"),
-                description = _([[
+            ]],
+        },
+        {
+            id = "footnote-inpage_epub_smaller",
+            title = _("In-page EPUB footnotes (smaller)"),
+            description = _([[
 Show EPUB footnote text at the bottom of pages that contain links to them.
 This only works with footnotes that have specific attributes set by the publisher.]]),
-                -- Restrict this to non-FB2 documents, as FB2 can have <a type="note">
-                -- and we don't want to have them smaller
-                css = [[
+            -- Restrict this to non-FB2 documents, as FB2 can have <a type="note">
+            -- and we don't want to have them smaller
+            css = [[
 *[type~="note"],
 *[type~="endnote"],
 *[type~="footnote"],
@@ -831,103 +860,80 @@ This only works with footnotes that have specific attributes set by the publishe
         margin: 0 !important;
         font-size: 0.8rem !important;
 }
-                ]],
-                separator = true,
-            },
-            {
-                id = "footnote-inpage_wikipedia";
-                title = _("In-page Wikipedia footnotes"),
-                description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
-                css = [[
-ol.references > li {
-    -cr-hint: footnote-inpage;
-    list-style-position: -cr-outside;
-    margin: 0 !important;
-}
-/* hide backlinks */
-ol.references > li > .noprint { display: none; }
-ol.references > li > .mw-cite-backlink { display: none; }
-                ]],
-            },
-            {
-                id = "footnote-inpage_wikipedia_smaller";
-                title = _("In-page Wikipedia footnotes (smaller)"),
-                description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
-                css = [[
-ol.references > li {
-    -cr-hint: footnote-inpage;
-    list-style-position: -cr-outside;
-    margin: 0 !important;
-    font-size: 0.8rem !important;
-}
-/* hide backlinks */
-ol.references > li > .noprint { display: none; }
-ol.references > li > .mw-cite-backlink { display: none; }
-                ]],
-                separator = true,
-            },
-            -- We can add other classic classnames to the 2 following
-            -- tweaks (except when named 'calibreN', as the N number is
-            -- usually random across books).
-            {
-                id = "footnote-inpage_classic_classnames";
-                title = _("In-page classic classname footnotes"),
-                description = _([[
-Show footnotes with classic classnames at the bottom of pages.
-This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
-                css = [[
-.footnote, .footnotes, .fn,
-.note, .note1, .note2, .note3,
-.ntb, .ntb-txt, .ntb-txt-j,
-.przypis, .przypis1, /* Polish footnotes */
-.voetnoten /* Dutch footnotes */
-{
-    -cr-hint: footnote-inpage;
-    margin: 0 !important;
-}
-                ]],
-            },
-            {
-                id = "footnote-inpage_classic_classnames_smaller";
-                title = _("In-page classic classname footnotes (smaller)"),
-                description = _([[
-Show footnotes with classic classnames at the bottom of pages.
-This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
-                css = [[
-.footnote, .footnotes, .fn,
-.note, .note1, .note2, .note3,
-.ntb, .ntb-txt, .ntb-txt-j,
-.przypis, .przypis1, /* Polish footnotes */
-.voetnoten /* Dutch footnotes */
-{
-    -cr-hint: footnote-inpage;
-    margin: 0 !important;
-    font-size: 0.8rem !important;
-}
-                ]],
-            },
+            ]],
+            separator = true,
         },
         {
-            id = "no_pseudo_element_before_after";
-            title = _("Disable before/after pseudo elements"),
-            description = _([[Disable generated text from ::before and ::after pseudo elements, usually used to add cosmetic text around some content.]]),
+            id = "footnote-inpage_wikipedia",
+            title = _("In-page Wikipedia footnotes"),
+            description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
             css = [[
-*::before { display: none !important; }
-*::after  { display: none !important; }
+ol.references > li {
+    -cr-hint: footnote-inpage;
+    list-style-position: -cr-outside;
+    margin: 0 !important;
+}
+/* hide backlinks */
+ol.references > li > .noprint { display: none; }
+ol.references > li > .mw-cite-backlink { display: none; }
             ]],
         },
         {
-            id = "pure_black_and_white";
-            title = _("Pure black and white"),
-            description = _([[Enforce black text and borders, and remove backgrounds.]]),
+            id = "footnote-inpage_wikipedia_smaller",
+            title = _("In-page Wikipedia footnotes (smaller)"),
+            description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
             css = [[
-* {
-    color: black !important;
-    border-color: black !important;
-    background-color: transparent !important;
-    background-image: !important;
+ol.references > li {
+    -cr-hint: footnote-inpage;
+    list-style-position: -cr-outside;
+    margin: 0 !important;
+    font-size: 0.8rem !important;
 }
-            ]], -- (This last empty background-image: works for cancelling any previous one
+/* hide backlinks */
+ol.references > li > .noprint { display: none; }
+ol.references > li > .mw-cite-backlink { display: none; }
+            ]],
+            separator = true,
+        },
+        -- We can add other classic classnames to the 2 following
+        -- tweaks (except when named 'calibreN', as the N number is
+        -- usually random across books).
+        {
+            id = "footnote-inpage_classic_classnames",
+            title = _("In-page classic classname footnotes"),
+            description = _([[
+Show footnotes with classic classnames at the bottom of pages.
+This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
+            css = [[
+.footnote, .footnotes, .fn,
+.note, .note1, .note2, .note3,
+.ntb, .ntb-txt, .ntb-txt-j,
+.przypis, .przypis1, /* Polish footnotes */
+.voetnoten /* Dutch footnotes */
+{
+    -cr-hint: footnote-inpage;
+    margin: 0 !important;
+}
+            ]],
+        },
+        {
+            id = "footnote-inpage_classic_classnames_smaller",
+            title = _("In-page classic classname footnotes (smaller)"),
+            description = _([[
+Show footnotes with classic classnames at the bottom of pages.
+This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
+            css = [[
+.footnote, .footnotes, .fn,
+.note, .note1, .note2, .note3,
+.ntb, .ntb-txt, .ntb-txt-j,
+.przypis, .przypis1, /* Polish footnotes */
+.voetnoten /* Dutch footnotes */
+{
+    -cr-hint: footnote-inpage;
+    margin: 0 !important;
+    font-size: 0.8rem !important;
+}
+            ]],
         },
     },
     -- No current need for workarounds

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -820,6 +820,8 @@ function TouchMenu:onSwipe(arg, ges_ev)
         self:onPrevPage()
     elseif direction == "north" then
         self:closeMenu()
+    elseif direction == "south" then
+        self:onBack()
     end
 end
 

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -933,9 +933,9 @@ hr.koreaderwikifrontpage {
 
 /* So many links, make them look like normal text except for underline */
 a {
-    display:inline;
+    display: inline;
     text-decoration: underline;
-    color: black;
+    color: inherit;
     font-weight: inherit;
 }
 /* No underline for links without their href that we removed */


### PR DESCRIPTION
#### bump crengine: style tweaks helpers, other fixes

Includes https://github.com/koreader/crengine/pull/485 :
- CSS: add "-cr-hint: late" to increase selectors specificity
- CSS: add a few non-static "-cr-only-if:" values
- getStyledImageSize(): fix missing images when gRenderDPI=0
  Closes #9281
- Text: fix possible crash with floats and `<br/>`
- LVImg: fix crash on GIF images without color table
  Closes #9297

Discussion, decisions and screenshots at https://github.com/koreader/koreader/pull/5863#issuecomment-1154234889 and follow ups.

#### Style tweaks: reorganize menu items

Make them a bit more logically grouped by topic.  Update a few priorities.
There should be no wording/css change (except for duplicating some paragraph horizontal margin one).
I made "In-page footnotes" be a first level menu (it was in Misc, thought about moving it into Page and margins, but well, it's probably one of the most often accessed, so let it be there).

#### Style tweaks: handle conflicting/redundant tweaks

Disable redundant or incompatible tweaks when enabling some.
This makes the menu more dynamic to show what's impacted, save some re-renderings, and may avoid the user trying combinations that would have no effect.

#### Style tweaks: add "Reset main text font size"

#### Style tweaks: add In-page footnote font size and fix-up tweaks

Should help fixing many footnotes text size and layout issues without having to hack a Book style tweak.
See https://github.com/koreader/koreader/pull/5863#issuecomment-1173097714 (but I probably did some rewording after).
![image](https://user-images.githubusercontent.com/24273478/177574111-115b85e3-a1d9-4c52-ba96-0e2c2d42226f.png)
![image](https://user-images.githubusercontent.com/24273478/177574188-1bbbe511-f74e-472a-b0b3-bb08bf5322ba.png)
![image](https://user-images.githubusercontent.com/24273478/177574415-39c8f32b-1736-43f7-b8fc-48020c3a7799.png)

Rewording suggesions welcome (including for each `description`, not screenshoted above).

#### TouchMenu: add swipe south to go back to parent menu
https://github.com/koreader/koreader/pull/5863#issuecomment-1175578046

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9300)
<!-- Reviewable:end -->
