### PR TITLE
ReaderHighlight: pdf multi-page highlights

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -821,10 +821,7 @@ function ReaderHighlight:onShowHighlightNoteOrDialog(page, index)
         return true
     end
     local item = self.view.highlight.saved[page][index]
-    local bookmark_note = self.ui.bookmark:getBookmarkNote({
-        page = self.ui.document.info.has_pages and item.pos0.page or item.pos0,
-        datetime = item.datetime,
-    })
+    local bookmark_note = self.ui.bookmark:getBookmarkNote({datetime = item.datetime})
     if bookmark_note then
         local textviewer
         textviewer = TextViewer:new{

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1781,7 +1781,7 @@ function ReaderHighlight:writePdfAnnotation(action, page, item, content)
     if self.ui.rolling or G_reader_settings:readSetting("save_document") == "disable" then
         return
     end
-    logger.dbg("write to pdf document", action, hl_or_bm)
+    logger.dbg("write to pdf document", action, item)
     local function doAction(_action, _page, _item, _content)
         if _action == "save" then
             return self.ui.document:saveHighlight(_page, _item)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1788,13 +1788,13 @@ function ReaderHighlight:writePdfAnnotation(action, page, hl_or_bm, content)
     else
         item = hl_or_bm
     end
-    local function doAction(action, page, item, content)
-        if action == "save" then
-            return self.ui.document:saveHighlight(page, item)
-        elseif action == "delete" then
-            return self.ui.document:deleteHighlight(page, item)
-        elseif action == "content" then
-            return self.ui.document:updateHighlightContents(page, item, content)
+    local function doAction(_action, _page, _item, _content)
+        if _action == "save" then
+            return self.ui.document:saveHighlight(_page, _item)
+        elseif _action == "delete" then
+            return self.ui.document:deleteHighlight(_page, _item)
+        elseif _action == "content" then
+            return self.ui.document:updateHighlightContents(_page, _item, _content)
         end
     end
     local can_write

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -199,12 +199,15 @@ function ReaderThumbnail:resetCachedPagesForBookmarks(...)
             end
         else
             if bm.page and type(bm.page) == "number" then
-                local p = bm.page
-                if not start_page or p < start_page then
-                    start_page = p
-                end
-                if not end_page or p > end_page then
-                    end_page = p
+                local bm_page0 = (bm.pos0 and bm.pos0.page) or bm.page
+                local bm_page1 = (bm.pos1 and bm.pos1.page) or bm.page
+                for p = bm_page0, bm_page1 do
+                    if not start_page or p < start_page then
+                        start_page = p
+                    end
+                    if not end_page or p > end_page then
+                        end_page = p
+                    end
                 end
             end
         end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -540,8 +540,8 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
             if boxes then
                 local drawer = item.drawer or self.highlight.saved_drawer
                 local draw_note_mark = self.highlight.note_mark and
-                    self.ui.bookmark:getBookmarkNote({ page = page, datetime = item.datetime, })
-                for _, box in pairs(boxes) do
+                    self.ui.bookmark:getBookmarkNote({datetime = item.datetime})
+                for _, box in ipairs(boxes) do
                     local rect = self:pageToScreenTransform(page, box)
                     if rect then
                         self:drawHighlightRect(bb, x, y, rect, drawer, draw_note_mark)
@@ -588,8 +588,8 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
                     if boxes then
                         local drawer = item.drawer or self.highlight.saved_drawer
                         local draw_note_mark = self.highlight.note_mark and
-                            self.ui.bookmark:getBookmarkNote({ page = item.pos0, datetime = item.datetime, })
-                        for _, box in pairs(boxes) do
+                            self.ui.bookmark:getBookmarkNote({datetime = item.datetime})
+                        for _, box in ipairs(boxes) do
                             self:drawHighlightRect(bb, x, y, box, drawer, draw_note_mark)
                             if draw_note_mark and self.highlight.note_mark == "sidemark" then
                                 draw_note_mark = false -- side mark in the first line only

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -590,9 +590,11 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
                         local draw_note_mark = self.highlight.note_mark and
                             self.ui.bookmark:getBookmarkNote({datetime = item.datetime})
                         for _, box in ipairs(boxes) do
-                            self:drawHighlightRect(bb, x, y, box, drawer, draw_note_mark)
-                            if draw_note_mark and self.highlight.note_mark == "sidemark" then
-                                draw_note_mark = false -- side mark in the first line only
+                            if box.h ~= 0 then
+                                self:drawHighlightRect(bb, x, y, box, drawer, draw_note_mark)
+                                if draw_note_mark and self.highlight.note_mark == "sidemark" then
+                                    draw_note_mark = false -- side mark in the first line only
+                                end
                             end
                         end -- end for each box
                     end -- end if boxes

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -506,32 +506,53 @@ function ReaderView:drawSavedHighlight(bb, x, y)
     end
 end
 
+-- Returns the list of highlights in page.
+-- The list includes full single-page highlights and parts of multi-page highlights.
+function ReaderView:getPageSavedHighlights(page)
+    local highlights = {}
+    local is_reflow = self.document.configurable.text_wrap
+    self.document.configurable.text_wrap = 0
+    for page_num, page_highlights in pairs(self.highlight.saved) do
+        for i, highlight in ipairs(page_highlights) do
+            -- old single-page reflow highlights do not have page in position
+            local pos0_page = highlight.pos0.page or page_num
+            local pos1_page = highlight.pos1.page or page_num
+            if pos0_page <= page and page <= pos1_page then
+                if pos0_page == pos1_page then -- single-page highlight
+                    table.insert(highlights, highlight)
+                else -- multi-page highlight
+                    local item = self.ui.highlight:getSavedExtendedHighlightPage(highlight, page, i)
+                    table.insert(highlights, item)
+                end
+            end
+        end
+    end
+    self.document.configurable.text_wrap = is_reflow
+    return highlights
+end
+
 function ReaderView:drawPageSavedHighlight(bb, x, y)
     local pages = self:getCurrentPageList()
-    for _, page in pairs(pages) do
-        local items = self.highlight.saved[page]
-        if items then
-            for i = 1, #items do
-                local item = items[i]
-                local pos0, pos1 = item.pos0, item.pos1
-                local boxes = self.document:getPageBoxesFromPositions(page, pos0, pos1)
-                if boxes then
-                    local drawer = item.drawer or self.highlight.saved_drawer
-                    local draw_note_mark = self.highlight.note_mark and
-                        self.ui.bookmark:getBookmarkNote({ page = page, datetime = item.datetime, })
-                    for _, box in pairs(boxes) do
-                        local rect = self:pageToScreenTransform(page, box)
-                        if rect then
-                            self:drawHighlightRect(bb, x, y, rect, drawer, draw_note_mark)
-                            if draw_note_mark and self.highlight.note_mark == "sidemark" then
-                                draw_note_mark = false -- side mark in the first line only
-                            end
+    for _, page in ipairs(pages) do
+        local items = self:getPageSavedHighlights(page)
+        for _, item in ipairs(items) do
+            local boxes = self.document:getPageBoxesFromPositions(page, item.pos0, item.pos1)
+            if boxes then
+                local drawer = item.drawer or self.highlight.saved_drawer
+                local draw_note_mark = self.highlight.note_mark and
+                    self.ui.bookmark:getBookmarkNote({ page = page, datetime = item.datetime, })
+                for _, box in pairs(boxes) do
+                    local rect = self:pageToScreenTransform(page, box)
+                    if rect then
+                        self:drawHighlightRect(bb, x, y, rect, drawer, draw_note_mark)
+                        if draw_note_mark and self.highlight.note_mark == "sidemark" then
+                            draw_note_mark = false -- side mark in the first line only
                         end
-                    end -- end for each box
-                end -- end if boxes
-            end -- end for each highlight
+                    end
+                end
+            end
         end
-    end -- end for each page
+    end
 end
 
 function ReaderView:drawXPointerSavedHighlight(bb, x, y)

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1184,7 +1184,7 @@ Transform position in native page to reflowed page.
 ]]--
 function KoptInterface:nativeToReflowPosTransform(doc, pageno, pos)
     local kc = self:getCachedContext(doc, pageno)
-    local rpos = {}
+    local rpos = {page = pageno}
     rpos.x, rpos.y = kc:nativeToReflowPosTransform(pos.x, pos.y)
     return rpos
 end
@@ -1194,7 +1194,7 @@ Transform position in reflowed page to native page.
 ]]--
 function KoptInterface:reflowToNativePosTransform(doc, pageno, abs_pos, rel_pos)
     local kc = self:getCachedContext(doc, pageno)
-    local npos = {}
+    local npos = {page = pageno}
     npos.x, npos.y = kc:reflowToNativePosTransform(abs_pos.x, abs_pos.y, rel_pos.x, rel_pos.y)
     return npos
 end
@@ -1294,6 +1294,11 @@ Returns 1 if positions are ordered (if ppos2 is after ppos1), -1 if not, 0 if sa
 Positions of the word boxes containing ppos1 and ppos2 are compared.
 --]]
 function KoptInterface:comparePositions(doc, ppos1, ppos2)
+    if ppos1.page < ppos2.page then
+        return 1
+    elseif ppos1.page > ppos2.page then
+        return -1
+    end
     local box1 = self:getWordFromPosition(doc, ppos1).pbox
     local box2 = self:getWordFromPosition(doc, ppos2).pbox
     if box1.y == box2.y then

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -121,6 +121,10 @@ function PdfDocument:getTextFromPositions(spos0, spos1)
     return self.koptinterface:getTextFromPositions(self, spos0, spos1)
 end
 
+function PdfDocument:getTextBoxes(pageno)
+    return self.koptinterface:getTextBoxes(self, pageno)
+end
+
 function PdfDocument:getPageBoxesFromPositions(pageno, ppos0, ppos1)
     return self.koptinterface:getPageBoxesFromPositions(self, pageno, ppos0, ppos1)
 end


### PR DESCRIPTION
Available via Select mode. (nothing new to show in screenshots)

Some technical details:
(1) pboxes are not saved in bookmarks anymore
(2) for highlights made in reflow mode `page` is stored in `position` now (but older bookmarks exist, so some check is needed in sorting)
(3) for multi-page pdf highlights new key `ext` is saved to the highlight structure, contains positions and pboxes of each page
(4) to draw a pdf page readerview now must scan all the pages of the document to find extended pages of multi-page highlights
(5) writing highlight to pdf annotation: fixed a bug with changing highlight style (the note was killed after that); the note is saved for each page of multi-page highlight (we can hover the mouse over any part of the highlighted text to see the note).
(6) note marker (pencil) is shown on every page of multi-page highlight at the beginning of the highlighted text
(7) I expect that no changes to Exporter and KOHighlights are needed

Closes https://github.com/koreader/koreader/issues/7811
Closes https://github.com/koreader/koreader/issues/7812
Closes https://github.com/koreader/koreader/issues/7824

As no recent reports confirming the issue, highlighting in reflow mode seems to work good, so:
Closes https://github.com/koreader/koreader/issues/6843
Closes  https://github.com/koreader/koreader/issues/6826

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9850)
<!-- Reviewable:end -->
