### PR TITLE
Filemanager copy/move: add support of centralized sdr folders

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -989,10 +989,17 @@ function FileManager:pasteHere(file)
     local function updateSidecar(move)
         if DocSettings:hasSidecarFile(orig) then
             local dest_sidecar_dir = DocSettings:getSidecarDir(dest_file)
-            BaseUtil.execute(self.mkdir_bin, dest_sidecar_dir)
+            DocSettings:ensureSideca(dest_sidecar_dir)
             BaseUtil.execute(self.cp_bin, DocSettings:getSidecarFile(orig), dest_sidecar_dir)
             if move then
                 DocSettings:open(orig):purge()
+            end
+        end
+        local orig_history_path = DocSettings:getHistoryPath(orig)
+        if lfs.attributes(orig_history_path, "mode") == "file" then
+            BaseUtil.execute(self.cp_bin, orig_history_path, DocSettings:getHistoryPath(dest_file))
+            if move then
+                os.remove(orig_history_path)
             end
         end
     end


### PR DESCRIPTION
`pasteHere()` fixed and optimized.

Support for centralized sdr storage provided by the patches https://github.com/koreader/koreader/issues/4831#issuecomment-548245804 (a file with a doc metadata in koreader/history) and https://github.com/koreader/koreader/issues/9265#issuecomment-1382729422 (a folder with doc metadata in a user defined folder).
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10051)
<!-- Reviewable:end -->