### PR TITLE
ReaderRolling: quicker partial rerenderings with EPUBs

### DIFF
--- a/frontend/apps/reader/modules/readerflipping.lua
+++ b/frontend/apps/reader/modules/readerflipping.lua
@@ -6,6 +6,13 @@ local Screen = require("device").screen
 
 local ReaderFlipping = WidgetContainer:extend{
     orig_reflow_mode = 0,
+    -- Icons to show during crengine partial rerendering automation
+    rolling_rendering_state_icons = {
+        PARTIALLY_RERENDERED = "cre.render.partial",
+        FULL_RENDERING_IN_BACKGROUND = "cre.render.working",
+        FULL_RENDERING_READY = "cre.render.ready",
+        RELOADING_DOCUMENT = "cre.render.reload",
+    },
 }
 
 function ReaderFlipping:init()
@@ -38,11 +45,54 @@ function ReaderFlipping:resetLayout()
     self[1].dimen.w = new_screen_width
 end
 
+function ReaderFlipping:getRollingRenderingStateIconWidget()
+    if not self.rolling_rendering_state_widgets then
+        self.rolling_rendering_state_widgets = {}
+    end
+    local widget = self.rolling_rendering_state_widgets[self.ui.rolling.rendering_state]
+    if widget == nil then    -- not met yet
+        local icon_size = Screen:scaleBySize(32)
+        for k, v in pairs(self.ui.rolling.RENDERING_STATE) do -- known states
+            if v == self.ui.rolling.rendering_state then -- current state
+                local icon = self.rolling_rendering_state_icons[k] -- our icon (or none) for this state
+                if icon then
+                    self.rolling_rendering_state_widgets[v] = IconWidget:new{
+                        icon = icon,
+                        width = icon_size,
+                        height = icon_size,
+                        alpha = not self.ui.rolling.cre_top_bar_enabled,
+                            -- if top status bar enabled, have them opaque, as they
+                            -- will be displayed over the bar
+                            -- otherwise, keep their alpha so some bits of text is
+                            -- visible if displayed over the text when small margins
+                    }
+                else
+                    self.rolling_rendering_state_widgets[v] = false
+                end
+                break
+            end
+        end
+        widget = self.rolling_rendering_state_widgets[self.ui.rolling.rendering_state]
+    end
+    return widget or nil -- return nil if cached widget is false
+end
+
+function ReaderFlipping:onSetStatusLine()
+    -- Reset these widgets: we want new ones with proper alpha/opaque
+    self.rolling_rendering_state_widgets = nil
+end
+
 function ReaderFlipping:paintTo(bb, x, y)
     if self.ui.highlight.select_mode then
         if self[1][1] ~= self.select_mode_widget then
             self[1][1] = self.select_mode_widget
         end
+    elseif self.ui.rolling and self.ui.rolling.rendering_state then
+        local widget = self:getRollingRenderingStateIconWidget()
+        if self[1][1] ~= widget then
+            self[1][1] = widget
+        end
+        if not widget then return end -- nothing to get painted
     else
         if self[1][1] ~= self.flipping_widget then
             self[1][1] = self.flipping_widget

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -747,13 +747,22 @@ function ReaderStyleTweak:onDispatcherRegisterActions()
 end
 
 local BOOK_TWEAK_SAMPLE_CSS = [[
-p.someTitleClassName { text-indent: 0; }
-
-DIV.advertisement { display: none !important; }
-
+/* Remove indent from some P used as titles */
+p.someTitleClassName {
+    text-indent: 0;
+}
+/* Get in-page footnotes when no tweak works */
 .footnoteContainerClassName {
     -cr-hint: footnote-inpage;
-    margin: 0 !important;
+}
+/* Help getting some alternative ToC when no headings */
+.someSeparatorClassName {
+    -cr-hint: toc-level1;
+    break-before: always;
+}
+/* Hide annoying content */
+DIV.someAdvertisement {
+    display: none !important;
 }
 ]]
 

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -407,10 +407,12 @@ function ReaderThumbnail:_getPageImage(page)
     if self.ui.view.highlight.lighten_factor < 0.3 then
         self.ui.view.highlight.lighten_factor = 0.3 -- make lighten highlight a bit darker
     end
+    self.ui.highlight.select_mode = false -- Remove any select mode icon
 
     if self.ui.rolling then
         -- CRE documents: pages all have the aspect ratio of our screen (alt top status bar
         -- will be croped out after drawing), we will show them just as rendered.
+        self.ui.rolling.rendering_state = nil -- Remove any partial rerendering icon
         self.ui.view:onSetViewMode("page") -- Get out of scroll mode
         if self.ui.font.gamma_index < 30 then  -- Increase font gamma (if not already increased),
             self.ui.document:setGammaIndex(30) -- as downscaling will make text grayer
@@ -503,6 +505,7 @@ end
 
 -- CRE: emitted after a re-rendering
 ReaderThumbnail.onDocumentRerendered = ReaderThumbnail.resetCache
+ReaderThumbnail.onDocumentPartiallyRerendered = ReaderThumbnail.resetCache
 -- Emitted When adding/removing/updating bookmarks and highlights
 ReaderThumbnail.onBookmarkAdded = ReaderThumbnail.resetCachedPagesForBookmarks
 ReaderThumbnail.onBookmarkRemoved = ReaderThumbnail.resetCachedPagesForBookmarks

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -190,6 +190,14 @@ function ReaderView:paintTo(bb, x, y)
         elseif self.view_mode == "scroll" then
             self:drawScrollView(bb, x, y)
         end
+        local should_repaint = self.ui.rolling:handlePartialRerendering()
+        if should_repaint then
+            -- ReaderRolling may have repositionned on another page containing
+            -- the xpointer of the top of the original page: recalling this is
+            -- all there is to do.
+            self:paintTo(bb, x, y)
+            return
+        end
     end
 
     -- dim last read area
@@ -226,7 +234,8 @@ function ReaderView:paintTo(bb, x, y)
         self.footer:paintTo(bb, x, y)
     end
     -- paint flipping or select mode sign
-    if self.flipping_visible or self.ui.highlight.select_mode then
+    if self.flipping_visible or self.ui.highlight.select_mode
+            or (self.ui.rolling and self.ui.rolling.rendering_state) then
         self.flipping:paintTo(bb, x, y)
     end
     for _, m in pairs(self.view_modules) do

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -233,6 +233,22 @@ function CreDocument:setupDefaultView()
     self._document:setIntProperty("crengine.image.scaling.zoomout.inline.mode", 0)
     self._document:setIntProperty("crengine.image.scaling.zoomout.inline.scale", 1)
 
+    -- crengine won't create a cache for small documents, which could actually
+    -- makes re-opening small files slower than big files!
+    -- Also, we need a cache for ReaderRolling's partial rerenderings handling.
+    -- In crengine code:
+    -- A cache is created if the file size is larger than:
+    --   crengine.cache.filesize.min = PROP_MIN_FILE_SIZE_TO_CACHE: default 300000
+    --   (fallback: DOCUMENT_CACHING_SIZE_THRESHOLD=1048576)
+    -- A cache is searched for (to be used) only if the file size is larger than 65535:
+    --   hardcoded not overridable: DOCUMENT_CACHING_MIN_SIZE=65535
+    -- Other related variables:
+    --   PROP_FORCED_MIN_FILE_SIZE_TO_CACHE: not used (a hardcoded value of 30000 is used instead)
+    --     (if filesize < 30000: swapToCache simulated but not really done)
+    --   DOCUMENT_CACHING_MAX_RAM_USAGE 8388608: not used
+    -- Force having a cache with small documents (but at least > 65K)
+    self._document:setIntProperty("crengine.cache.filesize.min", 65536)
+
     -- If switching to two pages on view, we want it to behave like two columns
     -- and each view to be a single page number (instead of the default of two).
     -- This ensures that page number and count are consistent between top and

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -322,9 +322,9 @@ function CreDocument:render()
     logger.dbg("CreDocument: rendering done.")
 end
 
-function CreDocument:getDocumentRenderingHash()
+function CreDocument:getDocumentRenderingHash(extended)
     if self.been_rendered then
-        return self._document:getDocumentRenderingHash()
+        return self._document:getDocumentRenderingHash(extended)
     end
     return 0
 end
@@ -1390,12 +1390,36 @@ function CreDocument:setCallback(func)
     return self._document:setCallback(func)
 end
 
+function CreDocument:canBePartiallyRerendered()
+    return self._document:canBePartiallyRerendered()
+end
+
+function CreDocument:isPartialRerenderingEnabled()
+    return self._document:isPartialRerenderingEnabled()
+end
+
+function CreDocument:enablePartialRerendering(enable)
+    return self._document:enablePartialRerendering(enable)
+end
+
+function CreDocument:getPartialRerenderingsCount()
+    return self._document:getPartialRerenderingsCount()
+end
+
+function CreDocument:isRerenderingDelayed()
+    return self._document:isRerenderingDelayed()
+end
+
 function CreDocument:isBuiltDomStale()
     return self._document:isBuiltDomStale()
 end
 
 function CreDocument:hasCacheFile()
     return self._document:hasCacheFile()
+end
+
+function CreDocument:isCacheFileStale()
+    return self._document:isCacheFileStale()
 end
 
 function CreDocument:invalidateCacheFile()
@@ -1794,6 +1818,8 @@ function CreDocument:setupCallCache()
             elseif name == "getPageFlow" then no_wrap = true
             elseif name == "getPageNumberInFlow" then no_wrap = true
             elseif name == "getTotalPagesLeft" then no_wrap = true
+            elseif name == "getDocumentRenderingHash" then no_wrap = true
+            elseif name == "getPartialRerenderingsCount" then no_wrap = true
 
             -- Some get* have different results by page/pos
             elseif name == "getLinkFromPosition" then cache_by_tag = true

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -83,6 +83,8 @@ local order = {
         "document_save",
         "document_end_action",
         "language_support",
+        "----------------------------",
+        "partial_rerendering",
     },
     device = {
         "keyboard_layout",

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -143,7 +143,7 @@ function ImageWidget:_loadfile()
             width = self.width
             height = self.height
         end
-        local hash = "image|"..self.file.."|"..(width or "").."|"..(height or "")
+        local hash = "image|"..self.file.."|"..(width or "").."|"..(height or "")..tostring(self.alpha)
         -- Do the scaling for DPI here, so it can be cached and not re-done
         -- each time in _render() (but not if scale_factor, to avoid double scaling)
         local scale_for_dpi_here = false

--- a/frontend/ui/widget/multiconfirmbox.lua
+++ b/frontend/ui/widget/multiconfirmbox.lua
@@ -41,6 +41,7 @@ local MultiConfirmBox = InputContainer:extend{
     modal = true,
     text = _("no text"),
     face = Font:getFace("infofont"),
+    icon = "notice-question",
     choice1_text = _("Choice 1"),
     choice1_text_func = nil,
     choice2_text = _("Choice 2"),
@@ -77,7 +78,8 @@ function MultiConfirmBox:init()
     local content = HorizontalGroup:new{
         align = "center",
         IconWidget:new{
-            icon = "notice-question",
+            icon = self.icon,
+            alpha = true,
         },
         HorizontalSpan:new{ width = Size.span.horizontal_default },
         TextBoxWidget:new{

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -170,7 +170,7 @@ function TouchMenuItem:onTapSelect(arg, ges)
     if self.item.enabled_func then
         enabled = self.item.enabled_func()
     end
-    if enabled == false then return end
+    if enabled == false then return true end -- don't propagate
 
     local tap_on_checkmark = false
     if ges and ges.pos and ges.pos.x then
@@ -182,7 +182,7 @@ function TouchMenuItem:onTapSelect(arg, ges)
     end
 
     -- If the menu hasn't actually been drawn yet, don't do anything (as it's confusing, and the coordinates may be wrong).
-    if not self.item_frame.dimen then return end
+    if not self.item_frame.dimen then return true end
 
     if G_reader_settings:isFalse("flash_ui") then
         self.menu:onMenuSelect(self.item, tap_on_checkmark)
@@ -225,9 +225,21 @@ function TouchMenuItem:onHoldSelect(arg, ges)
     if self.item.enabled_func then
         enabled = self.item.enabled_func()
     end
-    if enabled == false then return end
+    if enabled == false then
+        -- Allow help_text to be displayed even if menu item disabled
+        if self.item.help_text or type(self.item.help_text_func) == "function" then
+            local help_text = self.item.help_text
+            if self.item.help_text_func then
+                help_text = self.item.help_text_func(self)
+            end
+            if help_text then
+                UIManager:show(InfoMessage:new{ text = help_text, })
+            end
+        end
+        return true -- don't propagate
+    end
 
-    if not self.item_frame.dimen then return end
+    if not self.item_frame.dimen then return true end
 
     if G_reader_settings:isFalse("flash_ui") then
         self.menu:onMenuHold(self.item, self.text_truncated)


### PR DESCRIPTION
#### Book style tweak: revamp sample tweak

Add comments and a new one with `-cr-hint: toc-level1` (that I've been using quite frequently lately for books with no or bad ToC, and had to go find the syntax in our style tweaks).

#### TouchMenu: allow help_text on disabled menu items

Also don't propagate tap/hold on disabled menu items.
(When top and bottom menu displayed at the same time, tap on a disabled top menu item could active some bottom toggle change.)

#### MultiConfirmBox: allow changing icon


#### ImageWidget: account for alpha in the cache hash


#### CreDocument: enable crengine cache with smaller documents

crengine would not create a cache for small documents, which could actually makes re-opening small files slower than big files!

#### bump crengine: support for partial rerenderings

Includes:
- https://github.com/koreader/crengine/pull/506
  - Cache: minor simplifications 
  - Cache: improve cache file reproducibility
- https://github.com/koreader/crengine/pull/507
  - CHM: minor cleanup
  - LVStream: minor cleanups
  - LVStream: fix and improve `LVZipDecodeStream` implementation
  - LVStream: disable CRC checks for ZIP streams
- https://github.com/koreader/crengine/pull/508
  - CSS: optimize :nth-child/of-type() and :nth-last-child/of-type()
  - Page splitting: fix oversight in flags handling.
    Closes #10073.
  - Update _doc_rendering_hash also when loading from cache
  - getDocumentRenderingHash(extended): add parameter
  - Toggleable support for partial rerenderings of individual DocFragments

#### ReaderRolling: quicker partial rerenderings with EPUBs

Only available with EPUBs containing 2 or more fragments, and a file size large enough to ensure a cache file is used.
The idea is simply, on any rendering setting change, to skip the rerendering of the full book and to defer any rerendering to the moment we draw a DocFragment, and render only it.
So, on a setting change, only the fragment containing the current page will be rerendered, and the new fragments we may cross while turning pages.
When having done so, KOReader is in a degraded state (the full page count is incorrect, the ToC is invalid...).
So, a full rerendering is needed, and one will happen in the background, and when the user is idle, we reload seamlessly and quickly from the cache file it has made.
ReaderFlipping will show the new icons proposed in #10086 in the top left corner to let it know at which steps in this procress we are (see screenshots there for the upcoming KOReader behaviour).

Discussed and details all along https://github.com/koreader/koreader/issues/9087#issuecomment-1407432928.
Closes #9087. Closes #9547. Closes #6896.

I've put the menu item under `Gear > Document >`, dunno if there is a better place (but it it works fine, we shouldn't need to touch it often):
![image](https://user-images.githubusercontent.com/24273478/218874644-251f8eb9-c40a-4f22-a2d3-e1300278b796.png)

Timings and behaviour of the automation open for tweaking.
I've enabled it by default, so nightly users can help testing it, we'll see how good or bad it behave and if we should let it enabled for next stable.
About the other modules with which it could have bad interactions, I just took care of disabling statistics, and trashing Page browser thumbnails.
People will probably find other places where thing may look odd, or crash. Feedback welcome.
(We'll take care of the crashes, but we may let the strange things be strange, and have them back to normal after the reload.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10124)
<!-- Reviewable:end -->
