### PR TITLE
AutoWarmth: add a choice to control warmth and/or night mode

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -784,11 +784,11 @@ function AutoWarmth:getWarmthMenu()
         return {
             mode = mode,
             text_func = function()
-                if Device:hasNaturalLight() then
+                if Device:hasNaturalLight() and self.control_warmth then
                     if self.warmth[num] <= 100 then
                         return T(_("%1: %2 %"), text, self.warmth[num])
                     else
-                        return T(_("%1: 100 % + ☾"), text)
+                        return T(_("%1: 100 % %2"), text, self.control_nightmode and "+ ☾" or "")
                     end
                 else
                     if self.warmth[num] <= 100 then
@@ -960,12 +960,12 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
 
         if not t[num] then -- entry deactivated
             return retval .. "\n"
-        elseif Device:hasNaturalLight() then
+        elseif Device:hasNaturalLight() and self.control_warmth then
             if self.current_times_h[num] == t[num] then
                 if self.warmth[num] <= 100 then
                     return retval .. " (💡" .. self.warmth[num] .."%)\n"
                 else
-                    return retval .. " (💡100% + ☾)\n"
+                    return retval .. " (💡100%" .. (self.control_nightmode and " + ☾" or "") .. ")\n"
                 end
             else
                 return retval .. "\n"

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -887,6 +887,7 @@ function AutoWarmth:getWarmthMenu()
                     G_reader_settings:makeTrue("autowarmth_control_warmth")
                     G_reader_settings:makeTrue("autowarmth_control_nightmode")
                 end
+                self:scheduleMidnightUpdate()
                 if touchmenu_instance then self:updateItems(touchmenu_instance) end
             end,
             keep_menu_open = true,

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -829,7 +829,7 @@ function AutoWarmth:getWarmthMenu()
                     })
                 else
                     UIManager:show(ConfirmBox:new{
-                        text = _("Nightmode"),
+                        text = _("Night mode"),
                         ok_text = _("Set"),
                         ok_callback = function()
                             self.warmth[num] = 110

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -74,6 +74,14 @@ function AutoWarmth:init()
         or { 90, 90, 80, 60, 20, 20, 20, 60, 80, 90, 90}
     self.fl_off_during_day = G_reader_settings:readSetting("autowarmth_fl_off_during_day")
 
+    self.control_warmth = G_reader_settings:nilOrTrue("autowarmth_control_warmth")
+    self.control_nightmode = G_reader_settings:nilOrTrue("autowarmth_control_nightmode")
+    if not self.control_warmth and not self.control_nightmode then
+        logger.dbg("AutoWarmth: autowarmth_control_warmth and autowarmth_control_nightmode are both false, set them to true")
+        self.control_warmth = true
+        self.control_nightmode = true
+    end
+
     -- schedule recalculation shortly afer midnight
     self:scheduleMidnightUpdate()
 end
@@ -369,9 +377,11 @@ end
 -- Set warmth and schedule the next warmth change
 function AutoWarmth:setWarmth(val, schedule_next, force_warmth)
     if val then
-        DeviceListener:onSetNightMode(val > 100)
+        if self.control_nightmode then
+            DeviceListener:onSetNightMode(val > 100)
+        end
 
-        if Device:hasNaturalLight() then
+        if Device:hasNaturalLight() and self.control_warmth then
             val = math.min(val, 100) -- "mask" night mode
             Powerd:setWarmth(val, force_warmth)
         end
@@ -665,7 +675,7 @@ function AutoWarmth:getScheduleMenu()
         self:scheduleMidnightUpdate()
         if touchmenu_instance then self:updateItems(touchmenu_instance) end
     end
-    -- mode == nil ... show alway
+    -- mode == nil ... show always
     --      == true ... easy mode
     --      == false ... expert mode
     local function getScheduleMenuEntry(text, num, mode)
@@ -767,7 +777,7 @@ function AutoWarmth:getScheduleMenu()
 end
 
 function AutoWarmth:getWarmthMenu()
-    -- mode == nil ... show alway
+    -- mode == nil ... show always
     --      == true ... easy mode
     --      == false ... expert mode
     local function getWarmthMenuEntry(text, num, mode)
@@ -789,7 +799,7 @@ function AutoWarmth:getWarmthMenu()
                 end
             end,
             callback = function(touchmenu_instance)
-                if Device:hasNaturalLight() then
+                if Device:hasNaturalLight() and self.control_warmth then
                     UIManager:show(SpinWidget:new{
                         title_text = text,
                         info_text = _("Enter percentage of warmth."),
@@ -808,8 +818,8 @@ function AutoWarmth:getWarmthMenu()
                             self:scheduleMidnightUpdate()
                             if touchmenu_instance then self:updateItems(touchmenu_instance) end
                         end,
-                        extra_text = _("Use night mode"),
-                        extra_callback = function()
+                        extra_text = self.control_nightmode and  _("Use night mode"),
+                        extra_callback = self.control_nightmode and function()
                             self.warmth[num] = 110
                             self.warmth[#self.warmth - num + 1] = 110
                             G_reader_settings:saveSetting("autowarmth_warmth", self.warmth)
@@ -844,12 +854,44 @@ function AutoWarmth:getWarmthMenu()
                     })
                 end
             end,
-
             keep_menu_open = true,
         }
     end
 
     local retval = {
+        {
+            text_func = function()
+                if Device:hasNaturalLight() then
+                    return T(_("Control: %1%2%3"), self.control_warmth and _("warmth") or "",
+                            self.control_warmth and self.control_nightmode and string.format(" %s ", _("and")) or "",
+                            self.control_nightmode and _("night mode") or "")
+                else
+                    return _("Control: night mode")
+                end
+            end,
+            enabled_func = function()
+                return Device:hasNaturalLight()
+            end,
+            callback = function(touchmenu_instance)
+                if self.control_warmth and self.control_nightmode then
+                    self.control_nightmode = false
+                    G_reader_settings:makeFalse("autowarmth_control_nightmode")
+                elseif self.control_warmth and not self.control_nightmode then
+                    self.control_warmth = false
+                    self.control_nightmode = true
+                    G_reader_settings:makeFalse("autowarmth_control_warmth")
+                    G_reader_settings:makeTrue("autowarmth_control_nightmode")
+                else
+                    self.control_warmth = true
+                    self.control_nightmode = true
+                    G_reader_settings:makeTrue("autowarmth_control_warmth")
+                    G_reader_settings:makeTrue("autowarmth_control_nightmode")
+                end
+                if touchmenu_instance then self:updateItems(touchmenu_instance) end
+            end,
+            keep_menu_open = true,
+            separator = true,
+        },
         {
             text = Device:hasNaturalLight() and _("Set warmth and night mode for:") or _("Set night mode for:"),
             enabled_func = function() return false end,


### PR DESCRIPTION
This shall fix #9498. 

Add a menu entry in the "Warmth and night mode settings" menu

![grafik](https://user-images.githubusercontent.com/36999612/189490240-cabc6b6d-24b9-435e-bd46-5d19b6076401.png)

![grafik](https://user-images.githubusercontent.com/36999612/189490307-8399f16b-cb34-44fe-a6eb-76e029036936.png)

![grafik](https://user-images.githubusercontent.com/36999612/189490338-9a69e962-3266-4ffd-b4c2-f959af17defd.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9504)
<!-- Reviewable:end -->
