### PR TITLE
Add file dialog buttons to change book status

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -343,7 +343,7 @@ function FileManager:setupLayout()
                 self:refreshPath()
                 UIManager:close(self.file_dialog)
             end
-            table.insert(buttons, filemanagerutil.getStatusButtonsRow(file, status_button_callback))
+            table.insert(buttons, filemanagerutil.genStatusButtonsRow(file, status_button_callback))
             table.insert(buttons, {}) -- separator
             table.insert(buttons, {
                 filemanagerutil.genResetSettingsButton(file, nil, status_button_callback),

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -342,7 +342,7 @@ function FileManager:setupLayout()
             local status = filemanagerutil.getStatus(file)
             table.insert(buttons, {
                 {
-                    text = _("Mark as reading"),
+                    text = _("Reading"),
                     id = "mark_as_reading", -- used by covermenu
                     enabled = status ~= "reading",
                     callback = function()
@@ -352,7 +352,7 @@ function FileManager:setupLayout()
                     end,
                 },
                 {
-                    text = _("Put on hold"),
+                    text = _("On hold"),
                     id = "put_on_hold", -- used by covermenu
                     enabled = status ~= "abandoned",
                     callback = function()
@@ -362,7 +362,7 @@ function FileManager:setupLayout()
                     end,
                 },
                 {
-                    text = _("Mark as read"),
+                    text = _("Finished"),
                     id = "mark_as_read", -- used by covermenu
                     enabled = status ~= "complete",
                     callback = function()

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -344,11 +344,7 @@ function FileManager:setupLayout()
                 self:refreshPath()
                 UIManager:close(self.file_dialog)
             end
-            table.insert(buttons, {
-                filemanagerutil.genStatusButton("reading", status ~= "reading", file, status_button_callback),
-                filemanagerutil.genStatusButton("abandoned", status ~= "abandoned", file, status_button_callback),
-                filemanagerutil.genStatusButton("complete", status ~= "complete", file, status_button_callback),
-            })
+            table.insert(buttons, filemanagerutil.getStatusButtonsRow(status, file, status_button_callback))
             table.insert(buttons, {}) -- separator
             table.insert(buttons, {
                 {

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -343,6 +343,7 @@ function FileManager:setupLayout()
             table.insert(buttons, {
                 {
                     text = _("Mark as reading"),
+                    id = "mark_as_reading", -- used by covermenu
                     enabled = status ~= "reading",
                     callback = function()
                         filemanagerutil.setStatus(file, "reading")
@@ -352,6 +353,7 @@ function FileManager:setupLayout()
                 },
                 {
                     text = _("Put on hold"),
+                    id = "put_on_hold", -- used by covermenu
                     enabled = status ~= "abandoned",
                     callback = function()
                         filemanagerutil.setStatus(file, "abandoned")
@@ -361,6 +363,7 @@ function FileManager:setupLayout()
                 },
                 {
                     text = _("Mark as read"),
+                    id = "mark_as_read", -- used by covermenu
                     enabled = status ~= "complete",
                     callback = function()
                         filemanagerutil.setStatus(file, "complete")
@@ -373,6 +376,7 @@ function FileManager:setupLayout()
             table.insert(buttons, {
                 {
                     text = _("Reset settings"),
+                    id = "reset_settings", -- used by covermenu
                     enabled = DocSettings:hasSidecarFile(BaseUtil.realpath(file)),
                     callback = function()
                         UIManager:show(ConfirmBox:new{

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -373,7 +373,7 @@ function FileManager:setupLayout()
             table.insert(buttons, {
                 {
                     text = _("Reset settings"),
-                    enabled = is_file and DocSettings:hasSidecarFile(BaseUtil.realpath(file)),
+                    enabled = DocSettings:hasSidecarFile(BaseUtil.realpath(file)),
                     callback = function()
                         UIManager:show(ConfirmBox:new{
                             text = T(_("Reset settings for this document?\n\n%1\n\nAny highlights or bookmarks will be permanently lost."), BD.filepath(file)),

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -351,19 +351,19 @@ function FileManager:setupLayout()
                     end,
                 },
                 {
-                    text = _("Mark as read"),
-                    enabled = status ~= "complete",
+                    text = _("Put on hold"),
+                    enabled = status ~= "abandoned",
                     callback = function()
-                        filemanagerutil.setStatus(file, "complete")
+                        filemanagerutil.setStatus(file, "abandoned")
                         self:refreshPath()
                         UIManager:close(self.file_dialog)
                     end,
                 },
                 {
-                    text = _("Put on hold"),
-                    enabled = status ~= "abandoned",
+                    text = _("Mark as read"),
+                    enabled = status ~= "complete",
                     callback = function()
-                        filemanagerutil.setStatus(file, "abandoned")
+                        filemanagerutil.setStatus(file, "complete")
                         self:refreshPath()
                         UIManager:close(self.file_dialog)
                     end,

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -339,15 +339,7 @@ function FileManager:setupLayout()
         end
 
         if is_file then
-            local status = nil
-            if DocSettings:hasSidecarFile(file) then
-                local docinfo = DocSettings:open(file) -- no io handles created, do not close
-                if docinfo.data.summary and docinfo.data.summary.status and docinfo.data.summary.status ~= "" then
-                    status = docinfo.data.summary.status
-                else
-                    status = "reading"
-                end
-            end
+            local status = filemanagerutil.getStatus(file)
             table.insert(buttons, {
                 {
                     text = _("Mark as reading"),

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -340,37 +340,27 @@ function FileManager:setupLayout()
 
         if is_file then
             local status = filemanagerutil.getStatus(file)
+            local function genStatusButton(to_status)
+                local status_text = {
+                    reading   = _("Reading"),
+                    abandoned = _("On hold"),
+                    complete  = _("Finished"),
+                }
+                return {
+                    text = status_text[to_status],
+                    id = to_status, -- used by covermenu
+                    enabled = status ~= to_status,
+                    callback = function()
+                        filemanagerutil.setStatus(file, to_status)
+                        self:refreshPath()
+                        UIManager:close(self.file_dialog)
+                    end,
+                }
+            end
             table.insert(buttons, {
-                {
-                    text = _("Reading"),
-                    id = "mark_as_reading", -- used by covermenu
-                    enabled = status ~= "reading",
-                    callback = function()
-                        filemanagerutil.setStatus(file, "reading")
-                        self:refreshPath()
-                        UIManager:close(self.file_dialog)
-                    end,
-                },
-                {
-                    text = _("On hold"),
-                    id = "put_on_hold", -- used by covermenu
-                    enabled = status ~= "abandoned",
-                    callback = function()
-                        filemanagerutil.setStatus(file, "abandoned")
-                        self:refreshPath()
-                        UIManager:close(self.file_dialog)
-                    end,
-                },
-                {
-                    text = _("Finished"),
-                    id = "mark_as_read", -- used by covermenu
-                    enabled = status ~= "complete",
-                    callback = function()
-                        filemanagerutil.setStatus(file, "complete")
-                        self:refreshPath()
-                        UIManager:close(self.file_dialog)
-                    end,
-                },
+                genStatusButton("reading"),
+                genStatusButton("abandoned"),
+                genStatusButton("complete"),
             })
             table.insert(buttons, {}) -- separator
             table.insert(buttons, {

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -335,13 +335,52 @@ function FileManager:setupLayout()
                     end,
                 }
             )
+            table.insert(buttons, {}) -- separator
         end
 
         if is_file then
+            local status = nil
+            if DocSettings:hasSidecarFile(file) then
+                local docinfo = DocSettings:open(file) -- no io handles created, do not close
+                if docinfo.data.summary and docinfo.data.summary.status and docinfo.data.summary.status ~= "" then
+                    status = docinfo.data.summary.status
+                else
+                    status = "reading"
+                end
+            end
+            table.insert(buttons, {
+                {
+                    text = _("Mark as reading"),
+                    enabled = status ~= "reading",
+                    callback = function()
+                        filemanagerutil.setStatus(file, "reading")
+                        self:refreshPath()
+                        UIManager:close(self.file_dialog)
+                    end,
+                },
+                {
+                    text = _("Mark as read"),
+                    enabled = status ~= "complete",
+                    callback = function()
+                        filemanagerutil.setStatus(file, "complete")
+                        self:refreshPath()
+                        UIManager:close(self.file_dialog)
+                    end,
+                },
+                {
+                    text = _("Put on hold"),
+                    enabled = status ~= "abandoned",
+                    callback = function()
+                        filemanagerutil.setStatus(file, "abandoned")
+                        self:refreshPath()
+                        UIManager:close(self.file_dialog)
+                    end,
+                },
+            })
+            table.insert(buttons, {}) -- separator
             table.insert(buttons, {
                 {
                     text = _("Reset settings"),
-                    id = "reset_settings", -- used by covermenu
                     enabled = is_file and DocSettings:hasSidecarFile(BaseUtil.realpath(file)),
                     callback = function()
                         UIManager:show(ConfirmBox:new{

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -339,31 +339,14 @@ function FileManager:setupLayout()
         end
 
         if is_file then
-            local status = filemanagerutil.getStatus(file)
             local function status_button_callback()
                 self:refreshPath()
                 UIManager:close(self.file_dialog)
             end
-            table.insert(buttons, filemanagerutil.getStatusButtonsRow(status, file, status_button_callback))
+            table.insert(buttons, filemanagerutil.getStatusButtonsRow(file, status_button_callback))
             table.insert(buttons, {}) -- separator
             table.insert(buttons, {
-                {
-                    text = _("Reset settings"),
-                    id = "reset_settings", -- used by covermenu
-                    enabled = DocSettings:hasSidecarFile(BaseUtil.realpath(file)),
-                    callback = function()
-                        UIManager:show(ConfirmBox:new{
-                            text = T(_("Reset settings for this document?\n\n%1\n\nAny highlights or bookmarks will be permanently lost."), BD.filepath(file)),
-                            ok_text = _("Reset"),
-                            ok_callback = function()
-                                filemanagerutil.purgeSettings(file)
-                                require("readhistory"):fileSettingsPurged(file)
-                                self:refreshPath()
-                                UIManager:close(self.file_dialog)
-                            end,
-                        })
-                    end,
-                },
+                filemanagerutil.genResetSettingsButton(file, nil, status_button_callback),
                 {
                     text_func = function()
                         if ReadCollection:checkItemExist(file) then

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -340,27 +340,14 @@ function FileManager:setupLayout()
 
         if is_file then
             local status = filemanagerutil.getStatus(file)
-            local function genStatusButton(to_status)
-                local status_text = {
-                    reading   = _("Reading"),
-                    abandoned = _("On hold"),
-                    complete  = _("Finished"),
-                }
-                return {
-                    text = status_text[to_status],
-                    id = to_status, -- used by covermenu
-                    enabled = status ~= to_status,
-                    callback = function()
-                        filemanagerutil.setStatus(file, to_status)
-                        self:refreshPath()
-                        UIManager:close(self.file_dialog)
-                    end,
-                }
+            local function status_button_callback()
+                self:refreshPath()
+                UIManager:close(self.file_dialog)
             end
             table.insert(buttons, {
-                genStatusButton("reading"),
-                genStatusButton("abandoned"),
-                genStatusButton("complete"),
+                filemanagerutil.genStatusButton("reading", status ~= "reading", file, status_button_callback),
+                filemanagerutil.genStatusButton("abandoned", status ~= "abandoned", file, status_button_callback),
+                filemanagerutil.genStatusButton("complete", status ~= "complete", file, status_button_callback),
             })
             table.insert(buttons, {}) -- separator
             table.insert(buttons, {

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -46,28 +46,15 @@ end
 function FileManagerCollection:onMenuHold(item)
     self.collfile_dialog = nil
     local status = filemanagerutil.getStatus(item.file)
-    local function genStatusButton(to_status)
-        local status_text = {
-            reading   = _("Reading"),
-            abandoned = _("On hold"),
-            complete  = _("Finished"),
-        }
-        return {
-            text = status_text[to_status],
-            id = to_status, -- used by covermenu
-            enabled = status ~= to_status,
-            callback = function()
-                filemanagerutil.setStatus(item.file, to_status)
-                self._manager:updateItemTable()
-                UIManager:close(self.collfile_dialog)
-            end,
-        }
+    local function status_button_callback()
+        self._manager:updateItemTable()
+        UIManager:close(self.collfile_dialog)
     end
     local buttons = {
         {
-            genStatusButton("reading"),
-            genStatusButton("abandoned"),
-            genStatusButton("complete"),
+            filemanagerutil.genStatusButton("reading", status ~= "reading", item.file, status_button_callback),
+            filemanagerutil.genStatusButton("abandoned", status ~= "abandoned", item.file, status_button_callback),
+            filemanagerutil.genStatusButton("complete", status ~= "complete", item.file, status_button_callback),
         },
         {},
         {

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -46,38 +46,28 @@ end
 function FileManagerCollection:onMenuHold(item)
     self.collfile_dialog = nil
     local status = filemanagerutil.getStatus(item.file)
+    local function genStatusButton(to_status)
+        local status_text = {
+            reading   = _("Reading"),
+            abandoned = _("On hold"),
+            complete  = _("Finished"),
+        }
+        return {
+            text = status_text[to_status],
+            id = to_status, -- used by covermenu
+            enabled = status ~= to_status,
+            callback = function()
+                filemanagerutil.setStatus(item.file, to_status)
+                self._manager:updateItemTable()
+                UIManager:close(self.collfile_dialog)
+            end,
+        }
+    end
     local buttons = {
         {
-            {
-                text = _("Reading"),
-                id = "mark_as_reading", -- used by covermenu
-                enabled = status ~= "reading",
-                callback = function()
-                    filemanagerutil.setStatus(item.file, "reading")
-                    self._manager:updateItemTable()
-                    UIManager:close(self.collfile_dialog)
-                end,
-            },
-            {
-                text = _("On hold"),
-                id = "put_on_hold", -- used by covermenu
-                enabled = status ~= "abandoned",
-                callback = function()
-                    filemanagerutil.setStatus(item.file, "abandoned")
-                    self._manager:updateItemTable()
-                    UIManager:close(self.collfile_dialog)
-                end,
-            },
-            {
-                text = _("Finished"),
-                id = "mark_as_read", -- used by covermenu
-                enabled = status ~= "complete",
-                callback = function()
-                    filemanagerutil.setStatus(item.file, "complete")
-                    self._manager:updateItemTable()
-                    UIManager:close(self.collfile_dialog)
-                end,
-            },
+            genStatusButton("reading"),
+            genStatusButton("abandoned"),
+            genStatusButton("complete"),
         },
         {},
         {

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -50,7 +50,7 @@ function FileManagerCollection:onMenuHold(item)
         UIManager:close(self.collfile_dialog)
     end
     local buttons = {
-        filemanagerutil.getStatusButtonsRow(item.file, status_button_callback),
+        filemanagerutil.genStatusButtonsRow(item.file, status_button_callback),
         {},
         {
             filemanagerutil.genResetSettingsButton(item.file, currently_opened_file, status_button_callback),

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -56,19 +56,19 @@ function FileManagerCollection:onMenuHold(item)
                 end,
             },
             {
-                text = _("Mark as read"),
-                enabled = status ~= "complete",
+                text = _("Put on hold"),
+                enabled = status ~= "abandoned",
                 callback = function()
-                    filemanagerutil.setStatus(item.file, "complete")
+                    filemanagerutil.setStatus(item.file, "abandoned")
                     self._manager:updateItemTable()
                     UIManager:close(self.collfile_dialog)
                 end,
             },
             {
-                text = _("Put on hold"),
-                enabled = status ~= "abandoned",
+                text = _("Mark as read"),
+                enabled = status ~= "complete",
                 callback = function()
-                    filemanagerutil.setStatus(item.file, "abandoned")
+                    filemanagerutil.setStatus(item.file, "complete")
                     self._manager:updateItemTable()
                     UIManager:close(self.collfile_dialog)
                 end,

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -8,6 +8,7 @@ local ReadCollection = require("readcollection")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local Screen = require("device").screen
+local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local BaseUtil = require("ffi/util")
 local util = require("util")
 local _ = require("gettext")
@@ -42,7 +43,38 @@ end
 
 function FileManagerCollection:onMenuHold(item)
     self.collfile_dialog = nil
+    local status = filemanagerutil.getStatus(item.file)
     local buttons = {
+        {
+            {
+                text = _("Mark as reading"),
+                enabled = status ~= "reading",
+                callback = function()
+                    filemanagerutil.setStatus(item.file, "reading")
+                    self._manager:updateItemTable()
+                    UIManager:close(self.collfile_dialog)
+                end,
+            },
+            {
+                text = _("Mark as read"),
+                enabled = status ~= "complete",
+                callback = function()
+                    filemanagerutil.setStatus(item.file, "complete")
+                    self._manager:updateItemTable()
+                    UIManager:close(self.collfile_dialog)
+                end,
+            },
+            {
+                text = _("Put on hold"),
+                enabled = status ~= "abandoned",
+                callback = function()
+                    filemanagerutil.setStatus(item.file, "abandoned")
+                    self._manager:updateItemTable()
+                    UIManager:close(self.collfile_dialog)
+                end,
+            },
+        },
+        {},
         {
             {
                 text = _("Sort"),

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -50,6 +50,7 @@ function FileManagerCollection:onMenuHold(item)
         {
             {
                 text = _("Mark as reading"),
+                id = "mark_as_reading", -- used by covermenu
                 enabled = status ~= "reading",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "reading")
@@ -59,6 +60,7 @@ function FileManagerCollection:onMenuHold(item)
             },
             {
                 text = _("Put on hold"),
+                id = "put_on_hold", -- used by covermenu
                 enabled = status ~= "abandoned",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "abandoned")
@@ -68,6 +70,7 @@ function FileManagerCollection:onMenuHold(item)
             },
             {
                 text = _("Mark as read"),
+                id = "mark_as_read", -- used by covermenu
                 enabled = status ~= "complete",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "complete")
@@ -80,6 +83,7 @@ function FileManagerCollection:onMenuHold(item)
         {
             {
                 text = _("Reset settings"),
+                id = "reset_settings", -- used by covermenu
                 enabled = DocSettings:hasSidecarFile(BaseUtil.realpath(item.file)),
                 callback = function()
                     UIManager:show(ConfirmBox:new{

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -85,6 +85,7 @@ function FileManagerCollection:onMenuHold(item)
         {
             {
                 text = _("Book information"),
+                id = "book_information", -- used by covermenu
                 enabled = FileManagerBookInfo:isSupported(item.file),
                 callback = function()
                     FileManagerBookInfo:show(item.file)

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -50,10 +50,10 @@ function FileManagerCollection:onMenuHold(item)
         UIManager:close(self.collfile_dialog)
     end
     local buttons = {
-        filemanagerutil.getStatusButtonsRow(item.file, currently_opened_file, status_button_callback),
+        filemanagerutil.getStatusButtonsRow(item.file, status_button_callback),
         {},
         {
-            filemanagerutil.genResetSettingsButton(item.file, nil, status_button_callback),
+            filemanagerutil.genResetSettingsButton(item.file, currently_opened_file, status_button_callback),
             {
                 text = _("Remove from collection"),
                 callback = function()

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -49,7 +49,7 @@ function FileManagerCollection:onMenuHold(item)
     local buttons = {
         {
             {
-                text = _("Mark as reading"),
+                text = _("Reading"),
                 id = "mark_as_reading", -- used by covermenu
                 enabled = status ~= "reading",
                 callback = function()
@@ -59,7 +59,7 @@ function FileManagerCollection:onMenuHold(item)
                 end,
             },
             {
-                text = _("Put on hold"),
+                text = _("On hold"),
                 id = "put_on_hold", -- used by covermenu
                 enabled = status ~= "abandoned",
                 callback = function()
@@ -69,7 +69,7 @@ function FileManagerCollection:onMenuHold(item)
                 end,
             },
             {
-                text = _("Mark as read"),
+                text = _("Finished"),
                 id = "mark_as_read", -- used by covermenu
                 enabled = status ~= "complete",
                 callback = function()

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -51,11 +51,7 @@ function FileManagerCollection:onMenuHold(item)
         UIManager:close(self.collfile_dialog)
     end
     local buttons = {
-        {
-            filemanagerutil.genStatusButton("reading", status ~= "reading", item.file, status_button_callback),
-            filemanagerutil.genStatusButton("abandoned", status ~= "abandoned", item.file, status_button_callback),
-            filemanagerutil.genStatusButton("complete", status ~= "complete", item.file, status_button_callback),
-        },
+        filemanagerutil.getStatusButtonsRow(status, item.file, status_button_callback),
         {},
         {
             {

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -95,6 +95,7 @@ function FileManagerHistory:onMenuHold(item)
         {
             {
                 text = _("Mark as reading"),
+                id = "mark_as_reading", -- used by covermenu
                 enabled = is_file and status ~= "reading",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "reading")
@@ -109,6 +110,7 @@ function FileManagerHistory:onMenuHold(item)
             },
             {
                 text = _("Put on hold"),
+                id = "put_on_hold", -- used by covermenu
                 enabled = is_file and status ~= "abandoned",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "abandoned")
@@ -123,6 +125,7 @@ function FileManagerHistory:onMenuHold(item)
             },
             {
                 text = _("Mark as read"),
+                id = "mark_as_read", -- used by covermenu
                 enabled = is_file and status ~= "complete",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "complete")
@@ -140,6 +143,7 @@ function FileManagerHistory:onMenuHold(item)
         {
             {
                 text = _("Reset settings"),
+                id = "reset_settings", -- used by covermenu
                 enabled = item.file ~= currently_opened_file and DocSettings:hasSidecarFile(FFIUtil.realpath(item.file)),
                 callback = function()
                     UIManager:show(ConfirmBox:new{

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -94,7 +94,7 @@ function FileManagerHistory:onMenuHold(item)
     local buttons = {
         {
             {
-                text = _("Mark as reading"),
+                text = _("Reading"),
                 id = "mark_as_reading", -- used by covermenu
                 enabled = is_file and status ~= "reading",
                 callback = function()
@@ -109,7 +109,7 @@ function FileManagerHistory:onMenuHold(item)
                 end,
             },
             {
-                text = _("Put on hold"),
+                text = _("On hold"),
                 id = "put_on_hold", -- used by covermenu
                 enabled = is_file and status ~= "abandoned",
                 callback = function()
@@ -124,7 +124,7 @@ function FileManagerHistory:onMenuHold(item)
                 end,
             },
             {
-                text = _("Mark as read"),
+                text = _("Finished"),
                 id = "mark_as_read", -- used by covermenu
                 enabled = is_file and status ~= "complete",
                 callback = function()

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -90,33 +90,20 @@ function FileManagerHistory:onMenuHold(item)
     local currently_opened_file = readerui_instance and readerui_instance.document and readerui_instance.document.file
     self.histfile_dialog = nil
     local status = filemanagerutil.getStatus(item.file)
-    local function genStatusButton(to_status)
-        local status_text = {
-            reading   = _("Reading"),
-            abandoned = _("On hold"),
-            complete  = _("Finished"),
-        }
-        return {
-            text = status_text[to_status],
-            id = to_status, -- used by covermenu
-            enabled = not item.dim and status ~= to_status,
-            callback = function()
-                filemanagerutil.setStatus(item.file, to_status)
-                if self._manager.filter ~= "all" then
-                    self._manager:fetchStatuses(false)
-                else
-                    self._manager.statuses_fetched = false
-                end
-                self._manager:updateItemTable()
-                UIManager:close(self.histfile_dialog)
-            end,
-        }
+    local function status_button_callback()
+        if self._manager.filter ~= "all" then
+            self._manager:fetchStatuses(false)
+        else
+            self._manager.statuses_fetched = false
+        end
+        self._manager:updateItemTable()
+        UIManager:close(self.histfile_dialog)
     end
     local buttons = {
         {
-            genStatusButton("reading"),
-            genStatusButton("abandoned"),
-            genStatusButton("complete"),
+            filemanagerutil.genStatusButton("reading", not item.dim and status ~= "reading", item.file, status_button_callback),
+            filemanagerutil.genStatusButton("abandoned", not item.dim and status ~= "abandoned", item.file, status_button_callback),
+            filemanagerutil.genStatusButton("complete", not item.dim and status ~= "complete", item.file, status_button_callback),
         },
         {},
         {

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -107,10 +107,10 @@ function FileManagerHistory:onMenuHold(item)
                 end,
             },
             {
-                text = _("Mark as read"),
-                enabled = status ~= "complete",
+                text = _("Put on hold"),
+                enabled = status ~= "abandoned",
                 callback = function()
-                    filemanagerutil.setStatus(item.file, "complete")
+                    filemanagerutil.setStatus(item.file, "abandoned")
                     if self._manager.filter ~= "all" then
                         self._manager:fetchStatuses(false)
                     else
@@ -121,10 +121,10 @@ function FileManagerHistory:onMenuHold(item)
                 end,
             },
             {
-                text = _("Put on hold"),
-                enabled = status ~= "abandoned",
+                text = _("Mark as read"),
+                enabled = status ~= "complete",
                 callback = function()
-                    filemanagerutil.setStatus(item.file, "abandoned")
+                    filemanagerutil.setStatus(item.file, "complete")
                     if self._manager.filter ~= "all" then
                         self._manager:fetchStatuses(false)
                     else

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -140,7 +140,7 @@ function FileManagerHistory:onMenuHold(item)
         },
     }
     if not item.dim then
-        table.insert(buttons, 1, filemanagerutil.getStatusButtonsRow(item.file, status_button_callback))
+        table.insert(buttons, 1, filemanagerutil.genStatusButtonsRow(item.file, status_button_callback))
         table.insert(buttons, 2, {})
     end
     self.histfile_dialog = ButtonDialogTitle:new{

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -89,12 +89,13 @@ function FileManagerHistory:onMenuHold(item)
     local readerui_instance = require("apps/reader/readerui"):_getRunningInstance()
     local currently_opened_file = readerui_instance and readerui_instance.document and readerui_instance.document.file
     self.histfile_dialog = nil
+    local is_file = lfs.attributes(item.file, "mode") == "file"
     local status = filemanagerutil.getStatus(item.file)
     local buttons = {
         {
             {
                 text = _("Mark as reading"),
-                enabled = status ~= "reading",
+                enabled = is_file and status ~= "reading",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "reading")
                     if self._manager.filter ~= "all" then
@@ -108,7 +109,7 @@ function FileManagerHistory:onMenuHold(item)
             },
             {
                 text = _("Put on hold"),
-                enabled = status ~= "abandoned",
+                enabled = is_file and status ~= "abandoned",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "abandoned")
                     if self._manager.filter ~= "all" then
@@ -122,7 +123,7 @@ function FileManagerHistory:onMenuHold(item)
             },
             {
                 text = _("Mark as read"),
-                enabled = status ~= "complete",
+                enabled = is_file and status ~= "complete",
                 callback = function()
                     filemanagerutil.setStatus(item.file, "complete")
                     if self._manager.filter ~= "all" then

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -101,12 +101,6 @@ function FileManagerHistory:onMenuHold(item)
     end
     local buttons = {
         {
-            filemanagerutil.genStatusButton("reading", not item.dim and status ~= "reading", item.file, status_button_callback),
-            filemanagerutil.genStatusButton("abandoned", not item.dim and status ~= "abandoned", item.file, status_button_callback),
-            filemanagerutil.genStatusButton("complete", not item.dim and status ~= "complete", item.file, status_button_callback),
-        },
-        {},
-        {
             {
                 text = _("Reset settings"),
                 id = "reset_settings", -- used by covermenu
@@ -169,6 +163,10 @@ function FileManagerHistory:onMenuHold(item)
              },
         },
     }
+    if not item.dim then
+        table.insert(buttons, 1, filemanagerutil.getStatusButtonsRow(status, item.file, status_button_callback))
+        table.insert(buttons, 2, {})
+    end
     self.histfile_dialog = ButtonDialogTitle:new{
         title = BD.filename(item.text:match("([^/]+)$")),
         title_align = "center",

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -112,27 +112,10 @@ function filemanagerutil.setStatus(file, status)
     docinfo:flush()
 end
 
--- Generate a book status file dialog button
-function filemanagerutil.genStatusButton(to_status, current_status, file, caller_callback)
-    local status_text = {
-        reading   = _("Reading"),
-        abandoned = _("On hold"),
-        complete  = _("Finished"),
-    }
-    return {
-        text = status_text[to_status],
-        id = to_status, -- used by covermenu
-        enabled = current_status ~= to_status,
-        callback = function()
-            filemanagerutil.setStatus(file, to_status)
-            caller_callback()
-        end,
-    }
-end
-
 -- Generate all book status file dialog buttons in a row
 function filemanagerutil.getStatusButtonsRow(file, caller_callback)
-    local function genStatusButton(to_status, current_status)
+    local status = filemanagerutil.getStatus(file)
+    local function genStatusButton(to_status)
         local status_text = {
             reading   = _("Reading"),
             abandoned = _("On hold"),
@@ -141,14 +124,13 @@ function filemanagerutil.getStatusButtonsRow(file, caller_callback)
         return {
             text = status_text[to_status],
             id = to_status, -- used by covermenu
-            enabled = current_status ~= to_status,
+            enabled = status ~= to_status,
             callback = function()
                 filemanagerutil.setStatus(file, to_status)
                 caller_callback()
             end,
         }
     end
-    local status = filemanagerutil.getStatus(file)
     return {
         genStatusButton("reading", status, file, caller_callback),
         genStatusButton("abandoned", status, file, caller_callback),

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -108,4 +108,22 @@ function filemanagerutil.setStatus(file, status)
     docinfo:flush()
 end
 
+-- Generate a book status file dialog button
+function filemanagerutil.genStatusButton(to_status, enabled, file, caller_callback)
+    local status_text = {
+        reading   = _("Reading"),
+        abandoned = _("On hold"),
+        complete  = _("Finished"),
+    }
+    return {
+        text = status_text[to_status],
+        id = to_status, -- used by covermenu
+        enabled = enabled,
+        callback = function()
+            filemanagerutil.setStatus(file, to_status)
+            caller_callback()
+        end,
+    }
+end
+
 return filemanagerutil

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -132,9 +132,9 @@ function filemanagerutil.getStatusButtonsRow(file, caller_callback)
         }
     end
     return {
-        genStatusButton("reading", status, file, caller_callback),
-        genStatusButton("abandoned", status, file, caller_callback),
-        genStatusButton("complete", status, file, caller_callback),
+        genStatusButton("reading"),
+        genStatusButton("abandoned"),
+        genStatusButton("complete"),
     }
 end
 

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -81,7 +81,7 @@ end
 function filemanagerutil.setStatus(file, status)
     -- In case the book doesn't have a sidecar file, this'll create it
     local docinfo = DocSettings:open(file)
-    local summary = nil
+    local summary
     if docinfo.data.summary and docinfo.data.summary.status then
         -- Book already had the full BookStatus table in its sidecar, easy peasy!
         docinfo.data.summary.status = status

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -113,7 +113,7 @@ function filemanagerutil.setStatus(file, status)
 end
 
 -- Generate all book status file dialog buttons in a row
-function filemanagerutil.getStatusButtonsRow(file, caller_callback)
+function filemanagerutil.genStatusButtonsRow(file, caller_callback)
     local status = filemanagerutil.getStatus(file)
     local function genStatusButton(to_status)
         local status_text = {

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -63,6 +63,20 @@ function filemanagerutil.resetDocumentSettings(file)
     end
 end
 
+-- Get a document's status ("new", "reading", "complete", or "abandoned")
+function filemanagerutil.getStatus(file)
+    local status = "new"
+    if DocSettings:hasSidecarFile(file) then
+        local docinfo = DocSettings:open(file) -- no io handles created, do not close
+        if docinfo.data.summary and docinfo.data.summary.status and docinfo.data.summary.status ~= "" then
+            status = docinfo.data.summary.status
+        else
+            status = "reading"
+        end
+    end
+    return status
+end
+
 -- Set a document's status
 function filemanagerutil.setStatus(file, status)
     -- In case the book doesn't have a sidecar file, this'll create it

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -63,4 +63,35 @@ function filemanagerutil.resetDocumentSettings(file)
     end
 end
 
+-- Set a document's status
+function filemanagerutil.setStatus(file, status)
+    -- In case the book doesn't have a sidecar file, this'll create it
+    local docinfo = DocSettings:open(file)
+    local summary = nil
+    if docinfo.data.summary and docinfo.data.summary.status then
+        -- Book already had the full BookStatus table in its sidecar, easy peasy!
+        docinfo.data.summary.status = status
+        docinfo.data.summary.modified = os.date("%Y-%m-%d", os.time())
+        summary = docinfo.data.summary
+    else
+        -- No BookStatus table, create a minimal one...
+        if docinfo.data.summary then
+            -- Err, a summary table with no status entry? Should never happen...
+            summary = { status = status }
+            -- Append the status entry to the existing summary...
+            require("util").tableMerge(docinfo.data.summary, summary)
+            docinfo.data.summary.modified = os.date("%Y-%m-%d", os.time())
+            summary = docinfo.data.summary
+        else
+            -- No summary table at all, create a minimal one
+            summary = {
+                status = status,
+                modified = os.date("%Y-%m-%d", os.time())
+            }
+        end
+    end
+    docinfo:saveSetting("summary", summary)
+    docinfo:flush()
+end
+
 return filemanagerutil

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -2,10 +2,14 @@
 This module contains miscellaneous helper functions for FileManager
 ]]
 
+local BD = require("ui/bidi")
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local DocSettings = require("docsettings")
+local UIManager = require("ui/uimanager")
 local util = require("ffi/util")
 local _ = require("gettext")
+local T = util.template
 
 local filemanagerutil = {}
 
@@ -59,7 +63,7 @@ function filemanagerutil.resetDocumentSettings(file)
             end
         end
         doc_settings:makeTrue("docsettings_reset_done") -- for readertypeset block_rendering_mode
-        doc_settings:close()
+        doc_settings:flush()
     end
 end
 
@@ -127,11 +131,49 @@ function filemanagerutil.genStatusButton(to_status, current_status, file, caller
 end
 
 -- Generate all book status file dialog buttons in a row
-function filemanagerutil.getStatusButtonsRow(current_status, file, caller_callback)
+function filemanagerutil.getStatusButtonsRow(file, caller_callback)
+    local function genStatusButton(to_status, current_status)
+        local status_text = {
+            reading   = _("Reading"),
+            abandoned = _("On hold"),
+            complete  = _("Finished"),
+        }
+        return {
+            text = status_text[to_status],
+            id = to_status, -- used by covermenu
+            enabled = current_status ~= to_status,
+            callback = function()
+                filemanagerutil.setStatus(file, to_status)
+                caller_callback()
+            end,
+        }
+    end
+    local status = filemanagerutil.getStatus(file)
     return {
-        filemanagerutil.genStatusButton("reading", current_status, file, caller_callback),
-        filemanagerutil.genStatusButton("abandoned", current_status, file, caller_callback),
-        filemanagerutil.genStatusButton("complete", current_status, file, caller_callback),
+        genStatusButton("reading", status, file, caller_callback),
+        genStatusButton("abandoned", status, file, caller_callback),
+        genStatusButton("complete", status, file, caller_callback),
+    }
+end
+
+-- Generate a "Reset settings" file dialog button
+function filemanagerutil.genResetSettingsButton(file, currently_opened_file, caller_callback)
+    return {
+        text = _("Reset"),
+        id = "reset", -- used by covermenu
+        enabled = file ~= currently_opened_file and DocSettings:hasSidecarFile(util.realpath(file)),
+        callback = function()
+            UIManager:show(ConfirmBox:new{
+                text = T(_("Reset this document?\n\n%1\n\nAll document progress, settings, bookmarks, highlights, and notes will be permanently lost."),
+                    BD.filepath(file)),
+                ok_text = _("Reset"),
+                ok_callback = function()
+                    filemanagerutil.purgeSettings(file)
+                    require("readhistory"):fileSettingsPurged(file)
+                    caller_callback()
+                end,
+            })
+        end,
     }
 end
 

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -109,7 +109,7 @@ function filemanagerutil.setStatus(file, status)
 end
 
 -- Generate a book status file dialog button
-function filemanagerutil.genStatusButton(to_status, enabled, file, caller_callback)
+function filemanagerutil.genStatusButton(to_status, current_status, file, caller_callback)
     local status_text = {
         reading   = _("Reading"),
         abandoned = _("On hold"),
@@ -118,11 +118,20 @@ function filemanagerutil.genStatusButton(to_status, enabled, file, caller_callba
     return {
         text = status_text[to_status],
         id = to_status, -- used by covermenu
-        enabled = enabled,
+        enabled = current_status ~= to_status,
         callback = function()
             filemanagerutil.setStatus(file, to_status)
             caller_callback()
         end,
+    }
+end
+
+-- Generate all book status file dialog buttons in a row
+function filemanagerutil.getStatusButtonsRow(current_status, file, caller_callback)
+    return {
+        filemanagerutil.genStatusButton("reading", current_status, file, caller_callback),
+        filemanagerutil.genStatusButton("abandoned", current_status, file, caller_callback),
+        filemanagerutil.genStatusButton("complete", current_status, file, caller_callback),
     }
 end
 

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -62,7 +62,7 @@ function ReaderStatus:onEndOfBook()
                         if self.settings.data.summary and self.settings.data.summary.status == "complete" then
                             return _("Mark as reading")
                         else
-                            return _("Mark as read")
+                            return _("Mark as finished")
                         end
                     end,
                     callback = function()
@@ -245,7 +245,7 @@ function ReaderStatus:onMarkBook(mark_read)
     if self.settings.data.summary then
         if self.settings.data.summary.status and self.settings.data.summary.status == "complete" then
             if mark_read then
-                -- Keep mark as read.
+                -- Keep mark as finished.
                 self.settings.data.summary.status = "complete"
             else
                 -- Change current status from read (complete) to reading

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -546,7 +546,7 @@ common_settings.document_end_action = {
     text = _("End of document action"),
     sub_item_table = {
         {
-            text = _("Always mark as read"),
+            text = _("Always mark as finished"),
             checked_func = function()
                 return G_reader_settings:isTrue("end_document_auto_mark")
             end,

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -43,6 +43,16 @@ local nb_drawings_since_last_collectgarbage = 0
 -- in the real Menu class or instance
 local CoverMenu = {}
 
+function CoverMenu:updateCache(file, status)
+    if self.cover_info_cache and self.cover_info_cache[file] then
+        if status then
+            self.cover_info_cache[file][3] = status
+        else
+            self.cover_info_cache[file] = nil
+        end
+    end
+end
+
 function CoverMenu:updateItems(select_number)
     -- As done in Menu:updateItems()
     local old_dimen = self.dimen and self.dimen:copy()
@@ -310,9 +320,7 @@ function CoverMenu:updateItems(select_number)
                         enabled = bookinfo and true or false,
                         callback = function()
                             -- Wipe the cache
-                            if self.cover_info_cache and self.cover_info_cache[file] then
-                                self.cover_info_cache[file] = nil
-                            end
+                            self:updateCache(file)
                             BookInfoManager:deleteBookInfo(file)
                             UIManager:close(self.file_dialog)
                             self:updateItems()
@@ -334,9 +342,7 @@ function CoverMenu:updateItems(select_number)
                 local orig_purge_callback = button.callback
                 button.callback = function()
                     -- Wipe the cache
-                    if self.cover_info_cache and self.cover_info_cache[file] then
-                        self.cover_info_cache[file] = nil
-                    end
+                    self:updateCache(file)
                     -- And then purge the sidecar folder as expected
                     orig_purge_callback()
                 end
@@ -347,9 +353,7 @@ function CoverMenu:updateItems(select_number)
                     local orig_status_callback = button.callback
                     button.callback = function()
                         -- Update the cache
-                        if self.cover_info_cache and self.cover_info_cache[file] then
-                            self.cover_info_cache[file][3] = status
-                        end
+                        self:updateCache(file, status)
                         -- And then set the status on file as expected
                         orig_status_callback()
                     end
@@ -469,9 +473,7 @@ function CoverMenu:onHistoryMenuHold(item)
             enabled = bookinfo and true or false,
             callback = function()
                 -- Wipe the cache
-                if self.cover_info_cache and self.cover_info_cache[file] then
-                    self.cover_info_cache[file] = nil
-                end
+                self:updateCache(file)
                 BookInfoManager:deleteBookInfo(file)
                 UIManager:close(self.histfile_dialog)
                 self:updateItems()
@@ -493,9 +495,7 @@ function CoverMenu:onHistoryMenuHold(item)
     local orig_purge_callback = button.callback
     button.callback = function()
         -- Wipe the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file] = nil
-        end
+        self:updateCache(file)
         -- And then purge the sidecar folder as expected
         orig_purge_callback()
     end
@@ -507,9 +507,7 @@ function CoverMenu:onHistoryMenuHold(item)
             local orig_status_callback = button.callback
             button.callback = function()
                 -- Update the cache
-                if self.cover_info_cache and self.cover_info_cache[file] then
-                    self.cover_info_cache[file][3] = status
-                end
+                self:updateCache(file, status)
                 -- And then set the status on file as expected
                 orig_status_callback()
             end
@@ -622,9 +620,7 @@ function CoverMenu:onCollectionsMenuHold(item)
             enabled = bookinfo and true or false,
             callback = function()
                 -- Wipe the cache
-                if self.cover_info_cache and self.cover_info_cache[file] then
-                    self.cover_info_cache[file] = nil
-                end
+                self:updateCache(file)
                 BookInfoManager:deleteBookInfo(file)
                 UIManager:close(self.collfile_dialog)
                 self:updateItems()
@@ -646,9 +642,7 @@ function CoverMenu:onCollectionsMenuHold(item)
     local orig_purge_callback = button.callback
     button.callback = function()
         -- Wipe the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file] = nil
-        end
+        self:updateCache(file)
         -- And then purge the sidecar folder as expected
         orig_purge_callback()
     end
@@ -659,9 +653,7 @@ function CoverMenu:onCollectionsMenuHold(item)
         local orig_status_callback = button.callback
         button.callback = function()
             -- Update the cache
-            if self.cover_info_cache and self.cover_info_cache[file] then
-                self.cover_info_cache[file][3] = status
-            end
+            self:updateCache(file, status)
             -- And then set the status on file as expected
             orig_status_callback()
         end

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -625,6 +625,28 @@ function CoverMenu:onCollectionsMenuHold(item)
         },
     })
 
+    -- Fudge the setting resets (e.g. "Reset settings" button) to also trash the cover_info_cache
+    local orig_purgeSettings = filemanagerutil.purgeSettings
+    filemanagerutil.purgeSettings = function(f)
+        -- Wipe the cache
+        if self.cover_info_cache and self.cover_info_cache[f] then
+            self.cover_info_cache[f] = nil
+        end
+        -- And then purge the sidecar folder as expected
+        orig_purgeSettings(f)
+    end
+
+    -- Fudge status changes (e.g. "Mark as read" button) to also update the cover_info_cache
+    local orig_setStatus = filemanagerutil.setStatus
+    filemanagerutil.setStatus = function(f, status)
+        -- Update the cache
+        if self.cover_info_cache and self.cover_info_cache[f] then
+            self.cover_info_cache[f][3] = status
+        end
+        -- And then set the status on file as expected
+        orig_setStatus(f, status)
+    end
+
     -- Create the new ButtonDialog, and let UIManager show it
     local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
     self.collfile_dialog = ButtonDialogTitle:new{

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -342,35 +342,17 @@ function CoverMenu:updateItems(select_number)
                 end
 
                 -- Fudge the status change button callbacks to also update the cover_info_cache
-                button = self.file_dialog.button_table:getButtonById("reading")
-                local orig_reading_callback = button.callback
-                button.callback = function()
-                    -- Update the cache
-                    if self.cover_info_cache and self.cover_info_cache[file] then
-                        self.cover_info_cache[file][3] = "reading"
+                for _, status in ipairs({"reading", "abandoned", "complete"}) do
+                    button = self.file_dialog.button_table:getButtonById(status)
+                    local orig_status_callback = button.callback
+                    button.callback = function()
+                        -- Update the cache
+                        if self.cover_info_cache and self.cover_info_cache[file] then
+                            self.cover_info_cache[file][3] = status
+                        end
+                        -- And then set the status on file as expected
+                        orig_status_callback()
                     end
-                    -- And then set the status on file as expected
-                    orig_reading_callback()
-                end
-                button = self.file_dialog.button_table:getButtonById("abandoned")
-                local orig_abandoned_callback = button.callback
-                button.callback = function()
-                    -- Update the cache
-                    if self.cover_info_cache and self.cover_info_cache[file] then
-                        self.cover_info_cache[file][3] = "abandoned"
-                    end
-                    -- And then set the status on file as expected
-                    orig_abandoned_callback()
-                end
-                button = self.file_dialog.button_table:getButtonById("complete")
-                local orig_complete_callback = button.callback
-                button.callback = function()
-                    -- Update the cache
-                    if self.cover_info_cache and self.cover_info_cache[file] then
-                        self.cover_info_cache[file][3] = "complete"
-                    end
-                    -- And then set the status on file as expected
-                    orig_complete_callback()
                 end
 
                 -- Replace the "Book information" button callback to use directly our bookinfo
@@ -519,40 +501,18 @@ function CoverMenu:onHistoryMenuHold(item)
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
-    button = self.histfile_dialog.button_table:getButtonById("reading")
-    if button then
-        local orig_reading_callback = button.callback
-        button.callback = function()
-            -- Update the cache
-            if self.cover_info_cache and self.cover_info_cache[file] then
-                self.cover_info_cache[file][3] = "reading"
+    for _, status in ipairs({"reading", "abandoned", "complete"}) do
+        button = self.histfile_dialog.button_table:getButtonById(status)
+        if button then
+            local orig_status_callback = button.callback
+            button.callback = function()
+                -- Update the cache
+                if self.cover_info_cache and self.cover_info_cache[file] then
+                    self.cover_info_cache[file][3] = status
+                end
+                -- And then set the status on file as expected
+                orig_status_callback()
             end
-            -- And then set the status on file as expected
-            orig_reading_callback()
-        end
-    end
-    button = self.histfile_dialog.button_table:getButtonById("abandoned")
-    if button then
-        local orig_abandoned_callback = button.callback
-        button.callback = function()
-            -- Update the cache
-            if self.cover_info_cache and self.cover_info_cache[file] then
-                self.cover_info_cache[file][3] = "abandoned"
-            end
-            -- And then set the status on file as expected
-            orig_abandoned_callback()
-        end
-    end
-    button = self.histfile_dialog.button_table:getButtonById("complete")
-    if button then
-        local orig_complete_callback = button.callback
-        button.callback = function()
-            -- Update the cache
-            if self.cover_info_cache and self.cover_info_cache[file] then
-                self.cover_info_cache[file][3] = "complete"
-            end
-            -- And then set the status on file as expected
-            orig_complete_callback()
         end
     end
 
@@ -694,35 +654,17 @@ function CoverMenu:onCollectionsMenuHold(item)
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
-    button = self.collfile_dialog.button_table:getButtonById("reading")
-    local orig_reading_callback = button.callback
-    button.callback = function()
-        -- Update the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file][3] = "reading"
+    for _, status in ipairs({"reading", "abandoned", "complete"}) do
+        button = self.collfile_dialog.button_table:getButtonById(status)
+        local orig_status_callback = button.callback
+        button.callback = function()
+            -- Update the cache
+            if self.cover_info_cache and self.cover_info_cache[file] then
+                self.cover_info_cache[file][3] = status
+            end
+            -- And then set the status on file as expected
+            orig_status_callback()
         end
-        -- And then set the status on file as expected
-        orig_reading_callback()
-    end
-    button = self.collfile_dialog.button_table:getButtonById("abandoned")
-    local orig_abandoned_callback = button.callback
-    button.callback = function()
-        -- Update the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file][3] = "abandoned"
-        end
-        -- And then set the status on file as expected
-        orig_abandoned_callback()
-    end
-    button = self.collfile_dialog.button_table:getButtonById("complete")
-    local orig_complete_callback = button.callback
-    button.callback = function()
-        -- Update the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file][3] = "complete"
-        end
-        -- And then set the status on file as expected
-        orig_complete_callback()
     end
 
     -- Replace Book information callback to use directly our bookinfo

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -520,34 +520,40 @@ function CoverMenu:onHistoryMenuHold(item)
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
     button = self.histfile_dialog.button_table:getButtonById("reading")
-    local orig_reading_callback = button.callback
-    button.callback = function()
-        -- Update the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file][3] = "reading"
+    if button then
+        local orig_reading_callback = button.callback
+        button.callback = function()
+            -- Update the cache
+            if self.cover_info_cache and self.cover_info_cache[file] then
+                self.cover_info_cache[file][3] = "reading"
+            end
+            -- And then set the status on file as expected
+            orig_reading_callback()
         end
-        -- And then set the status on file as expected
-        orig_reading_callback()
     end
     button = self.histfile_dialog.button_table:getButtonById("abandoned")
-    local orig_abandoned_callback = button.callback
-    button.callback = function()
-        -- Update the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file][3] = "abandoned"
+    if button then
+        local orig_abandoned_callback = button.callback
+        button.callback = function()
+            -- Update the cache
+            if self.cover_info_cache and self.cover_info_cache[file] then
+                self.cover_info_cache[file][3] = "abandoned"
+            end
+            -- And then set the status on file as expected
+            orig_abandoned_callback()
         end
-        -- And then set the status on file as expected
-        orig_abandoned_callback()
     end
     button = self.histfile_dialog.button_table:getButtonById("complete")
-    local orig_complete_callback = button.callback
-    button.callback = function()
-        -- Update the cache
-        if self.cover_info_cache and self.cover_info_cache[file] then
-            self.cover_info_cache[file][3] = "complete"
+    if button then
+        local orig_complete_callback = button.callback
+        button.callback = function()
+            -- Update the cache
+            if self.cover_info_cache and self.cover_info_cache[file] then
+                self.cover_info_cache[file][3] = "complete"
+            end
+            -- And then set the status on file as expected
+            orig_complete_callback()
         end
-        -- And then set the status on file as expected
-        orig_complete_callback()
     end
 
     -- Replace Book information callback to use directly our bookinfo

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -330,7 +330,7 @@ function CoverMenu:updateItems(select_number)
                 }
 
                 -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-                local button = self.file_dialog.button_table:getButtonById("reset_settings")
+                local button = self.file_dialog.button_table:getButtonById("reset")
                 local orig_purge_callback = button.callback
                 button.callback = function()
                     -- Wipe the cache
@@ -507,7 +507,7 @@ function CoverMenu:onHistoryMenuHold(item)
     }
 
     -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-    local button = self.histfile_dialog.button_table:getButtonById("reset_settings")
+    local button = self.histfile_dialog.button_table:getButtonById("reset")
     local orig_purge_callback = button.callback
     button.callback = function()
         -- Wipe the cache
@@ -682,7 +682,7 @@ function CoverMenu:onCollectionsMenuHold(item)
     }
 
     -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-    local button = self.collfile_dialog.button_table:getButtonById("reset_settings")
+    local button = self.collfile_dialog.button_table:getButtonById("reset")
     local orig_purge_callback = button.callback
     button.callback = function()
         -- Wipe the cache

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -342,35 +342,35 @@ function CoverMenu:updateItems(select_number)
                 end
 
                 -- Fudge the status change button callbacks to also update the cover_info_cache
-                button = self.file_dialog.button_table:getButtonById("mark_as_reading")
-                local orig_mark_as_reading_callback = button.callback
+                button = self.file_dialog.button_table:getButtonById("reading")
+                local orig_reading_callback = button.callback
                 button.callback = function()
                     -- Update the cache
                     if self.cover_info_cache and self.cover_info_cache[file] then
                         self.cover_info_cache[file][3] = "reading"
                     end
                     -- And then set the status on file as expected
-                    orig_mark_as_reading_callback()
+                    orig_reading_callback()
                 end
-                button = self.file_dialog.button_table:getButtonById("put_on_hold")
-                local orig_put_on_hold_callback = button.callback
+                button = self.file_dialog.button_table:getButtonById("abandoned")
+                local orig_abandoned_callback = button.callback
                 button.callback = function()
                     -- Update the cache
                     if self.cover_info_cache and self.cover_info_cache[file] then
                         self.cover_info_cache[file][3] = "abandoned"
                     end
                     -- And then set the status on file as expected
-                    orig_put_on_hold_callback()
+                    orig_abandoned_callback()
                 end
-                button = self.file_dialog.button_table:getButtonById("mark_as_read")
-                local orig_mark_as_read_callback = button.callback
+                button = self.file_dialog.button_table:getButtonById("complete")
+                local orig_complete_callback = button.callback
                 button.callback = function()
                     -- Update the cache
                     if self.cover_info_cache and self.cover_info_cache[file] then
                         self.cover_info_cache[file][3] = "complete"
                     end
                     -- And then set the status on file as expected
-                    orig_mark_as_read_callback()
+                    orig_complete_callback()
                 end
 
                 -- Replace the "Book information" button callback to use directly our bookinfo
@@ -519,35 +519,35 @@ function CoverMenu:onHistoryMenuHold(item)
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
-    button = self.histfile_dialog.button_table:getButtonById("mark_as_reading")
-    local orig_mark_as_reading_callback = button.callback
+    button = self.histfile_dialog.button_table:getButtonById("reading")
+    local orig_reading_callback = button.callback
     button.callback = function()
         -- Update the cache
         if self.cover_info_cache and self.cover_info_cache[file] then
             self.cover_info_cache[file][3] = "reading"
         end
         -- And then set the status on file as expected
-        orig_mark_as_reading_callback()
+        orig_reading_callback()
     end
-    button = self.histfile_dialog.button_table:getButtonById("put_on_hold")
-    local orig_put_on_hold_callback = button.callback
+    button = self.histfile_dialog.button_table:getButtonById("abandoned")
+    local orig_abandoned_callback = button.callback
     button.callback = function()
         -- Update the cache
         if self.cover_info_cache and self.cover_info_cache[file] then
             self.cover_info_cache[file][3] = "abandoned"
         end
         -- And then set the status on file as expected
-        orig_put_on_hold_callback()
+        orig_abandoned_callback()
     end
-    button = self.histfile_dialog.button_table:getButtonById("mark_as_read")
-    local orig_mark_as_read_callback = button.callback
+    button = self.histfile_dialog.button_table:getButtonById("complete")
+    local orig_complete_callback = button.callback
     button.callback = function()
         -- Update the cache
         if self.cover_info_cache and self.cover_info_cache[file] then
             self.cover_info_cache[file][3] = "complete"
         end
         -- And then set the status on file as expected
-        orig_mark_as_read_callback()
+        orig_complete_callback()
     end
 
     -- Replace Book information callback to use directly our bookinfo
@@ -688,35 +688,35 @@ function CoverMenu:onCollectionsMenuHold(item)
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
-    button = self.collfile_dialog.button_table:getButtonById("mark_as_reading")
-    local orig_mark_as_reading_callback = button.callback
+    button = self.collfile_dialog.button_table:getButtonById("reading")
+    local orig_reading_callback = button.callback
     button.callback = function()
         -- Update the cache
         if self.cover_info_cache and self.cover_info_cache[file] then
             self.cover_info_cache[file][3] = "reading"
         end
         -- And then set the status on file as expected
-        orig_mark_as_reading_callback()
+        orig_reading_callback()
     end
-    button = self.collfile_dialog.button_table:getButtonById("put_on_hold")
-    local orig_put_on_hold_callback = button.callback
+    button = self.collfile_dialog.button_table:getButtonById("abandoned")
+    local orig_abandoned_callback = button.callback
     button.callback = function()
         -- Update the cache
         if self.cover_info_cache and self.cover_info_cache[file] then
             self.cover_info_cache[file][3] = "abandoned"
         end
         -- And then set the status on file as expected
-        orig_put_on_hold_callback()
+        orig_abandoned_callback()
     end
-    button = self.collfile_dialog.button_table:getButtonById("mark_as_read")
-    local orig_mark_as_read_callback = button.callback
+    button = self.collfile_dialog.button_table:getButtonById("complete")
+    local orig_complete_callback = button.callback
     button.callback = function()
         -- Update the cache
         if self.cover_info_cache and self.cover_info_cache[file] then
             self.cover_info_cache[file][3] = "complete"
         end
         -- And then set the status on file as expected
-        orig_mark_as_read_callback()
+        orig_complete_callback()
     end
 
     -- Replace Book information callback to use directly our bookinfo

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -527,6 +527,7 @@ function CoverBrowser:setupFileManagerDisplayMode(display_mode)
     -- In both mosaic and list modes, replace original methods with those from
     -- our generic CoverMenu
     local CoverMenu = require("covermenu")
+    FileChooser.updateCache = CoverMenu.updateCache
     FileChooser.updateItems = CoverMenu.updateItems
     FileChooser.onCloseWidget = CoverMenu.onCloseWidget
 
@@ -592,6 +593,7 @@ local function _FileManagerHistory_updateItemTable(self)
         -- In both mosaic and list modes, replace original methods with those from
         -- our generic CoverMenu
         local CoverMenu = require("covermenu")
+        hist_menu.updateCache = CoverMenu.updateCache
         hist_menu.updateItems = CoverMenu.updateItems
         hist_menu.onCloseWidget = CoverMenu.onCloseWidget
         -- Also replace original onMenuHold (it will use original method, so remember it)
@@ -670,6 +672,7 @@ local function _FileManagerCollections_updateItemTable(self)
         -- In both mosaic and list modes, replace original methods with those from
         -- our generic CoverMenu
         local CoverMenu = require("covermenu")
+        coll_menu.updateCache = CoverMenu.updateCache
         coll_menu.updateItems = CoverMenu.updateItems
         coll_menu.onCloseWidget = CoverMenu.onCloseWidget
         -- Also replace original onMenuHold (it will use original method, so remember it)

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -279,7 +279,7 @@ function Wallabag:addToMainMenu(menu_items)
                                 separator = true,
                             },
                             {
-                                text = _("Mark as read instead of deleting"),
+                                text = _("Mark as finished instead of deleting"),
                                 checked_func = function() return self.is_archiving_deleted end,
                                 callback = function()
                                     self.is_archiving_deleted = not self.is_archiving_deleted


### PR DESCRIPTION
Closes #8954.

Change is made to file manager, history, and collections alike. Most time-consuming part was understanding the inner workings of coverbrowser to allow compatibility with it.

Lots of code duplication due to historical reasons causes changes to look larger than they are, when it's mostly the same thing copied across the 3 view modules, and coverbrowser further trying to overwrite each separately. The special attention given to coverbrowser is simply because of the special cache it uses...

Ridealong tweaks:
- Remove the "Mark as reading/read" button from File Manager as it's superseded by this
- Add "Reset settings" button to Collections viewer to parallel File Manager and History, and to avoid having the ugly 2-button, 1-button, 2-button layout
- Rename "Sort" button in Collections viewer to be "Sort collection" to clarify that it's for sorting all files, not just the one being held down on
- Use existing `getButtonById` for fudging the "Book information" button callback instead of previously raw indexing into the buttons table, to be more resilient to changes that would bork the indexing (like these)
  - Fix this previously non-working fudging

### File manager buttons:
![file manager buttons](https://user-images.githubusercontent.com/10296053/209515334-372ddab3-7dbe-4e26-a7a3-ba953fe8d0cc.png)

### History buttons:
![history buttons](https://user-images.githubusercontent.com/10296053/209515326-53eaddeb-ca6d-45f1-acdf-323e2ebceca5.png)

### Favorites/Collections buttons:
![favorites buttons](https://user-images.githubusercontent.com/10296053/209515321-dffd2138-648c-4f38-ac56-63934f10d47e.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9953)
<!-- Reviewable:end -->
