### PR TITLE
UIManager: Fix handling of toast widgets in sendEvent

### DIFF
--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -157,11 +157,12 @@ function Notification:notify(arg, refresh_after)
     return false
 end
 
-function Notification:_cleanShownStack(idx)
+function Notification:_cleanShownStack()
     -- Clean stack of shown notifications
-    if idx then
+    if self._shown_idx then
+        -- If this field exists, this is the first time this instance was closed since its init.
         -- This notification is no longer displayed
-        Notification._shown_list[idx] = false
+        Notification._shown_list[self._shown_idx] = false
     end
     -- We remove from the stack's tail all slots no longer displayed.
     -- Even if slots at top are available, we'll keep adding new
@@ -179,7 +180,7 @@ function Notification:_cleanShownStack(idx)
 end
 
 function Notification:onCloseWidget()
-    self:_cleanShownStack(self._shown_idx)
+    self:_cleanShownStack()
     self._shown_idx = nil -- Don't do something stupid if this same instance gets closed multiple times
     UIManager:setDirty(nil, function()
         return "ui", self.frame.dimen

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -208,4 +208,27 @@ function Notification:onTapClose()
     return true
 end
 
+-- Toasts should go bye-bye on user input, without stopping the event's propagation.
+function Notification:onKeyPress(key)
+    if self.toast then
+        UIManager:close(self)
+        return false
+    end
+    return InputContainer.onKeyPress(self, key)
+end
+function Notification:onKeyRepeat(key)
+    if self.toast then
+        UIManager:close(self)
+        return false
+    end
+    return InputContainer.onKeyRepeat(self, key)
+end
+function Notification:onGesture(ev)
+    if self.toast then
+        UIManager:close(self)
+        return false
+    end
+    return InputContainer.onGesture(self, ev)
+end
+
 return Notification

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -47,7 +47,8 @@ local Notification = InputContainer:extend{
     timeout = 2, -- default to 2 seconds
     toast = true, -- closed on any event, and let the event propagate to next top widget
 
-    _nums_shown = {}, -- actual static class member, array of stacked notifications
+    _shown_list = {}, -- actual static class member, array of stacked notifications (value is show time or false).
+    _shown_idx = nil, -- index of this instance in the class's _shown_list array (assumes each Notification object is only shown once).
 
     SOURCE_BOTTOM_MENU_ICON = SOURCE_BOTTOM_MENU_ICON,
     SOURCE_BOTTOM_MENU_TOGGLE = SOURCE_BOTTOM_MENU_TOGGLE,
@@ -110,8 +111,8 @@ function Notification:init()
     local notif_height = self.frame:getSize().h
 
     self:_cleanShownStack()
-    table.insert(Notification._nums_shown, UIManager:getTime())
-    self.num = #Notification._nums_shown
+    table.insert(Notification._shown_list, UIManager:getTime())
+    self._shown_idx = #Notification._shown_list
 
     self[1] = VerticalGroup:new{
         align = "center",
@@ -156,30 +157,30 @@ function Notification:notify(arg, refresh_after)
     return false
 end
 
-function Notification:_cleanShownStack(num)
+function Notification:_cleanShownStack(idx)
     -- Clean stack of shown notifications
-    if num then
+    if idx then
         -- This notification is no longer displayed
-        Notification._nums_shown[num] = false
+        Notification._shown_list[idx] = false
     end
-    -- We remove from the stack tail all slots no longer displayed.
+    -- We remove from the stack's tail all slots no longer displayed.
     -- Even if slots at top are available, we'll keep adding new
     -- notifications only at the tail/bottom (easier for the eyes
     -- to follow what is happening).
     -- As a sanity check, we also forget those shown for
     -- more than 30s in case no close event was received.
     local expire_time = UIManager:getTime() - time.s(30)
-    for i=#Notification._nums_shown, 1, -1 do
-        if Notification._nums_shown[i] and Notification._nums_shown[i] > expire_time then
+    for i = #Notification._shown_list, 1, -1 do
+        if Notification._shown_list[i] and Notification._shown_list[i] > expire_time then
             break -- still shown (or not yet expired)
         end
-        table.remove(Notification._nums_shown, i)
+        table.remove(Notification._shown_list, i)
     end
 end
 
 function Notification:onCloseWidget()
-    self:_cleanShownStack(self.num)
-    self.num = nil -- avoid mess in case onCloseWidget is called multiple times
+    self:_cleanShownStack(self._shown_idx)
+    self._shown_idx = nil -- Don't do something stupid if this same instance gets closed multiple times
     UIManager:setDirty(nil, function()
         return "ui", self.frame.dimen
     end)

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -47,8 +47,8 @@ local Notification = InputContainer:extend{
     timeout = 2, -- default to 2 seconds
     toast = true, -- closed on any event, and let the event propagate to next top widget
 
-    _shown_list = {}, -- actual static class member, array of stacked notifications (value is show time or false).
-    _shown_idx = nil, -- index of this instance in the class's _shown_list array (assumes each Notification object is only shown once).
+    _shown_list = {}, -- actual static class member, array of stacked notifications (value is show (well, init) time or false).
+    _shown_idx = nil, -- index of this instance in the class's _shown_list array (assumes each Notification object is only shown (well, init) once).
 
     SOURCE_BOTTOM_MENU_ICON = SOURCE_BOTTOM_MENU_ICON,
     SOURCE_BOTTOM_MENU_TOGGLE = SOURCE_BOTTOM_MENU_TOGGLE,

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -15,9 +15,10 @@ local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
-local Input = Device.input
 local time = require("ui/time")
+local _ = require("gettext")
 local Screen = Device.screen
+local Input = Device.input
 
 local band = bit.band
 
@@ -41,7 +42,7 @@ local SOURCE_ALL = SOURCE_BOTTOM_MENU + SOURCE_DISPATCHER + SOURCE_OTHER
 
 local Notification = InputContainer:extend{
     face = Font:getFace("x_smallinfofont"),
-    text = "Null Message",
+    text = _("N/A"),
     margin = Size.margin.default,
     padding = Size.padding.default,
     timeout = 2, -- default to 2 seconds


### PR DESCRIPTION
The ultimate goal is for toast widgets (i.e., Notification when flagged as such) to:
  * Not stop event propagation
  * Close themselves when the event was emitted by user input.

Instead of doing event filtering in UIManager, we simply overload the onGesture & onKey* handlers in Notification to do just that, and just make sure UIManager will *send* those events to toasts, but without affecting the usual semantics of top widget selection and event propagation (which is as simple as just calling handleEvent on them unchecked ;p).

Thanks to @poire-z for the brainstorming in https://github.com/koreader/koreader/issues/9594 ;).

This also happens to fix a bug in which we might have looped on the top widget twice, because of an array vs. hash mishap ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9617)
<!-- Reviewable:end -->
