### PR TITLE
[i18n] FileManagerMenu: remove stray newline from metadata location translation

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -852,7 +852,7 @@ function FileManagerMenu:moveBookMetadata()
                 UIManager:show(ConfirmBox:new{
                     text = T(N_("1 book with metadata not in your preferred location found.",
                               "%1 books with metadata not in your preferred location found.",
-                              books_to_move_nb), books_to_move_nb) .. "\n"
+                              books_to_move_nb), books_to_move_nb) .. "\n" ..
                               _("Move book metadata to your preferred location?"),
                     ok_text = _("Move"),
                     ok_callback = function()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -852,8 +852,8 @@ function FileManagerMenu:moveBookMetadata()
                 UIManager:show(ConfirmBox:new{
                     text = T(N_("1 book with metadata not in your preferred location found.",
                               "%1 books with metadata not in your preferred location found.",
-                              books_to_move_nb), books_to_move_nb) ..
-                              _("\nMove book metadata to your preferred location?"),
+                              books_to_move_nb), books_to_move_nb) .. "\n"
+                              _("Move book metadata to your preferred location?"),
                     ok_text = _("Move"),
                     ok_callback = function()
                         UIManager:close(self.menu_container)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10174)
<!-- Reviewable:end -->
