### PR TITLE
Highlight: add note marker

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1098,7 +1098,11 @@ function ReaderBookmark:renameBookmark(item, from_highlight, is_new_note, new_te
                             end
                         end
                         UIManager:close(self.input)
-                        if not from_highlight then
+                        if from_highlight then
+                            if self.view.highlight.note_mark then
+                                UIManager:setDirty(self.dialog, "ui") -- refresh note mark
+                            end
+                        else
                             bookmark.type = self:getBookmarkType(bookmark)
                             bookmark.text_orig = bookmark.text
                             bookmark.text = DISPLAY_PREFIX[bookmark.type] .. bookmark.text

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1100,7 +1100,7 @@ function ReaderBookmark:renameBookmark(item, from_highlight, is_new_note, new_te
                         UIManager:close(self.input)
                         if from_highlight then
                             if self.view.highlight.note_mark then
-                                UIManager:setDirty(self.dialog, "ui") -- refresh note mark
+                                UIManager:setDirty(self.dialog, "ui") -- refresh note marker
                             end
                         else
                             bookmark.type = self:getBookmarkType(bookmark)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -427,7 +427,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                         self.view.highlight.note_mark = radio.provider
                         G_reader_settings:saveSetting("highlight_note_mark", radio.provider)
                     end
-                    self.view:getNoteMarkPosition()
+                    self.view:setupNoteMarkPosition()
                     UIManager:setDirty(self.dialog, "ui")
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -398,7 +398,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
             local notemark = self.view.highlight.note_mark or "none"
             for __, v in ipairs(note_mark) do
                 if v[2] == notemark then
-                    return T(_("Note mark: %1"), string.lower(v[1]))
+                    return T(_("Note marker: %1"), string.lower(v[1]))
                 end
             end
         end,
@@ -415,17 +415,17 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 })
             end
             UIManager:show(require("ui/widget/radiobuttonwidget"):new{
-                title_text = _("Note mark"),
+                title_text = _("Note marker"),
                 width_factor = 0.5,
                 keep_shown_on_apply = true,
                 radio_buttons = radio_buttons,
                 callback = function(radio)
                     if radio.provider == "none" then
                         self.view.highlight.note_mark = nil
-                        G_reader_settings:delSetting("highlight_note_mark")
+                        G_reader_settings:delSetting("highlight_note_marker")
                     else
                         self.view.highlight.note_mark = radio.provider
-                        G_reader_settings:saveSetting("highlight_note_mark", radio.provider)
+                        G_reader_settings:saveSetting("highlight_note_marker", radio.provider)
                     end
                     self.view:setupNoteMarkPosition()
                     UIManager:setDirty(self.dialog, "ui")

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -427,6 +427,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                         self.view.highlight.note_mark = radio.provider
                         G_reader_settings:saveSetting("highlight_note_mark", radio.provider)
                     end
+                    self.view:getNoteMarkPosition()
                     UIManager:setDirty(self.dialog, "ui")
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -307,6 +307,13 @@ local highlight_style = {
     {_("Invert"), "invert"},
 }
 
+local note_mark = {
+    {_("None"), "none"},
+    {_("Underline"), "underline"},
+    {_("Side line"), "sideline"},
+    {_("Side mark"), "sidemark"},
+}
+
 local long_press_action = {
     {_("Ask with popup dialog"), "ask"},
     {_("Do nothing"), "nothing"},
@@ -384,6 +391,46 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 end
             }
             UIManager:show(spin_widget)
+        end,
+    })
+    table.insert(menu_items.highlight_options.sub_item_table, {
+        text_func = function()
+            local notemark = self.view.highlight.note_mark or "none"
+            for __, v in ipairs(note_mark) do
+                if v[2] == notemark then
+                    return T(_("Note mark: %1"), string.lower(v[1]))
+                end
+            end
+        end,
+        callback = function(touchmenu_instance)
+            local notemark = self.view.highlight.note_mark or "none"
+            local radio_buttons = {}
+            for _, v in ipairs(note_mark) do
+                table.insert(radio_buttons, {
+                    {
+                        text = v[1],
+                        checked = v[2] == notemark,
+                        provider = v[2],
+                    },
+                })
+            end
+            UIManager:show(require("ui/widget/radiobuttonwidget"):new{
+                title_text = _("Note mark"),
+                width_factor = 0.5,
+                keep_shown_on_apply = true,
+                radio_buttons = radio_buttons,
+                callback = function(radio)
+                    if radio.provider == "none" then
+                        self.view.highlight.note_mark = nil
+                        G_reader_settings:delSetting("highlight_note_mark")
+                    else
+                        self.view.highlight.note_mark = radio.provider
+                        G_reader_settings:saveSetting("highlight_note_mark", radio.provider)
+                    end
+                    UIManager:setDirty(self.dialog, "ui")
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end,
+            })
         end,
     })
     if self.document.info.has_pages then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -563,7 +563,7 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
                 if boxes then
                     local drawer = item.drawer or self.highlight.saved_drawer
                     local is_note_mark = self.highlight.note_mark and
-                        self.ui.bookmark:getBookmarkNote({ page = page, datetime = item.datetime, })                        
+                        self.ui.bookmark:getBookmarkNote({ page = page, datetime = item.datetime, })
                     for _, box in pairs(boxes) do
                         local rect = self:pageToScreenTransform(page, box)
                         if rect then
@@ -612,7 +612,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
                     if boxes then
                         local drawer = item.drawer or self.highlight.saved_drawer
                         local is_note_mark = self.highlight.note_mark and
-                            self.ui.bookmark:getBookmarkNote({ page = item.pos0, datetime = item.datetime, })                        
+                            self.ui.bookmark:getBookmarkNote({ page = item.pos0, datetime = item.datetime, })
                         for _, box in pairs(boxes) do
                             self:drawHighlightRect(bb, x, y, box, drawer, is_note_mark)
                             if is_note_mark and self.highlight.note_mark == "sidemark" then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -43,7 +43,7 @@ local ReaderView = OverlapGroup:extend{
     -- highlight with "lighten" or "underscore" or "strikeout" or "invert"
     highlight = {
         lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor", 0.2),
-        note_mark = G_reader_settings:readSetting("highlight_note_mark"),
+        note_mark = G_reader_settings:readSetting("highlight_note_marker"),
         temp_drawer = "invert",
         temp = {},
         saved_drawer = "lighten",
@@ -1182,7 +1182,7 @@ end
 function ReaderView:setupNoteMarkPosition()
     local is_sidemark = self.highlight.note_mark == "sidemark"
 
-    -- set/free note mark sign
+    -- set/free note marker sign
     if is_sidemark then
         if not self.note_mark_sign then
             self.note_mark_sign = TextWidget:new{

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -674,7 +674,7 @@ function ReaderView:recalculate()
         self.state.offset.x = (self.dimen.w - self.visible_area.w) / 2
     end
 
-    self:getNoteMarkPosition()
+    self:setupNoteMarkPosition()
 
     -- Flag a repaint so self:paintTo will be called
     -- NOTE: This is also unfortunately called during panning, essentially making sure we'll never be using "fast" for pans ;).
@@ -1179,7 +1179,7 @@ function ReaderView:getTapZones()
     return forward_zone, backward_zone
 end
 
-function ReaderView:getNoteMarkPosition()
+function ReaderView:setupNoteMarkPosition()
     local is_sidemark = self.highlight.note_mark == "sidemark"
 
     -- set/free note mark sign


### PR DESCRIPTION
Mark notes with an additional indicator to distinguish them from highlights.
Indicators:
-underline, in black color (highlight underscore is grey)
-side vertical line (of 3 px width)
-side mark - a pencil sign
Side line/mark are located:
-for cre documents - floating position in a fixed distance from the edge of the text
-for pdf documents - fixed position in a fixed distance from the edge of the screen
For RTL (mirrored) layout side line/mark are located in the left margin.
Closes https://github.com/koreader/koreader/issues/9356.

![01](https://user-images.githubusercontent.com/62179190/182046747-5b808ef6-e779-47de-ab33-29e20112cad3.png)
![02](https://user-images.githubusercontent.com/62179190/182046748-87b99981-c767-4f44-a259-f09c87cf27b9.png)
![03](https://user-images.githubusercontent.com/62179190/182046750-68a2ca3b-60ff-46a0-a010-170fa6df2c63.png)
![04](https://user-images.githubusercontent.com/62179190/182046752-e777a7b9-8a2c-4a1b-a85f-4e62dd268174.png)

Two-page mode
![05](https://user-images.githubusercontent.com/62179190/182046753-02420ed2-c527-4c8c-8850-a393ad746d6b.png)
![06](https://user-images.githubusercontent.com/62179190/182046754-1bb634ca-0c03-46a6-ad82-d7c9ad272a54.png)

Mirrored layout
![07](https://user-images.githubusercontent.com/62179190/182046755-19b59b82-1d16-481c-8fcb-33a2569823bc.png)
![08](https://user-images.githubusercontent.com/62179190/182046756-b50c099e-4b81-4785-84ce-aba63a001265.png)

pdf
![09](https://user-images.githubusercontent.com/62179190/182046757-ebb93781-f72d-403c-8f54-e281a62937f3.png)
![10](https://user-images.githubusercontent.com/62179190/182046758-a1fe696b-4e66-463f-8682-cc8051610359.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9395)
<!-- Reviewable:end -->
