### PR TITLE
Kobo: Unbreak input translation when a viewport is involved

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2199,8 +2199,8 @@ function ReaderFooter:_updateFooterText(force_repaint, force_recompute)
     if force_repaint then
         -- If there was a visibility change, notify ReaderView
         if self.visibility_change then
-            self.ui:handleEvent(Event:new("ReaderFooterVisibilityChange"))
             self.visibility_change = nil
+            self.ui:handleEvent(Event:new("ReaderFooterVisibilityChange"))
         end
 
         -- NOTE: Getting the dimensions of the widget is impossible without having drawn it first,

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -968,19 +968,15 @@ end
 function ReaderView:onReaderFooterVisibilityChange()
     -- Don't bother ReaderRolling with this nonsense, the footer's height is NOT handled via visible_area there ;)
     if self.ui.paging and self.state.page then
-        -- NOTE: Simply relying on recalculate would be a wee bit too much: it'd reset the in-page offsets,
-        --       which would be wrong, and is also not necessary, since the footer is at the bottom of the screen ;).
-        --       So, simply mangle visible_area's height ourselves...
+        -- We don't need to do anything if reclaim is enabled ;).
         if not self.footer.settings.reclaim_height then
-            -- NOTE: Yes, this means that toggling reclaim_height requires a page switch (for a proper recalculate).
-            --       Thankfully, most of the time, the quirks are barely noticeable ;).
-            if self.footer_visible then
-                self.visible_area.h = self.visible_area.h - self.footer:getHeight()
-            else
-                self.visible_area.h = self.visible_area.h + self.footer:getHeight()
-            end
+            -- NOTE: Mimic what onSetFullScreen does, since, without reclaim, toggling the footer affects the available area,
+            --       so we need to recompute the full layout.
+            self.ui:handleEvent(Event:new("SetDimensions", Screen:getSize()))
+            -- NOTE: Scroll mode's behavior after this might be suboptimal (until next page),
+            --       but I'm not familiar enough with it to make it behave...
+            --       (e.g., RedrawCurrentPage & co will snap to the top of the "current" page).
         end
-        self.ui:handleEvent(Event:new("ViewRecalculate", self.visible_area, self.page_area))
     end
 end
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -330,8 +330,8 @@ function Device:retrieveNetworkInfo()
     end
 end
 
-function Device:setViewport(x,y,w,h)
-    logger.info(string.format("Switching viewport to new geometry [x=%d,y=%d,w=%d,h=%d]",x, y, w, h))
+function Device:setViewport(x, y, w, h)
+    logger.info(string.format("Switching viewport to new geometry [x=%d,y=%d,w=%d,h=%d]", x, y, w, h))
     local viewport = Geom:new{x=x, y=y, w=w, h=h}
     self.screen:setViewport(viewport)
 end
@@ -379,13 +379,13 @@ function Device:_toggleStatusBarVisibility()
     local statusbar_height = android.getStatusBarHeight()
     local new_height = height - statusbar_height
 
+    local Input = require("device/input")
     if not is_fullscreen and self.viewport then
         statusbar_height = 0
         -- reset touchTranslate to normal
-        self.input:registerEventAdjustHook(
-            self.input.adjustTouchTranslate,
-            {x = 0 + self.viewport.x, y = 0 + self.viewport.y}
-        )
+        -- (since we don't setup any hooks besides the viewport one,
+        -- (we can just reset the hook to the default NOP instead of piling on +/- translations...)
+        self.input.eventAdjustHook = Input.eventAdjustHook
     end
 
     local viewport = Geom:new{x=0, y=statusbar_height, w=width, h=new_height}

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -197,6 +197,9 @@ function Device:init()
         self.powerd = require("device/generic/powerd"):new{device = self}
     end
 
+    -- NOTE: This needs to run *after* implementation-specific event hooks,
+    --       especially if those require swapping/mirroring...
+    --       (e.g., Device implementations should setup their own hooks *before* calling this via Generic.init(self)).
     if self.viewport then
         logger.dbg("setting a viewport:", self.viewport)
         self.screen:setViewport(self.viewport)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -752,7 +752,13 @@ function Kobo:init()
         dodgy_rtc = dodgy_rtc,
     }
 
+    -- Input handling on Kobo is a thing of nightmares, start by setting up the actual evdev handler...
+    self:setTouchEventHandler()
+    -- And then handle the extra shenanigans if necessary.
+    self:initEventAdjustHooks()
+
     -- Let generic properly setup the standard stuff
+    -- (*after* we've set our input hooks, so that the viewport translation runs last).
     Generic.init(self)
 
     -- Various HW Buttons, Switches & Synthetic NTX events
@@ -770,11 +776,6 @@ function Kobo:init()
     -- fake_events is only used for usb plug & charge events so far (generated via uevent, c.f., input/iput-kobo.h in base).
     -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status (... but only when Nickel is running ;p)
     self.input.open("fake_events")
-
-    -- Input handling on Kobo is a thing of nightmares, start by setting up the actual evdev handler...
-    self:setTouchEventHandler()
-    -- And then handle the extra shenanigans if necessary.
-    self:initEventAdjustHooks()
 
     -- See if the device supports key repeat
     if not self:getKeyRepeat() then


### PR DESCRIPTION
The translation was applied *before* platform-specific input hooks, which, well, broke it, because we always swap x/y on Kobo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10008)
<!-- Reviewable:end -->
