### PR TITLE
BookMap: allow tap on ToC titles and outside page slots

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -236,7 +236,7 @@ function ReaderStatistics:initData()
 end
 
 function ReaderStatistics:isEnabled()
-    return self.settings.is_enabled
+    return not self:isDocless() and self.settings.is_enabled
 end
 
 -- Reset the (volatile) stats on page count changes (e.g., after a font size update)


### PR DESCRIPTION
This helps jumping to page when ToC chapters are short and the bookmap page rows narrow.
![image](https://user-images.githubusercontent.com/24273478/182416687-2581a345-216d-40df-bb24-2646e31d4bf0.png)
Previously, we needed to tap exactly on the page slots (black in there) to see these pages in PageBrowser, which might be frustrating.
Now, we can tap in the yellow regions, and it would show the expected page.

(Not sure why I made tap so restrictive... I hope there wasn't a reason I can't find out now.)

Also fix crash when invoking BookMap and PageBrowser on a PicDocument (considered DocLess by Statistics).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9400)
<!-- Reviewable:end -->
