### PR TITLE
TextViewer: allow close on any multiswipe

### DIFF
--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -107,6 +107,16 @@ function TextViewer:init()
                     }
                 },
             },
+            MultiSwipe = {
+                GestureRange:new{
+                    ges = "multiswipe",
+                    range = Geom:new{
+                        x = 0, y = 0,
+                        w = Screen:getWidth(),
+                        h = Screen:getHeight(),
+                    }
+                },
+            },
         }
     end
 
@@ -291,6 +301,14 @@ function TextViewer:onTapClose(arg, ges_ev)
     if ges_ev.pos:notIntersectWith(self.frame.dimen) then
         self:onClose()
     end
+    return true
+end
+
+function TextViewer:onMultiSwipe(arg, ges_ev)
+    -- For consistency with other fullscreen widgets where swipe south can't be
+    -- used to close and where we then allow any multiswipe to close, allow any
+    -- multiswipe to close this widget too.
+    self:onClose()
     return true
 end
 


### PR DESCRIPTION
Similar to most fullscreen widgets (#8726), even if TextViewer is mostly not-fullscreen, but just nearly fullscreen :).
https://github.com/koreader/koreader/pull/8726#issuecomment-1294207467 :
> I got used to using multiswipes to close all these fullscreen widgets.
There's one place where this habit doesnt work: TextViewer. It's usually (always?) not fullscreen.
Any problem/inconsistency you would see if it would also multiswipe-close ?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9720)
<!-- Reviewable:end -->
