### PR TITLE
fix not shown as a desktop application

### DIFF
--- a/platform/appimage/koreader.appdata.xml
+++ b/platform/appimage/koreader.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component>
+<component type="desktop-application">
   <id>rocks.koreader.KOReader</id>
   <launchable type="desktop-id">rocks.koreader.KOReader.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
To make it shown as a desktop application and listed on flathub.org, the app data must mark it as a desktop application: https://github.com/flathub/flathub/wiki/AppData-Guidelines#header

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10076)
<!-- Reviewable:end -->
