### PR TITLE
Update Czech-English Dictonary with inflections

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -102,9 +102,9 @@ local dictionaries = {
         name = "GNU/FDL Anglicko/Český slovník",
         lang_in = "Czech",
         lang_out = "English",
-        entries = 178904, -- ~90000 each way
+        entries = 88994,
         license = _("GNU/FDL"),
-        url = "http://http.debian.net/debian/pool/non-free/s/stardict-english-czech/stardict-english-czech_20161201.orig.tar.gz",
+        url = "https://github.com/Vuizur/czech-dictionary-extender/releases/download/1.0.0/czech-english-dict.tar.gz",
     },
     {
         name = "GNU/FDL Německo/Český slovník",


### PR DESCRIPTION
This adds inflections to the Czech-English dictionary. I have tested the dictionary, but not the download within KOReader, as mentioned in https://github.com/koreader/koreader/issues/9037 (because I haven't set up the dev environment yet). So it would be nice if someone could test it with this ebook, for example: [mistr_a_marketka.zip](https://github.com/koreader/koreader/files/9181609/mistr_a_marketka.zip)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9370)
<!-- Reviewable:end -->
