### PR TITLE
fix(Makefile): add "luajit" binary to android zip file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,10 @@ androidupdate: all
 	# in runtime luajit-launcher's libluajit.so will be loaded
 	-rm $(INSTALL_DIR)/koreader/libs/libluajit.so
 
+	# needs to be done because otherwise "luajit" is not included in the android build
+	cp $(ANDROID_LAUNCHER_DIR)/jni/luajit/luajit/src/luajit $(INSTALL_DIR)/koreader/luajit
+	file $(INSTALL_DIR)/koreader/luajit | grep ARM || exit 1
+
         # fresh APK assets
 	rm -rfv $(ANDROID_ASSETS) $(ANDROID_LIBS_ROOT)
 	mkdir -p $(ANDROID_ASSETS) $(ANDROID_LIBS_ABI)


### PR DESCRIPTION
This PR adds the `luajit` binary to the android output, required for running `ntx_io.lua` in `TolinoWarmthController.kt`

required for https://github.com/koreader/android-luajit-launcher/pull/382

Note: this PR adds the generated `luajit` binary to the 7z package, because it was not there before, i dont know if this is the proper way, but for now it worked for me

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9511)
<!-- Reviewable:end -->
