### PR TITLE
Restart KOReader: add a ConfirmBox instead of a plain InfoMessage

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -501,7 +501,7 @@ To:
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_startup_no_fbdepth")
-                UIManager:restart()
+                UIManager:askForRestart()
             end,
         })
     end
@@ -514,7 +514,7 @@ To:
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_abort_on_crash")
-                UIManager:restart()
+                UIManager:askForRestart()
             end,
         })
     end
@@ -593,7 +593,7 @@ To:
                     mxcfb_bypass_wait_for = not Device:hasReliableMxcWaitFor()
                 end
                 G_reader_settings:saveSetting("mxcfb_bypass_wait_for", not mxcfb_bypass_wait_for)
-                UIManager:restart()
+                UIManager:askForRestart()
             end,
         })
     end
@@ -610,7 +610,7 @@ To:
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("pb_ignore_b288_quirks")
-                UIManager:restart()
+                UIManager:askForRestart()
             end,
         })
     end
@@ -630,7 +630,7 @@ To:
         end,
         callback = function()
             G_reader_settings:flipNilOrTrue("use_xtext")
-            UIManager:restart()
+            UIManager:askForRestart()
         end,
     })
     table.insert(self.menu_items.developer_options.sub_item_table, {
@@ -643,7 +643,7 @@ To:
                 end,
                 callback = function()
                     G_reader_settings:flipNilOrFalse("dev_reverse_ui_layout_mirroring")
-                    UIManager:restart()
+                    UIManager:askForRestart()
                 end
             },
             {
@@ -653,7 +653,7 @@ To:
                 end,
                 callback = function()
                     G_reader_settings:flipNilOrFalse("dev_reverse_ui_text_direction")
-                    UIManager:restart()
+                    UIManager:askForRestart()
                 end
             }
         }

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -453,7 +453,7 @@ To:
                             -- Also remove from the Cache objet references to the cache files we've just deleted
                             local Cache = require("cache")
                             Cache.cached = {}
-                            UIManager:restart(_("Caches cleared. Please restart KOReader."))
+                            UIManager:askForRestart(_("Caches cleared. Please restart KOReader."))
                         end,
                     })
                 end,

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -453,10 +453,7 @@ To:
                             -- Also remove from the Cache objet references to the cache files we've just deleted
                             local Cache = require("cache")
                             Cache.cached = {}
-                            local InfoMessage = require("ui/widget/infomessage")
-                            UIManager:show(InfoMessage:new{
-                                text = _("Caches cleared. Please restart KOReader."),
-                            })
+                            UIManager:restart(_("Caches cleared. Please restart KOReader."))
                         end,
                     })
                 end,
@@ -504,10 +501,7 @@ To:
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_startup_no_fbdepth")
-                local InfoMessage = require("ui/widget/infomessage")
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                UIManager:restart()
             end,
         })
     end
@@ -520,10 +514,7 @@ To:
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("dev_abort_on_crash")
-                local InfoMessage = require("ui/widget/infomessage")
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                UIManager:restart()
             end,
         })
     end
@@ -602,10 +593,7 @@ To:
                     mxcfb_bypass_wait_for = not Device:hasReliableMxcWaitFor()
                 end
                 G_reader_settings:saveSetting("mxcfb_bypass_wait_for", not mxcfb_bypass_wait_for)
-                local InfoMessage = require("ui/widget/infomessage")
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                UIManager:restart()
             end,
         })
     end
@@ -622,10 +610,7 @@ To:
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("pb_ignore_b288_quirks")
-                local InfoMessage = require("ui/widget/infomessage")
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                UIManager:restart()
             end,
         })
     end
@@ -645,10 +630,7 @@ To:
         end,
         callback = function()
             G_reader_settings:flipNilOrTrue("use_xtext")
-            local InfoMessage = require("ui/widget/infomessage")
-            UIManager:show(InfoMessage:new{
-                text = _("This will take effect on next restart."),
-            })
+            UIManager:restart()
         end,
     })
     table.insert(self.menu_items.developer_options.sub_item_table, {
@@ -661,10 +643,7 @@ To:
                 end,
                 callback = function()
                     G_reader_settings:flipNilOrFalse("dev_reverse_ui_layout_mirroring")
-                    local InfoMessage = require("ui/widget/infomessage")
-                    UIManager:show(InfoMessage:new{
-                        text = _("This will take effect on next restart."),
-                    })
+                    UIManager:restart()
                 end
             },
             {
@@ -674,10 +653,7 @@ To:
                 end,
                 callback = function()
                     G_reader_settings:flipNilOrFalse("dev_reverse_ui_text_direction")
-                    local InfoMessage = require("ui/widget/infomessage")
-                    UIManager:show(InfoMessage:new{
-                        text = _("This will take effect on next restart."),
-                    })
+                    UIManager:restart()
                 end
             }
         }

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -320,11 +320,11 @@ function DeviceListener:onRequestSuspend()
 end
 
 function DeviceListener:onRequestReboot()
-    UIManager:reboot()
+    UIManager:askForReboot()
 end
 
 function DeviceListener:onRequestPowerOff()
-    UIManager:powerOff()
+    UIManager:askForPowerOff()
 end
 
 function DeviceListener:onExit(callback)

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -573,10 +573,10 @@ end
 -- Set device event handlers common to all devices
 function Device:_setEventHandlers(UIManager)
     if self:canReboot() then
-        UIManager.event_handlers.Reboot = function()
+        UIManager.event_handlers.Reboot = function(message_text)
             local ConfirmBox = require("ui/widget/confirmbox")
             UIManager:show(ConfirmBox:new{
-                text = _("Are you sure you want to reboot the device?"),
+                text = message_text or _("Are you sure you want to reboot the device?"),
                 ok_text = _("Reboot"),
                 ok_callback = function()
                     local Event = require("ui/event")
@@ -590,10 +590,10 @@ function Device:_setEventHandlers(UIManager)
     end
 
     if self:canPowerOff() then
-        UIManager.event_handlers.PowerOff = function()
+        UIManager.event_handlers.PowerOff = function(message_text)
             local ConfirmBox = require("ui/widget/confirmbox")
             UIManager:show(ConfirmBox:new{
-                text = _("Are you sure you want to power off the device?"),
+                text = message_text or _("Are you sure you want to power off the device?"),
                 ok_text = _("Power off"),
                 ok_callback = function()
                     local Event = require("ui/event")
@@ -620,7 +620,7 @@ function Device:_setEventHandlers(UIManager)
             })
         end
     else
-        UIManager.event_handlers.Restart =  function(message_text)
+        UIManager.event_handlers.Restart = function(message_text)
             local InfoMessage = require("ui/widget/infomessage")
             UIManager:show(InfoMessage:new{
                 text = message_text or _("This will take effect on next restart."),

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -606,6 +606,28 @@ function Device:_setEventHandlers(UIManager)
         UIManager.event_handlers.PowerOff = function() end
     end
 
+    if self:canRestart() then
+        UIManager.event_handlers.Restart = function(message_text)
+            local ConfirmBox = require("ui/widget/confirmbox")
+            UIManager:show(ConfirmBox:new{
+                text = message_text or _("This will take effect on next restart."),
+                ok_text = _("Restart now"),
+                ok_callback = function()
+                    local Event = require("ui/event")
+                    UIManager:broadcastEvent(Event:new("Restart"))
+                end,
+                cancel_text = _("Restart later"),
+            })
+        end
+    else
+        UIManager.event_handlers.Restart =  function(message_text)
+            local InfoMessage = require("ui/widget/infomessage")
+            UIManager:show(InfoMessage:new{
+                text = message_text or _("This will take effect on next restart."),
+            })
+        end
+    end
+
     self:setEventHandlers(UIManager)
 end
 

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -185,7 +185,7 @@ function PluginLoader:genPluginManagerSubItem()
                 G_reader_settings:saveSetting("plugins_disabled", plugins_disabled)
                 if self.show_info then
                     self.show_info = false
-                    UIManager:restart()
+                    UIManager:askForRestart()
                 end
             end,
             help_text = plugin.description,

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -173,7 +173,6 @@ function PluginLoader:genPluginManagerSubItem()
                 return plugin.enable
             end,
             callback = function()
-                local InfoMessage = require("ui/widget/infomessage")
                 local UIManager = require("ui/uimanager")
                 local _ = require("gettext")
                 local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
@@ -185,10 +184,8 @@ function PluginLoader:genPluginManagerSubItem()
                 end
                 G_reader_settings:saveSetting("plugins_disabled", plugins_disabled)
                 if self.show_info then
-                    UIManager:show(InfoMessage:new{
-                        text = _("This will take effect on next restart."),
-                    })
                     self.show_info = false
+                    UIManager:restart()
                 end
             end,
             help_text = plugin.description,

--- a/frontend/ui/elements/common_exit_menu_table.lua
+++ b/frontend/ui/elements/common_exit_menu_table.lua
@@ -39,7 +39,7 @@ if Device:canReboot() then
         text = _("Reboot the device"),
         keep_menu_open = true,
         callback = function()
-            UIManager:reboot()
+            UIManager:askForReboot()
         end
     }
 end
@@ -48,7 +48,7 @@ if Device:canPowerOff() then
         text = _("Power off"),
         keep_menu_open = true,
         callback = function()
-            UIManager:powerOff()
+            UIManager:askForPowerOff()
         end
     }
 end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -198,9 +198,7 @@ if Device:isKobo() then
         callback = function()
             G_reader_settings:toggle("ignore_power_sleepcover")
             G_reader_settings:makeFalse("ignore_open_sleepcover")
-            UIManager:show(InfoMessage:new{
-                text = _("This will take effect on next restart."),
-            })
+            UIManager:restart()
         end
     }
 
@@ -212,9 +210,7 @@ if Device:isKobo() then
         callback = function()
             G_reader_settings:toggle("ignore_open_sleepcover")
             G_reader_settings:makeFalse("ignore_power_sleepcover")
-            UIManager:show(InfoMessage:new{
-                text = _("This will take effect on next restart."),
-            })
+            UIManager:restart()
         end
     }
 end
@@ -272,9 +268,7 @@ if not Device:isAlwaysFullscreen() then
                 local api = Device.firmware_rev
                 local needs_restart = api < 19 and api >= 16
                 if needs_restart then
-                    UIManager:show(InfoMessage:new{
-                        text = _("This will take effect on next restart.")
-                    })
+                    UIManager:restart()
                 end
             end
         end,
@@ -450,9 +444,7 @@ if Device:hasKeyboard() then
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("backspace_as_back")
-            UIManager:show(InfoMessage:new{
-                text = _("This will take effect on next restart."),
-            })
+            UIManager:restart()
         end,
     }
 end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -198,7 +198,7 @@ if Device:isKobo() then
         callback = function()
             G_reader_settings:toggle("ignore_power_sleepcover")
             G_reader_settings:makeFalse("ignore_open_sleepcover")
-            UIManager:restart()
+            UIManager:askForRestart()
         end
     }
 
@@ -210,7 +210,7 @@ if Device:isKobo() then
         callback = function()
             G_reader_settings:toggle("ignore_open_sleepcover")
             G_reader_settings:makeFalse("ignore_power_sleepcover")
-            UIManager:restart()
+            UIManager:askForRestart()
         end
     }
 end
@@ -268,7 +268,7 @@ if not Device:isAlwaysFullscreen() then
                 local api = Device.firmware_rev
                 local needs_restart = api < 19 and api >= 16
                 if needs_restart then
-                    UIManager:restart()
+                    UIManager:askForRestart()
                 end
             end
         end,
@@ -444,7 +444,7 @@ if Device:hasKeyboard() then
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("backspace_as_back")
-            UIManager:restart()
+            UIManager:askForRestart()
         end,
     }
 end

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -76,7 +76,7 @@ function FontSettings:getSystemFontMenuItems()
         callback = function()
             G_reader_settings:saveSetting("system_fonts", not usesSystemFonts())
             local UIManager = require("ui/uimanager")
-            UIManager:restart()
+            UIManager:askForRestart()
         end,
     }}
 

--- a/frontend/ui/elements/font_settings.lua
+++ b/frontend/ui/elements/font_settings.lua
@@ -76,10 +76,7 @@ function FontSettings:getSystemFontMenuItems()
         callback = function()
             G_reader_settings:saveSetting("system_fonts", not usesSystemFonts())
             local UIManager = require("ui/uimanager")
-            local InfoMessage = require("ui/widget/infomessage")
-            UIManager:show(InfoMessage:new{
-                text = _("This will take effect on next restart.")
-            })
+            UIManager:restart()
         end,
     }}
 

--- a/frontend/ui/elements/font_ui_fallbacks.lua
+++ b/frontend/ui/elements/font_ui_fallbacks.lua
@@ -145,7 +145,7 @@ local getSubMenuItems = function()
                         return
                     end
                 end
-                UIManager:restart()
+                UIManager:askForRestart()
             end,
         }
         table.insert(menu_items, item)

--- a/frontend/ui/elements/font_ui_fallbacks.lua
+++ b/frontend/ui/elements/font_ui_fallbacks.lua
@@ -145,9 +145,7 @@ local getSubMenuItems = function()
                         return
                     end
                 end
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                UIManager:restart()
             end,
         }
         table.insert(menu_items, item)

--- a/frontend/ui/elements/menu_activate.lua
+++ b/frontend/ui/elements/menu_activate.lua
@@ -1,4 +1,3 @@
-local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 
@@ -16,9 +15,7 @@ return {
                 else
                     G_reader_settings:saveSetting("activate_menu", "swipe_tap")
                 end
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                UIManager:restart()
             end,
         },
         {
@@ -32,9 +29,7 @@ return {
                 else
                     G_reader_settings:saveSetting("activate_menu", "swipe_tap")
                 end
-                UIManager:show(InfoMessage:new{
-                    text = _("This will take effect on next restart."),
-                })
+                UIManager:restart()
             end,
             separator = true,
         },

--- a/frontend/ui/elements/menu_activate.lua
+++ b/frontend/ui/elements/menu_activate.lua
@@ -15,7 +15,7 @@ return {
                 else
                     G_reader_settings:saveSetting("activate_menu", "swipe_tap")
                 end
-                UIManager:restart()
+                UIManager:askForRestart()
             end,
         },
         {
@@ -29,7 +29,7 @@ return {
                 else
                     G_reader_settings:saveSetting("activate_menu", "swipe_tap")
                 end
-                UIManager:restart()
+                UIManager:askForRestart()
             end,
             separator = true,
         },

--- a/frontend/ui/elements/screen_disable_double_tap_table.lua
+++ b/frontend/ui/elements/screen_disable_double_tap_table.lua
@@ -1,4 +1,3 @@
-local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 
@@ -10,8 +9,6 @@ return {
     callback = function()
         local disabled = G_reader_settings:nilOrTrue("disable_double_tap")
         G_reader_settings:saveSetting("disable_double_tap", not disabled)
-        UIManager:show(InfoMessage:new{
-            text = _("This will take effect on next restart."),
-        })
+        UIManager:restart()
     end,
 }

--- a/frontend/ui/elements/screen_disable_double_tap_table.lua
+++ b/frontend/ui/elements/screen_disable_double_tap_table.lua
@@ -9,6 +9,6 @@ return {
     callback = function()
         local disabled = G_reader_settings:nilOrTrue("disable_double_tap")
         G_reader_settings:saveSetting("disable_double_tap", not disabled)
-        UIManager:restart()
+        UIManager:askForRestart()
     end,
 }

--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -17,7 +17,7 @@ local function setDPI(dpi_val)
     G_reader_settings:saveSetting("screen_dpi", dpi_val)
     -- Passing a nil properly resets to defaults/auto
     Device:setScreenDPI(dpi_val)
-    UIManager:restart(text)
+    UIManager:askForRestart(text)
 end
 
 local function spinWidgetSetDPI(touchmenu_instance)

--- a/frontend/ui/elements/screen_dpi_menu_table.lua
+++ b/frontend/ui/elements/screen_dpi_menu_table.lua
@@ -10,16 +10,14 @@ local function dpi() return Screen:getDPI() end
 local function custom() return G_reader_settings:readSetting("custom_screen_dpi") end
 
 local function setDPI(dpi_val)
-    local InfoMessage = require("ui/widget/infomessage")
     local UIManager = require("ui/uimanager")
-    UIManager:show(InfoMessage:new{
-        text = dpi_val and T(_("DPI set to %1. This will take effect after restarting."), dpi_val)
-               or _("DPI set to auto. This will take effect after restarting."),
-    })
+    local text = dpi_val and T(_("DPI set to %1. This will take effect after restarting."), dpi_val)
+               or _("DPI set to auto. This will take effect after restarting.")
     -- If this is set to nil, reader.lua doesn't call setScreenDPI
     G_reader_settings:saveSetting("screen_dpi", dpi_val)
     -- Passing a nil properly resets to defaults/auto
     Device:setScreenDPI(dpi_val)
+    UIManager:restart(text)
 end
 
 local function spinWidgetSetDPI(touchmenu_instance)

--- a/frontend/ui/elements/waveform_level.lua
+++ b/frontend/ui/elements/waveform_level.lua
@@ -1,6 +1,5 @@
 local _ = require("gettext")
 local Device = require("device")
-local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local Screen = Device.screen
 local T = require("ffi/util").template
@@ -22,9 +21,7 @@ for i=0, Screen.wf_level_max do
         callback = function()
             Screen.wf_level = i
             G_reader_settings:saveSetting("wf_level", i)
-            UIManager:show(InfoMessage:new{
-                text = _("This will take effect on next restart."),
-            })
+            UIManager:restart()
         end,
     })
 end

--- a/frontend/ui/elements/waveform_level.lua
+++ b/frontend/ui/elements/waveform_level.lua
@@ -21,7 +21,7 @@ for i=0, Screen.wf_level_max do
         callback = function()
             Screen.wf_level = i
             G_reader_settings:saveSetting("wf_level", i)
-            UIManager:restart()
+            UIManager:askForRestart()
         end,
     })
 end

--- a/frontend/ui/language.lua
+++ b/frontend/ui/language.lua
@@ -94,7 +94,7 @@ function Language:changeLanguage(lang_locale)
     local UIManager = require("ui/uimanager")
     _.changeLang(lang_locale)
     G_reader_settings:saveSetting("language", lang_locale)
-    UIManager:restart(_("Please restart KOReader for the new language setting to take effect."))
+    UIManager:askForRestart(_("Please restart KOReader for the new language setting to take effect."))
 end
 
 function Language:genLanguageSubItem(lang_locale)

--- a/frontend/ui/language.lua
+++ b/frontend/ui/language.lua
@@ -91,14 +91,10 @@ function Language:isLanguageRTL(lang_locale)
 end
 
 function Language:changeLanguage(lang_locale)
-    local InfoMessage = require("ui/widget/infomessage")
     local UIManager = require("ui/uimanager")
     _.changeLang(lang_locale)
     G_reader_settings:saveSetting("language", lang_locale)
-    UIManager:show(InfoMessage:new{
-        text = _("Please restart KOReader for the new language setting to take effect."),
-        timeout = 3,
-    })
+    UIManager:restart(_("Please restart KOReader for the new language setting to take effect."))
 end
 
 function Language:genLanguageSubItem(lang_locale)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -501,7 +501,7 @@ function NetworkMgr:getPowersaveMenuTable()
         callback = function()
             G_reader_settings:flipNilOrFalse("auto_disable_wifi")
             -- NOTE: Well, not exactly, but the activity check wouldn't be (un)scheduled until the next Network(Dis)Connected event...
-            UIManager:restart()
+            UIManager:askForRestart()
         end,
     }
 end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -501,9 +501,7 @@ function NetworkMgr:getPowersaveMenuTable()
         callback = function()
             G_reader_settings:flipNilOrFalse("auto_disable_wifi")
             -- NOTE: Well, not exactly, but the activity check wouldn't be (un)scheduled until the next Network(Dis)Connected event...
-            UIManager:show(InfoMessage:new{
-                text = _("This will take effect on next restart."),
-            })
+            UIManager:restart()
         end,
     }
 end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1570,6 +1570,15 @@ function UIManager:powerOff()
     end
 end
 
+function UIManager:restart(message_text)
+    -- Should always exist, as defined in `generic/device` or overwritten with `setEventHandlers`
+    if self.event_handlers.PowerOff then
+        -- Give the other event handlers a chance to be executed.
+        -- 'PowerOff' event will be sent by the handler
+        UIManager:nextTick(self.event_handlers.Restart, message_text)
+    end
+end
+
 --[[--
 Release standby lock.
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1552,29 +1552,29 @@ function UIManager:suspend()
     end
 end
 
-function UIManager:reboot()
+function UIManager:askForReboot(message_text)
     -- Should always exist, as defined in `generic/device` or overwritten with `setEventHandlers`
     if self.event_handlers.Reboot then
         -- Give the other event handlers a chance to be executed.
         -- 'Reboot' event will be sent by the handler
-        UIManager:nextTick(self.event_handlers.Reboot)
+        UIManager:nextTick(self.event_handlers.Reboot, message_text)
     end
 end
 
-function UIManager:powerOff()
+function UIManager:askForPowerOff(message_text)
     -- Should always exist, as defined in `generic/device` or overwritten with `setEventHandlers`
     if self.event_handlers.PowerOff then
         -- Give the other event handlers a chance to be executed.
         -- 'PowerOff' event will be sent by the handler
-        UIManager:nextTick(self.event_handlers.PowerOff)
+        UIManager:nextTick(self.event_handlers.PowerOff, message_text)
     end
 end
 
-function UIManager:restart(message_text)
+function UIManager:askForRestart(message_text)
     -- Should always exist, as defined in `generic/device` or overwritten with `setEventHandlers`
     if self.event_handlers.PowerOff then
         -- Give the other event handlers a chance to be executed.
-        -- 'PowerOff' event will be sent by the handler
+        -- 'Restart' event will be sent by the handler
         UIManager:nextTick(self.event_handlers.Restart, message_text)
     end
 end


### PR DESCRIPTION
Maybe not the most important change, but esp. during development it might save some taps.

![grafik](https://user-images.githubusercontent.com/36999612/205075293-b82dd2fb-c935-4a76-a5d3-6bede827c7fb.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9853)
<!-- Reviewable:end -->
