### PR TITLE
Input: Fix a bunch of multi-slot corner cases

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -273,8 +273,8 @@ function Device:onPowerEvent(ev)
                     end
                 end
                 self:resume()
-                Screensaver:close()
-                if self:needsScreenRefreshAfterResume() then
+                local widget_was_closed = Screensaver:close()
+                if widget_was_closed and self:needsScreenRefreshAfterResume() then
                     UIManager:scheduleIn(1, function() self.screen:refreshFull() end)
                 end
                 self.screen_saver_mode = false

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -128,11 +128,8 @@ Feeds touch events to state machine.
 
 For drivers that bundle multiple slots in the same input frame,
 events are consumed in LIFO order, because of table.remove ;).
-Note that, in a single input frame, if the same slot gets multiple *consecutive* events,
-only the last one is kept. On the other hand, if the slot *changes* after SYN_MT_REPORT,
-they are *both* kept: i.e., for a sequence (where the number is the slot, and the letter is the order)
-1a -> 1b -> 2a in an input frame, what's processed by this function ends up being 2a -> 1b;
-but for 1a -> 2a -> 1b -> 2b, it's 2b -> 1b -> 2a -> 1a ;).
+Note that, in a single input frame, if the same slot gets multiple events,
+only the last one is kept.
 --]]
 function GestureDetector:feedEvent(tevs)
     repeat

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -84,12 +84,12 @@ local GestureDetector = {
     pending_hold_timer = {},
     track_ids = {},
     tev_stacks = {},
-    -- latest feeded touch event in each slots
+    -- latest touch events fed in each slot
     last_tevs = {},
     first_tevs = {},
     -- for multiswipe gestures
     multiswipe_directions = {},
-    -- detecting status on each slots
+    -- detecting status on each slot
     detectings = {},
     -- for single/double tap
     last_taps = {},
@@ -125,6 +125,14 @@ end
 
 --[[--
 Feeds touch events to state machine.
+
+For drivers that bundle multiple slots in the same input frame,
+events are consumed in LIFO order, because of table.remove ;).
+Note that, in a single input frame, if the same slot gets multiple *consecutive* events,
+only the last one is kept. On the other hand, if the slot *changes* after SYN_MT_REPORT,
+they are *both* kept: i.e., for a sequence (where the number is the slot, and the letter is the order)
+1a -> 1b -> 2a in an input frame, what's processed by this function ends up being 2a -> 1b;
+but for 1a -> 2a -> 1b -> 2b, it's 2b -> 1b -> 2a -> 1a ;).
 --]]
 function GestureDetector:feedEvent(tevs)
     repeat

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -395,8 +395,8 @@ function GestureDetector:tapState(tev)
         self:probeClockSource(tev.timev)
     end
 
-    logger.dbg("in tap state...")
     local slot = tev.slot
+    logger.dbg("slot", slot, "in tap state...")
     if tev.id == -1 then
         local s1 = self.input.main_finger_slot
         local s2 = self.input.main_finger_slot + 1
@@ -563,8 +563,8 @@ function GestureDetector:handleNonTap(tev)
 end
 
 function GestureDetector:panState(tev)
-    logger.dbg("in pan state...")
     local slot = tev.slot
+    logger.dbg("slot", slot, "in pan state...")
     if tev.id == -1 then
         -- end of pan, signal swipe gesture if necessary
         if self:isSwipe(slot) then
@@ -816,8 +816,8 @@ function GestureDetector:handlePanRelease(tev)
 end
 
 function GestureDetector:holdState(tev, hold)
-    logger.dbg("in hold state...")
     local slot = tev.slot
+    logger.dbg("slot", slot, "in hold state...")
     -- When we switch to hold state, we pass an additional boolean param "hold".
     if tev.id ~= -1 and hold and self.last_tevs[slot].x and self.last_tevs[slot].y then
         self.states[slot] = self.holdState
@@ -835,7 +835,8 @@ function GestureDetector:holdState(tev, hold)
         logger.dbg("hold_release detected in slot", slot)
         local last_x = self.last_tevs[slot].x
         local last_y = self.last_tevs[slot].y
-        self:clearState(slot)
+        -- NOTE: Don't leave multiple slots "stuck" in hold state, as we've cleared their timeouts in the main input loop anyway.
+        self:clearStates()
         return {
             ges = "hold_release",
             pos = Geom:new{

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -126,31 +126,29 @@ end
 --[[--
 Feeds touch events to state machine.
 
-For drivers that bundle multiple slots in the same input frame,
-events are consumed in LIFO order, because of table.remove ;).
-Note that, in a single input frame, if the same slot gets multiple events,
-only the last one is kept.
+Note that, in a single input frame, if the same slot gets multiple events, only the last one is kept.
+Every slot in the input frame is consumed, and that in FIFO order (slot order based on appearance in the frame).
 --]]
 function GestureDetector:feedEvent(tevs)
-    repeat
-        local tev = table.remove(tevs)
-        if tev then
-            local slot = tev.slot
-            if not self.states[slot] then
-                self:clearState(slot) -- initiate state
-            end
-            local ges = self.states[slot](self, tev)
-            if tev.id ~= -1 then
-                -- NOTE: tev is actually a simple reference to Input's self.ev_slots[slot],
-                --       which means self.last_tevs[slot] doesn't actually point to the *previous*
-                --       input frame for a given slot, but always points to the *current* input frame for that slot!
-                --       Compare to self.first_tevs below, which does create a copy...
-                self.last_tevs[slot] = tev
-            end
-            -- return no more than one gesture
-            if ges then return ges end
+    local gestures = {}
+    for _, tev in ipairs(tevs) do
+        local slot = tev.slot
+        if not self.states[slot] then
+            self:clearState(slot) -- initialize slot state
         end
-    until tev == nil
+        local ges = self.states[slot](self, tev)
+        if tev.id ~= -1 then
+            -- NOTE: tev is actually a simple reference to Input's self.ev_slots[slot],
+            --       which means self.last_tevs[slot] doesn't actually point to the *previous*
+            --       input frame for a given slot, but always points to the *current* input frame for that slot!
+            --       Compare to self.first_tevs below, which does create a copy...
+            self.last_tevs[slot] = tev
+        end
+        if ges then
+            table.insert(gestures, ges)
+        end
+    end
+    return gestures
 end
 
 function GestureDetector:deepCopyEv(tev)
@@ -420,7 +418,8 @@ function GestureDetector:tapState(tev)
                 }
                 local tap_span = pos0:distance(pos1)
                 logger.dbg("two-finger tap detected with span", tap_span)
-                self:clearStates()
+                self:clearState(s1)
+                self:clearState(s2)
                 return {
                     ges = "two_finger_tap",
                     pos = pos0:midpoint(pos1),
@@ -577,7 +576,8 @@ function GestureDetector:panState(tev)
             local s2 = self.input.main_finger_slot + 1
             if self.detectings[s1] and self.detectings[s2] then
                 local ges_ev = self:handleTwoFingerPan(tev)
-                self:clearStates()
+                self:clearState(s1)
+                self:clearState(s2)
                 if ges_ev then
                     if ges_ev.ges == "two_finger_pan" then
                         ges_ev.ges = "two_finger_swipe"
@@ -812,7 +812,8 @@ function GestureDetector:handlePanRelease(tev)
     if self.detectings[s1] and self.detectings[s2] then
         logger.dbg("two finger pan release detected")
         pan_ev.ges = "two_finger_pan_release"
-        self:clearStates()
+        self:clearState(s1)
+        self:clearState(s2)
     else
         logger.dbg("pan release detected in slot", slot)
         self:clearState(slot)
@@ -840,8 +841,7 @@ function GestureDetector:holdState(tev, hold)
         logger.dbg("hold_release detected in slot", slot)
         local last_x = self.last_tevs[slot].x
         local last_y = self.last_tevs[slot].y
-        -- NOTE: Don't leave multiple slots "stuck" in hold state, as we've cleared their timeouts in the main input loop anyway.
-        self:clearStates()
+        self:clearState(slot)
         return {
             ges = "hold_release",
             pos = Geom:new{

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -815,7 +815,7 @@ function Input:handleTouchEvLegacy(ev)
     -- In those devices the 'handleTouchEv' function doesn't work as expected. Use this function instead.
     if ev.type == C.EV_ABS then
         if #self.MTSlots == 0 then
-            table.insert(self.MTSlots, self:getMtSlot(self.cur_slot))
+            self:addSlot(self.cur_slot)
         end
         if ev.code == C.ABS_X then
             self:setCurrentMtSlot("x", ev.value)
@@ -989,8 +989,6 @@ function Input:initMtSlot(slot)
 end
 
 function Input:setMtSlot(slot, key, val)
-    self:initMtSlot(slot)
-
     self.ev_slots[slot][key] = val
 end
 

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -252,10 +252,12 @@ function Kindle:outofScreenSaver()
     if self.screen_saver_mode == true then
         if self:supportsScreensaver() then
             local Screensaver = require("ui/screensaver")
-            Screensaver:close()
-            -- And redraw everything in case the framework managed to screw us over...
-            local UIManager = require("ui/uimanager")
-            UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
+            local widget_was_closed = Screensaver:close()
+            if widget_was_closed then
+                -- And redraw everything in case the framework managed to screw us over...
+                local UIManager = require("ui/uimanager")
+                UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
+            end
         else
             -- Stop awesome again if need be...
             if os.getenv("AWESOME_STOPPED") == "yes" then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -776,6 +776,9 @@ function Screensaver:close()
         self.delayed_close = true
     elseif screensaver_delay == "disable" then
         self:close_widget()
+        -- NOTE: Notify platforms that race with the native system (e.g., Kindle or needsScreenRefreshAfterResume)
+        --       that we've actually closed the widget *right now*.
+        return true
     elseif screensaver_delay == "gesture" then
         if self.screensaver_widget then
             self.screensaver_widget:showWaitForGestureMessage()

--- a/spec/unit/focusmanager_spec.lua
+++ b/spec/unit/focusmanager_spec.lua
@@ -219,7 +219,7 @@ describe("FocusManager module", function()
             Hold = { {"Sym", "AA"}, doc = "tap and hold the widget", event="Hold" },
             HalfFocusUp = { {"Alt", "Up"},    doc = "move focus half columns up",    event = "FocusHalfMove", args = {"up"} },
         }
-        local m = Input.modifiers;
+        local m = Input.modifiers
         m.Sym = true
         assert.is_true(focusmanager:isAlternativeKey(Key:new("AA", m)))
         m.Sym = false

--- a/spec/unit/input_spec.lua
+++ b/spec/unit/input_spec.lua
@@ -6,7 +6,7 @@ describe("input module", function()
         ffi = require("ffi")
         C = ffi.C
         require("ffi/linux_input_h")
-        Input = require("device/input")
+        Input = require("device").input
     end)
 
     describe("handleTouchEvPhoenix", function()


### PR DESCRIPTION
* Avoid a double-free by clearing the right timerfd callback (fix #9376).
* Avoid getting semi-stuck in random hold states when triggering multi-slot holds.
* Random completely unrelated fix for #9285
* Various fixes for slightly erroneous MT handling on some drivers.
* And more generic MT handling fixes to ensure every slot gets processed, which prevents "missing" gestures, most notably contact lifts.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9377)
<!-- Reviewable:end -->
