### PR TITLE
ScreenSaver: Refactor gesture lock to behave regardless of configuration

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -17,13 +17,11 @@ local function no() return false end
 
 local Device = {
     screen_saver_mode = false,
-    charging_mode = false,
-    survive_screen_saver = false,
+    screen_saver_lock = false,
     is_cover_closed = false,
     model = nil,
     powerd = nil,
     screen = nil,
-    screen_dpi_override = nil,
     input = nil,
     home_dir = nil,
     -- For Kobo, wait at least 15 seconds before calling suspend script. Otherwise, suspend might
@@ -47,7 +45,6 @@ local Device = {
     hasNaturalLight = no, -- FL warmth implementation specific to NTX boards (Kobo, Cervantes)
     hasNaturalLightMixer = no, -- Same, but only found on newer boards
     hasNaturalLightApi = no,
-    needsTouchScreenProbe = no,
     hasClipboard = yes, -- generic internal clipboard on all devices
     hasEinkScreen = yes,
     hasExternalSD = no, -- or other storage volume that cannot be accessed using the File Manager

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -283,7 +283,6 @@ function Kindle:usbPlugIn()
     --       shooting themselves in the foot (c.f., https://github.com/koreader/koreader/issues/3220)!
     --       On the upside, we don't have to bother waking up the WM to show us the USBMS screen :D.
     -- NOTE: If the device is put in USBNet mode before we even start, everything's peachy, though :).
-    self.charging_mode = true
 end
 
 function Kindle:intoScreenSaver()
@@ -365,7 +364,6 @@ end
 
 function Kindle:usbPlugOut()
     -- NOTE: See usbPlugIn(), we don't have anything fancy to do here either.
-    self.charging_mode = false
 end
 
 function Kindle:wakeupFromSuspend()

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -805,35 +805,12 @@ function Screensaver:show()
         self.screensaver_widget.modal = true
         self.screensaver_widget.dithered = true
 
-        -- NOTE: ScreenSaver itself is not a widget, so make sure we cleanup behind us...
-        self.screensaver_widget.onCloseWidget = function(this)
-            -- this is self.screensaver_widget (i.e., an object instantiated from ScreenSaverWidget)
-            local super = getmetatable(this)
-            -- super is the class object of self.screensaver_widget (i.e., ScreenSaverWidget)
-            if super.onCloseWidget then
-                super.onCloseWidget(this)
-            end
-            -- self is ScreenSaver (upvalue)
-            self:cleanup()
-        end
-
         UIManager:show(self.screensaver_widget, "full")
     end
 
     -- Setup the gesture lock through an additional invisible widget, so that it works regardless of the configuration.
     if with_gesture_lock then
         self.screensaver_lock_widget = ScreenSaverLockWidget:new{}
-
-        -- If we don't have a ScreenSaverWidget handling cleanup for us, it'll fall to us...
-        if not self.screensaver_widget then
-            self.screensaver_lock_widget.onCloseWidget = function(this)
-                local super = getmetatable(this)
-                if super.onCloseWidget then
-                    super.onCloseWidget(this)
-                end
-                self:cleanup()
-            end
-        end
 
         -- It's flagged as modal, so it'll stay on top
         UIManager:show(self.screensaver_lock_widget)

--- a/frontend/ui/widget/screensaverlockwidget.lua
+++ b/frontend/ui/widget/screensaverlockwidget.lua
@@ -1,0 +1,135 @@
+local Device = require("device")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local InfoMessage = require("ui/widget/infomessage")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local UIManager = require("ui/uimanager")
+local util = require("util")
+local _ = require("gettext")
+local Screen = Device.screen
+
+local ScreenSaverLockWidget = InputContainer:extend{
+    name = "ScreenSaverLock",
+    modal = true,     -- So it's on top the window stack
+    invisible = true, -- So UIManager ignores it refresh-wise
+}
+
+function ScreenSaverLockWidget:init()
+    if Device:isTouchDevice() then
+        if G_reader_settings:readSetting("screensaver_delay") == "gesture" then
+            self:setupGestureEvents()
+        end
+        if not self.has_exit_screensaver_gesture then
+            -- Exit with gesture not enabled, or no configured gesture found: allow exiting with tap
+            local range = Geom:new{
+                x = 0, y = 0,
+                w = Screen:getWidth(),
+                h = Screen:getHeight(),
+            }
+            self.ges_events.Tap = { GestureRange:new{ ges = "tap", range = range } }
+        end
+    end
+end
+
+function ScreenSaverLockWidget:setupGestureEvents()
+    -- The configured gesture(s) won't trigger, because this widget is at top
+    -- of the UI stack and will prevent ReaderUI/Filemanager from getting
+    -- and handling any configured gesture event.
+    -- We need to find all the ones configured for the "exit_screensaver" action,
+    -- and clone them so they are handled by this widget.
+    local ReaderUI = require("apps/reader/readerui")
+    local ui = ReaderUI.instance
+    if not ui then
+        local FileManager = require("apps/filemanager/filemanager")
+        ui = FileManager.instance
+    end
+    if ui and ui.gestures and ui.gestures.gestures then
+        local multiswipe_already_met = false
+        for gesture, actions in pairs(ui.gestures.gestures) do
+            if util.stringStartsWith(gesture, "multiswipe") then
+                -- All multiswipes are handled by the single handler for "multiswipe"
+                -- We only need to clone one of them
+                gesture = "multiswipe"
+            end
+            if actions["exit_screensaver"] and (gesture ~= "multiswipe" or not multiswipe_already_met) then
+                if gesture == "multiswipe" then
+                    multiswipe_already_met = true
+                end
+                -- Clone the gesture found in our self.ges_events
+                local ui_gesture = ui._zones[gesture]
+                if ui_gesture and ui_gesture.handler then
+                    -- We can reuse its GestureRange object
+                    self.ges_events[gesture] = { ui_gesture.gs_range }
+                    -- For each of them, we need a distinct event and its handler.
+                    -- This handler will call the original handler (created by gestures.koplugin)
+                    -- which, after some checks (like swipe distance and direction, and multiswipe
+                    -- directions), will emit normally the configured real ExitScreensaver event,
+                    -- that this widget (being at top of the UI stack) will get and that
+                    -- onExitScreensaver() will handle.
+                    local event_name = "TriggerExitScreensaver_" .. gesture
+                    self.ges_events[gesture].event = event_name
+                    self["on"..event_name] = function(this, args, ev)
+                        ui_gesture.handler(ev)
+                        return true
+                    end
+                end
+            end
+        end
+    end
+    if next(self.ges_events) then -- we found a gesture configured
+        self.has_exit_screensaver_gesture = true
+        -- Override handleEvent(), so we can stop any event from propagating to widgets
+        -- below this one (we may get some from other multiswipe as the handler does
+        -- not filter the one we are interested with, but also when multiple actions
+        -- are assigned to a single gesture).
+        self.handleEvent = function(this, event)
+            InputContainer.handleEvent(this, event)
+            return true
+        end
+    end
+end
+
+function ScreenSaverLockWidget:showWaitForGestureMessage()
+    -- We just paint an InfoMessage on screen directly: we don't want
+    -- another widget that we would need to prevent catching events
+    local infomsg = InfoMessage:new{
+        text = self.has_exit_screensaver_gesture
+                    and _("Waiting for specific gesture to exit screensaver.")
+                     or _("No exit screensaver gesture configured. Tap to exit.")
+    }
+    infomsg:paintTo(Screen.bb, 0, 0)
+    infomsg:onShow() -- get the screen refreshed
+    infomsg:free()
+end
+
+function ScreenSaverLockWidget:onClose()
+    UIManager:close(self)
+    -- Close the actual Screensaver, if any
+    local Screensaver = require("ui/screensaver")
+    if Screensaver.screensaver_widget then
+        Screensaver.screensaver_widget:onClose()
+    end
+    return true
+end
+-- That's the Event Dispatcher will send us ;)
+ScreenSaverLockWidget.onExitScreensaver = ScreenSaverLockWidget.onClose
+ScreenSaverLockWidget.onTap = ScreenSaverLockWidget.onClose
+
+function ScreenSaverLockWidget:onCloseWidget()
+    -- If we don't have a ScreenSaverWidget, request a full repaint to dismiss our InfoMessage.
+    local Screensaver = require("ui/screensaver")
+    if not Screensaver.screensaver_widget then
+        UIManager:setDirty("all", "full")
+    end
+end
+
+-- NOTE: We duplicate this bit of logic from ScreenSaverWidget, because not every Screensaver config will spawn one...
+function ScreenSaverLockWidget:onResume()
+    Device.screen_saver_lock = true
+end
+
+function ScreenSaverLockWidget:onSuspend()
+    Device.screen_saver_lock = false
+end
+
+return ScreenSaverLockWidget

--- a/frontend/ui/widget/screensaverlockwidget.lua
+++ b/frontend/ui/widget/screensaverlockwidget.lua
@@ -120,6 +120,9 @@ function ScreenSaverLockWidget:onCloseWidget()
     local Screensaver = require("ui/screensaver")
     if not Screensaver.screensaver_widget then
         UIManager:setDirty("all", "full")
+
+        -- And take care of cleanup in its place, too
+        Screensaver:cleanup()
     end
 end
 

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -3,10 +3,8 @@ local Event = require("ui/event")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local FrameContainer = require("ui/widget/container/framecontainer")
-local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local UIManager = require("ui/uimanager")
-local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
 
@@ -21,92 +19,14 @@ function ScreenSaverWidget:init()
         self.key_events.AnyKeyPressed = { { Device.input.group.Any } }
     end
     if Device:isTouchDevice() then
-        if G_reader_settings:readSetting("screensaver_delay") == "gesture" then
-            self:setupGestureEvents()
-        end
-        if not self.has_exit_screensaver_gesture then
-            -- Exit with gesture not enabled, or no configured gesture found: allow exiting with tap
-            local range = Geom:new{
-                x = 0, y = 0,
-                w = Screen:getWidth(),
-                h = Screen:getHeight(),
-            }
-            self.ges_events.Tap = { GestureRange:new{ ges = "tap", range = range } }
-        end
+        local range = Geom:new{
+            x = 0, y = 0,
+            w = Screen:getWidth(),
+            h = Screen:getHeight(),
+        }
+        self.ges_events.Tap = { GestureRange:new{ ges = "tap", range = range } }
     end
     self:update()
-end
-
-function ScreenSaverWidget:setupGestureEvents()
-    -- The configured gesture(s) won't trigger, because this widget is at top
-    -- of the UI stack and will prevent ReaderUI/Filemanager from getting
-    -- and handling any configured gesture event.
-    -- We need to find all the ones configured for the "exit_screensaver" action,
-    -- and clone them so they are handled by this widget.
-    local ReaderUI = require("apps/reader/readerui")
-    local ui = ReaderUI:_getRunningInstance()
-    if not ui then
-        local FileManager = require("apps/filemanager/filemanager")
-        ui = FileManager.instance
-    end
-    if ui and ui.gestures and ui.gestures.gestures then
-        local multiswipe_already_met = false
-        for gesture, actions in pairs(ui.gestures.gestures) do
-            if util.stringStartsWith(gesture, "multiswipe") then
-                -- All multiswipes are handled by the single handler for "multiswipe"
-                -- We only need to clone one of them
-                gesture = "multiswipe"
-            end
-            if actions["exit_screensaver"] and (gesture ~= "multiswipe" or not multiswipe_already_met) then
-                if gesture == "multiswipe" then
-                    multiswipe_already_met = true
-                end
-                -- Clone the gesture found in our self.ges_events
-                local ui_gesture = ui._zones[gesture]
-                if ui_gesture and ui_gesture.handler then
-                    -- We can reuse its GestureRange object
-                    self.ges_events[gesture] = { ui_gesture.gs_range }
-                    -- For each of them, we need a distinct event and its handler.
-                    -- This handler will call the original handler (created by gestures.koplugin)
-                    -- which, after some checks (like swipe distance and direction, and multiswipe
-                    -- directions), will emit normally the configured real ExitScreensaver event,
-                    -- that this widget (being at top of the UI stack) will get and that
-                    -- onExitScreensaver() will handle.
-                    local event_name = "TriggerExitScreensaver_" .. gesture
-                    self.ges_events[gesture].event = event_name
-                    self["on"..event_name] = function(this, args, ev)
-                        ui_gesture.handler(ev)
-                        return true
-                    end
-                end
-            end
-        end
-    end
-    if next(self.ges_events) then -- we found a gesture configured
-        self.has_exit_screensaver_gesture = true
-        -- Override handleEvent(), so we can stop any event from propagating to widgets
-        -- below this one (we may get some from other multiswipe as the handler does
-        -- not filter the one we are insterested with, but also when multiple actions
-        -- are assigned to a single gesture).
-        self.handleEvent = function(this, event)
-            InputContainer.handleEvent(this, event)
-            return true
-        end
-        self.key_events = {} -- also disable exit with keys
-    end
-end
-
-function ScreenSaverWidget:showWaitForGestureMessage(msg)
-    -- We just paint an InfoMessage on screen directly: we don't want
-    -- another widget that we would need to prevent catching events
-    local infomsg = InfoMessage:new{
-        text = self.has_exit_screensaver_gesture
-                    and _("Waiting for specific gesture to exit screensaver.")
-                     or _("No exit screensaver gesture configured. Tap to exit.")
-    }
-    infomsg:paintTo(Screen.bb, 0, 0)
-    infomsg:onShow() -- get the screen refreshed
-    infomsg:free()
 end
 
 function ScreenSaverWidget:update()
@@ -163,9 +83,6 @@ ScreenSaverWidget.onAnyKeyPressed = ScreenSaverWidget.onClose
 ScreenSaverWidget.onExitScreensaver = ScreenSaverWidget.onClose
 
 function ScreenSaverWidget:onCloseWidget()
-    Device.screen_saver_mode = false
-    Device.screen_saver_lock = false
-
     -- Restore to previous rotation mode, if need be.
     if Device.orig_rotation_mode then
         Screen:setRotationMode(Device.orig_rotation_mode)

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -97,6 +97,10 @@ function ScreenSaverWidget:onCloseWidget()
     -- Will come after the Resume event, iff screensaver_delay is set.
     -- Comes *before* it otherwise.
     UIManager:broadcastEvent(Event:new("OutOfScreenSaver"))
+
+    -- NOTE: ScreenSaver itself is neither a Widget nor an instantiated object, so make sure we cleanup behind us...
+    local Screensaver = require("ui/screensaver")
+    Screensaver:cleanup()
 end
 
 function ScreenSaverWidget:onResume()

--- a/reader.lua
+++ b/reader.lua
@@ -188,13 +188,6 @@ CanvasContext:init(Device)
 -- Handle one time migration stuff (settings, deprecation, ...) in case of an upgrade...
 require("ui/data/onetime_migration")
 
--- Touch screen (this may display some widget, on first install on Kobo Touch,
--- so have it done after CanvasContext:init() but before Bidi.setup() to not
--- have mirroring mess x/y probing).
-if Device:needsTouchScreenProbe() then
-    Device:touchScreenProbe()
-end
-
 -- UI mirroring for RTL languages, and text shaping configuration
 local Bidi = require("ui/bidi")
 Bidi.setup(lang_locale)

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -91,7 +91,6 @@ describe("device module", function()
             local Screen = kobo_dev.screen
 
             assert.is.same("Kobo_trilogy_C", kobo_dev.model)
-            assert.falsy(kobo_dev:needsTouchScreenProbe())
             local x, y = Screen:getWidth()-5, 10
             -- mirror x, then switch_xy
             local ev_x = {
@@ -140,7 +139,6 @@ describe("device module", function()
             local Screen = kobo_dev.screen
 
             assert.is.same("Kobo_trilogy_C", kobo_dev.model)
-            assert.falsy(kobo_dev:needsTouchScreenProbe())
             local x, y = Screen:getWidth()-5, 10
             local ev_x = {
                 type = C.EV_ABS,


### PR DESCRIPTION
Go through a dedicated sticky invisible widget instead of piggybacking on ScreenSaverWidget, so that we behave if there are other InputContainers in ScreenSaverWidget, or if there aren't any ScreenSaverWidget at all.

Fix #9911, fix #9955

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9964)
<!-- Reviewable:end -->
