### PR TITLE
ReaderHighlight: set default long-press action with a gesture

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -20,30 +20,7 @@ local C_ = _.pgettext
 local T = require("ffi/util").template
 local Screen = Device.screen
 
-local ReaderHighlight = InputContainer:extend{
-    long_press_action = {
-        "ask",
-        "nothing",
-        "highlight",
-        "select",
-        "note",
-        "translate",
-        "wikipedia",
-        "dictionary",
-        "search",
-    },
-    long_press_action_text = {
-        _("Ask with popup dialog"),
-        _("Do nothing"),
-        _("Highlight"),
-        _("Select and highlight"),
-        _("Add note"),
-        _("Translate"),
-        _("Wikipedia"),
-        _("Dictionary"),
-        _("Fulltext search"),
-    },
-}
+local ReaderHighlight = InputContainer:extend{}
 
 local function inside_box(pos, box)
     if pos then
@@ -336,6 +313,18 @@ local note_mark = {
     {_("Side mark"), "sidemark"},
 }
 
+local long_press_action = {
+    {_("Ask with popup dialog"), "ask"},
+    {_("Do nothing"), "nothing"},
+    {_("Highlight"), "highlight"},
+    {_("Select and highlight"), "select"},
+    {_("Add note"), "note"},
+    {_("Translate"), "translate"},
+    {_("Wikipedia"), "wikipedia"},
+    {_("Dictionary"), "dictionary"},
+    {_("Fulltext search"), "search"},
+}
+
 function ReaderHighlight:addToMainMenu(menu_items)
     -- insert table to main reader menu
     if not Device:isTouchDevice() and Device:hasDPad() then
@@ -502,11 +491,11 @@ The interval value is in seconds and can range from 3 to 20 seconds.]]),
             },
         },
     }
-    for i, v in ipairs(self.long_press_action) do
+    for i, v in ipairs(long_press_action) do
         table.insert(menu_items.long_press.sub_item_table, {
-            text = self.long_press_action_text[i],
+            text = v[1],
             checked_func = function()
-                return v == G_reader_settings:readSetting("default_highlight_action", "ask")
+                return G_reader_settings:readSetting("default_highlight_action", "ask") == v[2]
             end,
             radio = true,
             callback = function()
@@ -1546,20 +1535,22 @@ function ReaderHighlight:onHoldRelease()
     return true
 end
 
-function ReaderHighlight:onSetHighlightAction(action_num_or_name, no_notification)
-    local action_num, action_name
-    if type(action_num_or_name) == "number" then -- called from self
-        action_num  = action_num_or_name
-        action_name = self.long_press_action[action_num_or_name]
-    else -- "string", called from Dispatcher
-        action_num  = util.arrayContains(self.long_press_action, action_num_or_name)
-        action_name = action_num_or_name
+function ReaderHighlight:getHighlightActions() -- for Dispatcher
+    local action_nums, action_texts = {}, {}
+    for i, v in ipairs(long_press_action) do
+        table.insert(action_nums, i)
+        table.insert(action_texts, v[1])
     end
-    G_reader_settings:saveSetting("default_highlight_action", action_name)
-    self.view.highlight.disabled = action_name == "nothing"
+    return action_nums, action_texts
+end
+
+function ReaderHighlight:onSetHighlightAction(action_num, no_notification)
+    local v = long_press_action[action_num]
+    G_reader_settings:saveSetting("default_highlight_action", v[2])
+    self.view.highlight.disabled = v[2] == "nothing"
     if not no_notification then -- fired with a gesture
         UIManager:show(Notification:new{
-            text = T(_("Default highlight action changed to '%1'."), self.long_press_action_text[action_num]),
+            text = T(_("Default highlight action changed to '%1'."), v[1]),
         })
     end
     return true
@@ -1568,13 +1559,13 @@ end
 function ReaderHighlight:onCycleHighlightAction()
     local current_action = G_reader_settings:readSetting("default_highlight_action", "ask")
     local next_action_num
-    for i, v in ipairs(self.long_press_action) do
-        if v == current_action then
+    for i, v in ipairs(long_press_action) do
+        if v[2] == current_action then
             next_action_num = i + 1
             break
         end
     end
-    if next_action_num > #self.long_press_action then
+    if next_action_num > #long_press_action then
         next_action_num = 1
     end
     self:onSetHighlightAction(next_action_num)

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -33,6 +33,7 @@ local KoptOptions = require("ui/data/koptoptions")
 local Device = require("device")
 local Event = require("ui/event")
 local Notification = require("ui/widget/notification")
+local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
 local UIManager = require("ui/uimanager")
 local util = require("util")
@@ -136,6 +137,7 @@ local settingsList = {
     toggle_page_change_animation = {category="none", event="TogglePageChangeAnimation", title=_("Toggle page turn animations"), reader=true, condition=Device:canDoSwipeAnimation()},
     toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), reader=true, separator=true},
     swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page turn buttons"), reader=true, condition=Device:hasKeys(), separator=true},
+    set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args=ReaderHighlight.long_press_action, toggle=ReaderHighlight.long_press_action_text, reader=true},
     cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
     cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true},
     page_jmp = {category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), reader=true},
@@ -324,6 +326,7 @@ local dispatcher_menu_order = {
     "swap_page_turn_buttons",
     "zoom",
     "zoom_factor_change",
+    "set_highlight_action",
     "cycle_highlight_action",
     "cycle_highlight_style",
     "panel_zoom_toggle",

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -137,7 +137,7 @@ local settingsList = {
     toggle_page_change_animation = {category="none", event="TogglePageChangeAnimation", title=_("Toggle page turn animations"), reader=true, condition=Device:canDoSwipeAnimation()},
     toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), reader=true, separator=true},
     swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page turn buttons"), reader=true, condition=Device:hasKeys(), separator=true},
-    set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args=ReaderHighlight.long_press_action, toggle=ReaderHighlight.long_press_action_text, reader=true},
+    set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args_func=ReaderHighlight.getHighlightActions, reader=true},
     cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
     cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true},
     page_jmp = {category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Go %1 pages"), reader=true},


### PR DESCRIPTION
(1) Add "Add note" default 'long-press on text' action
(2) Allow setting the default action with a gesture (will help a little bit to https://github.com/koreader/koreader/issues/9695).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9723)
<!-- Reviewable:end -->
