### PR TITLE
InputText: fix 'number' hint

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -350,9 +350,14 @@ function InputText:init()
     end
     -- Beware other cases where implicit conversion to text may be done
     -- at some point, but checkTextEditability() would say "not editable".
-    if self.input_type == "number" and type(self.text) == "number" then
-        -- checkTextEditability() fails if self.text stays not a string
-        self.text = tostring(self.text)
+    if self.input_type == "number" then
+        if type(self.text) == "number" then
+            -- checkTextEditability() fails if self.text stays not a string
+            self.text = tostring(self.text)
+        end
+        if type(self.hint) == "number" then
+            self.hint = tostring(self.hint)
+        end
     end
     self:initTextBox(self.text)
     self:checkTextEditability()


### PR DESCRIPTION
When `input_type ==  "number"` convert the hint to "string" type.
Closes https://github.com/koreader/koreader/issues/9359.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9362)
<!-- Reviewable:end -->
