### PR TITLE
DocSettings: add support of centralized sdr storage

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -883,7 +883,7 @@ function FileManager:pasteHere(file)
     dest_path = lfs.attributes(dest_path, "mode") == "directory" and dest_path or dest_path:match("(.*/)")
     local dest_file = BaseUtil.joinPath(dest_path, orig_name)
     local is_file = lfs.attributes(orig_file, "mode") == "file"
-    
+
     local function infoCopyFile()
         if self:copyRecursive(orig_file, dest_path) then
             if is_file then
@@ -913,7 +913,7 @@ function FileManager:pasteHere(file)
             })
         end
     end
-    
+
     local function doPaste()
         local ok = self.cutfile and infoMoveFile() or infoCopyFile()
         if ok then

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -1,4 +1,3 @@
-local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local Device = require("device")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
@@ -9,7 +8,6 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local Screen = require("device").screen
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local _ = require("gettext")
-local T = require("ffi/util").template
 
 local FileManagerCollection = WidgetContainer:extend{
     coll_menu_title = _("Favorites"),

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -2,17 +2,14 @@ local BD = require("ui/bidi")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local Device = require("device")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
-local InfoMessage = require("ui/widget/infomessage")
 local Menu = require("ui/widget/menu")
 local ReadCollection = require("readcollection")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local Screen = require("device").screen
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
-local BaseUtil = require("ffi/util")
-local util = require("util")
 local _ = require("gettext")
-local T = BaseUtil.template
+local T = require("ffi/util").template
 
 local FileManagerCollection = WidgetContainer:extend{
     coll_menu_title = _("Favorites"),
@@ -42,97 +39,74 @@ function FileManagerCollection:updateItemTable()
 end
 
 function FileManagerCollection:onMenuHold(item)
-    local readerui_instance = require("apps/reader/readerui"):_getRunningInstance()
-    local currently_opened_file = readerui_instance and readerui_instance.document and readerui_instance.document.file
     self.collfile_dialog = nil
     local function status_button_callback()
-        self._manager:updateItemTable()
         UIManager:close(self.collfile_dialog)
+        self._manager:updateItemTable()
     end
-    local buttons = {
-        filemanagerutil.genStatusButtonsRow(item.file, status_button_callback),
-        {},
+    local is_currently_opened = item.file == (self.ui.document and self.ui.document.file)
+
+    local buttons = {}
+    if not (item.dim or is_currently_opened) then
+        table.insert(buttons, filemanagerutil.genStatusButtonsRow(item.file, status_button_callback))
+        table.insert(buttons, {}) -- separator
+    end
+    table.insert(buttons, {
+        filemanagerutil.genResetSettingsButton(item.file, status_button_callback, is_currently_opened),
         {
-            filemanagerutil.genResetSettingsButton(item.file, currently_opened_file, status_button_callback),
-            {
-                text = _("Remove from collection"),
-                callback = function()
-                    ReadCollection:removeItem(item.file, self._manager.coll_menu.collection)
-                    self._manager:updateItemTable()
-                    UIManager:close(self.collfile_dialog)
-                end,
-            },
+            text = _("Remove from favorites"),
+            callback = function()
+                UIManager:close(self.collfile_dialog)
+                ReadCollection:removeItem(item.file, self._manager.coll_menu.collection)
+                self._manager:updateItemTable()
+            end,
         },
+    })
+    table.insert(buttons, {
         {
-            {
-                text = _("Sort collection"),
-                callback = function()
-                    UIManager:close(self.collfile_dialog)
-                    local item_table = {}
-                    for i=1, #self._manager.coll_menu.item_table do
-                        table.insert(item_table, {text = self._manager.coll_menu.item_table[i].text, label = self._manager.coll_menu.item_table[i].file})
+            text = _("Sort favorites"),
+            callback = function()
+                UIManager:close(self.collfile_dialog)
+                local item_table = {}
+                for _, v in ipairs(self._manager.coll_menu.item_table) do
+                    table.insert(item_table, {text = v.text, label = v.file})
+                end
+                local SortWidget = require("ui/widget/sortwidget")
+                local sort_item
+                sort_item = SortWidget:new{
+                    title = _("Sort favorites"),
+                    item_table = item_table,
+                    callback = function()
+                        local new_order_table = {}
+                        for i, v in ipairs(sort_item.item_table) do
+                            table.insert(new_order_table, {
+                                file = v.label,
+                                order = i,
+                            })
+                        end
+                        ReadCollection:writeCollection(new_order_table, self._manager.coll_menu.collection)
+                        self._manager:updateItemTable()
                     end
-                    local SortWidget = require("ui/widget/sortwidget")
-                    local sort_item
-                    sort_item = SortWidget:new{
-                        title = _("Sort favorites"),
-                        item_table = item_table,
-                        callback = function()
-                            local new_order_table = {}
-                            for i=1, #sort_item.item_table do
-                                table.insert(new_order_table, {
-                                    file = sort_item.item_table[i].label,
-                                    order = i
-                                })
-                            end
-                            ReadCollection:writeCollection(new_order_table, self._manager.coll_menu.collection)
-                            self._manager:updateItemTable()
-                        end
-                    }
-                    UIManager:show(sort_item)
-                end,
-            },
-            {
-                text = _("Book information"),
-                id = "book_information", -- used by covermenu
-                enabled = FileManagerBookInfo:isSupported(item.file),
-                callback = function()
-                    FileManagerBookInfo:show(item.file)
-                    UIManager:close(self.collfile_dialog)
-                end,
-            },
+                }
+                UIManager:show(sort_item)
+            end,
         },
-    }
-    -- NOTE: Duplicated from frontend/apps/filemanager/filemanager.lua
+        {
+            text = _("Book information"),
+            id = "book_information", -- used by covermenu
+            callback = function()
+                UIManager:close(self.collfile_dialog)
+                FileManagerBookInfo:show(item.file)
+            end,
+        },
+    })
+
     if Device:canExecuteScript(item.file) then
+        local function button_callback()
+            UIManager:close(self.collfile_dialog)
+        end
         table.insert(buttons, {
-            {
-                -- @translators This is the script's programming language (e.g., shell or python)
-                text = T(_("Execute %1 script"), util.getScriptType(item.file)),
-                enabled = true,
-                callback = function()
-                    UIManager:close(self.collfile_dialog)
-                    local script_is_running_msg = InfoMessage:new{
-                            -- @translators %1 is the script's programming language (e.g., shell or python), %2 is the filename
-                            text = T(_("Running %1 script %2…"), util.getScriptType(item.file), BD.filename(BaseUtil.basename(item.file))),
-                    }
-                    UIManager:show(script_is_running_msg)
-                    UIManager:scheduleIn(0.5, function()
-                        local rv = os.execute(BaseUtil.realpath(item.file))
-                        UIManager:close(script_is_running_msg)
-                        if rv == 0 then
-                            UIManager:show(InfoMessage:new{
-                                text = _("The script exited successfully."),
-                            })
-                        else
-                            UIManager:show(InfoMessage:new{
-                                text = T(_("The script returned a non-zero status code: %1!"), bit.rshift(rv, 8)),
-                                icon = "notice-warning",
-                            })
-                        end
-                    end)
-                end,
-            }
+            filemanagerutil.genExecuteScriptButton(item.file, button_callback)
         })
     end
 

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -40,7 +40,7 @@ function ReaderStatus:onEndOfBook()
         self:openFileBrowser()
         return
     end
-    
+
     -- Should we start by marking the book as read?
     if G_reader_settings:isTrue("end_document_auto_mark") then
         self:onMarkBook(true)

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -1,4 +1,3 @@
-local BD = require("ui/bidi")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
 local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local Device = require("device")
@@ -8,7 +7,6 @@ local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local util = require("util")
 local _ = require("gettext")
-local T = require("ffi/util").template
 
 local ReaderStatus = WidgetContainer:extend{
     document = nil,
@@ -36,46 +34,39 @@ end
 
 function ReaderStatus:onEndOfBook()
     Device:performHapticFeedback("CONTEXT_CLICK")
-    local settings = G_reader_settings:readSetting("end_document_action")
-    local choose_action
-    local collate = true
     local QuickStart = require("ui/quickstart")
     local last_file = G_reader_settings:readSetting("lastfile")
-    if last_file and last_file == QuickStart.quickstart_filename then
+    if last_file == QuickStart.quickstart_filename then
         self:openFileBrowser()
         return
     end
-    if G_reader_settings:readSetting("collate") == "access" then
-        collate = false
-    end
-
+    
     -- Should we start by marking the book as read?
     if G_reader_settings:isTrue("end_document_auto_mark") then
         self:onMarkBook(true)
     end
 
-    local top_wg = UIManager:getTopmostVisibleWidget() or {}
-    if (settings == "pop-up" or settings == nil) and top_wg.name ~= "end_document" then
+    local next_file_enabled = G_reader_settings:readSetting("collate") ~= "access"
+    local settings = G_reader_settings:readSetting("end_document_action")
+    local top_widget = UIManager:getTopmostVisibleWidget() or {}
+    if (settings == "pop-up" or settings == nil) and top_widget.name ~= "end_document" then
+        local button_dialog
         local buttons = {
             {
                 {
                     text_func = function()
-                        if self.settings.data.summary and self.settings.data.summary.status == "complete" then
-                            return _("Mark as reading")
-                        else
-                            return _("Mark as finished")
-                        end
+                        return self.summary.status == "complete" and _("Mark as reading") or _("Mark as finished")
                     end,
                     callback = function()
                         self:onMarkBook()
-                        UIManager:close(choose_action)
+                        UIManager:close(button_dialog)
                     end,
                 },
                 {
                     text = _("Book status"),
                     callback = function()
                         self:onShowBookStatus()
-                        UIManager:close(choose_action)
+                        UIManager:close(button_dialog)
                     end,
                 },
 
@@ -85,15 +76,15 @@ function ReaderStatus:onEndOfBook()
                     text = _("Go to beginning"),
                     callback = function()
                         self.ui:handleEvent(Event:new("GoToBeginning"))
-                        UIManager:close(choose_action)
+                        UIManager:close(button_dialog)
                     end,
                 },
                 {
                     text = _("Open next file"),
-                    enabled = collate,
+                    enabled = next_file_enabled,
                     callback = function()
                         self:onOpenNextDocumentInFolder()
-                        UIManager:close(choose_action)
+                        UIManager:close(button_dialog)
                     end,
                 },
             },
@@ -101,46 +92,38 @@ function ReaderStatus:onEndOfBook()
                 {
                     text = _("Delete file"),
                     callback = function()
-                        self:deleteFile(self.document.file, false)
-                        UIManager:close(choose_action)
+                        self:deleteFile()
+                        UIManager:close(button_dialog)
                     end,
                 },
                 {
                     text = _("File browser"),
                     callback = function()
                         self:openFileBrowser()
-                        UIManager:close(choose_action)
-                    end,
-                },
-            },
-            {
-                {
-                    text = _("Cancel"),
-                    callback = function()
-                        UIManager:close(choose_action)
+                        UIManager:close(button_dialog)
                     end,
                 },
             },
         }
-        choose_action = ButtonDialogTitle:new{
+        button_dialog = ButtonDialogTitle:new{
             name = "end_document",
             title = _("You've reached the end of the document.\nWhat would you like to do?"),
             title_align = "center",
             buttons = buttons,
         }
-
-        UIManager:show(choose_action)
+        UIManager:show(button_dialog)
     elseif settings == "book_status" then
         self:onShowBookStatus()
     elseif settings == "next_file" then
-        if G_reader_settings:readSetting("collate") ~= "access" then
+        if next_file_enabled then
             local info = InfoMessage:new{
                 text = _("Searching next file…"),
             }
             UIManager:show(info)
             UIManager:forceRePaint()
             UIManager:close(info)
-            -- Delay until the next tick, as this will destroy the Document instance, but we may not be the final Event caught by said Document...
+            -- Delay until the next tick, as this will destroy the Document instance,
+            -- but we may not be the final Event caught by said Document...
             UIManager:nextTick(function()
                 self:onOpenNextDocumentInFolder()
             end)
@@ -171,7 +154,7 @@ function ReaderStatus:onEndOfBook()
     elseif settings == "delete_file" then
         -- Ditto
         UIManager:nextTick(function()
-            self:deleteFile(self.document.file, true)
+            self:deleteFile()
         end)
     end
 end
@@ -200,28 +183,17 @@ function ReaderStatus:onOpenNextDocumentInFolder()
     end
 end
 
-function ReaderStatus:deleteFile(file, text_end_book)
-    local ConfirmBox = require("ui/widget/confirmbox")
-    local message_end_book = ""
-    if text_end_book then
-        message_end_book = "You've reached the end of the document.\n"
+function ReaderStatus:deleteFile()
+    self.settings:flush() -- enable additional warning text for newly opened file
+    local FileManager = require("apps/filemanager/filemanager")
+    local function pre_delete_callback()
+        self.ui:onClose()
     end
-    UIManager:show(ConfirmBox:new{
-        text = T(_("%1Are you sure that you want to delete this file?\n%2\nIf you delete a file, it is permanently lost."), message_end_book, BD.filepath(file)),
-        ok_text = _("Delete"),
-        ok_callback = function()
-            local FileManager = require("apps/filemanager/filemanager")
-            self.ui:onClose()
-            FileManager:deleteFile(file)
-            require("readhistory"):fileDeleted(file) -- (will update "lastfile")
-            if FileManager.instance then
-                FileManager.instance.file_chooser:refreshPath()
-            else
-                local path = util.splitFilePathName(file)
-                FileManager:showFiles(path)
-            end
-        end,
-    })
+    local function post_delete_callback()
+        local path = util.splitFilePathName(self.document.file)
+        FileManager:showFiles(path)
+    end
+    FileManager:showDeleteFileDialog(self.document.file, post_delete_callback, pre_delete_callback)
 end
 
 function ReaderStatus:onShowBookStatus(before_show_callback)
@@ -240,31 +212,18 @@ function ReaderStatus:onShowBookStatus(before_show_callback)
     return true
 end
 
--- If mark_read is true then we change status only from reading/abandoned to read (complete).
--- Otherwise we change status from reading/abandoned to read or from read to reading.
+-- If mark_read is true then we change status only from reading/abandoned to complete.
+-- Otherwise we change status from reading/abandoned to complete or from complete to reading.
 function ReaderStatus:onMarkBook(mark_read)
-    if self.settings.data.summary then
-        if self.settings.data.summary.status and self.settings.data.summary.status == "complete" then
-            if mark_read then
-                -- Keep mark as finished.
-                self.settings.data.summary.status = "complete"
-            else
-                -- Change current status from read (complete) to reading
-                self.settings.data.summary.status = "reading"
-            end
-        else
-            self.settings.data.summary.status = "complete"
-        end
-    else
-        self.settings.data.summary = {status = "complete"}
-    end
+    self.summary.status = (not mark_read and self.summary.status == "complete") and "reading" or "complete"
     -- If History is called over Reader, it will read the file to get the book status, so save and flush
-    self.settings:saveSetting("summary", self.settings.data.summary)
+    self.settings:saveSetting("summary", self.summary)
     self.settings:flush()
 end
 
 function ReaderStatus:onReadSettings(config)
     self.settings = config
+    self.summary = config:readSetting("summary") or {}
 end
 
 return ReaderStatus

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -43,6 +43,8 @@ local nb_drawings_since_last_collectgarbage = 0
 -- in the real Menu class or instance
 local CoverMenu = {}
 
+local book_statuses = {"reading", "abandoned", "complete"}
+
 function CoverMenu:updateCache(file, status)
     if self.cover_info_cache and self.cover_info_cache[file] then
         if status then
@@ -348,8 +350,9 @@ function CoverMenu:updateItems(select_number)
                 end
 
                 -- Fudge the status change button callbacks to also update the cover_info_cache
-                for _, status in ipairs({"reading", "abandoned", "complete"}) do
+                for _, status in ipairs(book_statuses) do
                     button = self.file_dialog.button_table:getButtonById(status)
+                    if not button then break end -- status buttons are not shown
                     local orig_status_callback = button.callback
                     button.callback = function()
                         -- Update the cache
@@ -501,16 +504,15 @@ function CoverMenu:onHistoryMenuHold(item)
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
-    for _, status in ipairs({"reading", "abandoned", "complete"}) do
+    for _, status in ipairs(book_statuses) do
         button = self.histfile_dialog.button_table:getButtonById(status)
-        if button then
-            local orig_status_callback = button.callback
-            button.callback = function()
-                -- Update the cache
-                self:updateCache(file, status)
-                -- And then set the status on file as expected
-                orig_status_callback()
-            end
+        if not button then break end -- status buttons are not shown
+        local orig_status_callback = button.callback
+        button.callback = function()
+            -- Update the cache
+            self:updateCache(file, status)
+            -- And then set the status on file as expected
+            orig_status_callback()
         end
     end
 
@@ -648,8 +650,9 @@ function CoverMenu:onCollectionsMenuHold(item)
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
-    for _, status in ipairs({"reading", "abandoned", "complete"}) do
+    for _, status in ipairs(book_statuses) do
         button = self.collfile_dialog.button_table:getButtonById(status)
+        if not button then break end -- status buttons are not shown
         local orig_status_callback = button.callback
         button.callback = function()
             -- Update the cache
@@ -694,7 +697,7 @@ function CoverMenu:onCloseWidget()
     -- Propagate a call to free() to all our sub-widgets, to release memory used by their _bb
     self.item_group:free()
 
-    -- Clean any short term cache (used by ListMenu to cache some DocSettings info)
+    -- Clean any short term cache (used by ListMenu to cache some Doc Settings info)
     self.cover_info_cache = nil
 
     -- Force garbage collecting when leaving too

--- a/spec/unit/filemanager_spec.lua
+++ b/spec/unit/filemanager_spec.lua
@@ -32,7 +32,7 @@ describe("FileManager module", function()
             assert.Equals(w.text, "File not found:\n"..tmp_fn)
         end
         assert.is_nil(lfs.attributes(tmp_fn))
-        filemanager:deleteFile(tmp_fn)
+        filemanager:deleteFile(tmp_fn, true)
         UIManager.show = old_show
         filemanager:onClose()
     end)
@@ -61,7 +61,7 @@ describe("FileManager module", function()
         UIManager.show = function(self, w)
             assert.Equals(w.text, "Deleted file:\n"..tmp_fn)
         end
-        filemanager:deleteFile(tmp_fn)
+        filemanager:deleteFile(tmp_fn, true)
         UIManager.show = old_show
         filemanager:onClose()
 
@@ -83,6 +83,10 @@ describe("FileManager module", function()
 
         local tmp_sidecar = docsettings:getSidecarDir(util.realpath(tmp_fn))
         lfs.mkdir(tmp_sidecar)
+        local tmp_sidecar_file = docsettings:getSidecarFile(util.realpath(tmp_fn))
+        local tmpsf = io.open(tmp_sidecar_file, "w")
+        tmpsf:write("{}")
+        tmpsf:close()
         local tmp_history = docsettings:getHistoryPath(tmp_fn)
         local tmpfp = io.open(tmp_history, "w")
         tmpfp:write("{}")
@@ -97,7 +101,7 @@ describe("FileManager module", function()
         UIManager.show = function(self, w)
             assert.Equals(w.text, "Deleted file:\n"..tmp_fn)
         end
-        filemanager:deleteFile(tmp_fn)
+        filemanager:deleteFile(tmp_fn, true)
         UIManager.show = old_show
         filemanager:onClose()
 

--- a/spec/unit/filemanager_spec.lua
+++ b/spec/unit/filemanager_spec.lua
@@ -36,7 +36,7 @@ describe("FileManager module", function()
         UIManager.show = old_show
         filemanager:onClose()
     end)
-    it("should not delete settings for non-document file", function()
+    it("should not delete not empty sidecar folder", function()
         local filemanager = FileManager:new{
             dimen = Screen:getSize(),
             root_path = "../../test",
@@ -47,16 +47,19 @@ describe("FileManager module", function()
 
         local tmp_sidecar = docsettings:getSidecarDir(util.realpath(tmp_fn))
         lfs.mkdir(tmp_sidecar)
-        local tmp_history = docsettings:getHistoryPath(tmp_fn)
-        local tmpfp = io.open(tmp_history, "w")
-        tmpfp:write("{}")
-        tmpfp:close()
+        local tmp_sidecar_file = docsettings:getSidecarFile(util.realpath(tmp_fn))
+        local tmp_sidecar_file_foo = tmp_sidecar_file .. ".foo" -- non-docsettings file
+        local tmpsf = io.open(tmp_sidecar_file, "w")
+        tmpsf:write("{}")
+        tmpsf:close()
+        util.copyFile(tmp_sidecar_file, tmp_sidecar_file_foo)
         local old_show = UIManager.show
 
         -- make sure file exists
         assert.is_not_nil(lfs.attributes(tmp_fn))
         assert.is_not_nil(lfs.attributes(tmp_sidecar))
-        assert.is_not_nil(lfs.attributes(tmp_history))
+        assert.is_not_nil(lfs.attributes(tmp_sidecar_file))
+        assert.is_not_nil(lfs.attributes(tmp_sidecar_file_foo))
 
         UIManager.show = function(self, w)
             assert.Equals(w.text, "Deleted file:\n"..tmp_fn)
@@ -65,12 +68,11 @@ describe("FileManager module", function()
         UIManager.show = old_show
         filemanager:onClose()
 
-        -- make sure history file exists
+        -- make sure sdr folder exists
         assert.is_nil(lfs.attributes(tmp_fn))
         assert.is_not_nil(lfs.attributes(tmp_sidecar))
-        assert.is_not_nil(lfs.attributes(tmp_history))
+        os.remove(tmp_sidecar_file_foo)
         os.remove(tmp_sidecar)
-        os.remove(tmp_history)
     end)
     it("should delete document with its settings", function()
         local filemanager = FileManager:new{


### PR DESCRIPTION
(1) Support of the new centralized sdr storage in file operations and other modules (continue of https://github.com/koreader/koreader/pull/10074).
(2) Added unified Delete file dialog (successor of the closed https://github.com/koreader/koreader/pull/10011). Closes https://github.com/koreader/koreader/issues/10001. Closes https://github.com/koreader/koreader/issues/9978.
(3) Added unified "Execute script" file dialog button.
(4) Correct access to DocSettings in `filemanagerutils`.
(5) Minor fixes caused with the new book status buttons in the file popup dialogs in FM, History and Collections (https://github.com/koreader/koreader/pull/9953). Checkmark added (https://github.com/koreader/koreader/pull/9953#issuecomment-1431155936).
(6) Closes https://github.com/koreader/koreader/issues/9952.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10132)
<!-- Reviewable:end -->
