### PR TITLE
kindle: allow stopping the framework on 5.X

### DIFF
--- a/platform/kindle/extensions/koreader/menu.json
+++ b/platform/kindle/extensions/koreader/menu.json
@@ -25,7 +25,6 @@
 		},
 		{
 			"name": "Start KOReader (no framework)",
-			"if": "\"Kindle2\" -m \"KindleDX\" -m \"KindleDXG\" -m \"Kindle3\" -m \"Kindle4\" -m || || || ||",
 			"priority": 4,
 			"action": "/mnt/us/koreader/koreader.sh",
 			"params": "--kual --framework_stop",

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -56,6 +56,7 @@ if [ "${INIT_TYPE}" = "upstart" ]; then
 fi
 
 # Keep track of what we do with pillow...
+export STOP_FRAMEWORK="no"
 export AWESOME_STOPPED="no"
 export CVM_STOPPED="no"
 export VOLUMD_STOPPED="no"
@@ -87,12 +88,10 @@ elif [ "${1}" = "--asap" ]; then
     # Start as soon as possible, without sleeping to workaround UI quirks
     shift 1
     NO_SLEEP="yes"
-    STOP_FRAMEWORK="no"
     REEXEC_FLAGS="${REEXEC_FLAGS} --asap"
     # Don't sleep during eips calls either...
     export EIPS_NO_SLEEP="true"
 else
-    STOP_FRAMEWORK="no"
     NO_SLEEP="no"
 fi
 


### PR DESCRIPTION
this reclaims a bunch of memory useful on low memory devices

based on https://github.com/mireq/KOReader-without-framework-support-for-Amazon-Kindle
https://github.com/koreader/koreader/issues/2663#issuecomment-1126975284
https://github.com/koreader/koreader/issues/796#issuecomment-634423039

The memory usage om my PW5 drops by ~ 100MB

Currently testing on my PW5, will see what happens in the next week or so.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9419)
<!-- Reviewable:end -->
