### PR TITLE
Fix broken translation metadata

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -38,7 +38,7 @@ local UIManager = require("ui/uimanager")
 local util = require("util")
 local _ = require("gettext")
 local C_ = _.pgettext
-local N_ = _.ngettext
+local NC_ = _.npgettext
 local T = require("ffi/util").template
 
 local Dispatcher = {
@@ -570,7 +570,7 @@ function Dispatcher:menuTextFunc(settings)
             if item == "settings" then item = next(settings, item) end
             action_name = Dispatcher:getNameFromItem(item, settings)
         else
-            action_name = T(N_("", "%1 actions", count), count)
+            action_name = T(NC_("Dispatcher", "", "%1 actions", count), count)
         end
     end
     return action_name


### PR DESCRIPTION
Should fix https://github.com/koreader/koreader/discussions/9719

Regression introduced in https://github.com/koreader/koreader/pull/9682 by my fault.

See the xgettext error message:

```
frontend/dispatcher.lua:573: warning: Empty msgid.  It is reserved by GNU gettext:
                                      gettext("") returns the header entry with
                                      meta information, not the empty string.
xgettext: warning: msgid '' is used without plural and with plural.
                   xgettext.c:1975: Here is the occurrence without plural.
                   frontend/dispatcher.lua:573: Here is the occurrence with plural.
                   Workaround: If the msgid is a sentence, change the wording of the sentence; otherwise, use contexts for disambiguation.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9726)
<!-- Reviewable:end -->
