### PR TITLE
Dispatcher: Fix subtle bug with modified items being added twice to the sort index

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -518,7 +518,9 @@ function Dispatcher:_addToOrder(location, settings, item)
                 end
             end
         else
-            table.insert(location[settings].settings.order, item)
+            if not util.arrayContains(location[settings].settings.order, item) then
+                table.insert(location[settings].settings.order, item)
+            end
         end
     end
 end


### PR DESCRIPTION

Discovered by @poire-z in https://github.com/koreader/koreader/pull/9531#issuecomment-1274839234

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9628)
<!-- Reviewable:end -->
