### PR TITLE
Optimization: Use constant folding for divisions not a power of two

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -889,10 +889,10 @@ function FileManagerMenu:_getTabIndexFromLocation(ges)
     if not ges then
         return last_tab_index
     -- if the start position is far right
-    elseif ges.pos.x > 2 * Screen:getWidth() / 3 then
+    elseif ges.pos.x > Screen:getWidth() * (2/3) then
         return BD.mirroredUILayout() and 1 or #self.tab_item_table
     -- if the start position is far left
-    elseif ges.pos.x < Screen:getWidth() / 3 then
+    elseif ges.pos.x < Screen:getWidth() * (1/3) then
         return BD.mirroredUILayout() and #self.tab_item_table or 1
     -- if center return the last index
     else

--- a/frontend/apps/reader/modules/readerdevicestatus.lua
+++ b/frontend/apps/reader/modules/readerdevicestatus.lua
@@ -64,7 +64,7 @@ function ReaderDeviceStatus:init()
             if statm then
                 local dummy, rss = statm:read("*number", "*number")
                 statm:close()
-                rss = math.floor(rss * 4096 / 1024 / 1024)
+                rss = math.floor(rss * (4096 / 1024 / 1024))
                 if rss >= self.memory_threshold then
                     if self.memory_confirm_box then
                         UIManager:close(self.memory_confirm_box)

--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -17,8 +17,8 @@ function ReaderDogear:init()
     -- to not overwrite the book text.
     -- For other documents, there is no easy way to know if valuable content
     -- may be hidden by the icon (kopt's page_margin is quite obscure).
-    self.dogear_min_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 40)
-    self.dogear_max_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) / 32)
+    self.dogear_min_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) * (1/40))
+    self.dogear_max_size = math.ceil(math.min(Screen:getWidth(), Screen:getHeight()) * (1/32))
     self.dogear_size = nil
     self.dogear_y_offset = 0
     self.top_pad = nil

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -390,7 +390,7 @@ local footerTextGeneratorMap = {
             local title = doc_info.title:gsub(" ", "\xC2\xA0") -- replace space with no-break-space
             local title_widget = TextWidget:new{
                 text = title,
-                max_width = footer._saved_screen_width * footer.settings.book_title_max_width_pct * 0.01,
+                max_width = footer._saved_screen_width * footer.settings.book_title_max_width_pct * (1/100),
                 face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
                 bold = footer.settings.text_font_bold,
             }
@@ -410,7 +410,7 @@ local footerTextGeneratorMap = {
             chapter_title = chapter_title:gsub(" ", "\xC2\xA0") -- replace space with no-break-space
             local chapter_widget = TextWidget:new{
                 text = chapter_title,
-                max_width = footer._saved_screen_width * footer.settings.book_chapter_max_width_pct * 0.01,
+                max_width = footer._saved_screen_width * footer.settings.book_chapter_max_width_pct * (1/100),
                 face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
                 bold = footer.settings.text_font_bold,
             }
@@ -2168,7 +2168,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
             self.footer_text.height = 0
         else
             -- Alongside a progress bar, it's the bar's width plus whatever's left.
-            local text_max_available_ratio = (100 - self.settings.progress_bar_min_width_pct) * 0.01
+            local text_max_available_ratio = (100 - self.settings.progress_bar_min_width_pct) * (1/100)
             self.footer_text:setMaxWidth(math.floor(text_max_available_ratio * self._saved_screen_width - 2 * self.settings.progress_margin_width - self.horizontal_margin))
             -- Add some spacing between the text and the bar
             self.text_width = self.footer_text:getSize().w + self.horizontal_margin

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -352,7 +352,7 @@ local footerTextGeneratorMap = {
             local dummy, rss = statm:read("*number", "*number")
             statm:close()
             -- we got the nb of 4Kb-pages used, that we convert to MiB
-            rss = math.floor(rss * 4096 / 1024 / 1024)
+            rss = math.floor(rss * (4096 / 1024 / 1024))
             return (prefix .. " %d"):format(rss)
         end
         return ""
@@ -390,7 +390,7 @@ local footerTextGeneratorMap = {
             local title = doc_info.title:gsub(" ", "\xC2\xA0") -- replace space with no-break-space
             local title_widget = TextWidget:new{
                 text = title,
-                max_width = footer._saved_screen_width * footer.settings.book_title_max_width_pct / 100,
+                max_width = footer._saved_screen_width * footer.settings.book_title_max_width_pct * 0.01,
                 face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
                 bold = footer.settings.text_font_bold,
             }
@@ -410,7 +410,7 @@ local footerTextGeneratorMap = {
             chapter_title = chapter_title:gsub(" ", "\xC2\xA0") -- replace space with no-break-space
             local chapter_widget = TextWidget:new{
                 text = chapter_title,
-                max_width = footer._saved_screen_width * footer.settings.book_chapter_max_width_pct / 100,
+                max_width = footer._saved_screen_width * footer.settings.book_chapter_max_width_pct * 0.01,
                 face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
                 bold = footer.settings.text_font_bold,
             }
@@ -2168,7 +2168,7 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
             self.footer_text.height = 0
         else
             -- Alongside a progress bar, it's the bar's width plus whatever's left.
-            local text_max_available_ratio = (100 - self.settings.progress_bar_min_width_pct) / 100
+            local text_max_available_ratio = (100 - self.settings.progress_bar_min_width_pct) * 0.01
             self.footer_text:setMaxWidth(math.floor(text_max_available_ratio * self._saved_screen_width - 2 * self.settings.progress_margin_width - self.horizontal_margin))
             -- Add some spacing between the text and the bar
             self.text_width = self.footer_text:getSize().w + self.horizontal_margin

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2022,8 +2022,8 @@ end
 function ReaderHighlight:onMoveHighlightIndicator(args)
     if self.view.visible_area and self._current_indicator_pos then
         local dx, dy, quick_move = unpack(args)
-        local quick_move_distance_dx = self.view.visible_area.w / 5 -- quick move distance: fifth of visible_area
-        local quick_move_distance_dy = self.view.visible_area.h / 5
+        local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
+        local quick_move_distance_dy = self.view.visible_area.h * (1/5)
         -- single move distance, small and capable to move on word with small font size and narrow line height
         local move_distance = Size.item.height_default / 4
         local rect = self._current_indicator_pos:copy()

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -433,10 +433,10 @@ function ReaderMenu:_getTabIndexFromLocation(ges)
     if not ges then
         return self.last_tab_index
     -- if the start position is far right
-    elseif ges.pos.x > 2 * Screen:getWidth() / 3 then
+    elseif ges.pos.x > Screen:getWidth() * (2/3) then
         return BD.mirroredUILayout() and 1 or #self.tab_item_table
     -- if the start position is far left
-    elseif ges.pos.x < Screen:getWidth() / 3 then
+    elseif ges.pos.x < Screen:getWidth() * (1/3) then
         return BD.mirroredUILayout() and #self.tab_item_table or 1
     -- if center return the last index
     else

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -542,7 +542,7 @@ end
 
 function ReaderPaging:onGotoPercent(percent)
     logger.dbg("goto document offset in percent:", percent)
-    local dest = math.floor(self.number_of_pages * percent * 0.01)
+    local dest = math.floor(self.number_of_pages * percent * (1/100))
     if dest < 1 then dest = 1 end
     if dest > self.number_of_pages then
         dest = self.number_of_pages
@@ -908,8 +908,8 @@ function ReaderPaging:onGotoPageRel(diff)
     local x_pan_off, y_pan_off = 0, 0
     local right_to_left = self.ui.document.configurable.writing_direction and self.ui.document.configurable.writing_direction > 0
     local bottom_to_top = self.ui.zooming.zoom_bottom_to_top
-    local h_progress = 1 - self.ui.zooming.zoom_overlap_h * 0.01
-    local v_progress = 1 - self.ui.zooming.zoom_overlap_v * 0.01
+    local h_progress = 1 - self.ui.zooming.zoom_overlap_h * (1/100)
+    local v_progress = 1 - self.ui.zooming.zoom_overlap_v * (1/100)
     local old_va = self.visible_area
     local old_page = self.current_page
     local x, y, w, h = "x", "y", "w", "h"

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -542,7 +542,7 @@ end
 
 function ReaderPaging:onGotoPercent(percent)
     logger.dbg("goto document offset in percent:", percent)
-    local dest = math.floor(self.number_of_pages * percent / 100)
+    local dest = math.floor(self.number_of_pages * percent * 0.01)
     if dest < 1 then dest = 1 end
     if dest > self.number_of_pages then
         dest = self.number_of_pages
@@ -908,8 +908,8 @@ function ReaderPaging:onGotoPageRel(diff)
     local x_pan_off, y_pan_off = 0, 0
     local right_to_left = self.ui.document.configurable.writing_direction and self.ui.document.configurable.writing_direction > 0
     local bottom_to_top = self.ui.zooming.zoom_bottom_to_top
-    local h_progress = 1 - self.ui.zooming.zoom_overlap_h / 100
-    local v_progress = 1 - self.ui.zooming.zoom_overlap_v / 100
+    local h_progress = 1 - self.ui.zooming.zoom_overlap_h * 0.01
+    local v_progress = 1 - self.ui.zooming.zoom_overlap_v * 0.01
     local old_va = self.visible_area
     local old_page = self.current_page
     local x, y, w, h = "x", "y", "w", "h"

--- a/frontend/apps/reader/modules/readerpanning.lua
+++ b/frontend/apps/reader/modules/readerpanning.lua
@@ -40,8 +40,8 @@ function ReaderPanning:onPanning(args, _)
     local dx, dy = unpack(args)
     -- for now, bounds checking/calculation is done in the view
     self.view:PanningUpdate(
-        dx * self.panning_steps.normal * self.dimen.w / 100,
-        dy * self.panning_steps.normal * self.dimen.h / 100)
+        dx * self.panning_steps.normal * self.dimen.w * 0.01,
+        dy * self.panning_steps.normal * self.dimen.h * 0.01)
     return true
 end
 

--- a/frontend/apps/reader/modules/readerpanning.lua
+++ b/frontend/apps/reader/modules/readerpanning.lua
@@ -40,8 +40,8 @@ function ReaderPanning:onPanning(args, _)
     local dx, dy = unpack(args)
     -- for now, bounds checking/calculation is done in the view
     self.view:PanningUpdate(
-        dx * self.panning_steps.normal * self.dimen.w * 0.01,
-        dy * self.panning_steps.normal * self.dimen.h * 0.01)
+        dx * self.panning_steps.normal * self.dimen.w * (1/100),
+        dy * self.panning_steps.normal * self.dimen.h * (1/100))
     return true
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -696,7 +696,7 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
         -- where xpointer target is (and remove if after 1s)
         local screen_y, screen_x = self.ui.document:getScreenPositionFromXPointer(marker_xp)
         local doc_margins = self.ui.document:getPageMargins()
-        local marker_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0)
+        local marker_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent * 0.01)
         -- Make it 4/5 of left margin wide (and bigger when huge margin)
         local marker_w = math.floor(math.max(doc_margins["left"] - Screen:scaleBySize(5), doc_margins["left"] * 4/5))
 
@@ -794,7 +794,7 @@ function ReaderRolling:onGotoViewRel(diff)
         local pan_diff = diff * page_visible_height
         if self.view.page_overlap_enable then
             local overlap_lines = G_reader_settings:readSetting("copt_overlap_lines") or 1
-            local overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent/100.0) * overlap_lines
+            local overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent * 0.01) * overlap_lines
             if pan_diff > overlap_h then
                 pan_diff = pan_diff - overlap_h
             elseif pan_diff < -overlap_h then
@@ -1023,9 +1023,9 @@ end
 
 function ReaderRolling:_gotoPercent(new_percent)
     if self.view.view_mode == "page" then
-        self:_gotoPage(new_percent * self.ui.document:getPageCount() / 100)
+        self:_gotoPage(new_percent * self.ui.document:getPageCount() * 0.01)
     else
-        self:_gotoPos(new_percent * self.ui.document.info.doc_height / 100)
+        self:_gotoPos(new_percent * self.ui.document.info.doc_height * 0.01)
     end
 end
 
@@ -1151,24 +1151,24 @@ function ReaderRolling:handleEngineCallback(ev, ...)
         self:showEngineProgress(0) -- Start initial delay countdown
     elseif ev == "OnLoadFileProgress" then
         -- Initial load from file (step 1/2) or from cache (step 1/1)
-        self:showEngineProgress(args[1]/100/2)
+        self:showEngineProgress(args[1]*0.01/2)
     elseif ev == "OnNodeStylesUpdateStart" then -- Start of re-rendering
         self:showEngineProgress(0) -- Start initial delay countdown
     elseif ev == "OnNodeStylesUpdateProgress" then
         -- Update node styles (step 1/2 on re-rendering)
-        self:showEngineProgress(args[1]/100/2)
+        self:showEngineProgress(args[1]*0.01/2)
     elseif ev == "OnFormatStart" then -- Start of step 2/2
         self:showEngineProgress(1/2) -- 50%, in case of no OnFormatProgress
     elseif ev == "OnFormatProgress" then
         -- Paragraph formatting and page splitting (step 2/2 after load
         -- from file, step 2/2 on re-rendering)
-        self:showEngineProgress(1/2 + args[1]/100/2)
+        self:showEngineProgress(1/2 + args[1]*0.01/2)
     elseif ev == "OnSaveCacheFileStart" then -- Start of cache file save
         self:showEngineProgress(1) -- Start initial delay countdown, fully filled
     elseif ev == "OnSaveCacheFileProgress" then
         -- Cache file save (when closing book after initial load from
         -- file or re-rendering)
-        self:showEngineProgress(1 - args[1]/100) -- unfill progress
+        self:showEngineProgress(1 - args[1]*0.01) -- unfill progress
     elseif ev == "OnDocumentReady" or ev == "OnSaveCacheFileEnd" then
         self:showEngineProgress() -- cleanup
     elseif ev == "OnLoadFileError" then
@@ -1214,7 +1214,7 @@ function ReaderRolling:showEngineProgress(percent)
             y = y + self.current_header_height
         end
 
-        local w = math.floor(Screen:getWidth() / 3)
+        local w = math.floor(Screen:getWidth() * (1/3))
         local h = Size.line.progress
         if self.engine_progress_widget then
             self.engine_progress_widget:setPercentage(percent)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -696,7 +696,7 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
         -- where xpointer target is (and remove if after 1s)
         local screen_y, screen_x = self.ui.document:getScreenPositionFromXPointer(marker_xp)
         local doc_margins = self.ui.document:getPageMargins()
-        local marker_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent * 0.01)
+        local marker_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent * (1/100))
         -- Make it 4/5 of left margin wide (and bigger when huge margin)
         local marker_w = math.floor(math.max(doc_margins["left"] - Screen:scaleBySize(5), doc_margins["left"] * 4/5))
 
@@ -794,7 +794,7 @@ function ReaderRolling:onGotoViewRel(diff)
         local pan_diff = diff * page_visible_height
         if self.view.page_overlap_enable then
             local overlap_lines = G_reader_settings:readSetting("copt_overlap_lines") or 1
-            local overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent * 0.01) * overlap_lines
+            local overlap_h = Screen:scaleBySize(self.ui.font.font_size * 1.1 * self.ui.font.line_space_percent * (1/100)) * overlap_lines
             if pan_diff > overlap_h then
                 pan_diff = pan_diff - overlap_h
             elseif pan_diff < -overlap_h then
@@ -1023,9 +1023,9 @@ end
 
 function ReaderRolling:_gotoPercent(new_percent)
     if self.view.view_mode == "page" then
-        self:_gotoPage(new_percent * self.ui.document:getPageCount() * 0.01)
+        self:_gotoPage(new_percent * self.ui.document:getPageCount() * (1/100))
     else
-        self:_gotoPos(new_percent * self.ui.document.info.doc_height * 0.01)
+        self:_gotoPos(new_percent * self.ui.document.info.doc_height * (1/100))
     end
 end
 
@@ -1151,24 +1151,24 @@ function ReaderRolling:handleEngineCallback(ev, ...)
         self:showEngineProgress(0) -- Start initial delay countdown
     elseif ev == "OnLoadFileProgress" then
         -- Initial load from file (step 1/2) or from cache (step 1/1)
-        self:showEngineProgress(args[1]*0.01/2)
+        self:showEngineProgress(args[1]*(1/100/2))
     elseif ev == "OnNodeStylesUpdateStart" then -- Start of re-rendering
         self:showEngineProgress(0) -- Start initial delay countdown
     elseif ev == "OnNodeStylesUpdateProgress" then
         -- Update node styles (step 1/2 on re-rendering)
-        self:showEngineProgress(args[1]*0.01/2)
+        self:showEngineProgress(args[1]*(1/100/2))
     elseif ev == "OnFormatStart" then -- Start of step 2/2
         self:showEngineProgress(1/2) -- 50%, in case of no OnFormatProgress
     elseif ev == "OnFormatProgress" then
         -- Paragraph formatting and page splitting (step 2/2 after load
         -- from file, step 2/2 on re-rendering)
-        self:showEngineProgress(1/2 + args[1]*0.01/2)
+        self:showEngineProgress(1/2 + args[1]*(1/100/2))
     elseif ev == "OnSaveCacheFileStart" then -- Start of cache file save
         self:showEngineProgress(1) -- Start initial delay countdown, fully filled
     elseif ev == "OnSaveCacheFileProgress" then
         -- Cache file save (when closing book after initial load from
         -- file or re-rendering)
-        self:showEngineProgress(1 - args[1]*0.01) -- unfill progress
+        self:showEngineProgress(1 - args[1]*(1/100)) -- unfill progress
     elseif ev == "OnDocumentReady" or ev == "OnSaveCacheFileEnd" then
         self:showEngineProgress() -- cleanup
     elseif ev == "OnLoadFileError" then

--- a/frontend/apps/reader/modules/readerscrolling.lua
+++ b/frontend/apps/reader/modules/readerscrolling.lua
@@ -385,7 +385,7 @@ function ReaderScrolling:_setupAction()
         local dist = math.floor(self._velocity * self._inertial_scroll_interval)
         if math.abs(dist) < self.end_scroll_dist then
             -- Decrease it even more so scrolling stops sooner
-            self._velocity = self._velocity / 1.5
+            self._velocity = self._velocity * (2/3)
         end
         -- self._stats_scroll_iterations = self._stats_scroll_iterations + 1
         -- self._stats_scroll_distance = self._stats_scroll_distance + dist

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -123,7 +123,7 @@ function ReaderThumbnail:setupCache()
         local max_bytes = math.ceil(N * Screen:getWidth() * Screen:getHeight() * Blitbuffer.TYPE_TO_BPP[self.bb_type] / 8)
         -- We don't really care about limiting any number of slots, so allow
         -- for at least 5 pages of 10x10 tiles
-        local avg_itemsize = math.ceil(max_bytes / 500)
+        local avg_itemsize = math.ceil(max_bytes * (1/500))
         self.tile_cache = Cache:new{
             size = max_bytes,
             avg_itemsize = avg_itemsize, -- will make slots=500

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -32,7 +32,7 @@ local ReaderView = OverlapGroup:extend{
 
     -- single page state
     state = nil, -- table
-    outer_page_color = Blitbuffer.gray(G_defaults:readSetting("DOUTER_PAGE_COLOR") / 15),
+    outer_page_color = Blitbuffer.gray(G_defaults:readSetting("DOUTER_PAGE_COLOR") * (1/15)),
     -- highlight with "lighten" or "underscore" or "strikeout" or "invert"
     highlight = nil, -- table
     highlight_visible = true,
@@ -42,7 +42,7 @@ local ReaderView = OverlapGroup:extend{
     note_mark_pos_x2 = nil, -- page 2 in two-page mode
     -- PDF/DjVu continuous paging
     page_scroll = nil,
-    page_bgcolor = Blitbuffer.gray(G_defaults:readSetting("DBACKGROUND_COLOR") / 15),
+    page_bgcolor = Blitbuffer.gray(G_defaults:readSetting("DBACKGROUND_COLOR") * (1/15)),
     page_states = nil, -- table
     -- properties of the gap drawn between each page in scroll mode:
     page_gap = nil, -- table
@@ -95,7 +95,7 @@ function ReaderView:init()
     self.page_states = {}
     self.page_gap = {
         -- color (0 = white, 8 = gray, 15 = black)
-        color = Blitbuffer.gray((G_reader_settings:readSetting("page_gap_color") or 8) / 15),
+        color = Blitbuffer.gray((G_reader_settings:readSetting("page_gap_color") or 8) * (1/15)),
     }
     self.visible_area = Geom:new{x = 0, y = 0, w = 0, h = 0}
     self.page_area = Geom:new{x = 0, y = 0, w = 0, h = 0}

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -322,7 +322,7 @@ function Kindle:outofScreenSaver()
                         -- The banner on a 1236x1648 PW5 is 1235x125; we refresh the bottom 10% of the screen to be safe.
                         local Geom = require("ui/geometry")
                         local screen_height = self.screen:getHeight()
-                        local refresh_height = math.ceil(screen_height / 10)
+                        local refresh_height = math.ceil(screen_height * 0.1)
                         local refresh_region = Geom:new{
                             x = 0,
                             y = screen_height - 1 - refresh_height,

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -322,7 +322,7 @@ function Kindle:outofScreenSaver()
                         -- The banner on a 1236x1648 PW5 is 1235x125; we refresh the bottom 10% of the screen to be safe.
                         local Geom = require("ui/geometry")
                         local screen_height = self.screen:getHeight()
-                        local refresh_height = math.ceil(screen_height * 0.1)
+                        local refresh_height = math.ceil(screen_height * (1/10))
                         local refresh_region = Geom:new{
                             x = 0,
                             y = screen_height - 1 - refresh_height,

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -42,7 +42,7 @@ function KoboPowerD:_syncKoboLightOnStart()
                     -- ColorSetting is stored as a color temperature scale in Kelvin,
                     -- from 1500 to 6400
                     -- so normalize this to [0, 100] on our end.
-                    new_warmth = (100 - Math.round((new_color - 1500) / 49))
+                    new_warmth = (100 - Math.round((new_color - 1500) * (1/49)))
                 end
             end
             if is_frontlight_on == nil then
@@ -303,7 +303,7 @@ function KoboPowerD:turnOffFrontlightHW()
     end
     ffiUtil.runInSubProcess(function()
         for i = 1,5 do
-            self:setIntensityHW(math.floor(self.fl_intensity - ((self.fl_intensity / 5) * i)))
+            self:setIntensityHW(math.floor(self.fl_intensity - ((self.fl_intensity * (1/5)) * i)))
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then
@@ -336,7 +336,7 @@ function KoboPowerD:turnOnFrontlightHW()
     end
     ffiUtil.runInSubProcess(function()
         for i = 1,5 do
-            self:setIntensityHW(math.ceil(self.fl_min + ((self.fl_intensity / 5) * i)))
+            self:setIntensityHW(math.ceil(self.fl_min + ((self.fl_intensity * (1/5)) * i)))
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then

--- a/frontend/optmath.lua
+++ b/frontend/optmath.lua
@@ -16,7 +16,7 @@ Rounds a percentage.
 @treturn int rounded percentage
 ]]
 function Math.roundPercent(percent)
-    return math.floor(percent * 1e4) * 1e-4
+    return math.floor(percent * 10000) / 10000
 end
 
 --[[--

--- a/frontend/optmath.lua
+++ b/frontend/optmath.lua
@@ -16,7 +16,7 @@ Rounds a percentage.
 @treturn int rounded percentage
 ]]
 function Math.roundPercent(percent)
-    return math.floor(percent * 10000) / 10000
+    return math.floor(percent * 1e4) * 1e-4
 end
 
 --[[--

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -25,7 +25,7 @@ local function convertSizeTo(px, format)
     local format_factor = 1 -- we are defaulting on mm
 
     if format == "pt" then
-        format_factor =  format_factor * 2660 / 1000 -- see https://www.wikiwand.com/en/Metric_typographic_units
+        format_factor =  format_factor * (2660 / 1000) -- see https://www.wikiwand.com/en/Metric_typographic_units
     elseif format == "in" then
         format_factor = 1 / 25.4
     end

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -46,7 +46,7 @@ table.insert(page_turns_tap_zones_sub_items, {
             value_max = 100,
             default_value = math.floor(G_defaults:readSetting("DTAP_ZONE_FORWARD").w * 100),
             callback = function(spin)
-                G_reader_settings:saveSetting("page_turns_tap_zone_forward_size_ratio", spin.value / 100)
+                G_reader_settings:saveSetting("page_turns_tap_zone_forward_size_ratio", spin.value * 0.01)
                 ReaderUI.instance.view:setupTouchZones()
                 if touchmenu_instance then touchmenu_instance:updateItems() end
             end,

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -46,7 +46,7 @@ table.insert(page_turns_tap_zones_sub_items, {
             value_max = 100,
             default_value = math.floor(G_defaults:readSetting("DTAP_ZONE_FORWARD").w * 100),
             callback = function(spin)
-                G_reader_settings:saveSetting("page_turns_tap_zone_forward_size_ratio", spin.value * 0.01)
+                G_reader_settings:saveSetting("page_turns_tap_zone_forward_size_ratio", spin.value * (1/100))
                 ReaderUI.instance.view:setupTouchZones()
                 if touchmenu_instance then touchmenu_instance:updateItems() end
             end,

--- a/frontend/ui/elements/timeout_android.lua
+++ b/frontend/ui/elements/timeout_android.lua
@@ -22,7 +22,7 @@ local timeout_custom7 = 30 * 60 * 1000
 local function humanReadableTimeout(timeout)
     local sec = timeout / 1000
     if sec >= 60 then
-        return T(N_("1 minute", "%1 minutes", sec), sec / 60)
+        return T(N_("1 minute", "%1 minutes", sec), sec * (1/60))
     else
         return T(N_("1 second", "%1 seconds", sec), sec)
     end

--- a/frontend/ui/elements/timeout_android.lua
+++ b/frontend/ui/elements/timeout_android.lua
@@ -20,7 +20,7 @@ local timeout_custom6 = 25 * 60 * 1000
 local timeout_custom7 = 30 * 60 * 1000
 
 local function humanReadableTimeout(timeout)
-    local sec = timeout / 1000
+    local sec = timeout * (1/1000)
     if sec >= 60 then
         return T(N_("1 minute", "%1 minutes", sec), sec * (1/60))
     else

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -372,7 +372,7 @@ function OTAManager:_buildLocalPackage()
         -- Defaults to a sane-ish value as-of now, in case shit happens...
         local blocks = 6405
         if tarball_size then
-            blocks = tarball_size / (512 * 20)
+            blocks = tarball_size * (1/(512 * 20))
         end
         -- And since we want a percentage, devise the exact value we need for tar to spit out exactly 100 checkpoints ;).
         local cpoints = blocks * (1/100)

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -375,7 +375,7 @@ function OTAManager:_buildLocalPackage()
             blocks = tarball_size / (512 * 20)
         end
         -- And since we want a percentage, devise the exact value we need for tar to spit out exactly 100 checkpoints ;).
-        local cpoints = blocks * 0.01
+        local cpoints = blocks * (1/100)
         return os.execute(string.format(
             "./tar --no-recursion -cf %s -C .. -T %s --checkpoint=%d --checkpoint-action=exec='./fbink -q -y -6 -P $(($TAR_CHECKPOINT/%d))'",
             self.installed_package, self.package_indexfile, cpoints, cpoints))

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -375,7 +375,7 @@ function OTAManager:_buildLocalPackage()
             blocks = tarball_size / (512 * 20)
         end
         -- And since we want a percentage, devise the exact value we need for tar to spit out exactly 100 checkpoints ;).
-        local cpoints = blocks / 100
+        local cpoints = blocks * 0.01
         return os.execute(string.format(
             "./tar --no-recursion -cf %s -C .. -T %s --checkpoint=%d --checkpoint-action=exec='./fbink -q -y -6 -P $(($TAR_CHECKPOINT/%d))'",
             self.installed_package, self.package_indexfile, cpoints, cpoints))

--- a/frontend/ui/time.lua
+++ b/frontend/ui/time.lua
@@ -133,7 +133,7 @@ end
 --- Converts an fts time to a Lua (decimal) number (sec.usecs) (accurate to the ms, rounded to 4 decimal places)
 function time.to_number(time_fts)
     -- Round to 4 decimal places
-    return math.floor(time.to_s(time_fts) * 10000 + 0.5) / 10000
+    return math.floor(time.to_s(time_fts) * 10000 + 0.5) * (1/10000)
 end
 
 --- Converts an fts to a Lua (int) number (resolution: 1µs)

--- a/frontend/ui/time.lua
+++ b/frontend/ui/time.lua
@@ -133,7 +133,7 @@ end
 --- Converts an fts time to a Lua (decimal) number (sec.usecs) (accurate to the ms, rounded to 4 decimal places)
 function time.to_number(time_fts)
     -- Round to 4 decimal places
-    return math.floor(time.to_s(time_fts) * 1e4 + 0.5) * 1e-4
+    return math.floor(time.to_s(time_fts) * 10000 + 0.5) / 10000
 end
 
 --- Converts an fts to a Lua (int) number (resolution: 1µs)

--- a/frontend/ui/time.lua
+++ b/frontend/ui/time.lua
@@ -133,7 +133,7 @@ end
 --- Converts an fts time to a Lua (decimal) number (sec.usecs) (accurate to the ms, rounded to 4 decimal places)
 function time.to_number(time_fts)
     -- Round to 4 decimal places
-    return math.floor(time.to_s(time_fts) * 10000 + 0.5) / 10000
+    return math.floor(time.to_s(time_fts) * 1e4 + 0.5) * 1e-4
 end
 
 --- Converts an fts to a Lua (int) number (resolution: 1µs)

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -398,7 +398,7 @@ function BookMapRow:init()
             local y = self.pages_frame_height + 1
             if self.bookmarked_pages[page] then
                 -- Shift it a bit down to keep bookmark glyph(s) readable
-                y = y + math.floor(self.span_height / 3)
+                y = y + math.floor(self.span_height * (1/3))
             end
             local num = self.previous_locations[page]
             table.insert(self.indicators, {
@@ -415,7 +415,7 @@ function BookMapRow:init()
             local y = self.pages_frame_height + 1
             if self.bookmarked_pages[page] then
                 -- Shift it a bit down to keep bookmark glyph(s) readable
-                y = y + math.floor(self.span_height / 3)
+                y = y + math.floor(self.span_height * (1/3))
             end
             table.insert(self.indicators, {
                 c = self.extra_symbols_pages[page],
@@ -430,7 +430,7 @@ function BookMapRow:init()
             local y = self.pages_frame_height + 1
             if self.bookmarked_pages[page] then
                 -- Shift it a bit down to keep bookmark glyph(s) readable
-                y = y + math.floor(self.span_height / 3)
+                y = y + math.floor(self.span_height * (1/3))
             end
             table.insert(self.indicators, {
                 c = 0x25B2, -- black up-pointing triangle
@@ -1323,7 +1323,7 @@ end
 function BookMapWidget:onSpread(arg, ges)
     local updated = false
     if ges.direction == "horizontal" or ges.direction == "diagonal" then
-        local new_pages_per_row = math.floor(self.pages_per_row / 1.5)
+        local new_pages_per_row = math.floor(self.pages_per_row * (2/3))
         if (self.pages_per_row < self.fit_pages_per_row and new_pages_per_row > self.fit_pages_per_row)
                 or (self.pages_per_row > self.fit_pages_per_row and new_pages_per_row < self.fit_pages_per_row) then
             new_pages_per_row = self.fit_pages_per_row

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -406,8 +406,8 @@ function BookStatusWidget:genStatisticsGroup(width)
 
     local statistics_group = VerticalGroup:new{ align = "left" }
 
-    local tile_width = width / 3
-    local tile_height = height / 2
+    local tile_width = width * (1/3)
+    local tile_height = height * (1/2)
 
     local titles_group = HorizontalGroup:new{
         align = "center",

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -52,7 +52,7 @@ function FrontLightWidget:init()
     self.fl.max = self.powerd.fl_max
     self.fl.cur = self.powerd:frontlightIntensity()
     local fl_steps = self.fl.max - self.fl.min + 1
-    self.fl.stride = math.ceil(fl_steps / 25)
+    self.fl.stride = math.ceil(fl_steps * (1/25))
     self.fl.steps = math.ceil(fl_steps / self.fl.stride)
     if (self.fl.steps - 1) * self.fl.stride < self.fl.max - self.fl.min then
         self.fl.steps = self.fl.steps + 1
@@ -70,7 +70,7 @@ function FrontLightWidget:init()
         self.nl.cur = self.powerd:toNativeWarmth(self.powerd:frontlightWarmth())
 
         local nl_steps = self.nl.max - self.nl.min + 1
-        self.nl.stride = math.ceil(nl_steps / 25)
+        self.nl.stride = math.ceil(nl_steps * (1/25))
         self.nl.steps = math.ceil(nl_steps / self.nl.stride)
         if (self.nl.steps - 1) * self.nl.stride < self.nl.max - self.nl.min then
             self.nl.steps = self.nl.steps + 1
@@ -172,7 +172,7 @@ function FrontLightWidget:layout()
     self.fl_level = TextWidget:new{
         text = tostring(self.fl.cur),
         face = self.medium_font_face,
-        max_width = math.floor(self.screen_width * 0.95 - 1.275 * self.fl_minus.width - 1.275 * self.fl_plus.width),
+        max_width = math.floor(self.screen_width * 0.95 - 1.275 * (self.fl_minus.width + self.fl_plus.width)),
     }
     local fl_level_container = CenterContainer:new{
         dimen = Geom:new{
@@ -215,7 +215,7 @@ function FrontLightWidget:layout()
         end,
     }
     local fl_spacer = HorizontalSpan:new{
-        width = math.floor((self.screen_width * 0.95 - 1.2 * self.fl_minus.width - 1.2 * self.fl_plus.width - 1.2 * fl_toggle.width) / 2),
+        width = math.floor((self.screen_width * 0.95 - 1.2 * (self.fl_minus.width + self.fl_plus.width + fl_toggle.width)) / 2),
     }
     local fl_buttons_above = HorizontalGroup:new{
         align = "center",
@@ -301,7 +301,7 @@ function FrontLightWidget:layout()
         self.nl_level = TextWidget:new{
             text = tostring(self.nl.cur),
             face = self.medium_font_face,
-            max_width = math.floor(self.screen_width * 0.95 - 1.275 * self.nl_minus.width - 1.275 * self.nl_plus.width),
+            max_width = math.floor(self.screen_width * 0.95 - 1.275 * (self.nl_minus.width + self.nl_plus.width)),
         }
         local nl_level_container = CenterContainer:new{
             dimen = Geom:new{
@@ -333,7 +333,7 @@ function FrontLightWidget:layout()
             end,
         }
         local nl_spacer = HorizontalSpan:new{
-            width = math.floor((self.screen_width * 0.95 - 1.2 * self.nl_minus.width - 1.2 * self.nl_plus.width) / 2),
+            width = math.floor((self.screen_width * 0.95 - 1.2 * (self.nl_minus.width + self.nl_plus.width)) / 2),
         }
         local nl_buttons_above = HorizontalGroup:new{
             align = "center",

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -31,7 +31,7 @@ local logger = require("logger")
 
 -- DPI_SCALE can't change without a restart, so let's compute it now
 local function get_dpi_scale()
-    local size_scale = math.min(Screen:getWidth(), Screen:getHeight()) / 600
+    local size_scale = math.min(Screen:getWidth(), Screen:getHeight()) * (1/600)
     local dpi_scale = Screen:scaleByDPI(1)
     return math.max(0, (math.log((size_scale+dpi_scale)/2)/0.69)^2)
 end
@@ -403,7 +403,7 @@ function ImageWidget:getScaleFactorExtrema()
     local memfree, _ = util.calcFreeMem()
 
     local screen_area = Screen:getWidth() * Screen:getHeight()
-    local min_area = math.ceil(screen_area / 10000)
+    local min_area = math.ceil(screen_area * (1/10000))
     local max_area
     if memfree then
         -- If we have access to memory statistics, limit the requested bb size to 25% of the available RAM.

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -879,7 +879,7 @@ function Menu:init()
         bordersize = self.border_size,
         padding = 0,
         margin = 0,
-        radius = self.is_popout and math.floor(self.dimen.w / 20) or 0,
+        radius = self.is_popout and math.floor(self.dimen.w * (1/20)) or 0,
         content
     }
 
@@ -1414,13 +1414,13 @@ end
 function Menu.getItemFontSize(perpage)
     -- Get adjusted font size for the given nb of items per page:
     -- item font size between 14 and 24 for better matching
-    return math.floor(24 - ((perpage - 6) / 18) * 10)
+    return math.floor(24 - ((perpage - 6) * (1/18)) * 10)
 end
 
 function Menu.getItemMandatoryFontSize(perpage)
     -- Get adjusted font size for the given nb of items per page:
     -- "mandatory" font size between 12 and 18 for better matching
-    return math.floor(18 - (perpage - 6) / 3)
+    return math.floor(18 - (perpage - 6) * (1/3))
 end
 
 function Menu.getMenuText(item)

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -56,7 +56,7 @@ function SkimToWidget:init()
     local button_span_unit_width = Size.span.horizontal_small
     local larger_span_units = 3 -- 3 x small span width
     local nb_span_units = 2 + 2*larger_span_units
-    local button_width = math.floor( (inner_width - nb_span_units * button_span_unit_width) / 5)
+    local button_width = math.floor( (inner_width - nb_span_units * button_span_unit_width) * (1/5))
     local button_inner_width = button_width - 2 * (Size.border.button + Size.padding.button)
     -- Update inner_width (possibly smaller because of math.floor())
     inner_width = button_width * 5 + nb_span_units * button_span_unit_width

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -156,8 +156,8 @@ function SortWidget:init()
     local padding = Size.padding.large
     self.width_widget = self.dimen.w - 2 * padding
     self.item_width = self.dimen.w - 2 * padding
-    self.footer_center_width = math.floor(self.width_widget * 22 / 100)
-    self.footer_button_width = math.floor(self.width_widget * 12 / 100)
+    self.footer_center_width = math.floor(self.width_widget * (22/100))
+    self.footer_button_width = math.floor(self.width_widget * (12/100))
     self.item_height = Size.item.height_big
     -- group for footer
     local chevron_left = "chevron.left"

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -133,12 +133,12 @@ function util.secondsToClock(seconds, withoutSeconds, withDays)
         local days = "0"
         local hours
         if withDays then
-            days = string.format("%d", seconds / (24*3600)) -- implicit math.floor for string.format
-            hours = string.format("%02d", (seconds / 3600) % 24)
+            days = string.format("%d", seconds * (1/(24*3600))) -- implicit math.floor for string.format
+            hours = string.format("%02d", (seconds * (1/3600)) % 24)
         else
-            hours = string.format("%02d", seconds / 3600)
+            hours = string.format("%02d", seconds * (1/3600))
         end
-        local mins = string.format("%02d", round(seconds % 3600 / 60))
+        local mins = string.format("%02d", round(seconds % 3600 * (1/60)))
         if withoutSeconds then
             if mins == "60" then
                 -- Can only happen because of rounding, which only happens if withoutSeconds...

--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -295,7 +295,7 @@ function AutoDim:autodim_task()
     local check_delay = time.s(self.autodim_starttime_m * 60) - idle_duration
     if check_delay <= 0 then
         self.autodim_save_fl = self.autodim_save_fl or Powerd:frontlightIntensity()
-        self.autodim_end_fl = math.floor(self.autodim_save_fl * self.autodim_fraction / 100 + 0.5)
+        self.autodim_end_fl = math.floor(self.autodim_save_fl * self.autodim_fraction * (1/100) + 0.5)
         -- Clamp `self.autodim_end_fl` to 1 if `self.autodim_fraction` ~= 0
         if self.autodim_fraction ~= 0 and self.autodim_end_fl == 0 then
             self.autodim_end_fl = 1

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -378,19 +378,19 @@ function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
     local day, hour, minute, second
     local day_max, hour_max, min_max, sec_max
     if time_scale == 2 then
-        day = math.floor(setting_val / (24*3600))
-        hour = math.floor(setting_val / 3600) % 24
-        day_max = math.floor(range[2] / (24*3600)) - 1
+        day = math.floor(setting_val * (1/(24*3600)))
+        hour = math.floor(setting_val * (1/3600)) % 24
+        day_max = math.floor(range[2] * (1/(24*3600))) - 1
         hour_max = 23
     elseif time_scale == 1 then
-        hour = math.floor(setting_val / 3600)
-        minute = math.floor(setting_val / 60) % 60
-        hour_max = math.floor(range[2] / 3600) - 1
+        hour = math.floor(setting_val * (1/3600))
+        minute = math.floor(setting_val * (1/60)) % 60
+        hour_max = math.floor(range[2] * (1/3600)) - 1
         min_max = 59
     else
-        minute = math.floor(setting_val / 60)
+        minute = math.floor(setting_val * (1/60))
         second = math.floor(setting_val) % 60
-        min_max =  math.floor(range[2] / 60) - 1
+        min_max =  math.floor(range[2] * (1/60)) - 1
         sec_max = 59
     end
 
@@ -439,13 +439,13 @@ function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
         default_callback = function()
             local day, hour, min, sec -- luacheck: ignore 431
             if time_scale == 2 then
-                day = math.floor(default_value / (24*3600))
-                hour = math.floor(default_value / 3600) % 24
+                day = math.floor(default_value * (1/(24*3600)))
+                hour = math.floor(default_value * (1/3600)) % 24
             elseif time_scale == 1 then
-                hour = math.floor(default_value / 3600)
-                min = math.floor(default_value / 60) % 60
+                hour = math.floor(default_value * (1/3600))
+                min = math.floor(default_value * (1/60)) % 60
             else
-                min = math.floor(default_value / 60)
+                min = math.floor(default_value * (1/60))
                 sec = math.floor(default_value % 60)
             end
             time_spinner:update(nil, nil, day, hour, min, sec) -- It is ok to pass nils here.

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -148,7 +148,7 @@ function AutoTurn:addToMainMenu(menu_items)
         callback = function(menu)
             local DateTimeWidget = require("ui/widget/datetimewidget")
             local autoturn_seconds = G_reader_settings:readSetting("autoturn_timeout_seconds", 30)
-            local autoturn_minutes = math.floor(autoturn_seconds / 60)
+            local autoturn_minutes = math.floor(autoturn_seconds * (1/60))
             autoturn_seconds = autoturn_seconds % 60
             local autoturn_spin = DateTimeWidget:new {
                 title_text = _("Autoturn time"),

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -37,7 +37,7 @@ local activate_closer_midnight = 4
 local midnight_index = 11
 
 local device_max_warmth = Device:hasNaturalLight() and Powerd.fl_warmth_max or 100
-local device_warmth_fit_scale = device_max_warmth / 100
+local device_warmth_fit_scale = device_max_warmth * (1/100)
 
 local function frac(x)
     return x - math.floor(x)
@@ -54,7 +54,7 @@ local AutoWarmth = WidgetContainer:extend{
 function AutoWarmth:getTimezoneOffset()
     local utcdate   = os.date("!*t")
     local localdate = os.date("*t")
-    return os.difftime(os.time(localdate), os.time(utcdate))/3600
+    return os.difftime(os.time(localdate), os.time(utcdate)) * (1/3600)
 end
 
 function AutoWarmth:init()
@@ -704,7 +704,7 @@ function AutoWarmth:getScheduleMenu()
                     min = mm,
                     ok_text = _("Set time"),
                     callback = function(time)
-                        local new_time = time.hour + time.min / 60
+                        local new_time = time.hour + time.min * (1/60)
                         local function get_valid_time(n, dir)
                             for i = n+dir, dir > 0 and midnight_index or 1, dir do
                                 if self.scheduler_times[i] then

--- a/plugins/autowarmth.koplugin/suntime.lua
+++ b/plugins/autowarmth.koplugin/suntime.lua
@@ -593,7 +593,7 @@ function SunTime:getTimeInSec(val)
     else
         val = val*3600
     end
-    return math.floor(val * 1000 ) / 1000
+    return math.floor(val * 1e4 ) * 1e-4
 end
 
 return SunTime

--- a/plugins/autowarmth.koplugin/suntime.lua
+++ b/plugins/autowarmth.koplugin/suntime.lua
@@ -593,7 +593,7 @@ function SunTime:getTimeInSec(val)
     else
         val = val*3600
     end
-    return math.floor(val * 1e4 ) * 1e-4
+    return math.floor(val * 1000) * (1/1000)
 end
 
 return SunTime

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -47,7 +47,7 @@ local BookInfoManager = require("bookinfomanager")
 local corner_mark_size = -1
 local corner_mark
 
-local scale_by_size = Screen:scaleBySize(1000000) / 1000000
+local scale_by_size = Screen:scaleBySize(1e6) * 1e-6
 
 -- ItemShortCutIcon (for keyboard navigation) is private to menu.lua and can't be accessed,
 -- so we need to redefine it
@@ -191,7 +191,7 @@ function ListMenuItem:update()
     local function _fontSize(nominal, max)
         -- The nominal font size is based on 64px ListMenuItem height.
         -- Keep ratio of font size to item height
-        local font_size = math.floor(nominal * dimen.h / 64 / scale_by_size)
+        local font_size = math.floor(nominal * dimen.h * (1/64) / scale_by_size)
         -- But limit it to the provided max, to avoid huge font size when
         -- only 4-6 items per page
         if max and font_size >= max then
@@ -201,7 +201,7 @@ function ListMenuItem:update()
     end
     -- Will speed up a bit if we don't do all font sizes when
     -- looking for one that make text fit
-    local fontsize_dec_step = math.ceil(_fontSize(100) / 100)
+    local fontsize_dec_step = math.ceil(_fontSize(100) * (1/100))
 
     -- We'll draw a border around cover images, it may not be
     -- needed with some covers, but it's nicer when cover is
@@ -476,7 +476,7 @@ function ListMenuItem:update()
             }
 
             -- Create or replace corner_mark if needed
-            local mark_size = math.floor(dimen.h / 6)
+            local mark_size = math.floor(dimen.h * (1/6))
             -- Just fits under the page info text, which in turn adapts to the ListMenuItem height.
             if mark_size ~= corner_mark_size then
                 corner_mark_size = mark_size

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -47,7 +47,7 @@ local BookInfoManager = require("bookinfomanager")
 local corner_mark_size = -1
 local corner_mark
 
-local scale_by_size = Screen:scaleBySize(1e6) * 1e-6
+local scale_by_size = Screen:scaleBySize(1000000) * (1/1000000)
 
 -- ItemShortCutIcon (for keyboard navigation) is private to menu.lua and can't be accessed,
 -- so we need to redefine it

--- a/plugins/perceptionexpander.koplugin/main.lua
+++ b/plugins/perceptionexpander.koplugin/main.lua
@@ -220,7 +220,7 @@ function PerceptionExpander:saveSettings(fields)
 
         local line_intensity = fields[3] ~= "" and tonumber(fields[3]) or self.line_color_intensity * 10
         if line_intensity then
-            self.line_color_intensity = line_intensity / 10
+            self.line_color_intensity = line_intensity * (1/10)
         end
         self.shift_each_pages = fields[4] ~= "" and tonumber(fields[4]) or self.shift_each_pages
     end

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -45,8 +45,8 @@ end
 function ReadTimer:remainingTime()
     if self:scheduled() then
         local remainder = self:remaining()
-        local hours = math.floor(remainder / 3600)
-        local minutes = math.floor(remainder % 3600 / 60)
+        local hours = math.floor(remainder * (1/3600))
+        local minutes = math.floor(remainder % 3600 * (1/60))
         local seconds = math.floor(remainder % 60)
         return hours, minutes, seconds
     end

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -125,7 +125,7 @@ function CalendarDay:init()
     local inner_h = self.height - 2*self.border
     if self.show_histo then
         if not self.histo_height then
-            self.histo_height = inner_h / 3
+            self.histo_height = inner_h * (1/3)
         end
         self.histo_w = BottomContainer:new{
             dimen = Geom:new{w = inner_w, h = inner_h},
@@ -419,9 +419,9 @@ function CalendarView:init()
     self.inner_padding = Size.padding.small
 
     -- 7 days in a week
-    self.day_width = math.floor((self.dimen.w - 2*self.outer_padding - 6*self.inner_padding) / 7)
+    self.day_width = math.floor((self.dimen.w - 2*self.outer_padding - 6*self.inner_padding) * (1/7))
     -- Put back the possible 7px lost in rounding into outer_padding
-    self.outer_padding = math.floor((self.dimen.w - 7*self.day_width - 6*self.inner_padding) / 2)
+    self.outer_padding = math.floor((self.dimen.w - 7*self.day_width - 6*self.inner_padding) * (1/2))
 
     self.content_width = self.dimen.w - 2*self.outer_padding
 
@@ -557,7 +557,7 @@ function CalendarView:init()
     -- At most 6 weeks in a month
     local available_height = self.dimen.h - self.title_bar:getHeight()
                             - self.page_info:getSize().h - self.day_names:getSize().h
-    self.week_height = math.floor((available_height - 7*self.inner_padding) / 6)
+    self.week_height = math.floor((available_height - 7*self.inner_padding) * (1/6))
     self.day_border = Size.border.default
     if self.show_hourly_histogram then
         -- day num + nb_book_spans + histogram: ceil() as histogram rarely

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -128,7 +128,7 @@ function ReaderProgress:genSingleHeader(title)
     local padding_span = HorizontalSpan:new{ width = self.padding }
     local line_width = (self.screen_width - header_title:getSize().w) / 2 - self.padding * 2
     local line_container = LeftContainer:new{
-        dimen = Geom:new{ w = line_width, h = self.screen_height / 25 },
+        dimen = Geom:new{ w = line_width, h = self.screen_height * (1/25) },
         LineWidget:new{
             background = BG_COLOR,
             dimen = Geom:new{
@@ -139,7 +139,7 @@ function ReaderProgress:genSingleHeader(title)
     }
 
     return VerticalGroup:new{
-        VerticalSpan:new{ width = Screen:scaleBySize(self.header_span), height = self.screen_height / 25 },
+        VerticalSpan:new{ width = Screen:scaleBySize(self.header_span), height = self.screen_height * (1/25) },
         HorizontalGroup:new{
             align = "center",
             padding_span,
@@ -150,7 +150,7 @@ function ReaderProgress:genSingleHeader(title)
             line_container,
             padding_span,
         },
-        VerticalSpan:new{ width = Size.span.vertical_large, height = self.screen_height / 25 },
+        VerticalSpan:new{ width = Size.span.vertical_large, height = self.screen_height * (1/25) },
     }
 end
 
@@ -168,7 +168,7 @@ function ReaderProgress:genDoubleHeader(title_left, title_right)
     local padding_span = HorizontalSpan:new{ width = self.padding }
     local line_width = (self.screen_width - header_title_left:getSize().w - header_title_right:getSize().w - self.padding * 7) / 4
     local line_container = LeftContainer:new{
-        dimen = Geom:new{ w = line_width, h = self.screen_height / 25 },
+        dimen = Geom:new{ w = line_width, h = self.screen_height * (1/25) },
         LineWidget:new{
             background = BG_COLOR,
             dimen = Geom:new{
@@ -179,7 +179,7 @@ function ReaderProgress:genDoubleHeader(title_left, title_right)
     }
 
     return VerticalGroup:new{
-        VerticalSpan:new{ width = Screen:scaleBySize(25), height = self.screen_height / 25 },
+        VerticalSpan:new{ width = Screen:scaleBySize(25), height = self.screen_height * (1/25) },
         HorizontalGroup:new{
             align = "center",
             padding_span,
@@ -196,7 +196,7 @@ function ReaderProgress:genDoubleHeader(title_left, title_right)
             line_container,
             padding_span,
         },
-        VerticalSpan:new{ width = Size.span.vertical_large, height = self.screen_height / 25 },
+        VerticalSpan:new{ width = Size.span.vertical_large, height = self.screen_height * (1/25) },
     }
 end
 
@@ -251,7 +251,7 @@ function ReaderProgress:genWeekStats(stats_day)
             align = "center",
             padding = Size.padding.small,
             LeftContainer:new{
-                dimen = Geom:new{ w = self.screen_width , h = height / 3 },
+                dimen = Geom:new{ w = self.screen_width , h = height * (1/3) },
                 TextWidget:new{
                     padding = Size.padding.small,
                     text = date_format_show .. " - " .. util.secondsToClockDuration(user_duration_format, select_day_time, true),
@@ -262,7 +262,7 @@ function ReaderProgress:genWeekStats(stats_day)
         local titles_group = HorizontalGroup:new{
             align = "center",
             LeftContainer:new{
-                dimen = Geom:new{ w = self.screen_width , h = height / 3 },
+                dimen = Geom:new{ w = self.screen_width , h = height * (1/3) },
                 ProgressWidget:new{
                     width = math.floor((self.screen_width * 0.005) + (self.screen_width * 0.9 * select_day_time / max_week_time)),
                     height = Screen:scaleBySize(14),
@@ -291,8 +291,8 @@ function ReaderProgress:genSummaryDay(width)
         dimen = Geom:new{ w = width, h = height },
     }
     local statistics_group = VerticalGroup:new{ align = "left" }
-    local tile_width = width / 4
-    local tile_height = height / 3
+    local tile_width = width * (1/4)
+    local tile_height = height * (1/3)
     local user_duration_format = G_reader_settings:readSetting("duration_format")
 
     local titles_group = HorizontalGroup:new{
@@ -386,8 +386,8 @@ function ReaderProgress:genSummaryWeek(width)
         dimen = Geom:new{ w = width, h = height },
     }
     local statistics_group = VerticalGroup:new{ align = "left" }
-    local tile_width = width / 4
-    local tile_height = height / 3
+    local tile_width = width * (1/4)
+    local tile_height = height * (1/3)
     local user_duration_format = G_reader_settings:readSetting("duration_format")
     local total_group = HorizontalGroup:new{
         align = "center",
@@ -457,14 +457,14 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = tostring(math.floor(total_pages / 7)),
+                text = tostring(math.floor(total_pages * (1/7))),
                 face = self.medium_font_face,
             }
         },
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = util.secondsToClockDuration(user_duration_format, math.floor(total_time) / 7, true),
+                text = util.secondsToClockDuration(user_duration_format, math.floor(total_time) * (1/7), true),
                 face = self.medium_font_face,
             }
         }

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -160,10 +160,10 @@ function SystemStat:appendSystemInfo()
         self:put({_("System information"), ""})
         -- @translators Ticks is a highly technical term. See https://superuser.com/a/101202 The correct translation is likely to simply be "ticks".
         self:put({_("  Total ticks (million)"),
-                 string.format("%.2f", stat.cpu.total * (1/1e6))})
+                 string.format("%.2f", stat.cpu.total * (1/1000000))})
         -- @translators Ticks is a highly technical term. See https://superuser.com/a/101202 The correct translation is likely to simply be "ticks".
         self:put({_("  Idle ticks (million)"),
-                 string.format("%.2f", stat.cpu.idle * (1/1e6))})
+                 string.format("%.2f", stat.cpu.idle * (1/1000000))})
         self:put({_("  Processor usage %"),
                  string.format("%.2f", (1 - stat.cpu.idle / stat.cpu.total) * 100)})
     end
@@ -209,7 +209,7 @@ function SystemStat:appendProcessInfo()
             self:put({_("  Processor usage %"),
                      string.format("%.2f", n1 / sys_stat.cpu.total * 100)})
         else
-            self:put({_("  Processor usage ticks (million)"), n1 * (1/1e6)})
+            self:put({_("  Processor usage ticks (million)"), n1 * (1/1000000)})
         end
     end
 

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -160,10 +160,10 @@ function SystemStat:appendSystemInfo()
         self:put({_("System information"), ""})
         -- @translators Ticks is a highly technical term. See https://superuser.com/a/101202 The correct translation is likely to simply be "ticks".
         self:put({_("  Total ticks (million)"),
-                 string.format("%.2f", stat.cpu.total / 1000000)})
+                 string.format("%.2f", stat.cpu.total * (1/1e6))})
         -- @translators Ticks is a highly technical term. See https://superuser.com/a/101202 The correct translation is likely to simply be "ticks".
         self:put({_("  Idle ticks (million)"),
-                 string.format("%.2f", stat.cpu.idle / 1000000)})
+                 string.format("%.2f", stat.cpu.idle * (1/1e6))})
         self:put({_("  Processor usage %"),
                  string.format("%.2f", (1 - stat.cpu.idle / stat.cpu.total) * 100)})
     end
@@ -209,7 +209,7 @@ function SystemStat:appendProcessInfo()
             self:put({_("  Processor usage %"),
                      string.format("%.2f", n1 / sys_stat.cpu.total * 100)})
         else
-            self:put({_("  Processor usage ticks (million)"), n1 / 1000000})
+            self:put({_("  Processor usage ticks (million)"), n1 * (1/1e6)})
         end
     end
 

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1026,8 +1026,8 @@ function VocabularyBuilderWidget:init()
     local padding = Size.padding.large
     self.width_widget = self.dimen.w - 2 * padding
     self.item_width = self.dimen.w - 2 * padding
-    self.footer_center_width = math.floor(self.width_widget * 32 / 100)
-    self.footer_button_width = math.floor(self.width_widget * 12 / 100)
+    self.footer_center_width = math.floor(self.width_widget * (32/100))
+    self.footer_button_width = math.floor(self.width_widget * (12/100))
     -- group for footer
     local chevron_left = "chevron.left"
     local chevron_right = "chevron.right"

--- a/spec/unit/time_spec.lua
+++ b/spec/unit/time_spec.lua
@@ -71,12 +71,12 @@ describe("Time module", function()
         assert.is.same(time.s(-6) + time.us(999000), time.s(-5.001))
 
         local tv = time.s(-6) + time.us(1000)
-        assert.is.same(-5.999, time.to_number(tv))
+        assert.is.is_true(math.abs(-5.999 - time.to_number(tv)) < 1e-9) -- we only have nano second precision
         assert.is.same(time.s(-6) + time.us(1000), time.s(-5.999))
 
         -- We lose precision because of rounding if we go higher resolution than a ms...
         tv = time.s(-6) + time.us(101)
-        assert.is.same(-5.9999, time.to_number(tv))
+        assert.is.is_true(math.abs(-5.9999 - time.to_number(tv)) < 1e-9) -- ns precision
         assert.is.same(time.s(-6) + time.us(100), time.s(-5.9999))
         --                                 ^ precision loss
 


### PR DESCRIPTION
This PR is a minimal optimization. See https://luapower.com/luajit-notes#luajit-assumptions

When `c` is a constant `x/c` is slower than `x * (1/c)` (if c is not a power of two).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9609)
<!-- Reviewable:end -->
