### PR TITLE
Add method to MultiInputDialog to return input fields

### DIFF
--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -212,6 +212,14 @@ function MultiInputDialog:getFields()
     return fields
 end
 
+function MultiInputDialog:getInputFields()
+    local fields = {}
+    for i=1, #input_field do
+        table.insert(fields, input_field[i])
+    end
+    return fields
+end
+
 function MultiInputDialog:onSwitchFocus(inputbox)
     -- unfocus current inputbox
     self._input_widget:unfocus()


### PR DESCRIPTION
In order to update the field's text value after it's been rendered, the input field needs to be returned, and not just the text value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9484)
<!-- Reviewable:end -->
