### PR TITLE
Kindle: NetworkMgr: isWifiOn isConnected

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -84,7 +84,7 @@ local function isWifiUp()
     local out = file:read("*number")
     file:close()
 
-    return out == 1
+    return true, out == 1
 end
 
 --[[

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -248,6 +248,9 @@ end
 function NetworkMgr:isConnected()
     if Device:isAndroid() or Device:isCervantes() or Device:isPocketBook() or Device:isEmulator() then
         return self:isWifiOn()
+    elseif Device:isKindle() then
+        local on, connected =  self:isWifiOn()
+        return on and connected
     else
         -- Pull the default gateway first, so we don't even try to ping anything if there isn't one...
         local default_gw


### PR DESCRIPTION
isWifiOn for kindle currently returns if the interface is connected, change this to doing what is says isWifiOn the file is only present if the wireless interface is up.

isConnected pings the gateway, rely on the kernel for a more reliable check.

Whan connecting to my android phone's wifi hotspot to remote debug from my phone, the network is connected yet the phone(gateway) does not respond to pings leading koreader to shut down the connection thinking it is unsuccessful

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10059)
<!-- Reviewable:end -->
