### PR TITLE
ReaderHighlight: fix ending fragment check in continuous mode

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1473,7 +1473,7 @@ function ReaderHighlight:onHoldRelease()
 
     if self.select_mode then -- extended highlighting, ending fragment
         if self.selected_text then
-            if self.ui.document.info.has_pages and self.ui.paging.current_page ~= self.highlight_page then
+            if self.ui.paging and self.hold_pos.page ~= self.highlight_page then
                 self.ui.paging:_gotoPage(self.highlight_page)
                 UIManager:show(Notification:new{
                     text = _("Fragments must be within one page"),


### PR DESCRIPTION
We cannot make multi-page highlighting in pdf yet, so need to check if starting and ending fragments are within one page.
In pdf continuous mode `current_page` is not accurate, let's use `hold_pos.page` of the ending fragment instead.
Closes https://github.com/koreader/koreader/issues/9729.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9769)
<!-- Reviewable:end -->
