### PR TITLE
cloudstorage: Fix directory listing for some WebDAV servers

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -133,7 +133,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
 
             local item_path = (path == "" and has_trailing_slash) and item_name or path .. "/" .. item_name
-            if item:find("<[^:]*:collection/>") then
+            if item:find("<[^:]*:collection[^<]*/>") then
                 item_name = item_name .. "/"
                 if not is_current_dir then
                     table.insert(webdav_list, {


### PR DESCRIPTION
(sub)folders on some WebDAV servers are not listed in cloudstorage due to strict xml element matching of `<d:collection>`  elements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9847)
<!-- Reviewable:end -->
