### PR TITLE
Filemanagerutil: let abbreviate manage extra slash

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -17,7 +17,7 @@ function filemanagerutil.abbreviate(path)
     if not path then return "" end
     if G_reader_settings:nilOrTrue("shorten_home_dir") then
         local home_dir = G_reader_settings:readSetting("home_dir") or filemanagerutil.getDefaultDir()
-        if path == home_dir then
+        if path == home_dir or path == home_dir .. "/" then
             return _("Home")
         end
         local len = home_dir:len()


### PR DESCRIPTION
Correspond `filemanagerutil.abbreviate` with `util.splitFilePathName`.
Closes https://github.com/koreader/koreader/issues/9782.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9785)
<!-- Reviewable:end -->
