### PR TITLE
Implement GSensor support for more moderm PocketBooks

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -228,6 +228,11 @@ function PocketBook:init()
         self.input:disableRotationMap()
     end
 
+    -- If InkView tells us this device has a gsensor enable the event based functionality
+    if inkview.QueryGSensor() ~= 0 then
+        self.hasGSensor = yes
+    end
+
     -- In contrast to kobo/kindle, pocketbook-devices do not use linux/input events directly.
     -- To be able to use input.lua nevertheless,
     -- we make inkview-events look like linux/input events or handle them directly here.


### PR DESCRIPTION
Requires: https://github.com/koreader/koreader-base/pull/1562 and https://github.com/koreader/koreader-base/pull/1566
Issue: #9427

~~I feel I will need to ask for a lot of forgiveness now after writing this stuff. Most likely this implementation is completely in the wrong place and implemented completely in the wrong way but it actually works.~~

~~Because the lack of a proper event when the screen is rotated (I've looked, and looked, and looked even more but didn't find one). The only way I know ATM is polling the GSensor every second and just broadcasting an event for the screen change when there was a change found.~~

~~Most likely this is extremely inefficient so feel free to point me to a better way of doing this. But I was not able to find some more guiding implementation on the gyro when it is not event based.~~

~~Only enabled on my device for now because I don't know what devices have the more modern API and am unable to test this code on all of them.~~

~~I'm sorry for the mess :>~~

Now with the event based implementation. This is tested on my PocketBook and working nicely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9873)
<!-- Reviewable:end -->
