### PR TITLE
AutoWarmth: add option to toggle/set frontlight on day/night

### DIFF
--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -312,20 +312,17 @@ function AutoDim:ramp_task()
     self.isCurrentlyDimming = true -- this will disable rescheduling of the `autodim_task`
     local fl_level = Powerd:frontlightIntensity()
     if fl_level > self.autodim_end_fl then
-        Powerd:setIntensity(fl_level - 1)
+        fl_level = fl_level - 1
+        Powerd:setIntensity(fl_level)
         self.ramp_event_countdown = self.ramp_event_countdown - 1
         if self.ramp_event_countdown <= 0 then
             -- Update footer on every self.ramp_event_countdown call
             self:updateFooter()
             self.ramp_event_countdown = self.ramp_event_countdown_startvalue
+            self.last_ramp_scheduling_time = nil
         end
         self:_schedule_ramp_task(self.autodim_step_time_s) -- Reschedule only if ramp is not finished
         -- `isCurrentlyDimming` stays true, to flag we have a dimmed FL.
-    end
-    if fl_level == self.autodim_end_fl and self.ramp_event_countdown_startvalue > 0 then
-        -- Update footer at the end of the ramp.
-        self:updateFooter()
-        self.last_ramp_scheduling_time = nil
     end
 end
 

--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -209,7 +209,6 @@ end
 function AutoDim:onEnterStandby()
     self:_unschedule_autodim_task()
     -- don't unschedule ramp task, as this is done in onLeaveStandby if necessary
-    self.autodim_fl_save = nil
 end
 
 function AutoDim:onLeaveStandby()
@@ -240,11 +239,14 @@ function AutoDim:onFrontlightTurnedOff()
     self.last_ramp_scheduling_time = nil
     UIManager:unschedule(self.ramp_task)
 
-    if self.autodim_fl_save then
+    if self.autodim_save_fl then
         Device.powerd.fl_intensity = self.autodim_save_fl
     end
-    self.autodim_fl_save = nil
-    UIManager:close(self.trap_widget) -- don't swallow input events from now
+    self.autodim_save_fl = nil
+    if self.trap_widget then
+        UIManager:close(self.trap_widget) -- don't swallow input events from now
+        self.trap_widget = nil
+    end
     self:_schedule_autodim_task() -- reschedule
 end
 

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -46,6 +46,7 @@ local AutoWarmth = WidgetContainer:new{
     name = "autowarmth",
     sched_times_s = {},
     sched_warmths = {},
+    fl_turned_off = nil -- true/false if autowarmth has toggled the frontlight
 }
 
 -- get timezone offset in hours (including dst)
@@ -70,6 +71,7 @@ function AutoWarmth:init()
         or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth = G_reader_settings:readSetting("autowarmth_warmth")
         or { 90, 90, 80, 60, 20, 20, 20, 60, 80, 90, 90}
+    self.fl_off_during_day = G_reader_settings:saveSetting("autowarmth_fl_off_during_day")
 
     -- schedule recalculation shortly afer midnight
     self:scheduleMidnightUpdate()
@@ -441,6 +443,22 @@ function AutoWarmth:getSubMenuItems()
             end,
             text = Device:hasNaturalLight() and _("Warmth and night mode settings") or _("Night mode settings"),
             sub_item_table = self:getWarmthMenu(),
+        },
+        {
+            checked_func = function()
+                return self.fl_off_during_day
+            end,
+            text = _("Frontlight off during the day"),
+            callback = function(touchmenu_instance)
+                self.fl_off_during_day = not self.fl_off_during_day
+				print("xxx fl_off_during_day", self.fl_off_during_day)
+                G_reader_settings:saveSetting("autowarmth_fl_off_during_day", self.fl_off_during_day)
+                self:scheduleMidnightUpdate()
+                if touchmenu_instance then
+                    self:updateItems(touchmenu_instance)
+                end
+            end,
+            keep_menu_open = true,
             separator = true,
         },
         self:getTimesMenu(_("Currently active parameters")),

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -475,7 +475,14 @@ function AutoWarmth:getSubMenuItems()
             callback = function(touchmenu_instance)
                 self.fl_off_during_day = not self.fl_off_during_day
                 G_reader_settings:saveSetting("autowarmth_fl_off_during_day", self.fl_off_during_day)
+
                 self:scheduleMidnightUpdate()
+                -- Turn the fl on during day if necessary;
+                -- no need to turn it off as this is done trough `scheduleMidnightUpdate()`
+                if not self.fl_off_during_day and Device.powerd:isFrontlightOff() then
+                    Device.powerd:turnOnFrontlight()
+                end
+
                 if touchmenu_instance then
                     self:updateItems(touchmenu_instance)
                 end

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -334,6 +334,7 @@ function AutoWarmth:scheduleNextWarmthChange(time_s, search_pos, from_resume)
             if Device.powerd:isFrontlightOn() then
                 if self.fl_turned_off ~= true then -- can be false or nil
                     Device.powerd:turnOffFrontlight()
+                    UIManager:broadcastEvent(Event:new("FrontlightTurnedOff"))
                 end
             end
             self.fl_turned_off = true

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -326,11 +326,11 @@ function AutoWarmth:scheduleNextWarmthChange(time_s, search_pos, from_resume)
         UIManager:scheduleIn(delay_s, self.setWarmth, self, next_warmth, true) -- no setWarmth rescheduling, force warmth
     end
 
-	-- Check if AutoWarmth shall toggle frontlight daytime and twilight
+    -- Check if AutoWarmth shall toggle frontlight daytime and twilight
     if self.fl_off_during_day then
         if time_s > self.current_times_h[5]*3600 and time_s < self.current_times_h[7]*3600 then
             -- during daytime (depending on choosens activation: SunTime, fixed Schedule, closer...
-			-- turn on frontlight off once, user can override this selection by a gesture
+            -- turn on frontlight off once, user can override this selection by a gesture
             if Device.powerd:isFrontlightOn() then
                 if self.fl_turned_off ~= true then -- can be false or nil
                     Device.powerd:turnOffFrontlight()
@@ -479,7 +479,6 @@ function AutoWarmth:getSubMenuItems()
             text = _("Frontlight off during the day"),
             callback = function(touchmenu_instance)
                 self.fl_off_during_day = not self.fl_off_during_day
-                print("xxx fl_off_during_day", self.fl_off_during_day)
                 G_reader_settings:saveSetting("autowarmth_fl_off_during_day", self.fl_off_during_day)
                 self:scheduleMidnightUpdate()
                 if touchmenu_instance then

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -196,11 +196,11 @@ function AutoWarmth:scheduleMidnightUpdate(from_resume)
         local time2_h = times_h[index2]
         if not time2_h then return end -- to near to the pole
         local warmth_diff = math.min(self.warmth[index2], 100) - math.min(self.warmth[index1], 100)
-        if warmth_diff ~= 0 then
-            local time_diff_s = SunTime:getTimeInSec(time2_h) - time1_s
+        local time_diff_s = SunTime:getTimeInSec(time2_h) - time1_s
+        if warmth_diff ~= 0 and time_diff_s > 0 then
             local delta_t = time_diff_s / math.abs(warmth_diff) -- cannot be inf, no problem
             local delta_w = warmth_diff > 0 and 1 or -1
-            for i = 1, math.abs(warmth_diff)-1 do
+            for i = 1, math.abs(warmth_diff) - 1 do
                 local next_warmth = math.min(self.warmth[index1], 100) + delta_w * i
                 -- only apply warmth for steps the hardware has (e.g. Tolino has 0-10 hw steps
                 -- which map to warmth 0, 10, 20, 30 ... 100)
@@ -347,7 +347,6 @@ function AutoWarmth:scheduleNextWarmthChange(time_s, search_pos, from_resume)
             self.fl_turned_off = false
         end
     end
-    print("xxx", time_s)
 end
 
 -- Set warmth and schedule the next warmth change
@@ -690,7 +689,7 @@ function AutoWarmth:getScheduleMenu()
                             UIManager:show(ConfirmBox:new{
                                 text = _("This time is before the previous time.\nAdjust the previous time?"),
                                 ok_callback = function()
-                                    for i = num-1, 1, -1 do
+                                    for i = num - 1, 1, -1 do
                                         if self.scheduler_times[i] then
                                             if new_time < self.scheduler_times[i] then
                                                 self.scheduler_times[i] = new_time

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -328,30 +328,26 @@ function AutoWarmth:scheduleNextWarmthChange(time_s, search_pos, from_resume)
 
     -- Check if AutoWarmth shall toggle frontlight daytime and twilight
     if self.fl_off_during_day then
-        if time_s > self.current_times_h[5]*3600 and time_s < self.current_times_h[7]*3600 then
+        if time_s >= self.current_times_h[5]*3600 and time_s < self.current_times_h[7]*3600 then
             -- during daytime (depending on choosens activation: SunTime, fixed Schedule, closer...
             -- turn on frontlight off once, user can override this selection by a gesture
             if Device.powerd:isFrontlightOn() then
                 if self.fl_turned_off ~= true then -- can be false or nil
                     Device.powerd:turnOffFrontlight()
-                    self.fl_turned_off = true
-                end
-            else
-                if self.fl_turned_off ~= false then -- can be true or nil
-                    Device.powerd:turnOnFrontlight()
-                    self.fl_turned_off = false
                 end
             end
+            self.fl_turned_off = true
         else
             -- outside of selected daytime, turn on frontlight once, user can override this selection by a gesture
             if Device.powerd:isFrontlightOff() then
                 if self.fl_turned_off ~= false then -- can be true or nil
                     Device.powerd:turnOnFrontlight()
-                    self.fl_turned_off = false
                 end
             end
+            self.fl_turned_off = false
         end
     end
+    print("xxx", time_s)
 end
 
 -- Set warmth and schedule the next warmth change
@@ -484,7 +480,6 @@ function AutoWarmth:getSubMenuItems()
                 if touchmenu_instance then
                     self:updateItems(touchmenu_instance)
                 end
-                print("xxx self.fl_turned_off", self.fl_turned_off)
             end,
             keep_menu_open = true,
             separator = true,


### PR DESCRIPTION
I was experimenting with a solution to dim the frontlight smoothly on sun set/rise. 
Too long to explain: This does not work, as I don't want to find out how the intensity of devices maps to brightness felt by us humans. (maybe or next year, or the year after or in 2525).

So, this solution stupidly turns the frontlight _on_ (toggle)  between sunset and sunrise, and turns the frontlight _off_ (toggle) during daytime, **once** (per day). The user can override the selection of the plugin, but on the next day/night change AutoWarmth toggles again (if necessary).
This should also work with autosuspend (which I really, really love from the users view, but from the developers point :/)

Draft by now, as some more test will follow, so no need to review _as long this PR is in draft state_.
But as always ( :) ), improvements on wording (menu) are welcomed.


![grafik](https://user-images.githubusercontent.com/36999612/179309195-d796253b-0a0a-437c-8d6f-ea7bd760eb87.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9337)
<!-- Reviewable:end -->
