### PR TITLE
Delete crash.log on "Restart KOReader"

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -716,4 +716,8 @@ function Device:_afterNotCharging()
     UIManager:broadcastEvent(Event:new("NotCharging"))
 end
 
+function Device:deleteCrashLog()
+    return os.remove("crash.log")
+end
+
 return Device

--- a/frontend/ui/elements/common_exit_menu_table.lua
+++ b/frontend/ui/elements/common_exit_menu_table.lua
@@ -1,5 +1,6 @@
 local Device = require("device")
 local Event = require("ui/event")
+local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 
@@ -22,6 +23,17 @@ exit_settings.restart_koreader = {
     text = _("Restart KOReader"),
     callback = function()
         UIManager:broadcastEvent(Event:new("Restart"))
+    end,
+    hold_callback = function()
+        if Device:deleteCrashLog() then
+            UIManager:show(InfoMessage:new{
+                text = _("KOReader log file deleted:\n'crash.log'"),
+            })
+        end
+        local restart_delay_s = 1.5 -- time to read the message
+        UIManager:scheduleIn(restart_delay_s, function()
+            UIManager:broadcastEvent(Event:new("Restart"))
+        end)
     end,
 }
 if not Device:canRestart()  then


### PR DESCRIPTION
A tiny feature I was missing during debug: Delete the crash.log on restart of KOReader.

This PR allows deleting the crash.log on a long press on "Restart KOReader".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10067)
<!-- Reviewable:end -->
