### PR TITLE
Filemanager popup menu: add Book status button etc.

### DIFF
--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -1,15 +1,12 @@
 local BD = require("ui/bidi")
-local DocumentRegistry = require("document/documentregistry")
 local DocSettings = require("docsettings")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
-local ImageViewer = require("ui/widget/imageviewer")
 local InfoMessage = require("ui/widget/infomessage")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local logger = require("logger")
 local _ = require("gettext")
-local util = require("util")
 
 local BookInfoManager = require("bookinfomanager")
 

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -127,7 +127,11 @@ function ReaderStatistics:init()
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
     self:checkInitDatabase()
-    BookStatusWidget.getStats = function()
+    BookStatusWidget.getStats = function(_, stats)
+        if stats then -- called from file browser popup menu "Book status"
+            self.data = stats
+            self.id_curr_book = self:getIdBookDB()
+        end
         return self:getStatsBookStatus(self.id_curr_book, self.settings.is_enabled)
     end
     ReaderFooter.getAvgTimePerPage = function()


### PR DESCRIPTION
UX
- Add <kbd>Book status</kbd> button
- Add <kbd>Mark as read</kbd>, <kbd>Book description</kbd>, <kbd>Book cover</kbd> buttons in classic mode (they existed in non-classic modes)
- Buttons repositioning

Fix
- FileManager: do not delete History entry if file deletion failed
- Covermenu: remove code duplication
- BookStatusWidet: flush changes on close only

Classic mode
<img width="300" alt="01" src="https://user-images.githubusercontent.com/62179190/209547628-83862dd8-f01a-4f20-8e38-07d20d40a291.png">

Non-classic modes
<img width="300" alt="02" src="https://user-images.githubusercontent.com/62179190/209547648-8b77f48d-a7b2-48b8-9d34-d12d8fc6e72d.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9956)
<!-- Reviewable:end -->
