### PR TITLE
Touchmenu: close on check

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1270,44 +1270,6 @@ function FileManager:getSortingMenuTable()
     }
 end
 
-function FileManager:getStartWithMenuTable()
-    local start_with_setting = G_reader_settings:readSetting("start_with") or "filemanager"
-    local start_withs = {
-        filemanager = {_("file browser"), _("Start with file browser")},
-        history = {_("history"), _("Start with history")},
-        favorites = {_("favorites"), _("Start with favorites")},
-        folder_shortcuts = {_("folder shortcuts"), _("Start with folder shortcuts")},
-        last = {_("last file"), _("Start with last file")},
-    }
-    local set_sw_table = function(start_with)
-        return {
-            text = start_withs[start_with][2],
-            checked_func = function()
-                return start_with_setting == start_with
-            end,
-            callback = function()
-                start_with_setting = start_with
-                G_reader_settings:saveSetting("start_with", start_with)
-            end,
-        }
-    end
-    return {
-        text_func = function()
-            return T(
-                _("Start with: %1"),
-                start_withs[start_with_setting][1]
-            )
-        end,
-        sub_item_table = {
-            set_sw_table("filemanager"),
-            set_sw_table("history"),
-            set_sw_table("favorites"),
-            set_sw_table("folder_shortcuts"),
-            set_sw_table("last"),
-        }
-    }
-end
-
 --- @note: This is the *only* safe way to instantiate a new FileManager instance!
 function FileManager:showFiles(path, focused_file)
     -- Warn about and close any pre-existing FM instances first...

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -411,7 +411,40 @@ To:
         checked_func = function() return self.ui.file_chooser.reverse_collate end,
         callback = function() self.ui:toggleReverseCollate() end
     }
-    self.menu_items.start_with = self.ui:getStartWithMenuTable()
+
+    -- "Start with" menu
+    local start_withs = {
+        filemanager      = _("file browser"),
+        history          = _("history"),
+        favorites        = _("favorites"),
+        folder_shortcuts = _("folder shortcuts"),
+        last             = _("last file"),
+    }
+    local set_sw_table = function(start_with)
+        return {
+            text = start_withs[start_with],
+            checked_func = function()
+                return start_with == G_reader_settings:readSetting("start_with", "filemanager")
+            end,
+            callback = function()
+                G_reader_settings:saveSetting("start_with", start_with)
+            end,
+            close_on_check = true,
+        }
+    end
+    self.menu_items.start_with = {
+        text_func = function()
+            return T(_("Start with: %1"), start_withs[G_reader_settings:readSetting("start_with", "filemanager")])
+        end,
+        sub_item_table = {
+            set_sw_table("filemanager"),
+            set_sw_table("history"),
+            set_sw_table("favorites"),
+            set_sw_table("folder_shortcuts"),
+            set_sw_table("last"),
+        },
+    }
+
     if Device:supportsScreensaver() then
         self.menu_items.screensaver = {
             text = _("Screensaver"),

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -876,6 +876,9 @@ function TouchMenu:onMenuSelect(item, tap_on_checkmark)
                 callback(self)
                 if refresh then
                     self:updateItems()
+                    if item.close_on_check then
+                        self:backToUpperMenu()
+                    end
                 elseif not item.keep_menu_open then
                     self:closeMenu()
                 end


### PR DESCRIPTION
Some of homogenous submenus with checkboxes work as a radiobutton table: one item only can be selected.
Let's save a tap and go to the upper level immediately after selection, provided the upper menu item displays the selected option.
For example: "Start with" menu (the code moved from the filemanager to the filemanagermenu module).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9784)
<!-- Reviewable:end -->
