### PR TITLE
A couple of fixes

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -62,7 +62,6 @@ end
 
 local ReaderDictionary = WidgetContainer:extend{
     data_dir = nil,
-    dict_window_list = nil, -- array
     lookup_msg = _("Searching dictionary for:\n%1"),
 }
 
@@ -100,7 +99,6 @@ local function getDictionaryFixHtmlFunc(path)
 end
 
 function ReaderDictionary:init()
-    self.dict_window_list = {}
     self.disable_lookup_history = G_reader_settings:isTrue("disable_lookup_history")
     self.dicts_order = G_reader_settings:readSetting("dicts_order", {})
     self.dicts_disabled = G_reader_settings:readSetting("dicts_disabled", {})
@@ -967,9 +965,8 @@ end
 
 function ReaderDictionary:showDict(word, results, boxes, link, tweak_buttons_func)
     if results and results[1] then
-        logger.dbg("showing quick lookup window", #self.dict_window_list+1, ":", word, results)
+        logger.dbg("showing quick lookup window", #DictQuickLookup.window_list+1, ":", word, results)
         self.dict_window = DictQuickLookup:new{
-            window_list = self.dict_window_list,
             ui = self.ui,
             highlight = self.highlight,
             tweak_buttons_func = tweak_buttons_func,
@@ -993,7 +990,6 @@ function ReaderDictionary:showDict(word, results, boxes, link, tweak_buttons_fun
                 self:onHtmlDictionaryLinkTapped(dictionary, html_link)
             end,
         }
-        table.insert(self.dict_window_list, self.dict_window)
         if self.lookup_progress_msg then
             -- If we have a lookup InfoMessage that ended up being displayed, make
             -- it *not* refresh on close if it is hidden by our DictQuickLookup

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -2,6 +2,7 @@ local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
+local DictQuickLookup = require("ui/widget/dictquicklookup")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local KeyValuePage = require("ui/widget/keyvaluepage")
@@ -553,11 +554,11 @@ function ReaderWikipedia:getWikiLanguages(first_lang)
         end
     end
     local update_wiki_languages_on_close = false
-    if self.dict_window_list.rotated_update_wiki_languages_on_close ~= nil then
+    if DictQuickLookup.rotated_update_wiki_languages_on_close ~= nil then
         -- Flag set by DictQuickLookup when rotating, forwarding the flag
         -- of the rotated out DictQuickLookup instance: trust it
-        update_wiki_languages_on_close = self.dict_window_list.rotated_update_wiki_languages_on_close
-        self.dict_window_list.rotated_update_wiki_languages_on_close = nil
+        update_wiki_languages_on_close = DictQuickLookup.rotated_update_wiki_languages_on_close
+        DictQuickLookup.rotated_update_wiki_languages_on_close = nil
     else
         -- Not a rotation. Only if it's the first request with the current
         -- first language, we will have it (and any lang rotation from it)
@@ -567,8 +568,8 @@ function ReaderWikipedia:getWikiLanguages(first_lang)
         -- from them) won't update it.
         if is_first_lang then
             update_wiki_languages_on_close = true
-            for i=1, #self.dict_window_list-1 do -- (ignore the last one, which is the one calling this)
-                if self.dict_window_list[i].is_wiki then
+            for i = #DictQuickLookup.window_list-1, 1, -1 do -- (ignore the last one, which is the one calling this)
+                if DictQuickLookup.window_list[i].is_wiki then
                     -- Another upper Wikipedia result: only this one may update it
                     update_wiki_languages_on_close = false
                     break

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -55,6 +55,11 @@ local DictQuickLookup = InputContainer:extend{
     -- refresh_callback will be called before we trigger full refresh in onSwipe
     refresh_callback = nil,
     html_dictionary_link_tapped_callback = nil,
+
+    -- Static class member, holds a ref to the currently opened widgets (in instantiation order).
+    window_list = {},
+    -- Static class member, used by ReaderWiktionary to communicate state from a closed widget to the next opened one.
+    rotated_update_wiki_languages_on_close = nil,
 }
 
 local highlight_strings = {
@@ -384,6 +389,9 @@ function DictQuickLookup:init()
                     callback = function()
                         self:onClose()
                     end,
+                    hold_callback = function()
+                        self:onHoldClose()
+                    end,
                 },
             },
         }
@@ -471,7 +479,7 @@ function DictQuickLookup:init()
                         if self.is_wiki then
                             -- We're rotating: forward this flag from the one we're closing so
                             -- that ReaderWikipedia can give it to the one we'll be showing
-                            self.window_list.rotated_update_wiki_languages_on_close = self.update_wiki_languages_on_close
+                            DictQuickLookup.rotated_update_wiki_languages_on_close = self.update_wiki_languages_on_close
                             self:lookupWikipedia(false, nil, nil, self.wiki_languages[2])
                             self:onClose(true)
                         else
@@ -485,6 +493,9 @@ function DictQuickLookup:init()
                     text = _("Close"),
                     callback = function()
                         self:onClose()
+                    end,
+                    hold_callback = function()
+                        self:onHoldClose()
                     end,
                 },
             },
@@ -698,6 +709,10 @@ function DictQuickLookup:init()
         dimen = self.region,
         self.movable,
     }
+
+    -- We're a new window
+    table.insert(DictQuickLookup.window_list, self)
+
     UIManager:setDirty(self, function()
         return "partial", self.dict_frame.dimen
     end)
@@ -900,6 +915,15 @@ function DictQuickLookup:onCloseWidget()
         end
     end
 
+    -- Drop our ref from the static class member
+    for i = #DictQuickLookup.window_list, 1, -1 do
+        local window = DictQuickLookup.window_list[i]
+        -- We should only find a single match, but, better safe than sorry...
+        if window == self then
+            table.remove(DictQuickLookup.window_list, i)
+        end
+    end
+
     -- NOTE: Drop region to make it a full-screen flash
     UIManager:setDirty(nil, function()
         return "flashui", nil
@@ -1095,12 +1119,7 @@ end
 
 function DictQuickLookup:onClose(no_clear)
     UIManager:close(self)
-    for i = #self.window_list, 1, -1 do
-        local window = self.window_list[i]
-        if window == self then
-            table.remove(self.window_list, i)
-        end
-    end
+
     if self.update_wiki_languages_on_close then
         -- except if we got no result for current language
         if not self.results.no_result then
@@ -1119,8 +1138,10 @@ function DictQuickLookup:onClose(no_clear)
 end
 
 function DictQuickLookup:onHoldClose(no_clear)
-    while #self.window_list > 0 do
-        self.window_list[#self.window_list]:onClose(no_clear)
+    -- Pop the windows FILO
+    for i = #DictQuickLookup.window_list, 1, -1 do
+        local window = DictQuickLookup.window_list[i]
+        window:onClose(no_clear)
     end
     return true
 end
@@ -1271,8 +1292,8 @@ function DictQuickLookup:lookupWikipedia(get_fullpage, word, is_sane, lang)
     if not lang then
         -- Use the lang of the current or nearest is_wiki DictQuickLookup.
         -- Otherwise, first lang in ReaderWikipedia.wiki_languages will be used.
-        for i = #self.window_list, 1, -1 do
-            local window = self.window_list[i]
+        for i = #DictQuickLookup.window_list, 1, -1 do
+            local window = DictQuickLookup.window_list[i]
             if window.is_wiki and window.lang then
                 lang = window.lang
                 break


### PR DESCRIPTION
* Fix a DictQuickLookup regression since #9586 that broke Wikipedia and a few DictQuickLookup features, like mass-closing.
* ScreenSaver: Never inhibit the power event messages, except when explicitly requested. (Having a custom message set would prevent them to shwo up).
* ScreenSaver: Make the overlay message behave better when attached to a top message (i.e., position it below instead of over).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9612)
<!-- Reviewable:end -->
