### PR TITLE
Fix non-working power button on Kobo Sage

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -675,9 +675,7 @@ function Kobo:init()
         if util.fileExists("/dev/input/by-path/platform-bd71828-pwrkey-event") then
             -- Libra 2 w/ a BD71828 PMIC
             self.power_dev = "/dev/input/by-path/platform-bd71828-pwrkey-event"
-        end
-                
-        if util.fileExists("/dev/input/by-path/platform-bd71828-pwrkey.4.auto-event") then
+        elseif util.fileExists("/dev/input/by-path/platform-bd71828-pwrkey.4.auto-event") then
             -- Fix for Kobo Sage, presumably w/ a BD71828 PMIC?
             self.power_dev = "/dev/input/by-path/platform-bd71828-pwrkey.4.auto-event"
         end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -488,6 +488,7 @@ local KoboCadmus = Kobo:extend{
     ntx_dev = "/dev/input/by-path/platform-ntx_event0-event",
     touch_dev = "/dev/input/by-path/platform-0-0010-event",
     isSMP = yes,
+    automagic_sysfs = true,
 }
 
 -- Kobo Libra 2:
@@ -675,6 +676,12 @@ function Kobo:init()
             -- Libra 2 w/ a BD71828 PMIC
             self.power_dev = "/dev/input/by-path/platform-bd71828-pwrkey-event"
         end
+                
+        if util.fileExists("/dev/input/by-path/platform-bd71828-pwrkey.4.auto-event") then
+            -- Fix for Kobo Sage, presumably w/ a BD71828 PMIC?
+            self.power_dev = "/dev/input/by-path/platform-bd71828-pwrkey.4.auto-event"
+        end
+        
     end
 
     -- NOTE: i.MX5 devices have a wonky RTC that doesn't like alarms set further away that UINT16_MAX seconds from now...

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -679,7 +679,6 @@ function Kobo:init()
             -- Fix for Kobo Sage, presumably w/ a BD71828 PMIC?
             self.power_dev = "/dev/input/by-path/platform-bd71828-pwrkey.4.auto-event"
         end
-        
     end
 
     -- NOTE: i.MX5 devices have a wonky RTC that doesn't like alarms set further away that UINT16_MAX seconds from now...


### PR DESCRIPTION
Fix for #9895 

Seems to be a similar/identical issue to #9590 , the Sage fix is based on that but using `automagic_sysfs` and the `/dev/input/by-path/` which seems to be preferred in the existing code.

If the issue was caused by a hardware change, I'm optimistic this fix won't affect older devices that don't need it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9896)
<!-- Reviewable:end -->
