### PR TITLE
Adjust enabled cpu cores

### DIFF
--- a/frontend/document/canvascontext.lua
+++ b/frontend/document/canvascontext.lua
@@ -96,4 +96,8 @@ function CanvasContext:enableCPUCores(amount)
     return self.device:enableCPUCores(amount)
 end
 
+function CanvasContext:adjustEnabledCPUCores(amount)
+    return self.device:adjustEnabledCPUCores(amount)
+end
+
 return CanvasContext

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -426,7 +426,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
     end
 
     if hinting then
-        CanvasContext:enableCPUCores(2)
+        CanvasContext:adjustEnabledCPUCores(1)
     end
     self:preRenderPage()
 
@@ -442,7 +442,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
             logger.warn("aborting, since we do not have a specification for that part")
             -- required part not given, so abort
             if hinting then
-                CanvasContext:enableCPUCores(1)
+                CanvasContext:adjustEnabledCPUCores(-1)
             end
             return
         end
@@ -488,7 +488,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
 
     self:postRenderPage()
     if hinting then
-        CanvasContext:enableCPUCores(1)
+        CanvasContext:adjustEnabledCPUCores(-1)
     end
     return tile
 end

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -110,7 +110,7 @@ function KoptInterface:waitForContext(kc)
 
     if waited or self.bg_thread then
         -- Background thread is done, go back to a single CPU core.
-        CanvasContext:enableCPUCores(1)
+        CanvasContext:adjustEnabledCPUCores(-1)
         self.bg_thread = nil
     end
 
@@ -392,7 +392,7 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, re
     local cached = DocCache:check(hash, TileCacheItem)
     if not cached then
         if hinting then
-            CanvasContext:enableCPUCores(2)
+            CanvasContext:adjustEnabledCPUCores(1)
         end
 
         local page_size = Document.getNativePageDimensions(doc, pageno)
@@ -426,7 +426,7 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, re
         DocCache:insert(hash, tile)
 
         if hinting then
-            CanvasContext:enableCPUCores(1)
+            CanvasContext:adjustEnabledCPUCores(-1)
         end
 
         return tile
@@ -465,7 +465,7 @@ function KoptInterface:hintReflowedPage(doc, pageno, zoom, rotation, gamma, rend
     local cached = DocCache:check(hash)
     if not cached then
         if hinting then
-            CanvasContext:enableCPUCores(2)
+            CanvasContext:adjustEnabledCPUCores(1)
         end
 
         local kc = self:createContext(doc, pageno, bbox)

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -674,7 +674,7 @@ function BookInfoManager:collectSubprocesses()
 
     -- We're done, back to a single core
     if #self.subprocesses_pids == 0 then
-        Device:enableCPUCores(1)
+        Device:adjustEnabledCPUCores(-1)
     end
 end
 
@@ -717,7 +717,7 @@ function BookInfoManager:extractInBackground(files)
 
     -- If it's the first subprocess we're launching, enable 2 CPU cores
     if #self.subprocesses_pids == 0 then
-        Device:enableCPUCores(2)
+        Device:adjustEnabledCPUCores(1)
     end
 
     -- Run task in sub-process, and remember its pid


### PR DESCRIPTION
Allows to increase/decrease the number of online CPU cores.

If more cores requested than there are physically available, only a counter increments.
One core is always online, even if less than 1 core is requested.

See comments in https://github.com/koreader/koreader/pull/10124#discussion_r1106920437 and https://github.com/koreader/koreader/pull/10124#discussion_r1106978711

The changes in `generic/device.lua` are to test the behavior of the new methods. If the PR is accepted, we might want to keep them.

Draft as only slightly tested on the Emulator (not tested on a device yet).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10127)
<!-- Reviewable:end -->
