### PR TITLE
KeyValuePage: Don't compare potential nil with number

### DIFF
--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -291,6 +291,7 @@ local KeyValuePage = FocusManager:extend{
 }
 
 function KeyValuePage:init()
+    self.kv_pairs = self.kv_pairs or {}
     self.dimen = Geom:new{
         x = 0,
         y = 0,
@@ -594,10 +595,8 @@ function KeyValuePage:_populateItems()
     local unfit_items_count -- count item that needs to move or truncate key/value, not fit 1/2 ratio
     -- first we check if no unfit item at all
     local width_ratio
-    if key_widths[#key_widths] and
-       key_widths[#key_widths] <= key_w and
-       value_widths[#value_widths] and
-       value_widths[#value_widths] <= value_w then
+    if (#self.kv_pairs == 0) or
+        (key_widths[#key_widths] <= key_w and value_widths[#value_widths] <= value_w) then
         width_ratio = 1/2
     end
     if not width_ratio then

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -594,7 +594,10 @@ function KeyValuePage:_populateItems()
     local unfit_items_count -- count item that needs to move or truncate key/value, not fit 1/2 ratio
     -- first we check if no unfit item at all
     local width_ratio
-    if key_widths[#key_widths] <= key_w and value_widths[#value_widths] <= value_w then
+    if key_widths[#key_widths] and
+       key_widths[#key_widths] <= key_w and
+       value_widths[#value_widths] and
+       value_widths[#value_widths] <= value_w then
         width_ratio = 1/2
     end
     if not width_ratio then


### PR DESCRIPTION
When creating a KeyValuePage with an empty table of kv_pairs, it will throw an error unless there's a check to prevent that.

`./luajit: frontend/ui/widget/keyvaluepage.lua:601: attempt to compare nil with number`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9705)
<!-- Reviewable:end -->
