### PR TITLE
Keyboards/Menu: Lazy-load the layout-specific menu

### DIFF
--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -10,7 +10,6 @@ local UIManager = require("ui/uimanager")
 local VirtualKeyboard = require("ui/widget/virtualkeyboard")
 local Screen = Device.screen
 local T = require("ffi/util").template
-local dbg = require("dbg")
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
@@ -65,7 +64,7 @@ local function genLayoutSpecificSubmenu()
                 text = Language:getLanguageName(lang),
                 sub_item_table_func = function()
                     local keyboard = require(kb_pkg)
-                    if dbg.dassert(keyboard.genMenuItems ~= nil) then
+                    if keyboard.genMenuItems ~= nil then
                         return keyboard:genMenuItems()
                     else
                         return {


### PR DESCRIPTION
And do so only for the active layouts.

This prevents loading a potentially large amount of data without even having navigated to said menu (or having the layout enabled).

Noticed because the first TouchMenu open was hitching since the introduction of the ZH kb ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9584)
<!-- Reviewable:end -->
