### PR TITLE
kindle: track suspend time

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1,4 +1,5 @@
 local Generic = require("device/generic/device")
+local time = require("ui/time")
 local logger = require("logger")
 
 local function yes() return true end
@@ -147,6 +148,8 @@ local Kindle = Generic:new{
     isNightModeChallenged = no,
     -- NOTE: While this ought to behave on Zelda/Rex, turns out, nope, it really doesn't work on *any* of 'em :/ (c.f., ko#5884).
     canHWDither = no,
+    -- The time the device went into suspend
+    suspend_time = 0,
 }
 
 function Kindle:initNetworkManager(NetworkMgr)
@@ -277,10 +280,13 @@ end
 
 function Kindle:wakeupFromSuspend()
     self.powerd:wakeupFromSuspend()
+    self.last_suspend_time = time.boottime_or_realtime_coarse() - self.suspend_time
+    self.total_suspend_time = self.total_suspend_time + self.last_suspend_time
 end
 
 function Kindle:readyToSuspend()
     self.powerd:readyToSuspend()
+    self.suspend_time = time.boottime_or_realtime_coarse()
 end
 
 function Kindle:ambientBrightnessLevel()


### PR DESCRIPTION
~~`ui/time: fix for ldoc`~~

~~for some reason it does not bouild if there is a @module line~~

`kindle: track suspend time`

This is useful for the sysstat plugin not to have 00:00 for suspend time :)

Something similar should probably be done for the other `canSuspend` platforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9307)
<!-- Reviewable:end -->
