### PR TITLE
WakeupMgr: Explicitly invalidate the current alarm in unsetWakeupAlarm

### DIFF
--- a/frontend/device/wakeupmgr.lua
+++ b/frontend/device/wakeupmgr.lua
@@ -216,6 +216,13 @@ Unset wakeup alarm.
 Simple wrapper for @{ffi.rtc.unsetWakeupAlarm}.
 --]]
 function WakeupMgr:unsetWakeupAlarm()
+    -- Apparently, toggling the interrupt doesn't work on some RTCs,
+    -- and not necessarily the ones we've flagged as dodgy... (#10031).
+    -- Deal with this insanity by ensuring the alarm is not set in the future,
+    -- by overwriting the current alarm with an already expired disabled one.
+    logger.dbg("WakeupMgr:unsetWakeupAlarm will invalidate any future alarms")
+    local epoch = RTC:secondsFromNowToEpoch(-1)
+    self:setWakeupAlarm(epoch, false)
     return self.rtc:unsetWakeupAlarm()
 end
 

--- a/frontend/device/wakeupmgr.lua
+++ b/frontend/device/wakeupmgr.lua
@@ -221,8 +221,7 @@ function WakeupMgr:unsetWakeupAlarm()
     -- Deal with this insanity by ensuring the alarm is not set in the future,
     -- by overwriting the current alarm with an already expired disabled one.
     logger.dbg("WakeupMgr:unsetWakeupAlarm will invalidate any future alarms")
-    local epoch = RTC:secondsFromNowToEpoch(-1)
-    self:setWakeupAlarm(epoch, false)
+    self:setWakeupAlarm(0, false)
     return self.rtc:unsetWakeupAlarm()
 end
 


### PR DESCRIPTION
Apparently, toggling the rtc interrupt doesn't quite work on some boards?

Fix #10031

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10032)
<!-- Reviewable:end -->
