### PR TITLE
FontList: Always use the binary cache format

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -702,6 +702,13 @@ To:
             touchmenu_instance:updateItems()
         end,
     })
+    table.insert(self.menu_items.developer_options.sub_item_table, {
+        text = _("Dump the fontlist cache"),
+        callback = function()
+            local FontList = require("fontlist")
+            FontList:dumpFontList()
+        end,
+    })
 
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -6,7 +6,6 @@ local Persist = require("persist")
 local util = require("util")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
-local dbg = require("dbg")
 
 local FontList = {
     fontdir = "./fonts",

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -226,10 +226,11 @@ function FontList:dumpFontList()
     local f = io.open(path, "w")
     if f ~= nil then
         os.setlocale('C', 'numeric')
-        f:write("-- we can read Lua syntax here!\nreturn ")
+        f:write("return ")
         f:write(dump(self.fontinfo, nil, true))
-        f:write("\n")
         f:close()
+    else
+        return
     end
 
     -- FontList
@@ -237,11 +238,20 @@ function FontList:dumpFontList()
     f = io.open(path, "w")
     if f ~= nil then
         os.setlocale('C', 'numeric')
-        f:write("-- we can read Lua syntax here!\nreturn ")
+        f:write("return ")
         f:write(dump(self.fontlist, nil, true))
-        f:write("\n")
         f:close()
+    else
+        return
     end
+
+    local InfoMessage = require("ui/widget/infomessage")
+    local UIManager = require("ui/uimanager")
+    local _ = require("gettext")
+    local T = require("ffi/util").template
+    UIManager:show(InfoMessage:new{
+        text = T(_("Fontlist data has been dumped in:\n%1"), self.cachedir)
+    })
 end
 
 -- Try to determine the localized font name

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20220913
+local CURRENT_MIGRATION_DATE = 20220914
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -436,8 +436,8 @@ if last_migration_date < 20220819 then
 end
 
 -- Fontlist, cache format change (#9513)
-if last_migration_date < 20220913 then
-    logger.info("Performing one-time migration for 20220913")
+if last_migration_date < 20220914 then
+    logger.info("Performing one-time migration for 20220914")
 
     local cache_path = DataStorage:getDataDir() .. "/cache/fontlist"
     local ok, err = os.remove(cache_path .. "/fontinfo.dat")


### PR DESCRIPTION
Since I never actually needed to look into that data ever until today, let's just get rid of the weird debug-specific behavior.

Instead, just add a dedicated "Developer options" entry that will dump it on demand (and it'll be sorted to boot, which makes it 500% more usable).

Plus, since yesterday's change, the cache format switch between debug or not miiiight actually be crashy, so re-trigger the migration  ;p.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9519)
<!-- Reviewable:end -->
