### PR TITLE
ReaderDict: fix use of dicts with ifo with DOS line endings

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -134,7 +134,7 @@ function ReaderDictionary:init()
             if f then
                 local content = f:read("*all")
                 f:close()
-                local dictname = content:match("\nbookname=(.-)\n")
+                local dictname = content:match("\nbookname=(.-)\r?\n")
                 local is_html = content:find("sametypesequence=h", 1, true) ~= nil
                 -- sdcv won't use dict that don't have a bookname=
                 if dictname then


### PR DESCRIPTION
Fixed in upstream sdcv, but we need to also do it in our parsing of .ifo and picking out dict name.
Also includes minor bump of base/sdcv https://github.com/koreader/koreader-base/pull/1518
See https://github.com/koreader/koreader/issues/9535#issuecomment-1252771204 .
Closes #9535. Closes #9455.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9536)
<!-- Reviewable:end -->
