### PR TITLE
ReaderStatus: save status summary

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -257,6 +257,7 @@ function ReaderStatus:onMarkBook(mark_read)
     else
         self.settings.data.summary = {status = "complete"}
     end
+    -- If History is called over Reader, it will read the file to get the book status, so save and flush
     self.settings:saveSetting("summary", self.settings.data.summary)
     self.settings:flush()
 end

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -19,7 +19,6 @@ local ReaderStatus = WidgetContainer:extend{
 function ReaderStatus:init()
     if self.ui.document.is_pic then
         self.enabled = false
-        return
     else
         self.total_pages = self.document:getPageCount()
         self.ui.menu:registerToMainMenu(self)
@@ -258,6 +257,8 @@ function ReaderStatus:onMarkBook(mark_read)
     else
         self.settings.data.summary = {status = "complete"}
     end
+    self.settings:saveSetting("summary", self.settings.data.summary)
+    self.settings:flush()
 end
 
 function ReaderStatus:onReadSettings(config)

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -19,7 +19,6 @@ local ReaderStatus = WidgetContainer:extend{
 function ReaderStatus:init()
     if self.ui.document.is_pic then
         self.enabled = false
-        return
     else
         self.total_pages = self.document:getPageCount()
         self.ui.menu:registerToMainMenu(self)

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -19,6 +19,7 @@ local ReaderStatus = WidgetContainer:extend{
 function ReaderStatus:init()
     if self.ui.document.is_pic then
         self.enabled = false
+        return
     else
         self.total_pages = self.document:getPageCount()
         self.ui.menu:registerToMainMenu(self)


### PR DESCRIPTION
Saves current book status summary immediately on change in the "End of Book" dialog.
Closes https://github.com/koreader/koreader/issues/9616.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9619)
<!-- Reviewable:end -->
