### PR TITLE
Coverbrowser: sync display modes

### DIFF
--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -83,151 +83,81 @@ function CoverBrowser:addToMainMenu(menu_items)
         return
     end
 
+    local modes = {
+        { _("Classic (filename only)") },
+        { _("Mosaic with cover images"), "mosaic_image" },
+        { _("Mosaic with text covers"), "mosaic_text" },
+        { _("Detailed list with cover images and metadata"), "list_image_meta" },
+        { _("Detailed list with metadata, no images"), "list_only_meta" },
+        { _("Detailed list with cover images and filenames"), "list_image_filename" },
+    }
+    local sub_item_table, history_sub_item_table, collection_sub_item_table = {}, {}, {}
+    for i, v in ipairs(modes) do
+        local text, mode = unpack(v)
+        table.insert(sub_item_table, {
+            text = text,
+            checked_func = function()
+                return mode == filemanager_display_mode
+            end,
+            callback = function()
+                self:setupFileManagerDisplayMode(mode)
+                if BookInfoManager:getSetting("sync_display_modes") then
+                    self:setupHistoryDisplayMode(mode)
+                    self:setupCollectionDisplayMode(mode)
+                end
+            end,
+            separator = i == #modes,
+        })
+        table.insert(history_sub_item_table, {
+            text = text,
+            checked_func = function()
+                return mode == history_display_mode
+            end,
+            callback = function()
+                self:setupHistoryDisplayMode(mode)
+            end,
+        })
+        table.insert(collection_sub_item_table, {
+            text = text,
+            checked_func = function()
+                return mode == collection_display_mode
+            end,
+            callback = function()
+                self:setupCollectionDisplayMode(mode)
+            end,
+        })
+    end
+    table.insert(sub_item_table, {
+        text = _("Sync display modes"),
+        checked_func = function()
+            return BookInfoManager:getSetting("sync_display_modes")
+        end,
+        callback = function()
+            local do_sync = not BookInfoManager:getSetting("sync_display_modes")
+            BookInfoManager:saveSetting("sync_display_modes", do_sync)
+            if do_sync then
+                self:setupHistoryDisplayMode(filemanager_display_mode)
+                self:setupCollectionDisplayMode(filemanager_display_mode)
+            end
+        end,
+    })
+    table.insert(sub_item_table, {
+        text = _("History display mode"),
+        enabled_func = function()
+            return not BookInfoManager:getSetting("sync_display_modes")
+        end,
+        sub_item_table = history_sub_item_table,
+    })
+    table.insert(sub_item_table, {
+        text = _("Favorites display mode"),
+        enabled_func = function()
+            return not BookInfoManager:getSetting("sync_display_modes")
+        end,
+        sub_item_table = collection_sub_item_table,
+    })
     menu_items.filemanager_display_mode = {
         text = _("Display mode"),
-        sub_item_table = {
-            -- selecting these does not close menu, which may be nice
-            -- so one can see how they look below the menu
-            {
-                text = _("Classic (filename only)"),
-                checked_func = function() return not filemanager_display_mode end,
-                callback = function()
-                   self:setupFileManagerDisplayMode("")
-                end,
-            },
-            {
-                text = _("Mosaic with cover images"),
-                checked_func = function() return filemanager_display_mode == "mosaic_image" end,
-                callback = function()
-                   self:setupFileManagerDisplayMode("mosaic_image")
-                end,
-            },
-            {
-                text = _("Mosaic with text covers"),
-                checked_func = function() return filemanager_display_mode == "mosaic_text" end,
-                callback = function()
-                   self:setupFileManagerDisplayMode("mosaic_text")
-                end,
-            },
-            {
-                text = _("Detailed list with cover images and metadata"),
-                checked_func = function() return filemanager_display_mode == "list_image_meta" end,
-                callback = function()
-                   self:setupFileManagerDisplayMode("list_image_meta")
-                end,
-            },
-            {
-                text = _("Detailed list with metadata, no images"),
-                checked_func = function() return filemanager_display_mode == "list_only_meta" end,
-                callback = function()
-                   self:setupFileManagerDisplayMode("list_only_meta")
-                end,
-            },
-            {
-                text = _("Detailed list with cover images and filenames"),
-                checked_func = function() return filemanager_display_mode == "list_image_filename" end,
-                callback = function()
-                   self:setupFileManagerDisplayMode("list_image_filename")
-                end,
-                separator = true,
-            },
-            -- Plug the same choices for History here as a submenu
-            -- (Any other suitable place for that ?)
-            {
-                text = _("History display mode"),
-                sub_item_table = {
-                    {
-                        text = _("Classic (filename only)"),
-                        checked_func = function() return not history_display_mode end,
-                        callback = function()
-                           self:setupHistoryDisplayMode("")
-                        end,
-                    },
-                    {
-                        text = _("Mosaic with cover images"),
-                        checked_func = function() return history_display_mode == "mosaic_image" end,
-                        callback = function()
-                           self:setupHistoryDisplayMode("mosaic_image")
-                        end,
-                    },
-                    {
-                        text = _("Mosaic with text covers"),
-                        checked_func = function() return history_display_mode == "mosaic_text" end,
-                        callback = function()
-                           self:setupHistoryDisplayMode("mosaic_text")
-                        end,
-                    },
-                    {
-                        text = _("Detailed list with cover images and metadata"),
-                        checked_func = function() return history_display_mode == "list_image_meta" end,
-                        callback = function()
-                           self:setupHistoryDisplayMode("list_image_meta")
-                        end,
-                    },
-                    {
-                        text = _("Detailed list with metadata, no images"),
-                        checked_func = function() return history_display_mode == "list_only_meta" end,
-                        callback = function()
-                           self:setupHistoryDisplayMode("list_only_meta")
-                        end,
-                    },
-                    {
-                        text = _("Detailed list with cover images and filenames"),
-                        checked_func = function() return history_display_mode == "list_image_filename" end,
-                        callback = function()
-                           self:setupHistoryDisplayMode("list_image_filename")
-                        end,
-                    },
-                },
-            },
-            {
-                text = _("Favorites display mode"),
-                sub_item_table = {
-                    {
-                        text = _("Classic (filename only)"),
-                        checked_func = function() return not collection_display_mode end,
-                        callback = function()
-                            self:setupCollectionDisplayMode("")
-                        end,
-                    },
-                    {
-                        text = _("Mosaic with cover images"),
-                        checked_func = function() return collection_display_mode == "mosaic_image" end,
-                        callback = function()
-                            self:setupCollectionDisplayMode("mosaic_image")
-                        end,
-                    },
-                    {
-                        text = _("Mosaic with text covers"),
-                        checked_func = function() return collection_display_mode == "mosaic_text" end,
-                        callback = function()
-                            self:setupCollectionDisplayMode("mosaic_text")
-                        end,
-                    },
-                    {
-                        text = _("Detailed list with cover images and metadata"),
-                        checked_func = function() return collection_display_mode == "list_image_meta" end,
-                        callback = function()
-                            self:setupCollectionDisplayMode("list_image_meta")
-                        end,
-                    },
-                    {
-                        text = _("Detailed list with metadata, no images"),
-                        checked_func = function() return collection_display_mode == "list_only_meta" end,
-                        callback = function()
-                            self:setupCollectionDisplayMode("list_only_meta")
-                        end,
-                    },
-                    {
-                        text = _("Detailed list with cover images and filenames"),
-                        checked_func = function() return collection_display_mode == "list_image_filename" end,
-                        callback = function()
-                            self:setupCollectionDisplayMode("list_image_filename")
-                        end,
-                    },
-                },
-            },
-        },
+        sub_item_table = sub_item_table,
     }
 
     -- add Mosaic / Detailed list mode settings to File browser Settings submenu

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -101,7 +101,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             end,
             callback = function()
                 self:setupFileManagerDisplayMode(mode)
-                if BookInfoManager:getSetting("sync_display_modes") then
+                if BookInfoManager:getSetting("unified_display_mode") then
                     self:setupHistoryDisplayMode(mode)
                     self:setupCollectionDisplayMode(mode)
                 end
@@ -128,13 +128,13 @@ function CoverBrowser:addToMainMenu(menu_items)
         })
     end
     table.insert(sub_item_table, {
-        text = _("Sync display modes"),
+        text = _("Use this mode everywhere"),
         checked_func = function()
-            return BookInfoManager:getSetting("sync_display_modes")
+            return BookInfoManager:getSetting("unified_display_mode")
         end,
         callback = function()
-            local do_sync = not BookInfoManager:getSetting("sync_display_modes")
-            BookInfoManager:saveSetting("sync_display_modes", do_sync)
+            local do_sync = not BookInfoManager:getSetting("unified_display_mode")
+            BookInfoManager:saveSetting("unified_display_mode", do_sync)
             if do_sync then
                 self:setupHistoryDisplayMode(filemanager_display_mode)
                 self:setupCollectionDisplayMode(filemanager_display_mode)
@@ -144,14 +144,14 @@ function CoverBrowser:addToMainMenu(menu_items)
     table.insert(sub_item_table, {
         text = _("History display mode"),
         enabled_func = function()
-            return not BookInfoManager:getSetting("sync_display_modes")
+            return not BookInfoManager:getSetting("unified_display_mode")
         end,
         sub_item_table = history_sub_item_table,
     })
     table.insert(sub_item_table, {
         text = _("Favorites display mode"),
         enabled_func = function()
-            return not BookInfoManager:getSetting("sync_display_modes")
+            return not BookInfoManager:getSetting("unified_display_mode")
         end,
         sub_item_table = collection_sub_item_table,
     })


### PR DESCRIPTION
Not a frequently used feature but is helpful when testing and switching different modes.

<img width="250" alt="01" src="https://user-images.githubusercontent.com/62179190/223699574-bbf60999-85a4-4379-879d-7a1a086e3184.png">

<img width="250" alt="02" src="https://user-images.githubusercontent.com/62179190/223699582-7b086c12-f2f2-45e1-816d-1a29c99a0c64.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10188)
<!-- Reviewable:end -->
