### PR TITLE
TouchMenu: Search menu to search the menu

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1385,4 +1385,11 @@ function FileManager:onRefreshContent()
     self:onRefresh()
 end
 
+function FileManager:onMenuSearch()
+    if not self.ui then
+        self.menu:onShowMenu()
+    end
+    self.menu.menu_container[1]:onShowMenuSearch()
+end
+
 return FileManager

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -31,18 +31,23 @@ function FileManagerMenu:init()
         -- items in top menu
         filemanager_settings = {
             icon = "appbar.filebrowser",
+            text = _("Filebrowser"),
         },
         setting = {
             icon = "appbar.settings",
+            text = _("Settings"),
         },
         tools = {
             icon = "appbar.tools",
+            text = _("Tools"),
         },
         search = {
             icon = "appbar.search",
+            text = _("Search"),
         },
         main = {
             icon = "appbar.menu",
+            text = _("Hamburger"),
         },
     }
 

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -31,7 +31,7 @@ function ReaderMenu:init()
         },
         typeset = {
             icon = "appbar.typeset",
-            text = _("Typeset"),
+            text = _("Formatting"),
         },
         setting = {
             icon = "appbar.settings",

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -27,21 +27,27 @@ function ReaderMenu:init()
         -- items in top menu
         navi = {
             icon = "appbar.navigation",
+            text = _("Navigation"),
         },
         typeset = {
             icon = "appbar.typeset",
+            text = _("Typeset"),
         },
         setting = {
             icon = "appbar.settings",
+            text = _("Settings"),
         },
         tools = {
             icon = "appbar.tools",
+            text = _("Tools"),
         },
         search = {
             icon = "appbar.search",
+            text = _("Search"),
         },
         filemanager = {
             icon = "appbar.filebrowser",
+            text = _("Filebrowser"),
             remember = false,
             callback = function()
                 self:onTapCloseMenu()
@@ -51,6 +57,7 @@ function ReaderMenu:init()
         },
         main = {
             icon = "appbar.menu",
+            text = _("Hamburger"),
         }
     }
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -871,4 +871,11 @@ function ReaderUI:getCurrentPage()
     end
 end
 
+function ReaderUI:onMenuSearch()
+    if not self.ui then
+        self.menu:onShowMenu()
+    end
+    self.menu.menu_container[1]:onShowMenuSearch()
+end
+
 return ReaderUI

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -97,6 +97,7 @@ local settingsList = {
     fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), general=true},
     file_search = {category="none", event="ShowFileSearch", title=_("File search"), general=true, separator=true},
     show_menu = {category="none", event="ShowMenu", title=_("Show menu"), general=true},
+    menu_search = {category="none", event="MenuSearch", title=_("Menu search"), general=true},
     favorites = {category="none", event="ShowColl", arg="favorites", title=_("Favorites"), general=true},
     screenshot = {category="none", event="Screenshot", title=_("Screenshot"), general=true, separator=true},
 
@@ -227,6 +228,7 @@ local dispatcher_menu_order = {
     "file_search",
 
     "show_menu",
+    "menu_search",
     "screenshot",
 
     "exit_screensaver",

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -617,4 +617,12 @@ common_settings.units = {
     },
 }
 
+common_settings.search_menu = {
+    text = _("Menu Search"),
+    callback = function()
+        UIManager:sendEvent(Event:new("ShowMenuSearch"))
+    end,
+    keep_menu_open = true,
+}
+
 return common_settings

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -618,7 +618,7 @@ common_settings.units = {
 }
 
 common_settings.search_menu = {
-    text = _("Menu Search"),
+    text = _("Menu search"),
     callback = function()
         UIManager:sendEvent(Event:new("ShowMenuSearch"))
     end,

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -163,6 +163,7 @@ local order = {
         "----------------------------",
         "ota_update", -- if Device:hasOTAUpdates()
         "help",
+        "search_menu",
         "----------------------------",
         "exit_menu",
     },

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -216,6 +216,7 @@ local order = {
         "----------------------------",
         "ota_update", -- if Device:hasOTAUpdates()
         "help",
+        "search_menu",
         "----------------------------",
         "exit_menu",
     },

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -28,6 +28,7 @@ local GestureRange = require("ui/gesturerange")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
 local IconWidget = require("ui/widget/iconwidget")
+local ImageWidget = require("ui/widget/imagewidget")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local MovableContainer = require("ui/widget/container/movablecontainer")
 local Size = require("ui/size")
@@ -35,6 +36,7 @@ local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 local Input = Device.input
 local Screen = Device.screen
@@ -79,14 +81,34 @@ function ConfirmBox:init()
     local text_widget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 2/3),
+        width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * (self.width_percent or 2/3)),
     }
+
+    local image_widget
+    if self.show_icon then
+        --- @todo remove self.image support, only used in filemanagersearch
+        -- this requires self.image's lifecycle to be managed by ImageWidget
+        -- instead of caller, which is easy to introduce bugs
+        if self.image then
+            image_widget = ImageWidget:new{
+                image = self.image,
+                width = self.image_width,
+                height = self.image_height,
+                alpha = self.alpha ~= nil and self.alpha or false, -- default to false
+            }
+        else
+            image_widget = IconWidget:new{
+                icon = self.icon,
+                alpha = self.alpha == nil and true or self.alpha, -- default to true
+            }
+        end
+    else
+        image_widget = WidgetContainer:new()
+    end
+
     local content = HorizontalGroup:new{
         align = "center",
-        IconWidget:new{
-            icon = self.icon,
-            alpha = true,
-        },
+        image_widget,
         HorizontalSpan:new{ width = Size.span.horizontal_default },
         text_widget,
     }

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -27,10 +27,12 @@ local UIManager = require("ui/uimanager")
 local UnderlineContainer = require("ui/widget/container/underlinecontainer")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
+local Utf8Proc = require("ffi/utf8proc")
 local util = require("util")
 local getMenuText = require("ui/widget/menu").getMenuText
 local _ = require("gettext")
-local T = require("ffi/util").template
+local ffiUtil = require("ffi/util")
+local T = ffiUtil.template
 local Input = Device.input
 local Screen = Device.screen
 
@@ -476,6 +478,7 @@ function TouchMenu:init()
     end
 
     self.layout = {}
+    self.search_layout = {}
 
     self.ges_events.TapCloseAllMenus = {
         GestureRange:new{
@@ -660,8 +663,10 @@ function TouchMenu:updateItems()
     self:_recalculatePageLayout()
     self.item_group:clear()
     self.layout = {}
+    self.search_layout = {}
     table.insert(self.item_group, self.bar)
     table.insert(self.layout, self.bar.icon_widgets) -- for the focusmanager
+    table.insert(self.search_layout, self.bar.icon_widgets) -- for the menu search
 
     for c = 1, self.perpage do
         -- calculate index in item_table
@@ -669,6 +674,7 @@ function TouchMenu:updateItems()
         if i <= #self.item_table then
             local item = self.item_table[i]
             local item_tmp = TouchMenuItem:new{
+                name = "touch_menu_item " .. tostring(item.text) .. " xxx", -- xxx testing only, squish later
                 item = item,
                 menu = self,
                 dimen = Geom:new{
@@ -681,6 +687,7 @@ function TouchMenu:updateItems()
             if item_tmp:isEnabled() then
                 table.insert(self.layout, {[self.cur_tab] = item_tmp}) -- for the focusmanager
             end
+            table.insert(self.search_layout, {[self.cur_tab] = item_tmp}) -- for the menu search
             if item.separator and c ~= self.perpage and i ~= #self.item_table then
                 -- insert split line
                 table.insert(self.item_group, self.split_line)
@@ -797,7 +804,7 @@ function TouchMenu:onNextPage()
     elseif self.page == self.page_num then
         self.page = 1
     end
-        self:updateItems()
+    self:updateItems()
     return true
 end
 
@@ -819,6 +826,18 @@ end
 
 function TouchMenu:onLastPage()
     self.page = self.page_num
+    self:updateItems()
+    return true
+end
+
+function TouchMenu:onGotoPage(nb)
+    if nb > self.page_num then
+        self.page = self.page_num
+    elseif nb < 1 then
+        self.page = 1
+    else
+        self.page = nb
+    end
     self:updateItems()
     return true
 end
@@ -959,6 +978,391 @@ end
 
 function TouchMenu:onBack()
     self:backToUpperMenu()
+end
+
+------ the menu search functionality
+function TouchMenu:search(search_for)
+    local found_menu_items = {}
+
+    local extensive_search = G_reader_settings:readSetting("search_menu_extensive", false)
+
+    local MAX_MENU_DEPTH = 20 -- currently our menu needs at least 12 here
+    local function recurse(val, path, text, depth)
+        depth = depth + 1
+        if depth > MAX_MENU_DEPTH then
+            return
+        end
+
+        for i,v in ipairs(val) do
+            if type(v) == "table" then
+                local entry_text = v.text_func and v.text_func() or v.text
+                local indent = (" "):rep(math.min(depth, 6)) .."→ " -- all spaces here are Hair Space U+200A
+                local next_text = text .. "\n" .. indent .. entry_text
+                local next_path = path .. "." .. i
+                recurse(val[i], next_path, next_text, depth)
+                if Utf8Proc.lowercase(entry_text):find(search_for) then
+                    table.insert(found_menu_items, {entry_text, next_path, next_text})
+                end
+            end
+        end
+
+        if val.sub_item_table_func and extensive_search then
+            local sub_item_table = val.sub_item_table_func()
+            local perpage = ""
+            if sub_item_table.max_per_page then
+                perpage = "[" .. sub_item_table.max_per_page .."]"
+            end
+            recurse(sub_item_table, path .. ".sub_item_table_func" .. perpage , text, depth)
+        elseif val.sub_item_table then
+            local perpage = ""
+            if val.sub_item_table.max_per_page then
+                perpage = "[" .. val.sub_item_table.max_per_page .."]"
+            end
+            recurse(val.sub_item_table, path .. ".sub_item_table" .. perpage , text, depth)
+        end
+    end -- recurse
+
+    -- initial call of recurse
+    for i = 1, #self.tab_item_table do
+        recurse(self.tab_item_table[i], i, self.tab_item_table[i].text or "ROOT"..i, 0)
+    end
+
+--[[
+    for i = 1, #found_menu_items do
+        print("xxxxxxx->", i,
+            found_menu_items[i][1],
+            found_menu_items[i][2],
+            found_menu_items[i][3])
+    end
+]]
+    return found_menu_items
+end
+
+-- maybe this could be placed in UIManager?
+local function highlightWidget(widget, unhilight_in_s)
+    if not widget then return end
+    local highlight_dimen = widget.dimen
+    if highlight_dimen.w == 0 then
+        highlight_dimen.w = widget.width
+    end
+
+    UIManager:nextTick(function()
+        -- Highlight
+        widget.invert = true
+        UIManager:widgetInvert(widget, highlight_dimen.x, highlight_dimen.y, highlight_dimen.w)
+        UIManager:setDirty(nil, "fast", highlight_dimen)
+
+        UIManager:forceRePaint()
+        UIManager:yieldToEPDC()
+    end)
+
+    if unhilight_in_s then
+        -- Unhighlight
+        UIManager:scheduleIn(unhilight_in_s, function()
+            widget.invert = false
+            UIManager:widgetInvert(widget, highlight_dimen.x, highlight_dimen.y, highlight_dimen.w)
+            UIManager:setDirty(nil, "ui", highlight_dimen)
+        end)
+    end
+end
+
+function TouchMenu:_get_widget(tab_nb, nb)
+    return self.search_layout[nb + 1][tab_nb]
+end
+
+function TouchMenu:openMenu(path)
+    local TrapWidget = require("ui/widget/trapwidget")
+
+    local animation_time_s = G_reader_settings:readSetting("menu_search_animation_time_s", 1.0)
+
+    -- first switch to correct MenuTab
+    local sep_pos = path:find("%.")
+    local tab_nb = tonumber(path:sub(1, sep_pos - 1))
+
+    if not tab_nb then return end
+
+    path = path:sub(sep_pos + 1)
+    local item = self.tab_item_table[tab_nb]
+
+    self:switchMenuTab(tab_nb)
+    self.bar:switchToTab(tab_nb)
+    self:onMenuSelect(self.item_table)
+
+    -- Now go the menu path down the way
+    local items_to_show = {}
+    local dummy, num_of_sep = path:gsub("%.", "%.")
+    while num_of_sep > 1 do
+        sep_pos = path:find("%.")
+        local identifier = path:sub(1, sep_pos -1)
+        local item_nb = tonumber(identifier)
+        path = path:sub(sep_pos + 1)
+        if item_nb then
+            self:updateItems()
+            item = item[item_nb]
+            table.insert(items_to_show, {item_nb, item})
+        elseif identifier:find("sub_item_table_func") then
+            item = item.sub_item_table_func()
+        elseif identifier:find("sub_item_table") then
+            item = item.sub_item_table
+        end
+        num_of_sep = num_of_sep - 1
+    end
+
+    -- Now we are in the right menu, but maybe in the wrong page
+    sep_pos = path:find("%.")
+    if not sep_pos then
+        local logger = require("logger")
+        logger.err("TouchMenu: search; internal error") -- should not happen
+        return
+    end
+    local identifier = path:sub(sep_pos + 1)
+    local item_nb = tonumber(identifier)
+
+    local perpage
+    if path:find("sub_item_table_func%[") then
+        perpage = path:sub(#("sub_item_table_func%["), sep_pos - 2)
+    elseif path:find("sub_item_table%[") then
+        perpage = path:sub(#("sub_item_table%["), sep_pos - 2)
+    end
+    perpage = tonumber(perpage) or self.perpage
+
+    local function open_final_menu()
+        print("xxx", #items_to_show)
+        if #items_to_show > 0 then -- can be zero, if in the last menu
+            self:onMenuSelect(items_to_show[#items_to_show][2])
+        end
+        local page_nb = math.floor((item_nb - 1) / perpage) + 1
+        self:onGotoPage(page_nb)
+    end
+
+    if not (animation_time_s and animation_time_s > 0.0) then
+        open_final_menu()
+    else
+        self.trap_widget = TrapWidget:new{
+            dismiss_callback = function()
+                animation_time_s = 0
+                self.trap_widget = nil
+            end
+        }
+        UIManager:show(self.trap_widget) -- suppress taps during animaton
+
+        -- Animation functions
+        local function open_next_page(pages_to_show, force_first_page)
+            if animation_time_s == 0.0 then
+                UIManager.close(self.trap_widget)
+                self.trap_widget = nil
+                open_final_menu()
+                -- end of the animation here!
+                return
+            end
+            print("xxx pages_to_show", pages_to_show, force_first_page)
+            if force_first_page then
+                self:onFirstPage()
+            end
+
+            if pages_to_show == 1 then -- if we are on the last page
+                if self.page_num > 1 then
+                    highlightWidget(self.page_info_right_chev, animation_time_s)
+                end
+                highlightWidget(self:_get_widget(tab_nb, (item_nb - 1) % perpage + 1))
+                -- end of the animation here!
+            else
+                if self.page_num ~= 1 then
+                    highlightWidget(self.page_info_right_chev)
+                end
+                UIManager:scheduleIn(animation_time_s, function()
+                    self:onNextPage()
+                    if pages_to_show > 1 then
+                        UIManager:nextTick(open_next_page, pages_to_show - 1, false)
+                    end
+                end)
+            end
+        end
+
+        local function open_next_menu()
+            if animation_time_s == 0.0 then
+                UIManager:close(self.trap_widget)
+                self.trap_widget = nil
+                open_final_menu()
+                -- end of the animation here!
+                return
+            end
+
+            local x = table.remove(items_to_show, 1)
+            local next_menu_num, next_menu_item = x and x[1], x and x[2] -- might be nil
+
+            if next_menu_item then
+                highlightWidget(self:_get_widget(tab_nb, next_menu_num))
+                UIManager:scheduleIn(animation_time_s, function()
+                    self:onMenuSelect(next_menu_item)
+                    UIManager:nextTick(open_next_menu)
+                end)
+            else
+                -- no items left, but maybe on another page
+                local page_nb = math.floor(item_nb / perpage) + 1
+                UIManager:nextTick(open_next_page, page_nb, page_nb > 1)
+            end
+        end
+
+        -- Animate
+        UIManager:nextTick(open_next_menu)
+    end
+end
+
+function TouchMenu:onShowMenuSearch()
+    local InputDialog = require("ui/widget/inputdialog")
+    local CheckButton = require("ui/widget/checkbutton")
+    local ConfirmBox = require("ui/widget/confirmbox")
+    local Menu = require("ui/widget/menu")
+
+    local function show_search_results(search_string)
+        local found_menu_items = self:search(search_string)
+
+        local function get_current_search_results()
+            local function item_callback(i)
+                UIManager:close(self.results_menu_container)
+                UIManager:setDirty(nil, "ui")
+                self:openMenu(found_menu_items[i][2])
+            end
+            local function item_hold_callback(i)
+                local confirm_box
+                confirm_box = ConfirmBox:new{
+                    text = T(_("Open menu entry:\n'%1'\n\n%2"), found_menu_items[i][1], found_menu_items[i][3]),
+                    icon = "",
+                    ok_text = _("Open"),
+                    ok_callback = function()
+                        UIManager:close(confirm_box)
+                        item_callback(i)
+                    end,
+                    cancel_text = _("Dismiss"),
+                    width_percent = 0.95,
+                }
+                UIManager:show(confirm_box)
+            end
+
+            local result_items = {}
+            for i = 1, #found_menu_items do
+                table.insert(result_items,
+                    {
+                        text = found_menu_items[i][1],
+                        callback = function() item_callback(i) end,
+                        hold_callback = function() item_hold_callback(i) end,
+                    }
+                )
+            end
+            return result_items
+        end -- get_current_search_results()
+
+        if #found_menu_items > 0 then
+            local results_menu = Menu:new{
+                title = _("Search results"),
+                item_table = get_current_search_results(found_menu_items),
+                item_shortcuts = {},
+                width = math.floor(Screen:getWidth() * 0.9),
+                height = math.floor(Screen:getHeight() * 0.9),
+                single_line = true,
+                items_per_page = 10,
+                items_font_size = Menu.getItemFontSize(10),
+                onMenuSelect = function(item, pos)
+                    if pos.callback then pos.callback() end
+                end,
+                onMenuHold = function(item, pos)
+                    if pos.hold_callback then pos.hold_callback() end
+                end,
+                close_callback = function()
+                    UIManager:close(self.results_menu_container)
+                end
+            }
+
+            -- build container
+            self.results_menu_container = CenterContainer:new{
+                dimen = Screen:getSize(),
+                results_menu,
+            }
+
+            results_menu.show_parent = self.results_menu_container
+
+            UIManager:show(self.results_menu_container)
+
+        else
+            UIManager:show(InfoMessage:new{
+                text = T(_("No menus containing '%1' found."), search_string),
+            })
+        end
+    end -- show_search_results()
+
+    local search_dialog
+    search_dialog = InputDialog:new{
+        title = _("Search menu entry"),
+        description = _("Search for a menu entry containing the following text (case insensitive)."),
+        input = G_reader_settings:readSetting("menu_search_string", _("Help")),
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(search_dialog)
+                    end,
+                },
+                {
+                    text = _("Search"),
+                    callback = function()
+                        local search_for = search_dialog:getInputText()
+                        local status, err = pcall( function() ("test_string"):find(search_for) end)
+                        if status then
+                            search_for = Utf8Proc.lowercase(search_for)
+                            G_reader_settings:saveSetting("menu_search_string", search_for)
+                            UIManager:close(search_dialog)
+                            show_search_results(search_for)
+                        else
+                            err = err:sub(err:find("lua") + 10)  -- 10 = strlen("lua:1165: ")
+                            UIManager:show(InfoMessage:new{
+                                text = T(_("Malformed message:\n%1"), err)
+                            })
+                        end
+                    end,
+                },
+            }
+        },
+    }
+
+    local animation_time_s = G_reader_settings:readSetting("menu_search_animation_time_s", 1.0)
+    local check_button_animation = CheckButton:new{
+        text = _("Animation"),
+        checked = animation_time_s ~= 0.0,
+        parent = search_dialog,
+        callback = function()
+            animation_time_s = animation_time_s ~= 0.0 and 0.0 or 1.0
+            G_reader_settings:saveSetting("menu_search_animation_time_s", animation_time_s)
+        end,
+    }
+    search_dialog:addWidget(check_button_animation)
+
+--[[
+    -- Extensive_search will enable to scan sub_item_table_func() results too.
+    -- This can take (with a lot of system fonts enabled) quite some time and should not be done.
+    --- @todo Maybe caching of sub_item_table_func() results can improve things?
+    local extensive_search = G_reader_settings:readSetting("search_menu_extensive", false)
+    local check_button_restrict = CheckButton:new{
+        text = _("Extensive search"),
+        checked = extensive_search,
+        parent = search_dialog,
+        callback = function()
+            extensive_search = not extensive_search
+            G_reader_settings:saveSetting("search_menu_extensive", extensive_search)
+        end,
+        hold_callback = function()
+            UIManager:show(InfoMessage:new{
+                text = _("You can expand you search.\n(Attention: This can take a lot of time.)"),
+            })
+        end,
+    }
+    search_dialog:addWidget(check_button_restrict)
+]]
+
+    UIManager:show(search_dialog)
+    search_dialog:onShowKeyboard()
 end
 
 return TouchMenu

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -525,9 +525,7 @@ function AutoWarmth:addToMainMenu(menu_items)
     menu_items.autowarmth = {
         text = Device:hasNaturalLight() and _("Auto warmth and night mode") or _("Auto night mode"),
         checked_func = function() return self.activate ~= 0 end,
-        sub_item_table_func = function()
-            return self:getSubMenuItems()
-        end,
+        sub_item_table = self:getSubMenuItems(),
     }
 end
 


### PR DESCRIPTION
This should fix #9800.

What works:
- Search an entry (static or dynamic).
- Use Lua patterns for searching.
- Display search results. (With the path to navigate with long press)
- Select one result and open the menu there.
- All of that in the selected language :)
- Long press in the search results shows the path in the menu to find the entry
- The last search string is saved.
- "It should, in slow motion, open and navigate all the menus to where the menu item is, " does work now.
- The animation can be turned off.


![grafik](https://user-images.githubusercontent.com/36999612/203722149-28a47489-a9b3-4a63-9831-780bcb11a5e0.png)

![grafik](https://user-images.githubusercontent.com/36999612/203611404-738590f6-63ec-4741-9c00-120c130bfaf5.png)

![grafik](https://user-images.githubusercontent.com/36999612/203611492-583e2750-8c11-49b4-94ba-d6171be749ef.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9823)
<!-- Reviewable:end -->