### PR TITLE
Exclude text when excluding cover, random image as fallback

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -250,10 +250,14 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:supportsScreensaver() then
         local ss_book_settings = {
-            text = _("Exclude this book's cover from screensaver"),
+            text = _("Exclude this book's cover and text from screensaver"),
             enabled_func = function()
-                return not (self.ui == nil or self.ui.document == nil)
-                    and G_reader_settings:readSetting("screensaver_type") == "cover"
+                if self.ui and self.ui.document then
+                    local screensaverType = G_reader_settings:readSetting("screensaver_type")
+                    return screensaverType == "cover" or screensaverType == "disable"
+                else
+                    return false
+                end
             end,
             checked_func = function()
                 return self.ui and self.ui.doc_settings and self.ui.doc_settings:isTrue("exclude_screensaver")

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -250,7 +250,7 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:supportsScreensaver() then
         local ss_book_settings = {
-            text = _("Exclude this book's cover and text from screensaver"),
+            text = _("Exclude this book's content and cover from screensaver"),
             enabled_func = function()
                 if self.ui and self.ui.document then
                     local screensaverType = G_reader_settings:readSetting("screensaver_type")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -558,39 +558,32 @@ function Screensaver:setup(event, event_message)
         end
     end
     if self.screensaver_type == "bookstatus" then
-        if lastfile and lfs.attributes(lastfile, "mode") == "file" then
-            if not ui then
-                self.screensaver_type = "disable"
-                self.show_message = true
-            end
-        else
-            self.screensaver_type = "disable"
-            self.show_message = true
-        end
-    end
-    if self.screensaver_type == "random_image" then
-        local screensaver_dir = G_reader_settings:readSetting(self.prefix .. "screensaver_dir")
-                             or G_reader_settings:readSetting("screensaver_dir")
-        self.image_file = self:_getRandomImage(screensaver_dir)
-        if self.image_file == nil then
-            self.screensaver_type = "disable"
-            self.show_message = true
+        if not ui or not lastfile or lfs.attributes(lastfile, "mode") ~= "file" or (ui.doc_settings and ui.doc_settings:isTrue("exclude_screensaver")) then
+            self.screensaver_type = "random_image"
         end
     end
     if self.screensaver_type == "image_file" then
         self.image_file = G_reader_settings:readSetting(self.prefix .. "screensaver_image")
                        or G_reader_settings:readSetting("screensaver_image")
         if self.image_file == nil or lfs.attributes(self.image_file, "mode") ~= "file" then
-            self.screensaver_type = "disable"
-            self.show_message = true
+            self.screensaver_type = "random_image"
         end
     end
     if self.screensaver_type == "readingprogress" then
         -- This is implemented by the Statistics plugin
         if Screensaver.getReaderProgress == nil then
-            self.screensaver_type = "disable"
-            self.show_message = true
+            self.screensaver_type = "random_image"
         end
+    end
+    if self.screensaver_type == "disable" then
+        if ui and ui.doc_settings and ui.doc_settings:isTrue("exclude_screensaver") then
+            self.screensaver_type = "random_image"
+        end
+    end
+    if self.screensaver_type == "random_image" then
+        local screensaver_dir = G_reader_settings:readSetting(self.prefix .. "screensaver_dir")
+                             or G_reader_settings:readSetting("screensaver_dir")
+        self.image_file = self:_getRandomImage(screensaver_dir) or "resources/koreader.png" -- Fallback image
     end
 
     -- Use the right background setting depending on the effective mode, now that fallbacks have kicked in.


### PR DESCRIPTION
At the risk of juggling too many plates... This one belongs directly with excluding the cover; for any book where you want to exclude the cover, you likely want to exclude the text even more. ;)

* Make the "Exclude this book's cover from screensaver" into "Exclude this book's cover and text from screensaver"
  * Disable the "disabled" screensaver type if this is checked and we're currently inside that book
  * Disable "Book status" if this is checked, since it also includes the book cover
* Use random image as fallback for all screensaver types (it's the safest option from both a privacy and availability perspective) instead of "disable" (which can now be excluded with the above checkbox)
  * Use `resources/koreader.png` as fallback if random image folder empty, as it's guaranteed (though if someone wants to paint a beautiful picture featuring the KR logo, we can use that as the default instead)

Other minor:
* Fix some small code re-duplication for "bookstatus" block

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9912)
<!-- Reviewable:end -->
