### PR TITLE
Page turns: add backward tap zone width setting

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1157,10 +1157,10 @@ function ReaderView:getTapZones()
         }
     else -- user defined page turns tap zones
         local tap_zone_forward_w = G_reader_settings:readSetting("page_turns_tap_zone_forward_size_ratio", G_defaults:readSetting("DTAP_ZONE_FORWARD").w)
-        local tap_zone_backward_w = 1 - tap_zone_forward_w
+        local tap_zone_backward_w = G_reader_settings:readSetting("page_turns_tap_zone_backward_size_ratio", G_defaults:readSetting("DTAP_ZONE_BACKWARD").w)
         if tap_zones_type == "left_right" then
             forward_zone = {
-                ratio_x = tap_zone_backward_w, ratio_y = 0,
+                ratio_x = 1 - tap_zone_forward_w, ratio_y = 0,
                 ratio_w = tap_zone_forward_w, ratio_h = 1,
             }
             backward_zone = {
@@ -1169,7 +1169,7 @@ function ReaderView:getTapZones()
             }
         else
             forward_zone = {
-                ratio_x = 0, ratio_y = tap_zone_backward_w,
+                ratio_x = 0, ratio_y = 1 - tap_zone_forward_w,
                 ratio_w = 1, ratio_h = tap_zone_forward_w,
             }
             backward_zone = {

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -27,8 +27,8 @@ genTapZonesMenu("default")
 genTapZonesMenu("left_right")
 genTapZonesMenu("top_bottom")
 
-default_size_b = math.floor(G_defaults:readSetting("DTAP_ZONE_BACKWARD").w * 100)
-default_size_f = math.floor(G_defaults:readSetting("DTAP_ZONE_FORWARD").w * 100)
+local default_size_b = math.floor(G_defaults:readSetting("DTAP_ZONE_BACKWARD").w * 100)
+local default_size_f = math.floor(G_defaults:readSetting("DTAP_ZONE_FORWARD").w * 100)
 local function readTapZonesSize()
     local size_b, size_f
     if G_reader_settings:has("page_turns_tap_zone_forward_size_ratio") then

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -26,10 +26,27 @@ end
 genTapZonesMenu("default")
 genTapZonesMenu("left_right")
 genTapZonesMenu("top_bottom")
+
+default_size_b = math.floor(G_defaults:readSetting("DTAP_ZONE_BACKWARD").w * 100)
+default_size_f = math.floor(G_defaults:readSetting("DTAP_ZONE_FORWARD").w * 100)
+local function readTapZonesSize()
+    local size_b, size_f
+    if G_reader_settings:has("page_turns_tap_zone_forward_size_ratio") then
+        size_f = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_forward_size_ratio") * 100)
+        if G_reader_settings:has("page_turns_tap_zone_backward_size_ratio") then
+            size_b = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_backward_size_ratio") * 100)
+        else
+            size_b = 100 - size_f
+        end
+    else
+        size_b = default_size_b
+        size_f = default_size_f
+    end
+    return size_b, size_f
+end
 table.insert(page_turns_tap_zones_sub_items, {
     text_func = function()
-        local size = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_forward_size_ratio", G_defaults:readSetting("DTAP_ZONE_FORWARD").w) * 100)
-        return T(_("Forward tap zone size: %1%"), size)
+        return T(_("Backward / forward tap zone size: %1 % / %2 %"), readTapZonesSize())
     end,
     enabled_func = function()
         return G_reader_settings:readSetting("page_turns_tap_zones", "default") ~= "default"
@@ -37,16 +54,29 @@ table.insert(page_turns_tap_zones_sub_items, {
     keep_menu_open = true,
     callback = function(touchmenu_instance)
         local is_left_right = G_reader_settings:readSetting("page_turns_tap_zones") == "left_right"
-        local size = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_forward_size_ratio", G_defaults:readSetting("DTAP_ZONE_FORWARD").w) * 100)
-        UIManager:show(require("ui/widget/spinwidget"):new{
-            title_text = is_left_right and _("Forward tap zone width") or _("Forward tap zone height"),
+        local size_b, size_f = readTapZonesSize()
+        UIManager:show(require("ui/widget/doublespinwidget"):new{
+            title_text = is_left_right and _("Tap zones width") or _("Tap zones height"),
             info_text = is_left_right and _("Percentage of screen width") or _("Percentage of screen height"),
-            value = size,
-            value_min = 0,
-            value_max = 100,
-            default_value = math.floor(G_defaults:readSetting("DTAP_ZONE_FORWARD").w * 100),
-            callback = function(spin)
-                G_reader_settings:saveSetting("page_turns_tap_zone_forward_size_ratio", spin.value * (1/100))
+            left_text = _("Backward"),
+            left_value = size_b,
+            left_min = 0,
+            left_max = 100 - size_f,
+            left_default = default_size_b,
+            left_hold_step = 5,
+            right_text = _("Forward"),
+            right_value = size_f,
+            right_min = 0,
+            right_max = 100,
+            right_default = default_size_f,
+            right_hold_step = 5,
+            unit = "%",
+            callback = function(value_b, value_f)
+                if value_b + value_f > 100 then
+                    value_b = 100 - value_f
+                end
+                G_reader_settings:saveSetting("page_turns_tap_zone_backward_size_ratio", value_b * (1/100))
+                G_reader_settings:saveSetting("page_turns_tap_zone_forward_size_ratio", value_f * (1/100))
                 ReaderUI.instance.view:setupTouchZones()
                 if touchmenu_instance then touchmenu_instance:updateItems() end
             end,
@@ -143,7 +173,7 @@ When enabled the UI direction for the Table of Contents, Book Map, and Page Brow
 
 if Device:canDoSwipeAnimation() then
     table.insert(PageTurns.sub_item_table, {
-        text =_("Page Turn Animations"),
+        text =_("Page turn animations"),
         checked_func = function()
             return G_reader_settings:isTrue("swipe_animations")
         end,

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -56,7 +56,7 @@ table.insert(page_turns_tap_zones_sub_items, {
         local is_left_right = G_reader_settings:readSetting("page_turns_tap_zones") == "left_right"
         local size_b, size_f = readTapZonesSize()
         UIManager:show(require("ui/widget/doublespinwidget"):new{
-            title_text = is_left_right and _("Tap zones width") or _("Tap zones height"),
+            title_text = is_left_right and _("Tap zone width") or _("Tap zone height"),
             info_text = is_left_right and _("Percentage of screen width") or _("Percentage of screen height"),
             left_text = _("Backward"),
             left_value = size_b,

--- a/frontend/ui/elements/page_turns.lua
+++ b/frontend/ui/elements/page_turns.lua
@@ -29,7 +29,7 @@ genTapZonesMenu("top_bottom")
 
 local default_size_b = math.floor(G_defaults:readSetting("DTAP_ZONE_BACKWARD").w * 100)
 local default_size_f = math.floor(G_defaults:readSetting("DTAP_ZONE_FORWARD").w * 100)
-local function readTapZonesSize()
+local function getTapZonesSize()
     local size_b, size_f
     if G_reader_settings:has("page_turns_tap_zone_forward_size_ratio") then
         size_f = math.floor(G_reader_settings:readSetting("page_turns_tap_zone_forward_size_ratio") * 100)
@@ -46,7 +46,7 @@ local function readTapZonesSize()
 end
 table.insert(page_turns_tap_zones_sub_items, {
     text_func = function()
-        return T(_("Backward / forward tap zone size: %1 % / %2 %"), readTapZonesSize())
+        return T(_("Backward / forward tap zone size: %1 % / %2 %"), getTapZonesSize())
     end,
     enabled_func = function()
         return G_reader_settings:readSetting("page_turns_tap_zones", "default") ~= "default"
@@ -54,7 +54,7 @@ table.insert(page_turns_tap_zones_sub_items, {
     keep_menu_open = true,
     callback = function(touchmenu_instance)
         local is_left_right = G_reader_settings:readSetting("page_turns_tap_zones") == "left_right"
-        local size_b, size_f = readTapZonesSize()
+        local size_b, size_f = getTapZonesSize()
         UIManager:show(require("ui/widget/doublespinwidget"):new{
             title_text = is_left_right and _("Tap zone width") or _("Tap zone height"),
             info_text = is_left_right and _("Percentage of screen width") or _("Percentage of screen height"),


### PR DESCRIPTION
Allows to set backward and forward tap zone widths separately (and have a gap between them).

<img width="200" alt="01" src="https://user-images.githubusercontent.com/62179190/201348423-37adb841-9eaf-4bd4-8dae-0a32151d4a02.png">

<img width="200" alt="02" src="https://user-images.githubusercontent.com/62179190/201348438-177df884-567c-4b32-b2ef-6beace8c4766.png">

Closes https://github.com/koreader/koreader/issues/9466.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9772)
<!-- Reviewable:end -->
