### PR TITLE
Dispatcher: add unused singular to action plurals

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -570,7 +570,7 @@ function Dispatcher:menuTextFunc(settings)
             if item == "settings" then item = next(settings, item) end
             action_name = Dispatcher:getNameFromItem(item, settings)
         else
-            action_name = T(NC_("Dispatcher", "", "%1 actions", count), count)
+            action_name = T(NC_("Dispatcher", "1 action", "%1 actions", count), count)
         end
     end
     return action_name


### PR DESCRIPTION
Tools and humans alike are confused by leaving it empty. It should be inoffensive to resolve the problem by having an unused singular. Doing anything else would make it so we couldn't have the correct plurals in Slovak, among others.

Follow-up to https://github.com/koreader/koreader/pull/9726

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9734)
<!-- Reviewable:end -->
