### PR TITLE
Oh, hey, Lua already has a setvbuf wrapper ;p

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -1,24 +1,7 @@
 #!./luajit
 
 -- Enforce line-buffering for stdout (this is the default if it points to a tty, but we redirect to a file on most platforms).
-local ffi = require("ffi")
-local C = ffi.C
-
--- macOS is a special snowflake
-if ffi.os == "OSX" then
-    ffi.cdef[[
-extern struct _IO_FILE *__stdoutp;
-void setlinebuf(struct _IO_FILE *);
-]]
-    C.setlinebuf(C.__stdoutp)
-else
-    ffi.cdef[[
-extern struct _IO_FILE *stdout;
-void setlinebuf(struct _IO_FILE *);
-]]
-    C.setlinebuf(C.stdout)
-end
-
+io.stdout:setvbuf("line")
 -- Enforce a reliable locale for numerical representations
 os.setlocale("C", "numeric")
 


### PR DESCRIPTION
Sidenote for the crazy win32 people out there: it doesn't have a concept of line-buffering, so native win32 should use "no" here, but I'm *hoping* MinGW transparently handles this nonsense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9636)
<!-- Reviewable:end -->
