### PR TITLE
fix(version.lua::getShortVersion): handle "rev" being empty

### DIFF
--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -55,6 +55,7 @@ end
 function Version:getShortVersion()
     if not self.short then
         local rev = self:getCurrentRevision()
+        if (not rev or rev == "") then return "no version" end
         local year, month, point, revision = rev:match("v(%d%d%d%d)%.(%d%d)%.?(%d?%d?)-?(%d*)")
         self.short = year .. "." .. month
         if point and point ~= "" then

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -55,7 +55,7 @@ end
 function Version:getShortVersion()
     if not self.short then
         local rev = self:getCurrentRevision()
-        if (not rev or rev == "") then return "custom" end
+        if (not rev or rev == "") then return "unknown" end
         local year, month, point, revision = rev:match("v(%d%d%d%d)%.(%d%d)%.?(%d?%d?)-?(%d*)")
         self.short = year .. "." .. month
         if point and point ~= "" then

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -55,7 +55,7 @@ end
 function Version:getShortVersion()
     if not self.short then
         local rev = self:getCurrentRevision()
-        if (not rev or rev == "") then return "no version" end
+        if (not rev or rev == "") then return "custom" end
         local year, month, point, revision = rev:match("v(%d%d%d%d)%.(%d%d)%.?(%d?%d?)-?(%d*)")
         self.short = year .. "." .. month
         if point and point ~= "" then


### PR DESCRIPTION
This PR change that `Version:getShortVersion` in `frontend/version.lua` handles the case of `rev` being empty, which happened for me in a "dirty" git environment (it seems like `kodev release android` does not include a `git-rev` file)

for now i have set `no version` to return instead of a empty string to indicate that it is missing, though i could also change it to `no git-rev file` or `dirty` depending on what is wanted

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9502)
<!-- Reviewable:end -->
