### PR TITLE
Version history, InfoMessage Log and notification log

### DIFF
--- a/frontend/logfile.lua
+++ b/frontend/logfile.lua
@@ -1,0 +1,52 @@
+--[[--
+This module helps with writing information to log files
+]]
+
+local logfile = {}
+
+--- Returns last line in a log file and drop any lines except the last lines
+-- string path of the logfile
+-- int max_nb_log_lines maximum number of lines in the log file
+-- @treturn string,string  git-rev, model
+function logfile.getLastLineAndShrinkFile(path, max_nb_log_lines)
+    local log_file = io.open(path, "r")
+    local log_lines = {}
+    if log_file then
+        local next_line = log_file:read("*line")
+        while next_line do
+            table.insert(log_lines, next_line)
+            next_line = log_file:read("*line")
+        end
+        log_file:close()
+
+        max_nb_log_lines = max_nb_log_lines or math.huge
+        if #log_lines <= 0 then -- no need for shortening the log file
+            return ""
+        elseif #log_lines > max_nb_log_lines then -- keep only the last N-1 lines
+            local new_file = io.open(path .. ".new", "a")
+            for i = math.max(#log_lines - max_nb_log_lines, 1), #log_lines do
+                new_file:write(log_lines[i], "\n")
+            end
+            new_file:close()
+            os.remove(path)
+            os.rename(path .. ".new", path)
+        end
+    else -- log_file does not exist or can not be opened
+        return ""
+    end
+
+    return log_lines[#log_lines]
+end
+
+--- Document: ToDo
+function logfile.append(path, text)
+    local log_file = io.open(path, "a")
+    if not log_file then
+        return
+    end
+    log_file:write(text, "\n")
+    log_file:close()
+    return true
+end
+
+return logfile

--- a/frontend/ui/elements/screen_notification_menu_table.lua
+++ b/frontend/ui/elements/screen_notification_menu_table.lua
@@ -1,4 +1,6 @@
 local Notification = require("ui/widget/notification")
+local TextViewer = require("ui/widget/textviewer")
+local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 
 local band = bit.band
@@ -13,9 +15,10 @@ local function getMask()
 end
 
 return {
-    text = _("Notifications"),
+    text = _("Notifications and info-messages"),
     help_text = _([[Notification popups may be shown at the top of screen on various occasions.
-This allows selecting which to show or hide.]]),
+This allows selecting which to show or hide.\n
+Past notifications and info-massages can be retrieved.]]),
     checked_func = function()
         local value = G_reader_settings:readSetting("notification_sources_to_show_mask") or Notification.SOURCE_DEFAULT
         return  value ~= 0
@@ -74,6 +77,58 @@ This allows selecting which to show or hide.]]),
                         band(getMask(), Notification.SOURCE_BOTTOM_MENU)))
                 end
             end,
+            separator = true,
+        },
+        {
+            text = _("Show past notifications"),
+            help_text = _("Show the text of past Notifications."),
+            callback = function()
+                local file = io.open(Notification.log_file_name, "rb")
+                local content
+                if file then
+                    content = file:read("*all")
+                    file:close()
+                end
+
+                if not content then
+                    content = _("No notifications available.")
+                end
+
+                local textviewer
+                textviewer = TextViewer:new{
+                    title = _("Past notifications"),
+                    text = content,
+                    justified = false,
+                }
+                UIManager:show(textviewer)
+            end,
+            keep_menu_open = true,
+        },
+        {
+            text = _("Show past info-messages"),
+            help_text = _("Show the text of past info-messages."),
+            callback = function()
+                local InfoMessage = require("ui/widget/infomessage")
+                local file = io.open(InfoMessage.log_file_name, "rb")
+                local content
+                if file then
+                    content = file:read("*all")
+                    file:close()
+                end
+
+                if not content then
+                    content = _("No info-messages available.")
+                end
+                local textviewer
+                textviewer = TextViewer:new{
+                    title = _("Past info-messages"),
+                    text = content,
+                    justified = false,
+                    start_at_end = true,
+                }
+                UIManager:show(textviewer)
+            end,
+            keep_menu_open = true,
             separator = true,
         },
     }

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -40,9 +40,13 @@ local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local LogFile = require("logfile")
 local _ = require("gettext")
 local Input = Device.input
 local Screen = Device.screen
+
+local INFOMESSAGE_LOG_FILE = "infomessage.log"
+local NB_LOG_LINES = 500
 
 local InfoMessage = InputContainer:extend{
     modal = true,
@@ -74,6 +78,9 @@ local InfoMessage = InputContainer:extend{
     show_delay = nil,
     -- Set to true when it might be displayed after some processing, to avoid accidental dismissal
     flush_events_on_show = false,
+
+    log_file_name = INFOMESSAGE_LOG_FILE,
+    nb_log_lines = NB_LOG_LINES,
 }
 
 function InfoMessage:init()
@@ -249,6 +256,8 @@ function InfoMessage:onShow()
             UIManager:close(self)
         end)
     end
+
+    LogFile:append(self.log_file_name, os.date("%Y-%m-%d, %X:\n") .. self.text, self.nb_log_lines)
     return true
 end
 

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -15,12 +15,16 @@ local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
+local LogFile = require("logfile")
 local time = require("ui/time")
 local _ = require("gettext")
 local Screen = Device.screen
 local Input = Device.input
 
 local band = bit.band
+
+local NOTIFICATION_LOG_FILE = "notification.log"
+local NB_LOG_LINES = 10 -- todo
 
 -- The following constants are positions in a bitfield
 local SOURCE_BOTTOM_MENU_ICON     = 0x0001 -- icons in bottom menu
@@ -73,6 +77,9 @@ local Notification = InputContainer:extend{
     SOURCE_SOME = SOURCE_SOME,
     SOURCE_DEFAULT = SOURCE_DEFAULT,
     SOURCE_ALL = SOURCE_ALL,
+
+    log_file_name = NOTIFICATION_LOG_FILE,
+    nb_log_lines = NB_LOG_LINES,
 }
 
 function Notification:init()
@@ -204,6 +211,8 @@ function Notification:onShow()
     if self.timeout then
         UIManager:scheduleIn(self.timeout, function() UIManager:close(self) end)
     end
+
+    LogFile:append(self.log_file_name, os.date("%Y-%m-%d, %X: ") .. self.text, self.nb_log_lines)
     return true
 end
 

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -64,6 +64,7 @@ local TextViewer = InputContainer:extend{
     add_default_buttons = nil,
     default_hold_callback = nil, -- on each default button
     find_centered_lines_count = 5, -- line with find results to be not far from the center
+    start_at_end = nil, -- start viewing at the end
 }
 
 function TextViewer:init()
@@ -279,6 +280,10 @@ function TextViewer:init()
         dimen = self.region,
         self.movable,
     }
+
+    if self.start_at_end then
+        self.scroll_text_w:scrollToBottom()
+    end
 end
 
 function TextViewer:onCloseWidget()

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -2,6 +2,8 @@
 This module helps with retrieving version information.
 ]]
 
+local logfile = require("logfile")
+
 local VERSION_LOG_FILE = "version.log"
 local LAST_VERSION_NOT_FOUND = "last version not found"
 local MAX_NB_LOG_LINES = 365
@@ -90,62 +92,20 @@ function Version:getBuildDate()
     return self.date
 end
 
---- Returns the KOReader git-rev and model of the last line in the `VERSION_LOG_FILE`
---- and drop any lines except the last `MAX_NB_LOG_LINE's.
--- @treturn string,string  git-rev, model
-function Version:getLastVersion()
-    local log_file = io.open(VERSION_LOG_FILE, "r")
-    local log_lines = {}
-    if log_file then
-        local next_line = log_file:read("*line")
-        while next_line do
-            table.insert(log_lines, next_line)
-            next_line = log_file:read("*line")
-        end
-        log_file:close()
-
-        if #log_lines <= 0 then -- no need for shortening the log file
-            return LAST_VERSION_NOT_FOUND, ""
-        elseif #log_lines >= MAX_NB_LOG_LINES then -- keep only the last N-1 lines
-            local new_file = io.open(VERSION_LOG_FILE.."new", "a")
-            for i = math.max(#log_lines - MAX_NB_LOG_LINES + 1, 1), #log_lines do
-                new_file:write(log_lines[i], "\n")
-            end
-            new_file:close()
-            os.remove(VERSION_LOG_FILE)
-            os.rename(VERSION_LOG_FILE.."new", VERSION_LOG_FILE)
-        end
-    else -- log_file does not exist or can not be opened
-        return LAST_VERSION_NOT_FOUND, ""
-    end
-
-    local last_version_line = log_lines[#log_lines]
-    local dummy, dummy, last_version, last_model = last_version_line:match("(.-), (.-), (.-), (.-)$")
-
-    self.last_version = last_version or ""
-    self.last_model = last_model or ""
-    return self.last_version, self.last_model
-end
-
---- Appends KOReader git-rev, model and current date to the `VERSION_LOG_FILE`
---- in the format 'YYYY-mm-dd, HH:MM:SS, git-rev, model'
--- @string model device model (may contain spaces)
-function Version:appendVersionLog(model)
-    local file = io.open(VERSION_LOG_FILE, "a")
-    if not file then
-        return
-    end
-    file:write(os.date("%Y-%m-%d, %X, "), self.rev or LAST_VERSION_NOT_FOUND, ", ", model or "", "\n")
-    file:close()
-    return
-end
-
 --- Updates the `VERSION_LOG_FILE` and keep the file small
 -- @string model device model (may contain spaces)
 function Version:updateVersionLog(current_model)
-    local last_version, last_model = self:getLastVersion()
+    local last_line = logfile.getLastLineAndShrinkFile(VERSION_LOG_FILE, MAX_NB_LOG_LINES)
+
+    local dummy, dummy, last_version, last_model = last_line:match("(.-), (.-), (.-), (.-)$")
+    self.last_version = last_version or ""
+    self.last_model = last_model or ""
+
     if self.rev ~= last_version or current_model ~= last_model then
-        self:appendVersionLog(current_model)
+        -- Appends KOReader git-rev, model and current date to the `VERSION_LOG_FILE`
+        -- in the format 'YYYY-mm-dd, HH:MM:SS, git-rev, model'
+        logfile.append(VERSION_LOG_FILE,
+            os.date("%Y-%m-%d, %X, ") .. (self.rev or LAST_VERSION_NOT_FOUND) .. ", " .. (current_model or ""))
     end
 end
 

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -2,7 +2,7 @@
 This module helps with retrieving version information.
 ]]
 
-local logfile = require("logfile")
+local LogFile = require("logfile")
 
 local VERSION_LOG_FILE = "version.log"
 local LAST_VERSION_NOT_FOUND = "last version not found"
@@ -95,7 +95,7 @@ end
 --- Updates the `VERSION_LOG_FILE` and keep the file small
 -- @string model device model (may contain spaces)
 function Version:updateVersionLog(current_model)
-    local last_line = logfile.getLastLineAndShrinkFile(VERSION_LOG_FILE, MAX_NB_LOG_LINES)
+    local last_line = LogFile:getLastLineAndShrinkFile(VERSION_LOG_FILE, MAX_NB_LOG_LINES - 1)
 
     local dummy, dummy, last_version, last_model = last_line:match("(.-), (.-), (.-), (.-)$")
     self.last_version = last_version or ""
@@ -104,8 +104,9 @@ function Version:updateVersionLog(current_model)
     if self.rev ~= last_version or current_model ~= last_model then
         -- Appends KOReader git-rev, model and current date to the `VERSION_LOG_FILE`
         -- in the format 'YYYY-mm-dd, HH:MM:SS, git-rev, model'
-        logfile.append(VERSION_LOG_FILE,
-            os.date("%Y-%m-%d, %X, ") .. (self.rev or LAST_VERSION_NOT_FOUND) .. ", " .. (current_model or ""))
+        LogFile:append(VERSION_LOG_FILE,
+            os.date("%Y-%m-%d, %X, ") .. (self.rev or LAST_VERSION_NOT_FOUND) .. ", " .. (current_model or ""),
+            MAX_NB_LOG_LINES)
     end
 end
 

--- a/reader.lua
+++ b/reader.lua
@@ -27,8 +27,7 @@ userpatch.applyPatches(userpatch.early_once)
 userpatch.applyPatches(userpatch.early)
 
 local Version = require("version")
-local current_version = Version:getCurrentRevision()
-io.write(" [*] Version: ", current_version, "\n\n")
+io.write(" [*] Version: ", Version:getCurrentRevision(), "\n\n")
 
 -- Load default settings
 G_defaults = require("luadefaults"):open()
@@ -160,11 +159,8 @@ local hw_nightmode = Device.screen:getHWNightmode()
 if G_reader_settings:isTrue("night_mode") then
     Device.screen:toggleNightMode()
 end
--- Update the version log file if there was an update
-local last_version, last_model = Version:getLastVersion()
-if last_version ~= current_version or last_model ~= Device.model then
-    Version:appendVersionLog(Device.model)
-end
+-- Update the version log file if there was an update or the device has changed
+ Version:updateVersionLog(Device.model)
 -- Ensure the proper rotation on startup.
 -- We default to the rotation KOReader closed with.
 -- If the rotation is not locked it will be overridden by a book or the FM when opened.

--- a/reader.lua
+++ b/reader.lua
@@ -26,7 +26,9 @@ local userpatch = require("userpatch")
 userpatch.applyPatches(userpatch.early_once)
 userpatch.applyPatches(userpatch.early)
 
-io.write(" [*] Version: ", require("version"):getCurrentRevision(), "\n\n")
+local Version = require("version")
+local current_version = Version:getCurrentRevision()
+io.write(" [*] Version: ", current_version, "\n\n")
 
 -- Load default settings
 G_defaults = require("luadefaults"):open()
@@ -157,6 +159,11 @@ end
 local hw_nightmode = Device.screen:getHWNightmode()
 if G_reader_settings:isTrue("night_mode") then
     Device.screen:toggleNightMode()
+end
+-- Update the version log file if there was an update
+local last_version, last_model = Version:getLastVersion()
+if last_version ~= current_version or last_model ~= Device.model then
+    Version:appendVersionLog(Device.model)
 end
 -- Ensure the proper rotation on startup.
 -- We default to the rotation KOReader closed with.


### PR DESCRIPTION
This fixes ancient  https://github.com/koreader/koreader/issues/1257

On every start of KOReader it is checked if the current git revision matches the revision of the last KOReader start (and if the device model of the last start matches the current model).

The git-rev and device model (and the date of the start) is stored in the file `version.log` if a change in the revision or the model (but not the date of course) is detected. This might simplify bug/regression detection.

The proposed solution covers OTA as well as manual updates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10128)
<!-- Reviewable:end -->
