### PR TITLE
Kobo: Mimic Nickel's poweroff behavior on sunxi

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1273,8 +1273,13 @@ function Kobo:powerOff()
     -- Much like Nickel itself, disable the RTC alarm before powering down.
     self.wakeup_mgr:unsetWakeupAlarm()
 
-    -- Then shut down without init's help
-    os.execute("sleep 1 && poweroff -f &")
+    if self:isSunxi() then
+        -- On sunxi, apparently, we *do* go through init
+        os.execute("sleep 1 && poweroff &")
+    else
+        -- Then shut down without init's help
+        os.execute("sleep 1 && poweroff -f &")
+    end
 end
 
 function Kobo:reboot()


### PR DESCRIPTION
It goes through init, unlike on other models.

Re: #10121

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10122)
<!-- Reviewable:end -->
