### PR TITLE
Reader style tweaks: register in Dispatcher manually

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -125,9 +125,9 @@ function TweakInfoWidget:init()
     local buttons = {
         {
             {
-                text = self.is_tweak_registered and _("Don't show in action list") or _("Show in action list"),
+                text = self.is_tweak_in_dispatcher and _("Don't show in action list") or _("Show in action list"),
                 callback = function()
-                    self.toggle_tweak_registered_callback()
+                    self.toggle_tweak_in_dispatcher_callback()
                     UIManager:close(self)
                 end,
             },
@@ -439,7 +439,7 @@ function ReaderStyleTweak:onSaveSettings()
     end
     self.ui.doc_settings:saveSetting("style_tweaks", util.tableSize(self.doc_tweaks) > 0 and self.doc_tweaks or nil)
     G_reader_settings:saveSetting("style_tweaks", self.global_tweaks)
-    G_reader_settings:saveSetting("style_tweaks_registered", self.registered_tweaks)
+    G_reader_settings:saveSetting("style_tweaks_in_dispatcher", self.tweaks_in_dispatcher)
     self.ui.doc_settings:saveSetting("book_style_tweak", self.book_style_tweak)
     self.ui.doc_settings:saveSetting("book_style_tweak_enabled", self.book_style_tweak_enabled)
     self.ui.doc_settings:saveSetting("book_style_tweak_last_edit_pos", self.book_style_tweak_last_edit_pos)
@@ -455,7 +455,7 @@ local function dispatcherUnregisterStyleTweak(tweak_id)
 end
 
 function ReaderStyleTweak:init()
-    self.registered_tweaks = G_reader_settings:readSetting("style_tweaks_registered") or {}
+    self.tweaks_in_dispatcher = G_reader_settings:readSetting("style_tweaks_in_dispatcher") or {}
     self.tweaks_by_id = {}
     self.tweaks_table = {}
 
@@ -526,7 +526,7 @@ You can enable individual tweaks on this book with a tap, or view more details a
                     if self.global_tweaks[item.id] then
                         title = title .. "   ★"
                     end
-                    if self.registered_tweaks[item.id] then
+                    if self.tweaks_in_dispatcher[item.id] then
                         title = title .. "   \u{F144}"
                     end
                     return title
@@ -561,13 +561,13 @@ You can enable individual tweaks on this book with a tap, or view more details a
                             touchmenu_instance:updateItems()
                             self:updateCssText(true) -- apply it immediately
                         end,
-                        is_tweak_registered = self.registered_tweaks[item.id],
-                        toggle_tweak_registered_callback = function()
-                            if self.registered_tweaks[item.id] then
-                                self.registered_tweaks[item.id] = nil
+                        is_tweak_in_dispatcher = self.tweaks_in_dispatcher[item.id],
+                        toggle_tweak_in_dispatcher_callback = function()
+                            if self.tweaks_in_dispatcher[item.id] then
+                                self.tweaks_in_dispatcher[item.id] = nil
                                 dispatcherUnregisterStyleTweak(item.id)
                             else
-                                self.registered_tweaks[item.id] = item.title
+                                self.tweaks_in_dispatcher[item.id] = item.title
                                 dispatcherRegisterStyleTweak(item.id, item.title)
                             end
                             touchmenu_instance:updateItems()
@@ -741,7 +741,7 @@ function ReaderStyleTweak:onToggleStyleTweak(tweak_id, item)
 end
 
 function ReaderStyleTweak:onDispatcherRegisterActions()
-    for tweak_id, tweak_title in pairs(self.registered_tweaks) do
+    for tweak_id, tweak_title in pairs(self.tweaks_in_dispatcher) do
         dispatcherRegisterStyleTweak(tweak_id, tweak_title)
     end
 end

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -450,7 +450,7 @@ local function dispatcherRegisterStyleTweak(tweak_id, tweak_title)
         {category="none", event="ToggleStyleTweak", arg=tweak_id, title=T(_("Toggle style tweak: %1"), tweak_title), rolling=true})
 end
 
-local function dispatcherRemoveStyleTweak(tweak_id)
+local function dispatcherUnregisterStyleTweak(tweak_id)
     Dispatcher:removeAction("style_tweak_"..tweak_id)
 end
 
@@ -565,7 +565,7 @@ You can enable individual tweaks on this book with a tap, or view more details a
                         toggle_tweak_registered_callback = function()
                             if self.registered_tweaks[item.id] then
                                 self.registered_tweaks[item.id] = nil
-                                dispatcherRemoveStyleTweak(item.id)
+                                dispatcherUnregisterStyleTweak(item.id)
                             else
                                 self.registered_tweaks[item.id] = item.title
                                 dispatcherRegisterStyleTweak(item.id, item.title)

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -640,23 +640,23 @@ function Dispatcher:_addItem(caller, menu, location, settings, section)
         then
             if settingsList[k].category == "none" or settingsList[k].category == "arg" then
                 table.insert(menu, {
-                     text = settingsList[k].title,
-                     checked_func = function()
-                     return location[settings] ~= nil and location[settings][k] ~= nil
-                     end,
-                     callback = function(touchmenu_instance)
-                         if location[settings] == nil then
-                             location[settings] = {}
-                         end
-                         if location[settings][k] then
-                             location[settings][k] = nil
-                             Dispatcher:_removeFromOrder(location, settings, k)
-                         else
-                             location[settings][k] = true
-                             Dispatcher:_addToOrder(location, settings, k)
-                         end
-                         caller.updated = true
-                         if touchmenu_instance then touchmenu_instance:updateItems() end
+                    text = settingsList[k].title,
+                    checked_func = function()
+                        return location[settings] ~= nil and location[settings][k] ~= nil
+                    end,
+                    callback = function(touchmenu_instance)
+                        if location[settings] == nil then
+                            location[settings] = {}
+                        end
+                        if location[settings][k] then
+                            location[settings][k] = nil
+                            Dispatcher:_removeFromOrder(location, settings, k)
+                        else
+                            location[settings][k] = true
+                            Dispatcher:_addToOrder(location, settings, k)
+                        end
+                        caller.updated = true
+                        if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,
                     separator = settingsList[k].separator,
                 })
@@ -666,7 +666,7 @@ function Dispatcher:_addItem(caller, menu, location, settings, section)
                         return Dispatcher:getNameFromItem(k, location[settings])
                     end,
                     checked_func = function()
-                    return location[settings] ~= nil and location[settings][k] ~= nil
+                        return location[settings] ~= nil and location[settings][k] ~= nil
                     end,
                     callback = function(touchmenu_instance)
                         local SpinWidget = require("ui/widget/spinwidget")
@@ -714,7 +714,7 @@ function Dispatcher:_addItem(caller, menu, location, settings, section)
                         return Dispatcher:getNameFromItem(k, location[settings])
                     end,
                     checked_func = function()
-                    return location[settings] ~= nil and location[settings][k] ~= nil
+                        return location[settings] ~= nil and location[settings][k] ~= nil
                     end,
                     callback = function(touchmenu_instance)
                         local _ = require("gettext")

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -175,7 +175,7 @@ local settingsList = {
     embedded_css = {category="string", rolling=true},
     embedded_fonts = {category="string", rolling=true},
     smooth_scaling = {category="string", rolling=true},
-    nightmode_images = {category="string", rolling=true},
+    nightmode_images = {category="string", rolling=true, separator=true},
 
     -- parsed from KoptOptions
     kopt_trim_page = {category="string", paging=true},

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -681,7 +681,7 @@ function TouchMenu:updateItems()
             if item_tmp:isEnabled() then
                 table.insert(self.layout, {[self.cur_tab] = item_tmp}) -- for the focusmanager
             end
-            if item.separator and c ~= self.perpage then
+            if item.separator and c ~= self.perpage and i ~= #self.item_table then
                 -- insert split line
                 table.insert(self.item_group, self.split_line)
             end

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -59,7 +59,7 @@ local function dispatcherRegisterProfile(name)
         {category="none", event="ProfileExecute", arg=name, title=T(_("Profile %1"), name), general=true})
 end
 
-local function dispatcherRemoveProfile(name)
+local function dispatcherUnregisterProfile(name)
     Dispatcher:removeAction("profile_exec_"..name)
 end
 
@@ -143,7 +143,7 @@ function Profiles:getSubMenuItems()
                 end,
                 callback = function(touchmenu_instance)
                     if v.settings.registered then
-                        dispatcherRemoveProfile(k)
+                        dispatcherUnregisterProfile(k)
                         self.data[k].settings.registered = nil
                     else
                         dispatcherRegisterProfile(k)
@@ -166,7 +166,7 @@ function Profiles:getSubMenuItems()
                 callback = function(touchmenu_instance)
                     local function editCallback(new_name)
                         if v.settings.registered then
-                            dispatcherRemoveProfile(k)
+                            dispatcherUnregisterProfile(k)
                             dispatcherRegisterProfile(new_name)
                         end
                         self:renameAutostart(k, new_name)
@@ -205,7 +205,7 @@ function Profiles:getSubMenuItems()
                         ok_text = _("Delete"),
                         ok_callback = function()
                             if v.settings.registered then
-                                dispatcherRemoveProfile(k)
+                                dispatcherUnregisterProfile(k)
                             end
                             self:renameAutostart(k)
                             self.data[k] = nil


### PR DESCRIPTION
Style tweaks can be applied with a gesture or added to a profile.

<img width="250" alt="01" src="https://user-images.githubusercontent.com/62179190/202901564-a8e02ec1-5173-430b-82b4-19c66dd01561.png">
<img width="250" alt="02" src="https://user-images.githubusercontent.com/62179190/202901565-3fd81ba9-789d-41a8-b93e-b427b272968b.png">
<img width="250" alt="03" src="https://user-images.githubusercontent.com/62179190/202901569-ff52def2-b397-4acc-a80c-b18f030403bd.png">
<img width="250" alt="04" src="https://user-images.githubusercontent.com/62179190/202901570-9b3cb94b-df06-4ca3-86df-f9456742cd95.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9816)
<!-- Reviewable:end -->
