### PR TITLE
Kobo: Autodetect the Elan input device on both i2c buses

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -549,8 +549,11 @@ function Kobo:init()
 
         -- Input
         if util.fileExists("/dev/input/by-path/platform-1-0010-event") then
-            -- Elan (HWConfig TouchCtrl is ekth6)
+            -- Elan (HWConfig TouchCtrl is ekth6) on i2c bus 1
             self.touch_dev = "/dev/input/by-path/platform-1-0010-event"
+        elseif util.fileExists("/dev/input/by-path/platform-0-0010-event") then
+            -- Elan (HWConfig TouchCtrl is ekth6) on i2c bus 0
+            self.touch_dev = "/dev/input/by-path/platform-0-0010-event"
         else
             self.touch_dev = "/dev/input/event1"
         end


### PR DESCRIPTION
Hadn't noticed that the new Libra 2 has it on a different bus than the
Sage/Elipsa.

(Harmless because we kept the Sage & Elipsa hardcoded).

c.f., https://www.mobileread.com/forums/showpost.php?p=4238067&postcount=869,
thanks to @baskerville for the poke ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9322)
<!-- Reviewable:end -->
