### PR TITLE
Calibre: Log errors on wireless connection failures

### DIFF
--- a/frontend/ui/message/streammessagequeue.lua
+++ b/frontend/ui/message/streammessagequeue.lua
@@ -17,7 +17,7 @@ function StreamMessageQueue:start()
     self.socket = czmq.zsocket_new(self.context, C.ZMQ_STREAM)
     self.poller = czmq.zpoller_new(self.socket, nil)
     local endpoint = string.format("tcp://%s:%d", self.host, self.port)
-    logger.warn("connect to endpoint", endpoint)
+    logger.info("connecting to endpoint", endpoint)
     local rc = czmq.zsocket_connect(self.socket, endpoint)
     if rc ~= 0 then
         error("cannot connect to " .. endpoint)

--- a/frontend/ui/message/streammessagequeue.lua
+++ b/frontend/ui/message/streammessagequeue.lua
@@ -17,7 +17,7 @@ function StreamMessageQueue:start()
     self.socket = czmq.zsocket_new(self.context, C.ZMQ_STREAM)
     self.poller = czmq.zpoller_new(self.socket, nil)
     local endpoint = string.format("tcp://%s:%d", self.host, self.port)
-    logger.info("connecting to endpoint", endpoint)
+    logger.dbg("connecting to endpoint", endpoint)
     local rc = czmq.zsocket_connect(self.socket, endpoint)
     if rc ~= 0 then
         error("cannot connect to " .. endpoint)

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -146,12 +146,15 @@ function CalibreWireless:JSONReceiveCallback(host, port)
                     msg = _("Invalid password")
                     this.invalid_password = nil
                     this:disconnect()
+                    logger.warn("invalid password, disconnecting")
                 elseif this.disconnected_by_server then
                     msg = _("Disconnected by calibre")
                     this.disconnected_by_server = nil
+                    logger.info("disconnected by calibre")
                 else
                     msg = T(_("Connected to calibre server at %1"),
                         BD.ltr(T("%1:%2", this.calibre_socket.host, this.calibre_socket.port)))
+                    logger.info("connected successfully")
                 end
                 UIManager:show(InfoMessage:new{
                     text = msg,
@@ -175,7 +178,7 @@ function CalibreWireless:initCalibreMQ(host, port)
         self.calibre_socket:start()
         self.calibre_messagequeue = UIManager:insertZMQ(self.calibre_socket)
     end
-    logger.info("connected to calibre", host, port)
+    logger.info(string.format("connecting to calibre @ %s:%s", host, port))
 end
 
 -- will callback initCalibreMQ if inbox is confirmed to be set

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -240,7 +240,7 @@ function CalibreWireless:connect()
             address_type = "discovered"
         else
             ok = false
-            err = "Couldn't discover a calibre instance on the local network"
+            err = _("Couldn't discover a calibre instance on the local network")
             address_type = "unavailable"
         end
     else
@@ -256,10 +256,11 @@ function CalibreWireless:connect()
     if not ok then
         host = host or "????"
         port = port or "??"
-        logger.warn(string.format("Cannot connect to %s calibre server at %s:%s (%s)", address_type, host, port, err or "N/A"))
+        err = err or _("N/A")
+        logger.warn(string.format("Cannot connect to %s calibre server at %s:%s (%s)", address_type, host, port, err))
         UIManager:show(InfoMessage:new{
-            text = T(_("Cannot connect to calibre server at %1"),
-                        BD.ltr(T("%1:%2", host, port)))
+            text = T(_("Cannot connect to calibre server at %1 (%2)"),
+                        BD.ltr(T("%1:%2", host, port)), err)
         })
     else
         local inbox_dir = G_reader_settings:readSetting("inbox_dir")

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -111,7 +111,7 @@ function CalibreWireless:find_calibre_server()
             if dgram and host then
                 -- replied diagram has greet message from calibre and calibre hostname
                 -- calibre opds port and calibre socket port we will later connect to
-                local _, _, _, replied_port = dgram:match("(.-)%(on (.-)%);(.-),(.-)$")
+                local _, _, replied_port = dgram:match("calibre wireless device client %(on (.-)%);(%d+),(%d+)$")
                 return host, replied_port
             end
         end

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -254,9 +254,12 @@ function CalibreWireless:connect()
     end
 
     if not ok then
-        logger.warn(string.format("Cannot connect to %s calibre server at %s:%s (%s)", address_type, host or "????", port or "??", err or "N/A"))
+        host = host or "????"
+        port = port or "??"
+        logger.warn(string.format("Cannot connect to %s calibre server at %s:%s (%s)", address_type, host, port, err or "N/A"))
         UIManager:show(InfoMessage:new{
-            text = _("Cannot connect to calibre server."),
+            text = T(_("Cannot connect to calibre server at %1"),
+                        BD.ltr(T("%1:%2", host, port)))
         })
     else
         local inbox_dir = G_reader_settings:readSetting("inbox_dir")

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -267,7 +267,7 @@ function CalibreWireless:connect()
 end
 
 function CalibreWireless:disconnect()
-    logger.info("disconnect from calibre")
+    logger.info("disconnecting from calibre")
     self.connect_message = false
     if self.calibre_socket then
         self.calibre_socket:stop()


### PR DESCRIPTION
Also, get rid of the weird and clunky `failed_connect_callback` thingy, because it makes no sense?

Re #9908

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9914)
<!-- Reviewable:end -->
