### PR TITLE
Input: Unbreak evdev handling on Kobo single-touch devices

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -39,7 +39,6 @@ local Cervantes = Generic:new{
     isCervantes = yes,
     isAlwaysPortrait = yes,
     isTouchDevice = yes,
-    touch_legacy = true, -- SingleTouch input events
     touch_switch_xy = true,
     touch_mirrored_x = true,
     hasOTAUpdates = yes,
@@ -117,7 +116,7 @@ function Cervantes:initEventAdjustHooks()
         )
     end
 
-    if self.touch_legacy then
+    if not self:hasMultitouch() then
         self.input.handleTouchEv = self.input.handleTouchEvLegacy
     end
 end

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -39,6 +39,7 @@ local Cervantes = Generic:new{
     isCervantes = yes,
     isAlwaysPortrait = yes,
     isTouchDevice = yes,
+    touch_legacy = true, -- SingleTouch input events
     touch_switch_xy = true,
     touch_mirrored_x = true,
     hasOTAUpdates = yes,
@@ -116,7 +117,7 @@ function Cervantes:initEventAdjustHooks()
         )
     end
 
-    if not self:hasMultitouch() then
+    if self.touch_legacy then
         self.input.handleTouchEv = self.input.handleTouchEvLegacy
     end
 end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -721,22 +721,6 @@ function Input:handleTouchEv(ev)
             if tool and tool == 1 then
                 self:setCurrentMtSlot("id", -1)
             end
-
-        -- Emulate MT protocol on ST Kobos:
-        -- we "confirm" ABS_X, ABS_Y only when ABS_PRESSURE ~= 0
-        elseif ev.code == C.ABS_X then
-            self:setCurrentMtSlotChecked("abs_x", ev.value)
-        elseif ev.code == C.ABS_Y then
-            self:setCurrentMtSlotChecked("abs_y", ev.value)
-        elseif ev.code == C.ABS_PRESSURE then
-            if ev.value ~= 0 then
-                self:setCurrentMtSlot("id", 1)
-                self:confirmAbsxy()
-            else
-                self:cleanAbsxy()
-                self:setCurrentMtSlot("id", -1)
-            end
-        end
     elseif ev.type == C.EV_SYN then
         if ev.code == C.SYN_REPORT then
             for _, MTSlot in ipairs(self.MTSlots) do

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -722,6 +722,7 @@ function Input:handleTouchEv(ev)
             if tool and tool == 1 then
                 self:setCurrentMtSlot("id", -1)
             end
+        end
     elseif ev.type == C.EV_SYN then
         if ev.code == C.SYN_REPORT then
             for _, MTSlot in ipairs(self.MTSlots) do
@@ -739,6 +740,7 @@ function Input:handleTouchEv(ev)
         end
     end
 end
+
 function Input:handleTouchEvPhoenix(ev)
     -- Hack on handleTouchEV for the Kobo Aura
     -- It seems to be using a custom protocol:
@@ -798,6 +800,7 @@ function Input:handleTouchEvPhoenix(ev)
         end
     end
 end
+
 function Input:handleTouchEvLegacy(ev)
     -- Single Touch Protocol.
     -- Some devices emit both singletouch and multitouch events,

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -799,8 +799,9 @@ function Input:handleTouchEvPhoenix(ev)
     end
 end
 function Input:handleTouchEvLegacy(ev)
-    -- Single Touch Protocol. Some devices emit both singletouch and multitouch events.
-    -- In those devices the 'handleTouchEv' function doesn't work as expected. Use this function instead.
+    -- Single Touch Protocol.
+    -- Some devices emit both singletouch and multitouch events,
+    -- on those devices, the 'handleTouchEv' function may not behave as expected. Use this one instead.
     if ev.type == C.EV_ABS then
         if ev.code == C.ABS_X then
             self:setCurrentMtSlotChecked("x", ev.value)

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -459,6 +459,7 @@ end
 
 function Input:handleKeyBoardEv(ev)
     -- Detect loss of contact for the "snow" protocol...
+    -- NOTE: Some ST devices may also behave similarly, but we handle those via ABS_PRESSURE
     if self.snow_protocol then
         if ev.code == C.BTN_TOUCH and ev.value == 0 then
             -- Kernel sends it after loss of contact for *all* slots,
@@ -801,18 +802,15 @@ function Input:handleTouchEvLegacy(ev)
     -- Single Touch Protocol. Some devices emit both singletouch and multitouch events.
     -- In those devices the 'handleTouchEv' function doesn't work as expected. Use this function instead.
     if ev.type == C.EV_ABS then
-        if #self.MTSlots == 0 then
-            self:addSlot(self.cur_slot)
-        end
         if ev.code == C.ABS_X then
-            self:setCurrentMtSlot("x", ev.value)
+            self:setCurrentMtSlotChecked("x", ev.value)
         elseif ev.code == C.ABS_Y then
-            self:setCurrentMtSlot("y", ev.value)
+            self:setCurrentMtSlotChecked("y", ev.value)
         elseif ev.code == C.ABS_PRESSURE then
             if ev.value ~= 0 then
-                self:setCurrentMtSlot("id", 1)
+                self:setCurrentMtSlotChecked("id", 1)
             else
-                self:setCurrentMtSlot("id", -1)
+                self:setCurrentMtSlotChecked("id", -1)
             end
         end
     elseif ev.type == C.EV_SYN then
@@ -1041,16 +1039,6 @@ function Input:setupSlotData(value)
     else
         self:addSlotIfChanged(value)
     end
-end
-
-function Input:confirmAbsxy()
-    self:setCurrentMtSlot("x", self.ev_slots[self.cur_slot]["abs_x"])
-    self:setCurrentMtSlot("y", self.ev_slots[self.cur_slot]["abs_y"])
-end
-
-function Input:cleanAbsxy()
-    self:setCurrentMtSlot("abs_x", nil)
-    self:setCurrentMtSlot("abs_y", nil)
 end
 
 function Input:isEvKeyPress(ev)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -791,10 +791,10 @@ function Kobo:initEventAdjustHooks()
 
     if self.touch_snow_protocol then
         self.input.snow_protocol = true
-    end
-
-    if self.touch_phoenix_protocol then
+    elseif self.touch_phoenix_protocol then
         self.input.handleTouchEv = self.input.handleTouchEvPhoenix
+    elseif not self:hasMultitouch() then
+        self.input.handleTouchEv = self.input.handleTouchEvLegacy
     end
 
     -- Accelerometer on the Forma

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -143,7 +143,7 @@ function Remarkable:init()
     self.input = require("device/input"):new{
         device = self,
         event_map = require("device/remarkable/event_map"),
-        wacom_protol = true,
+        wacom_protocol = true,
     }
 
     self.input.open(self.input_wacom) -- Wacom

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -143,6 +143,7 @@ function Remarkable:init()
     self.input = require("device/input"):new{
         device = self,
         event_map = require("device/remarkable/event_map"),
+        wacom_protol = true,
     }
 
     self.input.open(self.input_wacom) -- Wacom


### PR DESCRIPTION
I'm not *entirely* sure why it broke, but it was a pretty crap workaround anyway, and @pazos already had a perfectly sane setup in place for Cervantes, so let's just repurpose that ;).

Fix #9464

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9465)
<!-- Reviewable:end -->
