### PR TITLE
Do not increment db sequences unnecessarily during cloud sync

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2893,7 +2893,10 @@ function ReaderStatistics.onSync(local_path, cached_path, income_path)
             title, authors, notes, last_open, highlights, pages, series, language, md5, total_read_time, total_read_pages
         ) SELECT
             title, authors, notes, last_open, highlights, pages, series, language, md5, total_read_time, total_read_pages
-        FROM income_db.book WHERE true ON CONFLICT (title, authors, md5) DO NOTHING;
+        FROM income_db.book
+        WHERE (title, authors, md5) NOT IN (
+            SELECT title, authors, md5 FROM book
+        );
 
         -- We create a book_id mapping temp table (view not possible due to attached db)
         CREATE TEMP TABLE book_id_map AS

--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -436,7 +436,7 @@ function VocabularyBuilder.onSync(local_path, cached_path, income_path)
     sql = sql .. [[
         -- We merge the local db with income db to form the synced db.
         -- First we do the books
-        INSERT OR IGNORE INTO title (name) SELECT name FROM income_db.title;
+        INSERT INTO title (name) SELECT name FROM income_db.title WHERE name NOT IN (SELECT name FROM title);
 
         -- Then update income db's book title id references
         UPDATE income_db.vocabulary SET title_id = ifnull(


### PR DESCRIPTION
I love the statistics cloud sync @weijiuqiao created for #9709.
One minor annoyance with the original version, though: *every* time you run the sync process, the sqlite autoincrement sequence increases by the total number of books in the database, even if literally nothing has changed in the statistics database.

When you do an insert using either `ON CONFLICT [...] DO NOTHING` or `INSERT OR IGNORE` to prevent duplicate rows, sqlite still increments the sequence counter for each of the duplicate rows that it did not insert.
The only way around that is to explicitly write the SQL statement so that it doesn't try to insert the duplicates in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9921)
<!-- Reviewable:end -->
