### PR TITLE
Screen Warmth: Fix a bug with syncing screen warmth on start

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -26,6 +26,10 @@ function KoboPowerD:_syncKoboLightOnStart()
     local is_frontlight_on = nil
     local new_warmth = nil
     local kobo_light_on_start = tonumber(G_defaults:readSetting("KOBO_LIGHT_ON_START"))
+
+    -- calculate the warmth scale that fits the device
+    self.warmth_scale = 100 / self.fl_warmth_max
+
     if kobo_light_on_start then
         if kobo_light_on_start > 0 then
             new_intensity = math.min(kobo_light_on_start, 100)
@@ -170,7 +174,7 @@ function KoboPowerD:init()
         if self:isFrontlightOnHW() then
             -- On devices with a mixer, setIntensity will *only* set the FL, so, ensure we honor the warmth, too.
             if self.device:hasNaturalLightMixer() then
-               self:setWarmth(self.fl_warmth)
+               self:setWarmth(self.fl_warmth, true)
             end
             -- Use setIntensity to ensure it sets fl_intensity, and because we don't want the ramping behavior of turnOn
             self:setIntensity(self:frontlightIntensityHW())
@@ -375,13 +379,6 @@ function KoboPowerD:afterResume()
     if self.fl == nil then return end
     -- Don't bother if the light was already off on suspend
     if not self.fl_was_on then return end
-    -- Update warmth state
-    if self.fl_warmth ~= nil then
-        -- And we need an explicit setWarmth if the device has a mixer, because turnOn won't touch the warmth on those ;).
-        if self.device:hasNaturalLightMixer() then
-            self:setWarmth(self.fl_warmth)
-        end
-    end
     -- Turn the frontlight back on
     self:turnOnFrontlight()
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -27,9 +27,6 @@ function KoboPowerD:_syncKoboLightOnStart()
     local new_warmth = nil
     local kobo_light_on_start = tonumber(G_defaults:readSetting("KOBO_LIGHT_ON_START"))
 
-    -- calculate the warmth scale that fits the device
-    self.warmth_scale = 100 / self.fl_warmth_max
-
     if kobo_light_on_start then
         if kobo_light_on_start > 0 then
             new_intensity = math.min(kobo_light_on_start, 100)
@@ -150,6 +147,8 @@ function KoboPowerD:init()
             -- Does this device's NaturalLight use a custom scale?
             self.fl_warmth_min = self.device.frontlight_settings.nl_min or self.fl_warmth_min
             self.fl_warmth_max = self.device.frontlight_settings.nl_max or self.fl_warmth_max
+            -- Generic does it *after* init, but we're going to need it *now*...
+            self.warmth_scale = 100 / self.fl_warmth_max
             -- If this device has a mixer, we can use the ioctl for brightness control, as it's much lower latency.
             if self.device:hasNaturalLightMixer() then
                 local kobolight = require("ffi/kobolight")

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -257,9 +257,6 @@ function AutoWarmth:scheduleMidnightUpdate(from_resume)
     UIManager:unschedule(self.setWarmth)
     UIManager:unschedule(self.setFrontlight)
 
-    -- Sync the current warmth.
-    Powerd:setWarmth(Powerd:frontlightWarmth(), true)
-
     SunTime:setPosition(self.location, self.latitude, self.longitude, self.timezone, self.altitude, true)
     SunTime:setAdvanced()
     SunTime:setDate() -- today

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -257,6 +257,9 @@ function AutoWarmth:scheduleMidnightUpdate(from_resume)
     UIManager:unschedule(self.setWarmth)
     UIManager:unschedule(self.setFrontlight)
 
+    -- Sync the current warmth.
+    Powerd:setWarmth(Powerd:frontlightWarmth(), true)
+
     SunTime:setPosition(self.location, self.latitude, self.longitude, self.timezone, self.altitude, true)
     SunTime:setAdvanced()
     SunTime:setDate() -- today


### PR DESCRIPTION
Today I got a strange behavior with AutoWarmth.

Starting the device (Sage) and going from NickelMenu to KOReader (during twilight), the warmth of the display did not change, although the correct warmth was displayed in the status bar.

A few reboots and KOReader restarts and Nickel-KOReader rounds later I found, that the first call of `Powerd:setWarmth` did nothing as `Powerd:frontlightWarmth()` (a somewhat ambiguous name; getWarmth would be better) returned the same value, as `setWarmth` wanted to set. 

So the question is, why did `frontlightWarmth()` return that value? Why to h.... does `frontlightWarmth()` knew, what value AutoWarmth wanted to set.

The PR fixes this special quirk by forcing `setWarmth()` to use the current value. That should not do much harm, as it gets called only on resume, AutoWarmth menu actions, leave standby and on midnight.

I am quite sure this PR does what it is expected to do. A hand full rounds of reboots, KOReader restarts and so on it works.

And now, as I wanted to reproduce the bug without the PR the strange news: _I can not reproduce it right now!_

Draft by now as either someone can confirm the bug or someone can explain the unwanted behaviour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10066)
<!-- Reviewable:end -->
