### PR TITLE
Notification: Fence the *display* update in an attempt to avoid upsetting some boards...

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -430,14 +430,14 @@ end
 
 function ReaderFont:onIncreaseFontSize(ges)
     local delta_int = self:gesToFontSize(ges)
-    Notification:notify(_("Increasing font size…"), true)
+    Notification:notify(_("Increasing font size…"), nil, true)
     self:onChangeSize(delta_int)
     return true
 end
 
 function ReaderFont:onDecreaseFontSize(ges)
     local delta_int = self:gesToFontSize(ges)
-    Notification:notify(_("Decreasing font size…"), true)
+    Notification:notify(_("Decreasing font size…"), nil, true)
     self:onChangeSize(-delta_int)
     return true
 end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1154,9 +1154,7 @@ function ReaderView:onToggleReadingOrder()
     self.inverse_reading_order = not self.inverse_reading_order
     self:setupTouchZones()
     local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout() -- mirrored reading
-    UIManager:show(Notification:new{
-        text = is_rtl and _("RTL page turning.") or _("LTR page turning."),
-    })
+    Notification:notify(is_rtl and _("RTL page turning.") or _("LTR page turning."))
     return true
 end
 

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -107,7 +107,7 @@ end
 
 function ButtonDialogTitle:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self[1][1].dimen
+        return "ui", self[1][1].dimen -- i.e., MovableContainer
     end)
 end
 

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -132,7 +132,7 @@ end
 
 function ButtonDialogTitle:paintTo(...)
     InputContainer.paintTo(self, ...)
-    self.dimen = self[1][1].dimen -- FrameContainer
+    self.dimen = self[1][1].dimen
 end
 
 return ButtonDialogTitle

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -611,7 +611,6 @@ function ConfigOption:init()
                     num_buttons = #self.options[c].values,
                     position = self.options[c].default_pos,
                     callback = function(arg)
-
                         if arg == "-" or arg == "+" then
                             Notification:setNotifySource(Notification.SOURCE_BOTTOM_MENU_FINE)
                             self.config:onConfigFineTuneChoose(self.options[c].values, self.options[c].name,

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -185,7 +185,7 @@ end
 
 function ConfirmBox:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self[1][1].dimen
+        return "ui", self.movable.dimen
     end)
     if self.flush_events_on_show then
         -- Discard queued and upcoming input events to avoid accidental dismissal
@@ -195,7 +195,7 @@ end
 
 function ConfirmBox:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "ui", self[1][1].dimen
+        return "ui", self.movable.dimen
     end)
 end
 
@@ -207,7 +207,7 @@ function ConfirmBox:onClose()
 end
 
 function ConfirmBox:onTapClose(arg, ges)
-    if ges.pos:notIntersectWith(self[1][1].dimen) then
+    if ges.pos:notIntersectWith(self.movable.dimen) then
         self:onClose()
     end
     -- Don't let it propagate to underlying widgets

--- a/frontend/ui/widget/datetimewidget.lua
+++ b/frontend/ui/widget/datetimewidget.lua
@@ -394,9 +394,6 @@ function DateTimeWidget:createLayout()
         }
     }
     self:refocusWidget()
-    UIManager:setDirty(self, function()
-        return "ui", self.date_frame.dimen
-    end)
 end
 
 function DateTimeWidget:update(year, month, day, hour, min, sec)

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -712,10 +712,6 @@ function DictQuickLookup:init()
 
     -- We're a new window
     table.insert(DictQuickLookup.window_list, self)
-
-    UIManager:setDirty(self, function()
-        return "partial", self.dict_frame.dimen
-    end)
 end
 
 -- Whether currently DictQuickLookup is working without a document.

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -213,7 +213,7 @@ function InfoMessage:onCloseWidget()
     end
 
     UIManager:setDirty(nil, function()
-        return "ui", self[1][1].dimen
+        return "ui", self.movable.dimen
     end)
 end
 
@@ -231,7 +231,7 @@ function InfoMessage:onShow()
     end
     -- set our region to be dirty, so UImanager will call our paintTo()
     UIManager:setDirty(self, function()
-        return "ui", self[1][1].dimen
+        return "ui", self.movable.dimen
     end)
     if self.flush_events_on_show then
         -- Discard queued and upcoming input events to avoid accidental dismissal
@@ -254,7 +254,7 @@ end
 
 function InfoMessage:getVisibleArea()
     if not self.invisible then
-        return self[1][1].dimen
+        return self.movable.dimen
     end
 end
 

--- a/frontend/ui/widget/keyboardlayoutdialog.lua
+++ b/frontend/ui/widget/keyboardlayoutdialog.lua
@@ -180,7 +180,7 @@ end
 
 function KeyboardLayoutDialog:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "ui", self[1][1].dimen
+        return "ui", self.movable.dimen
     end)
 end
 

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -147,7 +147,7 @@ end
 
 function MultiConfirmBox:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self[1][1].dimen   -- i.e., MovableContainer
+        return "ui", self[1][1].dimen -- i.e., MovableContainer
     end)
 end
 

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -147,7 +147,7 @@ end
 
 function MultiConfirmBox:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self[1][1].dimen
+        return "ui", self[1][1].dimen   -- i.e., MovableContainer
     end)
 end
 

--- a/frontend/ui/widget/naturallightwidget.lua
+++ b/frontend/ui/widget/naturallightwidget.lua
@@ -329,7 +329,6 @@ function NaturalLightWidget:createMainContent(width, height)
     table.insert(self.fl_container, vertical_group)
     -- Reset container height to what it actually contains
     self.fl_container.dimen.h = vertical_group:getSize().h
-    UIManager:setDirty(self, "ui")
     return self.fl_container
 end
 

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -32,13 +32,21 @@ local SOURCE_DISPATCHER           = 0x0020 -- dispatcher
 local SOURCE_OTHER                = 0x0040 -- all other sources (e.g. keyboard)
 
 -- All bottom menu bits
-local SOURCE_BOTTOM_MENU = SOURCE_BOTTOM_MENU_ICON + SOURCE_BOTTOM_MENU_TOGGLE + SOURCE_BOTTOM_MENU_FINE +
-        SOURCE_BOTTOM_MENU_MORE + SOURCE_BOTTOM_MENU_PROGRESS
+local SOURCE_BOTTOM_MENU = SOURCE_BOTTOM_MENU_ICON +
+                           SOURCE_BOTTOM_MENU_TOGGLE +
+                           SOURCE_BOTTOM_MENU_FINE +
+                           SOURCE_BOTTOM_MENU_MORE +
+                           SOURCE_BOTTOM_MENU_PROGRESS
 
 -- these values can be changed here
-local SOURCE_SOME = SOURCE_BOTTOM_MENU_FINE + SOURCE_DISPATCHER
-local SOURCE_DEFAULT = SOURCE_SOME + SOURCE_BOTTOM_MENU_MORE + SOURCE_BOTTOM_MENU_PROGRESS
-local SOURCE_ALL = SOURCE_BOTTOM_MENU + SOURCE_DISPATCHER + SOURCE_OTHER
+local SOURCE_SOME = SOURCE_BOTTOM_MENU_FINE +
+                    SOURCE_DISPATCHER
+local SOURCE_DEFAULT = SOURCE_SOME +
+                       SOURCE_BOTTOM_MENU_MORE +
+                       SOURCE_BOTTOM_MENU_PROGRESS
+local SOURCE_ALL = SOURCE_BOTTOM_MENU +
+                   SOURCE_DISPATCHER +
+                   SOURCE_OTHER
 
 local Notification = InputContainer:extend{
     face = Font:getFace("x_smallinfofont"),
@@ -140,7 +148,7 @@ function Notification:getNotifySource()
     return self.notify_source
 end
 
--- show popups if `source` or `self.notify_source` is not masked by the setting `notification_sources_to_show_mask`
+-- Display a notification popup if `source` or `self.notify_source` is not masked by the `notification_sources_to_show_mask` setting
 function Notification:notify(arg, source, refresh_after)
     source = source or self.notify_source
     local mask = G_reader_settings:readSetting("notification_sources_to_show_mask") or self.SOURCE_DEFAULT

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -196,7 +196,7 @@ end
 
 function Notification:onShow()
     -- NOTE: We use the elusive "[ui]" mode solely for the sake of NTX boards flagged as unreliable,
-    --       in the hope that this will save same from an EPDC race that might make them horribly crash.
+    --       in the hope that this will save them from an EPDC race that might make them horribly crash.
     --       c.f., https://github.com/koreader/koreader/issues/9806#issuecomment-1416827447
     UIManager:setDirty(self, function()
         return "[ui]", self.frame.dimen

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -189,7 +189,7 @@ end
 function Notification:onShow()
     -- triggered by the UIManager after we got successfully shown (not yet painted)
     UIManager:setDirty(self, function()
-        return "ui", self.frame.dimen
+        return "[ui]", self.frame.dimen
     end)
     if self.timeout then
         UIManager:scheduleIn(self.timeout, function() UIManager:close(self) end)

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -23,13 +23,13 @@ local Input = Device.input
 local band = bit.band
 
 -- The following constants are positions in a bitfield
-local SOURCE_BOTTOM_MENU_ICON =     0x0001 -- icons in bottom menu
-local SOURCE_BOTTOM_MENU_TOGGLE =   0x0002 -- toggles in bottom menu
-local SOURCE_BOTTOM_MENU_FINE =     0x0004 -- toggles with fine-tuning ("increase", "+" etc)
-local SOURCE_BOTTOM_MENU_MORE =     0x0008 -- three dots in bottom menu
+local SOURCE_BOTTOM_MENU_ICON     = 0x0001 -- icons in bottom menu
+local SOURCE_BOTTOM_MENU_TOGGLE   = 0x0002 -- toggles in bottom menu
+local SOURCE_BOTTOM_MENU_FINE     = 0x0004 -- toggles with fine-tuning ("increase", "+" etc)
+local SOURCE_BOTTOM_MENU_MORE     = 0x0008 -- three dots in bottom menu
 local SOURCE_BOTTOM_MENU_PROGRESS = 0x0010 -- progress indicator on bottom menu
-local SOURCE_DISPATCHER =           0x0020 -- dispatcher
-local SOURCE_OTHER =                0x0040 -- all other sources (e.g. keyboard)
+local SOURCE_DISPATCHER           = 0x0020 -- dispatcher
+local SOURCE_OTHER                = 0x0040 -- all other sources (e.g. keyboard)
 
 -- All bottom menu bits
 local SOURCE_BOTTOM_MENU = SOURCE_BOTTOM_MENU_ICON + SOURCE_BOTTOM_MENU_TOGGLE + SOURCE_BOTTOM_MENU_FINE +
@@ -140,10 +140,11 @@ function Notification:getNotifySource()
     return self.notify_source
 end
 
--- show popups if `self.notify_source` is not masked by the setting `notification_sources_to_show_mask`
-function Notification:notify(arg, refresh_after)
+-- show popups if `source` or `self.notify_source` is not masked by the setting `notification_sources_to_show_mask`
+function Notification:notify(arg, source, refresh_after)
+    source = source or self.notify_source
     local mask = G_reader_settings:readSetting("notification_sources_to_show_mask") or self.SOURCE_DEFAULT
-    if self.notify_source and band(mask, self.notify_source) ~= 0 then
+    if source and band(mask, self.notify_source) ~= 0 then
         UIManager:show(Notification:new{
             text = arg,
          })

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -195,7 +195,9 @@ function Notification:onCloseWidget()
 end
 
 function Notification:onShow()
-    -- triggered by the UIManager after we got successfully shown (not yet painted)
+    -- NOTE: We use the elusive "[ui]" mode solely for the sake of NTX boards flagged as unreliable,
+    --       in the hope that this will save same from an EPDC race that might make them horribly crash.
+    --       c.f., https://github.com/koreader/koreader/issues/9806#issuecomment-1416827447
     UIManager:setDirty(self, function()
         return "[ui]", self.frame.dimen
     end)

--- a/frontend/ui/widget/qrmessage.lua
+++ b/frontend/ui/widget/qrmessage.lua
@@ -81,7 +81,7 @@ end
 
 function QRMessage:onCloseWidget()
     UIManager:setDirty(nil, function()
-        return "ui", self[1][1].dimen
+        return "ui", self[1][1].dimen -- i.e., frame
     end)
 end
 

--- a/frontend/ui/widget/screensaverwidget.lua
+++ b/frontend/ui/widget/screensaverwidget.lua
@@ -50,9 +50,6 @@ function ScreenSaverWidget:update()
     }
     self.dithered = true
     self[1] = self.main_frame
-    UIManager:setDirty(self, function()
-        return "full", self.main_frame.dimen
-    end)
 end
 
 function ScreenSaverWidget:onShow()

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -279,9 +279,6 @@ function TextViewer:init()
         dimen = self.region,
         self.movable,
     }
-    UIManager:setDirty(self, function()
-        return "partial", self.frame.dimen
-    end)
 end
 
 function TextViewer:onCloseWidget()
@@ -292,7 +289,7 @@ end
 
 function TextViewer:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self.frame.dimen
+        return "partial", self.frame.dimen
     end)
     return true
 end

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -229,7 +229,7 @@ function ToggleSwitch:onTapSelect(arg, gev)
         end)
 
         UIManager:tickAfterNext(function()
-            Notification:setNotifySource(Notification.SOURCE_OTHER) -- only allow events, if they are activated
+            Notification:resetNotifySource() -- only allow events, if they are activated
         end)
     end
     return true

--- a/frontend/ui/widget/toggleswitch.lua
+++ b/frontend/ui/widget/toggleswitch.lua
@@ -229,7 +229,7 @@ function ToggleSwitch:onTapSelect(arg, gev)
         end)
 
         UIManager:tickAfterNext(function()
-            Notification:resetNotifySource() -- only allow events, if they are activated
+            Notification:resetNotifySource()
         end)
     end
     return true

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -747,7 +747,7 @@ function VirtualKeyPopup:init()
     self[1] = position_container
 
     UIManager:show(self)
-    -- Ensure the post-paint refresh will be able to grab updated coordinates from keyboard_frame
+    -- Ensure the post-paint refresh will be able to grab updated coordinates from keyboard_frame by using a refresh function
     UIManager:setDirty(self, function()
         return "ui", keyboard_frame.dimen
     end)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -347,7 +347,7 @@ function VirtualKey:update_keyboard(want_flash, want_a2)
     --       We flash the *full* keyboard when we release a hold.
     if want_flash then
         UIManager:setDirty(self.keyboard, function()
-            return "flashui", self.keyboard[1][1].dimen
+            return "flashui", self.keyboard.dimen
         end)
     else
         local refresh_type = "ui"
@@ -506,7 +506,7 @@ end
 function VirtualKeyPopup:onCloseWidget()
     self:free()
     UIManager:setDirty(nil, function()
-        return "ui", self[1][1].dimen
+        return "ui", self[1][1].dimen   -- i.e., keyboard_frame
     end)
 end
 
@@ -746,11 +746,7 @@ function VirtualKeyPopup:init()
 
     self[1] = position_container
 
-    UIManager:show(self)
-
-    UIManager:setDirty(self, function()
-        return "ui", keyboard_frame.dimen
-    end)
+    UIManager:show(self, "ui", keyboard_frame.dimen)
 end
 
 local VirtualKeyboard = FocusManager:extend{
@@ -923,7 +919,7 @@ function VirtualKeyboard:_refresh(want_flash, fullscreen)
         return
     end
     UIManager:setDirty(self, function()
-        return refresh_type, self[1][1].dimen
+        return refresh_type, self.dimen
     end)
 end
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -347,7 +347,7 @@ function VirtualKey:update_keyboard(want_flash, want_a2)
     --       We flash the *full* keyboard when we release a hold.
     if want_flash then
         UIManager:setDirty(self.keyboard, function()
-            return "flashui", self.keyboard.dimen
+            return "flashui", self.keyboard[1][1].dimen   -- i.e., keyboard_frame
         end)
     else
         local refresh_type = "ui"
@@ -746,7 +746,11 @@ function VirtualKeyPopup:init()
 
     self[1] = position_container
 
-    UIManager:show(self, "ui", keyboard_frame.dimen)
+    UIManager:show(self)
+    -- Ensure the post-paint refresh will be able to grab updated coordinates from keyboard_frame
+    UIManager:setDirty(self, function()
+        return "ui", keyboard_frame.dimen
+    end)
 end
 
 local VirtualKeyboard = FocusManager:extend{
@@ -919,7 +923,7 @@ function VirtualKeyboard:_refresh(want_flash, fullscreen)
         return
     end
     UIManager:setDirty(self, function()
-        return refresh_type, self.dimen
+        return refresh_type, self[1][1].dimen   -- i.e., keyboard_frame
     end)
 end
 
@@ -1036,6 +1040,8 @@ function VirtualKeyboard:addKeys()
         dimen = Screen:getSize(),
         keyboard_frame,
     }
+    -- Beware, this won't be updated post-paint, so the coordinates will stay at (0, 0)
+    -- (i.e., only the size is accurate, not the position).
     self.dimen = keyboard_frame:getSize()
 end
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -347,7 +347,7 @@ function VirtualKey:update_keyboard(want_flash, want_a2)
     --       We flash the *full* keyboard when we release a hold.
     if want_flash then
         UIManager:setDirty(self.keyboard, function()
-            return "flashui", self.keyboard[1][1].dimen   -- i.e., keyboard_frame
+            return "flashui", self.keyboard[1][1].dimen -- i.e., keyboard_frame
         end)
     else
         local refresh_type = "ui"
@@ -506,7 +506,7 @@ end
 function VirtualKeyPopup:onCloseWidget()
     self:free()
     UIManager:setDirty(nil, function()
-        return "ui", self[1][1].dimen   -- i.e., keyboard_frame
+        return "ui", self[1][1].dimen -- i.e., keyboard_frame
     end)
 end
 
@@ -923,7 +923,7 @@ function VirtualKeyboard:_refresh(want_flash, fullscreen)
         return
     end
     UIManager:setDirty(self, function()
-        return refresh_type, self[1][1].dimen   -- i.e., keyboard_frame
+        return refresh_type, self[1][1].dimen -- i.e., keyboard_frame
     end)
 end
 

--- a/plugins/opds.koplugin/opdscatalog.lua
+++ b/plugins/opds.koplugin/opdscatalog.lua
@@ -51,7 +51,7 @@ end
 
 function OPDSCatalog:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self[1].dimen  -- i.e., FrameContainer
+        return "ui", self[1].dimen -- i.e., FrameContainer
     end)
 end
 

--- a/plugins/opds.koplugin/opdscatalog.lua
+++ b/plugins/opds.koplugin/opdscatalog.lua
@@ -51,7 +51,7 @@ end
 
 function OPDSCatalog:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self[1].dimen
+        return "ui", self[1].dimen  -- i.e., FrameContainer
     end)
 end
 

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -389,7 +389,7 @@ end
 
 function MenuDialog:onShow()
     UIManager:setDirty(self, function()
-        return "flashui", self[1][1].dimen
+        return "flashui", self[1][1].dimen  -- i.e., FrameContainer
     end)
 end
 
@@ -435,7 +435,7 @@ function MenuDialog:onConfigChoose(values, name, event, args, position)
                 self:onChangeContextStatus(args, position)
             end
         end
-        UIManager:setDirty(nil, "ui", nil, true)
+        UIManager:setDirty(nil, "ui")
     end)
 end
 
@@ -622,7 +622,7 @@ end
 
 function WordInfoDialog:onShow()
     UIManager:setDirty(self, function()
-        return "flashui", self[1][1].dimen
+        return "flashui", self[1][1].dimen  -- i.e., MovableContainer
     end)
 end
 

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -389,7 +389,7 @@ end
 
 function MenuDialog:onShow()
     UIManager:setDirty(self, function()
-        return "flashui", self[1][1].dimen  -- i.e., FrameContainer
+        return "flashui", self[1][1].dimen -- i.e., FrameContainer
     end)
 end
 
@@ -622,7 +622,7 @@ end
 
 function WordInfoDialog:onShow()
     UIManager:setDirty(self, function()
-        return "flashui", self[1][1].dimen  -- i.e., MovableContainer
+        return "flashui", self[1][1].dimen -- i.e., MovableContainer
     end)
 end
 


### PR DESCRIPTION
Re: https://github.com/koreader/koreader/issues/9806#issuecomment-1416827447

Depends on https://github.com/koreader/koreader-base/pull/1576

Includes assorted cosmetics tweaks related to duplicate `setDirty` calls when instantiating widgets that already have an `onShow` handler doing it. (I left widgets doing it in `update` instead of `init` alone, on the assumption that callers *may* be relying on that behavior when updating widgets at runtime. This might actually never matter, and it certainly didn't for ScreenSaverWidget, which is why I removed it from there ;p).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10083)
<!-- Reviewable:end -->
