### PR TITLE
Spin off hms as selectable time format

### DIFF
--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -186,8 +186,8 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
 end
 
 --- Converts seconds to a clock type (classic or modern), based on the given format preference
---- "Classic" format calls secondsToClock, "Modern" and "Literal" formats call secondsToHClock
----- @string Either "modern" for 1h30'10", "literal" for 1h30m10s, or "classic" for 1:30:10
+--- "Classic" format calls secondsToClock, "Modern" and "Letters" formats call secondsToHClock
+---- @string Either "modern" for 1h30'10", "letters" for 1h30m10s, or "classic" for 1:30:10
 ---- @bool withoutSeconds if true 1h30' or 1h30m, if false 1h30'10" or 1h30m10s
 ---- @bool withDays, if hours>=24 include days in clock string 1d12h10m10s
 ---- @bool compact, if set removes all leading zeros (incl. units if necessary)
@@ -195,7 +195,7 @@ end
 function datetime.secondsToClockDuration(format, seconds, withoutSeconds, withDays, compact)
     if format == "modern" then
         return datetime.secondsToHClock(seconds, withoutSeconds, false, withDays, compact)
-    elseif format == "literal" then
+    elseif format == "letters" then
         return datetime.secondsToHClock(seconds, withoutSeconds, true, withDays, compact)
     else
          -- Assume "classic" to give safe default

--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -113,6 +113,7 @@ end
 ---- @bool withoutSeconds if true 1h30', if false 1h30'10"
 ---- @bool hmsFormat, if true format 1h30m10s
 ---- @bool withDays, if true format 1d12h30m10s
+---- @bool compact, if set removes all leading zeros (incl. units if necessary)
 ---- @treturn string clock string in the form of 1h30'10" or 1h30m10s
 function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, compact)
     local SECONDS_SYMBOL = "\""
@@ -185,16 +186,17 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
 end
 
 --- Converts seconds to a clock type (classic or modern), based on the given format preference
---- "Classic" format calls secondsToClock, and "Modern" format calls secondsToHClock
----- @string Either "modern" for 1h30'10" or "classic" for 1:30:10
+--- "Classic" format calls secondsToClock, "Modern" and "Literal" formats call secondsToHClock
+---- @string Either "modern" for 1h30'10", "literal" for 1h30m10s, or "classic" for 1:30:10
 ---- @bool withoutSeconds if true 1h30' or 1h30m, if false 1h30'10" or 1h30m10s
----- @bool hmsFormat, modern format only, if true format 1h30m or 1h30m10s
 ---- @bool withDays, if hours>=24 include days in clock string 1d12h10m10s
 ---- @bool compact, if set removes all leading zeros (incl. units if necessary)
 ---- @treturn string clock string in the specific format of 1h30', 1h30'10" resp. 1h30m, 1h30m10s
-function datetime.secondsToClockDuration(format, seconds, withoutSeconds, hmsFormat, withDays, compact)
+function datetime.secondsToClockDuration(format, seconds, withoutSeconds, withDays, compact)
     if format == "modern" then
-        return datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, compact)
+        return datetime.secondsToHClock(seconds, withoutSeconds, false, withDays, compact)
+    elseif format == "literal" then
+        return datetime.secondsToHClock(seconds, withoutSeconds, true, withDays, compact)
     else
          -- Assume "classic" to give safe default
         return datetime.secondsToClock(seconds, withoutSeconds, withDays)

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -89,8 +89,8 @@ common_settings.time = {
                 local text = C_("Time", "Classic")
                 if duration_format == "modern" then
                     text = C_("Time", "Modern")
-                elseif duration_format == "literal" then
-                    text = C_("Time", "Literal")
+                elseif duration_format == "letters" then
+                    text = C_("Time", "Letters")
                 end
                 return T(_("Duration format: %1"), text)
             end,
@@ -129,14 +129,14 @@ common_settings.time = {
                     text_func = function()
                         local datetime = require("datetime")
                         -- sample text shows 1h23m45s
-                        local duration_format_str = datetime.secondsToClockDuration("literal", 5025, false)
-                        return T(C_("Time", "Literal (%1)"), duration_format_str)
+                        local duration_format_str = datetime.secondsToClockDuration("letters", 5025, false)
+                        return T(C_("Time", "Letters (%1)"), duration_format_str)
                     end,
                     checked_func = function()
-                        return G_reader_settings:readSetting("duration_format") == "literal"
+                        return G_reader_settings:readSetting("duration_format") == "letters"
                     end,
                     callback = function()
-                        G_reader_settings:saveSetting("duration_format", "literal")
+                        G_reader_settings:saveSetting("duration_format", "letters")
                         UIManager:broadcastEvent(Event:new("UpdateFooter", true, true))
                     end,
                 },

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -7,6 +7,7 @@ local NetworkMgr = require("ui/network/manager")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 local N_ = _.ngettext
+local C_ = _.pgettext
 local Screen = Device.screen
 local T = require("ffi/util").template
 
@@ -85,7 +86,12 @@ common_settings.time = {
         {
             text_func = function ()
                 local duration_format = G_reader_settings:readSetting("duration_format", "classic")
-                local text = duration_format == "classic" and _("Classic") or _("Modern")
+                local text = C_("Time", "Classic")
+                if duration_format == "modern" then
+                    text = C_("Time", "Modern")
+                elseif duration_format == "literal" then
+                    text = C_("Time", "Literal")
+                end
                 return T(_("Duration format: %1"), text)
             end,
             sub_item_table = {
@@ -94,7 +100,7 @@ common_settings.time = {
                         local datetime = require("datetime")
                         -- sample text shows 1:23:45
                         local duration_format_str = datetime.secondsToClockDuration("classic", 5025, false)
-                        return T(_("Classic (%1)"), duration_format_str)
+                        return T(C_("Time", "Classic (%1)"), duration_format_str)
                     end,
                     checked_func = function()
                         return G_reader_settings:readSetting("duration_format") == "classic"
@@ -107,15 +113,30 @@ common_settings.time = {
                 {
                     text_func = function()
                         local datetime = require("datetime")
-                        -- sample text shows 1h23m45s
+                        -- sample text shows 1h23'45"
                         local duration_format_str = datetime.secondsToClockDuration("modern", 5025, false)
-                        return T(_("Modern (%1)"), duration_format_str)
+                        return T(C_("Time", "Modern (%1)"), duration_format_str)
                     end,
                     checked_func = function()
                         return G_reader_settings:readSetting("duration_format") == "modern"
                     end,
                     callback = function()
                         G_reader_settings:saveSetting("duration_format", "modern")
+                        UIManager:broadcastEvent(Event:new("UpdateFooter", true, true))
+                    end,
+                },
+                {
+                    text_func = function()
+                        local datetime = require("datetime")
+                        -- sample text shows 1h23m45s
+                        local duration_format_str = datetime.secondsToClockDuration("literal", 5025, false)
+                        return T(C_("Time", "Literal (%1)"), duration_format_str)
+                    end,
+                    checked_func = function()
+                        return G_reader_settings:readSetting("duration_format") == "literal"
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting("duration_format", "literal")
                         UIManager:broadcastEvent(Event:new("UpdateFooter", true, true))
                     end,
                 },

--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -55,7 +55,7 @@ function AutoDim:getAutoDimMenu()
                 text_func = function()
                     return self.autodim_starttime_m <= 0 and _("Idle time for dimmer") or
                     T(_("Idle time for dimmer: %1"),
-                        datetime.secondsToClockDuration("modern", self.autodim_starttime_m * 60, false, true, false, true))
+                        datetime.secondsToClockDuration("literal", self.autodim_starttime_m * 60, false, false, true))
                 end,
                 checked_func = function() return self.autodim_starttime_m > 0 end,
                 callback = function(touchmenu_instance)
@@ -94,7 +94,7 @@ function AutoDim:getAutoDimMenu()
             {
                 text_func = function()
                     return T(_("Dimmer duration: %1"),
-                        datetime.secondsToClockDuration("modern", self.autodim_duration_s, false, true, false, true))
+                        datetime.secondsToClockDuration("literal", self.autodim_duration_s, false, false, true))
                 end,
                 enabled_func = function() return self.autodim_starttime_m > 0 end,
                 callback = function(touchmenu_instance)

--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -55,7 +55,7 @@ function AutoDim:getAutoDimMenu()
                 text_func = function()
                     return self.autodim_starttime_m <= 0 and _("Idle time for dimmer") or
                     T(_("Idle time for dimmer: %1"),
-                        datetime.secondsToClockDuration("literal", self.autodim_starttime_m * 60, false, false, true))
+                        datetime.secondsToClockDuration("letters", self.autodim_starttime_m * 60, false, false, true))
                 end,
                 checked_func = function() return self.autodim_starttime_m > 0 end,
                 callback = function(touchmenu_instance)
@@ -94,7 +94,7 @@ function AutoDim:getAutoDimMenu()
             {
                 text_func = function()
                     return T(_("Dimmer duration: %1"),
-                        datetime.secondsToClockDuration("literal", self.autodim_duration_s, false, false, true))
+                        datetime.secondsToClockDuration("letters", self.autodim_duration_s, false, false, true))
                 end,
                 enabled_func = function() return self.autodim_starttime_m > 0 end,
                 callback = function(touchmenu_instance)

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -485,14 +485,14 @@ function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
                 self:_start()
             end
             if touchmenu_instance then touchmenu_instance:updateItems() end
-            local time_string = datetime.secondsToClockDuration("literal", self[setting],
+            local time_string = datetime.secondsToClockDuration("letters", self[setting],
                 time_scale == 2 or time_scale == 1, true)
             UIManager:show(InfoMessage:new{
                 text = T(_("%1: %2"), title, time_string),
                 timeout = 3,
             })
         end,
-        default_value = datetime.secondsToClockDuration("literal", default_value,
+        default_value = datetime.secondsToClockDuration("letters", default_value,
             time_scale == 2 or time_scale == 1, true),
         default_callback = function()
             local day, hour, min, sec -- luacheck: ignore 431
@@ -539,7 +539,7 @@ function AutoSuspend:addToMainMenu(menu_items)
         end,
         text_func = function()
             if self.auto_suspend_timeout_seconds and self.auto_suspend_timeout_seconds > 0 then
-                local time_string = datetime.secondsToClockDuration("literal",
+                local time_string = datetime.secondsToClockDuration("letters",
                     self.auto_suspend_timeout_seconds, true, true)
                 return T(_("Autosuspend timeout: %1"), time_string)
             else
@@ -565,7 +565,7 @@ function AutoSuspend:addToMainMenu(menu_items)
             end,
             text_func = function()
                 if self.autoshutdown_timeout_seconds and self.autoshutdown_timeout_seconds > 0 then
-                    local time_string = datetime.secondsToClockDuration("literal", self.autoshutdown_timeout_seconds,
+                    local time_string = datetime.secondsToClockDuration("letters", self.autoshutdown_timeout_seconds,
                         true, true)
                     return T(_("Autoshutdown timeout: %1"), time_string)
                 else
@@ -604,7 +604,7 @@ Upon user input, the device needs a certain amount of time to wake up. Generally
             end,
             text_func = function()
                 if self.auto_standby_timeout_seconds and self.auto_standby_timeout_seconds > 0 then
-                    local time_string = datetime.secondsToClockDuration("literal", self.auto_standby_timeout_seconds,
+                    local time_string = datetime.secondsToClockDuration("letters", self.auto_standby_timeout_seconds,
                         false, true, true)
                     return T(_("Autostandby timeout: %1"), time_string)
                 else

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -485,15 +485,15 @@ function AutoSuspend:pickTimeoutValue(touchmenu_instance, title, info, setting,
                 self:_start()
             end
             if touchmenu_instance then touchmenu_instance:updateItems() end
-            local time_string = datetime.secondsToClockDuration("modern", self[setting],
-                time_scale == 2 or time_scale == 1, true, true)
+            local time_string = datetime.secondsToClockDuration("literal", self[setting],
+                time_scale == 2 or time_scale == 1, true)
             UIManager:show(InfoMessage:new{
                 text = T(_("%1: %2"), title, time_string),
                 timeout = 3,
             })
         end,
-        default_value = datetime.secondsToClockDuration("modern", default_value,
-            time_scale == 2 or time_scale == 1, true, true),
+        default_value = datetime.secondsToClockDuration("literal", default_value,
+            time_scale == 2 or time_scale == 1, true),
         default_callback = function()
             local day, hour, min, sec -- luacheck: ignore 431
             if time_scale == 2 then
@@ -539,8 +539,8 @@ function AutoSuspend:addToMainMenu(menu_items)
         end,
         text_func = function()
             if self.auto_suspend_timeout_seconds and self.auto_suspend_timeout_seconds > 0 then
-                local time_string = datetime.secondsToClockDuration("modern",
-                    self.auto_suspend_timeout_seconds, true, true, true)
+                local time_string = datetime.secondsToClockDuration("literal",
+                    self.auto_suspend_timeout_seconds, true, true)
                 return T(_("Autosuspend timeout: %1"), time_string)
             else
                 return _("Autosuspend timeout")
@@ -565,8 +565,8 @@ function AutoSuspend:addToMainMenu(menu_items)
             end,
             text_func = function()
                 if self.autoshutdown_timeout_seconds and self.autoshutdown_timeout_seconds > 0 then
-                    local time_string = datetime.secondsToClockDuration("modern", self.autoshutdown_timeout_seconds,
-                        true, true, true)
+                    local time_string = datetime.secondsToClockDuration("literal", self.autoshutdown_timeout_seconds,
+                        true, true)
                     return T(_("Autoshutdown timeout: %1"), time_string)
                 else
                     return _("Autoshutdown timeout")
@@ -604,8 +604,8 @@ Upon user input, the device needs a certain amount of time to wake up. Generally
             end,
             text_func = function()
                 if self.auto_standby_timeout_seconds and self.auto_standby_timeout_seconds > 0 then
-                    local time_string = datetime.secondsToClockDuration("modern", self.auto_standby_timeout_seconds,
-                        false, true, true, true)
+                    local time_string = datetime.secondsToClockDuration("literal", self.auto_standby_timeout_seconds,
+                        false, true, true)
                     return T(_("Autostandby timeout: %1"), time_string)
                 else
                     return _("Autostandby timeout")

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -67,7 +67,7 @@ function AutoTurn:_start()
 
         local text
         if self.autoturn_distance == 1 then
-            local time_string = datetime.secondsToClockDuration("literal", self.autoturn_sec, false, true, true)
+            local time_string = datetime.secondsToClockDuration("letters", self.autoturn_sec, false, true, true)
             text = T(_("Autoturn is now active and will automatically turn the page every %1."), time_string)
         else
             text = T(_("Autoturn is now active and will automatically scroll %1 % of the page every %2 seconds."),
@@ -141,7 +141,7 @@ function AutoTurn:addToMainMenu(menu_items)
     menu_items.autoturn = {
         sorting_hint = "navi",
         text_func = function()
-            local time_string = datetime.secondsToClockDuration("literal", self.autoturn_sec, false, true, true)
+            local time_string = datetime.secondsToClockDuration("letters", self.autoturn_sec, false, true, true)
             return self:_enabled() and T(_("Autoturn: %1"), time_string) or _("Autoturn")
         end,
         checked_func = function() return self:_enabled() end,

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -67,7 +67,7 @@ function AutoTurn:_start()
 
         local text
         if self.autoturn_distance == 1 then
-            local time_string = datetime.secondsToClockDuration("modern", self.autoturn_sec, false, true, true, true)
+            local time_string = datetime.secondsToClockDuration("literal", self.autoturn_sec, false, true, true)
             text = T(_("Autoturn is now active and will automatically turn the page every %1."), time_string)
         else
             text = T(_("Autoturn is now active and will automatically scroll %1 % of the page every %2 seconds."),
@@ -141,7 +141,7 @@ function AutoTurn:addToMainMenu(menu_items)
     menu_items.autoturn = {
         sorting_hint = "navi",
         text_func = function()
-            local time_string = datetime.secondsToClockDuration("modern", self.autoturn_sec, false, true, true, true)
+            local time_string = datetime.secondsToClockDuration("literal", self.autoturn_sec, false, true, true)
             return self:_enabled() and T(_("Autoturn: %1"), time_string) or _("Autoturn")
         end,
         checked_func = function() return self:_enabled() end,

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -81,7 +81,7 @@ end
 local function duration(number)
     local duration_fmt = G_reader_settings:readSetting("duration_format", "classic")
     return type(number) ~= "number" and number or
-        datetime.secondsToClockDuration(duration_fmt, number, true, true, true)
+        datetime.secondsToClockDuration(duration_fmt, number, true, true)
 end
 
 function Usage:dump(kv_pairs, id)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1477,9 +1477,9 @@ function ReaderStatistics:getCurrentStat()
     local estimate_end_of_read_date = datetime.secondsToDate(tonumber(now_ts + estimate_days_to_read * 86400), true)
     local estimates_valid = time_to_read > 0 -- above values could be 'nan' and 'nil'
     local user_duration_format = G_reader_settings:readSetting("duration_format", "classic")
-    local avg_page_time_string = datetime.secondsToClockDuration(user_duration_format, self.avg_time, false, true)
-    local avg_day_time_string = datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true)
-    local time_to_read_string = estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false, true) or _("N/A")
+    local avg_page_time_string = datetime.secondsToClockDuration(user_duration_format, self.avg_time, false)
+    local avg_day_time_string = datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false)
+    local time_to_read_string = estimates_valid and datetime.secondsToClockDuration(user_duration_format, time_to_read, false) or _("N/A")
 
     -- Use more_arrow to indicate that an option shows another view
     -- Use " ⓘ" to indicate that an option will show an info message
@@ -1498,11 +1498,11 @@ function ReaderStatistics:getCurrentStat()
         -- Global statistics (may consider other books than current book)
 
         -- Since last resume
-        { _("Time spent reading this session"), datetime.secondsToClockDuration(user_duration_format, current_duration, false, true) },
+        { _("Time spent reading this session"), datetime.secondsToClockDuration(user_duration_format, current_duration, false) },
         { _("Pages read this session"), tonumber(current_pages), separator = true },
 
         -- Today
-        { _("Time spent reading today") .. " " .. more_arrow, datetime.secondsToClockDuration(user_duration_format, today_duration, false, true),
+        { _("Time spent reading today") .. " " .. more_arrow, datetime.secondsToClockDuration(user_duration_format, today_duration, false),
             callback = function()
                 local CalendarView = require("calendarview")
                 local title_callback = function(this)
@@ -1516,9 +1516,9 @@ function ReaderStatistics:getCurrentStat()
         -- Current book statistics (includes re-reads)
 
         -- Time-focused book stats
-        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true) },
+        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false) },
         -- capped to self.settings.max_sec per distinct page
-        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true) },
+        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false) },
         -- estimation, from current page to end of book
         { _("Estimated reading time left") .. " ⓘ", time_to_read_string, callback = estimated_popup, separator = true },
 
@@ -1635,8 +1635,8 @@ function ReaderStatistics:getBookStat(id_book)
         { _("Author(s)"), authors, separator = true },
 
         -- Time-focused book stats
-        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true) },
-        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false, true), separator = true },
+        { _("Total time spent on this book"), datetime.secondsToClockDuration(user_duration_format, total_time_book, false) },
+        { _("Time spent reading"), datetime.secondsToClockDuration(user_duration_format, book_read_time, false), separator = true },
 
         -- Day-focused book stats
         { _("Days reading this book") .. " " .. more_arrow, tonumber(total_days),
@@ -1656,7 +1656,7 @@ function ReaderStatistics:getBookStat(id_book)
                 UIManager:show(self.kv)
             end,
         },
-        { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false, true), separator = true },
+        { _("Average time per day"), datetime.secondsToClockDuration(user_duration_format, book_read_time/tonumber(total_days), false), separator = true },
 
         -- Date-focused book stats
         { _("Book start date"), T(N_("(1 day ago) %2", "(%1 days ago) %2", first_open_days_ago), first_open_days_ago, datetime.secondsToDate(tonumber(first_open), true)) },
@@ -1665,7 +1665,7 @@ function ReaderStatistics:getBookStat(id_book)
         -- Page-focused book stats
         { _("Last read page/Total pages"), string.format("%d / %d (%d%%)", last_page, pages, Math.round(100*last_page/pages)) },
         { _("Pages read"), string.format("%d (%d%%)", total_read_pages, Math.round(100*total_read_pages/pages)) },
-        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false, true), separator = true },
+        { _("Average time per page"), datetime.secondsToClockDuration(user_duration_format, avg_time_per_page, false), separator = true },
 
         -- Highlights
         { _("Book highlights"), highlights }
@@ -1872,7 +1872,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             local stop_month = os.time{year=year_end, month=month_end, day=1, hour=0, min=0 }
             table.insert(results, {
                 date_text,
-                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackMonthly(start_month, stop_month, date_text, book_mode)
                 end,
@@ -1886,7 +1886,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
             begin_week = begin_week - weekday * 86400
             table.insert(results, {
                 date_text,
-                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackWeekly(begin_week, begin_week + 7 * 86400, date_text, book_mode)
                 end,
@@ -1897,7 +1897,7 @@ function ReaderStatistics:getDatesFromAll(sdays, ptype, book_mode)
                 - 60 * tonumber(string.sub(time_book,3,4)) - tonumber(string.sub(time_book,5,6))
             table.insert(results, {
                 date_text,
-                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+                T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false), tonumber(result_book[2][i])),
                 callback = function()
                     self:callbackDaily(begin_day, begin_day + 86400, date_text)
                 end,
@@ -1938,7 +1938,7 @@ function ReaderStatistics:getDaysFromPeriod(period_begin, period_end)
             day=string.sub(result_book[1][i],9,10), hour=0, min=0, sec=0 }
         table.insert(results, {
             result_book[1][i],
-            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false), tonumber(result_book[2][i])),
             callback = function()
                 local kv = self.kv
                 UIManager:close(kv)
@@ -1982,7 +1982,7 @@ function ReaderStatistics:getBooksFromPeriod(period_begin, period_end, callback_
     for i=1, #result_book.title do
         table.insert(results, {
             result_book[1][i],
-            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[3][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false, true), tonumber(result_book[3][i])),
+            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[3][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[2][i]), false), tonumber(result_book[3][i])),
             book_id = tonumber(result_book[4][i]),
             callback = function()
                 local kv = self.kv
@@ -2090,7 +2090,7 @@ function ReaderStatistics:getDatesForBook(id_book)
     for i=1, #result_book.dates do
         table.insert(results, {
             result_book[1][i],
-            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false, true), tonumber(result_book[2][i])),
+            T(N_("%1 (%2 page)", "%1 (%2 pages)", tonumber(result_book[2][i])), datetime.secondsToClockDuration(user_duration_format, tonumber(result_book[3][i]), false), tonumber(result_book[2][i])),
             hold_callback = function(kv_page, kv_item)
                 self:resetStatsForBookForPeriod(id_book, result_book[4][i], result_book[5][i], result_book[1][i], function()
                     kv_page:removeKeyValueItem(kv_item) -- Reset, refresh what's displayed
@@ -2189,7 +2189,7 @@ function ReaderStatistics:getTotalStats()
         end
         table.insert(total_stats, {
             book_title,
-            datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true),
+            datetime.secondsToClockDuration(user_duration_format, total_time_book, false),
             callback = function()
                 local kv = self.kv
                 UIManager:close(self.kv)
@@ -2211,7 +2211,7 @@ function ReaderStatistics:getTotalStats()
     end
     conn:close()
 
-    return T(_("Total time spent reading: %1"), datetime.secondsToClockDuration(user_duration_format, total_books_time, false, true)), total_stats
+    return T(_("Total time spent reading: %1"), datetime.secondsToClockDuration(user_duration_format, total_books_time, false)), total_stats
 end
 
 function ReaderStatistics:genResetBookSubItemTable()
@@ -2291,7 +2291,7 @@ function ReaderStatistics:resetPerBook()
         if id_book ~= self.id_curr_book then
             table.insert(total_stats, {
                 book_title,
-                datetime.secondsToClockDuration(user_duration_format, total_time_book, false, true),
+                datetime.secondsToClockDuration(user_duration_format, total_time_book, false),
                 id_book,
                 callback = function(kv_page, kv_item)
                     UIManager:show(ConfirmBox:new{

--- a/plugins/statistics.koplugin/readerprogress.lua
+++ b/plugins/statistics.koplugin/readerprogress.lua
@@ -335,7 +335,7 @@ function ReaderProgress:genSummaryDay(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, self.current_duration, true, true),
+                text = datetime.secondsToClockDuration(user_duration_format, self.current_duration, true),
                 face = self.medium_font_face,
             },
         },
@@ -349,7 +349,7 @@ function ReaderProgress:genSummaryDay(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, self.today_duration, true, true),
+                text = datetime.secondsToClockDuration(user_duration_format, self.today_duration, true),
                 face = self.medium_font_face,
             },
         },
@@ -437,7 +437,7 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time), true, true),
+                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time), true),
                 face = self.medium_font_face,
             },
         },
@@ -451,7 +451,7 @@ function ReaderProgress:genSummaryWeek(width)
         CenterContainer:new{
             dimen = Geom:new{ w = tile_width, h = tile_height },
             TextWidget:new{
-                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time) * (1/7), true, true),
+                text = datetime.secondsToClockDuration(user_duration_format, math.floor(total_time) * (1/7), true),
                 face = self.medium_font_face,
             }
         }

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -70,21 +70,21 @@ function SystemStat:appendCounters()
         standby = Device.total_standby_time
     end
     self:put({"  " .. _("Up time"),
-            datetime.secondsToClockDuration("", time.to_s(uptime), false, true, true)})
+            datetime.secondsToClockDuration("", time.to_s(uptime), false, true)})
     if Device:canSuspend() or Device:canStandby() then
         local awake = uptime - suspend - standby
         self:put({"  " .. _("Time spent awake"),
-            datetime.secondsToClockDuration("", time.to_s(awake), false, true, true)
+            datetime.secondsToClockDuration("", time.to_s(awake), false, true)
             .. " (" .. Math.round((awake / uptime) * 100) .. "%)"})
     end
     if Device:canSuspend() then
         self:put({"  " .. _("Time in suspend"),
-            datetime.secondsToClockDuration("", time.to_s(suspend), false, true, true)
+            datetime.secondsToClockDuration("", time.to_s(suspend), false, true)
             .. " (" .. Math.round((suspend / uptime) * 100) .. "%)"})
     end
     if Device:canStandby() then
         self:put({"  " .. _("Time in standby"),
-            datetime.secondsToClockDuration("", time.to_s(standby), false, true, true)
+            datetime.secondsToClockDuration("", time.to_s(standby), false, true)
             .. " (" .. Math.round((standby / uptime) * 100) .. "%)"})
     end
     self:put({_("Counters"), ""})

--- a/spec/unit/datetime_spec.lua
+++ b/spec/unit/datetime_spec.lua
@@ -112,7 +112,7 @@ describe("datetime module", function()
             assert.is_equal("10h01'30\"",
                             datetime.secondsToClockDuration("modern", 36090, false))
             assert.is_equal("10h01m30s",
-                            datetime.secondsToClockDuration("literal", 36090, false))
+                            datetime.secondsToClockDuration("letters", 36090, false))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
             assert.is_equal("10:01:30",
@@ -126,9 +126,9 @@ describe("datetime module", function()
             assert.is_equal("10h02'",
                             datetime.secondsToClockDuration("modern", 36090, true))
             assert.is_equal("10h01m30s",
-                            datetime.secondsToClockDuration("literal", 36090, false))
+                            datetime.secondsToClockDuration("letters", 36090, false))
             assert.is_equal("10h02m",
-                            datetime.secondsToClockDuration("literal", 36090, true))
+                            datetime.secondsToClockDuration("letters", 36090, true))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
             assert.is_equal("10:02",

--- a/spec/unit/datetime_spec.lua
+++ b/spec/unit/datetime_spec.lua
@@ -109,8 +109,10 @@ describe("datetime module", function()
 
     describe("secondsToClockDuration()", function()
         it("should change type based on format", function()
+            assert.is_equal("10h01'30\"",
+                            datetime.secondsToClockDuration("modern", 36090, false))
             assert.is_equal("10h01m30s",
-                            datetime.secondsToClockDuration("modern", 36090, false, true))
+                            datetime.secondsToClockDuration("literal", 36090, false))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
             assert.is_equal("10:01:30",
@@ -119,28 +121,18 @@ describe("datetime module", function()
                             datetime.secondsToClockDuration(nil, 36090, false))
         end)
         it("should pass along withoutSeconds", function()
+            assert.is_equal("10h01'30\"",
+                            datetime.secondsToClockDuration("modern", 36090, false))
+            assert.is_equal("10h02'",
+                            datetime.secondsToClockDuration("modern", 36090, true))
             assert.is_equal("10h01m30s",
-                            datetime.secondsToClockDuration("modern", 36090, false, true))
+                            datetime.secondsToClockDuration("literal", 36090, false))
             assert.is_equal("10h02m",
-                            datetime.secondsToClockDuration("modern", 36090, true, true))
+                            datetime.secondsToClockDuration("literal", 36090, true))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
             assert.is_equal("10:02",
                             datetime.secondsToClockDuration("classic", 36090, true))
-        end)
-        it("should pass along hmsFormat for modern format", function()
-            assert.is_equal("10h01'30\"",
-                            datetime.secondsToClockDuration("modern", 36090))
-            assert.is_equal("10h01m30s",
-                            datetime.secondsToClockDuration("modern", 36090, false, true))
-            assert.is_equal("10h02m",
-                            datetime.secondsToClockDuration("modern", 36090, true, true))
-            assert.is_equal("10h02'",
-                            datetime.secondsToClockDuration("modern", 36090, true, false))
-            assert.is_equal("10:01:30",
-                            datetime.secondsToClockDuration("classic", 36090, false, true))
-            assert.is_equal("10:01:30",
-                            datetime.secondsToClockDuration("classic", 36090, false, false))
         end)
     end)
 


### PR DESCRIPTION
The bare minimum changes to do this as talked about in that other PR. Mostly updating `datetime.secondsToClockDuration()` usages. Updated tests

The name of the hms option is up for debate. "Literal" is the stand-in

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9924)
<!-- Reviewable:end -->
