### PR TITLE
feat(device.lua): add custom options for tolino

### DIFF
--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -1,10 +1,15 @@
-local isAndroid, _ = pcall(require, "android")
+local isAndroid, android = pcall(require, "android")
 local lfs = require("libs/libkoreader-lfs")
 local util = require("ffi/util")
 
 local function probeDevice()
     if isAndroid then
         util.noSDL()
+
+        if android.prop.model == "tolino" then
+            return require("device/tolino/device")
+        end
+
         return require("device/android/device")
     end
 

--- a/frontend/device/tolino/device.lua
+++ b/frontend/device/tolino/device.lua
@@ -1,0 +1,42 @@
+-- local Generic = require("device/generic/device")
+-- local Geom = require("ui/geometry")
+-- local WakeupMgr = require("device/wakeupmgr")
+-- local ffiUtil = require("ffi/util")
+-- local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
+-- local util = require("util")
+-- local _ = require("gettext")
+local A, android = pcall(require, "android")  -- luacheck: ignore
+local AndroidDevice = require("device/android/device")
+
+-- We're going to need a few <linux/fb.h> & <linux/input.h> constants...
+-- local ffi = require("ffi")
+-- local C = ffi.C
+-- require("ffi/linux_fb_h")
+-- require("ffi/linux_input_h")
+-- require("ffi/posix_h")
+
+local function yes() return true end
+local function no() return false end
+
+local TolinoDevice = AndroidDevice:new{
+    model = "Tolino"
+}
+
+function TolinoDevice:init()
+    AndroidDevice.init(self)
+    self.input.event_map = require("device/tolino/event_map")
+end
+
+-- Tolino Vision 5
+local TolinoVision5 = TolinoDevice:new{
+    model = "Tolino_vision_5",
+    hasEinkScreen = yes
+}
+
+if android.prop.hardwareType == "E70K00" then
+    return TolinoVision5
+else
+    logger.warn("unrecognized Tolino model ".. android.prop.product.hardwareType.. " using android generic")
+    return AndroidDevice
+end

--- a/frontend/device/tolino/event_map.lua
+++ b/frontend/device/tolino/event_map.lua
@@ -1,0 +1,35 @@
+return {
+    -- the following has mostly been copy-pasted from "device/android/event_map.lua"
+    [29] = "A", [30] = "B", [31] = "C", [32] = "D", [33] = "E", [34] = "F",
+    [35] = "G", [36] = "H", [37] = "I", [38] = "J", [39] = "K", [40] = "L",
+    [41] = "M", [42] = "N", [43] = "O", [44] = "P", [45] = "Q", [46] = "R",
+    [47] = "S", [48] = "T", [49] = "U", [50] = "V", [51] = "W", [52] = "X",
+    [53] = "Y", [54] = "Z", [ 7] = "0", [ 8] = "1", [ 9] = "2", [10] = "3",
+    [11] = "4", [12] = "5", [13] = "6", [14] = "7", [15] = "8", [16] = "9",
+
+    [4] = "Back",   -- BACK
+    [19] = "Up",    -- DPAD_UP
+    [20] = "Down",  -- DPAD_UP
+    [21] = "LPgBack",  -- DPAD_LEFT -- changed for Tolino Buttons (up key)
+    [22] = "LPgFwd", -- DPAD_RIGHT -- changed for Tolino Buttons (down key)
+    [23] = "Press", -- DPAD_CENTER
+    [24] = "LPgBack", -- VOLUME_UP
+    [25] = "LPgFwd",  -- VOLUME_DOWN
+    [27] = "Camera",  -- CAMERA
+    [56] = ".",     -- PERIOD
+    [59] = "Shift", -- SHIFT_LEFT
+    [60] = "Shift", -- SHIFT_RIGHT
+    [62] = " ",     -- SPACE
+    [63] = "Sym",   -- SYM
+    [66] = "Press", -- ENTER
+    [67] = "Del",   -- DEL
+    [76] = "/",     -- SLASH
+    [82] = "Menu",  -- MENU
+    [84] = "Search",--SEARCH
+    [92] = "LPgBack", -- PAGE_UP
+    [93] = "LPgFwd",  -- PAGE_DOWN
+
+    [104] = "LPgBack", -- T68 PageUp
+    [109] = "LPgFwd",  -- T68 PageDown
+    [139] = "Menu",    -- T68 Menu
+}


### PR DESCRIPTION
This PR adds a `device/tolino` directory with `device.lua` and `event_map.lua` and for now only detects and uses custom event_map configuration for model `E70K00`, uses android as base and fallback if model is not detected

fixes #9175

requires https://github.com/koreader/android-luajit-launcher/pull/381 (this is why this PR is a DRAFT)