### PR TITLE
A bundle of tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,7 @@ You can upload the whole `crash.log` file (zipped if necessary) on GitHub by dra
 
 If your issue doesn't directly concern a Lua crash, we'll quite likely need you to reproduce the issue with *verbose* debug logging enabled before providing the logs to us.
 To do so, from the file manager, go to [Tools] → More tools → Developer options, and tick both `Enable debug logging` and `Enable verbose debug logging`.
+You'll need to restart KOReader after toggling these on.
 
 If you instead opt to inline it, please do so behind a spoiler tag:
 <details>

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -463,9 +463,9 @@ function FileManager:setupLayout()
     }
 
     if Device:hasKeys() then
-        self.key_events.Home = { {"Home"}, doc = "go home" }
+        self.key_events.Home = { { "Home" } }
         -- Override the menu.lua way of handling the back key
-        self.file_chooser.key_events.Back = { {Device.input.group.Back}, doc = "go back" }
+        self.file_chooser.key_events.Back = { { Device.input.group.Back } }
         if not Device:hasFewKeys() then
             -- Also remove the handler assigned to the "Back" key by menu.lua
             self.file_chooser.key_events.Close = nil

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -49,9 +49,7 @@ function FileManagerMenu:init()
     self.registered_widgets = {}
 
     if Device:hasKeys() then
-        self.key_events = {
-            ShowMenu = { { "Menu" }, doc = "show menu" },
-        }
+        self.key_events.ShowMenu = { { "Menu" } }
     end
     self.activation_menu = G_reader_settings:readSetting("activate_menu")
     if self.activation_menu == nil then

--- a/frontend/apps/reader/modules/readerback.lua
+++ b/frontend/apps/reader/modules/readerback.lua
@@ -21,7 +21,7 @@ local ReaderBack = EventListener:extend{
 
 function ReaderBack:init()
     if Device:hasKeys() then
-        self.ui.key_events.Back = { {Device.input.group.Back}, doc = "Reader back" }
+        self.ui.key_events.Back = { { Device.input.group.Back } }
     end
     -- Regular function wrapping our method, to avoid re-creating
     -- an anonymous function at each page turn

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -38,11 +38,7 @@ local ReaderBookmark = InputContainer:extend{
 
 function ReaderBookmark:init()
     if Device:hasKeyboard() then
-        self.key_events = {
-            ShowBookmark = {
-                { "B" },
-                doc = "show bookmarks" },
-        }
+        self.key_events.ShowBookmark = { { "B" } }
     end
 
     if G_reader_settings:hasNot("bookmarks_items_per_page") then

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -20,9 +20,7 @@ function ReaderConfig:init()
     self.configurable:loadDefaults(self.options)
 
     if Device:hasKeys() then
-        self.key_events = {
-            ShowConfigMenu = { {{"Press","AA"}}, doc = "show config dialog" },
-        }
+        self.key_events.ShowConfigMenu = { { { "Press", "AA" } } }
     end
     self:initGesListener()
     if G_reader_settings:has("activate_menu") then

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -34,15 +34,17 @@ function ReaderFont:init()
     if Device:hasKeyboard() then
         -- add shortcut for keyboard
         self.key_events = {
-            ShowFontMenu = { {"F"}, doc = "show font menu" },
+            ShowFontMenu = { { "F" } },
             IncreaseSize = {
                 { "Shift", Input.group.PgFwd },
-                doc = "increase font size",
-                event = "ChangeSize", args = 0.5 },
+                event = "ChangeSize",
+                args = 0.5
+            },
             DecreaseSize = {
                 { "Shift", Input.group.PgBack },
-                doc = "decrease font size",
-                event = "ChangeSize", args = -0.5 },
+                event = "ChangeSize",
+                args = -0.5
+            },
         }
     end
     -- Build face_table for menu

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -55,19 +55,19 @@ function ReaderHighlight:init()
     if Device:hasDPad() then
         -- Used for text selection with dpad/keys
         local QUICK_INDICTOR_MOVE = true
-        self.key_events.StopHighlightIndicator = { {Device.input.group.Back}, doc = "Stop non-touch highlight", args = true } -- true: clear highlight selection
-        self.key_events.UpHighlightIndicator = { {"Up"}, doc = "move indicator up", event = "MoveHighlightIndicator", args = {0, -1} }
-        self.key_events.DownHighlightIndicator = { {"Down"}, doc = "move indicator down", event = "MoveHighlightIndicator", args = {0, 1} }
+        self.key_events.StopHighlightIndicator  = { { Device.input.group.Back }, args = true } -- true: clear highlight selection
+        self.key_events.UpHighlightIndicator    = { { "Up" },    event = "MoveHighlightIndicator", args = {0, -1} }
+        self.key_events.DownHighlightIndicator  = { { "Down" },  event = "MoveHighlightIndicator", args = {0, 1} }
         -- let FewKeys device can move indicator left
-        self.key_events.LeftHighlightIndicator = { {"Left"}, doc = "move indicator left", event = "MoveHighlightIndicator", args = {-1, 0} }
-        self.key_events.RightHighlightIndicator = { {"Right"}, doc = "move indicator right", event = "MoveHighlightIndicator", args = {1, 0} }
-        self.key_events.HighlightPress = { {"Press"}, doc = "highlight start or end" }
+        self.key_events.LeftHighlightIndicator  = { { "Left" },  event = "MoveHighlightIndicator", args = {-1, 0} }
+        self.key_events.RightHighlightIndicator = { { "Right" }, event = "MoveHighlightIndicator", args = {1, 0} }
+        self.key_events.HighlightPress          = { { "Press" } }
         if Device:hasKeys() then
-            self.key_events.QuickUpHighlightIndicator = { {"Shift", "Up"}, doc = "quick move indicator up", event = "MoveHighlightIndicator", args = {0, -1, QUICK_INDICTOR_MOVE} }
-            self.key_events.QuickDownHighlightIndicator = { {"Shift", "Down"}, doc = "quick move indicator down", event = "MoveHighlightIndicator", args = {0, 1, QUICK_INDICTOR_MOVE} }
-            self.key_events.QuickLeftHighlightIndicator = { {"Shift", "Left"}, doc = "quick move indicator left", event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICTOR_MOVE} }
-            self.key_events.QuickRightHighlightIndicator = { {"Shift", "Right"}, doc = "quick move indicator right", event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICTOR_MOVE} }
-            self.key_events.StartHighlightIndicator = { {"H"}, doc = "start non-touch highlight" }
+            self.key_events.QuickUpHighlightIndicator    = { { "Shift", "Up" },    event = "MoveHighlightIndicator", args = {0, -1, QUICK_INDICTOR_MOVE} }
+            self.key_events.QuickDownHighlightIndicator  = { { "Shift", "Down" },  event = "MoveHighlightIndicator", args = {0, 1, QUICK_INDICTOR_MOVE} }
+            self.key_events.QuickLeftHighlightIndicator  = { { "Shift", "Left" },  event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICTOR_MOVE} }
+            self.key_events.QuickRightHighlightIndicator = { { "Shift", "Right" }, event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICTOR_MOVE} }
+            self.key_events.StartHighlightIndicator      = { { "H" } }
         end
     end
 
@@ -233,8 +233,8 @@ function ReaderHighlight:init()
 end
 
 function ReaderHighlight:setupTouchZones()
-    -- deligate gesture listener to readerui
-    self.ges_events = {}
+    -- delegate gesture listener to readerui
+    self.ges_events = nil
     self.onGesture = nil
 
     if not Device:isTouchDevice() then return end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -27,24 +27,23 @@ local ReaderLink = InputContainer:extend{
 
 function ReaderLink:init()
     if Device:hasKeys() then
-        self.key_events.SelectNextPageLink = {
-            {"Tab" },
-            doc = "select next page link",
-            event = "SelectNextPageLink",
+        self.key_events = {
+            SelectNextPageLink = {
+                { "Tab" },
+                event = "SelectNextPageLink",
+            },
+            SelectPrevPageLink = {
+                { "Shift", "Tab" },
+                { "Sym", "Tab" }, -- Shift or Sym + Tab
+                event = "SelectPrevPageLink",
+            },
+            GotoSelectedPageLink = {
+                { "Press" },
+                event = "GotoSelectedPageLink",
+            },
+            -- "Back" is handled by ReaderBack, which will call our onGoBackLink()
+            -- when G_reader_settings:readSetting("back_in_reader") == "previous_location"
         }
-        self.key_events.SelectPrevPageLink = {
-            {"Shift", "Tab" },
-            {"Sym", "Tab" }, -- Right Shift + Tab
-            doc = "select previous page link",
-            event = "SelectPrevPageLink",
-        }
-        self.key_events.GotoSelectedPageLink = {
-            { "Press" },
-            doc = "go to selected page link",
-            event = "GotoSelectedPageLink",
-        }
-        -- "Back" is handled by ReaderBack, which will call our onGoBackLink()
-        -- when G_reader_settings:readSetting("back_in_reader") == "previous_location"
     end
     if Device:isTouchDevice() then
         self.ui:registerTouchZones({

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -58,16 +58,16 @@ function ReaderMenu:init()
 
     if Device:hasKeys() then
         if Device:isTouchDevice() then
-            self.key_events.TapShowMenu = { { "Menu" }, doc = "show menu", }
+            self.key_events.TapShowMenu = { { "Menu" } }
             if Device:hasFewKeys() then
-                self.key_events.TapShowMenu = { { { "Menu", "Right" } }, doc = "show menu", }
+                self.key_events.TapShowMenu = { { { "Menu", "Right" } } }
             end
         else
             -- map menu key to only top menu because bottom menu is only
             -- designed for touch devices
-            self.key_events.ShowMenu = { { "Menu" }, doc = "show menu", }
+            self.key_events.ShowMenu = { { "Menu" } }
             if Device:hasFewKeys() then
-                self.key_events.ShowMenu = { { { "Menu", "Right" } }, doc = "show menu", }
+                self.key_events.ShowMenu = { { { "Menu", "Right" } } }
             end
         end
     end
@@ -83,8 +83,8 @@ function ReaderMenu:getPreviousFile()
 end
 
 function ReaderMenu:onReaderReady()
-    -- deligate gesture listener to readerui
-    self.ges_events = {}
+    -- delegate gesture listener to readerui
+    self.ges_events = nil
     self.onGesture = nil
     if not Device:isTouchDevice() then return end
 

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -41,60 +41,79 @@ local ReaderPaging = InputContainer:extend{
 }
 
 function ReaderPaging:init()
-    self.key_events = {}
     if Device:hasKeys() then
         self.key_events.GotoNextPage = {
-            { {"RPgFwd", "LPgFwd", "Right" } }, doc = "go to next page",
-            event = "GotoViewRel", args = 1,
+            { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and "Right" } },
+            event = "GotoViewRel",
+            args = 1,
         }
         self.key_events.GotoPrevPage = {
-            { { "RPgBack", "LPgBack", "Left" } }, doc = "go to previous page",
-            event = "GotoViewRel", args = -1,
+            { { "RPgBack", "LPgBack", not Device:hasFewKeys() and "Left" } },
+            event = "GotoViewRel",
+            args = -1,
         }
-        if Device:hasFewKeys() then
-            table.remove(self.key_events.GotoNextPage[1][1], 3) -- right
-            table.remove(self.key_events.GotoPrevPage[1][1], 3) -- left
-        end
         self.key_events.GotoNextPos = {
-            { {"Down" } }, doc = "go to next position",
-            event = "GotoPosRel", args = 1,
+            { "Down" },
+            event = "GotoPosRel",
+            args = 1,
         }
         self.key_events.GotoPrevPos = {
-            { { "Up" } }, doc = "go to previous position",
-            event = "GotoPosRel", args = -1,
+            { "Up" },
+            event = "GotoPosRel",
+            args = -1,
         }
 
     end
     if Device:hasKeyboard() then
         self.key_events.GotoFirst = {
-            {"1"}, doc = "go to start", event = "GotoPercent", args = 0,
+            { "1" },
+            event = "GotoPercent",
+            args = 0,
         }
         self.key_events.Goto11 = {
-            {"2"}, doc = "go to 11%", event = "GotoPercent", args = 11,
+            { "2" },
+            event = "GotoPercent",
+            args = 11,
         }
         self.key_events.Goto22 = {
-            {"3"}, doc = "go to 22%", event = "GotoPercent", args = 22,
+            { "3" },
+            event = "GotoPercent",
+            args = 22,
         }
         self.key_events.Goto33 = {
-            {"4"}, doc = "go to 33%", event = "GotoPercent", args = 33,
+            { "4" },
+            event = "GotoPercent",
+            args = 33,
         }
         self.key_events.Goto44 = {
-            {"5"}, doc = "go to 44%", event = "GotoPercent", args = 44,
+            { "5" },
+            event = "GotoPercent",
+            args = 44,
         }
         self.key_events.Goto55 = {
-            {"6"}, doc = "go to 55%", event = "GotoPercent", args = 55,
+            { "6" },
+            event = "GotoPercent",
+            args = 55,
         }
         self.key_events.Goto66 = {
-            {"7"}, doc = "go to 66%", event = "GotoPercent", args = 66,
+            { "7" },
+            event = "GotoPercent",
+            args = 66,
         }
         self.key_events.Goto77 = {
-            {"8"}, doc = "go to 77%", event = "GotoPercent", args = 77,
+            { "8" },
+            event = "GotoPercent",
+            args = 77,
         }
         self.key_events.Goto88 = {
-            {"9"}, doc = "go to 88%", event = "GotoPercent", args = 88,
+            { "9" },
+            event = "GotoPercent",
+            args = 88,
         }
         self.key_events.GotoLast = {
-            {"0"}, doc = "go to end", event = "GotoPercent", args = 100,
+            { "0" },
+            event = "GotoPercent",
+            args = 100,
         }
     end
     self.pan_interval = time.s(1 / self.pan_rate)
@@ -106,7 +125,8 @@ function ReaderPaging:onReaderReady()
 end
 
 function ReaderPaging:setupTouchZones()
-    self.ges_events = {}
+    -- delegate gesture listener to readerui
+    self.ges_events = nil
     self.onGesture = nil
     if not Device:isTouchDevice() then return end
 

--- a/frontend/apps/reader/modules/readerpanning.lua
+++ b/frontend/apps/reader/modules/readerpanning.lua
@@ -17,17 +17,25 @@ function ReaderPanning:init()
         self.key_events = {
             -- these will all generate the same event, just with different arguments
             MoveUp = {
-                { "Up" }, doc = "move visible area up",
-                event = "Panning", args = {0, -1} },
+                { "Up" },
+                event = "Panning",
+                args = {0, -1}
+            },
             MoveDown = {
-                { "Down" }, doc = "move visible area down",
-                event = "Panning", args = {0,  1} },
+                { "Down" },
+                event = "Panning",
+                args = {0,  1}
+            },
             MoveLeft = {
-                { "Left" }, doc = "move visible area left",
-                event = "Panning", args = {-1, 0} },
+                { "Left" },
+                event = "Panning",
+                args = {-1, 0}
+            },
             MoveRight = {
-                { "Right" }, doc = "move visible area right",
-                event = "Panning", args = {1,  0} },
+                { "Right" },
+                event = "Panning",
+                args = {1,  0}
+            },
         }
     end
 end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -60,58 +60,78 @@ function ReaderRolling:init()
     self.key_events = {}
     if Device:hasKeys() then
         self.key_events.GotoNextView = {
-            { {"RPgFwd", "LPgFwd", "Right" } },
-            doc = "go to next view",
-            event = "GotoViewRel", args = 1,
+            { { "RPgFwd", "LPgFwd", "Right" } },
+            event = "GotoViewRel",
+            args = 1,
         }
         self.key_events.GotoPrevView = {
             { { "RPgBack", "LPgBack", "Left" } },
-            doc = "go to previous view",
-            event = "GotoViewRel", args = -1,
+            event = "GotoViewRel",
+            args = -1,
         }
     end
     if Device:hasDPad() then
         self.key_events.MoveUp = {
             { "Up" },
-            doc = "move view up",
-            event = "Panning", args = {0, -1},
+            event = "Panning",
+            args = {0, -1},
         }
         self.key_events.MoveDown = {
             { "Down" },
-            doc = "move view down",
-            event = "Panning", args = {0,  1},
+            event = "Panning",
+            args = {0,  1},
         }
     end
     if Device:hasKeyboard() then
         self.key_events.GotoFirst = {
-            {"1"}, doc = "go to start", event = "GotoPercent", args = 0,
+            { "1" },
+            event = "GotoPercent",
+            args = 0,
         }
         self.key_events.Goto11 = {
-            {"2"}, doc = "go to 11%", event = "GotoPercent", args = 11,
+            { "2" },
+            event = "GotoPercent",
+            args = 11,
         }
         self.key_events.Goto22 = {
-            {"3"}, doc = "go to 22%", event = "GotoPercent", args = 22,
+            { "3" },
+            event = "GotoPercent",
+            args = 22,
         }
         self.key_events.Goto33 = {
-            {"4"}, doc = "go to 33%", event = "GotoPercent", args = 33,
+            { "4" },
+            event = "GotoPercent",
+            args = 33,
         }
         self.key_events.Goto44 = {
-            {"5"}, doc = "go to 44%", event = "GotoPercent", args = 44,
+            { "5" },
+            event = "GotoPercent",
+            args = 44,
         }
         self.key_events.Goto55 = {
-            {"6"}, doc = "go to 55%", event = "GotoPercent", args = 55,
+            { "6" },
+            event = "GotoPercent",
+            args = 55,
         }
         self.key_events.Goto66 = {
-            {"7"}, doc = "go to 66%", event = "GotoPercent", args = 66,
+            { "7" },
+            event = "GotoPercent",
+            args = 66,
         }
         self.key_events.Goto77 = {
-            {"8"}, doc = "go to 77%", event = "GotoPercent", args = 77,
+            { "8" },
+            event = "GotoPercent",
+            args = 77,
         }
         self.key_events.Goto88 = {
-            {"9"}, doc = "go to 88%", event = "GotoPercent", args = 88,
+            { "9" },
+            event = "GotoPercent",
+            args = 88,
         }
         self.key_events.GotoLast = {
-            {"0"}, doc = "go to end", event = "GotoPercent", args = 100,
+            { "0" },
+            event = "GotoPercent",
+            args = 100,
         }
     end
     self.pan_interval = time.s(1 / self.pan_rate)
@@ -311,7 +331,8 @@ function ReaderRolling:onReaderReady()
 end
 
 function ReaderRolling:setupTouchZones()
-    self.ges_events = {}
+    -- delegate gesture listener to readerui
+    self.ges_events = nil
     self.onGesture = nil
     if not Device:isTouchDevice() then return end
 

--- a/frontend/apps/reader/modules/readerrotation.lua
+++ b/frontend/apps/reader/modules/readerrotation.lua
@@ -12,13 +12,15 @@ function ReaderRotation:init()
         self.key_events = {
             -- these will all generate the same event, just with different arguments
             RotateLeft = {
-                {"J"},
-                doc = "rotate left by 90 degrees",
-                event = "Rotate", args = -90 },
+                { "J" },
+                event = "Rotate",
+                args = -90
+            },
             RotateRight = {
-                {"K"},
-                doc = "rotate right by 90 degrees",
-                event = "Rotate", args = 90 },
+                { "K" },
+                event = "Rotate",
+                args = 90
+            },
         }
     end
 end

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -51,9 +51,7 @@ function TweakInfoWidget:init()
         }
     end
     if Device:hasKeys() then
-        self.key_events = {
-            Close = { {Device.input.group.Back}, doc = "cancel" }
-        }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
 
     local content = VerticalGroup:new{

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -36,11 +36,7 @@ local ReaderToc = InputContainer:extend{
 
 function ReaderToc:init()
     if Device:hasKeyboard() then
-        self.key_events = {
-            ShowToc = {
-                { "T" },
-                doc = "show Table of Content menu" },
-        }
+        self.key_events.ShowToc = { { "T" } }
     end
 
     if G_reader_settings:hasNot("toc_items_per_page") then

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -95,48 +95,48 @@ function ReaderZooming:init()
         self.key_events = {
             ZoomIn = {
                 { "Shift", Input.group.PgFwd },
-                doc = "zoom in",
-                event = "Zoom", args = "in"
+                event = "Zoom",
+                args = "in",
             },
             ZoomOut = {
                 { "Shift", Input.group.PgBack },
-                doc = "zoom out",
-                event = "Zoom", args = "out"
+                event = "Zoom",
+                args = "out",
             },
             ZoomToFitPage = {
                 { "A" },
-                doc = "zoom to fit page",
-                event = "SetZoomMode", args = "page"
+                event = "SetZoomMode",
+                args = "page",
             },
             ZoomToFitContent = {
                 { "Shift", "A" },
-                doc = "zoom to fit content",
-                event = "SetZoomMode", args = "content"
+                event = "SetZoomMode",
+                args = "content",
             },
             ZoomToFitPageWidth = {
                 { "S" },
-                doc = "zoom to fit page width",
-                event = "SetZoomMode", args = "pagewidth"
+                event = "SetZoomMode",
+                args = "pagewidth",
             },
             ZoomToFitContentWidth = {
                 { "Shift", "S" },
-                doc = "zoom to fit content width",
-                event = "SetZoomMode", args = "contentwidth"
+                event = "SetZoomMode",
+                args = "contentwidth",
             },
             ZoomToFitPageHeight = {
                 { "D" },
-                doc = "zoom to fit page height",
-                event = "SetZoomMode", args = "pageheight"
+                event = "SetZoomMode",
+                args = "pageheight",
             },
             ZoomToFitContentHeight = {
                 { "Shift", "D" },
-                doc = "zoom to fit content height",
-                event = "SetZoomMode", args = "contentheight"
+                event = "SetZoomMode",
+                args = "contentheight",
             },
             ZoomManual = {
                 { "Shift", "M" },
-                doc = "manual zoom mode",
-                event = "SetZoomMode", args = "manual"
+                event = "SetZoomMode",
+                args = "manual",
             },
         }
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -123,8 +123,8 @@ function ReaderUI:init()
     SettingsMigration:migrateSettings(self.doc_settings)
 
     if Device:hasKeys() then
-        self.key_events.Home = { {"Home"}, doc = "open file browser" }
-        self.key_events.Reload = { {"F5"}, doc = "reload document" }
+        self.key_events.Home = { { "Home" } }
+        self.key_events.Reload = { { "F5" } }
     end
 
     -- a view container (so it must be child #1!)

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -1350,6 +1350,9 @@ function GestureDetector:adjustGesCoordinate(ges)
             ges.direction = translateGesDirCoordinate(ges.direction, ges_coordinate_translation_90)
             if ges.ges == "multiswipe" then
                 ges.multiswipe_directions = translateMultiswipeGesDirCoordinate(ges.multiswipe_directions, ges_coordinate_translation_90)
+                logger.dbg("GestureDetector: Landscape translation for multiswipe:", ges.multiswipe_directions)
+            else
+                logger.dbg("GestureDetector: Landscape translation for ges:", ges.ges, ges.direction)
             end
             if ges.relative then
                 ges.relative.x, ges.relative.y = -ges.relative.y, ges.relative.x
@@ -1362,6 +1365,7 @@ function GestureDetector:adjustGesCoordinate(ges)
             elseif ges.direction == "vertical" then
                 ges.direction = "horizontal"
             end
+            logger.dbg("GestureDetector: Landscape translation for ges:", ges.ges, ges.direction)
         end
     elseif mode == self.screen.ORIENTATION_LANDSCAPE_ROTATED then
         -- in landscape mode rotated 270
@@ -1378,6 +1382,9 @@ function GestureDetector:adjustGesCoordinate(ges)
             ges.direction = translateGesDirCoordinate(ges.direction, ges_coordinate_translation_270)
             if ges.ges == "multiswipe" then
                 ges.multiswipe_directions = translateMultiswipeGesDirCoordinate(ges.multiswipe_directions, ges_coordinate_translation_270)
+                logger.dbg("GestureDetector: Inverted landscape translation for multiswipe:", ges.multiswipe_directions)
+            else
+                logger.dbg("GestureDetector: Inverted landscape translation for ges:", ges.ges, ges.direction)
             end
             if ges.relative then
                 ges.relative.x, ges.relative.y = ges.relative.y, -ges.relative.x
@@ -1390,6 +1397,7 @@ function GestureDetector:adjustGesCoordinate(ges)
             elseif ges.direction == "vertical" then
                 ges.direction = "horizontal"
             end
+            logger.dbg("GestureDetector: Inverted landscape translation for ges:", ges.ges, ges.direction)
         end
     elseif mode == self.screen.ORIENTATION_PORTRAIT_ROTATED then
         -- in portrait mode rotated 180
@@ -1406,21 +1414,16 @@ function GestureDetector:adjustGesCoordinate(ges)
             ges.direction = translateGesDirCoordinate(ges.direction, ges_coordinate_translation_180)
             if ges.ges == "multiswipe" then
                 ges.multiswipe_directions = translateMultiswipeGesDirCoordinate(ges.multiswipe_directions, ges_coordinate_translation_180)
+                logger.dbg("GestureDetector: Inverted portrait translation for multiswipe:", ges.multiswipe_directions)
+            else
+                logger.dbg("GestureDetector: Inverted portrait translation for ges:", ges.ges, ges.direction)
             end
             if ges.relative then
                 ges.relative.x, ges.relative.y = -ges.relative.x, -ges.relative.y
             end
-        elseif ges.ges == "pinch" or ges.ges == "spread"
-                or ges.ges == "inward_pan"
-                or ges.ges == "outward_pan" then
-            if ges.direction == "horizontal" then
-                ges.direction = "horizontal"
-            elseif ges.direction == "vertical" then
-                ges.direction = "vertical"
-            end
         end
+        -- pinch/spread are unaffected
     end
-    logger.dbg("adjusted ges:", ges.ges, ges.multiswipe_directions or ges.direction)
     return ges
 end
 

--- a/frontend/device/key.lua
+++ b/frontend/device/key.lua
@@ -51,8 +51,10 @@ least one key in this table must match.
 
 E.g.:
 
-Key:match({ "Alt", "K" }) -- match Alt-K
-Key:match({ "Alt", { "K", "L" }}) -- match Alt-K _or_ Alt-L
+Key:match({ "K" }) -- match K
+Key:match({ { "K", "L" } }) -- match K _or_ L
+Key:match({ "Alt", "K" }) -- match Alt+K
+Key:match({ "Alt", { "K", "L" }}) -- match Alt+K _or_ Alt+L
 ]]
 function Key:match(sequence)
     local mod_keys = {} -- a hash table for checked modifiers

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -368,6 +368,11 @@ function Kindle:readyToSuspend()
     self.suspend_time = time.boottime_or_realtime_coarse()
 end
 
+-- We add --no-same-permissions --no-same-owner to make the userstore fuse proxy happy...
+function Kindle:untar(archive, extract_to)
+    return os.execute(("./tar --no-same-permissions --no-same-owner -xf %q -C %q"):format(archive, extract_to))
+end
+
 function Kindle:setEventHandlers(UIManager)
     UIManager.event_handlers.Suspend = function()
         self.powerd:toggleSuspend()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -599,13 +599,11 @@ local KindlePaperWhite5 = Kindle:extend{
     canDoSwipeAnimation = yes,
 }
 
-local KindleScribe = Kindle:extend{
-    model = "KindleScribe",
+local KindleBasic4 = Kindle:extend{
+    model = "KindleBasic4",
     isMTK = yes,
     isTouchDevice = yes,
     hasFrontlight = yes,
-    hasNaturalLight = yes,
-    hasNaturalLightMixer = yes,
     display_dpi = 300,
     -- TBD
     touch_dev = "/dev/input/by-path/platform-1001e000.i2c-event",
@@ -1110,7 +1108,7 @@ function KindlePaperWhite5:init()
     self.input.open("fake_events")
 end
 
-function KindleScribe:init()
+function KindleBasic4:init()
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     -- TBD, assume PW5 for now
     self.powerd = require("device/kindle/powerd"):new{
@@ -1170,7 +1168,7 @@ KindlePaperWhite4.exit = KindleTouch.exit
 KindleBasic3.exit = KindleTouch.exit
 KindleOasis3.exit = KindleTouch.exit
 KindlePaperWhite5.exit = KindleTouch.exit
-KindleScribe.exit = KindleTouch.exit
+KindleBasic4.exit = KindleTouch.exit
 
 function Kindle3:exit()
     -- send double menu key press events to trigger screen refresh
@@ -1225,7 +1223,7 @@ local pw4_set = Set { "0PP", "0T1", "0T2", "0T3", "0T4", "0T5", "0T6",
 local kt4_set = Set { "10L", "0WF", "0WG", "0WH", "0WJ", "0VB" }
 local koa3_set = Set { "11L", "0WQ", "0WP", "0WN", "0WM", "0WL" }
 local pw5_set = Set { "1LG", "1Q0", "1PX", "1VD", "219", "21A", "2BH", "2BJ", "2DK" }
-local scribe_set = Set { "22D", "25T", "23A", "2AQ", "2AP", "1XH", "22C" }
+local kt5_set = Set { "22D", "25T", "23A", "2AQ", "2AP", "1XH", "22C" }
 
 if kindle_sn_lead == "B" or kindle_sn_lead == "9" then
     local kindle_devcode = string.sub(kindle_sn, 3, 4)
@@ -1270,8 +1268,8 @@ else
         return KindleOasis3
     elseif pw5_set[kindle_devcode_v2] then
         return KindlePaperWhite5
-    elseif scribe_set[kindle_devcode_v2] then
-        return KindleScribe
+    elseif kt5_set[kindle_devcode_v2] then
+        return KindleBasic4
     end
 end
 

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -206,7 +206,7 @@ end
 
 function KindlePowerD:checkUnexpectedWakeup()
     local state = self:getPowerdState()
-    logger.info("Powerd resume state:", state)
+    logger.dbg("Powerd resume state:", state)
     -- If we moved on to the active state,
     -- then we were woken by user input not our alarm.
     if state ~= "screenSaver" and state ~= "suspended" then return end
@@ -214,7 +214,7 @@ function KindlePowerD:checkUnexpectedWakeup()
     if self.device.wakeup_mgr:isWakeupAlarmScheduled() and self.device.wakeup_mgr:wakeupAction() then
         logger.info("Kindle scheduled wakeup")
     else
-        logger.info("Kindle unscheduled wakeup")
+        logger.warn("Kindle unscheduled wakeup")
     end
 end
 
@@ -228,7 +228,7 @@ function KindlePowerD:initWakeupMgr()
     if self.lipc_handle == nil then return end
 
     function KindlePowerD:wakeupFromSuspend()
-        logger.info("Kindle wakeupFromSuspend")
+        logger.dbg("Kindle wakeupFromSuspend")
         -- Give the device a few seconds to settle.
         -- This filters out user input resumes -> device will resume to active
         -- Also the Kindle stays in Ready to suspend for 10 seconds
@@ -238,7 +238,7 @@ function KindlePowerD:initWakeupMgr()
     end
 
     function KindlePowerD:readyToSuspend()
-        logger.info("Kindle readyToSuspend")
+        logger.dbg("Kindle readyToSuspend")
         if self.device.wakeup_mgr:isWakeupAlarmScheduled() then
             local now = os.time()
             local alarm = self.device.wakeup_mgr:getWakeupAlarmEpoch()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -428,6 +428,7 @@ local KoboLuna = Kobo:extend{
     hasFrontlight = yes,
     touch_phoenix_protocol = true,
     display_dpi = 212,
+    hasReliableMxcWaitFor = no, -- Board is similar to the Libra 2, but it's such an unpopular device that reports are scarce.
 }
 
 -- Kobo Elipsa
@@ -534,6 +535,9 @@ local KoboGoldfinch = Kobo:extend{
     },
     battery_sysfs = "/sys/class/power_supply/battery",
     power_dev = "/dev/input/by-path/platform-bd71828-pwrkey-event",
+    -- Board is eerily similar to the Libra 2, which, unfortunately, means it's also buggy as hell...
+    -- c.f., https://github.com/koreader/koreader/issues/9552#issuecomment-1293000313
+    hasReliableMxcWaitFor = no,
 }
 
 function Kobo:setupChargingLED()

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -62,6 +62,10 @@ local PocketBook = Generic:extend{
     --- @fixme: Never actually set anywhere?
     is_using_raw_input = nil,
 
+    -- InkView may have started translating button codes based on rotation on newer devices...
+    -- That historically wasn't the case, hence this defaulting to false.
+    inkview_translates_buttons = false,
+
     -- Will be set appropriately at init
     isB288SoC = no,
 
@@ -215,6 +219,11 @@ function PocketBook:init()
             end
         end,
     }
+
+    -- If InkView translates buttons for us, disable our own translation map
+    if self.inkview_translates_buttons then
+        self.input.rotation_map = nil
+    end
 
     -- in contrast to kobo/kindle, pocketbook-devices do not use linux/input
     -- events directly. To be able to use input.lua nevertheless, we make
@@ -593,6 +602,8 @@ local PocketBook700 = PocketBook:extend{
     display_dpi = 300,
     isAlwaysPortrait = yes,
     hasNaturalLight = yes,
+    -- c.f., https://github.com/koreader/koreader/issues/9556
+    inkview_translates_buttons = true,
 }
 
 -- PocketBook InkPad 3 (740)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20220930
+local CURRENT_MIGRATION_DATE = 20221027
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -476,6 +476,16 @@ if last_migration_date < 20220930 then
     ok, err = os.rename(defaults_path, archived_path)
     if not ok then
        logger.warn("os.rename:", err)
+    end
+end
+
+-- Extend the 20220205 hack to *all* the devices flagged as unreliable...
+if last_migration_date < 20221027 then
+    logger.info("Performing one-time migration for 20221027")
+
+    local Device = require("device")
+    if Device:isKobo() and not Device:hasReliableMxcWaitFor() then
+        G_reader_settings:makeFalse("followed_link_marker")
     end
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -456,7 +456,14 @@ if last_migration_date < 20220930 then
     if not load_defaults then
         logger.warn("loadfile:", err)
     else
-        load_defaults()
+        -- User input, there may be syntax errors, go through pcall like we used to.
+        local ok, perr = pcall(load_defaults)
+        if not ok then
+            logger.warn("Failed to execute defaults.persistent.lua:", perr)
+            -- Don't keep *anything* around, to make it more obvious that something went screwy...
+            logger.warn("/!\\ YOU WILL HAVE TO MIGRATE YOUR CUSTOM defaults.lua SETTINGS MANUALLY /!\\")
+            defaults = {}
+        end
     end
 
     for k, v in pairs(defaults) do

--- a/frontend/ui/elements/mass_storage.lua
+++ b/frontend/ui/elements/mass_storage.lua
@@ -1,6 +1,7 @@
 local Device = require("device")
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
+local logger = require("logger")
 local _ = require("gettext")
 
 local MassStorage = {}
@@ -61,6 +62,7 @@ function MassStorage:start(never_ask)
             ok_callback = function()
                 -- save settings before activating USBMS:
                 UIManager:flushSettings()
+                logger.info("Exiting KOReader to enter USBMS mode...")
                 UIManager:broadcastEvent(Event:new("Close"))
                 UIManager:quit(86)
             end,
@@ -73,6 +75,7 @@ function MassStorage:start(never_ask)
     else
         -- save settings before activating USBMS:
         UIManager:flushSettings()
+        logger.info("Exiting KOReader to enter USBMS mode...")
         UIManager:broadcastEvent(Event:new("Close"))
         UIManager:quit(86)
     end

--- a/frontend/ui/widget/bboxwidget.lua
+++ b/frontend/ui/widget/bboxwidget.lua
@@ -51,14 +51,14 @@ function BBoxWidget:init()
         }
     else
         self._confirm_stage = 1 -- 1 for left-top, 2 for right-bottom
-        self.key_events.MoveIndicatorUp = { { "Up" }, doc="Move indicator up", event="MoveIndicator", args = { 0, -1 } }
-        self.key_events.MoveIndicatorDown = { { "Down" }, doc="Move indicator down", event="MoveIndicator", args = { 0, 1 } }
-        self.key_events.MoveIndicatorLeft = { { "Left" }, doc="Move indicator left", event="MoveIndicator", args = { -1, 0 } }
-        self.key_events.MoveIndicatorRight = { { "Right" }, doc="Move indicator right", event="MoveIndicator", args = { 1, 0 } }
+        self.key_events.MoveIndicatorUp    = { { "Up" },    event="MoveIndicator", args = { 0, -1 } }
+        self.key_events.MoveIndicatorDown  = { { "Down" },  event="MoveIndicator", args = { 0, 1 } }
+        self.key_events.MoveIndicatorLeft  = { { "Left" },  event="MoveIndicator", args = { -1, 0 } }
+        self.key_events.MoveIndicatorRight = { { "Right" }, event="MoveIndicator", args = { 1, 0 } }
     end
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close windows" }
-        self.key_events.Select = { {"Press"}, doc = "confirm adjust" }
+        self.key_events.Close = { { Device.input.group.Back } }
+        self.key_events.Select = { { "Press" } }
     end
 end
 

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -548,43 +548,45 @@ function BookMapWidget:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {Input.group.Back}, doc = "close page" },
-            ScrollRowUp = {{"Up"}, doc = "scroll up"},
-            ScrollRowDown = {{"Down"}, doc = "scrol down"},
-            ScrollPageUp = {{Input.group.PgBack}, doc = "prev page"},
-            ScrollPageDown = {{Input.group.PgFwd}, doc = "next page"},
+            Close = { { Input.group.Back } },
+            ScrollRowUp = { { "Up" } },
+            ScrollRowDown = { { "Down" } },
+            ScrollPageUp = { { Input.group.PgBack } },
+            ScrollPageDown = { { Input.group.PgFwd } },
         }
     end
     if Device:isTouchDevice() then
-        self.ges_events.Swipe = {
-            GestureRange:new{
-                ges = "swipe",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.MultiSwipe = {
-            GestureRange:new{
-                ges = "multiswipe",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.Tap = {
-            GestureRange:new{
-                ges = "tap",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.Pinch = {
-            GestureRange:new{
-                ges = "pinch",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.Spread = {
-            GestureRange:new{
-                ges = "spread",
-                range = self.dimen,
-            }
+        self.ges_events = {
+            Swipe = {
+                GestureRange:new{
+                    ges = "swipe",
+                    range = self.dimen,
+                }
+            },
+            MultiSwipe = {
+                GestureRange:new{
+                    ges = "multiswipe",
+                    range = self.dimen,
+                }
+            },
+            Tap = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = self.dimen,
+                }
+            },
+            Pinch = {
+                GestureRange:new{
+                    ges = "pinch",
+                    range = self.dimen,
+                }
+            },
+            Spread = {
+                GestureRange:new{
+                    ges = "spread",
+                    range = self.dimen,
+                }
+            },
         }
         -- No need for any long-press handler: page slots may be small and we can't
         -- really target a precise page slot with our fat finger above it...

--- a/frontend/ui/widget/bookstatuswidget.lua
+++ b/frontend/ui/widget/bookstatuswidget.lua
@@ -98,7 +98,7 @@ function BookStatusWidget:init()
     }
 
     if Device:hasKeys() then
-        self.key_events.Close = { { Device.input.group.Back }, doc = "close dialog" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -190,14 +190,12 @@ function Button:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Tap Button",
         },
         HoldSelectButton = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Button",
         },
         -- Safe-guard for when used inside a MovableContainer
         HoldReleaseSelectButton = {

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -62,9 +62,7 @@ local ButtonDialog = InputContainer:extend{
 function ButtonDialog:init()
     if Device:hasKeys() then
         local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
-        self.key_events = {
-            Close = { { close_keys }, doc = "close button dialog" }
-        }
+        self.key_events.Close = { { close_keys } }
     end
     if Device:isTouchDevice() then
         self.ges_events.TapClose = {

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -45,9 +45,7 @@ function ButtonDialogTitle:init()
     if self.dismissable then
         if Device:hasKeys() then
             local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
-            self.key_events = {
-                Close = { { close_keys }, doc = "close button dialog" }
-            }
+            self.key_events.Close = { { close_keys } }
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -103,14 +103,12 @@ function CheckButton:initCheckButton(checked)
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Tap Button",
         },
         HoldCheckButton = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Button",
         },
         -- Safe-guard for when used inside a MovableContainer
         HoldReleaseCheckButton = {
@@ -118,7 +116,6 @@ function CheckButton:initCheckButton(checked)
                 ges = "hold_release",
                 range = self.dimen,
             },
-            doc = "Hold Release Button",
         }
     }
 end

--- a/frontend/ui/widget/closebutton.lua
+++ b/frontend/ui/widget/closebutton.lua
@@ -57,7 +57,6 @@ function CloseButton:init()
             -- drawn. so use callback to get range at runtime.
             range = function() return self.dimen end,
         },
-        doc = "Tap on close button",
     }
 
     self.ges_events.HoldClose = {
@@ -65,7 +64,6 @@ function CloseButton:init()
             ges = "hold_release",
             range = function() return self.dimen end,
         },
-        doc = "Hold on close button",
     }
 end
 

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -60,14 +60,12 @@ function OptionTextItem:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Select Option Item",
         },
         HoldSelect = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Option Item",
         },
     }
 end
@@ -134,14 +132,12 @@ function OptionIconItem:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Select Option Item",
         },
         HoldSelect = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Option Item",
         },
 
     }
@@ -898,7 +894,7 @@ function ConfigDialog:init()
     if Device:hasKeys() then
         -- set up keyboard events
         local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
-        self.key_events.Close = { { close_keys }, doc = "close config menu" }
+        self.key_events.Close = { { close_keys } }
     end
 end
 

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -72,7 +72,7 @@ function ConfirmBox:init()
             }
         end
         if Device:hasKeys() then
-            self.key_events.Close = { {Device.input.group.Back}, doc = "cancel" }
+            self.key_events.Close = { { Device.input.group.Back } }
         end
     end
     local text_widget = TextBoxWidget:new{

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -1,23 +1,33 @@
 --[[--
-An InputContainer is a WidgetContainer that handles user input events including multi touches
-and key presses.
+An InputContainer is a WidgetContainer that handles user input events including multi touches and key presses.
 
 See @{InputContainer:registerTouchZones} for examples of how to listen for multi touch input.
 
-This example illustrates how to listen for a key press input event:
+This example illustrates how to listen for a key press input event via the `key_events` hashmap:
 
-    PanBy20 = {
-        { "Shift", Input.group.Cursor },
-        seqtext = "Shift+Cursor",
-        doc = "pan by 20px",
-        event = "Pan", args = 20, is_inactive = true,
+    key_events = {
+        PanBy20 = {
+            { "Shift", Input.group.Cursor }, -- Shift + (any member of) Cursor
+            event = "Pan",
+            args = 20,
+            is_inactive = true,
+        },
+        PanNormal = {
+            { Input.group.Cursor }, -- Any member of Cursor (itself an array)
+            event = "Pan",
+            args = 10,
+        },
+        Exit = {
+            { "Alt", "F4" }, -- Alt + F4
+            { "Ctrl", "Q" }, -- Ctrl + Q
+        },
+        Home = {
+            { { "Home", "H" } }, -- Any of Home or H (note the extra nesting!)
+        },
+        End = {
+            { "End" }, -- NOTE: For a *single* key, we can forgo the nesting (c.f., match @ device/key).
+        },
     },
-    PanNormal = {
-        { Input.group.Cursor },
-        seqtext = "Cursor",
-        doc = "pan by 10 px", event = "Pan", args = 10,
-    },
-    Quit = { {"Home"} },
 
 It is recommended to reference configurable sequences from another table
 and to store that table as a configuration setting.
@@ -214,6 +224,7 @@ function InputContainer:onKeyPress(key)
     for name, seq in pairs(self.key_events) do
         if not seq.is_inactive then
             for _, oneseq in ipairs(seq) do
+                -- NOTE: key is a device/key object, this isn't string.match!
                 if key:match(oneseq) then
                     local eventname = seq.event or name
                     return self:handleEvent(Event:new(eventname, seq.args, key))

--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -74,14 +74,15 @@ function MovableContainer:init()
         -- which is somehow nice and gives a kind of magnetic move that
         -- stick the widget to some invisible rulers.
         -- (Touch is needed for accurate pan)
-        self.ges_events = {}
-        self.ges_events.MovableTouch = not ignore.touch and { GestureRange:new{ ges = "touch", range = range } } or nil
-        self.ges_events.MovableSwipe = not ignore.swipe and { GestureRange:new{ ges = "swipe", range = range } } or nil
-        self.ges_events.MovableHold = not ignore.hold and { GestureRange:new{ ges = "hold", range = range } } or nil
-        self.ges_events.MovableHoldPan = not ignore.hold_pan and { GestureRange:new{ ges = "hold_pan", range = range } } or nil
-        self.ges_events.MovableHoldRelease = not ignore.hold_release and { GestureRange:new{ ges = "hold_release", range = range } } or nil
-        self.ges_events.MovablePan = not ignore.pan and { GestureRange:new{ ges = "pan", range = range } } or nil
-        self.ges_events.MovablePanRelease = not ignore.pan_release and { GestureRange:new{ ges = "pan_release", range = range } } or nil
+        self.ges_events = {
+            MovableTouch       = not ignore.touch        and { GestureRange:new{ ges = "touch", range = range } } or nil,
+            MovableSwipe       = not ignore.swipe        and { GestureRange:new{ ges = "swipe", range = range } } or nil,
+            MovableHold        = not ignore.hold         and { GestureRange:new{ ges = "hold", range = range } } or nil,
+            MovableHoldPan     = not ignore.hold_pan     and { GestureRange:new{ ges = "hold_pan", range = range } } or nil,
+            MovableHoldRelease = not ignore.hold_release and { GestureRange:new{ ges = "hold_release", range = range } } or nil,
+            MovablePan         = not ignore.pan          and { GestureRange:new{ ges = "pan", range = range } } or nil,
+            MovablePanRelease  = not ignore.pan_release  and { GestureRange:new{ ges = "pan_release", range = range } } or nil,
+        }
     end
 end
 

--- a/frontend/ui/widget/container/scrollablecontainer.lua
+++ b/frontend/ui/widget/container/scrollablecontainer.lua
@@ -79,14 +79,15 @@ function ScrollableContainer:init()
         --   Pan happens if he doesn't hold at start, but holds at end
         --   Swipe happens if he doesn't hold at any moment
         -- (Touch is needed for accurate pan)
-        self.ges_events = {}
-        self.ges_events.ScrollableTouch = not ignore.touch and { GestureRange:new{ ges = "touch", range = range } } or nil
-        self.ges_events.ScrollableSwipe = not ignore.swipe and { GestureRange:new{ ges = "swipe", range = range } } or nil
-        self.ges_events.ScrollableHold = not ignore.hold and { GestureRange:new{ ges = "hold", range = range } } or nil
-        self.ges_events.ScrollableHoldPan = not ignore.hold_pan and { GestureRange:new{ ges = "hold_pan", range = range } } or nil
-        self.ges_events.ScrollableHoldRelease = not ignore.hold_release and { GestureRange:new{ ges = "hold_release", range = range } } or nil
-        self.ges_events.ScrollablePan = not ignore.pan and { GestureRange:new{ ges = "pan", range = range } } or nil
-        self.ges_events.ScrollablePanRelease = not ignore.pan_release and { GestureRange:new{ ges = "pan_release", range = range } } or nil
+        self.ges_events = {
+            ScrollableTouch       = not ignore.touch        and { GestureRange:new{ ges = "touch", range = range } } or nil,
+            ScrollableSwipe       = not ignore.swipe        and { GestureRange:new{ ges = "swipe", range = range } } or nil,
+            ScrollableHold        = not ignore.hold         and { GestureRange:new{ ges = "hold", range = range } } or nil,
+            ScrollableHoldPan     = not ignore.hold_pan     and { GestureRange:new{ ges = "hold_pan", range = range } } or nil,
+            ScrollableHoldRelease = not ignore.hold_release and { GestureRange:new{ ges = "hold_release", range = range } } or nil,
+            ScrollablePan         = not ignore.pan          and { GestureRange:new{ ges = "pan", range = range } } or nil,
+            ScrollablePanRelease  = not ignore.pan_release  and { GestureRange:new{ ges = "pan_release", range = range } } or nil,
+        }
     end
 end
 

--- a/frontend/ui/widget/datetimewidget.lua
+++ b/frontend/ui/widget/datetimewidget.lua
@@ -117,18 +117,16 @@ function DateTimeWidget:init()
     end
     self.width = self.width or math.floor(math.min(self.screen_width, self.screen_height) * width_scale_factor)
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close date widget" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
     if Device:isTouchDevice() then
-        self.ges_events = {
-            TapClose = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = Geom:new{
-                        w = self.screen_width,
-                        h = self.screen_height,
-                    }
-                },
+        self.ges_events.TapClose = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    w = self.screen_width,
+                    h = self.screen_height,
+                }
             },
         }
     end

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -96,9 +96,9 @@ function DictQuickLookup:init()
     self.image_alt_face = Font:getFace("cfont", font_size_alt)
     if Device:hasKeys() then
         self.key_events = {
-            ReadPrevResult = {{Input.group.PgBack}, doc = "read prev result"},
-            ReadNextResult = {{Input.group.PgFwd}, doc = "read next result"},
-            Close = { {Input.group.Back}, doc = "close quick lookup" }
+            ReadPrevResult = { { Input.group.PgBack } },
+            ReadNextResult = { { Input.group.PgFwd } },
+            Close = { { Input.group.Back } },
         }
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -67,18 +67,16 @@ function DoubleSpinWidget:init()
         self.width = math.floor(math.min(self.screen_width, self.screen_height) * self.width_factor)
     end
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close doublespin widget" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
     if Device:isTouchDevice() then
-        self.ges_events = {
-            TapClose = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = Geom:new{
-                        w = self.screen_width,
-                        h = self.screen_height,
-                    }
-                },
+        self.ges_events.TapClose = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    w = self.screen_width,
+                    h = self.screen_height,
+                }
             },
         }
     end

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -46,26 +46,26 @@ local function populateEventMappings()
     if Device:hasDPad() then
         local event_keys = {}
         -- these will all generate the same event, just with different arguments
-        table.insert(event_keys, {"FocusUp",    { {"Up"},    doc = "move focus up",    event = "FocusMove", args = {0, -1} } })
-        table.insert(event_keys, {"FocusRight", { {"Right"}, doc = "move focus right", event = "FocusMove", args = {1,  0} } })
-        table.insert(event_keys, {"FocusDown",  { {"Down"},  doc = "move focus down",  event = "FocusMove", args = {0,  1} } })
-        table.insert(event_keys, {"Press",      { {"Press"}, doc = "tap the widget",   event="Press" }})
+        table.insert(event_keys, { "FocusUp",    { { "Up" },    event = "FocusMove", args = {0, -1} } })
+        table.insert(event_keys, { "FocusRight", { { "Right" }, event = "FocusMove", args = {1,  0} } })
+        table.insert(event_keys, { "FocusDown",  { { "Down" },  event = "FocusMove", args = {0,  1} } })
+        table.insert(event_keys, { "Press",      { { "Press" }, event = "Press" } })
         local FEW_KEYS_END_INDEX = #event_keys -- Few keys device: only setup up, down, right and press
 
-        table.insert(event_keys, {"FocusLeft",  { {"Left"},  doc = "move focus left",         event = "FocusMove", args = {-1, 0} } })
+        table.insert(event_keys, { "FocusLeft",  { { "Left" },  event = "FocusMove", args = {-1, 0} } })
         local NORMAL_KEYS_END_INDEX = #event_keys
 
         -- Advanced Feature: following event handlers can be enabled via settings.reader.lua
-        -- Key combinations (Sym, Alt+Up, Tab, Shift+Tab and so on) are not used but shown as examples here
-        table.insert(event_keys, {"Hold",           { {"Sym", "AA"}, doc = "tap and hold the widget", event="Hold" } })
+        -- Key combinations (Sym+AA, Alt+Up, Tab, Shift+Tab and so on) are not used but shown as examples here
+        table.insert(event_keys, { "Hold",           { { "Sym", "AA" },    event = "Hold" } })
         -- half rows/columns move, it is helpful for slow device like Kindle DX to move quickly
-        table.insert(event_keys, {"HalfFocusUp",    { {"Alt", "Up"},    doc = "move focus half columns up",    event = "FocusHalfMove", args = {"up"} } })
-        table.insert(event_keys, {"HalfFocusRight", { {"Alt", "Right"}, doc = "move focus half rows right",    event = "FocusHalfMove", args = {"right"} } })
-        table.insert(event_keys, {"HalfFocusDown",  { {"Alt", "Down"},  doc = "move focus half columns down",  event = "FocusHalfMove", args = {"down"} } })
-        table.insert(event_keys, {"HalfFocusLeft",  { {"Alt", "Left"},  doc = "move focus half rows left",     event = "FocusHalfMove", args = {"left"} } })
+        table.insert(event_keys, { "HalfFocusUp",    { { "Alt", "Up" },    event = "FocusHalfMove", args = {"up"} } })
+        table.insert(event_keys, { "HalfFocusRight", { { "Alt", "Right" }, event = "FocusHalfMove", args = {"right"} } })
+        table.insert(event_keys, { "HalfFocusDown",  { { "Alt", "Down" },  event = "FocusHalfMove", args = {"down"} } })
+        table.insert(event_keys, { "HalfFocusLeft",  { { "Alt", "Left" },  event = "FocusHalfMove", args = {"left"} } })
         -- for PC navigation behavior support
-        table.insert(event_keys, {"FocusNext",      { {"Tab"},            doc = "move focus to next widget",     event="FocusNext"} })
-        table.insert(event_keys, {"FocusPrevious",  { {"Shift", "Tab"},   doc = "move focus to previous widget", event="FocusPrevious"} })
+        table.insert(event_keys, { "FocusNext",      { { "Tab" },          event = "FocusNext" } })
+        table.insert(event_keys, { "FocusPrevious",  { { "Shift", "Tab" }, event = "FocusPrevious" } })
 
         for i = 1, FEW_KEYS_END_INDEX do
             local key_name = event_keys[i][1]

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -188,8 +188,8 @@ function FootnoteWidget:init()
     end
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {Device.input.group.Back}, doc = "cancel" },
-            Follow = { {"Press"}, doc = "follow link" },
+            Close = { { Device.input.group.Back } },
+            Follow = { { "Press" } },
         }
     end
 

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -80,7 +80,7 @@ function FrontLightWidget:init()
 
     -- Input
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close frontlight" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
     if Device:isTouchDevice() then
         self.ges_events = {

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -27,12 +27,10 @@ local HtmlBoxWidget = InputContainer:extend{
 
 function HtmlBoxWidget:init()
     if Device:isTouchDevice() then
-        self.ges_events = {
-            TapText = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = function() return self.dimen end,
-                },
+        self.ges_events.TapText = {
+            GestureRange:new{
+                ges = "tap",
+                range = function() return self.dimen end,
             },
         }
     end

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -81,21 +81,18 @@ function IconButton:initGesListener()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Tap IconButton",
         },
         HoldIconButton = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold IconButton",
         },
         HoldReleaseIconButton = {
             GestureRange:new{
                 ges = "hold_release",
                 range = self.dimen,
             },
-            doc = "Hold Release IconButton",
         }
     }
 end

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -84,16 +84,16 @@ function ImageViewer:init()
         if type(self.image) == "table" then
             -- if self.image is a table, then use hardware keys to change image
             self.key_events = {
-                Close = { {Device.input.group.Back}, doc = "close viewer" },
-                ShowPrevImage = { {Device.input.group.PgBack}, doc = "Previous image" },
-                ShowNextImage = { {Device.input.group.PgFwd}, doc = "Next image" },
+                Close = { { Device.input.group.Back } },
+                ShowPrevImage = { { Device.input.group.PgBack } },
+                ShowNextImage = { { Device.input.group.PgFwd } },
             }
         else
             -- otherwise, use hardware keys to zoom in/out
             self.key_events = {
-                Close = { {Device.input.group.Back}, doc = "close viewer" },
-                ZoomIn = { {Device.input.group.PgBack}, doc = "Zoom In" },
-                ZoomOut = { {Device.input.group.PgFwd}, doc = "Zoom out" },
+                Close = { { Device.input.group.Back } },
+                ZoomIn = { { Device.input.group.PgBack } },
+                ZoomOut = { { Device.input.group.PgFwd } },
             }
         end
     end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -79,10 +79,7 @@ local InfoMessage = InputContainer:extend{
 function InfoMessage:init()
     if self.dismissable then
         if Device:hasKeys() then
-            self.key_events = {
-                AnyKeyPressed = { { Input.group.Any },
-                    seqtext = "any key", doc = "close dialog" }
-            }
+            self.key_events.AnyKeyPressed = { { Input.group.Any } }
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -433,17 +433,15 @@ function InputDialog:init()
         frame
     }
     if Device:isTouchDevice() then -- is used to hide the keyboard with a tap outside of inputbox
-        self.ges_events = {
-            Tap = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self[1].dimen, -- screen above the keyboard
-                },
+        self.ges_events.Tap = {
+            GestureRange:new{
+                ges = "tap",
+                range = self[1].dimen, -- screen above the keyboard
             },
         }
     end
     if Device:hasKeys() then
-        self.key_events.CloseDialog = { {Device.input.group.Back}, doc = "close dialog" }
+        self.key_events.CloseDialog = { { Device.input.group.Back } }
     end
     if self._added_widgets then
         for _, widget in ipairs(self._added_widgets) do

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -168,7 +168,7 @@ function KeyboardLayoutDialog:init()
         self.movable,
     }
     if Device:hasKeys() then
-        self.key_events.CloseDialog = { {Device.input.group.Back}, doc = "close dialog" }
+        self.key_events.CloseDialog = { { Device.input.group.Back } }
     end
 end
 

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -302,9 +302,9 @@ function KeyValuePage:init()
     end
 
     if Device:hasKeys() then
-        self.key_events.Close = {{Input.group.Back}, doc = "close page" }
-        self.key_events.NextPage = {{Input.group.PgFwd}, doc = "next page"}
-        self.key_events.PrevPage = {{Input.group.PgBack}, doc = "prev page"}
+        self.key_events.Close = { { Input.group.Back } }
+        self.key_events.NextPage = { { Input.group.PgFwd } }
+        self.key_events.PrevPage = { { Input.group.PgBack } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -128,14 +128,12 @@ function MenuItem:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Select Menu Item",
         },
         HoldSelect = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Menu Item",
         },
     }
 
@@ -923,16 +921,12 @@ function Menu:init()
 
     if Device:hasKeys() then
         -- set up keyboard events
-        self.key_events.Close = { {Input.group.Back}, doc = "close menu" }
+        self.key_events.Close = { { Input.group.Back } }
         if Device:hasFewKeys() then
-            self.key_events.Close = { {"Left"}, doc = "close menu" }
+            self.key_events.Close = { { "Left" } }
         end
-        self.key_events.NextPage = {
-            {Input.group.PgFwd}, doc = "goto next page of the menu"
-        }
-        self.key_events.PrevPage = {
-            {Input.group.PgBack}, doc = "goto previous page of the menu"
-        }
+        self.key_events.NextPage = { { Input.group.PgFwd } }
+        self.key_events.PrevPage = { { Input.group.PgBack } }
     end
 
     if Device:hasDPad() then
@@ -940,11 +934,9 @@ function Menu:init()
         self.key_events.FocusRight = nil
         -- shortcut icon is not needed for touch device
         if self.is_enable_shortcut then
-            self.key_events.SelectByShortCut = { {self.item_shortcuts} }
+            self.key_events.SelectByShortCut = { { self.item_shortcuts } }
         end
-        self.key_events.Right = {
-            {"Right"}, doc = "hold  menu item"
-        }
+        self.key_events.Right = { { "Right" } }
     end
 
     if #self.item_table > 0 then

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -71,7 +71,7 @@ function MultiConfirmBox:init()
             }
         end
         if Device:hasKeys() then
-            self.key_events.Close = { {Device.input.group.Back}, doc = "cancel" }
+            self.key_events.Close = { { Device.input.group.Back } }
         end
     end
     local content = HorizontalGroup:new{

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -204,12 +204,10 @@ function NetworkItem:init()
     }
 
     if Device:isTouchDevice() then
-        self.ges_events = {
-            TapSelect = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = self.dimen,
-                }
+        self.ges_events.TapSelect = {
+            GestureRange:new{
+                ges = "tap",
+                range = self.dimen,
             }
         }
     end

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -71,10 +71,7 @@ function Notification:init()
     if not self.toast then
         -- If not toast, closing is handled in here
         if Device:hasKeys() then
-            self.key_events = {
-                AnyKeyPressed = { { Input.group.Any },
-                    seqtext = "any key", doc = "close dialog" }
-            }
+            self.key_events.AnyKeyPressed = { { Input.group.Any } }
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -52,49 +52,51 @@ function PageBrowserWidget:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            Close = { {Device.input.group.Back}, doc = "close page" },
-            ScrollRowUp = {{"Up"}, doc = "scroll up"},
-            ScrollRowDown = {{"Down"}, doc = "scrol down"},
-            ScrollPageUp = {{Input.group.PgBack}, doc = "prev page"},
-            ScrollPageDown = {{Input.group.PgFwd}, doc = "next page"},
+            Close = { { Device.input.group.Back } },
+            ScrollRowUp = { { "Up" } },
+            ScrollRowDown = { { "Down" } },
+            ScrollPageUp = { { Input.group.PgBack } },
+            ScrollPageDown = { { Input.group.PgFwd } },
         }
     end
     if Device:isTouchDevice() then
-        self.ges_events.Swipe = {
-            GestureRange:new{
-                ges = "swipe",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.MultiSwipe = {
-            GestureRange:new{
-                ges = "multiswipe",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.Tap = {
-            GestureRange:new{
-                ges = "tap",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.Hold = {
-            GestureRange:new{
-                ges = "hold",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.Pinch = {
-            GestureRange:new{
-                ges = "pinch",
-                range = self.dimen,
-            }
-        }
-        self.ges_events.Spread = {
-            GestureRange:new{
-                ges = "spread",
-                range = self.dimen,
-            }
+        self.ges_events = {
+            Swipe = {
+                GestureRange:new{
+                    ges = "swipe",
+                    range = self.dimen,
+                }
+            },
+            MultiSwipe = {
+                GestureRange:new{
+                    ges = "multiswipe",
+                    range = self.dimen,
+                }
+            },
+            Tap = {
+                GestureRange:new{
+                    ges = "tap",
+                    range = self.dimen,
+                }
+            },
+            Hold = {
+                GestureRange:new{
+                    ges = "hold",
+                    range = self.dimen,
+                }
+            },
+            Pinch = {
+                GestureRange:new{
+                    ges = "pinch",
+                    range = self.dimen,
+                }
+            },
+            Spread = {
+                GestureRange:new{
+                    ges = "spread",
+                    range = self.dimen,
+                }
+            },
         }
     end
 

--- a/frontend/ui/widget/physicalkeyboard.lua
+++ b/frontend/ui/widget/physicalkeyboard.lua
@@ -83,9 +83,7 @@ function PhysicalKeyboard:init()
     for _,row in ipairs(Device.keyboard_layout) do
         util.arrayAppend(all_keys, row)
     end
-    self.key_events = {
-        KeyPress = { { all_keys }, }
-    }
+    self.key_events.KeyPress = { { all_keys } }
 
     self.dimen = Geom:new{ x = 0, y = 0, w = 0, h = 0 }
 

--- a/frontend/ui/widget/qrmessage.lua
+++ b/frontend/ui/widget/qrmessage.lua
@@ -43,10 +43,7 @@ local QRMessage = InputContainer:extend{
 
 function QRMessage:init()
     if Device:hasKeys() then
-        self.key_events = {
-            AnyKeyPressed = { { Input.group.Any },
-                seqtext = "any key", doc = "close dialog" }
-        }
+        self.key_events.AnyKeyPressed = { { Input.group.Any } }
     end
     if Device:isTouchDevice() then
         self.ges_events.TapClose = {

--- a/frontend/ui/widget/radiobuttonwidget.lua
+++ b/frontend/ui/widget/radiobuttonwidget.lua
@@ -49,19 +49,17 @@ function RadioButtonWidget:init()
         self.width = math.floor(math.min(self.screen_width, self.screen_height) * self.width_factor)
     end
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close widget" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
-    self.ges_events = {
-        TapClose = {
-            GestureRange:new{
-                ges = "tap",
-                range = Geom:new{
-                    w = self.screen_width,
-                    h = self.screen_height,
-                }
-            },
+    self.ges_events.TapClose = {
+        GestureRange:new{
+            ges = "tap",
+            range = Geom:new{
+                w = self.screen_width,
+                h = self.screen_height,
+            }
         },
-        }
+    }
     self:update()
 end
 

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -18,12 +18,9 @@ local ScreenSaverWidget = InputContainer:extend{
 
 function ScreenSaverWidget:init()
     if Device:hasKeys() then
-        self.key_events = {
-            AnyKeyPressed = { { Device.input.group.Any }, seqtext = "any key", doc = "close widget" },
-        }
+        self.key_events.AnyKeyPressed = { { Device.input.group.Any } }
     end
     if Device:isTouchDevice() then
-        self.ges_events = {}
         if G_reader_settings:readSetting("screensaver_delay") == "gesture" then
             self:setupGestureEvents()
         end
@@ -34,7 +31,7 @@ function ScreenSaverWidget:init()
                 w = Screen:getWidth(),
                 h = Screen:getHeight(),
             }
-            self.ges_events["Tap"] = { GestureRange:new{ ges = "tap", range = range } }
+            self.ges_events.Tap = { GestureRange:new{ ges = "tap", range = range } }
         end
     end
     self:update()

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -79,8 +79,8 @@ function ScrollHtmlWidget:init()
 
     if Device:hasKeys() then
         self.key_events = {
-            ScrollDown = {{Input.group.PgFwd}, doc = "scroll down"},
-            ScrollUp = {{Input.group.PgBack}, doc = "scroll up"},
+            ScrollDown = { { Input.group.PgFwd } },
+            ScrollUp = { { Input.group.PgBack } },
         }
     end
 end

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -118,8 +118,8 @@ function ScrollTextWidget:init()
     end
     if Device:hasKeys() then
         self.key_events = {
-            ScrollDown = {{Input.group.PgFwd}, doc = "scroll down"},
-            ScrollUp = {{Input.group.PgBack}, doc = "scroll up"},
+            ScrollDown = { { Input.group.PgFwd } },
+            ScrollUp = { { Input.group.PgBack } },
         }
     end
 end

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -27,21 +27,19 @@ function SkimToWidget:init()
     local screen_height = Screen:getHeight()
 
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close skimto page" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
     if Device:isTouchDevice() then
-        self.ges_events = {
-            TapProgress = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = Geom:new{
-                        x = 0, y = 0,
-                        w = screen_width,
-                        h = screen_height,
-                    }
-                },
+        self.ges_events.TapProgress = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    x = 0, y = 0,
+                    w = screen_width,
+                    h = screen_height,
+                }
             },
-         }
+        }
     end
 
     self.buttons_layout = {}

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -141,9 +141,9 @@ function SortWidget:init()
         h = self.height or Screen:getHeight(),
     }
     if Device:hasKeys() then
-        self.key_events.Close = { { Device.input.group.Back }, doc = "close dialog" }
-        self.key_events.NextPage = { { Device.input.group.PgFwd}, doc = "next page"}
-        self.key_events.PrevPage = { { Device.input.group.PgBack}, doc = "prev page"}
+        self.key_events.Close = { { Device.input.group.Back } }
+        self.key_events.NextPage = { { Device.input.group.PgFwd } }
+        self.key_events.PrevPage = { { Device.input.group.PgBack } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -65,20 +65,18 @@ function SpinWidget:init()
         self.width = math.floor(math.min(self.screen_width, self.screen_height) * self.width_factor)
     end
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close spin widget" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
     if Device:isTouchDevice() then
-        self.ges_events = {
-            TapClose = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = Geom:new{
-                        w = self.screen_width,
-                        h = self.screen_height,
-                    }
-                },
+        self.ges_events.TapClose = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{
+                    w = self.screen_width,
+                    h = self.screen_height,
+                }
             },
-         }
+        }
     end
 
     if self.unit and self.unit ~= "" then

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -162,12 +162,10 @@ function TextBoxWidget:init()
     self.dimen = Geom:new(self:getSize())
 
     if Device:isTouchDevice() then
-        self.ges_events = {
-            TapImage = {
-                GestureRange:new{
-                    ges = "tap",
-                    range = function() return self.dimen end,
-                },
+        self.ges_events.TapImage = {
+            GestureRange:new{
+                ges = "tap",
+                range = function() return self.dimen end,
             },
         }
     end

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -82,9 +82,7 @@ function TextViewer:init()
     self._old_virtual_line_num = 1
 
     if Device:hasKeys() then
-        self.key_events = {
-            Close = { {Device.input.group.Back}, doc = "close text viewer" }
-        }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
 
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -118,14 +118,12 @@ function ToggleSwitch:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Toggle switch",
         },
         HoldSelect = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold switch",
         },
     }
 end

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -55,14 +55,12 @@ function TouchMenuItem:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Select Menu Item",
         },
         HoldSelect = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Menu Item",
         },
     }
 
@@ -496,12 +494,12 @@ function TouchMenu:init()
         }
     }
 
-    self.key_events.Back = { {Input.group.Back}, doc = "back to upper menu or close touchmenu" }
+    self.key_events.Back = { { Input.group.Back } }
     if Device:hasFewKeys() then
-        self.key_events.Back = { {"Left"}, doc = "back to upper menu or close touchmenu" }
+        self.key_events.Back = { { "Left" } }
     end
-    self.key_events.NextPage = { {Input.group.PgFwd}, doc = "next page" }
-    self.key_events.PrevPage = { {Input.group.PgBack}, doc = "previous page" }
+    self.key_events.NextPage = { { Input.group.PgFwd } }
+    self.key_events.PrevPage = { { Input.group.PgBack } }
 
     local icons = {}
     for _, v in ipairs(self.tab_item_table) do

--- a/frontend/ui/widget/trapwidget.lua
+++ b/frontend/ui/widget/trapwidget.lua
@@ -41,20 +41,19 @@ function TrapWidget:init()
         h = Screen:getHeight(),
     }
     if Device:hasKeys() then
-        self.key_events = {
-            AnyKeyPressed = { { Input.group.Any },
-                seqtext = "any key", doc = "dismiss" }
-        }
+        self.key_events.AnyKeyPressed = { { Input.group.Any } }
     end
     if Device:isTouchDevice() then
-        self.ges_events.TapDismiss = {
-            GestureRange:new{ ges = "tap", range = full_screen, }
-        }
-        self.ges_events.HoldDismiss = {
-            GestureRange:new{ ges = "hold", range = full_screen, }
-        }
-        self.ges_events.SwipeDismiss = {
-            GestureRange:new{ ges = "swipe", range = full_screen, }
+        self.ges_events = {
+            TapDismiss = {
+                GestureRange:new{ ges = "tap", range = full_screen, }
+            },
+            HoldDismiss = {
+                GestureRange:new{ ges = "hold", range = full_screen, }
+            },
+            SwipeDismiss = {
+                GestureRange:new{ ges = "swipe", range = full_screen, }
+            },
         }
     end
     if self.text then

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -666,17 +666,15 @@ function VirtualKeyPopup:init()
     }
     keyboard_frame.dimen = keyboard_frame:getSize()
 
-    self.ges_events = {
-        TapClose = {
-            GestureRange:new{
-                ges = "tap",
-            }
-        },
+    self.ges_events.TapClose = {
+        GestureRange:new{
+            ges = "tap",
+        }
     }
     self.tap_interval_override = time.ms(G_reader_settings:readSetting("ges_tap_interval_on_keyboard_ms", 0))
 
     if Device:hasKeys() then
-        self.key_events.Close = { {Device.input.group.Back}, doc = "close keyboard" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
 
     local offset_x = 2*keyboard_frame.bordersize + keyboard_frame.padding + parent_key.keyboard.key_padding
@@ -801,7 +799,7 @@ function VirtualKeyboard:init()
     self:initLayer(self.keyboard_layer)
     self.tap_interval_override = time.ms(G_reader_settings:readSetting("ges_tap_interval_on_keyboard_ms", 0))
     if Device:hasKeys() then
-        self.key_events.Close = { {"Back"}, doc = "close keyboard" }
+        self.key_events.Close = { { "Back" } }
     end
     if keyboard.wrapInputBox then
         self.uwrap_func = keyboard.wrapInputBox(self.inputbox) or self.uwrap_func

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -528,14 +528,16 @@ function AutoSuspend:addToMainMenu(menu_items)
         }
     end
     if Device:canStandby() then
-        --- @fixme: Reword the final warning when we have more data on the hangs on some Kobo kernels (e.g., #9038).
         local standby_help = _([[Standby puts the device into a power-saving state in which the screen is on and user input can be performed.
 
 Standby can not be entered if Wi-Fi is on.
 
-Upon user input, the device needs a certain amount of time to wake up. Generally, the newer the device, the less noticeable this delay will be, but it can be fairly aggravating on slower devices.
-
-This is experimental on most devices, except those running on a sunxi SoC (Kobo Elipsa & Sage), so much so that it might in fact hang some of the more broken kernels out there (Kobo Libra 2).]])
+Upon user input, the device needs a certain amount of time to wake up. Generally, the newer the device, the less noticeable this delay will be, but it can be fairly aggravating on slower devices.]])
+        -- Add a big fat warning on unreliable NTX boards
+        if Device:isKobo() and not Device:hasReliableMxcWaitFor() then
+            standby_help = standby_help .. "\n" ..
+                           _([[Your device is known to be extremely unreliable, as such, failure to enter a power-saving state *may* hang the kernel, resulting in a full device hang or a device restart.]])
+        end
 
         menu_items.autostandby = {
             sorting_hint = "device",

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -141,14 +141,12 @@ function ListMenuItem:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Select Menu Item",
         },
         HoldSelect = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Menu Item",
         },
     }
 

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -391,14 +391,12 @@ function MosaicMenuItem:init()
                 ges = "tap",
                 range = self.dimen,
             },
-            doc = "Select Menu Item",
         },
         HoldSelect = {
             GestureRange:new{
                 ges = "hold",
                 range = self.dimen,
             },
-            doc = "Hold Menu Item",
         },
     }
 

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -369,7 +369,6 @@ function Gestures:multiswipeRecorder(touchmenu_instance)
                 w = Screen:getWidth(),
                 h = Screen:getHeight(),
             },
-            doc = "Multiswipe in gesture creator"
         }
     }
 

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -396,9 +396,9 @@ function CalendarView:init()
     end
 
     if Device:hasKeys() then
-        self.key_events.Close = {{Input.group.Back}, doc = "close page" }
-        self.key_events.NextMonth = {{Input.group.PgFwd}, doc = "next page"}
-        self.key_events.PrevMonth = {{Input.group.PgBack}, doc = "prev page"}
+        self.key_events.Close = { { Input.group.Back } }
+        self.key_events.NextMonth = { { Input.group.PgFwd } }
+        self.key_events.PrevMonth = { { Input.group.PgBack } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -59,11 +59,8 @@ function ReaderProgress:init()
         return "ui", self.dimen
     end)
     if Device:hasKeys() then
-        self.key_events = {
-            --don't get locked in on non touch devices
-            AnyKeyPressed = { { Device.input.group.Any },
-            seqtext = "any key", doc = "close dialog" }
-        }
+        -- don't get locked in on non touch devices
+        self.key_events.AnyKeyPressed = { { Device.input.group.Any } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -154,7 +154,7 @@ local MenuDialog = FocusManager:extend{
 function MenuDialog:init()
     self.layout = {}
     if Device:hasKeys() then
-        self.key_events.Close = { { Device.input.group.Back }, doc = "close dialog" }
+        self.key_events.Close = { { Device.input.group.Back } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Tap = {
@@ -412,7 +412,7 @@ local word_info_dialog_width
 function WordInfoDialog:init()
     if self.dismissable then
         if Device:hasKeys() then
-            self.key_events.Close = { { Device.input.group.Back }, doc = "close dialog" }
+            self.key_events.Close = { { Device.input.group.Back } }
         end
         if Device:isTouchDevice() then
             self.ges_events.Tap = {
@@ -1022,9 +1022,9 @@ function VocabularyBuilderWidget:init()
         h = self.height or Screen:getHeight(),
     }
     if Device:hasKeys() then
-        self.key_events.Close = { { Device.input.group.Back }, doc = "close dialog" }
-        self.key_events.NextPage = { { Device.input.group.PgFwd}, doc = "next page"}
-        self.key_events.PrevPage = { { Device.input.group.PgBack}, doc = "prev page"}
+        self.key_events.Close = { { Device.input.group.Back } }
+        self.key_events.NextPage = { { Device.input.group.PgFwd } }
+        self.key_events.PrevPage = { { Device.input.group.PgBack } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {

--- a/spec/unit/focusmanager_spec.lua
+++ b/spec/unit/focusmanager_spec.lua
@@ -216,8 +216,8 @@ describe("FocusManager module", function()
     it("alternative key", function()
         local focusmanager = FocusManager:new{}
         focusmanager.extra_key_events = {
-            Hold = { {"Sym", "AA"}, doc = "tap and hold the widget", event="Hold" },
-            HalfFocusUp = { {"Alt", "Up"},    doc = "move focus half columns up",    event = "FocusHalfMove", args = {"up"} },
+            Hold = { { "Sym", "AA" }, event="Hold" },
+            HalfFocusUp = { { "Alt", "Up" }, event = "FocusHalfMove", args = {"up"} },
         }
         local m = Input.modifiers
         m.Sym = true

--- a/tools/kobo_touch_probe.lua
+++ b/tools/kobo_touch_probe.lua
@@ -39,12 +39,10 @@ local TouchProbe = InputContainer:extend{
 }
 
 function TouchProbe:init()
-    self.ges_events = {
-        TapProbe = {
-            GestureRange:new{
-                ges = "tap",
-            }
-        },
+    self.ges_events.TapProbe = {
+        GestureRange:new{
+            ges = "tap",
+        }
     }
     self.image_widget = ImageWidget:new{
         file = "tools/kobo-touch-probe.png",

--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -129,7 +129,7 @@ Background = InputContainer:new{
     key_events = {
         OpenDialog = { { "Press" } },
         OpenConfirmBox = { { "Del" } },
-        QuitApplication = { { {"Home","Back"} } }
+        QuitApplication = { { { "Home", "Back" } } },
     },
     -- contains a gray rectangular desktop
     FrameContainer:new{


### PR DESCRIPTION
* InputContainer: Drop dead code in the form of `seqtext` & `doc` fields. I'm not sure if they're remnants of KPV or of an aoborted design, but it's been very dead code for a very long while.
This spurred a bit of cleanup along the way ;p.
* Persist: Make sure data is flushed to disk on save (fix https://github.com/koreader/koreader/issues/9552#issuecomment-1287144009)
* GestureDetector: Only log adjusted gestures for gestures actually requiring a rotation adjustment ;).
* Kobo: Flag all the boards similar to the Libra 2 as broken^Wbuggy, and enable the full set of workarounds there (re: https://github.com/koreader/koreader/issues/9552).
* USBMS: Add a nicer info-level log message when entering USBMS, because apparently people are confused by the UIManager:quit ones.
* Kobo: Downgrade a few non-failure PM log messages to debug.
* Kindle: Ditto (that one's for you @hius07 ;p).
* GH: Update the issue template to mention that toggling verbose debug logging requires a restart.
* AutoSuspend: Update the standby help message to be friendlier to everyone, but specifically warn affected users on the aforementioned broken^Wbuggy boards ;).
* Input: Allow disabling rotation_map entirely, and do so on the PB700 (fix #9556)
* PocketBook: Move low-level input event type translation to the low-level input modules.
* OTM: Deal with a fun little quirk of the `defaults.lua` migration (fix #9700)
* Kindle: Make sure `Device:untar` actually works when targeting the userstore fuse proxy (fix #9704)

Depends on https://github.com/koreader/koreader-base/pull/1544 & https://github.com/koreader/koreader-base/pull/1545

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9691)
<!-- Reviewable:end -->
