### PR TITLE
Button: fix long text alignment

### DIFF
--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -108,7 +108,7 @@ function Button:init()
                     self.label_widget = TextBoxWidget:new{
                         text = self.text,
                         line_height = 0,
-                        alignment = "center",
+                        alignment = self.align,
                         width = max_width,
                         height = max_height,
                         height_adjust = true,


### PR DESCRIPTION
Fix long text alignment (defect from https://github.com/koreader/koreader/pull/9526).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9778)
<!-- Reviewable:end -->
