### PR TITLE
Add spaces to Letters time format when non-compact, remove lead 0s

### DIFF
--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -100,10 +100,10 @@ function datetime.secondsToClock(seconds, withoutSeconds, withDays)
                 mins = string.format("%02d", 0)
                 hours = string.format("%02d", hours + 1)
             end
-            return  (days ~= "0" and (days .. "d") or "") .. hours .. ":" .. mins
+            return  (days ~= "0" and (days .. C_("Time", "d")) or "") .. hours .. ":" .. mins
         else
             local secs = string.format("%02d", seconds % 60)
-            return (days ~= "0" and (days .. "d") or "") .. hours .. ":" .. mins .. ":" .. secs
+            return (days ~= "0" and (days .. C_("Time", "d")) or "") .. hours .. ":" .. mins .. ":" .. secs
         end
     end
 end
@@ -181,6 +181,7 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
             if compact then
                 return withoutSeconds and time_string or (time_string .. C_("Time", "s"))
             else
+                time_string = time_string:gsub(C_("Time", "d"), C_("Time", "d") .. " ") -- add space after "d"
                 time_string = time_string:gsub(C_("Time", "h"), C_("Time", "h") .. " ") -- add space after "h"
                 return withoutSeconds and time_string or
                     (time_string:gsub(C_("Time", "m"), C_("Time", "m") .. " ") .. C_("Time", "s")) -- add space after "m"

--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -113,7 +113,7 @@ end
 ---- @bool withoutSeconds if true 1h30', if false 1h30'10"
 ---- @bool hmsFormat, if true format 1h 30m 10s
 ---- @bool withDays, if true format 1d12h30'10" or 1d 12h 30m 10s
----- @bool compact, if set removes all leading zeros (incl. units if necessary) and makes spaces hairline (if present)
+---- @bool compact, if set removes all leading zeros (incl. units if necessary) and turns thinspaces into hairspaces (if present)
 ---- @treturn string clock string in the form of 1h30'10" or 1h 30m 10s
 function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, compact)
     local SECONDS_SYMBOL = "\""
@@ -199,7 +199,7 @@ end
 ---- @string Either "modern" for 1h30'10", "letters" for 1h 30m 10s, or "classic" for 1:30:10
 ---- @bool withoutSeconds if true 1h30' or 1h 30m, if false 1h30'10" or 1h 30m 10s
 ---- @bool withDays, if hours>=24 include days in clock string 1d12h10'10" or 1d 12h 10m 10s
----- @bool compact, if set removes all leading zeros (incl. units if necessary) and makes spaces hairline (if present)
+---- @bool compact, if set removes all leading zeros (incl. units if necessary) and turns thinspaces into hairspaces (if present)
 ---- @treturn string clock string in the specific format of 1h30', 1h30'10" resp. 1h 30m, 1h 30m 10s
 function datetime.secondsToClockDuration(format, seconds, withoutSeconds, withDays, compact)
     if format == "modern" then

--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -111,10 +111,10 @@ end
 --- Converts seconds to a period of time string.
 ---- @int seconds number of seconds
 ---- @bool withoutSeconds if true 1h30', if false 1h30'10"
----- @bool hmsFormat, if true format 1h30m10s
----- @bool withDays, if true format 1d12h30m10s
----- @bool compact, if set removes all leading zeros (incl. units if necessary)
----- @treturn string clock string in the form of 1h30'10" or 1h30m10s
+---- @bool hmsFormat, if true format 1h 30m 10s
+---- @bool withDays, if true format 1d12h30'10" or 1d 12h 30m 10s
+---- @bool compact, if set removes all leading zeros (incl. units if necessary) and spaces (if present)
+---- @treturn string clock string in the form of 1h30'10" or 1h 30m 10s
 function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, compact)
     local SECONDS_SYMBOL = "\""
     seconds = tonumber(seconds)
@@ -150,7 +150,7 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
                 if compact then
                     return T(C_("Time", "%1s"), string.format("%d", seconds))
                 else
-                    return T(C_("Time", "%1m%2s"), "0", string.format("%02d", seconds))
+                    return T(C_("Time", "%1m %2s"), "0", string.format("%d", seconds))
                 end
             else
                 if compact then
@@ -177,7 +177,14 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
         end
 
         if hmsFormat then
-            return withoutSeconds and time_string or (time_string .. C_("Time", "s"))
+            time_string = time_string:gsub("0(%d)", "%1") -- delete all leading "0"s
+            if compact then
+                return withoutSeconds and time_string or (time_string .. C_("Time", "s"))
+            else
+                time_string = time_string:gsub(C_("Time", "h"), C_("Time", "h") .. " ") -- add space after "h"
+                return withoutSeconds and time_string or
+                    (time_string:gsub(C_("Time", "m"), C_("Time", "m") .. " ") .. C_("Time", "s")) -- add space after "m"
+            end
         else
             time_string = time_string:gsub(C_("Time", "m"), "'") -- replace m with '
             return withoutSeconds and time_string or (time_string .. SECONDS_SYMBOL)
@@ -187,11 +194,11 @@ end
 
 --- Converts seconds to a clock type (classic or modern), based on the given format preference
 --- "Classic" format calls secondsToClock, "Modern" and "Letters" formats call secondsToHClock
----- @string Either "modern" for 1h30'10", "letters" for 1h30m10s, or "classic" for 1:30:10
----- @bool withoutSeconds if true 1h30' or 1h30m, if false 1h30'10" or 1h30m10s
----- @bool withDays, if hours>=24 include days in clock string 1d12h10m10s
----- @bool compact, if set removes all leading zeros (incl. units if necessary)
----- @treturn string clock string in the specific format of 1h30', 1h30'10" resp. 1h30m, 1h30m10s
+---- @string Either "modern" for 1h30'10", "letters" for 1h 30m 10s, or "classic" for 1:30:10
+---- @bool withoutSeconds if true 1h30' or 1h 30m, if false 1h30'10" or 1h 30m 10s
+---- @bool withDays, if hours>=24 include days in clock string 1d12h10'10" or 1d 12h 10m 10s
+---- @bool compact, if set removes all leading zeros (incl. units if necessary) and spaces (if present)
+---- @treturn string clock string in the specific format of 1h30', 1h30'10" resp. 1h 30m, 1h 30m 10s
 function datetime.secondsToClockDuration(format, seconds, withoutSeconds, withDays, compact)
     if format == "modern" then
         return datetime.secondsToHClock(seconds, withoutSeconds, false, withDays, compact)

--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -111,10 +111,10 @@ end
 --- Converts seconds to a period of time string.
 ---- @int seconds number of seconds
 ---- @bool withoutSeconds if true 1h30', if false 1h30'10"
----- @bool hmsFormat, if true format 1h 30m 10s
----- @bool withDays, if true format 1d12h30'10" or 1d 12h 30m 10s
----- @bool compact, if set removes all leading zeros (incl. units if necessary) and spaces (if present)
----- @treturn string clock string in the form of 1h30'10" or 1h 30m 10s
+---- @bool hmsFormat, if true format 1h 30m 10s
+---- @bool withDays, if true format 1d12h30'10" or 1d 12h 30m 10s
+---- @bool compact, if set removes all leading zeros (incl. units if necessary) and makes spaces hairline (if present)
+---- @treturn string clock string in the form of 1h30'10" or 1h 30m 10s
 function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, compact)
     local SECONDS_SYMBOL = "\""
     seconds = tonumber(seconds)
@@ -150,7 +150,7 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
                 if compact then
                     return T(C_("Time", "%1s"), string.format("%d", seconds))
                 else
-                    return T(C_("Time", "%1m %2s"), "0", string.format("%d", seconds))
+                    return T(C_("Time", "%1m\xE2\x80\x89%2s"), "0", string.format("%d", seconds))
                 end
             else
                 if compact then
@@ -178,14 +178,15 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
 
         if hmsFormat then
             time_string = time_string:gsub("0(%d)", "%1") -- delete all leading "0"s
-            if compact then
-                return withoutSeconds and time_string or (time_string .. C_("Time", "s"))
-            else
-                time_string = time_string:gsub(C_("Time", "d"), C_("Time", "d") .. " ") -- add space after "d"
-                time_string = time_string:gsub(C_("Time", "h"), C_("Time", "h") .. " ") -- add space after "h"
-                return withoutSeconds and time_string or
-                    (time_string:gsub(C_("Time", "m"), C_("Time", "m") .. " ") .. C_("Time", "s")) -- add space after "m"
+            time_string = time_string:gsub(C_("Time", "d"), C_("Time", "d") .. "\xE2\x80\x89") -- add thin space after "d"
+            time_string = time_string:gsub(C_("Time", "h"), C_("Time", "h") .. "\xE2\x80\x89") -- add thin space after "h"
+            if not withoutSeconds then
+                time_string = time_string:gsub(C_("Time", "m"), C_("Time", "m") .. "\xE2\x80\x89") .. C_("Time", "s")  -- add thin space after "m"
             end
+            if compact then
+                time_string = time_string:gsub("\xE2\x80\x89", "\xE2\x80\x8A") -- replace thin space with hair space
+            end
+            return time_string
         else
             time_string = time_string:gsub(C_("Time", "m"), "'") -- replace m with '
             return withoutSeconds and time_string or (time_string .. SECONDS_SYMBOL)
@@ -195,11 +196,11 @@ end
 
 --- Converts seconds to a clock type (classic or modern), based on the given format preference
 --- "Classic" format calls secondsToClock, "Modern" and "Letters" formats call secondsToHClock
----- @string Either "modern" for 1h30'10", "letters" for 1h 30m 10s, or "classic" for 1:30:10
----- @bool withoutSeconds if true 1h30' or 1h 30m, if false 1h30'10" or 1h 30m 10s
----- @bool withDays, if hours>=24 include days in clock string 1d12h10'10" or 1d 12h 10m 10s
----- @bool compact, if set removes all leading zeros (incl. units if necessary) and spaces (if present)
----- @treturn string clock string in the specific format of 1h30', 1h30'10" resp. 1h 30m, 1h 30m 10s
+---- @string Either "modern" for 1h30'10", "letters" for 1h 30m 10s, or "classic" for 1:30:10
+---- @bool withoutSeconds if true 1h30' or 1h 30m, if false 1h30'10" or 1h 30m 10s
+---- @bool withDays, if hours>=24 include days in clock string 1d12h10'10" or 1d 12h 10m 10s
+---- @bool compact, if set removes all leading zeros (incl. units if necessary) and makes spaces hairline (if present)
+---- @treturn string clock string in the specific format of 1h30', 1h30'10" resp. 1h 30m, 1h 30m 10s
 function datetime.secondsToClockDuration(format, seconds, withoutSeconds, withDays, compact)
     if format == "modern" then
         return datetime.secondsToHClock(seconds, withoutSeconds, false, withDays, compact)

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -128,7 +128,7 @@ common_settings.time = {
                 {
                     text_func = function()
                         local datetime = require("datetime")
-                        -- sample text shows 1h23m45s
+                        -- sample text shows 1h 23m 45s
                         local duration_format_str = datetime.secondsToClockDuration("letters", 5025, false)
                         return T(C_("Time", "Letters (%1)"), duration_format_str)
                     end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -128,7 +128,7 @@ common_settings.time = {
                 {
                     text_func = function()
                         local datetime = require("datetime")
-                        -- sample text shows 1h 23m 45s
+                        -- sample text shows 1h 23m 45s
                         local duration_format_str = datetime.secondsToClockDuration("letters", 5025, false)
                         return T(C_("Time", "Letters (%1)"), duration_format_str)
                     end,

--- a/spec/unit/datetime_spec.lua
+++ b/spec/unit/datetime_spec.lua
@@ -47,7 +47,7 @@ describe("datetime module", function()
     end)
 
     describe("secondsToHClock()", function()
-        it("should convert seconds to 0'00'' format", function()
+        it("should convert seconds to 0' format", function()
             assert.is_equal("0'",
                             datetime.secondsToHClock(0, true))
             assert.is_equal("0'",
@@ -75,21 +75,37 @@ describe("datetime module", function()
             assert.is_equal("10h01'",
                             datetime.secondsToHClock(36060, true))
         end)
-        it("should round seconds to minutes in 0h00m format", function()
+        it("should round seconds to minutes in 0h 0m format", function()
             assert.is_equal("1m",
                 datetime.secondsToHClock(89, true, true))
             assert.is_equal("2m",
                 datetime.secondsToHClock(90, true, true))
             assert.is_equal("2m",
                 datetime.secondsToHClock(110, true, true))
-            assert.is_equal("1h00m",
+            assert.is_equal("1h 0m",
                 datetime.secondsToHClock(3600, true, true))
-            assert.is_equal("1h00m",
+            assert.is_equal("1h 0m",
                 datetime.secondsToHClock(3599, true, true))
             assert.is_equal("59m",
                 datetime.secondsToHClock(3569, true, true))
-            assert.is_equal("10h01m",
+            assert.is_equal("10h 1m",
                 datetime.secondsToHClock(36060, true, true))
+        end)
+        it("should round seconds to minutes in 0h0m format", function()
+            assert.is_equal("1m",
+                datetime.secondsToHClock(89, true, true, false, true))
+            assert.is_equal("2m",
+                datetime.secondsToHClock(90, true, true, false, true))
+            assert.is_equal("2m",
+                datetime.secondsToHClock(110, true, true, false, true))
+            assert.is_equal("1h0m",
+                datetime.secondsToHClock(3600, true, true, false, true))
+            assert.is_equal("1h0m",
+                datetime.secondsToHClock(3599, true, true, false, true))
+            assert.is_equal("59m",
+                datetime.secondsToHClock(3569, true, true, false, true))
+            assert.is_equal("10h1m",
+                datetime.secondsToHClock(36060, true, true, false, true))
         end)
         it("should convert seconds to 0h00'00'' format", function()
             assert.is_equal("0\"",
@@ -111,7 +127,7 @@ describe("datetime module", function()
         it("should change type based on format", function()
             assert.is_equal("10h01'30\"",
                             datetime.secondsToClockDuration("modern", 36090, false))
-            assert.is_equal("10h01m30s",
+            assert.is_equal("10h 1m 30s",
                             datetime.secondsToClockDuration("letters", 36090, false))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
@@ -125,9 +141,9 @@ describe("datetime module", function()
                             datetime.secondsToClockDuration("modern", 36090, false))
             assert.is_equal("10h02'",
                             datetime.secondsToClockDuration("modern", 36090, true))
-            assert.is_equal("10h01m30s",
+            assert.is_equal("10h 1m 30s",
                             datetime.secondsToClockDuration("letters", 36090, false))
-            assert.is_equal("10h02m",
+            assert.is_equal("10h 2m",
                             datetime.secondsToClockDuration("letters", 36090, true))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))

--- a/spec/unit/datetime_spec.lua
+++ b/spec/unit/datetime_spec.lua
@@ -44,22 +44,22 @@ describe("datetime module", function()
             assert.is_equal("00:02:00",
                             datetime.secondsToClock(120))
         end)
-        it("should convert seconds to 0d:00:00:00 format", function()
+        it("should convert seconds to 0d00:00:00 format", function()
             assert.is_equal("00:00:00",
                             datetime.secondsToClock(0, false, true))
             assert.is_equal("00:02:00",
                             datetime.secondsToClock(120, false, true))
-            assert.is_equal("5d:00:02:00",
+            assert.is_equal("5d00:02:00",
                             datetime.secondsToClock(432120, false, true))
         end)
-        it("should convert seconds to 0d:00:00 format", function()
+        it("should convert seconds to 0d00:00 format", function()
             assert.is_equal("00:00",
                             datetime.secondsToClock(0, true, true))
             assert.is_equal("00:02",
                             datetime.secondsToClock(120, true, true))
-            assert.is_equal("5d:00:02",
+            assert.is_equal("5d00:02",
                             datetime.secondsToClock(432110, true, true))
-            assert.is_equal("5d:00:02",
+            assert.is_equal("5d00:02",
                             datetime.secondsToClock(432120, true, true))
         end)
     end)
@@ -93,7 +93,7 @@ describe("datetime module", function()
             assert.is_equal("10h01'",
                             datetime.secondsToHClock(36060, true))
         end)
-        it("should round seconds to minutes in 0h 0m format", function()
+        it("should round seconds to minutes in 0h 0m (thinspace) format", function()
             assert.is_equal("1m",
                 datetime.secondsToHClock(89, true, true))
             assert.is_equal("2m",
@@ -109,7 +109,7 @@ describe("datetime module", function()
             assert.is_equal("10h\xE2\x80\x891m",
                 datetime.secondsToHClock(36060, true, true))
         end)
-        it("should round seconds to minutes in 0h0m format", function()
+        it("should round seconds to minutes in 0h 0m (hairspace) format", function()
             assert.is_equal("1m",
                 datetime.secondsToHClock(89, true, true, false, true))
             assert.is_equal("2m",
@@ -145,7 +145,7 @@ describe("datetime module", function()
         it("should change type based on format", function()
             assert.is_equal("10h01'30\"",
                             datetime.secondsToClockDuration("modern", 36090, false))
-            assert.is_equal("10h\xE2\x80\x8A1m\xE2\x80\x8A30s",
+            assert.is_equal("10h\xE2\x80\x891m\xE2\x80\x8930s",
                             datetime.secondsToClockDuration("letters", 36090, false))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
@@ -159,9 +159,9 @@ describe("datetime module", function()
                             datetime.secondsToClockDuration("modern", 36090, false))
             assert.is_equal("10h02'",
                             datetime.secondsToClockDuration("modern", 36090, true))
-            assert.is_equal("10h\xE2\x80\x8A1m\xE2\x80\x8A30s",
+            assert.is_equal("10h\xE2\x80\x891m\xE2\x80\x8930s",
                             datetime.secondsToClockDuration("letters", 36090, false))
-            assert.is_equal("10h\xE2\x80\x8A2m",
+            assert.is_equal("10h\xE2\x80\x892m",
                             datetime.secondsToClockDuration("letters", 36090, true))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
@@ -173,14 +173,14 @@ describe("datetime module", function()
                             datetime.secondsToClockDuration("modern", 208890, false, false))
             assert.is_equal("2d10h01'30\"",
                             datetime.secondsToClockDuration("modern", 208890, false, true))
-            assert.is_equal("58h\xE2\x80\x8A1m\xE2\x80\x8A30s",
+            assert.is_equal("58h\xE2\x80\x891m\xE2\x80\x8930s",
                             datetime.secondsToClockDuration("letters", 208890, false, false))
-            assert.is_equal("2d\xE2\x80\x8A10h\xE2\x80\x8A1m\xE2\x80\x8A30s",
+            assert.is_equal("2d\xE2\x80\x8910h\xE2\x80\x891m\xE2\x80\x8930s",
                             datetime.secondsToClockDuration("letters", 208890, false, true))
             assert.is_equal("58:01:30",
-                            datetime.secondsToClockDuration("classic", 36090, false, false))
-            assert.is_equal("2d:10:01:30",
-                            datetime.secondsToClockDuration("classic", 36090, false, true))
+                            datetime.secondsToClockDuration("classic", 208890, false, false))
+            assert.is_equal("2d10:01:30",
+                            datetime.secondsToClockDuration("classic", 208890, false, true))
         end)
     end)
 

--- a/spec/unit/datetime_spec.lua
+++ b/spec/unit/datetime_spec.lua
@@ -100,13 +100,13 @@ describe("datetime module", function()
                 datetime.secondsToHClock(90, true, true))
             assert.is_equal("2m",
                 datetime.secondsToHClock(110, true, true))
-            assert.is_equal("1h 0m",
+            assert.is_equal("1h\xE2\x80\x890m",
                 datetime.secondsToHClock(3600, true, true))
-            assert.is_equal("1h 0m",
+            assert.is_equal("1h\xE2\x80\x890m",
                 datetime.secondsToHClock(3599, true, true))
             assert.is_equal("59m",
                 datetime.secondsToHClock(3569, true, true))
-            assert.is_equal("10h 1m",
+            assert.is_equal("10h\xE2\x80\x891m",
                 datetime.secondsToHClock(36060, true, true))
         end)
         it("should round seconds to minutes in 0h0m format", function()
@@ -116,13 +116,13 @@ describe("datetime module", function()
                 datetime.secondsToHClock(90, true, true, false, true))
             assert.is_equal("2m",
                 datetime.secondsToHClock(110, true, true, false, true))
-            assert.is_equal("1h0m",
+            assert.is_equal("1h\xE2\x80\x8A0m",
                 datetime.secondsToHClock(3600, true, true, false, true))
-            assert.is_equal("1h0m",
+            assert.is_equal("1h\xE2\x80\x8A0m",
                 datetime.secondsToHClock(3599, true, true, false, true))
             assert.is_equal("59m",
                 datetime.secondsToHClock(3569, true, true, false, true))
-            assert.is_equal("10h1m",
+            assert.is_equal("10h\xE2\x80\x8A1m",
                 datetime.secondsToHClock(36060, true, true, false, true))
         end)
         it("should convert seconds to 0h00'00'' format", function()
@@ -145,7 +145,7 @@ describe("datetime module", function()
         it("should change type based on format", function()
             assert.is_equal("10h01'30\"",
                             datetime.secondsToClockDuration("modern", 36090, false))
-            assert.is_equal("10h 1m 30s",
+            assert.is_equal("10h\xE2\x80\x8A1m\xE2\x80\x8A30s",
                             datetime.secondsToClockDuration("letters", 36090, false))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
@@ -159,9 +159,9 @@ describe("datetime module", function()
                             datetime.secondsToClockDuration("modern", 36090, false))
             assert.is_equal("10h02'",
                             datetime.secondsToClockDuration("modern", 36090, true))
-            assert.is_equal("10h 1m 30s",
+            assert.is_equal("10h\xE2\x80\x8A1m\xE2\x80\x8A30s",
                             datetime.secondsToClockDuration("letters", 36090, false))
-            assert.is_equal("10h 2m",
+            assert.is_equal("10h\xE2\x80\x8A2m",
                             datetime.secondsToClockDuration("letters", 36090, true))
             assert.is_equal("10:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false))
@@ -173,9 +173,9 @@ describe("datetime module", function()
                             datetime.secondsToClockDuration("modern", 208890, false, false))
             assert.is_equal("2d10h01'30\"",
                             datetime.secondsToClockDuration("modern", 208890, false, true))
-            assert.is_equal("58h 1m 30s",
+            assert.is_equal("58h\xE2\x80\x8A1m\xE2\x80\x8A30s",
                             datetime.secondsToClockDuration("letters", 208890, false, false))
-            assert.is_equal("2d 10h 1m 30s",
+            assert.is_equal("2d\xE2\x80\x8A10h\xE2\x80\x8A1m\xE2\x80\x8A30s",
                             datetime.secondsToClockDuration("letters", 208890, false, true))
             assert.is_equal("58:01:30",
                             datetime.secondsToClockDuration("classic", 36090, false, false))

--- a/spec/unit/datetime_spec.lua
+++ b/spec/unit/datetime_spec.lua
@@ -44,6 +44,24 @@ describe("datetime module", function()
             assert.is_equal("00:02:00",
                             datetime.secondsToClock(120))
         end)
+        it("should convert seconds to 0d:00:00:00 format", function()
+            assert.is_equal("00:00:00",
+                            datetime.secondsToClock(0, false, true))
+            assert.is_equal("00:02:00",
+                            datetime.secondsToClock(120, false, true))
+            assert.is_equal("5d:00:02:00",
+                            datetime.secondsToClock(432120, false, true))
+        end)
+        it("should convert seconds to 0d:00:00 format", function()
+            assert.is_equal("00:00",
+                            datetime.secondsToClock(0, true, true))
+            assert.is_equal("00:02",
+                            datetime.secondsToClock(120, true, true))
+            assert.is_equal("5d:00:02",
+                            datetime.secondsToClock(432110, true, true))
+            assert.is_equal("5d:00:02",
+                            datetime.secondsToClock(432120, true, true))
+        end)
     end)
 
     describe("secondsToHClock()", function()
@@ -149,6 +167,20 @@ describe("datetime module", function()
                             datetime.secondsToClockDuration("classic", 36090, false))
             assert.is_equal("10:02",
                             datetime.secondsToClockDuration("classic", 36090, true))
+        end)
+        it("should pass along withDays", function()
+            assert.is_equal("58h01'30\"",
+                            datetime.secondsToClockDuration("modern", 208890, false, false))
+            assert.is_equal("2d10h01'30\"",
+                            datetime.secondsToClockDuration("modern", 208890, false, true))
+            assert.is_equal("58h 1m 30s",
+                            datetime.secondsToClockDuration("letters", 208890, false, false))
+            assert.is_equal("2d 10h 1m 30s",
+                            datetime.secondsToClockDuration("letters", 208890, false, true))
+            assert.is_equal("58:01:30",
+                            datetime.secondsToClockDuration("classic", 36090, false, false))
+            assert.is_equal("2d:10:01:30",
+                            datetime.secondsToClockDuration("classic", 36090, false, true))
         end)
     end)
 


### PR DESCRIPTION
Implements previous discussion at https://github.com/koreader/koreader/pull/9924#issuecomment-1435166341 by adding spaces between the days, hours, minutes, and seconds (@poire-z). When using the `compact` argument, the spaces will not be used.

In addition, noticed that the "removing leading zeros" contract of the `compact` argument is not met by the Letters format, and leading 0s don't look good anyway with this format (`1h 03m 27s` vs `1h 3m 27s`), so I removed these leading zeros entirely when using this format.

Previously: `1d03h38m`
Now: `1d 3h 38m` normally, `1d3h38m` when compact

Previously: `1d03h38m05s`
Now: `1d 3h 38m 5s` normally, `1d3h38m5s` when compact

Added unit tests, as well as unit tests for the existing `withDays` functionality. Also made the `d` letter for "days" into a translatable string like `h` `m` and `s` already were.

--

I can't confirm if the unit tests pass; running the `front` tests gives me this error in the Docker development environment:
```
[----------] Running tests from ./spec/front/unit/datetime_spec.lua
SDL2 not loaded:	libSDL2-2.0.so.0: cannot open shared object file: No such file or directory
frontend/device.lua:58: Could not find hardware abstraction for this platform. If you are trying to run the emulator, please ensure SDL is installed.

stack traceback:
	frontend/device.lua:58: in function 'probeDevice'
	frontend/device.lua:61: in main chunk

[----------] 0 tests from ./spec/front/unit/datetime_spec.lua (12.59 ms total)
```

I thought I ran this a few months ago without trouble. Looks like I have to emulate a device while running the frontend tests? Is there a way to do that?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10141)
<!-- Reviewable:end -->
