### PR TITLE
network: Allow auto_wifi_off on kindle & remarkable

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -497,7 +497,6 @@ function NetworkMgr:getPowersaveMenuTable()
         text = _("Disable Wi-Fi connection when inactive"),
         help_text = _([[This will automatically turn Wi-Fi off after a generous period of network inactivity, without disrupting workflows that require a network connection, so you can just keep reading without worrying about battery drain.]]),
         checked_func = function() return G_reader_settings:isTrue("auto_disable_wifi") end,
-        enabled_func = function() return Device:hasWifiManager() end,
         callback = function()
             G_reader_settings:flipNilOrFalse("auto_disable_wifi")
             -- NOTE: Well, not exactly, but the activity check wouldn't be (un)scheduled until the next Network(Dis)Connected event...
@@ -608,8 +607,12 @@ function NetworkMgr:getMenuTable(common_settings)
     common_settings.network_proxy = self:getProxyMenuTable()
     common_settings.network_info = self:getInfoMenuTable()
 
-    if Device:hasWifiManager() or Device:isEmulator() then
+    -- Allow auto_disable_wifi on devices where the net sysfs entry is exposed.
+    if self:getNetworkInterfaceName() then
         common_settings.network_powersave = self:getPowersaveMenuTable()
+    end
+
+    if Device:hasWifiManager() or Device:isEmulator() then
         common_settings.network_restore = self:getRestoreMenuTable()
         common_settings.network_dismiss_scan = self:getDismissScanMenuTable()
         common_settings.network_before_wifi_action = self:getBeforeWifiActionMenuTable()


### PR DESCRIPTION
They expose a network sysfs entry so we can track usage

Works for me on kindle, but i stop the amazon framework

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10096)
<!-- Reviewable:end -->
