### PR TITLE
BatteryStat: Show current battery percentage

### DIFF
--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -212,7 +212,7 @@ function BatteryStat:showStatistics()
                                 end)
                             end})
     self.kv_page = KeyValuePage:new{
-        title = _("Battery statistics"),
+        title = string.format(_("Battery statistics (now %d%%)"), self.awake_state.percentage),
         kv_pairs = kv_pairs,
         single_page = true,
     }

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -10,6 +10,7 @@ local dbg = require("dbg")
 local time = require("ui/time")
 local util = require("util")
 local _ = require("gettext")
+local T = require("ffi/util").template
 
 local State = {}
 
@@ -212,7 +213,7 @@ function BatteryStat:showStatistics()
                                 end)
                             end})
     self.kv_page = KeyValuePage:new{
-        title = string.format(_("Battery statistics (now %d%%)"), self.awake_state.percentage),
+        title = T(_("Battery statistics (now %1%)"), self.awake_state.percentage),
         kv_pairs = kv_pairs,
         single_page = true,
     }


### PR DESCRIPTION
While the Battery Statistics plugin is ~great~, it doesn't actually show the current battery level, which obviously makes it hard to interpret some of its data.

Now that I know something about the gettext strings, I'd like some feedback on the best way to proceed here. I thought the title would be a good, prominent place to put the battery percentage. The original "Battery statistics" was a gettext string. I saw an example in the AutoWarmth plugin where a gettext string is used inside a `string.format` call, so that's what I used, but I'm open to suggestions.

https://github.com/koreader/koreader/blob/d6b67f42d8a6605fe7a919ea8e8807aa14548340/plugins/autowarmth.koplugin/main.lua#L1204-L1206

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9814)
<!-- Reviewable:end -->
