### PR TITLE
ButtonTable, ReaderDogear and TextEditor tweaks and fixes

### DIFF
--- a/frontend/apps/reader/modules/readerdogear.lua
+++ b/frontend/apps/reader/modules/readerdogear.lua
@@ -54,7 +54,7 @@ function ReaderDogear:setupDogear(new_dogear_size)
 end
 
 function ReaderDogear:onReadSettings(config)
-    if not self.ui.document.info.has_pages then
+    if self.ui.rolling then
         -- Adjust to CreDocument margins (as done in ReaderTypeset)
         local h_margins = config:readSetting("copt_h_page_margins")
                        or G_reader_settings:readSetting("copt_h_page_margins")
@@ -71,7 +71,7 @@ function ReaderDogear:onReadSettings(config)
 end
 
 function ReaderDogear:onSetPageMargins(margins)
-    if self.ui.document.info.has_pages then
+    if not self.ui.rolling then
         -- we may get called by readerfooter (when hiding the footer)
         -- on pdf documents and get margins=nil
         return
@@ -86,7 +86,7 @@ function ReaderDogear:onSetPageMargins(margins)
 end
 
 function ReaderDogear:updateDogearOffset()
-    if self.ui.document.info.has_pages then
+    if not self.ui.rolling then
         return
     end
     self.dogear_y_offset = 0
@@ -99,6 +99,10 @@ function ReaderDogear:updateDogearOffset()
         self.top_pad.width = self.dogear_y_offset
         self.vgroup:resetLayout()
     end
+end
+
+function ReaderDogear:onReaderReady()
+    self:updateDogearOffset()
 end
 
 function ReaderDogear:onDocumentRerendered()

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -55,7 +55,12 @@ function ButtonTable:init()
                 icon_height = btn_entry.icon_height,
                 align = btn_entry.align,
                 enabled = btn_entry.enabled,
-                callback = btn_entry.callback,
+                callback = function()
+                    if self.show_parent and self.show_parent.movable then
+                        self.show_parent.movable:resetEventState()
+                    end
+                    btn_entry.callback()
+                end,
                 hold_callback = btn_entry.hold_callback,
                 allow_hold_when_disabled = btn_entry.allow_hold_when_disabled,
                 vsync = btn_entry.vsync,

--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -342,4 +342,11 @@ function MovableContainer:onMovablePanRelease(_, ges)
     return false
 end
 
+function MovableContainer:resetEventState()
+    -- Cancel some internal moving-or-about-to-move state.
+    -- Can be called explicitely to prevent bad widget interactions.
+    self._touch_pre_pan_was_inside = false
+    self._moving = false
+end
+
 return MovableContainer

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -240,7 +240,7 @@ Export text to QR code, that can be scanned, for example, by a phone.]]),
         local file_path = self.history[i]
         local directory, filename = util.splitFilePathName(file_path) -- luacheck: no unused
         table.insert(sub_item_table, {
-            text = T("%1. %2", i, BD.filename(filename)),
+            text = T("\u{f016} %1", BD.filename(filename)), -- file symbol
             keep_menu_open = true,
             callback = function(touchmenu_instance)
                 self:setupWhenDoneFunc(touchmenu_instance)


### PR DESCRIPTION
#### ButtonTable: reset MovableContainer state on button tap

Prevent any later hold_release event from being handled by MovableContainer as a moving touch+hold_release.
This issue was noticable when closing DictQuickLookup with long-press on close, resulting in the movable highlight actions ButtonTable moving to where the long-press happened.
Issue described at https://github.com/koreader/koreader/pull/9507#issuecomment-1328103992, and various alternative solutions proposed in next posts.

#### ReaderDogear: fix no y-offset after load with top status bar

Regression since #9651, fix item 4 of #9979, https://github.com/koreader/koreader/issues/9979#issuecomment-1368258192.

#### TextEditor: use a file symbol instead of numbers in history

Closes #9973 , by getting rid of the numbers :) and going with:
![image](https://user-images.githubusercontent.com/24273478/210166882-de19a7a8-8812-4c6b-8114-fd578693ef2c.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9985)
<!-- Reviewable:end -->
