### PR TITLE
[UIManager] Reverse order of _task_queue

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -250,7 +250,7 @@ function UIManager:schedule(sched_time, action, ...)
         --       c.f., https://reprog.wordpress.com/2010/04/19/are-you-one-of-the-10-percent/
         local mid = bit.rshift(lo + hi, 1)
         local mid_time = self._task_queue[mid].time
-        if sched_time >= mid_time then
+        if mid_time <= sched_time then
             hi = mid - 1
         else
             lo = mid + 1

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -237,10 +237,11 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
     end
 end
 
--- Schedule an execution task; task queue is in ascending order
+-- Schedule an execution task; task queue is in descending order
 function UIManager:schedule(sched_time, action, ...)
     local lo, hi = 1, #self._task_queue
-    -- Rightmost binary insertion
+    self._task_queue.len = hi + 1
+    -- Leftmost binary insertion
     while lo <= hi do
         -- NOTE: We should be (mostly) free from overflow here, thanks to LuaJIT's BitOp semantics.
         --       For more fun details about this particular overflow,
@@ -250,9 +251,9 @@ function UIManager:schedule(sched_time, action, ...)
         local mid = bit.rshift(lo + hi, 1)
         local mid_time = self._task_queue[mid].time
         if sched_time >= mid_time then
-            lo = mid + 1
-        else
             hi = mid - 1
+        else
+            lo = mid + 1
         end
     end
 
@@ -345,13 +346,19 @@ UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
     local removed = false
-    for i = #self._task_queue, 1, -1 do
+    local task_queue_len = #self._task_queue
+    for i = task_queue_len, 1, -1 do
         if self._task_queue[i].action == action then
             table.remove(self._task_queue, i)
+            task_queue_len = task_queue_len - 1
             removed = true
         end
     end
-    return removed
+    if removed then
+        self._task_queue.len = task_queue_len
+        return true
+    end
+    return false
 end
 dbg:guard(UIManager, 'unschedule',
     function(self, action) assert(action ~= nil) end)
@@ -891,10 +898,9 @@ end
 --]]
 
 function UIManager:getNextTaskTime()
-    if self._task_queue[1] then
-        return self._task_queue[1].time - time:now()
-    else
-        return nil
+    local next_task = self._task_queue[self._task_queue.len]
+    if next_task then
+        return next_task.time - time:now()
     end
 end
 
@@ -905,18 +911,19 @@ function UIManager:_checkTasks()
     -- Tasks due for execution might themselves schedule more tasks (that might also be immediately due for execution ;)).
     -- Flipping this switch ensures we'll consume all such tasks *before* yielding to input polling.
     self._task_queue_dirty = false
-    while self._task_queue[1] do
-        local task_time = self._task_queue[1].time
+    while self._task_queue[self._task_queue.len] do
+        local task_time = self._task_queue[self._task_queue.len].time
         if task_time <= self._now then
             -- Pop the upcoming task, as it is due for execution...
-            local task = table.remove(self._task_queue, 1)
+            local task = table.remove(self._task_queue, self._task_queue.len)
+            self._task_queue.len = self._task_queue.len - 1
             -- ...so do it now.
             -- NOTE: Said task's action might modify _task_queue.
             --       To avoid race conditions and catch new upcoming tasks during this call,
             --       we repeatedly check the head of the queue (c.f., #1758).
             task.action(unpack(task.args))
         else
-            -- As the queue is sorted in ascending order, it's safe to assume all items are currently future tasks.
+            -- As the queue is sorted in descending order, it's safe to assume all items are currently future tasks.
             wait_until = task_time
             break
         end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -911,8 +911,8 @@ function UIManager:_checkTasks()
     -- Tasks due for execution might themselves schedule more tasks (that might also be immediately due for execution ;)).
     -- Flipping this switch ensures we'll consume all such tasks *before* yielding to input polling.
     self._task_queue_dirty = false
-    local task = self._task_queue[self._task_queue.len]
-    while task do
+    while self._task_queue.len > 0 do
+        local task = self._task_queue[self._task_queue.len]
         local task_time = task.time
         if task_time <= self._now then
             -- Remove the upcoming task, as it is due for execution...
@@ -928,7 +928,6 @@ function UIManager:_checkTasks()
             wait_until = task_time
             break
         end
-        task = self._task_queue[self._task_queue.len]
     end
 
     return wait_until, self._now

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -346,19 +346,14 @@ UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
     local removed = false
-    local task_queue_len = self._task_queue.n
-    for i = task_queue_len, 1, -1 do
+    for i = self._task_queue.n, 1, -1 do
         if self._task_queue[i].action == action then
             table.remove(self._task_queue, i)
-            task_queue_len = task_queue_len - 1
+            self._task_queue.n = self._task_queue.n - 1
             removed = true
         end
     end
-    if removed then
-        self._task_queue.n = task_queue_len
-        return true
-    end
-    return false
+    return removed
 end
 dbg:guard(UIManager, 'unschedule',
     function(self, action) assert(action ~= nil) end)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -907,11 +907,10 @@ function UIManager:_checkTasks()
     -- Flipping this switch ensures we'll consume all such tasks *before* yielding to input polling.
     self._task_queue_dirty = false
     while self._task_queue.n > 0 do
-        local task = self._task_queue[self._task_queue.n]
-        local task_time = task.time
+        local task_time = self._task_queue[self._task_queue.n].time
         if task_time <= self._now then
             -- Remove the upcoming task, as it is due for execution...
-            table.remove(self._task_queue)
+            local task =  table.remove(self._task_queue)
             self._task_queue.n = self._task_queue.n - 1
             -- ...so do it now.
             -- NOTE: Said task's action might modify _task_queue.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -911,11 +911,12 @@ function UIManager:_checkTasks()
     -- Tasks due for execution might themselves schedule more tasks (that might also be immediately due for execution ;)).
     -- Flipping this switch ensures we'll consume all such tasks *before* yielding to input polling.
     self._task_queue_dirty = false
-    while self._task_queue[self._task_queue.len] do
-        local task_time = self._task_queue[self._task_queue.len].time
+    local task = self._task_queue[self._task_queue.len]
+    while task do
+        local task_time = task.time
         if task_time <= self._now then
-            -- Pop the upcoming task, as it is due for execution...
-            local task = table.remove(self._task_queue, self._task_queue.len)
+            -- Remove the upcoming task, as it is due for execution...
+            table.remove(self._task_queue)
             self._task_queue.len = self._task_queue.len - 1
             -- ...so do it now.
             -- NOTE: Said task's action might modify _task_queue.
@@ -927,6 +928,7 @@ function UIManager:_checkTasks()
             wait_until = task_time
             break
         end
+        task = self._task_queue[self._task_queue.len]
     end
 
     return wait_until, self._now

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -435,7 +435,7 @@ describe("Readerfooter module", function()
         os.remove(DocSettings:getHistoryPath(sample_epub))
         UIManager:quit()
 
-        assert.are.same({}, UIManager._task_queue)
+        assert.are.same(0, #UIManager._task_queue)
 
         local settings = G_reader_settings:readSetting("footer")
         settings.auto_refresh_time = true
@@ -473,7 +473,7 @@ describe("Readerfooter module", function()
         os.remove(DocSettings:getHistoryPath(sample_epub))
         UIManager:quit()
 
-        assert.are.same({}, UIManager._task_queue)
+        assert.are.same(0, #UIManager._task_queue)
 
         local settings = G_reader_settings:readSetting("footer")
         settings.disabled = true
@@ -503,7 +503,7 @@ describe("Readerfooter module", function()
         os.remove(DocSettings:getHistoryPath(sample_pdf))
         UIManager:quit()
 
-        assert.are.same({}, UIManager._task_queue)
+        assert.are.same(0, #UIManager._task_queue)
 
         local settings = G_reader_settings:readSetting("footer")
         settings.disabled = false
@@ -561,7 +561,7 @@ describe("Readerfooter module", function()
         os.remove(DocSettings:getHistoryPath(sample_pdf))
         UIManager:quit()
 
-        assert.are.same({}, UIManager._task_queue)
+        assert.are.same(0, #UIManager._task_queue)
 
         G_reader_settings:saveSetting("reader_footer_mode", 1)
         -- default settings
@@ -602,7 +602,7 @@ describe("Readerfooter module", function()
         os.remove(DocSettings:getHistoryPath(sample_pdf))
         UIManager:quit()
 
-        assert.are.same({}, UIManager._task_queue)
+        assert.are.same(0, #UIManager._task_queue)
 
         local settings = G_reader_settings:readSetting("footer")
         settings.all_at_once = true
@@ -640,7 +640,7 @@ describe("Readerfooter module", function()
         os.remove(DocSettings:getHistoryPath(sample_pdf))
         UIManager:quit()
 
-        assert.are.same({}, UIManager._task_queue)
+        assert.are.same(0, #UIManager._task_queue)
 
         G_reader_settings:saveSetting("reader_footer_mode", 0)
         local settings = G_reader_settings:readSetting("footer")
@@ -666,7 +666,7 @@ describe("Readerfooter module", function()
         os.remove(DocSettings:getHistoryPath(sample_epub))
         UIManager:quit()
 
-        assert.are.same({}, UIManager._task_queue)
+        assert.are.same(0, #UIManager._task_queue)
 
         local settings = G_reader_settings:readSetting("footer")
         settings.battery = false

--- a/spec/unit/taskqueue_bench.lua
+++ b/spec/unit/taskqueue_bench.lua
@@ -1,0 +1,78 @@
+require("commonrequire")
+
+local UIManager = require("ui/uimanager")
+
+local time = require("ui/time")
+
+local NB_TESTS = 40000
+local noop = function() end
+
+describe("UIManager simple checkTasks and scheduling benchmark", function()
+    local now = time.now()
+    local wait_until -- luacheck: no unused
+    UIManager:quit()
+    UIManager._task_queue = {}
+
+    -- use schedule here, to be agnostic of the _task_queue order (ascending, descending).
+    for i=1, NB_TESTS/2 do
+        UIManager:schedule(now + i, noop)
+        UIManager:schedule(now + NB_TESTS - i, noop)
+    end
+
+    for i=1, NB_TESTS do
+        wait_until, now = UIManager:_checkTasks() -- luacheck: no unused
+    end
+end)
+
+describe("UIManager schedule more sophiticated benchmark", function()
+    -- This BM is doing schedulings like the are done in real usage
+    -- with autosuspend, autodim, autowarmth and friends.
+    -- Additional _checkTask is called to better simulate bench this too.
+    local wait_until -- luacheck: no unused
+
+    local now = time.now()
+    UIManager:quit()
+
+    local function standby_dummy() end
+    local function autowarmth_dummy() end
+    local function dimmer_dummy() end
+
+    local function someTaps()
+        for j = 1,10 do
+            -- insert some random times for entering standby
+            UIManager:schedule(now + time.s(j), standby_dummy) -- standby
+            UIManager:unschedule(standby_dummy)
+        end
+    end
+
+    for i=1, NB_TESTS do
+        UIManager._task_queue = {}
+        UIManager:schedule(now + time.s(24*60*60), noop) -- shutdown
+        UIManager:schedule(now + time.s(15*60*60), noop) -- sleep
+        UIManager:schedule(now + time.s(55), noop) -- footer refresh
+        UIManager:schedule(now + time.s(130), noop) -- something
+        UIManager:schedule(now + time.s(10), noop) -- something else
+
+        for j = 1,5 do
+            someTaps()
+
+            for k = 1, 10 do
+                UIManager:schedule(now + time.s(k), standby_dummy) -- standby
+            end
+            now = now + 10
+
+            -- consume the last 10 standby_dummy, plus 10 checks.
+            for k = 1, 20 do
+                wait_until, now = UIManager:_checkTasks() -- luacheck: no unused
+            end
+
+            UIManager:schedule(now + time.s(15*60), autowarmth_dummy) -- autowarmth
+            UIManager:schedule(now + time.s(180), dimmer_dummy) -- dimmer
+
+            now = now + 30
+            UIManager:unschedule(dimmer_dummy)
+            UIManager:unschedule(autowarmth_dummy) -- remove autowarmth
+        end
+    end
+end)
+

--- a/spec/unit/taskqueue_bench.lua
+++ b/spec/unit/taskqueue_bench.lua
@@ -11,7 +11,7 @@ describe("UIManager simple checkTasks and scheduling benchmark", function()
     local now = time.now()
     local wait_until -- luacheck: no unused
     UIManager:quit()
-    UIManager._task_queue = {}
+    UIManager._task_queue = { n = 0 }
 
     -- use schedule here, to be agnostic of the _task_queue order (ascending, descending).
     for i=1, NB_TESTS/2 do
@@ -46,7 +46,7 @@ describe("UIManager more advanced checkTasks and scheduling benchmark", function
     end
 
     for i=1, NB_TESTS do
-        UIManager._task_queue = {}
+        UIManager._task_queue = { n = 0 }
         UIManager:schedule(now + time.s(24*60*60), noop) -- shutdown
         UIManager:schedule(now + time.s(15*60*60), noop) -- sleep
         UIManager:schedule(now + time.s(55), noop) -- footer refresh

--- a/spec/unit/taskqueue_bench.lua
+++ b/spec/unit/taskqueue_bench.lua
@@ -24,7 +24,7 @@ describe("UIManager simple checkTasks and scheduling benchmark", function()
     end
 end)
 
-describe("UIManager schedule more sophiticated benchmark", function()
+describe("UIManager more advanced checkTasks and scheduling benchmark", function()
     -- This BM is doing schedulings like the are done in real usage
     -- with autosuspend, autodim, autowarmth and friends.
     -- Additional _checkTask is called to better simulate bench this too.
@@ -75,4 +75,3 @@ describe("UIManager schedule more sophiticated benchmark", function()
         end
     end
 end)
-

--- a/spec/unit/taskqueue_bench.lua
+++ b/spec/unit/taskqueue_bench.lua
@@ -11,7 +11,7 @@ describe("UIManager simple checkTasks and scheduling benchmark", function()
     local now = time.now()
     local wait_until -- luacheck: no unused
     UIManager:quit()
-    UIManager._task_queue = { n = 0 }
+    UIManager._task_queue = {}
 
     -- use schedule here, to be agnostic of the _task_queue order (ascending, descending).
     for i=1, NB_TESTS/2 do
@@ -46,7 +46,7 @@ describe("UIManager more advanced checkTasks and scheduling benchmark", function
     end
 
     for i=1, NB_TESTS do
-        UIManager._task_queue = { n = 0 }
+        UIManager._task_queue = {}
         UIManager:schedule(now + time.s(24*60*60), noop) -- shutdown
         UIManager:schedule(now + time.s(15*60*60), noop) -- sleep
         UIManager:schedule(now + time.s(55), noop) -- footer refresh

--- a/spec/unit/uimanager_bench.lua
+++ b/spec/unit/uimanager_bench.lua
@@ -66,7 +66,7 @@ describe("UIManager more sophisticated schedule benchmark", function()
     end
 
     for i=1, NB_TESTS do
-        UIManager._task_queue = { n = 0 }
+        UIManager._task_queue = {}
         UIManager:schedule(now + time.s(24*60*60), noop) -- shutdown
         UIManager:schedule(now + time.s(15*60*60), noop) -- sleep
         UIManager:schedule(now + time.s(55), noop) -- footer refresh
@@ -91,7 +91,7 @@ describe("UIManager schedule massive collision tests", function()
 
     for i = 1, 6 do
         -- simple test (1000/10 collisions)
-        UIManager._task_queue = { n = 0 }
+        UIManager._task_queue = {}
         for j = 1, 10 do
             UIManager:schedule(math.random(10), j)
             -- check() -- enabling this takes really long O(n^2)
@@ -99,7 +99,7 @@ describe("UIManager schedule massive collision tests", function()
         check()
 
         -- armageddon test (10000 collisions)
-        UIManager._task_queue = { n = 0 }
+        UIManager._task_queue = {}
         for j = 1, 1e5 do
             UIManager:schedule(math.random(100), j)
             -- check() -- enabling this takes really long O(n^2)
@@ -114,7 +114,7 @@ describe("UIManager schedule massive ridiculous tests", function()
 
     for i = 1, 6 do
         -- simple test (1000 collisions)
-        UIManager._task_queue = { n = 0 }
+        UIManager._task_queue = {}
         local offs = 0
         for j = 1, 1e3 do
             UIManager:schedule(math.random(10), j + offs)

--- a/spec/unit/uimanager_bench.lua
+++ b/spec/unit/uimanager_bench.lua
@@ -49,7 +49,7 @@ describe("UIManager schedule simple benchmark", function()
     end
 end)
 
-describe("UIManager more sophiticated schedule benchmark", function()
+describe("UIManager more sophisticated schedule benchmark", function()
     -- This BM is doing schedulings like the are done in real usage
     -- with autosuspend, autodim, autowarmth and friends.
     local now = time.now()

--- a/spec/unit/uimanager_bench.lua
+++ b/spec/unit/uimanager_bench.lua
@@ -49,7 +49,7 @@ describe("UIManager schedule simple benchmark", function()
     end
 end)
 
-describe("UIManager schedule more sophiticated benchmark", function()
+describe("UIManager more sophiticated schedule benchmark", function()
     -- This BM is doing schedulings like the are done in real usage
     -- with autosuspend, autodim, autowarmth and friends.
     local now = time.now()

--- a/spec/unit/uimanager_bench.lua
+++ b/spec/unit/uimanager_bench.lua
@@ -10,11 +10,11 @@ local noop = function() end
 local function check()
     for i = 1, #UIManager._task_queue-1 do
         -- test for wrongly inserted time
-        assert.is_true(UIManager._task_queue[i].time <= UIManager._task_queue[i+1].time,
+        assert.is_true(UIManager._task_queue[i].time >= UIManager._task_queue[i+1].time,
             "time wrongly sorted")
         if UIManager._task_queue[i].time == UIManager._task_queue[i+1].time then
             -- for same time, test if later inserted action is after a former action
-            assert.is_true(UIManager._task_queue[i].action <= UIManager._task_queue[i+1].action,
+            assert.is_true(UIManager._task_queue[i].action >= UIManager._task_queue[i+1].action,
                 "ragnarock")
         end
     end
@@ -26,7 +26,7 @@ describe("UIManager checkTasks benchmark", function()
     UIManager:quit()
     UIManager._task_queue = {}
 
-    for i=1, NB_TESTS do
+    for i= NB_TESTS, 1, -1 do
         table.insert(
             UIManager._task_queue,
             { time = now + i, action = noop, args = {} }
@@ -43,7 +43,6 @@ describe("UIManager schedule simple benchmark", function()
     UIManager:quit()
     UIManager._task_queue = {}
 
-    -- Insert tasks at the beginning and at the end of the _task_queue
     for i=1, NB_TESTS/2 do
         UIManager:schedule(now + i, noop)
         UIManager:schedule(now + NB_TESTS - i, noop)
@@ -149,15 +148,17 @@ describe("UIManager unschedule benchmark", function()
     UIManager:quit()
     UIManager._task_queue = {}
 
-    for i=1, NB_TESTS do
+    for i=NB_TESTS, 1, -1 do
         table.insert(
             UIManager._task_queue,
             { time = now + i, action = 'a', args={} }
         )
     end
 
-    for i=1, NB_TESTS do
+    for i=1, NB_TESTS/2 do
         UIManager:schedule(now + i, noop)
+        UIManager:unschedule(noop)
+        UIManager:schedule(now + NB_TESTS - i, noop)
         UIManager:unschedule(noop)
     end
 end)

--- a/spec/unit/uimanager_bench.lua
+++ b/spec/unit/uimanager_bench.lua
@@ -24,7 +24,7 @@ describe("UIManager checkTasks benchmark", function()
     local now = time.now()
     local wait_until -- luacheck: no unused
     UIManager:quit()
-    UIManager._task_queue = {}
+    UIManager._task_queue = { n = 0 }
 
     for i= NB_TESTS, 1, -1 do
         table.insert(
@@ -41,7 +41,7 @@ end)
 describe("UIManager schedule simple benchmark", function()
     local now = time.now()
     UIManager:quit()
-    UIManager._task_queue = {}
+    UIManager._task_queue = { n = 0 }
 
     for i=1, NB_TESTS/2 do
         UIManager:schedule(now + i, noop)
@@ -68,7 +68,7 @@ describe("UIManager more sophisticated schedule benchmark", function()
     end
 
     for i=1, NB_TESTS do
-        UIManager._task_queue = {}
+        UIManager._task_queue = { n = 0 }
         UIManager:schedule(now + time.s(24*60*60), noop) -- shutdown
         UIManager:schedule(now + time.s(15*60*60), noop) -- sleep
         UIManager:schedule(now + time.s(55), noop) -- footer refresh
@@ -93,7 +93,7 @@ describe("UIManager schedule massive collision tests", function()
 
     for i = 1, 6 do
         -- simple test (1000/10 collisions)
-        UIManager._task_queue = {}
+        UIManager._task_queue = { n = 0 }
         for j = 1, 10 do
             UIManager:schedule(math.random(10), j)
             -- check() -- enabling this takes really long O(n^2)
@@ -101,7 +101,7 @@ describe("UIManager schedule massive collision tests", function()
         check()
 
         -- armageddon test (10000 collisions)
-        UIManager._task_queue = {}
+        UIManager._task_queue = { n = 0 }
         for j = 1, 1e5 do
             UIManager:schedule(math.random(100), j)
             -- check() -- enabling this takes really long O(n^2)
@@ -116,7 +116,7 @@ describe("UIManager schedule massive ridiculous tests", function()
 
     for i = 1, 6 do
         -- simple test (1000 collisions)
-        UIManager._task_queue = {}
+        UIManager._task_queue = { n = 0 }
         local offs = 0
         for j = 1, 1e3 do
             UIManager:schedule(math.random(10), j + offs)
@@ -146,7 +146,7 @@ end)
 describe("UIManager unschedule benchmark", function()
     local now = time.now()
     UIManager:quit()
-    UIManager._task_queue = {}
+    UIManager._task_queue = { n = 0 }
 
     for i=NB_TESTS, 1, -1 do
         table.insert(

--- a/spec/unit/uimanager_bench.lua
+++ b/spec/unit/uimanager_bench.lua
@@ -24,7 +24,6 @@ describe("UIManager checkTasks benchmark", function()
     local now = time.now()
     local wait_until -- luacheck: no unused
     UIManager:quit()
-    UIManager._task_queue = { n = 0 }
 
     for i= NB_TESTS, 1, -1 do
         table.insert(
@@ -41,7 +40,6 @@ end)
 describe("UIManager schedule simple benchmark", function()
     local now = time.now()
     UIManager:quit()
-    UIManager._task_queue = { n = 0 }
 
     for i=1, NB_TESTS/2 do
         UIManager:schedule(now + i, noop)
@@ -146,7 +144,6 @@ end)
 describe("UIManager unschedule benchmark", function()
     local now = time.now()
     UIManager:quit()
-    UIManager._task_queue = { n = 0 }
 
     for i=NB_TESTS, 1, -1 do
         table.insert(

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -138,7 +138,7 @@ describe("UIManager spec", function()
         UIManager:schedule(now + time.s(5), "5s");
         assert.are.same("5s", UIManager._task_queue[2].action)
 
-        -- insert task in place of "10s", as it'll expire shortyl afer "10s"
+        -- insert task in place of "10s", as it'll expire shortly afer "10s"
         -- NOTE: Can't use this here right now, as time.now, which is used internally,
         -- may or may not have moved, depending on host's performance and clock granularity
         -- (especially if host is fast and/or COARSE is available).

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -124,7 +124,9 @@ describe("UIManager spec", function()
         assert.are.same('quux', UIManager._task_queue[4].action)
     end)
 
-    it("should insert new tasks with same times after existing tasks", function()
+    it("should insert new tasks with same times before existing tasks", function()
+        local ffiutil = require("ffi/util")
+
         now = time.now()
         UIManager:quit()
 
@@ -136,10 +138,13 @@ describe("UIManager spec", function()
         UIManager:schedule(now + time.s(5), "5s");
         assert.are.same("5s", UIManager._task_queue[2].action)
 
-        -- insert task in place of "10s", as it'll expire later
-        -- NOTE: Can't use 10, as time.now, which is used internally, may or may not have moved,
-        --       depending on host's performance and clock granularity (especially if host is fast and/or COARSE is available).
-        UIManager:scheduleIn(11, 'foo') -- is a bit later than "10s", as time.now() is used internally
+        -- insert task in place of "10s", as it'll expire shortyl afer "10s"
+        -- NOTE: Can't use this here right now, as time.now, which is used internally,
+        -- may or may not have moved, depending on host's performance and clock granularity
+        -- (especially if host is fast and/or COARSE is available).
+        -- But a short wait (with the fts resolution) fixes this here.
+        ffiutil.usleep(1)
+        UIManager:scheduleIn(10, 'foo') -- is a bit later than "10s", as time.now() is used internally
         assert.are.same('foo', UIManager._task_queue[1].action)
 
         -- insert task in place of "10s", which was just shifted by foo

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -21,7 +21,6 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = noop, args = {} },
             { time = now - time.s(10), action = noop, args = {} },
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         UIManager:_checkTasks()
         assert.are.same(2, #UIManager._task_queue)
@@ -39,7 +38,6 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = noop, args = {} },
             { time = now - time.s(10), action = noop, args = {} },
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(future_time, wait_until)
@@ -53,7 +51,6 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = noop, args = {} },
             { time = now - time.s(10), action = noop, args = {} },
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(nil, wait_until)
@@ -75,7 +72,6 @@ describe("UIManager spec", function()
         UIManager._task_queue = {
             { time = future_time, action = '1', args = {} },
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'quz')
@@ -86,7 +82,6 @@ describe("UIManager spec", function()
         UIManager._task_queue = {
             { time = now, action = '1', args = {} },
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'foo')
@@ -105,7 +100,6 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = '2', args = {} },
             { time = now - time.s(10), action = '1', args = {} },
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         -- insert into the tail slot
         UIManager:scheduleIn(10, 'foo')
@@ -186,14 +180,12 @@ describe("UIManager spec", function()
             { time = now - time.s(10), action = '1', args = {} },
             { time = now - time.s(15), action = '3', args = {} },
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         -- insert into the tail slot
         UIManager:unschedule('3')
         assert.are.same({
             { time = now - time.us(5), action = '2', args = {} },
             { time = now - time.s(10), action = '1', args = {} },
-            n = 2,
         }, UIManager._task_queue)
     end)
 
@@ -217,7 +209,6 @@ describe("UIManager spec", function()
             },
             { time = now - time.s(15), action = task_to_remove, args = {} }, -- this will be called
         }
-        UIManager._task_queue.n = #UIManager._task_queue
 
         UIManager:_checkTasks()
         assert.are.same(2, run_count)

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -15,16 +15,17 @@ describe("UIManager spec", function()
         local future2 = future + time.s(5)
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = noop, args = {} },
-            { time = now - time.us(5), action = noop, args = {} },
-            { time = now, action = noop, args = {} },
-            { time = future, action = noop, args = {} },
             { time = future2, action = noop, args = {} },
+            { time = future, action = noop, args = {} },
+            { time = now, action = noop, args = {} },
+            { time = now - time.us(5), action = noop, args = {} },
+            { time = now - time.s(10), action = noop, args = {} },
         }
+        UIManager._task_queue.len = #UIManager._task_queue
         UIManager:_checkTasks()
-        assert.are.same(2, #UIManager._task_queue, 2)
-        assert.are.same(future, UIManager._task_queue[1].time)
-        assert.are.same(future2, UIManager._task_queue[2].time)
+        assert.are.same(2, #UIManager._task_queue)
+        assert.are.same(future, UIManager._task_queue[2].time)
+        assert.are.same(future2, UIManager._task_queue[1].time)
     end)
 
     it("should calcualte wait_until properly in checkTasks routine", function()
@@ -32,11 +33,13 @@ describe("UIManager spec", function()
         local future_time = now + time.s(60000)
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = noop, args = {} },
-            { time = now - time.us(5), action = noop, args = {} },
-            { time = now, action = noop, args = {} },
             { time = future_time, action = noop, args = {} },
+            { time = now, action = noop, args = {} },
+            { time = now - time.us(5), action = noop, args = {} },
+            { time = now - time.s(10), action = noop, args = {} },
         }
+        UIManager._task_queue.len = #UIManager._task_queue
+
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(future_time, wait_until)
     end)
@@ -45,10 +48,12 @@ describe("UIManager spec", function()
         now = time.now()
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = noop, args = {} },
-            { time = now - time.us(5), action = noop, args = {} },
             { time = now, action = noop, args = {} },
+            { time = now - time.us(5), action = noop, args = {} },
+            { time = now - time.s(10), action = noop, args = {} },
         }
+        UIManager._task_queue.len = #UIManager._task_queue
+
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(nil, wait_until)
     end)
@@ -73,7 +78,7 @@ describe("UIManager spec", function()
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'quz')
         assert.are.same(2, #UIManager._task_queue)
-        assert.are.same('quz', UIManager._task_queue[1].action)
+        assert.are.same('quz', UIManager._task_queue[2].action)
 
         UIManager:quit()
         UIManager._task_queue = {
@@ -82,35 +87,35 @@ describe("UIManager spec", function()
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'foo')
         assert.are.same(2, #UIManager._task_queue)
-        assert.are.same('foo', UIManager._task_queue[2].action)
+        assert.are.same('foo', UIManager._task_queue[1].action)
         UIManager:scheduleIn(155, 'bar')
         assert.are.same(3, #UIManager._task_queue)
-        assert.are.same('bar', UIManager._task_queue[3].action)
+        assert.are.same('bar', UIManager._task_queue[1].action)
     end)
 
     it("should insert new task in ascendant order", function()
         now = time.now()
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(10), action = '1', args = {} },
-            { time = now - time.us(5), action = '2', args = {} },
             { time = now, action = '3', args = {} },
+            { time = now - time.us(5), action = '2', args = {} },
+            { time = now - time.s(10), action = '1', args = {} },
         }
         -- insert into the tail slot
         UIManager:scheduleIn(10, 'foo')
-        assert.are.same('foo', UIManager._task_queue[4].action)
+        assert.are.same('foo', UIManager._task_queue[1].action)
         -- insert into the second slot
         UIManager:schedule(now - time.s(5), 'bar')
-        assert.are.same('bar', UIManager._task_queue[2].action)
+        assert.are.same('bar', UIManager._task_queue[4].action)
         -- insert into the head slot
         UIManager:schedule(now - time.s(15), 'baz')
-        assert.are.same('baz', UIManager._task_queue[1].action)
+        assert.are.same('baz', UIManager._task_queue[6].action)
         -- insert into the last second slot
         UIManager:scheduleIn(5, 'qux')
-        assert.are.same('qux', UIManager._task_queue[6].action)
+        assert.are.same('qux', UIManager._task_queue[2].action)
         -- insert into the middle slot
         UIManager:schedule(now - time.us(1), 'quux')
-        assert.are.same('quux', UIManager._task_queue[5].action)
+        assert.are.same('quux', UIManager._task_queue[4].action)
     end)
 
     it("should insert new tasks with same times after existing tasks", function()
@@ -122,43 +127,47 @@ describe("UIManager spec", function()
         UIManager:schedule(now, "now");
         assert.are.same("now", UIManager._task_queue[1].action)
         UIManager:schedule(now + time.s(10), "10s");
-        assert.are.same("10s", UIManager._task_queue[2].action)
+        assert.are.same("10s", UIManager._task_queue[1].action)
         UIManager:schedule(now + time.s(5), "5s");
         assert.are.same("5s", UIManager._task_queue[2].action)
 
         -- insert task at the end after "10s"
         -- NOTE: Can't use 10, as time.now, which is used internally, may or may not have moved,
         --       depending on host's performance and clock granularity (especially if host is fast and/or COARSE is available).
-        UIManager:scheduleIn(11, 'foo')
-        assert.are.same('foo', UIManager._task_queue[4].action)
+        UIManager:scheduleIn(10, 'foo') -- is a bit later than "10s", as time.now() is used internally
+        assert.are.same('foo', UIManager._task_queue[1].action)
 
         -- insert task at the second last position after "10s"
         UIManager:schedule(now + time.s(10), 'bar')
-        assert.are.same('bar', UIManager._task_queue[4].action)
+        assert.are.same('bar', UIManager._task_queue[2].action)
 
         -- insert task at the second last position after "bar"
         UIManager:schedule(now + time.s(10), 'baz')
-        assert.are.same('baz', UIManager._task_queue[5].action)
+        assert.are.same('baz', UIManager._task_queue[2].action)
 
         -- insert task after "5s"
         UIManager:schedule(now + time.s(5), 'nix')
-        assert.are.same('nix', UIManager._task_queue[3].action)
+        assert.are.same('nix', UIManager._task_queue[5].action)
         -- "barba" is later than "nix" anyway
         UIManager:scheduleIn(5, 'barba') -- is a bit later than "5s", as time.now() is used internally
-        assert.are.same('barba', UIManager._task_queue[4].action)
+        assert.are.same('barba', UIManager._task_queue[5].action)
 
-        -- "mama" is sheduled now and inserted after "now"
+        -- "papa" is shortly after "now"
+        UIManager:nextTick('papa') -- is a bit later than "now"
+        assert.are.same('papa', UIManager._task_queue[8].action)
+
+        -- "mama is shedule now and inserted after "now"
         UIManager:schedule(now, 'mama')
-        assert.are.same('mama', UIManager._task_queue[2].action)
+        assert.are.same('mama', UIManager._task_queue[9].action)
 
         -- "papa" is shortly after "now"
         -- NOTE: For the same reason as above, test this last, as time.now may not have moved...
-        UIManager:nextTick('papa') -- is a bit later than "now"
-        assert.are.same('papa', UIManager._task_queue[3].action)
+        UIManager:nextTick('papa1') -- is a bit later than "now"
+        assert.are.same('papa1', UIManager._task_queue[8].action)
 
         -- "letta" is shortly after "papa"
         UIManager:tickAfterNext('letta')
-        assert.are.same("function", type(UIManager._task_queue[4].action))
+        assert.are.same("function", type(UIManager._task_queue[8].action))
 
     end)
 
@@ -166,17 +175,19 @@ describe("UIManager spec", function()
         now = time.now()
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(15), action = '3', args = {} },
-            { time = now - time.s(10), action = '1', args = {} },
-            { time = now - time.us(6), action = '3', args = {} },
-            { time = now - time.us(5), action = '2', args = {} },
             { time = now, action = '3', args = {} },
+            { time = now - time.us(5), action = '2', args = {} },
+            { time = now - time.us(6), action = '3', args = {} },
+            { time = now - time.s(10), action = '1', args = {} },
+            { time = now - time.s(15), action = '3', args = {} },
         }
+        UIManager._task_queue.len = #UIManager._task_queue
         -- insert into the tail slot
         UIManager:unschedule('3')
         assert.are.same({
-            { time = now - time.s(10), action = '1', args = {} },
             { time = now - time.us(5), action = '2', args = {} },
+            { time = now - time.s(10), action = '1', args = {} },
+            len = 2,
         }, UIManager._task_queue)
     end)
 
@@ -188,7 +199,8 @@ describe("UIManager spec", function()
         end
         UIManager:quit()
         UIManager._task_queue = {
-            { time = now - time.s(15), action = task_to_remove, args = {} }, -- this will be called
+            { time = now, action = task_to_remove, args = {} }, -- this will be removed
+            { time = now - time.us(5), action = task_to_remove, args = {} }, -- this will be removed
             {
                 time = now - time.s(10),
                 action = function() -- this will be called, too
@@ -197,9 +209,10 @@ describe("UIManager spec", function()
                 end,
                 args = {},
             },
-            { time = now - time.us(5), action = task_to_remove, args = {} }, -- this will be removed
-            { time = now, action = task_to_remove, args = {} }, -- this will be removed
+            { time = now - time.s(15), action = task_to_remove, args = {} }, -- this will be called
         }
+        UIManager._task_queue.len = #UIManager._task_queue
+
         UIManager:_checkTasks()
         assert.are.same(2, run_count)
     end)

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -142,8 +142,8 @@ describe("UIManager spec", function()
         -- NOTE: Can't use this here right now, as time.now, which is used internally,
         -- may or may not have moved, depending on host's performance and clock granularity
         -- (especially if host is fast and/or COARSE is available).
-        -- But a short wait (with the fts resolution) fixes this here.
-        ffiutil.usleep(1)
+        -- But a short wait fixes this here.
+        ffiutil.usleep(1000)
         UIManager:scheduleIn(10, 'foo') -- is a bit later than "10s", as time.now() is used internally
         assert.are.same('foo', UIManager._task_queue[1].action)
 

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -21,7 +21,8 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = noop, args = {} },
             { time = now - time.s(10), action = noop, args = {} },
         }
-        UIManager._task_queue.len = #UIManager._task_queue
+        UIManager._task_queue.n = #UIManager._task_queue
+
         UIManager:_checkTasks()
         assert.are.same(2, #UIManager._task_queue)
         assert.are.same(future, UIManager._task_queue[2].time)
@@ -38,7 +39,7 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = noop, args = {} },
             { time = now - time.s(10), action = noop, args = {} },
         }
-        UIManager._task_queue.len = #UIManager._task_queue
+        UIManager._task_queue.n = #UIManager._task_queue
 
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(future_time, wait_until)
@@ -52,7 +53,7 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = noop, args = {} },
             { time = now - time.s(10), action = noop, args = {} },
         }
-        UIManager._task_queue.len = #UIManager._task_queue
+        UIManager._task_queue.n = #UIManager._task_queue
 
         wait_until, now = UIManager:_checkTasks()
         assert.are.same(nil, wait_until)
@@ -61,7 +62,7 @@ describe("UIManager spec", function()
     it("should insert new task properly in empty task queue", function()
         now = time.now()
         UIManager:quit()
-        UIManager._task_queue = {}
+        UIManager._task_queue = { n = 0 }
         assert.are.same(0, #UIManager._task_queue)
         UIManager:scheduleIn(50, 'foo')
         assert.are.same(1, #UIManager._task_queue)
@@ -75,6 +76,8 @@ describe("UIManager spec", function()
         UIManager._task_queue = {
             { time = future_time, action = '1', args = {} },
         }
+        UIManager._task_queue.n = #UIManager._task_queue
+
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'quz')
         assert.are.same(2, #UIManager._task_queue)
@@ -84,6 +87,8 @@ describe("UIManager spec", function()
         UIManager._task_queue = {
             { time = now, action = '1', args = {} },
         }
+        UIManager._task_queue.n = #UIManager._task_queue
+
         assert.are.same(1, #UIManager._task_queue)
         UIManager:scheduleIn(150, 'foo')
         assert.are.same(2, #UIManager._task_queue)
@@ -93,7 +98,7 @@ describe("UIManager spec", function()
         assert.are.same('bar', UIManager._task_queue[1].action)
     end)
 
-    it("should insert new task in ascendant order", function()
+    it("should insert new task in descendant order", function()
         now = time.now()
         UIManager:quit()
         UIManager._task_queue = {
@@ -101,6 +106,8 @@ describe("UIManager spec", function()
             { time = now - time.us(5), action = '2', args = {} },
             { time = now - time.s(10), action = '1', args = {} },
         }
+        UIManager._task_queue.n = #UIManager._task_queue
+
         -- insert into the tail slot
         UIManager:scheduleIn(10, 'foo')
         assert.are.same('foo', UIManager._task_queue[1].action)
@@ -121,7 +128,7 @@ describe("UIManager spec", function()
     it("should insert new tasks with same times after existing tasks", function()
         now = time.now()
         UIManager:quit()
-        UIManager._task_queue = {}
+        UIManager._task_queue = { n = 0 }
 
         -- insert task "5s" between "now" and "10s"
         UIManager:schedule(now, "now");
@@ -181,13 +188,14 @@ describe("UIManager spec", function()
             { time = now - time.s(10), action = '1', args = {} },
             { time = now - time.s(15), action = '3', args = {} },
         }
-        UIManager._task_queue.len = #UIManager._task_queue
+        UIManager._task_queue.n = #UIManager._task_queue
+
         -- insert into the tail slot
         UIManager:unschedule('3')
         assert.are.same({
             { time = now - time.us(5), action = '2', args = {} },
             { time = now - time.s(10), action = '1', args = {} },
-            len = 2,
+            n = 2,
         }, UIManager._task_queue)
     end)
 
@@ -211,7 +219,7 @@ describe("UIManager spec", function()
             },
             { time = now - time.s(15), action = task_to_remove, args = {} }, -- this will be called
         }
-        UIManager._task_queue.len = #UIManager._task_queue
+        UIManager._task_queue.n = #UIManager._task_queue
 
         UIManager:_checkTasks()
         assert.are.same(2, run_count)

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -62,7 +62,6 @@ describe("UIManager spec", function()
     it("should insert new task properly in empty task queue", function()
         now = time.now()
         UIManager:quit()
-        UIManager._task_queue = { n = 0 }
         assert.are.same(0, #UIManager._task_queue)
         UIManager:scheduleIn(50, 'foo')
         assert.are.same(1, #UIManager._task_queue)
@@ -128,7 +127,6 @@ describe("UIManager spec", function()
     it("should insert new tasks with same times after existing tasks", function()
         now = time.now()
         UIManager:quit()
-        UIManager._task_queue = { n = 0 }
 
         -- insert task "5s" between "now" and "10s"
         UIManager:schedule(now, "now");

--- a/spec/unit/uimanager_spec.lua
+++ b/spec/unit/uimanager_spec.lua
@@ -136,44 +136,39 @@ describe("UIManager spec", function()
         UIManager:schedule(now + time.s(5), "5s");
         assert.are.same("5s", UIManager._task_queue[2].action)
 
-        -- insert task at the end after "10s"
+        -- insert task in place of "10s", as it'll expire later
         -- NOTE: Can't use 10, as time.now, which is used internally, may or may not have moved,
         --       depending on host's performance and clock granularity (especially if host is fast and/or COARSE is available).
-        UIManager:scheduleIn(10, 'foo') -- is a bit later than "10s", as time.now() is used internally
+        UIManager:scheduleIn(11, 'foo') -- is a bit later than "10s", as time.now() is used internally
         assert.are.same('foo', UIManager._task_queue[1].action)
 
-        -- insert task at the second last position after "10s"
+        -- insert task in place of "10s", which was just shifted by foo
         UIManager:schedule(now + time.s(10), 'bar')
         assert.are.same('bar', UIManager._task_queue[2].action)
 
-        -- insert task at the second last position after "bar"
+        -- insert task in place of "bar"
         UIManager:schedule(now + time.s(10), 'baz')
         assert.are.same('baz', UIManager._task_queue[2].action)
 
-        -- insert task after "5s"
+        -- insert task in place of "5s"
         UIManager:schedule(now + time.s(5), 'nix')
         assert.are.same('nix', UIManager._task_queue[5].action)
-        -- "barba" is later than "nix" anyway
+        -- "barba" replaces "nix"
         UIManager:scheduleIn(5, 'barba') -- is a bit later than "5s", as time.now() is used internally
         assert.are.same('barba', UIManager._task_queue[5].action)
 
-        -- "papa" is shortly after "now"
+        -- "mama is sheduled now and as such inserted in "now"'s place
+        UIManager:schedule(now, 'mama')
+        assert.are.same('mama', UIManager._task_queue[8].action)
+
+        -- "papa" is shortly after "now", so inserted in its place
+        -- NOTE: For the same reason as above, test this last, as time.now may not have moved...
         UIManager:nextTick('papa') -- is a bit later than "now"
         assert.are.same('papa', UIManager._task_queue[8].action)
 
-        -- "mama is shedule now and inserted after "now"
-        UIManager:schedule(now, 'mama')
-        assert.are.same('mama', UIManager._task_queue[9].action)
-
-        -- "papa" is shortly after "now"
-        -- NOTE: For the same reason as above, test this last, as time.now may not have moved...
-        UIManager:nextTick('papa1') -- is a bit later than "now"
-        assert.are.same('papa1', UIManager._task_queue[8].action)
-
-        -- "letta" is shortly after "papa"
+        -- "letta" is shortly after "papa", so inserted in its place
         UIManager:tickAfterNext('letta')
         assert.are.same("function", type(UIManager._task_queue[8].action))
-
     end)
 
     it("should unschedule all the tasks with the same action", function()


### PR DESCRIPTION
In real life most scheduled tasks are in the near future. Tasks being long in the future are seldom rescheduled. 

In the current implementation if a near future task is scheduled it is inserted at the beginning of the task queue, and therefore most of the queue has to be shifted backwards. When such a task gets consumed, the whole queue is shifted forwards again. So there is a lot of shifting. The only benefit of this implementation is, that `_checkTasks` only needs to check `_task_queue[1]`.

This PR reverses the sorting order of the task_queue, so that tasks scheduled in the near future are at the end of the queue -> less shifting on insertion and consumption.

Additionally, there is a small benchmark `taskqueue_bench.lua` which tries to mimicry some real life usage with scheduling and consume tasks. This benchmark can be run on the current master branch or this PR.

For benching on master I get:
```
Benchmark #1: ./kodev test front taskqueue_bench.lua
  Time (mean ± σ):      5.398 s ±  0.073 s    [User: 5.138 s, System: 0.218 s]
  Range (min … max):    5.323 s …  5.540 s    10 runs
```
and for running it on this PR:
```
Benchmark #1: ./kodev test front taskqueue_bench.lua
  Time (mean ± σ):      4.544 s ±  0.029 s    [User: 4.276 s, System: 0.226 s]
  Range (min … max):    4.489 s …  4.585 s    10 runs
```

Which is an improvement of 16% (not bad).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9706)
<!-- Reviewable:end -->
