### PR TITLE
Fix page stats messed up after rerendering

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -110,7 +110,9 @@ function ReaderToc:onUpdateToc()
 end
 
 -- Be sure to update the ToC after a CRE rerendering
-ReaderToc.onDocumentRerendered = ReaderToc.onUpdateToc
+function ReaderToc:onDocumentRerendered()
+    self:onUpdateToc()
+end
 
 function ReaderToc:onPageUpdate(pageno)
     if UIManager.FULL_REFRESH_COUNT == -1 or G_reader_settings:isTrue("refresh_on_chapter_boundaries") then


### PR DESCRIPTION
Fix regression introduced by 48eb0231 #9651: on re-rerendering, the new pages count didn't reach the Statistics plugin.
So, if you change font size or margins, the stats for the page read since then were badly accounted, until a change of book or restart... I noticed that in Book map, strange nobody else did over the last 2.5 weeks.

(Stupid me... I explicitely put back the `return true` in :onUpdateToc - as nothing else should handle that event - and just use it as-is for onDocumentRerendered, which itself should propagate...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9775)
<!-- Reviewable:end -->
