### PR TITLE
network info is probably only available when connected

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -292,12 +292,13 @@ function Device:initNetworkManager(NetworkMgr)
         android.openWifiSettings()
     end
 
-    function NetworkMgr:isWifiOn()
+    function NetworkMgr:isConnected()
         local ok = android.getNetworkInfo()
         ok = tonumber(ok)
         if not ok then return false end
         return ok == 1
     end
+    NetworkMgr.isWifiOn = NetworkMgr.isConnected
 end
 
 function Device:performHapticFeedback(type)

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -12,20 +12,6 @@ local function getProductId()
     return product_id
 end
 
-local function isConnected()
-    -- read carrier state from sysfs (for eth0)
-    local file = io.open("/sys/class/net/eth0/carrier", "rb")
-
-    -- file exists while Wi-Fi module is loaded.
-    if not file then return 0 end
-
-    -- 0 means not connected, 1 connected
-    local out = file:read("*number")
-    file:close()
-
-    return out or 0
-end
-
 local function isMassStorageSupported()
     -- we rely on 3rd party package for that. It should be installed as part of KOReader prerequisites,
     local safemode_version = io.open("/usr/share/safemode/version", "rb")
@@ -190,9 +176,8 @@ function Cervantes:initNetworkManager(NetworkMgr)
     function NetworkMgr:restoreWifiAsync()
         os.execute("./restore-wifi-async.sh")
     end
-    function NetworkMgr:isWifiOn()
-        return 1 == isConnected()
-    end
+    NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
+    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
 end
 
 -- power functions: suspend, resume, reboot, poweroff

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -268,7 +268,7 @@ function Device:onPowerEvent(ev)
                 logger.dbg("Resuming...")
                 local UIManager = require("ui/uimanager")
                 UIManager:unschedule(self.suspend)
-                if self:hasWifiManager() and not self:isEmulator() then
+                if self:hasWifiManager() then
                     local network_manager = require("ui/network/manager")
                     if network_manager.wifi_was_on and G_reader_settings:isTrue("auto_restore_wifi") then
                         network_manager:restoreWifiAsync()

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -368,9 +368,10 @@ function PocketBook:initNetworkManager(NetworkMgr)
         end
     end
 
-    function NetworkMgr:isWifiOn()
+    function NetworkMgr:isConnected()
         return band(inkview.QueryNetwork(), C.NET_CONNECTED) ~= 0
     end
+    NetworkMgr.isWifiOn = NetworkMgr.isConnected
 end
 
 function PocketBook:getSoftwareVersion()

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -194,9 +194,8 @@ function Remarkable:initNetworkManager(NetworkMgr)
 
     NetworkMgr:setWirelessBackend("wpa_supplicant", {ctrl_interface = "/var/run/wpa_supplicant/wlan0"})
 
-    NetworkMgr.isWifiOn = function()
-        return NetworkMgr:isConnected()
-    end
+    NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
+    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
 end
 
 function Remarkable:setDateTime(year, month, day, hour, min, sec)

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -128,7 +128,6 @@ local Emulator = Device:extend{
     hasNaturalLight = yes,
     hasNaturalLightApi = yes,
     hasWifiToggle = yes,
-    hasWifiManager = yes,
     -- Not really, Device:reboot & Device:powerOff are not implemented, so we just exit ;).
     canPowerOff = yes,
     canReboot = yes,
@@ -367,6 +366,28 @@ function Device:setEventHandlers(UIManager)
     end
 end
 
+function Device:initNetworkManager(NetworkMgr)
+    function NetworkMgr:isWifiOn() return true end
+    function NetworkMgr:isConnected()
+        -- Pull the default gateway first, so we don't even try to ping anything if there isn't one...
+        local default_gw, std_out
+        if isCommand("ip") then
+            std_out = io.popen([[ip r | grep default | tail -n 1 | cut -d ' ' -f 3]], "r")
+        else
+            std_out = io.popen([[route -n | awk '$4 == "UG" {print $2}' | tail -n 1]], "r")
+        end
+
+        if std_out then
+            default_gw = std_out:read("*all")
+            std_out:close()
+            if not default_gw or default_gw == "" then
+                return false
+            end
+        end
+        return 0 == os.execute("ping -c1 -w2 " .. default_gw)
+    end
+end
+
 function Emulator:supportsScreensaver() return true end
 
 function Emulator:simulateSuspend()
@@ -401,6 +422,7 @@ function Emulator:initNetworkManager(NetworkMgr)
     function NetworkMgr:isWifiOn()
         return G_reader_settings:nilOrTrue("emulator_fake_wifi_connected")
     end
+    NetworkMgr.isConnected = NetworkMgr.isWifiOn
 end
 
 io.write("Starting SDL in " .. SDL.getBasePath() .. "\n")

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -172,9 +172,13 @@ function SonyPRSTUX:initNetworkManager(NetworkMgr)
         -- os.execute("./restore-wifi-async.sh")
     end
 
+    --[[
     function NetworkMgr:isWifiOn()
         return 0 == os.execute("wmiconfig -i wlan0 --wlan query | grep -q enabled")
     end
+    --]]
+    NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
+    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
 end
 
 

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -115,7 +115,7 @@ local network_activity_noise_margin = 12 -- unscaled_size_check: ignore
 
 -- Read the statistics/tx_packets sysfs entry for the current network interface.
 -- It *should* be the least noisy entry on an idle network...
--- The fact that auto_disable_wifi is only available on (Device:hasWifiManager() and not Device:isEmulator())
+-- The fact that auto_disable_wifi is only available on Device:hasWifiManager()
 -- allows us to get away with a Linux-only solution.
 function NetworkListener:_getTxPackets()
     -- read tx_packets stats from sysfs (for the right network if)
@@ -198,7 +198,7 @@ end
 
 function NetworkListener:onNetworkConnected()
     logger.dbg("NetworkListener: onNetworkConnected")
-    if not (Device:hasWifiManager() and not Device:isEmulator()) then
+    if not Device:hasWifiManager() then
         return
     end
 
@@ -218,7 +218,7 @@ end
 
 function NetworkListener:onNetworkDisconnected()
     logger.dbg("NetworkListener: onNetworkDisconnected")
-    if not (Device:hasWifiManager() and not Device:isEmulator()) then
+    if not Device:hasWifiManager() then
         return
     end
 


### PR DESCRIPTION
Follow up to #10059.

Many of the devices use the same function to back both `iswifion()` and `isConnected()`. I think they represent different things, 1. is the radio on 2. are we connected to a network.

I fixed this for kindle, but asking for the other devices,

- [x] Android: @pazos I am not sure exactly what the jni getNetworkInfo is looking for.
- [x] Cervantes: Uses the same check as Kindle, so if nobody objects, I will split it properly also. (`/sys/class/net/*/carrier`)
- [x] Kobo: `iswifion`: look for wifi module. `isConnected`: gateway ping
- [x] Pocketbook: @rjd22  Both: `band(inkview.QueryNetwork(), C.NET_CONNECTED) ~= 0`
- [x] Remarkable: Both: gateway ping. `isWifiOn` is aliased to `isConnected`
- [x] Sdl: `isWifiOn` not supported. `isConnected`: gateway ping
- [x] Sony-prstux: `iswifion`: `os.execute("wmiconfig -i wlan0 --wlan query | grep -q enabled")`. `isConnected`: gateway ping

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10062)
<!-- Reviewable:end -->
