### PR TITLE
Fix a couple bugs: keyvaluepage, syncservice, vocabbuilder

### DIFF
--- a/frontend/apps/cloudstorage/syncservice.lua
+++ b/frontend/apps/cloudstorage/syncservice.lua
@@ -27,7 +27,6 @@ local SyncService = Menu:extend{
 }
 
 function SyncService:init()
-    self.cs_settings = LuaSettings:open(DataStorage:getSettingsDir().."/cloudstorage.lua")
     self.item_table = self:generateItemTable()
     self.width = Screen:getWidth()
     self.height = Screen:getHeight()
@@ -37,7 +36,7 @@ end
 function SyncService:generateItemTable()
     local item_table = {}
     -- select and/or add server
-    local added_servers = self.cs_settings:readSetting("cs_servers") or {}
+    local added_servers = LuaSettings:open(DataStorage:getSettingsDir().."/cloudstorage.lua"):readSetting("cs_servers") or {}
     for _, server in ipairs(added_servers) do
         if server.type == "dropbox" or server.type == "webdav" then
             local item = {
@@ -73,6 +72,11 @@ function SyncService:generateItemTable()
         bold = true,
         callback = function()
             local cloud_storage = require("apps/cloudstorage/cloudstorage"):new{}
+            local onClose = cloud_storage.onClose
+            cloud_storage.onClose = function(this)
+                onClose(this)
+                self:switchItemTable(nil, self:generateItemTable())
+            end
             UIManager:show(cloud_storage)
         end
     })

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -644,8 +644,12 @@ function KeyValuePage:_populateItems()
                     unfit_items_count = total_cut_count
                 end
             elseif total_cut_count == 0 then
-                -- no cross-over, we take the longest key to compute ratio
-                width_ratio = (key_widths[#key_widths] + middle_padding) / frame_internal_width
+                -- no cross-over
+                if key_widths[#key_widths] >= key_w then
+                    width_ratio = (key_widths[#key_widths] + middle_padding) / frame_internal_width
+                else
+                    width_ratio = 1 - value_widths[#value_widths] / frame_internal_width
+                end
                 break
             else
                 unfit_items_count = total_cut_count

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1067,13 +1067,14 @@ function VocabItemWidget:onShowBookAssignment(title_changed_cb)
                 return info.name == book
             end,
             hold_callback = function(sort_item, onSuccess)
+                local book_title = self.item.book_title
                 self.show_parent:showChangeBookTitleDialog(sort_item, function()
                     onSuccess()
-                    if self.item.book_title == info.name then
-                        if book == self.item.book_title then
+                    if book_title == info.name then
+                        if book == book_title then
                             book = sort_item.text
                         end
-                        self.item.book_title = sort_item.text
+                        info.name = sort_item.text
                         if title_changed_cb then title_changed_cb(sort_item.text) end
                     end
                 end)


### PR DESCRIPTION
This fixes:
1. `keyvaluepage` key value too close when keys are short and values are long https://github.com/koreader/koreader/pull/9672#issuecomment-1314265246
2. `syncservice` not updating services after adding new ones
3. `vocabbuilder.main` not updating book title in the "more" dialogue when the book title is changed but not reassigned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9790)
<!-- Reviewable:end -->
