### PR TITLE
Test suite: get rid of argc in the _task_queue

### DIFF
--- a/spec/unit/uimanager_bench.lua
+++ b/spec/unit/uimanager_bench.lua
@@ -29,7 +29,7 @@ describe("UIManager checkTasks benchmark", function()
     for i=1, NB_TESTS do
         table.insert(
             UIManager._task_queue,
-            { time = now + i, action = noop, argc = 0, args = {} }
+            { time = now + i, action = noop, args = {} }
         )
     end
 
@@ -43,8 +43,10 @@ describe("UIManager schedule simple benchmark", function()
     UIManager:quit()
     UIManager._task_queue = {}
 
-    for i=1, NB_TESTS do
+    -- Insert tasks at the beginning and at the end of the _task_queue
+    for i=1, NB_TESTS/2 do
         UIManager:schedule(now + i, noop)
+        UIManager:schedule(now + NB_TESTS - i, noop)
     end
 end)
 
@@ -150,7 +152,7 @@ describe("UIManager unschedule benchmark", function()
     for i=1, NB_TESTS do
         table.insert(
             UIManager._task_queue,
-            { time = now + i, action = 'a', argc=0, args={} }
+            { time = now + i, action = 'a', args={} }
         )
     end
 

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -15,11 +15,11 @@ describe("UIManager spec", function()
         local future2 = future + time.s(5)
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = noop, args = {}, argc = 0 },
-            { time = now - time.us(5), action = noop, args = {}, argc = 0 },
-            { time = now, action = noop, args = {}, argc = 0 },
-            { time = future, action = noop, args = {}, argc = 0 },
-            { time = future2, action = noop, args = {}, argc = 0 },
+            { time = now - time.s(10), action = noop, args = {} },
+            { time = now - time.us(5), action = noop, args = {} },
+            { time = now, action = noop, args = {} },
+            { time = future, action = noop, args = {} },
+            { time = future2, action = noop, args = {} },
         }
         UIManager:_checkTasks()
         assert.are.same(2, #UIManager._task_queue, 2)
@@ -32,10 +32,10 @@ describe("UIManager spec", function()
         local future_time = now + time.s(60000)
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = noop, args = {}, argc = 0 },
-            { time = now - time.us(5), action = noop, args = {}, argc = 0 },
-            { time = now, action = noop, args = {}, argc = 0 },
-            { time = future_time, action = noop, args = {}, argc = 0 },
+            { time = now - time.s(10), action = noop, args = {} },
+            { time = now - time.us(5), action = noop, args = {} },
+            { time = now, action = noop, args = {} },
+            { time = future_time, action = noop, args = {} },
         }
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(future_time, wait_until)
@@ -45,9 +45,9 @@ describe("UIManager spec", function()
         now = time.now()
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = noop, args = {}, argc = 0 },
-            { time = now - time.us(5), action = noop, args = {}, argc = 0 },
-            { time = now, action = noop, args = {}, argc = 0 },
+            { time = now - time.s(10), action = noop, args = {} },
+            { time = now - time.us(5), action = noop, args = {} },
+            { time = now, action = noop, args = {} },
         }
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(nil, wait_until)
@@ -68,7 +68,7 @@ describe("UIManager spec", function()
         local future_time = now + time.s(10000)
         UIManager:quit()
         UIManager._task_queue = {
-            { time = future_time, action = '1', args = {}, argc = 0 },
+            { time = future_time, action = '1', args = {} },
         }
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'quz')
@@ -77,7 +77,7 @@ describe("UIManager spec", function()
 
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now, action = '1', args = {}, argc = 0 },
+            { time = now, action = '1', args = {} },
         }
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'foo')
@@ -92,9 +92,9 @@ describe("UIManager spec", function()
         now = time.now()
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = '1', args = {}, argc = 0 },
-            { time = now - time.us(5), action = '2', args = {}, argc = 0 },
-            { time = now, action = '3', args = {}, argc = 0 },
+            { time = now - time.s(10), action = '1', args = {} },
+            { time = now - time.us(5), action = '2', args = {} },
+            { time = now, action = '3', args = {} },
         }
         -- insert into the tail slot
         UIManager:scheduleIn(10, 'foo')
@@ -166,17 +166,17 @@ describe("UIManager spec", function()
         now = time.now()
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(15), action = '3', args = {}, argc = 0 },
-            { time = now - time.s(10), action = '1', args = {}, argc = 0 },
-            { time = now - time.us(6), action = '3', args = {}, argc = 0 },
-            { time = now - time.us(5), action = '2', args = {}, argc = 0 },
-            { time = now, action = '3', args = {}, argc = 0 },
+            { time = now - time.s(15), action = '3', args = {} },
+            { time = now - time.s(10), action = '1', args = {} },
+            { time = now - time.us(6), action = '3', args = {} },
+            { time = now - time.us(5), action = '2', args = {} },
+            { time = now, action = '3', args = {} },
         }
         -- insert into the tail slot
         UIManager:unschedule('3')
         assert.are.same({
-            { time = now - time.s(10), action = '1', args = {}, argc = 0 },
-            { time = now - time.us(5), action = '2', args = {}, argc = 0 },
+            { time = now - time.s(10), action = '1', args = {} },
+            { time = now - time.us(5), action = '2', args = {} },
         }, UIManager._task_queue)
     end)
 
@@ -188,7 +188,7 @@ describe("UIManager spec", function()
         end
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.us(5), action = task_to_remove, args = {}, argc = 0 },
+            { time = now - time.us(5), action = task_to_remove, args = {} },
             {
                 time = now - time.s(10),
                 action = function()
@@ -196,9 +196,8 @@ describe("UIManager spec", function()
                     UIManager:unschedule(task_to_remove)
                 end,
                 args = {},
-                argc = 0
             },
-            { time = now, action = task_to_remove, args = {}, argc = 0 },
+            { time = now, action = task_to_remove, args = {} },
         }
         UIManager:_checkTasks()
         assert.are.same(2, run_count)


### PR DESCRIPTION
argc was eliminated in https://github.com/koreader/koreader/pull/9624

Thanks to @hasezoey (https://github.com/koreader/koreader/pull/9680#issuecomment-1290440793)

Plus a minor change in the scheduling test, so that the _task_queue is not filled only from one end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9684)
<!-- Reviewable:end -->
