### PR TITLE
AutoWarmth: add message on user change of night mode

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -173,9 +173,9 @@ AutoWarmth._onEnterStandby = AutoWarmth._onSuspend
 function AutoWarmth:_onToggleNightMode()
     if self.control_nightmode and not self.hide_nightmode_warning then
         local radio_buttons = {
-            { {text = _("Show this warning again."), provider = 1} },
-            { {text = _("Hide the warning until the next book is opened."), provider = 2} },
-            { {text = _("Disable AutoWarmth's nightmode control."), provider = 3} },
+            { {text = _("Show this warning again"), provider = 1} },
+            { {text = _("Hide the warning until the next book is opened"), provider = 2} },
+            { {text = _("Disable AutoWarmth's nightmode control"), provider = 3} },
         }
         UIManager:show(require("ui/widget/radiobuttonwidget"):new{
             title_text = _("Night mode changed"),

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -199,7 +199,6 @@ function AutoWarmth:_onToggleNightMode()
             radio_buttons = radio_buttons,
             callback = function(radio)
                 radio.provider()
-                UIManager:setDirty(self.dialog, "ui")
             end,
         })
     end

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -170,11 +170,22 @@ end
 
 AutoWarmth._onEnterStandby = AutoWarmth._onSuspend
 
+function AutoWarmth:_onToggleNightMode()
+    if self.control_nightmode then
+        UIManager:show(InfoMessage:new{
+            text = _("Night mode changed by the user.\nThe AutoWarmth plugin might change it again."),
+            -- timeout = 4, -- make sure this long message is readable
+        })
+    end
+end
+
 function AutoWarmth:setEventHandlers()
     self.onResume = self._onResume
     self.onSuspend = self._onSuspend
     self.onEnterStandby = self._onEnterStandby
     self.onLeaveStandby = self._onLeaveStandby
+    self.onToggleNightMode = self._onToggleNightMode
+    self.onSetNightMode = self._onToggleNightMode
 end
 
 function AutoWarmth:clearEventHandlers()
@@ -182,6 +193,8 @@ function AutoWarmth:clearEventHandlers()
     self.onSuspend = nil
     self.onEnterStandby = nil
     self.onLeaveStandby = nil
+    self.onToggleNightMode = nil
+    self.onSetNightMode = nil
 end
 
 -- from_resume ... true if called from onResume

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -173,12 +173,21 @@ AutoWarmth._onEnterStandby = AutoWarmth._onSuspend
 function AutoWarmth:_onToggleNightMode()
     if self.control_nightmode and not AutoWarmth.hide_nightmode_warning then
         UIManager:show(ConfirmBox:new{
-            text = _("Night mode changed by the user.\nThe AutoWarmth plugin might change it again."),
+            text = _("Night mode changed.\nThe AutoWarmth plugin might change it again."),
             ok_text = _("Show warning again"),
             cancel_text = _("Hide warning"),
             cancel_callback = function()
                 AutoWarmth.hide_nightmode_warning = true
             end,
+            other_buttons = {{
+                {
+                    text = _("Disable AutoWarmth's nightmode"),
+                    callback = function()
+                        self.control_nightmode = false
+                    end,
+                }
+            }},
+            other_buttons_first = true,
         })
     end
 end

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -171,23 +171,26 @@ end
 AutoWarmth._onEnterStandby = AutoWarmth._onSuspend
 
 function AutoWarmth:_onToggleNightMode()
-    if self.control_nightmode and not AutoWarmth.hide_nightmode_warning then
-        UIManager:show(ConfirmBox:new{
-            text = _("Night mode changed.\nThe AutoWarmth plugin might change it again."),
-            ok_text = _("Show warning again"),
-            cancel_text = _("Hide warning"),
-            cancel_callback = function()
-                AutoWarmth.hide_nightmode_warning = true
+    if self.control_nightmode and not self.hide_nightmode_warning then
+        local radio_buttons = {
+            { {text = _("Show this warning again."), provider = 1} },
+            { {text = _("Hide the warning until the next book is opened."), provider = 2} },
+            { {text = _("Disable AutoWarmth's nightmode control."), provider = 3} },
+        }
+        UIManager:show(require("ui/widget/radiobuttonwidget"):new{
+            title_text = _("Night mode changed"),
+            info_text = _("The AutoWarmth plugin might change it again."),
+            width_factor = 0.9,
+            radio_buttons = radio_buttons,
+            callback = function(radio)
+                if radio.provider == 2 then
+                    self.hide_nightmode_warning = true
+                elseif radio.provider == 3 then
+                    self.control_nightmode = false
+                    G_reader_settings:makeFalse("autowarmth_control_nightmode")
+                end
+                UIManager:setDirty(self.dialog, "ui")
             end,
-            other_buttons = {{
-                {
-                    text = _("Disable AutoWarmth's nightmode"),
-                    callback = function()
-                        self.control_nightmode = false
-                    end,
-                }
-            }},
-            other_buttons_first = true,
         })
     end
 end

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -171,10 +171,14 @@ end
 AutoWarmth._onEnterStandby = AutoWarmth._onSuspend
 
 function AutoWarmth:_onToggleNightMode()
-    if self.control_nightmode then
-        UIManager:show(InfoMessage:new{
+    if self.control_nightmode and not AutoWarmth.hide_nightmode_warning then
+        UIManager:show(ConfirmBox:new{
             text = _("Night mode changed by the user.\nThe AutoWarmth plugin might change it again."),
-            -- timeout = 4, -- make sure this long message is readable
+            ok_text = _("Show warning again"),
+            cancel_text = _("Hide warning"),
+            cancel_callback = function()
+                AutoWarmth.hide_nightmode_warning = true
+            end,
         })
     end
 end

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -172,23 +172,33 @@ AutoWarmth._onEnterStandby = AutoWarmth._onSuspend
 
 function AutoWarmth:_onToggleNightMode()
     if self.control_nightmode and not self.hide_nightmode_warning then
+        local RadioButtonWidget = require("ui/widget/radiobuttonwidget")
         local radio_buttons = {
-            { {text = _("Show this warning again"), provider = 1} },
-            { {text = _("Hide the warning until the next book is opened"), provider = 2} },
-            { {text = _("Disable AutoWarmth's nightmode control"), provider = 3} },
+            {{
+                text = _("Show this warning again"),
+                provider = function() end
+            }},
+            {{
+                text = _("Hide the warning until the next book is opened"),
+                provider = function()
+                    self.hide_nightmode_warning = true
+                end,
+            }},
+            {{
+                text = _("Disable AutoWarmth's nightmode control"),
+                provider = function()
+                    self.control_nightmode = false
+                    G_reader_settings:makeFalse("autowarmth_control_nightmode")
+                end,
+            }},
         }
-        UIManager:show(require("ui/widget/radiobuttonwidget"):new{
+        UIManager:show(RadioButtonWidget:new{
             title_text = _("Night mode changed"),
             info_text = _("The AutoWarmth plugin might change it again."),
             width_factor = 0.9,
             radio_buttons = radio_buttons,
             callback = function(radio)
-                if radio.provider == 2 then
-                    self.hide_nightmode_warning = true
-                elseif radio.provider == 3 then
-                    self.control_nightmode = false
-                    G_reader_settings:makeFalse("autowarmth_control_nightmode")
-                end
+                radio.provider()
                 UIManager:setDirty(self.dialog, "ui")
             end,
         })


### PR DESCRIPTION
If the user changes night mode _and_ AutoWarmth controls night mode too, give the user an InfoMessage about that fact.

Tested for night mode menu entry and for gestures.

This should close https://github.com/koreader/koreader/discussions/9712 and #9737

As always rewording of the message is welcome ;-)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9715)
<!-- Reviewable:end -->
