### PR TITLE
Remember history status filter, show filtered count in view

### DIFF
--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -113,7 +113,7 @@ function FileManagerHistory:onMenuHold(item)
                             filemanagerutil.purgeSettings(item.file)
                             require("readhistory"):fileSettingsPurged(item.file)
                             if self.filter ~= "all" then
-                                self._manager:fetchStatuses(true)
+                                self._manager:fetchStatuses(false)
                             else
                                 self.statuses_fetched = false
                             end

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -112,10 +112,10 @@ function FileManagerHistory:onMenuHold(item)
                         ok_callback = function()
                             filemanagerutil.purgeSettings(item.file)
                             require("readhistory"):fileSettingsPurged(item.file)
-                            if self.filter ~= "all" then
+                            if self._manager.filter ~= "all" then
                                 self._manager:fetchStatuses(false)
                             else
-                                self.statuses_fetched = false
+                                self._manager.statuses_fetched = false
                             end
                             self._manager:updateItemTable()
                             UIManager:close(self.histfile_dialog)


### PR DESCRIPTION
This remembers the currently status filter in the History viewer as a user setting, added with #8820 (and answers #3406 a little better).

Since we had to (and still do) grab statuses from every book by opening up the files, I abided by @poire-z's concerns ([here](https://github.com/koreader/koreader/pull/8820#discussion_r809967780)) to make sure no extra work is added when the filter is off ("all"). I do this by only scanning the files for their status if there is a filter selected, and this data is re-used when showing the filter-selection dialog. If there is no filter currently selected, the filter-selection dialog scans the files like it did before. This means that just like before, if you have no filter selected, opening the History viewer will not scan all your history files, which can (apparently) be slow with large histories. Only when you have a filter selected will this scan occur when the History viewer is opened, but that's something you sign up for when you select a filter, so no surprises.

Other changes:
- Add number of books in the filter to the top title when a filter is selected.
- Move file status scanning to its own function because it can potentially now be called from two places.
- ~Removed the `statuses_fetched` variable because this can be inferred from whether the current filter is `all` or not.~
- Rename `status_text` to `filter_text` for slightly better understanding, especially in the `genFilterButton` callback.
- ~Move `updateItemTable` down to be closer to places it's called from.~

Question: Why don't we keep book statuses in `history.lua`? And how can a book be both in your history and "new"? :P We should probably also add a way to put a book on hold from the history viewer too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9822)
<!-- Reviewable:end -->
