### PR TITLE
Customizable bold font for fallback UI font

### DIFF
--- a/frontend/ui/elements/font_ui_fallbacks.lua
+++ b/frontend/ui/elements/font_ui_fallbacks.lua
@@ -55,8 +55,7 @@ Fonts for many languages can be downloaded at:
 
 https://fonts.google.com/noto
 
-Only fonts named "Noto Sans xyz" or "Noto Sans xyz UI" (regular, not bold nor italic, not Serif) will be available in this menu.]])
-more_info_text = more_info_text .. "\n" .. _("However, bold fonts will be used if their corresponding regular fonts exist.")
+Only fonts named "Noto Sans xyz" or "Noto Sans xyz UI" (regular, not bold nor italic, not Serif) will be available in this menu. However, bold fonts will be used if their corresponding regular fonts exist.]])
 
 local getSubMenuItems = function()
     genFallbackCandidates()

--- a/frontend/ui/elements/font_ui_fallbacks.lua
+++ b/frontend/ui/elements/font_ui_fallbacks.lua
@@ -56,6 +56,7 @@ Fonts for many languages can be downloaded at:
 https://fonts.google.com/noto
 
 Only fonts named "Noto Sans xyz" or "Noto Sans xyz UI" (regular, not bold nor italic, not Serif) will be available in this menu.]])
+more_info_text = more_info_text .. "\n" .. _("However, bold fonts will be used if their corresponding regular fonts exist.")
 
 local getSubMenuItems = function()
     genFallbackCandidates()

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -163,7 +163,7 @@ for _, font_path in ipairs(FontList:getFontList()) do
         break
     end
 end
-bold_candidates = nil
+bold_candidates = nil -- luacheck: ignore
 
 -- Helper functions with explicite names around
 -- bold/regular_font_variant tables

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -135,6 +135,16 @@ if G_reader_settings and G_reader_settings:has("font_ui_fallbacks") then
     logger.dbg("updated Font.fallbacks:", Font.fallbacks)
 end
 
+-- Match bold font to fallback by name. We do not use FontInfo name match
+-- to allow users more flexibility
+for _, fallback_font_path in ipairs(Font.fallbacks) do
+    if not _bold_font_variant[fallback_font_path] and fallback_font_path:find("-Regular") then -- has no bold and is regular by name
+        local bold_path = fallback_font_path:gsub("-Regular", "-Bold", 1, true)
+        Font.bold_font_variant[fallback_font_path] = bold_path
+        Font.regular_font_variant[bold_path] = fallback_font_path
+    end
+end
+
 -- Helper functions with explicite names around
 -- bold/regular_font_variant tables
 function Font:hasBoldVariant(name)

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -136,8 +136,8 @@ if G_reader_settings and G_reader_settings:has("font_ui_fallbacks") then
     logger.dbg("updated Font.fallbacks:", Font.fallbacks)
 end
 
--- We don't ship a bold variant for some ofg our fallback fonts. 
--- Allow users themselves to drop a Noto Sans Bold variant of their most used fallbacks, 
+-- We don't ship a bold variant for some of our fallback fonts.
+-- Allow users themselves to drop a Noto Sans Bold variant of their most used fallbacks,
 -- and we will use them if present.
 -- Match bold font to fallback by name. We do not use FontInfo name match
 -- to allow users more flexibility.

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -136,6 +136,9 @@ if G_reader_settings and G_reader_settings:has("font_ui_fallbacks") then
     logger.dbg("updated Font.fallbacks:", Font.fallbacks)
 end
 
+-- We don't ship a bold variant (for most of?) our fallback fonts. 
+-- Allow users themselves to drop a Noto Sans Bold variant of their most used fallbacks, 
+-- and we will use them if present.
 -- Match bold font to fallback by name. We do not use FontInfo name match
 -- to allow users more flexibility.
 -- Because the hardcoded fallback fonts' paths are their filenames not actual paths,

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -143,8 +143,8 @@ end
 local _fallback_fonts_without_bold = {}
 for _, fallback_font_path in ipairs(Font.fallbacks) do
     local _, font_name = util.splitFilePathName(fallback_font_path)
-    if font_name and 
-       not _bold_font_variant[fallback_font_path] and not _bold_font_variant[font_name] and 
+    if font_name and
+       not _bold_font_variant[fallback_font_path] and not _bold_font_variant[font_name] and
        font_name:find("-Regular") then
         local bold_font_name = font_name:gsub("-Regular", "-Bold", 1, true)
         _fallback_fonts_without_bold[bold_font_name] = fallback_font_path

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -140,29 +140,30 @@ end
 -- to allow users more flexibility.
 -- Because the hardcoded fallback fonts' paths are their filenames not actual paths,
 -- we need to match with filenames rather than paths
-local _fallback_fonts_without_bold = {}
+local bold_candidates = {} -- key: bold font's name, value: corresponding regular font's path
 for _, fallback_font_path in ipairs(Font.fallbacks) do
     local _, font_name = util.splitFilePathName(fallback_font_path)
-    if font_name and
-       not _bold_font_variant[fallback_font_path] and not _bold_font_variant[font_name] and
-       font_name:find("-Regular") then
+    if font_name and not _bold_font_variant[fallback_font_path]
+                 and not _bold_font_variant[font_name]
+                 and font_name:find("-Regular") then
         local bold_font_name = font_name:gsub("-Regular", "-Bold", 1, true)
-        _fallback_fonts_without_bold[bold_font_name] = fallback_font_path
+        bold_candidates[bold_font_name] = fallback_font_path
     end
 end
 
 for _, font_path in ipairs(FontList:getFontList()) do
     local _, bold_font_name = util.splitFilePathName(font_path)
-    local fallback_font_path = _fallback_fonts_without_bold[bold_font_name]
+    local fallback_font_path = bold_candidates[bold_font_name]
     if bold_font_name and fallback_font_path then
         Font.bold_font_variant[fallback_font_path] = font_path
         Font.regular_font_variant[font_path] = fallback_font_path
-        _fallback_fonts_without_bold[bold_font_name] = nil
+        bold_candidates[bold_font_name] = nil
     end
-    if #_fallback_fonts_without_bold == 0 then
+    if #bold_candidates == 0 then
         break
     end
 end
+bold_candidates = nil
 
 -- Helper functions with explicite names around
 -- bold/regular_font_variant tables

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -136,7 +136,7 @@ if G_reader_settings and G_reader_settings:has("font_ui_fallbacks") then
     logger.dbg("updated Font.fallbacks:", Font.fallbacks)
 end
 
--- We don't ship a bold variant (for most of?) our fallback fonts. 
+-- We don't ship a bold variant for some ofg our fallback fonts. 
 -- Allow users themselves to drop a Noto Sans Bold variant of their most used fallbacks, 
 -- and we will use them if present.
 -- Match bold font to fallback by name. We do not use FontInfo name match


### PR DESCRIPTION
This PR adds support for user-customizable bold fonts for fallback UI fonts, including default ones and user-added ones.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9621)
<!-- Reviewable:end -->
