### PR TITLE
Fix on tap toggling of checkmark in sort widget

### DIFF
--- a/frontend/ui/widget/checkmark.lua
+++ b/frontend/ui/widget/checkmark.lua
@@ -84,4 +84,12 @@ function CheckMark:init()
     self.dimen = unchecked_widget:getSize()
 end
 
+function CheckMark:paintTo(bb, x, y)
+    WidgetContainer.paintTo(self, bb, x, y)
+    -- We need to update self.dimen's x and y for any
+    -- ges.pos:intersectWith(check_mark) to work.
+    self.dimen.x = x
+    self.dimen.y = y
+end
+
 return CheckMark

--- a/frontend/ui/widget/checkmark.lua
+++ b/frontend/ui/widget/checkmark.lua
@@ -85,9 +85,10 @@ function CheckMark:init()
 end
 
 function CheckMark:paintTo(bb, x, y)
-    WidgetContainer.paintTo(self, bb, x, y)
-    -- We need to update self.dimen's x and y for any
-    -- ges.pos:intersectWith(check_mark) to work.
+    -- NOTE: Account for alignment/offsets computation being tacked on to self.dimen...
+    --       This is dumb and probably means we're doing something wonky... somewhere, but it works,
+    --       and allows us to keep sensible coordinates in dimen, so that they can be used for hitbox checks.
+    WidgetContainer.paintTo(self, bb, x - self.dimen.x, y - self.dimen.y)
     self.dimen.x = x
     self.dimen.y = y
 end


### PR DESCRIPTION
The x and y coordinates of SortItemWidget's checkmark widget were not updated, thus remained at their initial value 0. Consequently the [intersectWith check in SortItemWidget:onTap](https://github.com/koreader/koreader/blob/788ccac5613af02812ae210bb801e682836f1ca4/frontend/ui/widget/sortwidget.lua#L96) always evaluated to false, resulting in taps on checkmarks in the sort widget not being recognized.

I considered putting this directly in WidgetContainer so that intersectWith tests are also possible with other widgets than CheckMark that dervie from  WidgetContainer, but decided against it, because I found a [usage](https://github.com/koreader/koreader/blob/788ccac5613af02812ae210bb801e682836f1ca4/plugins/perceptionexpander.koplugin/main.lua#L73) of the ["offset" feature present in WidgetContainer](https://github.com/koreader/koreader/blob/788ccac5613af02812ae210bb801e682836f1ca4/frontend/ui/widget/container/widgetcontainer.lua#L58) in the perceptionexpander plugin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9941)
<!-- Reviewable:end -->
