### PR TITLE
Android: Leave the EV_MSC input handler alone.

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1305,9 +1305,11 @@ function Input:inhibitInput(toggle)
             self.handleTouchEv = self.voidEv
         end
         if not self._msc_ev_handler then
-            if not self.device:isPocketBook() then
+            if not self.device:isPocketBook() and not self.device:isAndroid() then
                 -- NOTE: PocketBook is a special snowflake, synthetic Power events are sent as EV_MSC.
                 --       Thankfully, that's all that EV_MSC is used for on that platform.
+                -- NOTE: Android, on the other hand, handles a *lot* of critical stuff over EV_MSC,
+                --       as it's used to communicate between Android and Lua land ;).
                 self._msc_ev_handler = self.handleMiscEv
                 self.handleMiscEv = self.voidEv
             end


### PR DESCRIPTION
It's used to communicate state changes from Android to Lua, we really really don't want to lose these ;).

Fix #9326

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9335)
<!-- Reviewable:end -->
