### PR TITLE
docs(Building): add section for Arch

### DIFF
--- a/doc/Building_targets.md
+++ b/doc/Building_targets.md
@@ -62,7 +62,14 @@ Building for Android requires `openjdk-8-jdk` and `p7zip-full`.
 For both Ubuntu and Debian, install the packages:
 
 ```
-sudo apt-get install openjdk-8-jdk p7zip-full
+sudo apt-get install openjdk-8-jdk p7zip-full ncurses
+```
+
+Note: In case a more up-to-date package manager is used (like Arch), then it may be necessary to link the following files because `ncurses` by default does not provide those anymore but are necessary for `android-ndk-r15c`:
+
+```sh
+sudo ln -sf ./libncursesw.so.6.3 ./libncurses.so.5
+sudo ln -sf ./libncursesw.so.6.3 ./libtinfo.so.5
 ```
 
 #### for Debian


### PR DESCRIPTION
This PR tries to add a section for Arch (and based on) for setting up a build environment.
The notes include what i had found setting it up on my system (Manjaro).

The install command may not include all required packages, because i had some previously installed (for other projects) so i dont quite know which relate to what / what needs to be installed extra than a base system

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9501)
<!-- Reviewable:end -->
