### PR TITLE
AutoDim: close trapper widget explicitly

### DIFF
--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -302,6 +302,10 @@ function AutoDim:autodim_task()
         end
         local fl_diff = self.autodim_save_fl - self.autodim_end_fl
         if fl_diff > 0 then
+            if self.trap_widget then
+                UIManager:close(self.trap_widget)
+            end
+
             self.trap_widget = TrapWidget:new{
                 dismiss_callback = function()
                     self:restoreFrontlight()


### PR DESCRIPTION
When AutoDim knocks in it sometimes happens, that a tap does not exit the trapper widget. So multiple taps (many of them) have to b done, before swallowing input events is done.

This PR fixes that, be explicitly closing the trapper widget (if there is one), before showing the other one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9675)
<!-- Reviewable:end -->
