### PR TITLE
IconButton: Fix highlights in RTL UI

### DIFF
--- a/frontend/ui/widget/container/centercontainer.lua
+++ b/frontend/ui/widget/container/centercontainer.lua
@@ -14,8 +14,7 @@ function CenterContainer:paintTo(bb, x, y)
         if self.dimen.h < content_size.h then
             self.ignore = "height"
         end
-    end
-    if self.ignore_if_over == "width" then -- align left borders
+    elseif self.ignore_if_over == "width" then -- align left borders
         if self.dimen.w < content_size.w then
             self.ignore = "width"
         end

--- a/frontend/ui/widget/container/widgetcontainer.lua
+++ b/frontend/ui/widget/container/widgetcontainer.lua
@@ -26,7 +26,7 @@ function WidgetContainer:getSize()
         -- return size of first child widget
         return self[1]:getSize()
     else
-        return Geom:new{ x= 0, y = 0, w = 0, h = 0 }
+        return Geom:new{ x = 0, y = 0, w = 0, h = 0 }
     end
 end
 

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -2,6 +2,7 @@
 Button with a big icon image! Designed for touch devices.
 --]]
 
+local BD = require("ui/bidi")
 local Device = require("device")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
@@ -102,6 +103,13 @@ function IconButton:onTapIconButton()
     if G_reader_settings:isFalse("flash_ui") or not self.allow_flash then
         self.callback()
     else
+        -- Mimic BiDi left/right switcheroos...
+        local h_padding
+        if BD.mirroredUILayout() then
+            h_padding = self.padding_right
+        else
+            h_padding = self.padding_left
+        end
         -- c.f., ui/widget/button for more gnarly details about the implementation, but the flow of the flash_ui codepath essentially goes like this:
         -- 1. Paint the highlight
         -- 2. Refresh the highlighted item (so we can see the highlight)
@@ -113,7 +121,7 @@ function IconButton:onTapIconButton()
         -- Highlight
         --
         self.image.invert = true
-        UIManager:widgetInvert(self.image, self.dimen.x + self.padding_left, self.dimen.y + self.padding_top)
+        UIManager:widgetInvert(self.image, self.dimen.x + h_padding, self.dimen.y + self.padding_top)
         UIManager:setDirty(nil, "fast", self.dimen)
 
         UIManager:forceRePaint()
@@ -122,7 +130,7 @@ function IconButton:onTapIconButton()
         -- Unhighlight
         --
         self.image.invert = false
-        UIManager:widgetInvert(self.image, self.dimen.x + self.padding_left, self.dimen.y + self.padding_top)
+        UIManager:widgetInvert(self.image, self.dimen.x + h_padding, self.dimen.y + self.padding_top)
 
         -- Callback
         --

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -292,6 +292,8 @@ end
 function TextWidget:getSize()
     self:updateSize()
     return Geom:new{
+        x = 0,
+        y = 0,
         w = self._length,
         h = self.forced_height or self._height,
     }


### PR DESCRIPTION
Noticed while testing #9941 in RTL mode.

Includes a few other trivial style fixes in separate commits.

I couldn't *quite* figure out what was responsible for inverting the padding values, though... (@poire-z? ;p).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9959)
<!-- Reviewable:end -->
