### PR TITLE
History: update last book access time

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -786,6 +786,7 @@ function ReaderUI:onClose(full_refresh)
         self:saveSettings()
     end
     if self.document ~= nil then
+        require("readhistory"):updateLastBookTime()
         -- Serialize the most recently displayed page for later launch
         DocCache:serialize(self.document.file)
         logger.dbg("closing document")

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -786,7 +786,7 @@ function ReaderUI:onClose(full_refresh)
         self:saveSettings()
     end
     if self.document ~= nil then
-        require("readhistory"):updateLastBookTime()
+        require("readhistory"):updateLastBookTime(self.tearing_down)
         -- Serialize the most recently displayed page for later launch
         DocCache:serialize(self.document.file)
         logger.dbg("closing document")

--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -286,6 +286,9 @@ end
 ---- @treturn string date+time
 function datetime.secondsToDateTime(seconds, twelve_hour_clock, use_locale)
     seconds = seconds or os.time()
+    if twelve_hour_clock == nil then
+        twelve_hour_clock = G_reader_settings:isTrue("twelve_hour_clock")
+    end
     local BD = require("ui/bidi")
     local date_string = datetime.secondsToDate(seconds, use_locale)
     local time_string = datetime.secondsToHour(seconds, twelve_hour_clock, not use_locale)

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -254,7 +254,7 @@ end
 
 --- Adds new item (last opened document) to the top of the history list.
 -- If item time (ts) is passed, add item to the history list at this time position.
-function ReadHistory:addItem(file, ts, no_flash)
+function ReadHistory:addItem(file, ts, no_flush)
     if file ~= nil and lfs.attributes(file, "mode") == "file" then
         local index = self:getIndexByFile(realpath(file))
         if ts and index and self.hist[index].time == ts then
@@ -273,7 +273,7 @@ function ReadHistory:addItem(file, ts, no_flash)
             index = ts and self:getIndexByTime(ts, file:gsub(".*/", "")) or 1
             table.insert(self.hist, index, buildEntry(now, file))
         end
-        if not no_flash then
+        if not no_flush then
             self:_reduce()
             self:_flush()
         end
@@ -282,11 +282,13 @@ function ReadHistory:addItem(file, ts, no_flash)
 end
 
 --- Updates last book access time on closing the document.
-function ReadHistory:updateLastBookTime()
+function ReadHistory:updateLastBookTime(no_flush)
     local now = os.time()
     self.hist[1].time = now
     self.hist[1].mandatory = datetime.secondsToDateTime(now)
-    self:_flush()
+    if not no_flush then
+        self:_flush()
+    end
 end
 
 --- Reloads history from history_file and legacy history folder.

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -569,7 +569,7 @@ function TouchMenu:init()
         text_font_bold = false,
         callback = function()
             UIManager:show(InfoMessage:new{
-                text = datetime.secondsToDateTime(os.time(), G_reader_settings:isTrue("twelve_hour_clock"), true),
+                text = datetime.secondsToDateTime(nil, nil, true),
             })
         end,
         hold_callback = function()

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -55,18 +55,18 @@ end
 function SystemStat:appendCounters()
     self:put({
         _("KOReader started at"),
-        datetime.secondsToDateTime(time.to_s(self.start_time, nil, true))
+        datetime.secondsToDateTime(time.to_s(self.start_time), nil, true)
     })
     if self.suspend_time then
        self:put({
            "  " .. _("Last suspend time"),
-           datetime.secondsToDateTime(time.to_s(self.suspend_time, nil, true))
+           datetime.secondsToDateTime(time.to_s(self.suspend_time), nil, true)
         })
     end
     if self.resume_time then
         self:put({
             "  " .. _("Last resume time"),
-           datetime.secondsToDateTime(time.to_s(self.resume_time, nil, true))
+           datetime.secondsToDateTime(time.to_s(self.resume_time), nil, true)
         })
     end
     local uptime = time.boottime_or_realtime_coarse() - self.start_monotonic_time

--- a/plugins/systemstat.koplugin/main.lua
+++ b/plugins/systemstat.koplugin/main.lua
@@ -53,21 +53,20 @@ function SystemStat:putSeparator()
 end
 
 function SystemStat:appendCounters()
-    local use_twelve_hour_clock = G_reader_settings:isTrue("twelve_hour_clock")
     self:put({
         _("KOReader started at"),
-        datetime.secondsToDateTime(time.to_s(self.start_time), use_twelve_hour_clock, true)
+        datetime.secondsToDateTime(time.to_s(self.start_time, nil, true))
     })
     if self.suspend_time then
        self:put({
            "  " .. _("Last suspend time"),
-           datetime.secondsToDateTime(time.to_s(self.suspend_time), use_twelve_hour_clock, true)
+           datetime.secondsToDateTime(time.to_s(self.suspend_time, nil, true))
         })
     end
     if self.resume_time then
         self:put({
             "  " .. _("Last resume time"),
-           datetime.secondsToDateTime(time.to_s(self.resume_time), use_twelve_hour_clock, true)
+           datetime.secondsToDateTime(time.to_s(self.resume_time, nil, true))
         })
     end
     local uptime = time.boottime_or_realtime_coarse() - self.start_monotonic_time


### PR DESCRIPTION
Updates book access time on closing the document.
Do not use sdr mtime to get the last access time. See https://github.com/koreader/koreader/pull/10149#issuecomment-1438824972
(Minor optimization of calling `secondsToDateTime`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10156)
<!-- Reviewable:end -->
