### PR TITLE
[i18n] Improve clarity for translators

### DIFF
--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -553,7 +553,7 @@ function CalibreSearch:prompt(message)
             if count == 0 then
                 info_text = _("No calibre libraries were found")
             else
-                info_text = T(_("Found %1 calibre libraries with %2 books:%3"), count, #self.books, paths)
+                info_text = T(_("Found %1 calibre libraries with %2 books:\n%3"), count, #self.books, paths)
             end
             UIManager:show(InfoMessage:new{ text = info_text })
         end,


### PR DESCRIPTION
> unimiso
> 
> Looking at lua, %3 seems to be a path list. I think it would be better to put \n before %3.

The path list will start with \n already, but an extra newline won't hurt and this string is really weird (i.e., people will naturally put a space or a newline in front of it).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10172)
<!-- Reviewable:end -->
