### PR TITLE
vocabbuilder.koplugin: support undo word study

### DIFF
--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -205,6 +205,10 @@ function VocabularyBuilder:gotOrForgot(item, isGot)
         due_time = current_time + 24 * 30 * 3600
     end
 
+    item.last_review_count = item.review_count
+    item.last_review_time = item.review_time
+    item.last_due_time = item.due_time
+
     item.review_count = target_count
     item.review_time = current_time
     item.due_time = due_time

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -398,9 +398,20 @@ function WordInfoDialog:init()
         end
     }
 
+    local buttons = {{reset_button, remove_button}}
+    if self.show_parent.item.last_due_time then
+        table.insert(buttons, {{
+            text = _("Undo study"),
+            callback = function()
+                self.undo_callback()
+                UIManager:close(self)
+            end
+        }})
+    end
+
     local focus_button = ButtonTable:new{
         width = width,
-        buttons = {{reset_button, remove_button}},
+        buttons = buttons,
         show_parent = self
     }
 
@@ -815,6 +826,19 @@ function VocabItemWidget:resetProgress()
     self.item.review_count = 0
     self.item.due_time = os.time()
     self.item.review_time = self.item.due_time
+    self.item.last_due_time = nil
+    self:initItemWidget()
+    UIManager:setDirty(self.show_parent, function()
+        return "ui", self[1].dimen end)
+end
+
+function VocabItemWidget:undo()
+    self.item.review_count = self.item.last_review_count or self.item.review_count
+    self.item.review_time = self.item.last_review_time or self.item.review_time
+    self.item.due_time = self.item.last_due_time or self.item.due_time
+    self.item.last_review_count = nil
+    self.item.last_review_time = nil
+    self.item.last_due_time = nil
     self:initItemWidget()
     UIManager:setDirty(self.show_parent, function()
         return "ui", self[1].dimen end)
@@ -838,6 +862,9 @@ function VocabItemWidget:showMore()
         end,
         reset_callback = function()
             self:resetProgress()
+        end,
+        undo_callback = function()
+            self:undo()
         end,
         show_parent = self
     }

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -834,7 +834,7 @@ end
 
 function VocabItemWidget:undo()
     self.item.review_count = self.item.last_review_count or self.item.review_count
-    self.item.review_time = self.item.last_review_time or self.item.review_time
+    self.item.review_time = self.item.last_review_time
     self.item.due_time = self.item.last_due_time or self.item.due_time
     self.item.last_review_count = nil
     self.item.last_review_time = nil

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -401,7 +401,7 @@ function WordInfoDialog:init()
     local buttons = {{reset_button, remove_button}}
     if self.show_parent.item.last_due_time then
         table.insert(buttons, {{
-            text = _("Undo study"),
+            text = _("Undo study status"),
             callback = function()
                 self.undo_callback()
                 UIManager:close(self)


### PR DESCRIPTION
Adds button to undo last study operation (got it/forgot) in more (...) per fr #9527
Closes #9527.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9528)
<!-- Reviewable:end -->
