### PR TITLE
[CI] Set macOS Github Action to macOS 12.00

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     # Please don't update to newer macOS version unless you can test that the new
     # action produces working binaries.
-    runs-on: macos-10.15
+    runs-on: macos-12.00
 
     steps:
       - name: XCode version
@@ -35,9 +35,9 @@ jobs:
 
       - name: Building in progress…
         run: |
-          export MACOSX_DEPLOYMENT_TARGET=10.15;
+          export MACOSX_DEPLOYMENT_TARGET=12.00;
           export PATH="$(brew --prefix)/opt/gettext/bin:$(brew --prefix)/opt/gnu-getopt/bin:$(brew --prefix)/opt/bison/bin:$(brew --prefix)/opt/grep/libexec/gnubin:${PATH}";
-          ./kodev release macos
+          ./kodev release macos -d
 
       - name: Uploading artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Doing a debug build using MACOSX_DEPLOYMENT_TARGET=12.00 produces a build that seems to work. The debug part isn't optimal but at least it builds and runs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9856)
<!-- Reviewable:end -->
