### PR TITLE
[spec] UIManager:_task_queue has to be sorted!

### DIFF
--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -188,16 +188,17 @@ describe("UIManager spec", function()
         end
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.us(5), action = task_to_remove, args = {} },
+            { time = now - time.s(15), action = task_to_remove, args = {} }, -- this will be called
             {
                 time = now - time.s(10),
-                action = function()
+                action = function() -- this will be called, too
                     run_count = run_count + 1
                     UIManager:unschedule(task_to_remove)
                 end,
                 args = {},
             },
-            { time = now, action = task_to_remove, args = {} },
+            { time = now - time.us(5), action = task_to_remove, args = {} }, -- this will be removed
+            { time = now, action = task_to_remove, args = {} }, -- this will be removed
         }
         UIManager:_checkTasks()
         assert.are.same(2, run_count)


### PR DESCRIPTION
Fixes a test case, where the `_task_queue` was not sorted before calling `_checkTasks`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9694)
<!-- Reviewable:end -->
