### PR TITLE
Exit menu: restore long-press to exit directly

### DIFF
--- a/frontend/ui/elements/common_exit_menu_table.lua
+++ b/frontend/ui/elements/common_exit_menu_table.lua
@@ -7,6 +7,9 @@ local exit_settings = {}
 
 exit_settings.exit_menu = {
     text = _("Exit"),
+    hold_callback = function()
+        UIManager:broadcastEvent(Event:new("Exit"))
+    end,
     -- submenu entries will be appended by xyz_menu_order_lua
 }
 exit_settings.exit = {


### PR DESCRIPTION
Unwillingly removed by #8459.
Closes #9999. (And this PR should be #10000 !!! :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10000)
<!-- Reviewable:end -->
