### PR TITLE
bump crengine: better SVG support with extended LunaSVG

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1008,7 +1008,9 @@ function ReaderHighlight:onHold(arg, ges)
     -- check if we were holding on an image
     -- we provide want_frames=true, so we get a list of images for
     -- animated GIFs (supported by ImageViewer)
-    local image = self.ui.document:getImageFromPosition(self.hold_pos, true)
+    -- We provide accept_cre_scalable_image=true to get, if the image is a SVG image,
+    -- a function that ImageViewer can use to get a perfect bb at any scale factor.
+    local image = self.ui.document:getImageFromPosition(self.hold_pos, true, true)
     if image then
         logger.dbg("hold on image")
         local ImageViewer = require("ui/widget/imageviewer")

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -122,6 +122,7 @@ function ReaderUI:init()
 
     if Device:hasKeys() then
         self.key_events.Home = { {"Home"}, doc = "open file browser" }
+        self.key_events.Reload = { {"F5"}, doc = "reload document" }
     end
 
     -- a view container (so it must be child #1!)
@@ -809,6 +810,10 @@ function ReaderUI:onHome()
     self:onClose()
     self:showFileManager()
     return true
+end
+
+function ReaderUI:onReload()
+    self:reloadDocument()
 end
 
 function ReaderUI:reloadDocument(after_close_callback)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1402,6 +1402,7 @@ function CreDocument:register(registry)
     registry:addProvider("prc", "application/vnd.palm", self)
     registry:addProvider("rtf", "application/rtf", self, 90)
     registry:addProvider("rtf.zip", "application/rtf+zip", self, 90) -- Alternative mimetype for OPDS.
+    registry:addProvider("svg", "image/svg+xml", self, 90)
     registry:addProvider("tcr", "application/tcr", self)
     registry:addProvider("txt", "text/plain", self, 90)
     registry:addProvider("txt.zip", "application/zip", self, 90)

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -389,7 +389,7 @@ function PdfDocument:register(registry)
     registry:addProvider("png", "image/png", self, 90)
     registry:addProvider("pnm", "image/x‑portable‑bitmap", self, 90)
     registry:addProvider("ppm", "image/x‑portable‑bitmap", self, 90)
-    registry:addProvider("svg", "image/svg+xml", self, 90)
+    registry:addProvider("svg", "image/svg+xml", self, 80)
     registry:addProvider("tif", "image/tiff", self, 90)
     registry:addProvider("tiff", "image/tiff", self, 90)
     -- Windows Media Photo == JPEG XR


### PR DESCRIPTION
#### Allow F5 key to reload document

As we do with web browsers.
(Dunno why I didn't think about it before, I was always closing and relaunching the emulator when hacking test HTML files to check cre tweaks :)

#### bump crengine: better SVG support with extended LunaSVG

Add thirdparty/lunasvg, patched and extended https://github.com/koreader/koreader-base/pull/1514

Includes https://github.com/koreader/crengine/pull/489 : 
- SerialBuf: allow serializing longer strings
- Support `<img src="data:image/svg+xml,<svg...`, remove `;-cr-plain,`
- CSS: attribute selectors: accept `'` or `"` as the quote char
- Embedded fonts: fix ignored name when sharing same url
- LVImg: fix possible crash on GIF images
- Fonts: `DrawTextString()`: allow collecting glyphs as SVG paths
- Images parsing: cache native sizes
- SVG: enhanced SVG support with LunaSVG extended
- Add ldomNode::isImage(), handle `<object>` and `<embed>` as images
- Handle the `<svg>` element as an SVG image
- Support SVG images as first class documents

cre.cpp: 
- `getImageDataFromPosition()`: allow getting a `creimage` Lua userdata object, so `ImageViewer` can request it to be rendered smoothed scaled to the requested size
- add `renderImageData()`, so frontend can use crengine to render SVG images (ie. for book covers)
- fix small memory leak

Make credocument the preferred engine for .svg files.

Closes #9298. Closes #6757. Closes #7026.

#### CRE/ImageViewer: get scaled blitbuffer when long-press on SVG

Get a Lua userdata wrapping a crengine LVSvgImageSource object when long-press on a SVG image, and have crengine/LunaSVG render it smoothly scaled to the requested size by ImageViewer.

#### RenderImage: use crengine to render SVG image data

Mostly only used when rendering cover and wikipedia images.
Our SVG icons are still rendered with `renderSVGImageFile()` and `libkoreader-nnsvg.so` (NanoSVG).

#### Wikipedia EPUBs: keep math SVG images

Because now we can render them correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9510)
<!-- Reviewable:end -->
