### PR TITLE
PathChooser: add creating folder

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -604,7 +604,6 @@ function CloudStorage:uploadFile(url)
     local path_chooser
     path_chooser = PathChooser:new{
         select_directory = false,
-        detailed_file_info = true,
         path = self.last_path,
         onConfirm = function(file_path)
             self.last_path = file_path:match("(.*)/")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -286,7 +286,6 @@ function Screensaver:chooseFile(document_cover)
                 local PathChooser = require("ui/widget/pathchooser")
                 local path_chooser = PathChooser:new{
                     select_directory = false,
-                    select_file = true,
                     file_filter = function(filename)
                         local suffix = util.getFileNameSuffix(filename)
                         if document_cover and DocumentRegistry:hasProvider(filename) then
@@ -295,7 +294,6 @@ function Screensaver:chooseFile(document_cover)
                             return true
                         end
                     end,
-                    detailed_file_info = true,
                     path = self.root_path,
                     onConfirm = function(file_path)
                         if document_cover then

--- a/plugins/bookshortcuts.koplugin/main.lua
+++ b/plugins/bookshortcuts.koplugin/main.lua
@@ -92,9 +92,6 @@ function BookShortcuts:getSubMenuItems()
             keep_menu_open = true,
             callback = function(touchmenu_instance)
                 local path_chooser = PathChooser:new{
-                    select_file = true,
-                    select_directory = true,
-                    detailed_file_info = true,
                     path = G_reader_settings:readSetting("home_dir"),
                     onConfirm = function(path)
                         self:addShortcut(path)

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -339,7 +339,6 @@ Do you want to proceed?]]),
         cancel_text = _("No"),
         ok_callback = function()
             local path_chooser = PathChooser:new{
-                select_directory = true,
                 select_file = false,
                 path = self.last_path,
                 onConfirm = function(dir_path)
@@ -380,9 +379,7 @@ end
 function TextEditor:chooseFile()
     self:loadSettings()
     local path_chooser = PathChooser:new{
-        select_file = true,
         select_directory = false,
-        detailed_file_info = true,
         path = self.last_path,
         onConfirm = function(file_path)
             -- Remember last_path only when we select a file from it


### PR DESCRIPTION
Long-press the left TitleBar Home button:

![1](https://user-images.githubusercontent.com/62179190/180020316-f4e46e4d-afc2-4640-a4bc-d251192b657e.png)

Got standard New folder dialog:

![2](https://user-images.githubusercontent.com/62179190/180020373-15a1d5a2-1267-4a83-8f42-c44c0319122f.png)

Closes https://github.com/koreader/koreader/issues/9330.

Minor optimization of the PathChooser call parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9354)
<!-- Reviewable:end -->
