### PR TITLE
Input: Don't set unnecessary input translations when viewports are involved

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -394,7 +394,7 @@ function Device:_toggleStatusBarVisibility()
         0, statusbar_height, width, new_height))
 
     self.screen:setViewport(viewport)
-    if is_fullscreen and self.viewport then
+    if is_fullscreen and self.viewport and self.viewport.y ~= 0 then
         self.input:registerEventAdjustHook(
             self.input.adjustTouchTranslate,
             {x = 0 - self.viewport.x, y = 0 - self.viewport.y}

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -203,10 +203,12 @@ function Device:init()
     if self.viewport then
         logger.dbg("setting a viewport:", self.viewport)
         self.screen:setViewport(self.viewport)
-        self.input:registerEventAdjustHook(
-            self.input.adjustTouchTranslate,
-            {x = 0 - self.viewport.x, y = 0 - self.viewport.y}
-        )
+        if self.viewport.x ~= 0 or self.viewport.y ~= 0 then
+            self.input:registerEventAdjustHook(
+                self.input.adjustTouchTranslate,
+                {x = 0 - self.viewport.x, y = 0 - self.viewport.y}
+            )
+        end
     end
 
     -- Handle button mappings shenanigans


### PR DESCRIPTION
Because a translation by (0, 0) is pretty dumb ;o).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10104)
<!-- Reviewable:end -->
