### PR TITLE
Cloudsync: dropbox token re-generation

### DIFF
--- a/frontend/apps/cloudstorage/syncservice.lua
+++ b/frontend/apps/cloudstorage/syncservice.lua
@@ -87,7 +87,11 @@ function SyncService.getReadablePath(server)
     local url = util.stringStartsWith(server.url, "/") and server.url:sub(2) or server.url
     url = util.urlDecode(url) or url
     url = util.stringEndsWith(url, "/") and url or url .. "/"
-    url = (server.address:sub(-1) == "/" and server.address or server.address .. "/") .. url
+    if server.type == "dropbox" then
+        url = "/" .. url
+    elseif sever.type == "webdav" then
+        url = (server.address:sub(-1) == "/" and server.address or server.address .. "/") .. url
+    end
     if url:sub(-2) == "//" then url = url:sub(1, -2) end
     return url
 end

--- a/frontend/apps/cloudstorage/syncservice.lua
+++ b/frontend/apps/cloudstorage/syncservice.lua
@@ -89,7 +89,7 @@ function SyncService.getReadablePath(server)
     url = util.stringEndsWith(url, "/") and url or url .. "/"
     if server.type == "dropbox" then
         url = "/" .. url
-    elseif sever.type == "webdav" then
+    elseif server.type == "webdav" then
         url = (server.address:sub(-1) == "/" and server.address or server.address .. "/") .. url
     end
     if url:sub(-2) == "//" then url = url:sub(1, -2) end

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1166,7 +1166,7 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                     SyncService.sync(self.settings.sync_server, db_location, self.onSync )
                 end,
                 enabled_func = function()
-                    return self.settings.sync_server ~= nil and self.settings.is_enabled and require("ui/network/manager"):isWifiOn()
+                    return self.settings.sync_server ~= nil and self.settings.is_enabled
                 end,
                 keep_menu_open = true,
                 separator = true,


### PR DESCRIPTION
This pr adds support for dropbox short-lived token for the cloudsync module. See #9861

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9862)
<!-- Reviewable:end -->
