### PR TITLE
NewsDownloader: Keep nil reference from being passed to UIManager  

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -678,7 +678,7 @@ function NewsDownloader:viewFeedList()
         }
     )
     -- Show the list of feeds.
-    if self.kv and #self.kv > 0 then
+    if self.kv then
         UIManager:close(self.kv)
     end
     self.kv = KeyValuePage:new{
@@ -693,7 +693,7 @@ function NewsDownloader:viewFeedList()
 end
 
 function NewsDownloader:viewFeedItem(data)
-    if #self.kv ~= 0 then
+    if self.kv then
         UIManager:close(self.kv)
     end
     self.kv = KeyValuePage:new{
@@ -802,7 +802,7 @@ function NewsDownloader:updateFeedConfig(id, key, value)
     -- Because this method is called at the menu,
     -- we might not have an active view. So this conditional
     -- statement avoids closing a null reference.
-    if #self.kv ~= 0 then
+    if self.kv then
         UIManager:close(self.kv)
     end
     -- It's possible that we will get a null value.

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -678,7 +678,7 @@ function NewsDownloader:viewFeedList()
         }
     )
     -- Show the list of feeds.
-    if self.kv ~= null and #self.kv ~= 0 then
+    if self.kv and #self.kv > 0 then
         UIManager:close(self.kv)
     end
     self.kv = KeyValuePage:new{

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -678,7 +678,7 @@ function NewsDownloader:viewFeedList()
         }
     )
     -- Show the list of feeds.
-    if #self.kv ~= 0 then
+    if self.kv ~= null and #self.kv ~= 0 then
         UIManager:close(self.kv)
     end
     self.kv = KeyValuePage:new{


### PR DESCRIPTION
*I can't believe I opened a PR and it didn't include unrelated commits.*

Can't reproduce, but most likely this is a fix for #9690

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9697)
<!-- Reviewable:end -->
