### PR TITLE
TouchMenu: simplify/remove enabled_func in use cases

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -387,7 +387,6 @@ function NetworkMgr:getWifiMenuTable()
     if Device:isAndroid() then
         return {
             text = _("Wi-Fi settings"),
-            enabled_func = function() return true end,
             callback = function() self:openSettings() end,
         }
     else

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -1074,7 +1074,7 @@ function AutoWarmth:getWarmthMenu()
         },
         {
             text = Device:hasNaturalLight() and _("Set warmth and night mode for:") or _("Set night mode for:"),
-            enabled_func = function() return false end,
+            enabled = false,
         },
         getWarmthMenuEntry(_("Solar noon"), 6, false),
         getWarmthMenuEntry(_("Sunset and sunrise"), 5),


### PR DESCRIPTION
Minimal simplifications of `enabled_func` in two cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9966)
<!-- Reviewable:end -->
