### PR TITLE
Calendar view's day view: visual tweaks

### DIFF
--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -845,7 +845,7 @@ function CalendarDayView:refreshTimeline()
         local offset_x = self.time_text_width + self.timeline_width * i / self.NB_VERTICAL_SEPARATORS_PER_HOUR
         table.insert(self.timeline, FrameContainer:new{
             width = Size.border.thin,
-            height = 24 * self.hour_height,
+            height = 24 * self.hour_height, -- unscaled_size_check: ignore
             background = Blitbuffer.COLOR_LIGHT_GRAY,
             bordersize = 0,
             padding = 0,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1220,6 +1220,13 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                     self:onShowCalendarView()
                 end,
             },
+            {
+                text = _("Today's timeline"),
+                keep_menu_open = true,
+                callback = function()
+                    self:onShowCalendarDayView()
+                end,
+            },
         },
     }
 end


### PR DESCRIPTION
- Add vertical lines every 10mn
I tried using a lighter gray than the one used for horizontal lines, but the thin lines were nearly invisible on my GloHD.
I also needed to add a top and bottom lines, otherwise the vertical lines reaching outwards a line felt a bit odd.
![image](https://user-images.githubusercontent.com/24273478/204053219-b4d7a10f-dc6b-4b6d-9857-434e89e9476c.png)

- If today, show an arrow indicator at current time
- Add "Today's timeline" to menu
![image](https://user-images.githubusercontent.com/24273478/204053320-8b36415a-1884-42a4-9e91-c0523ce80914.png)
Any better position/ordering ? (I have a thought for non-touch people that may have some habbits navigating with keys to reach CalendarView - they may reach now Today's timeline - but dunno where else to put it, as it's somehow a child of Calendar view.

- Rename badly named self.hour_width, which is a height

Suggested around https://github.com/koreader/koreader/pull/9813#issuecomment-1321938944.

It feels there is a bit of abuse of FrameContainer>CenterContainer>VerticalSpan to draw lines, while we have a LineWidget - but I went with the flow and used that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9832)
<!-- Reviewable:end -->
