### PR TITLE
Kobo: Add a debug option to turn the charging LED on PM entry failure

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -705,6 +705,17 @@ To:
             FontList:dumpFontList()
         end,
     })
+    if Device:isKobo() and Device:canToggleChargingLED() then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            text = _("Turn on the LED on PM entry failure"),
+            checked_func = function()
+                return G_reader_settings:isTrue("pm_debug_entry_failure")
+            end,
+            callback = function()
+                G_reader_settings:toggle("pm_debug_entry_failure")
+            end,
+        })
+    end
 
     self.menu_items.cloud_storage = {
         text = _("Cloud storage"),

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1019,8 +1019,15 @@ function Kobo:standby(max_duration)
 
     if ret then
         logger.info("Kobo standby: zZz zZz zZz zZz... And woke up!")
+        if G_reader_settings:isTrue("pm_debug_entry_failure") then
+            -- NOTE: This is a debug option where we coopt the charging LED, hence us not using setupChargingLED here.
+            self:toggleChargingLED(false)
+        end
     else
         logger.warn("Kobo standby: the kernel refused to enter standby!")
+        if G_reader_settings:isTrue("pm_debug_entry_failure") then
+            self:toggleChargingLED(true)
+        end
     end
 
     if max_duration then
@@ -1123,10 +1130,17 @@ function Kobo:suspend()
 
     if ret then
         logger.info("Kobo suspend: ZzZ ZzZ ZzZ... And woke up!")
+        if G_reader_settings:isTrue("pm_debug_entry_failure") then
+            -- NOTE: This is a debug option where we coopt the charging LED, hence us not using setupChargingLED here.
+            self:toggleChargingLED(false)
+        end
     else
         logger.warn("Kobo suspend: the kernel refused to enter suspend!")
         -- Reset state-extended back to 0 since we are giving up.
         writeToSys("0", "/sys/power/state-extended")
+        if G_reader_settings:isTrue("pm_debug_entry_failure") then
+            self:toggleChargingLED(true)
+        end
     end
 
     -- NOTE: Ideally, we'd need a way to warn the user that suspending

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1141,7 +1141,6 @@ function Kobo:suspend()
     if ret then
         logger.info("Kobo suspend: ZzZ ZzZ ZzZ... And woke up!")
         if G_reader_settings:isTrue("pm_debug_entry_failure") then
-            -- NOTE: This is a debug option where we coopt the charging LED, hence us not using setupChargingLED here.
             self:toggleChargingLED(false)
         end
     else

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1030,6 +1030,7 @@ function Kobo:standby(max_duration)
         logger.info("Kobo standby: zZz zZz zZz zZz... And woke up!")
         if G_reader_settings:isTrue("pm_debug_entry_failure") then
             -- NOTE: This is a debug option where we coopt the charging LED, hence us not using setupChargingLED here.
+            --       (It's called on resume anyway).
             self:toggleChargingLED(false)
         end
     else

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1254,6 +1254,17 @@ function Kobo:toggleChargingLED(toggle)
     if toggle == nil then
         return
     end
+    -- Don't do anything if the state is already correct
+    -- NOTE: What happens to the LED when attempting/successfully entering PM is... kind of a mess.
+    --       On a H2O, even *attempting* to enter PM will kill the light (and it'll stay off).
+    --       On a Forma, a failed attempt will *not* affect the light, but a successful one *will* kill it,
+    --       be that standby or suspend, but it'll be restored on wakeup...
+    --       On sunxi, PM appears to have zero effect on the LED.
+    if self.charging_led_state == toggle then
+        return
+    end
+    self.charging_led_state = toggle
+    logger.dbg("Kobo: Turning the charging LED", toggle and "on" or "off")
 
     -- NOTE: While most/all Kobos actually have a charging LED, and it can usually be fiddled with in a similar fashion,
     --       we've seen *extremely* weird behavior in the past when playing with it on older devices (c.f., #5479).


### PR DESCRIPTION
Because I'm kinda curious as to when exactly the PowerCover starts breaking all the things, and monitoring everything all the time is not practical...

(Also, re-enable the charging LED on the H2O).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9601)
<!-- Reviewable:end -->
