### PR TITLE
Change footer status bar type setting label from 'Prefix' to 'Item style'

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -97,7 +97,6 @@ local symbol_prefix = {
         pages_left_book = BD.mirroredUILayout() and "‹" or "›",
         pages_left = BD.mirroredUILayout() and "‹" or "›",
         battery = "",
-        -- @translators This is the footer compact item prefix for the number of bookmarks (bookmark count).
         bookmark_count = "☆",
         percentage = nil,
         book_time_to_read = nil,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1413,7 +1413,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     elseif self.settings.item_style == "compact" then
                         prefix_text = _("Compact")
                     end
-                    return T(_("Style: %1"), prefix_text)
+                    return T(_("Item style: %1"), prefix_text)
                 end,
                 sub_item_table = {
                     {

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -92,7 +92,7 @@ local symbol_prefix = {
         wifi_status_off = "",
         custom_text = "",
     },
-    compact_items = {
+    compact = {
         time = nil,
         pages_left_book = BD.mirroredUILayout() and "‹" or "›",
         pages_left = BD.mirroredUILayout() and "‹" or "›",
@@ -136,12 +136,12 @@ local PROGRESS_BAR_STYLE_THIN_DEFAULT_HEIGHT = 3
 -- android: guidelines for rounded corner margins
 local material_pixels = Screen:scaleByDPI(16)
 
--- functions that generates footer text for each mode
+-- functions that generate footer text for each mode
 local footerTextGeneratorMap = {
     empty = function() return "" end,
     frontlight = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].frontlight
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].frontlight
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
             if Device:isCervantes() or Device:isKobo() then
@@ -158,8 +158,8 @@ local footerTextGeneratorMap = {
         end
     end,
     frontlight_warmth = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].frontlight_warmth
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].frontlight_warmth
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
             local warmth = powerd:frontlightWarmth()
@@ -175,8 +175,8 @@ local footerTextGeneratorMap = {
         end
     end,
     battery = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].battery
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].battery
         local powerd = Device:getPowerDevice()
         local batt_lvl = 0
         local is_charging = false
@@ -190,13 +190,13 @@ local footerTextGeneratorMap = {
                 -- Sum both batteries for the actual text
                 batt_lvl = main_batt_lvl + aux_batt_lvl
                 -- But average 'em to compute the icon...
-                if symbol_type == "icons" or symbol_type == "compact_items" then
+                if symbol_style == "icons" or symbol_style == "compact" then
                     prefix = powerd:getBatterySymbol(powerd:isAuxCharged(), is_charging, batt_lvl / 2)
                 end
             else
                 is_charging = powerd:isCharging()
                 batt_lvl = main_batt_lvl
-                if symbol_type == "icons" or symbol_type == "compact_items" then
+                if symbol_style == "icons" or symbol_style == "compact" then
                    prefix = powerd:getBatterySymbol(powerd:isCharged(), is_charging, main_batt_lvl)
                 end
             end
@@ -207,8 +207,8 @@ local footerTextGeneratorMap = {
         end
 
         -- If we're using icons, use the fancy variable icon from powerd:getBatterySymbol
-        if symbol_type == "icons" or symbol_type == "compact_items" then
-            if symbol_type == "compact_items" then
+        if symbol_style == "icons" or symbol_style == "compact" then
+            if symbol_style == "compact" then
                 return BD.wrap(prefix)
             else
                 return BD.wrap(prefix) .. batt_lvl .. "%"
@@ -218,8 +218,8 @@ local footerTextGeneratorMap = {
         end
     end,
     bookmark_count = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].bookmark_count
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].bookmark_count
         local bookmark_count = footer.ui.bookmark:getNumberOfBookmarks()
         if footer.settings.all_at_once and footer.settings.hide_empty_generators and bookmark_count == 0 then
             return ""
@@ -227,8 +227,8 @@ local footerTextGeneratorMap = {
         return prefix .. " " .. tostring(bookmark_count)
     end,
     time = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].time
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].time
         local clock = datetime.secondsToHour(os.time(), G_reader_settings:isTrue("twelve_hour_clock"))
         if not prefix then
             return clock
@@ -261,8 +261,8 @@ local footerTextGeneratorMap = {
         end
     end,
     pages_left_book = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].pages_left_book
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].pages_left_book
         if footer.pageno then
             if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
                 -- (Page labels might not be numbers)
@@ -296,8 +296,8 @@ local footerTextGeneratorMap = {
         end
     end,
     pages_left = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].pages_left
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].pages_left
         local left = footer.ui.toc:getChapterPagesLeft(footer.pageno) or footer.ui.document:getTotalPagesLeft(footer.pageno)
         if footer.settings.pages_left_includes_current_page then
             left = left + 1
@@ -316,8 +316,8 @@ local footerTextGeneratorMap = {
         return current .. " ⁄⁄ " .. total
     end,
     percentage = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].percentage
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].percentage
         local digits = footer.settings.progress_pct_format
         local string_percentage = "%." .. digits .. "f%%"
         if footer.ui.document:hasHiddenFlows() then
@@ -332,20 +332,20 @@ local footerTextGeneratorMap = {
         return string_percentage:format(footer.progress_bar.percentage * 100)
     end,
     book_time_to_read = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].book_time_to_read
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].book_time_to_read
         local left = footer.ui.document:getTotalPagesLeft(footer.pageno)
         return footer:getDataFromStatistics(prefix and (prefix .. " ") or "", left)
     end,
     chapter_time_to_read = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].chapter_time_to_read
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].chapter_time_to_read
         local left = footer.ui.toc:getChapterPagesLeft(footer.pageno) or footer.ui.document:getTotalPagesLeft(footer.pageno)
         return footer:getDataFromStatistics(prefix .. " ", left)
     end,
     mem_usage = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].mem_usage
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].mem_usage
         local statm = io.open("/proc/self/statm", "r")
         if statm then
             local dummy, rss = statm:read("*number", "*number")
@@ -358,9 +358,9 @@ local footerTextGeneratorMap = {
     end,
     wifi_status = function(footer)
         -- NOTE: This one deviates a bit from the mold because, in icons mode, we simply use two different icons and no text.
-        local symbol_type = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_prefix
         local NetworkMgr = require("ui/network/manager")
-        if symbol_type == "icons" or symbol_type == "compact_items" then
+        if symbol_style == "icons" or symbol_style == "compact" then
             if NetworkMgr:isWifiOn() then
                 return symbol_prefix.icons.wifi_status
             else
@@ -371,7 +371,7 @@ local footerTextGeneratorMap = {
                 end
             end
         else
-            local prefix = symbol_prefix[symbol_type].wifi_status
+            local prefix = symbol_prefix[symbol_style].wifi_status
             if NetworkMgr:isWifiOn() then
                 return T(_("%1 On"), prefix)
             else
@@ -424,8 +424,8 @@ local footerTextGeneratorMap = {
         end
     end,
     custom_text = function(footer)
-        local symbol_type = footer.settings.item_prefix
-        local prefix = symbol_prefix[symbol_type].custom_text
+        local symbol_style = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_style].custom_text
         -- if custom_text contains only spaces, request to merge it with the text before and after,
         -- in other words, don't add a separator then.
         local merge = footer.custom_text:gsub(" ", ""):len() == 0
@@ -954,8 +954,8 @@ function ReaderFooter:updateFooterTextGenerator()
 end
 
 function ReaderFooter:progressPercentage(digits)
-    local symbol_type = self.settings.item_prefix
-    local prefix = symbol_prefix[symbol_type].percentage
+    local symbol_style = self.settings.item_prefix
+    local prefix = symbol_prefix[symbol_style].percentage
 
     local string_percentage
     if not prefix then
@@ -1410,7 +1410,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                         prefix_text = _("Icon prefixes")
                     elseif self.settings.item_prefix == "letters" then
                         prefix_text = _("Letter prefixes")
-                    elseif self.settings.item_prefix == "compact_items" then
+                    elseif self.settings.item_prefix == "compact" then
                         prefix_text = _("Compact")
                     end
                     return T(_("Style: %1"), prefix_text)
@@ -1422,7 +1422,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             for _, letter in pairs(symbol_prefix.icons) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(_("Icon Prefixes (%1)"), table.concat(sym_tbl, " "))
+                            return T(_("Icon prefixes (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "icons"
@@ -1438,7 +1438,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             for _, letter in pairs(symbol_prefix.letters) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(_("Letter Prefixes (%1)"), table.concat(sym_tbl, " "))
+                            return T(_("Letter prefixes (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "letters"
@@ -1451,16 +1451,16 @@ function ReaderFooter:addToMainMenu(menu_items)
                     {
                         text_func = function()
                             local sym_tbl = {}
-                            for _, letter in pairs(symbol_prefix.compact_items) do
+                            for _, letter in pairs(symbol_prefix.compact) do
                                 table.insert(sym_tbl, letter)
                             end
                             return T(_("Compact (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
-                            return self.settings.item_prefix == "compact_items"
+                            return self.settings.item_prefix == "compact"
                         end,
                         callback = function()
-                            self.settings.item_prefix = "compact_items"
+                            self.settings.item_prefix = "compact"
                             self:refreshFooter(true)
                         end,
                     },
@@ -2002,7 +2002,7 @@ end
 function ReaderFooter:genAllFooterText()
     local info = {}
     local separator = "  "
-    if self.settings.item_prefix == "compact_items" then
+    if self.settings.item_prefix == "compact" then
         separator = " "
     end
     local separator_symbol = self:get_separator_symbol()
@@ -2018,8 +2018,8 @@ function ReaderFooter:genAllFooterText()
         -- Skip empty generators, so they don't generate bogus separators
         local text, merge = gen(self)
         if text and text ~= "" then
-            if self.settings.item_prefix == "compact_items" then
-                -- remove whitespace from footer items if symbol_type is compact_items
+            if self.settings.item_prefix == "compact" then
+                -- remove whitespace from footer items if symbol_style is compact
                 -- use a hair-space to avoid issues with RTL display
                 text = text:gsub("%s", "\xE2\x80\x8A")
             end
@@ -2097,7 +2097,7 @@ function ReaderFooter:getDataFromStatistics(title, pages)
     local average_time_per_page = self:getAvgTimePerPage()
     local user_duration_format = G_reader_settings:readSetting("duration_format", "classic")
     if average_time_per_page then
-        sec = datetime.secondsToClockDuration(user_duration_format, pages * average_time_per_page, true, self.settings.item_prefix ~= "compact_items")
+        sec = datetime.secondsToClockDuration(user_duration_format, pages * average_time_per_page, true, self.settings.item_prefix ~= "compact")
     end
     return title .. sec
 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -140,7 +140,7 @@ local material_pixels = Screen:scaleByDPI(16)
 local footerTextGeneratorMap = {
     empty = function() return "" end,
     frontlight = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].frontlight
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
@@ -158,7 +158,7 @@ local footerTextGeneratorMap = {
         end
     end,
     frontlight_warmth = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].frontlight_warmth
         local powerd = Device:getPowerDevice()
         if powerd:isFrontlightOn() then
@@ -175,7 +175,7 @@ local footerTextGeneratorMap = {
         end
     end,
     battery = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].battery
         local powerd = Device:getPowerDevice()
         local batt_lvl = 0
@@ -218,7 +218,7 @@ local footerTextGeneratorMap = {
         end
     end,
     bookmark_count = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].bookmark_count
         local bookmark_count = footer.ui.bookmark:getNumberOfBookmarks()
         if footer.settings.all_at_once and footer.settings.hide_empty_generators and bookmark_count == 0 then
@@ -227,7 +227,7 @@ local footerTextGeneratorMap = {
         return prefix .. " " .. tostring(bookmark_count)
     end,
     time = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].time
         local clock = datetime.secondsToHour(os.time(), G_reader_settings:isTrue("twelve_hour_clock"))
         if not prefix then
@@ -261,7 +261,7 @@ local footerTextGeneratorMap = {
         end
     end,
     pages_left_book = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].pages_left_book
         if footer.pageno then
             if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
@@ -296,7 +296,7 @@ local footerTextGeneratorMap = {
         end
     end,
     pages_left = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].pages_left
         local left = footer.ui.toc:getChapterPagesLeft(footer.pageno) or footer.ui.document:getTotalPagesLeft(footer.pageno)
         if footer.settings.pages_left_includes_current_page then
@@ -316,7 +316,7 @@ local footerTextGeneratorMap = {
         return current .. " ⁄⁄ " .. total
     end,
     percentage = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].percentage
         local digits = footer.settings.progress_pct_format
         local string_percentage = "%." .. digits .. "f%%"
@@ -332,19 +332,19 @@ local footerTextGeneratorMap = {
         return string_percentage:format(footer.progress_bar.percentage * 100)
     end,
     book_time_to_read = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].book_time_to_read
         local left = footer.ui.document:getTotalPagesLeft(footer.pageno)
         return footer:getDataFromStatistics(prefix and (prefix .. " ") or "", left)
     end,
     chapter_time_to_read = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].chapter_time_to_read
         local left = footer.ui.toc:getChapterPagesLeft(footer.pageno) or footer.ui.document:getTotalPagesLeft(footer.pageno)
         return footer:getDataFromStatistics(prefix .. " ", left)
     end,
     mem_usage = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].mem_usage
         local statm = io.open("/proc/self/statm", "r")
         if statm then
@@ -358,7 +358,7 @@ local footerTextGeneratorMap = {
     end,
     wifi_status = function(footer)
         -- NOTE: This one deviates a bit from the mold because, in icons mode, we simply use two different icons and no text.
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local NetworkMgr = require("ui/network/manager")
         if symbol_style == "icons" or symbol_style == "compact" then
             if NetworkMgr:isWifiOn() then
@@ -424,7 +424,7 @@ local footerTextGeneratorMap = {
         end
     end,
     custom_text = function(footer)
-        local symbol_style = footer.settings.item_prefix
+        local symbol_style = footer.settings.item_style
         local prefix = symbol_prefix[symbol_style].custom_text
         -- if custom_text contains only spaces, request to merge it with the text before and after,
         -- in other words, don't add a separator then.
@@ -472,7 +472,7 @@ ReaderFooter.default_settings = {
     book_chapter = false,
     bookmark_count = false,
     chapter_progress = false,
-    item_prefix = "icons",
+    item_style = "icons",
     toc_markers_width = 2, -- unscaled_size_check: ignore
     text_font_size = 14, -- unscaled_size_check: ignore
     text_font_bold = false,
@@ -954,7 +954,7 @@ function ReaderFooter:updateFooterTextGenerator()
 end
 
 function ReaderFooter:progressPercentage(digits)
-    local symbol_style = self.settings.item_prefix
+    local symbol_style = self.settings.item_style
     local prefix = symbol_prefix[symbol_style].percentage
 
     local string_percentage
@@ -967,7 +967,7 @@ function ReaderFooter:progressPercentage(digits)
 end
 
 function ReaderFooter:textOptionTitles(option)
-    local symbol = self.settings.item_prefix
+    local symbol = self.settings.item_style
     local option_titles = {
         all_at_once = _("Show all at once"),
         reclaim_height = _("Reclaim bar height from bottom margin"),
@@ -1406,11 +1406,11 @@ function ReaderFooter:addToMainMenu(menu_items)
             {
                 text_func = function()
                     local prefix_text = ""
-                    if self.settings.item_prefix == "icons" then
+                    if self.settings.item_style == "icons" then
                         prefix_text = _("Icon prefixes")
-                    elseif self.settings.item_prefix == "letters" then
+                    elseif self.settings.item_style == "letters" then
                         prefix_text = _("Letter prefixes")
-                    elseif self.settings.item_prefix == "compact" then
+                    elseif self.settings.item_style == "compact" then
                         prefix_text = _("Compact")
                     end
                     return T(_("Style: %1"), prefix_text)
@@ -1425,10 +1425,10 @@ function ReaderFooter:addToMainMenu(menu_items)
                             return T(_("Icon prefixes (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
-                            return self.settings.item_prefix == "icons"
+                            return self.settings.item_style == "icons"
                         end,
                         callback = function()
-                            self.settings.item_prefix = "icons"
+                            self.settings.item_style = "icons"
                             self:refreshFooter(true)
                         end,
                     },
@@ -1441,10 +1441,10 @@ function ReaderFooter:addToMainMenu(menu_items)
                             return T(_("Letter prefixes (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
-                            return self.settings.item_prefix == "letters"
+                            return self.settings.item_style == "letters"
                         end,
                         callback = function()
-                            self.settings.item_prefix = "letters"
+                            self.settings.item_style = "letters"
                             self:refreshFooter(true)
                         end,
                     },
@@ -1457,10 +1457,10 @@ function ReaderFooter:addToMainMenu(menu_items)
                             return T(_("Compact (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
-                            return self.settings.item_prefix == "compact"
+                            return self.settings.item_style == "compact"
                         end,
                         callback = function()
-                            self.settings.item_prefix = "compact"
+                            self.settings.item_style = "compact"
                             self:refreshFooter(true)
                         end,
                     },
@@ -2002,7 +2002,7 @@ end
 function ReaderFooter:genAllFooterText()
     local info = {}
     local separator = "  "
-    if self.settings.item_prefix == "compact" then
+    if self.settings.item_style == "compact" then
         separator = " "
     end
     local separator_symbol = self:get_separator_symbol()
@@ -2018,7 +2018,7 @@ function ReaderFooter:genAllFooterText()
         -- Skip empty generators, so they don't generate bogus separators
         local text, merge = gen(self)
         if text and text ~= "" then
-            if self.settings.item_prefix == "compact" then
+            if self.settings.item_style == "compact" then
                 -- remove whitespace from footer items if symbol_style is compact
                 -- use a hair-space to avoid issues with RTL display
                 text = text:gsub("%s", "\xE2\x80\x8A")
@@ -2097,7 +2097,7 @@ function ReaderFooter:getDataFromStatistics(title, pages)
     local average_time_per_page = self:getAvgTimePerPage()
     local user_duration_format = G_reader_settings:readSetting("duration_format", "classic")
     if average_time_per_page then
-        sec = datetime.secondsToClockDuration(user_duration_format, pages * average_time_per_page, true, self.settings.item_prefix ~= "compact")
+        sec = datetime.secondsToClockDuration(user_duration_format, pages * average_time_per_page, true, self.settings.item_style ~= "compact")
     end
     return title .. sec
 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -341,8 +341,7 @@ local footerTextGeneratorMap = {
         local symbol_type = footer.settings.item_prefix
         local prefix = symbol_prefix[symbol_type].chapter_time_to_read
         local left = footer.ui.toc:getChapterPagesLeft(footer.pageno) or footer.ui.document:getTotalPagesLeft(footer.pageno)
-        return footer:getDataFromStatistics(
-            prefix .. " ", left)
+        return footer:getDataFromStatistics(prefix .. " ", left)
     end,
     mem_usage = function(footer)
         local symbol_type = footer.settings.item_prefix
@@ -1408,13 +1407,13 @@ function ReaderFooter:addToMainMenu(menu_items)
                 text_func = function()
                     local prefix_text = ""
                     if self.settings.item_prefix == "icons" then
-                        prefix_text = _("Icons")
-                    elseif self.settings.item_prefix == "compact_items" then
-                        prefix_text = _("Compact items")
+                        prefix_text = _("Icon prefixes")
                     elseif self.settings.item_prefix == "letters" then
-                        prefix_text = _("Letters")
+                        prefix_text = _("Letter prefixes")
+                    elseif self.settings.item_prefix == "compact_items" then
+                        prefix_text = _("Compact")
                     end
-                    return T(_("Prefix: %1"), prefix_text)
+                    return T(_("Style: %1"), prefix_text)
                 end,
                 sub_item_table = {
                     {
@@ -1423,7 +1422,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             for _, letter in pairs(symbol_prefix.icons) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(_("Icons (%1)"), table.concat(sym_tbl, " "))
+                            return T(_("Icon Prefixes (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "icons"
@@ -1436,32 +1435,32 @@ function ReaderFooter:addToMainMenu(menu_items)
                     {
                         text_func = function()
                             local sym_tbl = {}
-                            for _, letter in pairs(symbol_prefix.compact_items) do
-                                table.insert(sym_tbl, letter)
-                            end
-                            return T(_("Compact Items (%1)"), table.concat(sym_tbl, " "))
-                        end,
-                        checked_func = function()
-                            return self.settings.item_prefix == "compact_items"
-                        end,
-                        callback = function()
-                            self.settings.item_prefix = "compact_items"
-                            self:refreshFooter(true)
-                        end,
-                    },
-                    {
-                        text_func = function()
-                            local sym_tbl = {}
                             for _, letter in pairs(symbol_prefix.letters) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(_("Letters (%1)"), table.concat(sym_tbl, " "))
+                            return T(_("Letter Prefixes (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "letters"
                         end,
                         callback = function()
                             self.settings.item_prefix = "letters"
+                            self:refreshFooter(true)
+                        end,
+                    },
+                    {
+                        text_func = function()
+                            local sym_tbl = {}
+                            for _, letter in pairs(symbol_prefix.compact_items) do
+                                table.insert(sym_tbl, letter)
+                            end
+                            return T(_("Compact (%1)"), table.concat(sym_tbl, " "))
+                        end,
+                        checked_func = function()
+                            return self.settings.item_prefix == "compact_items"
+                        end,
+                        callback = function()
+                            self.settings.item_prefix = "compact_items"
                             self:refreshFooter(true)
                         end,
                     },
@@ -2098,7 +2097,7 @@ function ReaderFooter:getDataFromStatistics(title, pages)
     local average_time_per_page = self:getAvgTimePerPage()
     local user_duration_format = G_reader_settings:readSetting("duration_format", "classic")
     if average_time_per_page then
-        sec = datetime.secondsToClockDuration(user_duration_format, pages * average_time_per_page, true)
+        sec = datetime.secondsToClockDuration(user_duration_format, pages * average_time_per_page, true, self.settings.item_prefix ~= "compact_items")
     end
     return title .. sec
 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1408,11 +1408,11 @@ function ReaderFooter:addToMainMenu(menu_items)
                 text_func = function()
                     local prefix_text = ""
                     if self.settings.item_prefix == "icons" then
-                        prefix_text = C_("Status bar", "Icon")
+                        prefix_text = C_("Status bar", "Icons")
                     elseif self.settings.item_prefix == "compact_items" then
                         prefix_text = C_("Status bar", "Compact")
                     elseif self.settings.item_prefix == "letters" then
-                        prefix_text = C_("Status bar", "Letter")
+                        prefix_text = C_("Status bar", "Letters")
                     end
                     return T(_("Item style: %1"), prefix_text)
                 end,
@@ -1423,7 +1423,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             for _, letter in pairs(symbol_prefix.icons) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "Icon (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "Icons (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "icons"
@@ -1439,7 +1439,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             for _, letter in pairs(symbol_prefix.letters) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "Letter (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "Letters (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "letters"

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20221027
+local CURRENT_MIGRATION_DATE = 20221213
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -495,6 +495,18 @@ if last_migration_date < 20221027 then
         G_reader_settings:makeFalse("followed_link_marker")
     end
 end
+
+-- 20221213, Rename footer.item_prefix to footer.style (#9915)
+if last_migration_date < 20221213 then
+    logger.info("Performing one-time migration for 20221213")
+
+    local footer = G_reader_settings:child("footer")
+    if footer and footer:has("item_prefix") then
+        local item_prefix = footer:readSetting("item_prefix")
+        footer:saveSetting("item_style", item_prefix)
+        footer:delSetting("item_prefix")
+    end
+  end
 
 -- We're done, store the current migration date
 G_reader_settings:saveSetting("last_migration_date", CURRENT_MIGRATION_DATE)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20221213
+local CURRENT_MIGRATION_DATE = 20221027
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -495,18 +495,6 @@ if last_migration_date < 20221027 then
         G_reader_settings:makeFalse("followed_link_marker")
     end
 end
-
--- 20221213, Rename footer.item_prefix to footer.style (#9915)
-if last_migration_date < 20221213 then
-    logger.info("Performing one-time migration for 20221213")
-
-    local footer = G_reader_settings:child("footer")
-    if footer and footer:has("item_prefix") then
-        local item_prefix = footer:readSetting("item_prefix")
-        footer:saveSetting("item_style", item_prefix)
-        footer:delSetting("item_prefix")
-    end
-  end
 
 -- We're done, store the current migration date
 G_reader_settings:saveSetting("last_migration_date", CURRENT_MIGRATION_DATE)


### PR DESCRIPTION
Seems like at some point in the past, we've expanded from the original Icon/Letter/Compact paradigm applying only to prefixes. These 3 options today apply to the entirety of the footer status bar items. Some non-prefix-related things today that depend on whether the "Compact" option is selected:

- separation spacing between status bar items
- the width of the whitespace within the actual items themselves

This change adds one more thing: when the modern time format is selected, and the Compact option is not selected, we display time left in chapter and time left in book as full hms format (8m23s) instead of 8m23'. Compact remains in the 8m23' format.

And since this option was already extended beyond the prefix level, I've rechristened it with the more fitting name "Item style":
- I've changed the label for these options from "Prefix:" to "Item style:" in the settings.
- I changed the label "Compact Items" to just "Compact" since this option also incorporates compactness in the prefixes as well as the items. "Letter prefixes" and "Icon prefixes" remain with the same names since they're only different in their prefixes
- I moved "Compact" from between the other two to last in the list since it's more different from the Icon Prefixes and Letter Prefixes styles than they are to one another.

I updated variable names to match and added migration for the user setting `item_prefix` to `item_style`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9915)
<!-- Reviewable:end -->
