### PR TITLE
FIX: kodev wbuilder crashes with "attempt to index global 'G_defaults…

### DIFF
--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -1,10 +1,12 @@
 -- widget test utility
 -- usage: ./luajit tools/wtest.lua
 
-require "defaults"
 print(package.path)
 package.path = "common/?.lua;rocks/share/lua/5.1/?.lua;frontend/?.lua;" .. package.path
 package.cpath = "common/?.so;common/?.dll;/usr/lib/lua/?.so;rocks/lib/lua/5.1/?.so;" .. package.cpath
+
+-- Load default settings
+G_defaults = require("luadefaults"):open()
 
 local DataStorage = require("datastorage")
 local _ = require("gettext")


### PR DESCRIPTION
This pull request fixes #10084 by just adding the two lines discussed in the issue discussion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10088)
<!-- Reviewable:end -->
