### PR TITLE
CanvasContext.hasEinkScreen(): avoid crash on Android

### DIFF
--- a/frontend/document/canvascontext.lua
+++ b/frontend/document/canvascontext.lua
@@ -52,7 +52,11 @@ function CanvasContext:init(device)
         Mupdf.bgr = true
     end
 
-    self.hasEinkScreen = device.hasEinkScreen
+    -- This one may be called by a subprocess, and would crash on Android when
+    -- calling android.isEink() which is only allowed from the main thread.
+    local hasEinkScreen = device.hasEinkScreen()
+    self.hasEinkScreen = function() return hasEinkScreen end
+
     self.canHWDither = device.canHWDither
     self.fb_bpp = device.screen.fb_bpp
 end


### PR DESCRIPTION
It is used by CoverBrowser, in a subprocess, when extracting metadata from PicDocuments, and crash on Android as calling android methods is only allowed from the main thread.
See https://github.com/koreader/koreader/pull/9402#issuecomment-1205049364

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9417)
<!-- Reviewable:end -->
