### PR TITLE
[Document] Consistent menu entries in auto-save menu

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -510,7 +510,7 @@ common_settings.document_auto_save = {
         local interval = G_reader_settings:readSetting("auto_save_settings_interval_minutes")
         local s_interval
         if interval == false then
-            s_interval = _("only on close")
+            s_interval = _("only on close, suspend and exit")
         else
             s_interval = T(N_("every 1 m", "every %1 m", interval), interval)
         end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -484,7 +484,7 @@ local function genAutoSaveMenuItem(value)
     local setting_name = "auto_save_settings_interval_minutes"
     local text
     if not value then
-        text = _("Only on close, suspend and exit")
+        text = _("Only on close and suspend")
     else
         text = T(N_("Every minute", "Every %1 minutes", value), value)
     end
@@ -510,11 +510,11 @@ common_settings.document_auto_save = {
         local interval = G_reader_settings:readSetting("auto_save_settings_interval_minutes")
         local s_interval
         if interval == false then
-            s_interval = _("only on close, suspend and exit")
+            s_interval = _("only on close and suspend")
         else
             s_interval = T(N_("every 1 m", "every %1 m", interval), interval)
         end
-        return T(_("Auto-save book metadata: %1"), s_interval)
+        return T(_("Save book metadata: %1"), s_interval)
     end,
     help_text = auto_save_help_text,
     sub_item_table = {


### PR DESCRIPTION
See:
https://github.com/koreader/koreader/pull/9946#issuecomment-1364588746

This is what it looks with consistent menu entries
![grafik](https://user-images.githubusercontent.com/36999612/210720554-19562e85-fed5-4c00-b6d9-2515d4cf91b0.png)

A question for wording: I think `Save book metadata: only on close and suspend` should be long/informative enough.
1.) Why auto (this just eats space)?
2.) Do we have a manual save?
3.) Exit implies close, so on every exit the document would be closed anyway.

So I would prefer (not in this commit yet)

![grafik](https://user-images.githubusercontent.com/36999612/210721366-3da0b0e8-6873-4c52-9483-de130147b7c4.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/9995)
<!-- Reviewable:end -->
