### PR TITLE
kodev: fix grep warnings

### DIFF
--- a/kodev
+++ b/kodev
@@ -40,7 +40,7 @@ function assert_ret_zero() {
 }
 
 function check_submodules() {
-    if git submodule status | grep -qE '^\-'; then
+    if git submodule status | grep -qE '^-'; then
         kodev-fetch-thirdparty
     fi
 }


### PR DESCRIPTION
`grep: warning: stray \ before -`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10071)
<!-- Reviewable:end -->
