### PR TITLE
NewsDownloader: Strip byte order mark from xml string before parsing

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -437,6 +437,10 @@ function NewsDownloader:deserializeXMLString(xml_str)
     local libxml = require("lib/xml")
     -- Instantiate the object that parses the XML file as a Lua table.
     local xmlhandler = treehdl.simpleTreeHandler()
+
+    -- Remove UTF-8 byte order mark, as it will cause LuaXML to fail
+    xml_str = xml_str:gsub("^\xef\xbb\xbf", "", 1)
+
     -- Instantiate the object that parses the XML to a Lua table.
     local ok = pcall(function()
             libxml.xmlParser(xmlhandler):parse(xml_str)


### PR DESCRIPTION
Fixes #9467

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9468)
<!-- Reviewable:end -->
