### PR TITLE
[fix] CoverBrowser: fix calling upvalue crash in MosaicMenu

### DIFF
--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -577,7 +577,7 @@ function MosaicMenuItem:update()
             if DocSettings:hasSidecarFile(self.filepath) then
                 self.been_opened = true
                 self.menu:updateCache(self.filepath, nil, true, bookinfo.pages) -- create new cache entry if absent
-                _, percent_finished, status = unpack(self.menu.cover_info_cache[self.filepath])
+                dummy, percent_finished, status = unpack(self.menu.cover_info_cache[self.filepath])
             end
             self.percent_finished = percent_finished
             self.status = status


### PR DESCRIPTION
Regression introduced in #10140.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10164)
<!-- Reviewable:end -->
