### PR TITLE
Dispatcher: preserve profile name, show actions count

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -488,6 +488,17 @@ local function iter_func(settings)
     end
 end
 
+-- Returns the number of items present in the settings table
+function Dispatcher:_itemsCount(settings)
+    if settings then
+        local count = util.tableSize(settings)
+        if count > 0 and settings.settings ~= nil then
+            count = count - 1
+        end
+        return count
+    end
+end
+
 -- Returns a display name for the item.
 function Dispatcher:getNameFromItem(item, settings)
     if settingsList[item] == nil then
@@ -551,11 +562,8 @@ end
 function Dispatcher:menuTextFunc(settings)
     local action_name = _("Pass through")
     if settings then
-        local count = util.tableSize(settings)
+        local count = Dispatcher:_itemsCount(settings)
         if count == 0 then return _("Nothing") end
-        if count > 1 and settings.settings ~= nil then
-            count = count - 1
-        end
         if count == 1 then
             local item = next(settings)
             if item == "settings" then item = next(settings, item) end
@@ -798,10 +806,10 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         text = _("Nothing"),
         separator = true,
         checked_func = function()
-            return location[settings] ~= nil and next(location[settings]) == nil
+            return location[settings] ~= nil and Dispatcher:_itemsCount(location[settings]) == 0
         end,
         callback = function(touchmenu_instance)
-            local name = location[settings].settings and location[settings].settings.name
+            local name = location[settings] and location[settings].settings and location[settings].settings.name
             location[settings] = {}
             if name then
                 location[settings].settings = { name = name }
@@ -935,7 +943,7 @@ function Dispatcher:execute(settings, gesture)
     if settings.settings ~= nil and settings.settings.show_as_quickmenu == true then
         return Dispatcher:_showAsMenu(settings)
     end
-    local has_many = util.tableSize(settings) > (settings.settings ~= nil and 2 or 1)
+    local has_many = Dispatcher:_itemsCount(settings) > 1
     if has_many then
         UIManager:broadcastEvent(Event:new("BatchedUpdate"))
     end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -561,7 +561,7 @@ function Dispatcher:menuTextFunc(settings)
             if item == "settings" then item = next(settings, item) end
             action_name = Dispatcher:getNameFromItem(item, settings)
         else
-            action_name = _("Many")
+            action_name = T(_("%1 actions"), count)
         end
     end
     return action_name
@@ -801,7 +801,11 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
             return location[settings] ~= nil and next(location[settings]) == nil
         end,
         callback = function(touchmenu_instance)
+            local name = location[settings].settings and location[settings].settings.name
             location[settings] = {}
+            if name then
+                location[settings].settings = { name = name }
+            end
             caller.updated = true
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -38,6 +38,7 @@ local UIManager = require("ui/uimanager")
 local util = require("util")
 local _ = require("gettext")
 local C_ = _.pgettext
+local N_ = _.ngettext
 local T = require("ffi/util").template
 
 local Dispatcher = {
@@ -569,7 +570,7 @@ function Dispatcher:menuTextFunc(settings)
             if item == "settings" then item = next(settings, item) end
             action_name = Dispatcher:getNameFromItem(item, settings)
         else
-            action_name = T(_("%1 actions"), count)
+            action_name = T(N_("", "%1 actions", count), count)
         end
     end
     return action_name


### PR DESCRIPTION
(1) Preserve profile name when selecting the "Nothing" action.
(2) Show number of actions instead of "Many".


TODO after https://github.com/koreader/koreader/pull/9651#discussion_r1000918149: fix checkbox of the "Nothing" action for profiles with name.
https://github.com/koreader/koreader/blob/724db8775561651abbf24650b95b2d03a07d961d/frontend/dispatcher.lua#L800-L802

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9682)
<!-- Reviewable:end -->
