### PR TITLE
DocSettings: fix and migration

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -611,7 +611,7 @@ function FileManager:tapPlus()
                     enabled = actions_enabled,
                     callback = function()
                         UIManager:show(ConfirmBox:new{
-                            text = _("Move selected books metadata in accordance with the current 'Book metadata folder' setting?"),
+                            text = _("Move selected book metadata in accordance with the current 'Book metadata folder' setting?"),
                             ok_text = _("Move"),
                             ok_callback = function()
                                 UIManager:close(self.file_dialog)

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -605,27 +605,6 @@ function FileManager:tapPlus()
                     end
                 },
             },
-            {
-                {
-                    text = _("Move book metadata"),
-                    enabled = actions_enabled,
-                    callback = function()
-                        UIManager:show(ConfirmBox:new{
-                            text = _("Move selected book metadata in accordance with the current 'Book metadata folder' setting?"),
-                            ok_text = _("Move"),
-                            ok_callback = function()
-                                UIManager:close(self.file_dialog)
-                                for file in pairs(self.selected_files) do
-                                    if lfs.attributes(DocSettings:getSidecarFile(file), "mode") ~= "file" then
-                                        DocSettings:update(file, file)
-                                    end
-                                end
-                                self:onToggleSelectMode()
-                            end,
-                        })
-                    end
-                },
-            },
             {}, -- separator
             {
                 {

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -605,6 +605,27 @@ function FileManager:tapPlus()
                     end
                 },
             },
+            {
+                {
+                    text = _("Move book metadata"),
+                    enabled = actions_enabled,
+                    callback = function()
+                        UIManager:show(ConfirmBox:new{
+                            text = _("Move selected books metadata in accordance with the current 'Book metadata folder' setting?"),
+                            ok_text = _("Move"),
+                            ok_callback = function()
+                                UIManager:close(self.file_dialog)
+                                for file in pairs(self.selected_files) do
+                                    if lfs.attributes(DocSettings:getSidecarFile(file), "mode") ~= "file" then
+                                        DocSettings:update(file, file)
+                                    end
+                                end
+                                self:onToggleSelectMode()
+                            end,
+                        })
+                    end
+                },
+            },
             {}, -- separator
             {
                 {

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -425,7 +425,7 @@ To:
     end
 
     -- settings tab - Document submenu
-    self.menu_items.document_metadata_folder_move = {
+    self.menu_items.document_metadata_location_move = {
         text = _("Move book metadata"),
         keep_menu_open = true,
         callback = function()
@@ -838,7 +838,7 @@ function FileManagerMenu:moveBookMetadata()
         return books_to_move
     end
     UIManager:show(ConfirmBox:new{
-        text = _("Scan current folder and subfolders for book metadata?"),
+        text = _("Scan books in current folder and subfolders for their metadata location?"),
         ok_text = _("Scan"),
         ok_callback = function()
             local books_to_move = scanPath()
@@ -846,14 +846,14 @@ function FileManagerMenu:moveBookMetadata()
             if books_to_move_nb == 0 then
                 local InfoMessage = require("ui/widget/infomessage")
                 UIManager:show(InfoMessage:new{
-                    text = _("No books with metadata out of preferred location found."),
+                    text = _("No books with metadata not in your preferred location found."),
                 })
             else
                 UIManager:show(ConfirmBox:new{
-                    text = T(N_("1 book with metadata out of preferred location found.",
-                              "%1 books with metadata out of preferred location found.",
+                    text = T(N_("1 book with metadata not in your preferred location found.",
+                              "%1 books with metadata not in your preferred location found.",
                               books_to_move_nb), books_to_move_nb) ..
-                              _("\nDo you want to move book metadata to preferred location?"),
+                              _("\nMove book metadata to your preferred location?"),
                     ok_text = _("Move"),
                     ok_callback = function()
                         UIManager:close(self.menu_container)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -838,7 +838,7 @@ function FileManagerMenu:moveBookMetadata()
         return books_to_move
     end
     UIManager:show(ConfirmBox:new{
-        text = _("Scan books in the current folder for metadata location?"),
+        text = _("Scan current folder and subfolders for book metadata?"),
         ok_text = _("Scan"),
         ok_callback = function()
             local books_to_move = scanPath()
@@ -846,12 +846,14 @@ function FileManagerMenu:moveBookMetadata()
             if books_to_move_nb == 0 then
                 local InfoMessage = require("ui/widget/infomessage")
                 UIManager:show(InfoMessage:new{
-                    text = _("No books with improper metadata location found."),
+                    text = _("No books with metadata out of preferred location found."),
                 })
             else
                 UIManager:show(ConfirmBox:new{
-                    text = T(N_("1 book", "%1 books", books_to_move_nb), books_to_move_nb) ..
-                        _(" with improper metadata location found.\nDo you want to move metadata?"),
+                    text = T(N_("1 book with metadata out of preferred location found.",
+                              "%1 books with metadata out of preferred location found.",
+                              books_to_move_nb), books_to_move_nb) ..
+                              _("\nDo you want to move book metadata to preferred location?"),
                     ok_text = _("Move"),
                     ok_callback = function()
                         UIManager:close(self.menu_container)

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -98,11 +98,6 @@ function DocSettings:hasSidecarFile(doc_path)
         or lfs.attributes(self:getHistoryPath(doc_path), "mode") == "file"
 end
 
-function DocSettings:getLastSaveTime(doc_path) -- for readhistory
-    return lfs.attributes(self:getSidecarFile(doc_path, "doc"), "modification")
-        or lfs.attributes(self:getSidecarFile(doc_path, "dir"), "modification")
-end
-
 function DocSettings:getHistoryPath(doc_path)
     if doc_path == nil or doc_path == "" then return "" end
     return HISTORY_DIR .. "/[" .. doc_path:gsub("(.*/)([^/]+)", "%1] %2"):gsub("/", "#") .. ".lua"

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -248,7 +248,7 @@ function DocSettings:flush(data)
                 ffiutil.fsyncDirectory(sidecar_file)
             end
 
-            self:purge(false, sidecar_file) -- remove old candidates and empty sidecar folders
+            self:purge(sidecar_file) -- remove old candidates and empty sidecar folders
 
             break
         end
@@ -256,7 +256,7 @@ function DocSettings:flush(data)
 end
 
 --- Purges (removes) sidecar directory.
-function DocSettings:purge(full, sidecar_to_keep)
+function DocSettings:purge(sidecar_to_keep)
     -- Remove any of the old ones we may consider as candidates in DocSettings:open()
     if self.candidates then
         for _, t in ipairs(self.candidates) do
@@ -271,20 +271,12 @@ function DocSettings:purge(full, sidecar_to_keep)
         end
     end
 
-    local function purgeDir(dir, full_purge)
-        if lfs.attributes(dir, "mode") == "directory" then
-            if full_purge then
-                -- Asked to remove all the content of this .sdr directory, whether it's ours or not
-                ffiutil.purgeDir(dir)
-            else
-                -- If the sidecar folder ends up empty, os.remove() can delete it.
-                -- Otherwise, the following statement has no effect.
-                os.remove(dir)
-            end
-        end
+    if lfs.attributes(self.doc_sidecar_dir, "mode") == "directory" then
+        os.remove(self.doc_sidecar_dir) -- keep parent folders
     end
-    purgeDir(self.doc_sidecar_dir, full)
-    purgeDir(self.dir_sidecar_dir, full)
+    if lfs.attributes(self.dir_sidecar_dir, "mode") == "directory" then
+        util.removePath(self.dir_sidecar_dir) -- remove empty parent folders
+    end
 end
 
 --- Updates sidecar info for file rename/copy/move/delete operations.

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -204,6 +204,7 @@ function DocSettings:open(doc_path)
     else
         new.data = {}
     end
+    new.data.doc_path = doc_path
 
     return new
 end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -536,7 +536,7 @@ Book view settings, reading progress, highlights, bookmarks and notes (collectiv
 
 You can decide between two locations where these will be saved:
 - alongside the book file itself (the long time default): these sdr folders will be visible when you browse your library directories with another file browser or from your computer, which may clutter your vision of your library. But this allows you to move them along when you reorganize your library, and also survives any renaming of parent directories. Also, if you perform directory synchronization or backups, your settings will be part of them.
-- all inside koreader/docsettings/: these sdr folders will only be visible and used by KOReader, and won't clutter your vision of your library directories with another file browser or from your computer. But any reorganisation of your library (directories or filename moves and renamings) may result in KOReader not finding your previous settings for these books. These settings won't be part of any synchronisation or backups of your library.]])
+- all inside koreader/docsettings/: these sdr folders will only be visible and used by KOReader, and won't clutter your vision of your library directories with another file browser or from your computer. But any reorganisation of your library (directories or filename moves and renamings) may result in KOReader not finding your previous settings for these books. These settings won't be part of any synchronization or backups of your library.]])
 
 local function genMetadataFolderMenuItem(value)
     return {

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -528,13 +528,15 @@ common_settings.document = {
 
 local metadata_folder_str = {
     ["doc"] = _("book folder"),
-    ["dir"] = "koreader/docsettings",
+    ["dir"] = "koreader/docsettings/",
 }
 
 local metadata_folder_help_text = _([[
-Book view settings, reading progress, highlights, bookmarks and notes (collectively known as metadata) are stored in a separate folder named <book-name>.sdr.
+Book view settings, reading progress, highlights, bookmarks and notes (collectively known as metadata) are stored in a separate folder named <book-filename>.sdr (".sdr" meaning "sidecar").
 
-This sets the preferred location of the sdr folder: the book folder or koreader/docsettings.]])
+You can decide between two locations where these will be saved:
+- alongside the book file itself (the long time default): these sdr folders will be visible when you browse your library directories with another file browser or from your computer, which may clutter your vision of your library. But this allows you to move them along when you reorganize your library, and also survives any renaming of parent directories. Also, if you do directories synchronisation or backups, your settings will be part of them (which might be what you want, or not).
+- all inside koreader/docsettings/: these sdr folders will only be visible and used by KOReader, and won't clutter your vision of your library directories with another file browser or from your computer. But any reorganisation of your library (directories or filename moves and renamings) may result in KOReader not finding your previous settings for these books. These settings won't be part of any synchronisation or backups of your library.]])
 
 local function genMetadataFolderMenuItem(value)
     return {
@@ -548,7 +550,7 @@ local function genMetadataFolderMenuItem(value)
     }
 end
 
-common_settings.document_metadata_folder = {
+common_settings.document_metadata_location = {
     text_func = function()
         local value = G_reader_settings:readSetting("document_metadata_folder", "doc")
         return T(_("Book metadata location: %1"), metadata_folder_str[value])
@@ -558,7 +560,7 @@ common_settings.document_metadata_folder = {
         genMetadataFolderMenuItem("doc"),
         genMetadataFolderMenuItem("dir"),
         {
-            text = _("About book metadata preferred location"),
+            text = _("About book metadata location"),
             keep_menu_open = true,
             callback = function()
                 UIManager:show(InfoMessage:new{ text = metadata_folder_help_text, })

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -534,7 +534,7 @@ local metadata_folder_str = {
 local metadata_folder_help_text = _([[
 Book view settings, reading progress, highlights, bookmarks and notes (collectively known as metadata) are stored in a separate folder named <book-name>.sdr.
 
-This sets the location of the sdr folder: the book folder or koreader/docsettings.]])
+This sets the preferred location of the sdr folder: the book folder or koreader/docsettings.]])
 
 local function genMetadataFolderMenuItem(value)
     return {
@@ -551,12 +551,19 @@ end
 common_settings.document_metadata_folder = {
     text_func = function()
         local value = G_reader_settings:readSetting("document_metadata_folder", "doc")
-        return T(_("Book metadata folder: %1"), metadata_folder_str[value])
+        return T(_("Book metadata location: %1"), metadata_folder_str[value])
     end,
     help_text = metadata_folder_help_text,
     sub_item_table = {
         genMetadataFolderMenuItem("doc"),
         genMetadataFolderMenuItem("dir"),
+        {
+            text = _("About book metadata preferred location"),
+            keep_menu_open = true,
+            callback = function()
+                UIManager:show(InfoMessage:new{ text = metadata_folder_help_text, })
+            end,
+        },
     },
 }
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -557,15 +557,16 @@ common_settings.document_metadata_location = {
     end,
     help_text = metadata_folder_help_text,
     sub_item_table = {
-        genMetadataFolderMenuItem("doc"),
-        genMetadataFolderMenuItem("dir"),
         {
             text = _("About book metadata location"),
             keep_menu_open = true,
             callback = function()
                 UIManager:show(InfoMessage:new{ text = metadata_folder_help_text, })
             end,
+            separator = true,
         },
+        genMetadataFolderMenuItem("doc"),
+        genMetadataFolderMenuItem("dir"),
     },
 }
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -532,7 +532,7 @@ local metadata_folder_str = {
 }
 
 local metadata_folder_help_text = _([[
-Book view settings, reading progress, highlights, bookmarks and notes ("metadata") are stored in a separate folder named <book-name>.sdr.
+Book view settings, reading progress, highlights, bookmarks and notes (collectively known as metadata) are stored in a separate folder named <book-name>.sdr.
 
 This sets the location of the sdr folder: the book folder or koreader/docsettings.]])
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -531,6 +531,11 @@ local metadata_folder_str = {
     ["dir"] = "koreader/docsettings",
 }
 
+local metadata_folder_help_text = _([[
+Book view settings, reading progress, highlights, bookmarks and notes ("metadata") are stored in a separate folder named <book-name>.sdr.
+
+This sets the location of the sdr folder: the book folder or koreader/docsettings.]])
+
 local function genMetadataFolderMenuItem(value)
     return {
         text = metadata_folder_str[value],
@@ -548,6 +553,7 @@ common_settings.document_metadata_folder = {
         local value = G_reader_settings:readSetting("document_metadata_folder", "doc")
         return T(_("Book metadata folder: %1"), metadata_folder_str[value])
     end,
+    help_text = metadata_folder_help_text,
     sub_item_table = {
         genMetadataFolderMenuItem("doc"),
         genMetadataFolderMenuItem("dir"),

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -535,7 +535,7 @@ local metadata_folder_help_text = _([[
 Book view settings, reading progress, highlights, bookmarks and notes (collectively known as metadata) are stored in a separate folder named <book-filename>.sdr (".sdr" meaning "sidecar").
 
 You can decide between two locations where these will be saved:
-- alongside the book file itself (the long time default): these sdr folders will be visible when you browse your library directories with another file browser or from your computer, which may clutter your vision of your library. But this allows you to move them along when you reorganize your library, and also survives any renaming of parent directories. Also, if you do directories synchronisation or backups, your settings will be part of them (which might be what you want, or not).
+- alongside the book file itself (the long time default): these sdr folders will be visible when you browse your library directories with another file browser or from your computer, which may clutter your vision of your library. But this allows you to move them along when you reorganize your library, and also survives any renaming of parent directories. Also, if you perform directory synchronization or backups, your settings will be part of them.
 - all inside koreader/docsettings/: these sdr folders will only be visible and used by KOReader, and won't clutter your vision of your library directories with another file browser or from your computer. But any reorganisation of your library (directories or filename moves and renamings) may result in KOReader not finding your previous settings for these books. These settings won't be part of any synchronisation or backups of your library.]])
 
 local function genMetadataFolderMenuItem(value)

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -36,8 +36,8 @@ local order = {
         -- end common settings
     },
     document = {
-        "document_metadata_folder",
-        "document_metadata_folder_move",
+        "document_metadata_location",
+        "document_metadata_location_move",
         "document_auto_save",
         "document_save",
         "document_end_action",

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -37,6 +37,7 @@ local order = {
     },
     document = {
         "document_metadata_folder",
+        "document_metadata_folder_move",
         "document_auto_save",
         "document_save",
         "document_end_action",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -79,7 +79,7 @@ local order = {
         "status_bar",
     },
     document = {
-        "document_metadata_folder",
+        "document_metadata_location",
         "document_auto_save",
         "document_save",
         "document_end_action",

--- a/plugins/docsettingtweak.koplugin/main.lua
+++ b/plugins/docsettingtweak.koplugin/main.lua
@@ -101,7 +101,7 @@ end
 
 function DocSettingTweak:onDocSettingsLoad(doc_settings, document)
     -- check that the documents settings are empty & and that we have defaults to customize
-    if next(doc_settings.data) == nil and directory_defaults.data ~= nil then
+    if util.tableSize(doc_settings.data) == 1 and directory_defaults.data ~= nil then
         local base = G_reader_settings:readSetting("home_dir") or filemanagerutil.getDefaultDir()
         if document.file == nil or document.file == "" then
             return
@@ -111,6 +111,7 @@ function DocSettingTweak:onDocSettingsLoad(doc_settings, document)
         while directory:sub(1, #base) == base do
             if directory_defaults:has(directory) then
                 doc_settings.data = util.tableDeepCopy(directory_defaults:readSetting(directory))
+                doc_settings.data.doc_path = document.file
                 break
             else
                 if directory == "/" or directory == "." then

--- a/spec/unit/readerui_spec.lua
+++ b/spec/unit/readerui_spec.lua
@@ -21,7 +21,7 @@ describe("Readerui module", function()
         local doc_settings = DocSettings:open(sample_epub)
         assert.are.same(doc_settings.data, {doc_path = sample_epub})
         readerui:saveSettings()
-        assert.are_not.same(readerui.doc_settings.data, {})
+        assert.are_not.same(readerui.doc_settings.data, {doc_path = sample_epub})
         doc_settings = DocSettings:open(sample_epub)
         assert.truthy(doc_settings.data.last_xpointer)
         assert.are.same(doc_settings.data.last_xpointer,

--- a/spec/unit/readerui_spec.lua
+++ b/spec/unit/readerui_spec.lua
@@ -19,7 +19,7 @@ describe("Readerui module", function()
         -- remove history settings and sidecar settings
         DocSettings:open(sample_epub):purge()
         local doc_settings = DocSettings:open(sample_epub)
-        assert.are.same(doc_settings.data, {})
+        assert.are.same(doc_settings.data, {doc_path = sample_epub})
         readerui:saveSettings()
         assert.are_not.same(readerui.doc_settings.data, {})
         doc_settings = DocSettings:open(sample_epub)


### PR DESCRIPTION
(1) Use `util.removePath` for "dir" sdr folders.
(2) Add menu help text (draft).
(3) Add <kbd>Move book metadata</kbd> button in Filemanager select mode.

<img width="250" alt="01" src="https://user-images.githubusercontent.com/62179190/220118590-67c15ec7-dbee-44ee-b67d-c7aff79b9562.png">

<img width="250" alt="02" src="https://user-images.githubusercontent.com/62179190/220118600-8ca2db7d-3f98-44aa-8c2d-afccd76a7857.png">

<img width="250" alt="03" src="https://user-images.githubusercontent.com/62179190/220118602-62546b09-d439-4b64-9784-d88eaedb1277.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10149)
<!-- Reviewable:end -->
