### PR TITLE
Kobo: Fix a few bad interactions between suspend & checkUnexpectedWakeup

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -284,7 +284,7 @@ function Device:onPowerEvent(ev)
             -- Already in screen saver mode, no need to update UI/state before
             -- suspending the hardware. This usually happens when sleep cover
             -- is closed after the device was sent to suspend state.
-            logger.dbg("Already in screen saver mode, suspending...")
+            logger.dbg("Already in screen saver mode, going back to suspend...")
             self:rescheduleSuspend()
         end
     -- else we were not in screensaver mode

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1084,7 +1084,9 @@ end
 function Kobo:usbPlugOut()
     -- Reset the unexpected wakeup shenanigans, since we're no longer charging, meaning power savings are now critical again ;).
     -- NOTE: We don't reset it to 0 because, semantically, only resume should ever be allowed to do so.
-    self.unexpected_wakeup_count = 1
+    if self.unexpected_wakeup_count > 0 then
+        self.unexpected_wakeup_count = 1
+    end
 end
 
 function Kobo:saveSettings()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -872,10 +872,8 @@ function Kobo:checkUnexpectedWakeup()
     else
         -- We've hit an early resume, assume this is unexpected (as we only run if Kobo:resume hasn't already).
         logger.dbg("Kobo suspend: checking unexpected wakeup number", self.unexpected_wakeup_count)
-        if self.unexpected_wakeup_count == 0 or self.unexpected_wakeup_count > 20 then
-            -- Don't put device back to sleep under the following two cases:
-            --   1. a resume event triggered Kobo:resume() function
-            --   2. trying to put device back to sleep more than 20 times after unexpected wakeup
+        if self.unexpected_wakeup_count > 20 then
+            -- If we've failed to put the device back to sleep over 20 consecutive times, we give up.
             -- Broadcast a specific event, so that AutoSuspend can pick up the baton...
             local Event = require("ui/event")
             UIManager:broadcastEvent(Event:new("UnexpectedWakeupLimit"))
@@ -886,8 +884,6 @@ function Kobo:checkUnexpectedWakeup()
         self:suspend()
     end
 end
-
-function Kobo:getUnexpectedWakeup() return self.unexpected_wakeup_count end
 
 --- The function to put the device into standby, with enabled touchscreen.
 -- max_duration ... maximum time for the next standby, can wake earlier (e.g. Tap, Button ...)
@@ -1042,10 +1038,8 @@ function Kobo:suspend()
     -- NOTE: We unflag /sys/power/state-extended in Kobo:resume() to keep
     --       things tidy and easier to follow
 
-    -- Kobo:resume() will reset unexpected_wakeup_count = 0 to signal an
-    -- expected wakeup, which gets checked in checkUnexpectedWakeup().
+    -- Kobo:resume() will reset unexpected_wakeup_count and unschedule the check to signal a sane wakeup.
     self.unexpected_wakeup_count = self.unexpected_wakeup_count + 1
-    -- We're assuming Kobo:resume() will be called in the next 15 seconds in ordrer to cancel that check.
     logger.dbg("Kobo suspend: scheduling unexpected wakeup guard")
     UIManager:scheduleIn(15, self.checkUnexpectedWakeup, self)
 end
@@ -1089,7 +1083,9 @@ end
 
 function Kobo:usbPlugOut()
     -- Reset the unexpected wakeup shenanigans, since we're no longer charging, meaning power savings are now critical again ;).
-    self.unexpected_wakeup_count = 0
+    -- NOTE: We don't reset it to 0 to avoid tripping an early UnexpectedWakeupLimit.
+    --       (ALso, because, semantically, only resume should ever clear this).
+    self.unexpected_wakeup_count = 1
 end
 
 function Kobo:saveSettings()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1082,7 +1082,7 @@ function Kobo:resume()
 end
 
 function Kobo:usbPlugOut()
-    -- Rewind the unexpected wakeup shenanigans, since we're no longer charging, meaning power savings are now critical again ;).
+    -- Rewind the unexpected wakeup counter, since we're no longer charging, meaning power savings are now critical again ;).
     -- NOTE: We don't reset it to 0 because, semantically, only resume should ever be allowed to do so.
     if self.unexpected_wakeup_count > 0 then
         self.unexpected_wakeup_count = 1

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -847,6 +847,14 @@ local function getProductId()
     return product_id
 end
 
+-- NOTE: We overload this to make sure checkUnexpectedWakeup doesn't trip *before* the newly scheduled suspend
+function Kobo:rescheduleSuspend()
+    local UIManager = require("ui/uimanager")
+    UIManager:unschedule(self.suspend)
+    UIManager:unschedule(self.checkUnexpectedWakeup)
+    UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend, self)
+end
+
 function Kobo:checkUnexpectedWakeup()
     local UIManager = require("ui/uimanager")
     -- Just in case another event like SleepCoverClosed also scheduled a suspend

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1082,7 +1082,7 @@ function Kobo:resume()
 end
 
 function Kobo:usbPlugOut()
-    -- Reset the unexpected wakeup shenanigans, since we're no longer charging, meaning power savings are now critical again ;).
+    -- Rewind the unexpected wakeup shenanigans, since we're no longer charging, meaning power savings are now critical again ;).
     -- NOTE: We don't reset it to 0 because, semantically, only resume should ever be allowed to do so.
     if self.unexpected_wakeup_count > 0 then
         self.unexpected_wakeup_count = 1

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1083,8 +1083,7 @@ end
 
 function Kobo:usbPlugOut()
     -- Reset the unexpected wakeup shenanigans, since we're no longer charging, meaning power savings are now critical again ;).
-    -- NOTE: We don't reset it to 0 to avoid tripping an early UnexpectedWakeupLimit.
-    --       (ALso, because, semantically, only resume should ever clear this).
+    -- NOTE: We don't reset it to 0 because, semantically, only resume should ever be allowed to do so.
     self.unexpected_wakeup_count = 1
 end
 


### PR DESCRIPTION
Specifically, between checkUnexpectedWakeup & rescheduleSuspend, because we don't actually suspend *immediately*, we wait 15s, and if the unexpected wakeup guard fires *between* the two, shit goes wrong.

This was fairly easy to reproduce by plugging/unplugging a sleeping device (and a bit of "luck" with the timing); fix #9457.

Regression exposed by #9263, but the technical issue existed before that, and stems from an older refactor of checkUnexpectedWakeup that left some legacy and wonky behaviors in place ;). (Specifically, the counter set to 0 used to be meaningful at one point, but that was broken by design, so we switched to actually unscheduling the function, which is much saner. Unfortunately, the actual check for that older behavior was kept in place; and I tripped it with a poorly thought out tweak for something else in the aforementioned PR).

So, simplify all that to match the reality, making for slightly clearer semantics (and code) in the process :).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9499)
<!-- Reviewable:end -->
