### PR TITLE
Misc: Make --verbose do what it should be doing ;).

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -69,7 +69,7 @@ if G_reader_settings:isTrue("debug") and G_reader_settings:isTrue("debug_verbose
 -- Option parsing:
 local longopts = {
     debug = "d",
-    verbose = "d",
+    verbose = "v",
     profile = "p",
     help = "h",
 }


### PR DESCRIPTION
Stupid c/p typo exists since its inception in #6976

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10095)
<!-- Reviewable:end -->
