### PR TITLE
NetworkMgr: Refine isConnected check

### DIFF
--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -177,7 +177,7 @@ function Cervantes:initNetworkManager(NetworkMgr)
         os.execute("./restore-wifi-async.sh")
     end
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
-    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
+    NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
 end
 
 -- power functions: suspend, resume, reboot, poweroff

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -187,7 +187,7 @@ function Kindle:initNetworkManager(NetworkMgr)
     end
 
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
-    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
+    NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
 end
 
 function Kindle:supportsScreensaver()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -829,10 +829,7 @@ function Kobo:initNetworkManager(NetworkMgr)
         self:reconnectOrShowNetworkMenu(complete_callback)
     end
 
-    local net_if = os.getenv("INTERFACE")
-    if not net_if then
-        net_if = "eth0"
-    end
+    local net_if = os.getenv("INTERFACE") or "eth0"
     function NetworkMgr:getNetworkInterfaceName()
         return net_if
     end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -849,7 +849,7 @@ function Kobo:initNetworkManager(NetworkMgr)
     end
 
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
-    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
+    NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
 
     -- Kill Wi-Fi if NetworkMgr:isWifiOn() and NOT NetworkMgr:isConnected()
     -- (i.e., if the launcher left the Wi-Fi in an inconsistent state: modules loaded, but no route to gateway).

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -850,6 +850,8 @@ function Kobo:initNetworkManager(NetworkMgr)
 
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
     NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
+    -- Usually handled in NetworkMgr:init, but we'll need it *now*
+    NetworkMgr.interface = net_if
 
     -- Kill Wi-Fi if NetworkMgr:isWifiOn() and NOT NetworkMgr:isConnected()
     -- (i.e., if the launcher left the Wi-Fi in an inconsistent state: modules loaded, but no route to gateway).

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -850,6 +850,13 @@ function Kobo:initNetworkManager(NetworkMgr)
 
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
     NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
+
+    -- Kill Wi-Fi if NetworkMgr:isWifiOn() and NOT NetworkMgr:isConnected()
+    -- (i.e., if the launcher left the Wi-Fi in an inconsistent state: modules loaded, but no route to gateway).
+    if NetworkMgr:isWifiOn() and not NetworkMgr:isConnected() then
+        logger.info("Kobo Wi-Fi: Left in an inconsistent state by launcher!")
+        NetworkMgr:turnOffWifi()
+    end
 end
 
 function Kobo:setTouchEventHandler()

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -195,7 +195,7 @@ function Remarkable:initNetworkManager(NetworkMgr)
     NetworkMgr:setWirelessBackend("wpa_supplicant", {ctrl_interface = "/var/run/wpa_supplicant/wlan0"})
 
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
-    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
+    NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
 end
 
 function Remarkable:setDateTime(year, month, day, hour, min, sec)

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -178,7 +178,7 @@ function SonyPRSTUX:initNetworkManager(NetworkMgr)
     end
     --]]
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
-    NetworkMgr.isConnected = NetworkMgr.sysfsCarrierConnected
+    NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
 end
 
 

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -197,7 +197,7 @@ function NetworkMgr:ifHasAnAddress()
                     logger.err("getnameinfo:", ffi.string(C.gai_strerror(s)))
                     ok = false
                 else
-                    logger.dbg("NetworkMgr: Network interface", net_if, "was assigned IP address", ffi.string(host))
+                    logger.dbg("NetworkMgr: interface", net_if, "is up @", ffi.string(host))
                     ok = true
                 end
                 -- Regardless of failure, we only check a single if, so we're done

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -127,9 +127,10 @@ function NetworkMgr:sysfsCarrierConnected()
     local net_if = self:getNetworkInterfaceName()
     local file = io.open("/sys/class/net/" .. net_if .. "/carrier", "re")
 
-    -- File only exists while Wi-Fi module is loaded.
+    -- File only exists while Wi-Fi module is loaded, but may fail to read until the interface is brought up.
     if file then
-        -- 0 means not connected, 1 connected
+        -- 0 means the interface is down, 1 that it's up
+        -- This does *NOT* represent network association state for Wi-Fi (it'll return 1 as soon as ifup)!
         out = file:read("*number")
         file:close()
     end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -183,7 +183,7 @@ function NetworkMgr:ifHasAnAddress()
     local ok
     local ifa = ifaddr[0]
     while ifa ~= nil do
-        if ifa.ifa_addr ~= nil and ffi.string(ifa.ifa_name) == net_if then
+        if ifa.ifa_addr ~= nil and C.strcmp(ifa.ifa_name, net_if) == 0 then
             local family = ifa.ifa_addr.sa_family
             if family == C.AF_INET or family == C.AF_INET6 then
                 local host = ffi.new("char[?]", C.NI_MAXHOST)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -120,7 +120,7 @@ function NetworkMgr:restoreWifiAsync() end
 
 -- Helper functions for devices that use sysfs entries to check connectivity.
 function NetworkMgr:sysfsWifiOn()
-    -- Network interface directory exists while the Wi-Fi module is loaded.
+    -- Network interface directory only exists as long as the Wi-Fi module is loaded
     local net_if = self:getNetworkInterfaceName()
     return util.pathExists("/sys/class/net/".. net_if)
 end
@@ -132,7 +132,7 @@ function NetworkMgr:sysfsCarrierConnected()
     local net_if = self:getNetworkInterfaceName()
     local file = io.open("/sys/class/net/" .. net_if .. "/carrier", "re")
 
-    -- File only exists while Wi-Fi module is loaded, but may fail to read until the interface is brought up.
+    -- File only exists while the Wi-Fi module is loaded, but may fail to read until the interface is brought up.
     if file then
         -- 0 means the interface is down, 1 that it's up
         -- This does *NOT* represent network association state for Wi-Fi (it'll return 1 as soon as ifup)!
@@ -144,7 +144,8 @@ function NetworkMgr:sysfsCarrierConnected()
 end
 
 function NetworkMgr:sysfsInterfaceOperational()
-    -- Reads the interface's RFC2863 operational state from sysfs, and wait for it to be up (associated & authenticated)
+    -- Reads the interface's RFC2863 operational state from sysfs, and wait for it to be up
+    -- (For Wi-Fi, that means associated & successfully authenticated)
     local out
     local net_if = self:getNetworkInterfaceName()
     local file = io.open("/sys/class/net/" .. net_if .. "/operstate", "re")
@@ -152,7 +153,7 @@ function NetworkMgr:sysfsInterfaceOperational()
     -- Possible values: "unknown", "notpresent", "down", "lowerlayerdown", "testing", "dormant", "up"
     -- (c.f., Linux's <Documentation/ABI/testing/sysfs-class-net>)
     -- We're *assuming* all the drivers we care about implement this properly, so we can just rely on checking for "up".
-    -- On unsupported drivers, this would be stuck to "unknown" (c.f., Linux's <Documentation/networking/operstates.rst>)
+    -- On unsupported drivers, this would be stuck on "unknown" (c.f., Linux's <Documentation/networking/operstates.rst>)
     -- NOTE: This does *NOT* mean the interface has been assigned an IP!
     if file then
         out = file:read("*l")

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -77,13 +77,6 @@ function NetworkMgr:scheduleConnectivityCheck(callback, widget)
 end
 
 function NetworkMgr:init()
-    -- On Kobo, kill Wi-Fi if NetworkMgr:isWifiOn() and NOT NetworkMgr:isConnected()
-    -- (i.e., if the launcher left the Wi-Fi in an inconsistent state: modules loaded, but no route to gateway).
-    if Device:isKobo() and self:isWifiOn() and not self:isConnected() then
-        logger.info("Kobo Wi-Fi: Left in an inconsistent state by launcher!")
-        self:turnOffWifi()
-    end
-
     self:queryNetworkState()
     self.wifi_was_on = G_reader_settings:isTrue("wifi_was_on")
     if self.wifi_was_on and G_reader_settings:isTrue("auto_restore_wifi") then

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -172,6 +172,7 @@ function NetworkMgr:ifHasAnAddress()
     end
 
     -- It's up, do the getifaddrs dance to see if it was assigned an IP yet...
+    -- c.f., getifaddrs(3)
     local ifaddr = ffi.new("struct ifaddrs *[1]")
     if C.getifaddrs(ifaddr) == -1 then
         local errno = ffi.errno()

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -227,24 +227,24 @@ end
 
 int main(int argc, char *argv[]) {
     // Querying IPv6 would require a different in6_ifreq struct and more hoop-jumping...
-	struct ifreq ifr;
-	struct sockaddr_in sai;
-	strncpy(ifr.ifr_name, *++argv, IFNAMSIZ);
+    struct ifreq ifr;
+    struct sockaddr_in sai;
+    strncpy(ifr.ifr_name, *++argv, IFNAMSIZ);
 
-	int fd = socket(PF_INET, SOCK_DGRAM, 0);
-	ioctl(fd, SIOCGIFADDR, &ifr);
-	close(fd);
+    int fd = socket(PF_INET, SOCK_DGRAM, 0);
+    ioctl(fd, SIOCGIFADDR, &ifr);
+    close(fd);
 
-	/*
-	// inet_ntoa is deprecated
-	memcpy(&sai, &ifr.ifr_addr, sizeof(sai));
-	printf("ifr.ifr_addr: %s\n", inet_ntoa(sai.sin_addr));
-	*/
-	char host[NI_MAXHOST];
-	int s = getnameinfo(&ifr.ifr_addr, sizeof(struct sockaddr_in), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-	printf("ifr.ifr_addr: %s\n", host);
+    /*
+    // inet_ntoa is deprecated
+    memcpy(&sai, &ifr.ifr_addr, sizeof(sai));
+    printf("ifr.ifr_addr: %s\n", inet_ntoa(sai.sin_addr));
+    */
+    char host[NI_MAXHOST];
+    int s = getnameinfo(&ifr.ifr_addr, sizeof(struct sockaddr_in), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+    printf("ifr.ifr_addr: %s\n", host);
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }
 --]]
 

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -168,6 +168,7 @@ end
 function NetworkMgr:ifHasAnAddress()
     -- If the interface isn't operationally up, no need to go any further
     if not self:sysfsInterfaceOperational() then
+        logger.dbg("NetworkMgr: interface is not operational yet")
         return false
     end
 
@@ -176,7 +177,7 @@ function NetworkMgr:ifHasAnAddress()
     local ifaddr = ffi.new("struct ifaddrs *[1]")
     if C.getifaddrs(ifaddr) == -1 then
         local errno = ffi.errno()
-        logger.err("getifaddrs:", ffi.string(C.strerror(errno)))
+        logger.err("NetworkMgr: getifaddrs:", ffi.string(C.strerror(errno)))
         return false
     end
 
@@ -194,7 +195,7 @@ function NetworkMgr:ifHasAnAddress()
                                         nil, 0,
                                         C.NI_NUMERICHOST)
                 if s ~= 0 then
-                    logger.err("getnameinfo:", ffi.string(C.gai_strerror(s)))
+                    logger.err("NetworkMgr: getnameinfo:", ffi.string(C.gai_strerror(s)))
                     ok = false
                 else
                     logger.dbg("NetworkMgr: interface", net_if, "is up @", ffi.string(host))

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -83,7 +83,9 @@ function NetworkMgr:scheduleConnectivityCheck(callback, widget)
 end
 
 function NetworkMgr:init()
+    Device:initNetworkManager(self)
     self.interface = self:getNetworkInterfaceName()
+
     self:queryNetworkState()
     self.wifi_was_on = G_reader_settings:isTrue("wifi_was_on")
     if self.wifi_was_on and G_reader_settings:isTrue("auto_restore_wifi") then
@@ -99,6 +101,8 @@ function NetworkMgr:init()
             UIManager:scheduleIn(2, UIManager.broadcastEvent, UIManager, Event:new("NetworkConnected"))
         end
     end
+
+    return self
 end
 
 -- Following methods are Device specific which need to be initialized in
@@ -839,8 +843,4 @@ if G_defaults:readSetting("NETWORK_PROXY") then
     NetworkMgr:setHTTPProxy(G_defaults:readSetting("NETWORK_PROXY"))
 end
 
-
-Device:initNetworkManager(NetworkMgr)
-NetworkMgr:init()
-
-return NetworkMgr
+return NetworkMgr:init()


### PR DESCRIPTION
Spent some time testing #10062 today, and there were a few shortcomings ;).

* `carrier` is set to 1 as soon as the device is *administratively* up (in practice, as soon as we run `ifconfig up`). This is perfectly fine for `isWifiOn`, but absolutely not for `isConnected`, because we are not, actually, connected to *anything*, no attempt at associating has even been made at that point. Besides being semantically wrong, in practice, this will horribly break the connectivity check, because it expects that `isConnected` means we can talk to at least the LAN.
* Delving into the Linux docs reveals that `operstate` looks like a better candidate, as it reflects *operational status*; for Wi-Fi, that means associated and successfully authenticated. That's... closer, but still not it, because we still don't have an IP, so we technically can't talk to anything other than the AP.
* So, I've brought out the big guns (`getifaddrs`), and replicated a bit of code that I already use in the USBNetwork hack on Kindle, to detect whether we actually have an IP assigned. (Other approaches, like `/proc/net/route`, may not be entirely fool-proof, and/or get complicated when IPv6 enters the fray (which it does, on Kobo, Mk. 8+ devices are IPv6-enabled)).

TL;DR: Bunch of C via ffi, and `isConnected` now returns true only when the device is operationally up *and* we have an IP assigned.

I've only tested this on Kobo right now, so ping @yparitcher to check how it fares on Kindle ;).

Depends on https://github.com/koreader/koreader-base/pull/1579 & https://github.com/koreader/lj-wpaclient/pull/10

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10098)
<!-- Reviewable:end -->
