### PR TITLE
Added seconds in the markdown export

### DIFF
--- a/plugins/exporter.koplugin/template/md.lua
+++ b/plugins/exporter.koplugin/template/md.lua
@@ -46,7 +46,7 @@ local function prepareBookContent(book, formatting_options, highlight_formatting
             current_chapter = entry.chapter
             content = content .. "## " .. current_chapter .. "\n"
         end
-        content = content .. "### Page " .. entry.page .. " @ " .. os.date("%d %B %Y %I:%M %p", entry.time) .. "\n"
+        content = content .. "### Page " .. entry.page .. " @ " .. os.date("%d %B %Y %I:%M:%S %p", entry.time) .. "\n"
         if highlight_formatting then
             content = content .. string.format(formatters[formatting_options[entry.drawer]].formatter, entry.text) .."\n"
         else


### PR DESCRIPTION
This change will make the ids generated from the headers for TOC more unique in editors and static site generators since it is improbable that one person can make 2 highlights on a page in a second's time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10065)
<!-- Reviewable:end -->
