### PR TITLE
Kobo: Enable power/sleep button support for Nia

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -425,6 +425,7 @@ local KoboLuna = Kobo:new{
     hasFrontlight = yes,
     touch_phoenix_protocol = true,
     display_dpi = 212,
+    power_dev = "/dev/input/event2",
 }
 
 -- Kobo Elipsa


### PR DESCRIPTION
see my bug-report/issue: https://github.com/koreader/koreader/issues/9590

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9591)
<!-- Reviewable:end -->
