### PR TITLE
AutoWarmth: fix stupid typo

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -72,7 +72,7 @@ function AutoWarmth:init()
         or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth = G_reader_settings:readSetting("autowarmth_warmth")
         or { 90, 90, 80, 60, 20, 20, 20, 60, 80, 90, 90}
-    self.fl_off_during_day = G_reader_settings:saveSetting("autowarmth_fl_off_during_day")
+    self.fl_off_during_day = G_reader_settings:readSetting("autowarmth_fl_off_during_day")
 
     -- schedule recalculation shortly afer midnight
     self:scheduleMidnightUpdate()


### PR DESCRIPTION
See https://github.com/koreader/koreader/pull/9337#issuecomment-1198008045

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9382)
<!-- Reviewable:end -->
