### PR TITLE
NetworkManager: check iproute2 gateway as fallback for net-tools

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -258,9 +258,16 @@ function NetworkMgr:isConnected()
         if std_out then
             default_gw = std_out:read("*all")
             std_out:close()
-            if not default_gw or default_gw == "" then
-                return false
+        end
+        if not default_gw or default_gw == "" then
+            std_out = io.popen([[/sbin/ip r | grep default | tail -n 1 | cut -d ' ' -f 3]], "r")
+            if std_out then
+                default_gw = std_out:read("*all")
+                std_out:close()
             end
+        end
+        if not default_gw or default_gw == "" then
+            return false
         end
 
         -- `-c1` try only once; `-w2` wait 2 seconds


### PR DESCRIPTION
Closes #10087 that is "/sbin/route deprecated - infinite attempts to connect to wifi on newer linux distributions".

When net-tools is not installed I get a message that route was not found in koreader output (even with verbose not on). Do you want to silence it (ie add "2>/dev/null" after "route -n"?).
There is also the following ping command output which we could silence with ">/dev/null 2>&1").
Or do you prefer to keep these outputs for diagnosis purposes?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10092)
<!-- Reviewable:end -->
