### PR TITLE
ReaderBookmark: show current page

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1708,16 +1708,11 @@ function ReaderHighlight:onUnhighlight(bookmark_item)
             end
         end
     end
-    if bookmark_item and not idx then
-        logger.warn("unhighlight: bookmark_item not found among highlights", bookmark_item)
-        -- Remove it from bookmarks anyway, so we're not stuck with an
-        -- unremovable bookmark
-        self.ui.bookmark:removeBookmark(bookmark_item)
-        return
+    if idx then
+        logger.dbg("found highlight to delete on page", page, idx)
+        self:deleteHighlight(page, idx, bookmark_item)
+        return true
     end
-    logger.dbg("found highlight to delete on page", page, idx)
-    self:deleteHighlight(page, idx, bookmark_item)
-    return true
 end
 
 function ReaderHighlight:getHighlightBookmarkItem()
@@ -1887,7 +1882,7 @@ end
 
 function ReaderHighlight:editHighlight(page, i, is_new_note, text)
     local item = self.view.highlight.saved[page][i]
-    self.ui.bookmark:renameBookmark({
+    self.ui.bookmark:setBookmarkNote({
         page = self.ui.document.info.has_pages and page or item.pos0,
         datetime = item.datetime,
     }, true, is_new_note, text)


### PR DESCRIPTION
(1) Show book current page in the list of bookmarks, for easier navigation.
(2) Boookmark list is opened showing the page with the book current page.
(A lot of duplicated code in the module has been removed)

Opening the bookmark list
<img width="250" alt="01" src="https://user-images.githubusercontent.com/62179190/205580581-5af5c2b5-56ca-4def-ba18-785e3ca223be.png">

Reading forward, all bookmarks are behind
<img width="250" alt="02" src="https://user-images.githubusercontent.com/62179190/205580590-c5c9f77e-c03f-4423-95c6-55894583ec19.png">

Filtered
<img width="250" alt="03" src="https://user-images.githubusercontent.com/62179190/205580594-59a71c49-b464-4e0d-a7dd-fb37bd8f3aea.png">

Closes https://github.com/koreader/koreader/issues/8047.