### PR TITLE
zh_keyboard: make number pad symbol mode

### DIFF
--- a/frontend/ui/data/keyboardlayouts/zh_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/zh_keyboard.lua
@@ -7,7 +7,7 @@ Supports both simplified and traditional.
 Characters hardcoded on keys are uniform, no translation needed.
 In-place candidates can be turned off in keyboard settings.
 A Separation key 分隔 is used to finish inputting a character.
-A Switch key 换字 is used to iterate candidates.
+A Switch key 下一字 is used to iterate candidates.
 Stroke-wise deletion (input not finished) mapped to the default Del key.
 Character-wise deletion mapped to north of Separation key.
 
@@ -160,42 +160,40 @@ end
 
 return {
     min_layer = 1,
-    max_layer = 2,
-    shiftmode_keys = {["123"] = false},
-    symbolmode_keys = {["Sym"] = false},
+    max_layer = 4,
+    symbolmode_keys = {["123"] = true},
     utf8mode_keys = {["🌐"] = true},
-    umlautmode_keys = {["Äéß"] = false},  -- Disabled 'umlaut' keys
     keys = {
         -- first row
         {
             { label = "123" },
-            { JA.s_1, { label = "一", "㇐", north="——"} },
-            { JA.s_2, { label = "丨", "㇑"} },
-            { s_3,    { label = "丿", "㇒"} },
+            { "", { label = "一", "㇐", north="——"}, "", JA.s_1 },
+            { "", { label = "丨", "㇑"}, "", JA.s_2 },
+            { "", { label = "丿", "㇒"}, "", s_3 },
             { label = "", bold = false } -- backspace
         },
         -- second row
         {
             { label = "←" },
-            { JA.s_4, { label = "丶", "㇏", north="、" } },
-            { JA.s_5, { label = "𠃋", "㇜" } },
-            { JA.s_6, { ime.separator, north=ime.local_del, alt_label=ime.local_del } },
+            { "", { label = "丶", "㇏", north="、" }, "", JA.s_4 },
+            { "", { label = "𠃋", "㇜" }, "", JA.s_5 },
+            { "", { ime.separator, north=ime.local_del, alt_label=ime.local_del }, "", JA.s_6 },
             { label = "→" },
         },
         -- third row
         {
             { label = "↑" },
-            { JA.s_7, ime.switch_char },
-            { s_8,    comma_popup },
-            { JA.s_9, period_popup },
+            { "", ime.switch_char, "", JA.s_7 },
+            { "", comma_popup, "", s_8 },
+            { "", period_popup, "", JA.s_9 },
             { label = "↓" },
         },
         -- fourth row
         {
             { label = "🌐" },
-            { label = "空格",  " ", " ", width = 2.0 },
-            { JA.s_0, { label = "＊", W } },
-            { label = "⮠", "\n", "\n", bold = true }, -- return
+            { label = "空格",  " ", " ", " ", " ", width = 2.0 },
+            { "", { label = "＊", W }, "", JA.s_0 },
+            { label = "⮠", "\n", "\n", "\n", "\n", bold = true }, -- return
         },
     },
 


### PR DESCRIPTION
This PR makes zh_keyboard's number pad symbol mode instead of shift mode, so that numbers are shown when the keyboard is called expecting numeral input.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9654)
<!-- Reviewable:end -->
