### PR TITLE
vocabbuilder.koplugin: fix reset word progress bug

### DIFF
--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -945,6 +945,7 @@ end
 
 function VocabItemWidget:resetProgress()
     self.item.review_count = 0
+    self.item.streak_count = 0
     self.item.due_time = os.time()
     self.item.review_time = self.item.due_time
     self.item.last_due_time = nil


### PR DESCRIPTION
fixes #10194.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10195)
<!-- Reviewable:end -->
