### PR TITLE
Calendar view: properly use datetime module

### DIFF
--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -1,4 +1,3 @@
-
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local BottomContainer = require("ui/widget/container/bottomcontainer")

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -25,6 +25,7 @@ local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local Widget = require("ui/widget/widget")
+local datetime = require("datetime")
 local Input = Device.input
 local Screen = Device.screen
 local _ = require("gettext")
@@ -1013,9 +1014,6 @@ local MIN_MONTH = nil
 
 local CalendarView = FocusManager:extend{
     reader_statistics = nil,
-    monthTranslation = nil,
-    shortDayOfWeekTranslation = nil,
-    longDayOfWeekTranslation = nil,
     start_day_of_week = 2, -- 2 = Monday, 1-7 = Sunday-Saturday
     show_hourly_histogram = true,
     browse_future_months = false,
@@ -1026,8 +1024,7 @@ local CalendarView = FocusManager:extend{
     height = nil,
     cur_month = nil,
     weekdays = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" } -- in Lua wday order
-        -- (These do not need translations: they are the key into the provided
-        -- self.shortDayOfWeekTranslation and self.longDayOfWeekTranslation)
+        -- (These do not need translations: they are the keys into the datetime module translations)
 }
 
 function CalendarView:init()
@@ -1181,7 +1178,7 @@ function CalendarView:init()
     table.insert(self.day_names, HorizontalSpan:new{ width = self.outer_padding })
     for i = 0, 6 do
         local dayname = TextWidget:new{
-            text = self.shortDayOfWeekTranslation[self.weekdays[(self.start_day_of_week-1+i)%7 + 1]],
+            text = datetime.shortDayOfWeekTranslation[self.weekdays[(self.start_day_of_week-1+i)%7 + 1]],
             face = Font:getFace("xx_smallinfofont"),
             bold = true,
         }
@@ -1275,7 +1272,7 @@ function CalendarView:_populateItems()
         -- When hour is unspecified, Lua defaults to noon 12h00
     })
     -- Update title
-    local month_text = self.monthTranslation[os.date("%B", month_start_ts)] .. os.date(" %Y", month_start_ts)
+    local month_text = datetime.longMonthTranslation[os.date("%B", month_start_ts)] .. os.date(" %Y", month_start_ts)
     self.title_bar:setTitle(month_text)
     -- Update footer
     self.page_info_text:setText(self.cur_month)
@@ -1368,7 +1365,7 @@ function CalendarView:_populateItems()
                         local day = os.date("%Y-%m-%d", this.day_ts + 10800) -- use 3:00 to determine date (summer time change)
                         local date = os.date("*t", this.day_ts + 10800)
                         return string.format("%s (%s)", day,
-                            self.longDayOfWeekTranslation[self.weekdays[date.wday]])
+                            datetime.shortDayOfWeekToLongTranslation[self.weekdays[date.wday]])
                     end,
                     close_callback = function(this)
                         -- Refresh calendar in case some day stats were reset for some books

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2563,9 +2563,6 @@ function ReaderStatistics:onShowCalendarView()
     local CalendarView = require("calendarview")
     UIManager:show(CalendarView:new{
         reader_statistics = self,
-        monthTranslation = datetime.longMonthTranslation,
-        shortDayOfWeekTranslation = datetime.shortDayOfWeekTranslation,
-        longDayOfWeekTranslation = datetime.shortDayOfWeekToLongTranslation,
         start_day_of_week = self.settings.calendar_start_day_of_week,
         nb_book_spans = self.settings.calendar_nb_book_spans,
         show_hourly_histogram = self.settings.calendar_show_histogram,
@@ -2580,7 +2577,7 @@ function ReaderStatistics:onShowCalendarDayView()
     local title_callback = function(this)
         local day = os.date("%Y-%m-%d", this.day_ts + 10800) -- use 03:00 to determine date (summer time change)
         local date = os.date("*t", this.day_ts + 10800)
-        return string.format("%s (%s)", day, datetime.longDayOfWeekTranslation[CalendarView.weekdays[date.wday]])
+        return string.format("%s (%s)", day, datetime.shortDayOfWeekToLongTranslation[CalendarView.weekdays[date.wday]])
     end
     CalendarView:showCalendarDayView(self, title_callback)
 end

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -30,16 +30,6 @@ local ReaderProgress = InputContainer:extend{
     padding = Size.padding.fullscreen,
 }
 
-local dayOfWeekTranslation = {
-    ["Monday"] = _("Monday"),
-    ["Tuesday"] = _("Tuesday"),
-    ["Wednesday"] = _("Wednesday"),
-    ["Thursday"] = _("Thursday"),
-    ["Friday"] = _("Friday"),
-    ["Saturday"] = _("Saturday"),
-    ["Sunday"] = _("Sunday"),
-}
-
 function ReaderProgress:init()
     self.current_pages = tostring(self.current_pages)
     self.today_pages = tostring(self.today_pages)
@@ -243,7 +233,7 @@ function ReaderProgress:genWeekStats(stats_day)
         else
             select_day_time = 0
         end
-        date_format_show = dayOfWeekTranslation[os.date("%A", diff_time)] .. os.date(" (%d.%m)", diff_time)
+        date_format_show = datetime.shortDayOfWeekToLongTranslation[os.date("%a", diff_time)] .. os.date(" (%d.%m)", diff_time)
         local total_group = HorizontalGroup:new{
             align = "center",
             padding = Size.padding.small,


### PR DESCRIPTION
No need to pass the translations from main.lua to calendarview.lua.
Also use datetime translations in ReaderProgress.
Closes #9892.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9893)
<!-- Reviewable:end -->
