### PR TITLE
[AutoWarmth] optimisations and fixes to progressive warmth setting

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -750,7 +750,7 @@ function AutoWarmth:getScheduleMenu()
     end
 
     local retval = {
-        getScheduleMenuEntry(_("Solar midnight (previos day)"), 1, false),
+        getScheduleMenuEntry(_("Solar midnight (previous day)"), 1, false),
         getScheduleMenuEntry(_("Astronomical dawn"), 2, false),
         getScheduleMenuEntry(_("Nautical dawn"), 3, false),
         getScheduleMenuEntry(_("Civil dawn"), 4),

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -129,7 +129,7 @@ function AutoWarmth:leavePowerSavingState(from_resume)
     if resume_date.day == SunTime.date.day and resume_date.month == SunTime.date.month
         and resume_date.year == SunTime.date.year then
         local now_s = SunTime:getTimeInSec(resume_date)
-        self:scheduleNextWarmthChange(now_s, self.sched_warmth_index, from_resume)
+        self:scheduleNextWarmthChange(now_s, self.sched_warmth_index - 1, from_resume)
         -- Reschedule 1sec after midnight
         UIManager:scheduleIn(24*3600 + 1 - now_s, self.scheduleMidnightUpdate, self)
     else
@@ -203,7 +203,7 @@ function AutoWarmth:scheduleMidnightUpdate(from_resume)
                 -- which map to warmth 0, 10, 20, 30 ... 100)
                 if frac(next_warmth * device_warmth_fit_scale) == 0 then
                     table.insert(self.sched_times_s, time1_s + delta_t * i)
-                    table.insert(self.sched_warmths, math.floor(math.min(self.warmth[index1], 100) + delta_w * i))
+                    table.insert(self.sched_warmths, next_warmth)
                 end
             end
         end
@@ -305,11 +305,11 @@ function AutoWarmth:scheduleNextWarmthChange(time_s, search_pos, from_resume)
     local next_warmth = actual_warmth
     for i = self.sched_warmth_index, #self.sched_warmths do
         if self.sched_times_s[i] <= time_s then
-            actual_warmth = self.sched_warmths[i] or actual_warmth
+            actual_warmth = self.sched_warmths[i]
             local j = i
-            while j <= #self.sched_warmths and self.sched_times_s[j] <= time_s + delay_s do
+            while from_resume and j <= #self.sched_warmths and self.sched_times_s[j] <= time_s + delay_s do
                 -- Most times only one iteration through this loop
-                next_warmth = self.sched_warmths[j] or next_warmth
+                next_warmth = self.sched_warmths[j]
                 j = j + 1
             end
         else
@@ -324,6 +324,11 @@ function AutoWarmth:scheduleNextWarmthChange(time_s, search_pos, from_resume)
         if next_sched_time_s > 0 then
             -- This setWarmth will call scheduleNextWarmthChange which will schedule setWarmth again.
             UIManager:scheduleIn(next_sched_time_s, self.setWarmth, self, self.sched_warmths[self.sched_warmth_index], true)
+        else
+            -- ToDo: check if a schedule has to be in 1 sec or maybe later lets say at
+            -- self.sched_times_s[self.sched_warmth_index + 1 ] - time_s
+            UIManager:scheduleIn(1, self.setWarmth, self, self.sched_warmths[self.sched_warmth_index], true)
+            print("xxxxxxxxxxxxxx check this")
         end
     end
 
@@ -332,7 +337,7 @@ function AutoWarmth:scheduleNextWarmthChange(time_s, search_pos, from_resume)
         -- schedule setting of another valid warmth (=`next_warmth`) again (one time).
         -- On sane devices this schedule does no harm.
         -- see https://github.com/koreader/koreader/issues/8363
-        UIManager:scheduleIn(delay_s, self.setWarmth, self, next_warmth, true) -- no setWarmth rescheduling, force warmth
+        UIManager:scheduleIn(delay_s, self.setWarmth, self, next_warmth, false) -- no setWarmth rescheduling, force warmth
     end
 
     -- Check if AutoWarmth shall toggle frontlight daytime and twilight

--- a/plugins/autowarmth.koplugin/suntime.lua
+++ b/plugins/autowarmth.koplugin/suntime.lua
@@ -557,8 +557,10 @@ end
         if not self.midnight then
             self.midnight = self.noon + 12
         end
-        if not self.midnight_beginning then
+        if not self.midnight_beginning and self.midnight then
             self.midnight_beginning = self.midnight - 24
+        elseif not self.midnight and not self.midnight_beginning then
+            self.midnight = self.midnight_beginning + 24
         end
     elseif self.rise and not self.set then -- only sunrise on that day
         self.midnight = nil
@@ -580,7 +582,7 @@ end
     self.times[11] = self.midnight
 end
 
--- Get time in seconds (either actual time in hours or date struct)
+-- Get time in seconds, rounded to ms (either actual time in hours or date struct)
 function SunTime:getTimeInSec(val)
     if not val then
         val = os.date("*t")

--- a/plugins/autowarmth.koplugin/suntime.lua
+++ b/plugins/autowarmth.koplugin/suntime.lua
@@ -551,15 +551,15 @@ end
     -- Sometimes at high latitudes noon or midnight does not get calculated.
     -- Maybe there is a minor bug in the calculateNoon/calculateMidnight functions.
     if self.rise and self.set then
-        if not self.noon then
+        if not self.noon and self.rise and self.set then
             self.noon = (self.rise + self.set) / 2
         end
-        if not self.midnight then
+        if not self.midnight and self.noon then
             self.midnight = self.noon + 12
         end
         if not self.midnight_beginning and self.midnight then
             self.midnight_beginning = self.midnight - 24
-        elseif not self.midnight and not self.midnight_beginning then
+        elseif not self.midnight and self.midnight_beginning then
             self.midnight = self.midnight_beginning + 24
         end
     elseif self.rise and not self.set then -- only sunrise on that day

--- a/plugins/autowarmth.koplugin/suntime.lua
+++ b/plugins/autowarmth.koplugin/suntime.lua
@@ -587,10 +587,11 @@ function SunTime:getTimeInSec(val)
     end
 
     if type(val) == "table" then
-        return val.hour*3600 + val.min*60 + val.sec
+        val = val.hour*3600 + val.min*60 + val.sec
+    else
+        val = val*3600
     end
-
-    return val*3600
+    return math.floor(val * 1000 ) / 1000
 end
 
 return SunTime


### PR DESCRIPTION
Fixes a quirk introduced with  #9252, which schedules not the actual warmth, but the next but one warmth when leaving suspend or standby.

Imperceptible to the user:
* Reduce calculations (save minimal power, esp. when wake from standby).
* Fixes stupid reschedules of `scheduleNextWarmthChanges` which may lead to 30.000(!) schedulings  if the reschedule time is below 1 second (as `os.date` only gives a second resolution). This might sometimes happen but very  seldom, but can be provoked wit a fixed schedule. This is not really noticeable to the user, no hang or something, but anyway it will get fixed with this PR....
_(For documentation: Set all times to 16:17:00; Solar noon to 16:17:10;  Sunset to 16:18:00; Civil dusk to 16:19:00; Nautical dusk to 16:20; Astronomical dusk to 18:18; Set system time to 16:17:50 and log executions of `scheduleNextWarmthChanges`)_

~~ToDo: Check corner cases around midnight ... simulations in the time machine seems good.  But I want to wait a few day with real life usage.~~

Real life test OK.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9442)
<!-- Reviewable:end -->
