### PR TITLE
Vocabbuilder.koplugin: allow longer intervals

### DIFF
--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -218,7 +218,7 @@ function VocabularyBuilder:gotOrForgot(item, isGot)
     elseif target_count == 7 then
         due_time = current_time + 24 * 15 * 3600
     else
-        due_time = current_time + 24 * 30 * 3600
+        due_time = current_time + 24 * 3600 * 30 * 2 ^ (math.min(target_count - 8, 6))
     end
 
     item.last_streak_count = item.streak_count

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -864,8 +864,14 @@ function VocabItemWidget:getTimeSinceDue()
         readable_time = string.format("%d"..C_("Time", "m"), rounding(abs/60))
     elseif abs < 3600 * 24 then
         readable_time = string.format("%d"..C_("Time", "h"), rounding(abs/3600))
-    else
+    elseif abs < 3600 * 24 * 30 then
         readable_time = string.format("%d"..C_("Time", "d"), rounding(abs/3600/24))
+    elseif abs < 3600 * 24 * 365 then
+        local mo = rounding(abs/3600/24/3)/10
+        readable_time = string.format((mo==rounding(mo) and "%d" or "%.1f")..C_("Time", "mo"), mo)
+    else
+        local yr = rounding(abs/3600/24/36.5)/10
+        readable_time = string.format((yr==rounding(yr) and "%d" or "%.1f")..C_("Time", "yr"), yr)
     end
 
     if elapsed < 0 then

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -859,19 +859,17 @@ function VocabItemWidget:getTimeSinceDue()
 
     local rounding = elapsed > 0 and math.floor or math.ceil
     if abs < 60 then
-        readable_time = abs .. C_("Time", "s")
+        readable_time = T(C_("Time", "%1s"), abs)
     elseif abs < 3600 then
-        readable_time = string.format("%d"..C_("Time", "m"), rounding(abs/60))
+        readable_time = T(C_("Time", "%1m"), rounding(abs/60))
     elseif abs < 3600 * 24 then
-        readable_time = string.format("%d"..C_("Time", "h"), rounding(abs/3600))
+        readable_time = T(C_("Time", "%1h"), rounding(abs/3600))
     elseif abs < 3600 * 24 * 30 then
-        readable_time = string.format("%d"..C_("Time", "d"), rounding(abs/3600/24))
+        readable_time = T(C_("Time", "%1d"), rounding(abs/3600/24))
     elseif abs < 3600 * 24 * 365 then
-        local mo = rounding(abs/3600/24/3)/10
-        readable_time = string.format((mo==rounding(mo) and "%d" or "%.1f")..C_("Time", "mo"), mo)
+        readable_time = T(C_("Time", "%1 mo."), rounding(abs/3600/24/3)/10)
     else
-        local yr = rounding(abs/3600/24/36.5)/10
-        readable_time = string.format((yr==rounding(yr) and "%d" or "%.1f")..C_("Time", "yr"), yr)
+        readable_time = T(C_("Time", "%1 yr."), rounding(abs/3600/24/36.5)/10)
     end
 
     if elapsed < 0 then


### PR DESCRIPTION
This PR adds longer review intervals. See #9757.

(Not sure if `mo` and `yr` are the correct way to abbreviate month and year.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9764)
<!-- Reviewable:end -->
