### PR TITLE
ReaderHighlight: minor fixes

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -618,7 +618,7 @@ function ReaderHighlight:onTapSelectModeIcon()
     if not self.select_mode then return end
     UIManager:show(ConfirmBox:new{
         text = _("You are currently in SELECT mode.\nTo finish highlighting, long press where the highlight should end and press the HIGHLIGHT button.\nYou can also exit select mode by tapping on the start of the highlight."),
-        icon = "format-quote-close",
+        icon = "texture-box",
         ok_text = _("Exit select mode"),
         cancel_text = _("Close"),
         ok_callback = function()

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -756,9 +756,10 @@ function ReaderUI:notifyCloseDocument()
             self:closeDocument()
         else
             UIManager:show(ConfirmBox:new{
-                text = _("Do you want to save this document?"),
+                text = _("Do you want to save new highlights in this document to the pdf file?"),
                 ok_text = _("Save"),
                 cancel_text = _("Don't save"),
+                dismissable = false,
                 ok_callback = function()
                     self:closeDocument()
                 end,

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -756,9 +756,8 @@ function ReaderUI:notifyCloseDocument()
             self:closeDocument()
         else
             UIManager:show(ConfirmBox:new{
-                text = _("Do you want to save new highlights in this document to the pdf file?"),
-                ok_text = _("Save"),
-                cancel_text = _("Don't save"),
+                text = _("Write highlights into this PDF??"),
+                ok_text = _("Write"),
                 dismissable = false,
                 ok_callback = function()
                     self:closeDocument()


### PR DESCRIPTION
(1) ConfirmBox when saving highlights to pdf now requires button press. Closes https://github.com/koreader/koreader/issues/9328.
(2) Fixed icon in the select mode ConfirmBox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10142)
<!-- Reviewable:end -->
