### PR TITLE
ButtonDialogTitle: align upper borders

### DIFF
--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -71,6 +71,7 @@ function ButtonDialogTitle:init()
     }
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),
+        ignore_if_over = "height",
         MovableContainer:new{
             FrameContainer:new{
                 VerticalGroup:new{


### PR DESCRIPTION
Minor enhancement: if a ButtonDialogTitle is tall and exceeds the sreen height, align upper borders of the screen and the dialog, to see the dialog title.
Best applicable to new QuickMenus that may contain many actions/buttons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9631)
<!-- Reviewable:end -->
