### PR TITLE
fix: Crash loading extensions from pocketbook

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -296,7 +296,9 @@ function PocketBook:associateFileExtensions(assoc)
     local info = {}
     for l in io.lines("/ebrmain/config/extensions.cfg") do
         local m = { l:match("^([^:]*):([^:]*):([^:]*):([^:]*):(.*)") }
-        info[m[1]] = m
+        if #m > 0 then
+            info[m[1]] = m
+        end
     end
     local res = {"#koreader"}
     for k,v in pairs(assoc) do


### PR DESCRIPTION
In some versions of the /ebrmain/config/extensions.cfg file there is a
comment #ebrcfg. This will not match the regex and crashes koreader as
the table is empty.
Add a check to ensure the table is not empty while reading extensions
from the default file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9327)
<!-- Reviewable:end -->
