### PR TITLE
Optimize standby event handling

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -162,10 +162,6 @@ function ReaderCoptListener:onResume()
     self:headerRefresh()
 end
 
-function ReaderCoptListener:onLeaveStandby()
-    self:headerRefresh()
-end
-
 function ReaderCoptListener:onOutOfScreenSaver()
     if not self._delayed_screensaver then
         return
@@ -178,7 +174,6 @@ end
 -- Unschedule on these events
 ReaderCoptListener.onCloseDocument = ReaderCoptListener.unscheduleHeaderRefresh
 ReaderCoptListener.onSuspend = ReaderCoptListener.unscheduleHeaderRefresh
-ReaderCoptListener.onEnterStandby = ReaderCoptListener.unscheduleHeaderRefresh
 
 function ReaderCoptListener:setAndSave(setting, property, value)
     self.ui.document._document:setIntProperty(property, value)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2471,19 +2471,10 @@ function ReaderFooter:onOutOfScreenSaver()
     self:rescheduleFooterAutoRefreshIfNeeded()
 end
 
-function ReaderFooter:onLeaveStandby()
-    self:maybeUpdateFooter()
-    self:rescheduleFooterAutoRefreshIfNeeded()
-end
-
 function ReaderFooter:onSuspend()
     self:unscheduleFooterAutoRefresh()
     -- Reset the initial marker
     self.progress_bar.inital_percentage = nil
-end
-
-function ReaderFooter:onEnterStandby()
-    self:unscheduleFooterAutoRefresh()
 end
 
 function ReaderFooter:onCloseDocument()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -243,6 +243,16 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
     end
 end
 
+--- Shift the execution times of all scheduled tasks.
+-- UIManager uses CLOCK_MONOTONIC (which doesn't tick during standby), so shifting the execution
+-- time by a negative value will lead to an execution at the expected time.
+-- @param time if positive execute the tasks later, if negative the should be executed earlier
+function UIManager:shiftScheduledTasksBy(shift_time)
+    for i, v in ipairs(self._task_queue) do
+        v.time = v.time + shift_time
+    end
+end
+
 -- Schedule an execution task; task queue is in descending order
 function UIManager:schedule(sched_time, action, ...)
     local lo, hi = 1, #self._task_queue

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -246,7 +246,7 @@ end
 --- Shift the execution times of all scheduled tasks.
 -- UIManager uses CLOCK_MONOTONIC (which doesn't tick during standby), so shifting the execution
 -- time by a negative value will lead to an execution at the expected time.
--- @param time if positive execute the tasks later, if negative the should be executed earlier
+-- @param time if positive execute the tasks later, if negative they should be executed earlier
 function UIManager:shiftScheduledTasksBy(shift_time)
     for i, v in ipairs(self._task_queue) do
         v.time = v.time + shift_time

--- a/plugins/autodim.koplugin/main.lua
+++ b/plugins/autodim.koplugin/main.lua
@@ -212,44 +212,14 @@ function AutoDim:_onResume()
     self:_schedule_autodim_task()
 end
 
-function AutoDim:_onEnterStandby()
-    self:_unschedule_autodim_task()
-    -- don't unschedule ramp task, as this is done in onLeaveStandby if necessary
-end
-
-function AutoDim:_onLeaveStandby()
-    if self.isCurrentlyDimming then
-        if self.last_ramp_scheduling_time then
-            -- we are during the ramp down
-            local now = UIManager:getElapsedTimeSinceBoot()
-            local next_ramp_time_s = self.last_ramp_scheduling_time + time.s(self.autodim_step_time_s) - now
-            self:_unschedule_ramp_task() -- self.last_ramp_scheduling_time gets deleted with this call
-            self.isCurrentlyDimming = true -- as this gets deleted by `_unschedule_ramp_task()`
-            if next_ramp_time_s <= 0 then -- only happens, when standby is ended by a scheduled ramp_task()
-                self:ramp_task()
-            else
-                self:_schedule_ramp_task(time.to_s(next_ramp_time_s))
-            end
-        else
-            self:_unschedule_ramp_task()
-        end
-    else
-        self:autodim_task() -- check times and reschedule autodim_task if necessary
-    end
-end
-
 function AutoDim:setEventHandlers()
     self.onResume = self._onResume
     self.onSuspend = self._onSuspend
-    self.onEnterStandby = self._onEnterStandby
-    self.onLeaveStandby = self._onLeaveStandby
 end
 
 function AutoDim:clearEventHandlers()
     self.onResume = nil
     self.onSuspend = nil
-    self.onEnterStandby = nil
-    self.onLeaveStandby = nil
 end
 
 function AutoDim:onFrontlightTurnedOff()

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -641,7 +641,7 @@ function AutoSuspend:AllowStandbyHandler()
         UIManager:consumeInputEarlyAfterPM(true)
 
         -- When we exit this method, we are sure that the input polling deadline is zero (consumeInputEarly).
-        -- UIManagerger will check newly scheduled tasks before going to input polling again (with a new deadline).
+        -- UIManager will check newly scheduled tasks before going to input polling again (with a new deadline).
         self:_start_standby() -- Schedule the next standby check in the future.
     else
         -- When we exit this method, we are sure that the input polling deadline is approximately `wake_in`.

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -655,6 +655,8 @@ function AutoSuspend:AllowStandbyHandler()
         -- This obviously needs a matching implementation in Device, the canonical one being Kobo.
         Device:standby(wake_in)
 
+        UIManager:shiftScheduledTasksBy( - Device.last_standby_time)
+
         logger.dbg("AutoSuspend: left standby after", time.format_time(Device.last_standby_time), "s")
 
         -- We delay the LeaveStandby event (our onLeaveStandby handler is responsible for rescheduling everything properly),


### PR DESCRIPTION
Here I want to optimize the standby behavior, by minimizing the usage of the `onEnterStandby` and `onLeaveStandby` handlers.

The goal is to eliminate most of that handlers and optimize (speed) up the rest.
This can be achieved by just shifting the execution time of scheduled tasks by ` - Device.last_standby_time` (notice the sign, which means they should be executed earlier.) 
So it is not necessary to unschedule related tasks in `onEnterStandby` and reschedule them in `onLeaveStandby`.
The savings in the unschedule part might be smaller than the savings in the rescheduling part. (We will save a table delete and a binary insert in every case.)

As I won't eliminate the `onXXXStandby` events, everything will work as usual. The only difference is, that scheduled tasks will get executed `last_standby_time` earlier, as the clock has _not_ ticked for exactly that `last_standby_time` _(this is what we want, anyway)._

This initial commit is just a POC with changes in the `autosuspend`-plugin together with header and footer (and a private userpatch). Seems to work so far.

- [x] `autosuspend`-plugin
- [x] plus `UIManager`
- [x] `readerfooter`
- [x] `readercoptlistener`
- [x] `autowarmth`-plugin 
- [x] `autoturn`-plugin
- [x] `autodim`-plugin 

As always: Throw thoughts on my brain until it gets muddy or find logical errors. ;-)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10203)
<!-- Reviewable:end -->
