### PR TITLE
Kobo: Unbreak a slew of devices

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -144,6 +144,8 @@ local Kobo = Generic:extend{
     canPowerOff = yes,
     canSuspend = yes,
     supportsScreensaver = yes,
+    -- most Kobos are MT-capable
+    hasMultitouch = yes,
     -- most Kobos have X/Y switched for the touch screen
     touch_switch_xy = true,
     -- most Kobos have also mirrored X coordinates


### PR DESCRIPTION
Fix #10020, Regression since #10008

(hasMultiTouch is set by `Generic.init`, but we use it before that; so just set it properly ourselves in our superclass, because we don't actually need to rely on Generic's autodetection).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10019)
<!-- Reviewable:end -->
