### PR TITLE
ReaderUI: fix status and history

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -454,7 +454,7 @@ function ReaderUI:init()
     -- (so that filemanager can use it from sideCar file to display
     -- Book information).
     self.doc_settings:saveSetting("doc_props", self.document:getProps())
-    
+
     -- Set "reading" status if there is no status.
     local summary = self.doc_settings:readSetting("summary")
     if not (summary and summary.status) then


### PR DESCRIPTION
(1) Set initial status to "reading" on opening a book. Closes https://github.com/koreader/koreader/issues/9500.
(2) Save a book to history on success opening only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9993)
<!-- Reviewable:end -->
