### PR TITLE
TouchMenu: Keep the clock in the menu up to date

### DIFF
--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -656,6 +656,8 @@ function TouchMenu:_recalculatePageLayout()
 end
 
 function TouchMenu:updateItems()
+    UIManager:unschedule(self.updateItems)
+
     local old_dimen = self.dimen and self.dimen:copy()
     self:_recalculatePageLayout()
     self.item_group:clear()
@@ -742,6 +744,8 @@ function TouchMenu:updateItems()
         end
         return refresh_type, refresh_dimen
     end)
+
+    UIManager:scheduleIn(61 - tonumber(os.date("%S")), self.updateItems, self)
 end
 
 function TouchMenu:switchMenuTab(tab_num)
@@ -954,6 +958,7 @@ function TouchMenu:onTapCloseAllMenus(arg, ges_ev)
 end
 
 function TouchMenu:onClose()
+    UIManager:unschedule(self.updateItems)
     self:closeMenu()
 end
 


### PR DESCRIPTION
This PR keeps the clock at the bottom of the top menu up to date.

Is useful, if auto update of the footer is activated and there is the right clock. It is confusing if the menu shows a different time than the bottom line.

I am sure there is some pitfall in that PR, otherwise it would be too easy ;-)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9796)
<!-- Reviewable:end -->
