### PR TITLE
Statistics calendar view: adjust color palette to avoid pure black bars

### DIFF
--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -248,12 +248,12 @@ end
 local SPAN_COLORS = {
     { Blitbuffer.COLOR_BLACK, Blitbuffer.COLOR_WHITE },
     { Blitbuffer.COLOR_BLACK, Blitbuffer.COLOR_GRAY_E },
-    { Blitbuffer.COLOR_BLACK, Blitbuffer.COLOR_LIGHT_GRAY },
-    { Blitbuffer.COLOR_BLACK, Blitbuffer.COLOR_GRAY },
+    { Blitbuffer.COLOR_BLACK, Blitbuffer.COLOR_GRAY_D },
+    { Blitbuffer.COLOR_BLACK, Blitbuffer.COLOR_GRAY_B },
     { Blitbuffer.COLOR_WHITE, Blitbuffer.COLOR_GRAY_9 },
-    { Blitbuffer.COLOR_WHITE, Blitbuffer.COLOR_DARK_GRAY },
+    { Blitbuffer.COLOR_WHITE, Blitbuffer.COLOR_GRAY_7 },
     { Blitbuffer.COLOR_WHITE, Blitbuffer.COLOR_GRAY_5 },
-    { Blitbuffer.COLOR_WHITE, Blitbuffer.COLOR_BLACK },
+    { Blitbuffer.COLOR_WHITE, Blitbuffer.COLOR_GRAY_3 },
 }
 
 function CalendarWeek:update()


### PR DESCRIPTION
This PR changes the color palette of statistics plugin's calendar view's book bars, aiming at an increased difference among bar colors while removing the striking pure black.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9739)
<!-- Reviewable:end -->
