### PR TITLE
Add note about flows to screensaver variables message

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -138,12 +138,12 @@ end
 
 function Screensaver:expandSpecial(message, fallback)
     -- Expand special character sequences in given message.
-    -- %p percentage read
-    -- %c current page
-    -- %t total pages
     -- %T document title
     -- %A document authors
     -- %S document series
+    -- %c current page
+    -- %t total pages
+    -- %p percentage read
     -- %h time left in chapter
     -- %H time left in document
     -- %b battery level
@@ -213,12 +213,12 @@ function Screensaver:expandSpecial(message, fallback)
     end
 
     local replace = {
-        ["%c"] = currentpage,
-        ["%t"] = totalpages,
-        ["%p"] = percent,
         ["%T"] = title,
         ["%A"] = authors,
         ["%S"] = series,
+        ["%c"] = currentpage,
+        ["%t"] = totalpages,
+        ["%p"] = percent,
         ["%h"] = time_left_chapter,
         ["%H"] = time_left_document,
         ["%b"] = batt_lvl,
@@ -412,7 +412,7 @@ function Screensaver:setMessage()
     local input_dialog
     input_dialog = InputDialog:new{
         title = "Screensaver message",
-        description = _("Enter the message to be displayed by the screensaver. The following escape sequences can be used:\n  %p percentage read\n  %c current page number\n  %t total number of pages\n  %T title\n  %A authors\n  %S series\n  %h time left in chapter\n  %H time left in document\n  %b battery level"),
+        description = _("Enter the message to be displayed by the screensaver. The following escape sequences can be used:\n  %T  title\n  %A  author(s)\n  %S  series\n  %c  current page (or current page in flow)\n  %t  total pages (or total pages in flow)\n  %p  percentage read (or percentage read of flow)\n  %h  time left in chapter\n  %H  time left in document (or time left in flow)\n  %b  battery level"),
         input = screensaver_message,
         buttons = {
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -412,7 +412,17 @@ function Screensaver:setMessage()
     local input_dialog
     input_dialog = InputDialog:new{
         title = "Screensaver message",
-        description = _("Enter the message to be displayed by the screensaver. The following escape sequences can be used:\n  %T  title\n  %A  author(s)\n  %S  series\n  %c  current page number\n  %t  total page number\n  %p  percentage read\n  %h  time left in chapter\n  %H  time left in document\n  %b  battery level"),
+        description = _([[
+Enter the message to be displayed by the screensaver. The following escape sequences can be used:
+  %T title
+  %A author(s)
+  %S series
+  %c current page number
+  %t total page number
+  %p percentage read
+  %h time left in chapter
+  %H time left in document
+  %b battery level]]),
         input = screensaver_message,
         buttons = {
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -141,11 +141,11 @@ function Screensaver:expandSpecial(message, fallback)
     -- %T document title
     -- %A document authors
     -- %S document series
-    -- %c current page
-    -- %t total pages
-    -- %p percentage read
+    -- %c current page (if there are hidden flows, current page in current flow)
+    -- %t total pages (if there are hidden flows, total pages in current flow)
+    -- %p percentage read (if there are hidden flows, percentage read of current flow)
     -- %h time left in chapter
-    -- %H time left in document
+    -- %H time left in document (if there are hidden flows, time left in current flow)
     -- %b battery level
 
     if G_reader_settings:hasNot("lastfile") then
@@ -412,7 +412,7 @@ function Screensaver:setMessage()
     local input_dialog
     input_dialog = InputDialog:new{
         title = "Screensaver message",
-        description = _("Enter the message to be displayed by the screensaver. The following escape sequences can be used:\n  %T  title\n  %A  author(s)\n  %S  series\n  %c  current page (or current page in flow)\n  %t  total pages (or total pages in flow)\n  %p  percentage read (or percentage read of flow)\n  %h  time left in chapter\n  %H  time left in document (or time left in flow)\n  %b  battery level"),
+        description = _("Enter the message to be displayed by the screensaver. The following escape sequences can be used:\n  %T  title\n  %A  author(s)\n  %S  series\n  %c  current page number\n  %t  total page number\n  %p  percentage read\n  %h  time left in chapter\n  %H  time left in document\n  %b  battery level"),
         input = screensaver_message,
         buttons = {
             {


### PR DESCRIPTION
At @NiLuJe's request, I tried to add a note to the screensaver message about the variables that will only apply to the current flow if any flows are hidden (see #9905). Not the prettiest thing, nor the clearest, but not a lot of room to work with here and we're already cramped.

plus more sensible order and an extra space between symbol and description

![Reader_2022-12-12_211046 small](https://user-images.githubusercontent.com/10296053/207238840-56908488-55de-44c2-9b31-6faa401a6832.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9909)
<!-- Reviewable:end -->
