### PR TITLE
ReadingStatistics: Cleanup and tweaks

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1481,7 +1481,7 @@ function ReaderStatistics:getCurrentStat()
         { _("Pages read this session"), tonumber(current_pages), separator = true },
 
         -- Today
-        { _("Time spent reading today ▶"), datetime.secondsToClockDuration(user_duration_format, today_duration, false, true, true),
+        { _("Time spent reading today ▸"), datetime.secondsToClockDuration(user_duration_format, today_duration, false, true, true),
             callback = function()
                 local now_t = os.date("*t")
                 local seconds_from_midnight = now_t.hour * 3600 + now_t.min * 60 + now_t.sec
@@ -1501,7 +1501,7 @@ function ReaderStatistics:getCurrentStat()
         { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true, true), separator = true },
 
         -- Day-focused book stats
-        { _("Days reading this book ▶"), tonumber(total_days),
+        { _("Days reading this book ▸"), tonumber(total_days),
             callback = function()
                 local kv = self.kv
                 UIManager:close(self.kv)
@@ -1613,7 +1613,7 @@ function ReaderStatistics:getBookStat(id_book)
         { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false, true, true), separator = true },
 
         -- Day-focused book stats
-        { _("Days reading this book ▶"), tonumber(total_days),
+        { _("Days reading this book ▸"), tonumber(total_days),
             callback = function()
                 local kv = self.kv
                 UIManager:close(self.kv)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1607,6 +1607,7 @@ function ReaderStatistics:getBookStat(id_book)
     local last_open_days_ago = math.floor(tonumber(now_ts - last_open)/86400)
     local avg_time_per_page = book_read_time / book_read_pages
     local user_duration_format = G_reader_settings:readSetting("duration_format")
+    local more_arrow = BD.mirroredUILayout() and "◂" or "▸"
     return {
         -- Book metadata
         { _("Title"), title},
@@ -1619,7 +1620,7 @@ function ReaderStatistics:getBookStat(id_book)
         { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false, true), separator = true },
 
         -- Day-focused book stats
-        { _("Days reading this book ▸"), tonumber(total_days),
+        { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
             callback = function()
                 local kv = self.kv
                 UIManager:close(self.kv)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1479,11 +1479,11 @@ function ReaderStatistics:getCurrentStat()
         -- Global statistics (may consider other books than current book)
 
         -- Since last resume
-        { _("Time spent reading this session"), datetime.secondsToClockDuration(user_duration_format, current_duration, false, true, true) },
+        { _("Time spent reading this session"), datetime.secondsToClockDuration(user_duration_format, current_duration, false, true) },
         { _("Pages read this session"), tonumber(current_pages), separator = true },
 
         -- Today
-        { _("Time spent reading today") .. " " .. more_arrow, datetime.secondsToClockDuration(user_duration_format, today_duration, false, true, true),
+        { _("Time spent reading today") .. " " .. more_arrow, datetime.secondsToClockDuration(user_duration_format, today_duration, false, true),
             callback = function()
                 local CalendarView = require("calendarview")
                 local title_callback = function(this)
@@ -1497,11 +1497,11 @@ function ReaderStatistics:getCurrentStat()
         -- Current book statistics (includes re-reads)
 
         -- General book stats
-        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true, true) },
+        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true) },
         -- Capped to self.settings.max_sec per distinct page
-        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true, true) },
+        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true) },
         { _("Pages read"), string.format("%d (%d%%)", total_read_pages, Math.round(100*total_read_pages/self.data.pages)) },
-        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true, true), separator = true },
+        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true), separator = true },
 
         -- Day-focused book stats
         { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
@@ -1521,13 +1521,13 @@ function ReaderStatistics:getCurrentStat()
                 UIManager:show(self.kv)
             end,
         },
-        { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true, true), separator = true },
+        { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true), separator = true },
 
         -- Book progression
         { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
         { _("Estimated finish date"), estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A") },
         -- estimation, from current page to end of book
-        { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true, true) or _("N/A") },
+        { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true) or _("N/A") },
         { _("Current page/Total pages"), page_progress, separator = true },
 
         -- Highlights
@@ -1613,10 +1613,10 @@ function ReaderStatistics:getBookStat(id_book)
         { _("Author(s)"), authors, separator = true },
 
         -- General book stats
-        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true, true) },
-        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true, true) },
+        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true) },
+        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true) },
         { _("Pages read"), string.format("%d (%d%%)", total_read_pages, Math.round(100*total_read_pages/pages)) },
-        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false, true, true), separator = true },
+        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false, true), separator = true },
 
         -- Day-focused book stats
         { _("Days reading this book ▸"), tonumber(total_days),
@@ -1636,7 +1636,7 @@ function ReaderStatistics:getBookStat(id_book)
                 UIManager:show(self.kv)
             end,
         },
-        { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true, true), separator = true },
+        { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true), separator = true },
 
         -- Book progression
         { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
@@ -1848,7 +1848,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             local stop_month = os.time{year=year_end, month=month_end, day=1, hour=0, min=0 }
             table.insert(results, {
                 date_text,
-                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
+                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackMonthly(start_month, stop_month, date_text, book_mode)
                 end,
@@ -1862,7 +1862,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             begin_week = begin_week - weekday * 86400
             table.insert(results, {
                 date_text,
-                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
+                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackWeekly(begin_week, begin_week + 7 * 86400, date_text, book_mode)
                 end,
@@ -1873,7 +1873,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
                 - 60 * tonumber(string.sub(time_book,3,4)) - tonumber(string.sub(time_book,5,6))
             table.insert(results, {
                 date_text,
-                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
+                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackDaily(begin_day, begin_day + 86400, date_text)
                 end,
@@ -1914,7 +1914,7 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
             day=string.sub(result_book[1][i],9,10), hour=0, min=0, sec=0 }
         table.insert(results, {
             result_book[1][i],
-            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
+            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
             callback = function()
                 local kv = self.kv
                 UIManager:close(kv)
@@ -1958,7 +1958,7 @@ function ReaderStatistics:getBooksFromPeriod(period_begin, period_end, callback_
     for i=1, #result_book.title do
         table.insert(results, {
             result_book[1][i],
-            T(_("%1 (%2)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false, true, true), tonumber(result_book[3][i])),
+            T(_("%1 (%2)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false, true), tonumber(result_book[3][i])),
             book_id = tonumber(result_book[4][i]),
             callback = function()
                 local kv = self.kv
@@ -2066,7 +2066,7 @@ function ReaderStatistics:getDatesForBook(id_book)
     for i=1, #result_book.dates do
         table.insert(results, {
             result_book[1][i],
-            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
+            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
             hold_callback = function(kv_page, kv_item)
                 self:resetStatsForBookForPeriod(id_book, result_book[4][i], result_book[5][i], result_book[1][i], function()
                     kv_page:removeKeyValueItem(kv_item) -- Reset, refresh what's displayed
@@ -2165,7 +2165,7 @@ function ReaderStatistics:getTotalStats()
         end
         table.insert(total_stats, {
             book_title,
-            datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true, true),
+            datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true),
             callback = function()
                 local kv = self.kv
                 UIManager:close(self.kv)
@@ -2187,7 +2187,7 @@ function ReaderStatistics:getTotalStats()
     end
     conn:close()
 
-    return T(_("Total time spent reading: %1"), datetime.secondsToClockDuration(user_duration_format, total_books_time, false, true, true)), total_stats
+    return T(_("Total time spent reading: %1"), datetime.secondsToClockDuration(user_duration_format, total_books_time, false, true)), total_stats
 end
 
 function ReaderStatistics:genResetBookSubItemTable()
@@ -2267,7 +2267,7 @@ function ReaderStatistics:resetPerBook()
         if id_book ~= self.id_curr_book then
             table.insert(total_stats, {
                 book_title,
-                datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true, true),
+                datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true),
                 id_book,
                 callback = function(kv_page, kv_item)
                     UIManager:show(ConfirmBox:new{

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1456,11 +1456,11 @@ function ReaderStatistics:getCurrentStat()
     if (self.view.document:hasHiddenFlows()) then
         current_page = self.view.document:getPageNumberInFlow(self.view.state.page)
         total_pages = self.view.document:getTotalPagesInFlow(self.view.document:getPageFlow(current_page))
-        pages_format = "%d//%d (%d%%)"
+        pages_format = "%d // %d (%d%%)"
     else
         current_page = self.view.state.page
         total_pages = self.data.pages
-        pages_format = "%d/%d (%d%%)"
+        pages_format = "%d / %d (%d%%)"
     end
     local time_to_read = current_page and ((total_pages - current_page) * self.avg_time) or 0
     local estimate_days_to_read = math.ceil(time_to_read/(book_read_time/tonumber(total_days)))
@@ -1629,7 +1629,7 @@ function ReaderStatistics:getBookStat(id_book)
 
         -- Book progression
         { _("Book start date"), datetime.secondsToDate(tonumber(first_open), true) },
-        { _("Last read page/Total pages"), string.format("%d/%d (%d%%)", last_page, pages, Math.round(100*last_page/pages)) },
+        { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)) },
         { _("Last read date"), datetime.secondsToDate(tonumber(last_open), true), separator = true },
 
         -- Highlights

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1467,6 +1467,7 @@ function ReaderStatistics:getCurrentStat()
         total_pages = self.data.pages
         page_progress = ("%d / %d (%d%%)"):format(current_page, total_pages, Math.round(100*current_page/total_pages))
     end
+    local first_open_days_ago = math.floor(tonumber(now_ts - first_open)/86400)
     local time_to_read = current_page and ((total_pages - current_page) * self.avg_time) or 0
     local estimate_days_to_read = math.ceil(time_to_read/(book_read_time/tonumber(total_days)))
     local estimate_end_of_read_date = datetime.secondsToDate(tonumber(now_ts + estimate_days_to_read * 86400), true)
@@ -1523,8 +1524,8 @@ function ReaderStatistics:getCurrentStat()
         { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true, true), separator = true },
 
         -- Book progression
-        { _("Book start date"), datetime.secondsToDate(tonumber(first_open), true)},
-        { _("Estimated finish date"), estimates_valid and T(N_("%1 (1 day)", "%1 (%2 days)", estimate_days_to_read), estimate_end_of_read_date, estimate_days_to_read) or _("N/A") },
+        { _("Book start date"), T(N_("(1 day ago) %1", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
+        { _("Estimated finish date"), estimates_valid and T(N_("(in 1 day) %1", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A") },
         -- estimation, from current page to end of book
         { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true, true) or _("N/A") },
         { _("Current page/Total pages"), page_progress, separator = true },
@@ -1581,6 +1582,7 @@ function ReaderStatistics:getBookStat(id_book)
     conn:close()
 
     local book_read_pages, book_read_time = self:getPageTimeTotalStats(id_book)
+    local now_ts = os.time()
 
     if total_time_book == nil then
         total_time_book = 0
@@ -1589,7 +1591,7 @@ function ReaderStatistics:getBookStat(id_book)
         total_read_pages = 0
     end
     if first_open == nil then
-        first_open = os.time()
+        first_open = now_ts
     end
     total_time_book = tonumber(total_time_book)
     total_read_pages = tonumber(total_read_pages)
@@ -1601,6 +1603,8 @@ function ReaderStatistics:getBookStat(id_book)
     if pages == nil or pages == 0 then
         pages = 1
     end
+    local first_open_days_ago = math.floor(tonumber(now_ts - first_open)/86400)
+    local last_open_days_ago = math.floor(tonumber(now_ts - last_open)/86400)
     local avg_time_per_page = book_read_time / book_read_pages
     local user_duration_format = G_reader_settings:readSetting("duration_format")
     return {
@@ -1635,8 +1639,8 @@ function ReaderStatistics:getBookStat(id_book)
         { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true, true), separator = true },
 
         -- Book progression
-        { _("Book start date"), datetime.secondsToDate(tonumber(first_open), true) },
-        { _("Last read date"), datetime.secondsToDate(tonumber(last_open), true) },
+        { _("Book start date"), T(N_("(1 day ago) %1", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
+        { _("Last read date"), T(N_("(1 day ago) %1", "(%1 days ago) %2", last_open_days_ago), last_open_days_ago, datetime.secondsToDate(tonumber(last_open), true)) },
         { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)), separator = true },
 
         -- Highlights

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1726,7 +1726,7 @@ function ReaderStatistics:callbackMonthly(begin, finish, date_text, book_mode)
     else
         self.kv = KeyValuePage:new{
             title = date_text,
-            value_align = "right",
+            value_overflow_align = "right",
             kv_pairs = self:getDaysFromPeriod(begin, finish),
             callback_return = function()
                 UIManager:show(kv)
@@ -1755,7 +1755,7 @@ function ReaderStatistics:callbackWeekly(begin, finish, date_text, book_mode)
     else
         self.kv = KeyValuePage:new{
             title = date_text,
-            value_align = "right",
+            value_overflow_align = "right",
             kv_pairs = self:getDaysFromPeriod(begin, finish),
             callback_return = function()
                 UIManager:show(kv)
@@ -1920,7 +1920,7 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
                 UIManager:close(kv)
                 self.kv = KeyValuePage:new{
                     title = T(_("Books read %1"), result_book[1][i]),
-                    value_overflow_align = "right",
+                    value_align = "right",
                     kv_pairs = self:getBooksFromPeriod(time_begin, time_begin + 86400),
                     callback_return = function()
                         UIManager:show(kv)
@@ -1958,7 +1958,7 @@ function ReaderStatistics:getBooksFromPeriod(period_begin, period_end, callback_
     for i=1, #result_book.title do
         table.insert(results, {
             result_book[1][i],
-            T(_("%1 (%2)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false, true), tonumber(result_book[3][i])),
+            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false, true), tonumber(result_book[3][i])),
             book_id = tonumber(result_book[4][i]),
             callback = function()
                 local kv = self.kv

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1473,6 +1473,7 @@ function ReaderStatistics:getCurrentStat()
     local estimates_valid = time_to_read > 0 -- above values could be 'nan' and 'nil'
 
     local user_duration_format = G_reader_settings:readSetting("duration_format", "classic")
+    local more_arrow = BD.mirroredUILayout() and "◂" or "▸"
     return {
         -- Global statistics (may consider other books than current book)
 
@@ -1481,12 +1482,13 @@ function ReaderStatistics:getCurrentStat()
         { _("Pages read this session"), tonumber(current_pages), separator = true },
 
         -- Today
-        { _("Time spent reading today ▸"), datetime.secondsToClockDuration(user_duration_format, today_duration, false, true, true),
+        { _("Time spent reading today") .. " " .. more_arrow, datetime.secondsToClockDuration(user_duration_format, today_duration, false, true, true),
             callback = function()
-                local now_t = os.date("*t")
-                local seconds_from_midnight = now_t.hour * 3600 + now_t.min * 60 + now_t.sec
-                local today_midnight = now_ts - seconds_from_midnight
-                self:callbackDaily(today_midnight, today_midnight + 86400, T(_("Today (%1)"), datetime.secondsToDate(now_ts, true)))
+                local CalendarView = require("calendarview")
+                local title_callback = function(this)
+                    return T(_("Today (%1)"), datetime.secondsToDate(now_ts, true))
+                end
+                CalendarView:showCalendarDayView(self, title_callback)
             end,
         },
         { _("Pages read today"), tonumber(today_pages), separator = true },
@@ -1501,7 +1503,7 @@ function ReaderStatistics:getCurrentStat()
         { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true, true), separator = true },
 
         -- Day-focused book stats
-        { _("Days reading this book ▸"), tonumber(total_days),
+        { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
             callback = function()
                 local kv = self.kv
                 UIManager:close(self.kv)
@@ -1522,10 +1524,10 @@ function ReaderStatistics:getCurrentStat()
 
         -- Book progression
         { _("Book start date"), datetime.secondsToDate(tonumber(first_open), true)},
-        { _("Current page/Total pages"), page_progress },
+        { _("Estimated finish date"), estimates_valid and T(N_("%1 (1 day)", "%1 (%2 days)", estimate_days_to_read), estimate_end_of_read_date, estimate_days_to_read) or _("N/A") },
         -- estimation, from current page to end of book
         { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true, true) or _("N/A") },
-        { _("Estimated finish date"), estimates_valid and T(N_("%1 (1 day)", "%1 (%2 days)", estimate_days_to_read), estimate_end_of_read_date, estimate_days_to_read) or _("N/A"), separator = true },
+        { _("Current page/Total pages"), page_progress, separator = true },
 
         -- Highlights
         { _("Book highlights"), tonumber(highlights) }
@@ -1634,8 +1636,8 @@ function ReaderStatistics:getBookStat(id_book)
 
         -- Book progression
         { _("Book start date"), datetime.secondsToDate(tonumber(first_open), true) },
-        { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)) },
-        { _("Last read date"), datetime.secondsToDate(tonumber(last_open), true), separator = true },
+        { _("Last read date"), datetime.secondsToDate(tonumber(last_open), true) },
+        { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)), separator = true },
 
         -- Highlights
         { _("Book highlights"), highlights }

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1482,14 +1482,14 @@ function ReaderStatistics:getCurrentStat()
     local time_to_read_string = estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true) or _("N/A")
 
     -- Use more_arrow to indicate that an option shows another view
-    -- Use "*" to indicate that an option will show an info message
+    -- Use " ⓘ" to indicate that an option will show an info message
     local more_arrow = BD.mirroredUILayout() and "◂" or "▸"
 
     local estimated_popup = function()
         UIManager:show(InfoMessage:new{
-            text = T(N_("%1 page (%2%) of the book left.", "%1 pages (%2%) of the book left.", total_pages - current_page), total_pages - current_page, 100 - percent_read) ..
-                "\n\n" .. T(_("At the current rate of %1 per page, the book will be finished in %2 of reading time."), avg_page_time_string, time_to_read_string) ..
-                "\n\n" .. T(N_("At the current rate of %1 read per day, the book will be finished in %2 typical day of reading.", "At the current rate of %1 read per day, the book will be finished in %2 typical days of reading.", estimate_days_to_read), avg_day_time_string, estimate_days_to_read),
+            text = T(N_("There is 1 page (%2%) left to read.", "There are %1 pages (%2%) left to read.", total_pages - current_page), total_pages - current_page, 100 - percent_read) ..
+                "\n\n" .. T(_("At the current rate of %1 per page, that will take %2 of reading time."), avg_page_time_string, time_to_read_string) ..
+                "\n\n" .. T(N_("At the current rate of %1 per day, that will take 1 day.", "At the current rate of %1 per day, that will take %2 days.", estimate_days_to_read), avg_day_time_string, estimate_days_to_read),
             icon = "book.opened"
         })
     end
@@ -1520,7 +1520,7 @@ function ReaderStatistics:getCurrentStat()
         -- capped to self.settings.max_sec per distinct page
         { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true) },
         -- estimation, from current page to end of book
-        { _("Estimated reading time left") .. "*", time_to_read_string, callback = estimated_popup, separator = true },
+        { _("Estimated reading time left") .. " ⓘ", time_to_read_string, callback = estimated_popup, separator = true },
 
         -- Day-focused book stats
         { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
@@ -1544,7 +1544,7 @@ function ReaderStatistics:getCurrentStat()
 
         -- Date-focused book stats
         { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
-        { _("Estimated finish date") .. "*", estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A"), callback = estimated_popup, separator = true },
+        { _("Estimated finish date") .. " ⓘ", estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A"), callback = estimated_popup, separator = true },
 
         -- Page-focused book stats
         { _("Current page/Total pages"), page_progress_string },

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1853,7 +1853,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             local stop_month = os.time{year=year_end, month=month_end, day=1, hour=0, min=0 }
             table.insert(results, {
                 date_text,
-                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackMonthly(start_month, stop_month, date_text, book_mode)
                 end,
@@ -1867,7 +1867,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             begin_week = begin_week - weekday * 86400
             table.insert(results, {
                 date_text,
-                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackWeekly(begin_week, begin_week + 7 * 86400, date_text, book_mode)
                 end,
@@ -1878,7 +1878,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
                 - 60 * tonumber(string.sub(time_book,3,4)) - tonumber(string.sub(time_book,5,6))
             table.insert(results, {
                 date_text,
-                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackDaily(begin_day, begin_day + 86400, date_text)
                 end,
@@ -1919,7 +1919,7 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
             day=string.sub(result_book[1][i],9,10), hour=0, min=0, sec=0 }
         table.insert(results, {
             result_book[1][i],
-            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
             callback = function()
                 local kv = self.kv
                 UIManager:close(kv)
@@ -1963,7 +1963,7 @@ function ReaderStatistics:getBooksFromPeriod(period_begin, period_end, callback_
     for i=1, #result_book.title do
         table.insert(results, {
             result_book[1][i],
-            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false, true), tonumber(result_book[3][i])),
+            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[3][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false, true), tonumber(result_book[3][i])),
             book_id = tonumber(result_book[4][i]),
             callback = function()
                 local kv = self.kv
@@ -2071,7 +2071,7 @@ function ReaderStatistics:getDatesForBook(id_book)
     for i=1, #result_book.dates do
         table.insert(results, {
             result_book[1][i],
-            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
             hold_callback = function(kv_page, kv_item)
                 self:resetStatsForBookForPeriod(id_book, result_book[4][i], result_book[5][i], result_book[1][i], function()
                     kv_page:removeKeyValueItem(kv_item) -- Reset, refresh what's displayed

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1496,12 +1496,12 @@ function ReaderStatistics:getCurrentStat()
 
         -- Current book statistics (includes re-reads)
 
-        -- General book stats
+        -- Time-focused book stats
         { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true) },
-        -- Capped to self.settings.max_sec per distinct page
+        -- capped to self.settings.max_sec per distinct page
         { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true) },
-        { _("Pages read"), string.format("%d (%d%%)", total_read_pages, Math.round(100*total_read_pages/self.data.pages)) },
-        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true), separator = true },
+        -- estimation, from current page to end of book
+        { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true) or _("N/A"), separator = true },
 
         -- Day-focused book stats
         { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
@@ -1523,12 +1523,14 @@ function ReaderStatistics:getCurrentStat()
         },
         { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true), separator = true },
 
-        -- Book progression
+        -- Date-focused book stats
         { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
-        { _("Estimated finish date"), estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A") },
-        -- estimation, from current page to end of book
-        { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true) or _("N/A") },
-        { _("Current page/Total pages"), page_progress, separator = true },
+        { _("Estimated finish date"), estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A"), separator = true },
+
+        -- Page-focused book stats
+        { _("Current page/Total pages"), page_progress },
+        { _("Pages read"), string.format("%d (%d%%)", total_read_pages, Math.round(100*total_read_pages/self.data.pages)) },
+        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true), separator = true },
 
         -- Highlights
         { _("Book highlights"), tonumber(highlights) }
@@ -1613,11 +1615,9 @@ function ReaderStatistics:getBookStat(id_book)
         { _("Title"), title},
         { _("Author(s)"), authors, separator = true },
 
-        -- General book stats
+        -- Time-focused book stats
         { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true) },
-        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true) },
-        { _("Pages read"), string.format("%d (%d%%)", total_read_pages, Math.round(100*total_read_pages/pages)) },
-        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false, true), separator = true },
+        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true), separator = true },
 
         -- Day-focused book stats
         { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
@@ -1639,10 +1639,14 @@ function ReaderStatistics:getBookStat(id_book)
         },
         { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true), separator = true },
 
-        -- Book progression
+        -- Date-focused book stats
         { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
-        { _("Last read date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", last_open_days_ago), last_open_days_ago, datetime.secondsToDate(tonumber(last_open), true)) },
-        { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)), separator = true },
+        { _("Last read date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", last_open_days_ago), last_open_days_ago, datetime.secondsToDate(tonumber(last_open), true)), separator = true },
+
+        -- Page-focused book stats
+        { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)) },
+        { _("Pages read"), string.format("%d (%d%%)", total_read_pages, Math.round(100*total_read_pages/pages)) },
+        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false, true), separator = true },
 
         -- Highlights
         { _("Book highlights"), highlights }

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1842,7 +1842,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             local stop_month = os.time{year=year_end, month=month_end, day=1, hour=0, min=0 }
             table.insert(results, {
                 date_text,
-                T(_("Pages: (%1) Time: %2"), tonumber(result_book[2][i]), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true)),
+                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackMonthly(start_month, stop_month, date_text, book_mode)
                 end,
@@ -1856,7 +1856,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             begin_week = begin_week - weekday * 86400
             table.insert(results, {
                 date_text,
-                T(_("Pages: (%1) Time: %2"), tonumber(result_book[2][i]), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true)),
+                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackWeekly(begin_week, begin_week + 7 * 86400, date_text, book_mode)
                 end,
@@ -1867,7 +1867,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
                 - 60 * tonumber(string.sub(time_book,3,4)) - tonumber(string.sub(time_book,5,6))
             table.insert(results, {
                 date_text,
-                T(_("Pages: (%1) Time: %2"), tonumber(result_book[2][i]), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true)),
+                T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackDaily(begin_day, begin_day + 86400, date_text)
                 end,
@@ -1908,7 +1908,7 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
             day=string.sub(result_book[1][i],9,10), hour=0, min=0, sec=0 }
         table.insert(results, {
             result_book[1][i],
-            T(_("Pages: (%1) Time: %2"), tonumber(result_book[2][i]), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true)),
+            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
             callback = function()
                 local kv = self.kv
                 UIManager:close(kv)
@@ -2060,7 +2060,7 @@ function ReaderStatistics:getDatesForBook(id_book)
     for i=1, #result_book.dates do
         table.insert(results, {
             result_book[1][i],
-            T(_("Pages: (%1) Time: %2"), tonumber(result_book[2][i]), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true)),
+            T(_("%1 (%2 pages)"), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true, true), tonumber(result_book[2][i])),
             hold_callback = function(kv_page, kv_item)
                 self:resetStatsForBookForPeriod(id_book, result_book[4][i], result_book[5][i], result_book[1][i], function()
                     kv_page:removeKeyValueItem(kv_item) -- Reset, refresh what's displayed

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1524,8 +1524,8 @@ function ReaderStatistics:getCurrentStat()
         { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true, true), separator = true },
 
         -- Book progression
-        { _("Book start date"), T(N_("(1 day ago) %1", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
-        { _("Estimated finish date"), estimates_valid and T(N_("(in 1 day) %1", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A") },
+        { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
+        { _("Estimated finish date"), estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A") },
         -- estimation, from current page to end of book
         { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true, true) or _("N/A") },
         { _("Current page/Total pages"), page_progress, separator = true },
@@ -1639,8 +1639,8 @@ function ReaderStatistics:getBookStat(id_book)
         { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true, true), separator = true },
 
         -- Book progression
-        { _("Book start date"), T(N_("(1 day ago) %1", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
-        { _("Last read date"), T(N_("(1 day ago) %1", "(%1 days ago) %2", last_open_days_ago), last_open_days_ago, datetime.secondsToDate(tonumber(last_open), true)) },
+        { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
+        { _("Last read date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", last_open_days_ago), last_open_days_ago, datetime.secondsToDate(tonumber(last_open), true)) },
         { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)), separator = true },
 
         -- Highlights

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1486,7 +1486,7 @@ function ReaderStatistics:getCurrentStat()
                 local now_t = os.date("*t")
                 local seconds_from_midnight = now_t.hour * 3600 + now_t.min * 60 + now_t.sec
                 local today_midnight = now_ts - seconds_from_midnight
-                self:callbackDaily(today_midnight, today_midnight + 86400, os.date("Today (%A, %Y-%m-%d)", now_ts))
+                self:callbackDaily(today_midnight, today_midnight + 86400, T(_("Today (%1)"), datetime.secondsToDate(now_ts, true)))
             end,
         },
         { _("Pages read today"), tonumber(today_pages), separator = true },

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1452,15 +1452,20 @@ function ReaderStatistics:getCurrentStat()
 
     local current_page
     local total_pages
-    local pages_format
+    local page_progress
     if (self.view.document:hasHiddenFlows()) then
+        local flow = self.view.document:getPageFlow(self.view.state.page)
         current_page = self.view.document:getPageNumberInFlow(self.view.state.page)
-        total_pages = self.view.document:getTotalPagesInFlow(self.view.document:getPageFlow(current_page))
-        pages_format = "%d // %d (%d%%)"
+        total_pages = self.view.document:getTotalPagesInFlow(flow)
+        if flow == 0 then
+            page_progress = ("%d // %d (%d%%)"):format(current_page, total_pages, Math.round(100*current_page/total_pages))
+        else
+            page_progress = ("[%d / %d]%d (%d%%)"):format(current_page, total_pages, flow, Math.round(100*current_page/total_pages))
+        end
     else
         current_page = self.view.state.page
         total_pages = self.data.pages
-        pages_format = "%d / %d (%d%%)"
+        page_progress = ("%d / %d (%d%%)"):format(current_page, total_pages, Math.round(100*current_page/total_pages))
     end
     local time_to_read = current_page and ((total_pages - current_page) * self.avg_time) or 0
     local estimate_days_to_read = math.ceil(time_to_read/(book_read_time/tonumber(total_days)))
@@ -1517,7 +1522,7 @@ function ReaderStatistics:getCurrentStat()
 
         -- Book progression
         { _("Book start date"), datetime.secondsToDate(tonumber(first_open), true)},
-        { _("Current page/Total pages"), string.format(pages_format, current_page, total_pages, Math.round(100*current_page/total_pages)) },
+        { _("Current page/Total pages"), page_progress },
         -- estimation, from current page to end of book
         { _("Estimated time left"), estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true, true) or _("N/A") },
         { _("Estimated finish date"), estimates_valid and T(N_("%1 (1 day)", "%1 (%2 days)", estimate_days_to_read), estimate_end_of_read_date, estimate_days_to_read) or _("N/A"), separator = true },

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1480,6 +1480,9 @@ function ReaderStatistics:getCurrentStat()
     local avg_page_time_string = datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true)
     local avg_day_time_string = datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true)
     local time_to_read_string = estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true) or _("N/A")
+
+    -- Use more_arrow to indicate that an option shows another view
+    -- Use "*" to indicate that an option will show an info message
     local more_arrow = BD.mirroredUILayout() and "◂" or "▸"
 
     local estimated_popup = function()
@@ -1517,7 +1520,7 @@ function ReaderStatistics:getCurrentStat()
         -- capped to self.settings.max_sec per distinct page
         { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true) },
         -- estimation, from current page to end of book
-        { _("Estimated time left"), time_to_read_string, callback = estimated_popup, separator = true },
+        { _("Estimated reading time left") .. "*", time_to_read_string, callback = estimated_popup, separator = true },
 
         -- Day-focused book stats
         { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
@@ -1541,7 +1544,7 @@ function ReaderStatistics:getCurrentStat()
 
         -- Date-focused book stats
         { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
-        { _("Estimated finish date"), estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A"), callback = estimated_popup, separator = true },
+        { _("Estimated finish date") .. "*", estimates_valid and T(N_("(in 1 day) %2", "(in %1 days) %2", estimate_days_to_read), estimate_days_to_read, estimate_end_of_read_date) or _("N/A"), callback = estimated_popup, separator = true },
 
         -- Page-focused book stats
         { _("Current page/Total pages"), page_progress_string },

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -101,7 +101,7 @@ function ReaderProgress:getStatusContent(width)
         self:genSummaryWeek(width),
         self:genSingleHeader(_("Week progress")),
         self:genWeekStats(7),
-        self:genDoubleHeader(_("Current"), _("Today") ),
+        self:genDoubleHeader(_("Session"), _("Today") ),
         self:genSummaryDay(width),
     }
 end
@@ -233,7 +233,7 @@ function ReaderProgress:genWeekStats(stats_day)
         else
             select_day_time = 0
         end
-        date_format_show = datetime.shortDayOfWeekToLongTranslation[os.date("%a", diff_time)] .. os.date(" (%d.%m)", diff_time)
+        date_format_show = datetime.shortDayOfWeekToLongTranslation[os.date("%a", diff_time)] .. os.date(" (%Y-%m-%d)", diff_time)
         local total_group = HorizontalGroup:new{
             align = "center",
             padding = Size.padding.small,
@@ -241,7 +241,7 @@ function ReaderProgress:genWeekStats(stats_day)
                 dimen = Geom:new{ w = self.screen_width , h = height * (1/3) },
                 TextWidget:new{
                     padding = Size.padding.small,
-                    text = date_format_show .. " - " .. datetime.secondsToClockDuration(user_duration_format, select_day_time, true),
+                    text = date_format_show .. " — " .. datetime.secondsToClockDuration(user_duration_format, select_day_time, true, true),
                     face = Font:getFace("smallffont"),
                 },
             },
@@ -335,7 +335,7 @@ function ReaderProgress:genSummaryDay(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, self.current_duration, true),
+                text = datetime.secondsToClockDuration(user_duration_format, self.current_duration, true, true, true),
                 face = self.medium_font_face,
             },
         },
@@ -349,7 +349,7 @@ function ReaderProgress:genSummaryDay(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, self.today_duration, true),
+                text = datetime.secondsToClockDuration(user_duration_format, self.today_duration, true, true),
                 face = self.medium_font_face,
             },
         },
@@ -400,7 +400,7 @@ function ReaderProgress:genSummaryWeek(width)
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextBoxWidget:new{
                 alignment = "center",
-                text = _("Average\npages"),
+                text = _("Average\npages/day"),
                 face = self.small_font_face,
                 width = tile_width * 0.95,
             }
@@ -409,7 +409,7 @@ function ReaderProgress:genSummaryWeek(width)
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextBoxWidget:new{
                 alignment = "center",
-                text = _("Average\ntime"),
+                text = _("Average\ntime/day"),
                 face = self.small_font_face,
                 width = tile_width * 0.95,
             }
@@ -437,7 +437,7 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time), true),
+                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time), true, true, true),
                 face = self.medium_font_face,
             },
         },
@@ -451,7 +451,7 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time) * (1/7), true),
+                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time) * (1/7), true, true),
                 face = self.medium_font_face,
             }
         }

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -335,7 +335,7 @@ function ReaderProgress:genSummaryDay(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, self.current_duration, true, true, true),
+                text = datetime.secondsToClockDuration(user_duration_format, self.current_duration, true, true),
                 face = self.medium_font_face,
             },
         },
@@ -437,7 +437,7 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time), true, true, true),
+                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time), true, true),
                 face = self.medium_font_face,
             },
         },


### PR DESCRIPTION
I like the Reading Statistics plugin.

**Changes:**
- Reading Progress
  - Rename "Reading Progress" title "Current" to more descriptive "Session" (parity w/ Current Statistics that calls this concept a "session")
  - Change "Average / pages" to "Average / pages/day" and "Average / time" to "Average / time/day" since the old text is not intuitive to understand, and we have space, and fits pattern of "Total / time", etc.
  - Use more widespread YYYY-MM-DD date format instead of "MM.DD"

![reading progress changes](https://user-images.githubusercontent.com/10296053/206978545-3be27f2d-92fe-4544-93ca-f465584257d8.png)

- Current Statistics and per-book view
  - If book has non-linear fragments, use same logic as the status bar uses to show current page and remaining time
    - Add current page status spacing, "%d/%d" to "%d / %d" etc., to match status bar
  - Show on a single page since they're guaranteed to be short anyway
  - Make values align right to get rid of ugly layout where the values aren't aligned with one another
  - Re-order for more sensibility: this session, today, this book[general, day-focused, progression, highlights]
  - Rename a few rows to make more sense
  - Use new `datetime.secondsToDate()` call for start date and last read date/expected end date instead of 24-hour-clock-using `os.date()` that shows locale-ignorant "YYYY-MM-DD"
  - Add link to "Days reading this book"
  - (Current Statistics only) Add link to "Time spent reading today" row to show breakdown of how that time was spent (recycling "day" call)
  - (per-book view only) Say "Author(s)" instead of "Authors" in case of a single author

![current statistics changes](https://user-images.githubusercontent.com/10296053/206978889-6ddf5b9e-7801-4082-a919-78357bc9d774.png)

![per-book view changes](https://user-images.githubusercontent.com/10296053/206978622-e0fba569-ba4b-479e-8cb9-1784279acc76.png)

- All Views:
  - See "General" section below
  - Make the "Days reading <book>" view show time and pages the same way the date-to-books view shows them ("time (pages)")

![days reading changes](https://user-images.githubusercontent.com/10296053/206978657-a748e797-3629-4c28-9f13-895c79f70050.png)

- General, these are all RFC:
  -  Show duration with full hms (if modern format) when we have space because it's more readable
  -  Allow days in duration for where it's possible ("Total time" and "Session" > "Time") — dunno, do you prefer "47h" or "1d23h" when it comes to reading time?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9904)
<!-- Reviewable:end -->
