### PR TITLE
A small round of fixes

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -302,8 +302,12 @@ function KoboPowerD:turnOffFrontlightHW()
         return
     end
     ffiUtil.runInSubProcess(function()
-        for i = 1,5 do
-            self:setIntensityHW(math.floor(self.fl_intensity - ((self.fl_intensity * (1/5)) * i)))
+        for i = 1, 5 do
+            -- NOTE: Do *not* switch to (self.fl_intensity * (1/5) * i) here, it may lead to rounding errors,
+            --       which is problematic paired w/ math.floor because it doesn't round towards zero,
+            --       which means we may end up passing -1 to setIntensityHW, which will fail,
+            --       because we're bypassing the clamping usually done by setIntensity...
+            self:setIntensityHW(math.floor(self.fl_intensity - (self.fl_intensity / 5 * i)))
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then
@@ -335,8 +339,8 @@ function KoboPowerD:turnOnFrontlightHW()
         return
     end
     ffiUtil.runInSubProcess(function()
-        for i = 1,5 do
-            self:setIntensityHW(math.ceil(self.fl_min + ((self.fl_intensity * (1/5)) * i)))
+        for i = 1, 5 do
+            self:setIntensityHW(math.ceil(self.fl_min + (self.fl_intensity / 5 * i)))
             --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so only sleep on older devices,
             ---        otherwise we get a jump and not a ramp ;).
             if not self.device:hasNaturalLight() then

--- a/frontend/ui/time.lua
+++ b/frontend/ui/time.lua
@@ -171,7 +171,7 @@ end
 function time.split_s_us(time_fts)
     if not time_fts then return nil, nil end
     local sec = math.floor(time_fts * FTS2S)
-    local usec = math.floor(time_fts - sec * S2FTS) * FTS2US
+    local usec = math.floor((time_fts - sec * S2FTS) * FTS2US)
     -- Seconds and µs
     return sec, usec
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1118,8 +1118,8 @@ function UIManager:_repaint()
     --[[
     if start_idx > 1 then
         for i = 1, start_idx-1 do
-            local widget = self._window_stack[i]
-            logger.dbg("NOT painting widget:", widget.widget.name or widget.widget.id or tostring(widget))
+            local widget = self._window_stack[i].widget
+            logger.dbg("NOT painting widget:", widget.name or widget.id or tostring(widget))
         end
     end
     --]]
@@ -1333,13 +1333,16 @@ function UIManager:handleInput()
     -- for input events:
     repeat
         wait_until, now = self:_checkTasks()
-        --dbg("---------------------------------------------------")
-        --dbg("wait_until", wait_until)
-        --dbg("now", now)
-        --dbg("exec stack", self._task_queue)
-        --dbg("window stack", self._window_stack)
-        --dbg("dirty stack", self._dirty)
-        --dbg("---------------------------------------------------")
+        --[[
+        dbg("---------------------------------------------------")
+        dbg("wait_until", wait_until)
+        dbg("now       ", now)
+        dbg("#exec stack  ", #self._task_queue)
+        dbg("#window stack", #self._window_stack)
+        dbg("#dirty stack ", util.tableSize(self._dirty))
+        dbg("dirty?", self._task_queue_dirty)
+        dbg("---------------------------------------------------")
+        --]]
 
         -- stop when we have no window to show
         if not self._window_stack[1] and not self._run_forever then

--- a/frontend/ui/widget/datetimewidget.lua
+++ b/frontend/ui/widget/datetimewidget.lua
@@ -432,11 +432,6 @@ function DateTimeWidget:onShow()
     return true
 end
 
-function DateTimeWidget:onAnyKeyPressed()
-    UIManager:close(self)
-    return true
-end
-
 function DateTimeWidget:onTapClose(arg, ges_ev)
     if ges_ev.pos:notIntersectWith(self.date_frame.dimen) then
         self:onClose()

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -337,11 +337,6 @@ function DoubleSpinWidget:onShow()
     return true
 end
 
-function DoubleSpinWidget:onAnyKeyPressed()
-    self:onClose()
-    return true
-end
-
 function DoubleSpinWidget:onTapClose(arg, ges_ev)
     if ges_ev.pos:notIntersectWith(self.widget_frame.dimen) then
         self:onClose()

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -539,11 +539,6 @@ function FrontLightWidget:onShow()
     return true
 end
 
-function FrontLightWidget:onAnyKeyPressed()
-    UIManager:close(self)
-    return true
-end
-
 function FrontLightWidget:onClose()
     UIManager:close(self)
     return true

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -816,11 +816,6 @@ function ImageViewer:onClose()
     return true
 end
 
-function ImageViewer:onAnyKeyPressed()
-    self:onClose()
-    return true
-end
-
 function ImageViewer:onCloseWidget()
     -- Our ImageWidget (self._image_wg) is always a proper child widget, so it'll receive this event,
     -- and attempt to free its resources accordingly.

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -280,18 +280,12 @@ function InfoMessage:dismiss()
     UIManager:close(self)
 end
 
-function InfoMessage:onAnyKeyPressed()
-    self:dismiss()
-    if self.readonly ~= true then
-        return true
-    end
-end
-
 function InfoMessage:onTapClose()
     self:dismiss()
     if self.readonly ~= true then
         return true
     end
 end
+InfoMessage.onAnyKeyPressed = InfoMessage.onTapClose
 
 return InfoMessage

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -542,7 +542,7 @@ function InputText:initKeyboard()
     if self.input_type == "number" then
         keyboard_layer = 4
     end
-    self.key_events = nil
+    self.key_events = {}
     self.keyboard = Keyboard:new{
         keyboard_layer = keyboard_layer,
         inputbox = self,

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -199,17 +199,13 @@ function Notification:onShow()
     return true
 end
 
-function Notification:onAnyKeyPressed()
-    if self.toast then return end -- should not happen
-    UIManager:close(self)
-    return true
-end
 
 function Notification:onTapClose()
     if self.toast then return end -- should not happen
     UIManager:close(self)
     return true
 end
+Notification.onAnyKeyPressed = Notification.onTapClose
 
 -- Toasts should go bye-bye on user input, without stopping the event's propagation.
 function Notification:onKeyPress(key)

--- a/frontend/ui/widget/qrmessage.lua
+++ b/frontend/ui/widget/qrmessage.lua
@@ -99,15 +99,10 @@ function QRMessage:onShow()
     return true
 end
 
-function QRMessage:onAnyKeyPressed()
-    -- triggered by our defined key events
-    self.dismiss_callback()
-    UIManager:close(self)
-end
-
 function QRMessage:onTapClose()
     self.dismiss_callback()
     UIManager:close(self)
 end
+QRMessage.onAnyKeyPressed = QRMessage.onTapClose
 
 return QRMessage

--- a/frontend/ui/widget/radiobuttonwidget.lua
+++ b/frontend/ui/widget/radiobuttonwidget.lua
@@ -218,11 +218,6 @@ function RadioButtonWidget:onShow()
     return true
 end
 
-function RadioButtonWidget:onAnyKeyPressed()
-    self:onClose()
-    return true
-end
-
 function RadioButtonWidget:onTapClose(arg, ges_ev)
     if ges_ev.pos:notIntersectWith(self.widget_frame.dimen) then
         self:onClose()

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -19,7 +19,7 @@ local ScreenSaverWidget = InputContainer:extend{
 function ScreenSaverWidget:init()
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {Device.input.group.Back}, doc = "close widget" },
+            AnyKeyPressed = { { Device.input.group.Any }, seqtext = "any key", doc = "close widget" },
         }
     end
     if Device:isTouchDevice() then
@@ -112,11 +112,6 @@ function ScreenSaverWidget:showWaitForGestureMessage(msg)
     infomsg:free()
 end
 
-function ScreenSaverWidget:onExitScreensaver()
-    self:onClose()
-    return true
-end
-
 function ScreenSaverWidget:update()
     self.height = Screen:getHeight()
     self.width = Screen:getWidth()
@@ -167,11 +162,8 @@ function ScreenSaverWidget:onClose()
     UIManager:close(self)
     return true
 end
-
-function ScreenSaverWidget:onAnyKeyPressed()
-    self:onClose()
-    return true
-end
+ScreenSaverWidget.onAnyKeyPressed = ScreenSaverWidget.onClose
+ScreenSaverWidget.onExitScreensaver = ScreenSaverWidget.onClose
 
 function ScreenSaverWidget:onCloseWidget()
     -- Restore to previous rotation mode, if need be.

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -95,7 +95,7 @@ function ScreenSaverWidget:setupGestureEvents()
             InputContainer.handleEvent(this, event)
             return true
         end
-        self.key_events = nil -- also disable exit with keys
+        self.key_events = {} -- also disable exit with keys
     end
 end
 

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -372,11 +372,6 @@ function SkimToWidget:goToByEvent(event_name)
     end
 end
 
-function SkimToWidget:onAnyKeyPressed()
-    UIManager:close(self)
-    return true
-end
-
 function SkimToWidget:onFirstRowKeyPress(percent)
     local page = Math.round(percent * self.page_count)
     self:addOriginToLocationStack()

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -293,11 +293,6 @@ function SpinWidget:onShow()
     return true
 end
 
-function SpinWidget:onAnyKeyPressed()
-    self:onClose()
-    return true
-end
-
 function SpinWidget:onTapClose(arg, ges_ev)
     if ges_ev.pos:notIntersectWith(self.spin_frame.dimen) then
         self:onClose()

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -289,11 +289,6 @@ function TextViewer:onShow()
     return true
 end
 
-function TextViewer:onAnyKeyPressed()
-    UIManager:close(self)
-    return true
-end
-
 function TextViewer:onTapClose(arg, ges_ev)
     if ges_ev.pos:notIntersectWith(self.frame.dimen) then
         self:onClose()

--- a/frontend/ui/widget/trapwidget.lua
+++ b/frontend/ui/widget/trapwidget.lua
@@ -108,7 +108,7 @@ function TrapWidget:init()
     end
 end
 
-function TrapWidget:_dismissAndResent(evtype, ev)
+function TrapWidget:_dismissAndResend(evtype, ev)
     self.dismiss_callback()
     UIManager:close(self)
     if self.resend_event and evtype and ev then
@@ -125,19 +125,19 @@ function TrapWidget:_dismissAndResent(evtype, ev)
 end
 
 function TrapWidget:onAnyKeyPressed(_, ev)
-    return self:_dismissAndResent("KeyPress", ev)
+    return self:_dismissAndResend("KeyPress", ev)
 end
 
 function TrapWidget:onTapDismiss(_, ev)
-    return self:_dismissAndResent("Gesture", ev)
+    return self:_dismissAndResend("Gesture", ev)
 end
 
 function TrapWidget:onHoldDismiss(_, ev)
-    return self:_dismissAndResent("Gesture", ev)
+    return self:_dismissAndResend("Gesture", ev)
 end
 
 function TrapWidget:onSwipeDismiss(_, ev)
-    return self:_dismissAndResent("Gesture", ev)
+    return self:_dismissAndResend("Gesture", ev)
 end
 
 function TrapWidget:onShow()

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -479,10 +479,6 @@ function ReaderProgress:genSummaryWeek(width)
     }
 end
 
-function ReaderProgress:onAnyKeyPressed()
-    return self:onClose()
-end
-
 function ReaderProgress:onSwipe(arg, ges_ev)
     if ges_ev.direction == "south" then
         -- Allow easier closing with swipe up/down
@@ -499,17 +495,15 @@ function ReaderProgress:onSwipe(arg, ges_ev)
     end
 end
 
-function ReaderProgress:onMultiSwipe(arg, ges_ev)
-    -- For consistency with other fullscreen widgets where swipe south can't be
-    -- used to close and where we then allow any multiswipe to close, allow any
-    -- multiswipe to close this widget too.
-    self:onClose()
-    return true
-end
-
 function ReaderProgress:onClose()
     UIManager:close(self)
     return true
 end
+ReaderProgress.onAnyKeyPressed = ReaderProgress.onClose
+-- For consistency with other fullscreen widgets where swipe south can't be
+-- used to close and where we then allow any multiswipe to close, allow any
+-- multiswipe to close this widget too.
+ReaderProgress.onMultiSwipe = ReaderProgress.onClose
+
 
 return ReaderProgress


### PR DESCRIPTION
* Kobo: Unbreak frontlight toggle for some speciifc values (fix #9674, regression since #9609)
* ScreenSaver: Actually enable the `onAnyKeyPressed` handler (allowing one to close the ScreenSaver with page-turn buttons, for instance). [This is properly disabled when using the child lock pattern mode, because @poire-z rules ;)].
* Previous commit lead to a general cleanup of those handlers in the codebase, because it turns out it was *really* not the only dumb unused code c/p around ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9676)
<!-- Reviewable:end -->
