### PR TITLE
Add Russian Wiktionary dictionary

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -1116,6 +1116,14 @@ local dictionaries = {
         url = "https://gitlab.com/avsej/dicts-stardict-form-xdxf/raw/d636cc5e8d4a47e22ac7466f4af6d435a8a3f650/001/stardict-comn_dictd03_magus-2.4.2.tar.gz"
     },
     {
+        name = "Русский Викисловарь",
+        lang_in = "Russian",
+        lang_out = "Russian",
+        entries = 334418,
+        license = "CC-BY-SA/GFDL (dual-licensed)",
+        url = "https://github.com/Vuizur/ruwiktionary-htmldump-parser/raw/master/Russian-Russian-dict.tar.gz"
+    },
+    {
         name = "Русско-Белорусский математический словарь",
         lang_in = "Russian",
         lang_out = "Belarusian",


### PR DESCRIPTION
This adds a Russian-Russian dictionary that I created, extracted from Wiktionary.

The download/lua code is untested, so if someone would want to test it I have a random public domain Russian ebook:
[Гавриилиада_(Пушкин).zip](https://github.com/koreader/koreader/files/9568714/_.zip)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9517)
<!-- Reviewable:end -->
