### PR TITLE
ReaderHighlight: new icon in select mode ConfirmBox

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -618,6 +618,7 @@ function ReaderHighlight:onTapSelectModeIcon()
     if not self.select_mode then return end
     UIManager:show(ConfirmBox:new{
         text = _("You are currently in SELECT mode.\nTo finish highlighting, long press where the highlight should end and press the HIGHLIGHT button.\nYou can also exit select mode by tapping on the start of the highlight."),
+        icon = "format-quote-close",
         ok_text = _("Exit select mode"),
         cancel_text = _("Close"),
         ok_callback = function()

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -44,6 +44,7 @@ local ConfirmBox = InputContainer:extend{
     keep_dialog_open = false,
     text = _("no text"),
     face = Font:getFace("infofont"),
+    icon = "notice-question",
     ok_text = _("OK"),
     cancel_text = _("Cancel"),
     ok_callback = function() end,
@@ -83,7 +84,8 @@ function ConfirmBox:init()
     local content = HorizontalGroup:new{
         align = "center",
         IconWidget:new{
-            icon = "notice-question",
+            icon = self.icon,
+            alpha = true,
         },
         HorizontalSpan:new{ width = Size.span.horizontal_default },
         text_widget,


### PR DESCRIPTION
In the new select mode ConfirmBox actually there is no question, so the "notice-question" icon to be changed to the new select mode symbol.
(It can be just "notice-info" but it is not so interesting imho).

Old
<img width="250" alt="00" src="https://user-images.githubusercontent.com/62179190/203938459-2868f17b-3285-4325-8b1c-7a1fbd87fe7b.png">

Proposed
<img width="250" alt="01" src="https://user-images.githubusercontent.com/62179190/203938491-a599daa3-0807-4a50-92fd-04e825c77ed3.png">

Option
<img width="250" alt="02" src="https://user-images.githubusercontent.com/62179190/203938530-c1ac03d6-d6c5-469e-a493-d52260650921.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9830)
<!-- Reviewable:end -->
