### PR TITLE
FileManager: add Select button to the file long-press menu

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -181,7 +181,15 @@ function FileManager:setupLayout()
     local renameFile = function(file) self:renameFile(file) end
     local setHome = function(path) self:setHome(path) end
 
-    function file_chooser:onFileHold(file)  -- luacheck: ignore
+    function file_chooser:onFileHold(file)
+        if file_manager.select_mode then
+            file_manager:tapPlus()
+        else
+            self:_onFileHold(file)
+        end
+    end
+
+    function file_chooser:_onFileHold(file)  -- luacheck: ignore
         local is_file = lfs.attributes(file, "mode") == "file"
         local is_folder = lfs.attributes(file, "mode") == "directory"
         local is_not_parent_folder = BaseUtil.basename(file) ~= ".."
@@ -361,6 +369,15 @@ function FileManager:setupLayout()
                 }
             })
             table.insert(buttons, {
+                {
+                    text = _("Select"),
+                    callback = function()
+                        UIManager:close(self.file_dialog)
+                        file_manager:onToggleSelectMode()
+                        file_manager.selected_files[file] = true
+                        self:refreshPath()
+                    end,
+                },
                 {
                     text_func = function()
                         if ReadCollection:checkItemExist(file) then

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -185,11 +185,11 @@ function FileManager:setupLayout()
         if file_manager.select_mode then
             file_manager:tapPlus()
         else
-            self:_onFileHold(file)
+            self:showFileDialog(file)
         end
     end
 
-    function file_chooser:_onFileHold(file)  -- luacheck: ignore
+    function file_chooser:showFileDialog(file)  -- luacheck: ignore
         local is_file = lfs.attributes(file, "mode") == "file"
         local is_folder = lfs.attributes(file, "mode") == "directory"
         local is_not_parent_folder = BaseUtil.basename(file) ~= ".."

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -215,9 +215,11 @@ function FileManager:setupLayout()
                     text = _("Select"),
                     callback = function()
                         UIManager:close(self.file_dialog)
-                        file_manager:onToggleSelectMode()
-                        file_manager.selected_files[file] = true
-                        self:refreshPath()
+                        file_manager:onToggleSelectMode(true) -- no full screen refresh
+                        if is_file then
+                            file_manager.selected_files[file] = true
+                            self:refreshPath()
+                        end
                     end,
                 },
             },
@@ -575,12 +577,14 @@ function FileManager:onShowPlusMenu()
     return true
 end
 
-function FileManager:onToggleSelectMode()
+function FileManager:onToggleSelectMode(no_refresh)
     logger.dbg("toggle select mode")
     self.select_mode = not self.select_mode
     self.selected_files = self.select_mode and {} or nil
     self.title_bar:setRightIcon(self.select_mode and "check" or "plus")
-    self:onRefresh()
+    if not no_refresh then
+        self:onRefresh()
+    end
 end
 
 function FileManager:tapPlus()
@@ -703,7 +707,7 @@ function FileManager:tapPlus()
                 {
                     text = _("Select files"),
                     callback = function()
-                        self:onToggleSelectMode()
+                        self:onToggleSelectMode(true) -- no full screen refresh
                         UIManager:close(self.file_dialog)
                     end,
                 },

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -63,6 +63,12 @@ function ButtonDialogTitle:init()
             }
         end
     end
+    self.button_table = ButtonTable:new{
+        width = self.width,
+        buttons = self.buttons,
+        zero_sep = true,
+        show_parent = self,
+    }
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),
         MovableContainer:new{
@@ -81,12 +87,7 @@ function ButtonDialogTitle:init()
                         },
                     },
                     VerticalSpan:new{ width = Size.span.vertical_default },
-                    ButtonTable:new{
-                        width = self.width,
-                        buttons = self.buttons,
-                        zero_sep = true,
-                        show_parent = self,
-                    },
+                    self.button_table,
                 },
                 background = Blitbuffer.COLOR_WHITE,
                 bordersize = Size.border.window,

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -476,7 +476,6 @@ function FileChooser:onMenuSelect(item)
 end
 
 function FileChooser:onMenuHold(item)
-    if self.filemanager and self.filemanager.select_mode then return true end
     self:onFileHold(item.path)
     return true
 end

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -207,17 +207,17 @@ function CoverMenu:updateItems(select_number)
     -- (FileManager may replace file_chooser.onFileHold after we've been called once, so we need
     -- to replace it again if it is not ours)
     if not self.onFileHold_ours -- never replaced
-            or self._onFileHold ~= self.onFileHold_ours then -- it is no more ours
+            or self.showFileDialog ~= self.onFileHold_ours then -- it is no more ours
         -- We need to do it at nextTick, once FileManager has instantiated
         -- its FileChooser completely
         UIManager:nextTick(function()
             -- Store original function, so we can call it
-            self.onFileHold_orig = self._onFileHold
+            self.onFileHold_orig = self.showFileDialog
 
             -- Replace it with ours
             -- This causes luacheck warning: "shadowing upvalue argument 'self' on line 34".
             -- Ignoring it (as done in filemanager.lua for the same onFileHold)
-            self._onFileHold = function(self, file) -- luacheck: ignore
+            self.showFileDialog = function(self, file) -- luacheck: ignore
                 -- Call original function: it will create a ButtonDialogTitle
                 -- and store it as self.file_dialog, and UIManager:show() it.
                 self.onFileHold_orig(self, file)
@@ -404,7 +404,7 @@ function CoverMenu:updateItems(select_number)
             end
 
             -- Remember our function
-            self.onFileHold_ours = self._onFileHold
+            self.onFileHold_ours = self.showFileDialog
         end)
     end
     Menu.mergeTitleBarIntoLayout(self)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -207,17 +207,17 @@ function CoverMenu:updateItems(select_number)
     -- (FileManager may replace file_chooser.onFileHold after we've been called once, so we need
     -- to replace it again if it is not ours)
     if not self.onFileHold_ours -- never replaced
-            or self.onFileHold ~= self.onFileHold_ours then -- it is no more ours
+            or self._onFileHold ~= self.onFileHold_ours then -- it is no more ours
         -- We need to do it at nextTick, once FileManager has instantiated
         -- its FileChooser completely
         UIManager:nextTick(function()
             -- Store original function, so we can call it
-            self.onFileHold_orig = self.onFileHold
+            self.onFileHold_orig = self._onFileHold
 
             -- Replace it with ours
             -- This causes luacheck warning: "shadowing upvalue argument 'self' on line 34".
             -- Ignoring it (as done in filemanager.lua for the same onFileHold)
-            self.onFileHold = function(self, file) -- luacheck: ignore
+            self._onFileHold = function(self, file) -- luacheck: ignore
                 -- Call original function: it will create a ButtonDialogTitle
                 -- and store it as self.file_dialog, and UIManager:show() it.
                 self.onFileHold_orig(self, file)
@@ -404,7 +404,7 @@ function CoverMenu:updateItems(select_number)
             end
 
             -- Remember our function
-            self.onFileHold_ours = self.onFileHold
+            self.onFileHold_ours = self._onFileHold
         end)
     end
     Menu.mergeTitleBarIntoLayout(self)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -195,32 +195,32 @@ function CoverMenu:updateItems(select_number)
         UIManager:scheduleIn(1, self.items_update_action)
     end
 
-    -- (We may not need to do the following if we extend onFileHold
+    -- (We may not need to do the following if we extend showFileDialog
     -- code in filemanager.lua to check for existence and call a
     -- method: self:getAdditionalButtons() to add our buttons
     -- to its own set.)
 
-    -- We want to add some buttons to the onFileHold popup. This function
+    -- We want to add some buttons to the showFileDialog popup. This function
     -- is dynamically created by FileManager:init(), and we don't want
-    -- to override this... So, here, when we see the onFileHold function,
+    -- to override this... So, here, when we see the showFileDialog function,
     -- we replace it by ours.
-    -- (FileManager may replace file_chooser.onFileHold after we've been called once, so we need
+    -- (FileManager may replace file_chooser.showFileDialog after we've been called once, so we need
     -- to replace it again if it is not ours)
-    if not self.onFileHold_ours -- never replaced
-            or self.showFileDialog ~= self.onFileHold_ours then -- it is no more ours
+    if not self.showFileDialog_ours -- never replaced
+            or self.showFileDialog ~= self.showFileDialog_ours then -- it is no more ours
         -- We need to do it at nextTick, once FileManager has instantiated
         -- its FileChooser completely
         UIManager:nextTick(function()
             -- Store original function, so we can call it
-            self.onFileHold_orig = self.showFileDialog
+            self.showFileDialog_orig = self.showFileDialog
 
             -- Replace it with ours
             -- This causes luacheck warning: "shadowing upvalue argument 'self' on line 34".
-            -- Ignoring it (as done in filemanager.lua for the same onFileHold)
+            -- Ignoring it (as done in filemanager.lua for the same showFileDialog)
             self.showFileDialog = function(self, file) -- luacheck: ignore
                 -- Call original function: it will create a ButtonDialogTitle
                 -- and store it as self.file_dialog, and UIManager:show() it.
-                self.onFileHold_orig(self, file)
+                self.showFileDialog_orig(self, file)
 
                 local bookinfo = BookInfoManager:getBookInfo(file)
                 if not bookinfo or bookinfo._is_directory then
@@ -340,7 +340,6 @@ function CoverMenu:updateItems(select_number)
                             --       c.f., BookStatusWidget:generateSwitchGroup for the three possible constant values.
                             return status == "complete" and _("Mark as reading") or _("Mark as read")
                         end,
-                        enabled = true,
                         callback = function()
                             local status
                             if self.cover_info_cache and self.cover_info_cache[file] then
@@ -404,13 +403,13 @@ function CoverMenu:updateItems(select_number)
             end
 
             -- Remember our function
-            self.onFileHold_ours = self.showFileDialog
+            self.showFileDialog_ours = self.showFileDialog
         end)
     end
     Menu.mergeTitleBarIntoLayout(self)
 end
 
--- Similar to onFileHold setup just above, but for History,
+-- Similar to showFileDialog setup just above, but for History,
 -- which is plugged in main.lua _FileManagerHistory_updateItemTable()
 function CoverMenu:onHistoryMenuHold(item)
     -- Call original function: it will create a ButtonDialog
@@ -529,7 +528,7 @@ function CoverMenu:onHistoryMenuHold(item)
     return true
 end
 
--- Similar to onFileHold setup just above, but for Collections,
+-- Similar to showFileDialog setup just above, but for Collections,
 -- which is plugged in main.lua _FileManagerCollections_updateItemTable()
 function CoverMenu:onCollectionsMenuHold(item)
     -- Call original function: it will create a ButtonDialog

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -469,7 +469,7 @@ function CoverBrowser:refreshFileManagerInstance(cleanup, post_init)
         if cleanup then -- clean instance properties we may have set
             if fc.onFileHold_orig then
                 -- remove our onFileHold that extended file_dialog with new buttons
-                fc.onFileHold = fc.onFileHold_orig
+                fc.showFileDialog = fc.onFileHold_orig
                 fc.onFileHold_orig = nil
                 fc.onFileHold_ours = nil
             end

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -467,11 +467,11 @@ function CoverBrowser:refreshFileManagerInstance(cleanup, post_init)
     if fm then
         local fc = fm.file_chooser
         if cleanup then -- clean instance properties we may have set
-            if fc.onFileHold_orig then
-                -- remove our onFileHold that extended file_dialog with new buttons
-                fc.showFileDialog = fc.onFileHold_orig
-                fc.onFileHold_orig = nil
-                fc.onFileHold_ours = nil
+            if fc.showFileDialog_orig then
+                -- remove our showFileDialog that extended file_dialog with new buttons
+                fc.showFileDialog = fc.showFileDialog_orig
+                fc.showFileDialog_orig = nil
+                fc.showFileDialog_ours = nil
             end
         end
         if filemanager_display_mode then


### PR DESCRIPTION
Add usual way to start files selection: long-press the file and choose the <kbd>Select</kbd> button.
On pressing, the FM goes to the select mode and the file pressed is selected.
While in select mode, long-pressing on any file shows "Selection actions" pop-up menu (same as pressing the titlebar "Select" icon).

![01](https://user-images.githubusercontent.com/62179190/193069270-092d824a-acc0-43a4-9bd8-cb16829d4459.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9571)
<!-- Reviewable:end -->
