### PR TITLE
Use inkview to adjust image colors to look more bright

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -562,6 +562,7 @@ local PocketBook633 = PocketBook:extend{
     display_dpi = 300,
     color_saturation = 1.5,
     hasColorScreen = yes,
+    canHWDither = yes, -- Adjust color saturation with inkview
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
@@ -627,6 +628,7 @@ local PocketBook741 = PocketBook:extend{
     display_dpi = 300,
     color_saturation = 1.5,
     hasColorScreen = yes,
+    canHWDither = yes, -- Adjust color saturation with inkview
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
     usingForcedRotation = landscape_ccw,
@@ -643,6 +645,7 @@ local PocketBookColorLux = PocketBook:extend{
     display_dpi = 125,
     color_saturation = 1.5,
     hasColorScreen = yes,
+    canHWDither = yes, -- Adjust color saturation with inkview
     canUseCBB = no, -- 24bpp
 }
 function PocketBookColorLux:_model_init()

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -560,7 +560,7 @@ local PocketBook632 = PocketBook:extend{
 local PocketBook633 = PocketBook:extend{
     model = "PBColor",
     display_dpi = 300,
-    color_vibrance = 2.0,
+    color_saturation = 1.5,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
@@ -625,7 +625,7 @@ local PocketBook740_2 = PocketBook:extend{
 local PocketBook741 = PocketBook:extend{
     model = "PBInkPadColor",
     display_dpi = 300,
-    color_vibrance = 2.0,
+    color_saturation = 1.5,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
@@ -641,7 +641,7 @@ end
 local PocketBookColorLux = PocketBook:extend{
     model = "PBColorLux",
     display_dpi = 125,
-    color_vibrance = 2.0,
+    color_saturation = 1.5,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
 }

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -560,6 +560,7 @@ local PocketBook632 = PocketBook:extend{
 local PocketBook633 = PocketBook:extend{
     model = "PBColor",
     display_dpi = 300,
+    color_vibrance = 2.0,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
@@ -624,6 +625,7 @@ local PocketBook740_2 = PocketBook:extend{
 local PocketBook741 = PocketBook:extend{
     model = "PBInkPadColor",
     display_dpi = 300,
+    color_vibrance = 2.0,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
@@ -639,6 +641,7 @@ end
 local PocketBookColorLux = PocketBook:extend{
     model = "PBColorLux",
     display_dpi = 125,
+    color_vibrance = 2.0,
     hasColorScreen = yes,
     canUseCBB = no, -- 24bpp
 }


### PR DESCRIPTION
Needed for: https://github.com/koreader/koreader-base/pull/1484

Fixes: #8872

Adjust image colors for pocketbook color devices to supply brighter image colors. Make it a config option to we can adjust it to a sensible default for all devices later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9756)
<!-- Reviewable:end -->
