### PR TITLE
Bottom Menu: contrast has no units

### DIFF
--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -163,7 +163,7 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
                                             current, value_current, default)
         end
     else
-        if unit ~= "pt" then
+        if unit and unit ~= "pt" then
             unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
         end
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,


### PR DESCRIPTION
This should fix https://github.com/koreader/koreader/pull/9205#issuecomment-1200130686

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9392)
<!-- Reviewable:end -->
