### PR TITLE
More KOpt page margins, bump crengine, toggle bookmarks in PageBrowser

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -844,7 +844,7 @@ function ReaderBookmark:isBookmarkMatch(item, pn_or_xp)
     if self.ui.paging then
         return item.page == pn_or_xp
     else
-        return self.ui.document:isXPointerInCurrentPage(item.page)
+        return self.ui.document:getPageFromXPointer(item.page) == self.ui.document:getPageFromXPointer(pn_or_xp)
     end
 end
 
@@ -1190,8 +1190,17 @@ function ReaderBookmark:doesBookmarkMatchTable(item, match_table)
     end
 end
 
-function ReaderBookmark:toggleBookmark()
-    local pn_or_xp = self:getCurrentPageNumber()
+function ReaderBookmark:toggleBookmark(pageno)
+    local pn_or_xp
+    if pageno then
+        if self.ui.rolling then
+            pn_or_xp = self.ui.document:getPageXPointer(pageno)
+        else
+            pn_or_xp = pageno
+        end
+    else
+        pn_or_xp = self:getCurrentPageNumber()
+    end
     local index = self:getDogearBookmarkIndex(pn_or_xp)
     if index then
         self.ui:handleEvent(Event:new("BookmarkRemoved", self.bookmarks[index]))

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -831,6 +831,10 @@ function CreDocument:getXPointer()
     return self._document:getXPointer()
 end
 
+function CreDocument:getPageXPointer(page)
+    return self._document:getPageXPointer(page)
+end
+
 function CreDocument:isXPointerInDocument(xp)
     return self._document:isXPointerInDocument(xp)
 end

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -103,12 +103,18 @@ In 'semi-auto' and 'manual' modes, you may need to define areas once on an odd p
             {
                 name = "page_margin",
                 name_text = _("Margin"),
-                toggle = {C_("Page margin", "small"), C_("Page margin", "medium"), C_("Page margin", "large")},
-                values = {0.05, 0.10, 0.25},
+                buttonprogress = true,
+                values = {0.05, 0.10, 0.25, 0.40, 0.55, 0.70, 0.85, 1.00},
                 default_value = G_defaults:readSetting("DKOPTREADER_CONFIG_PAGE_MARGIN"),
                 event = "MarginUpdate",
                 name_text_hold_callback = optionsutil.showValues,
                 help_text = _([[Set margins to be applied after page-crop and zoom modes are applied.]]),
+                more_options = true,
+                more_options_param = {
+                    value_step = 0.01, value_hold_step = 0.10,
+                    value_min = 0, value_max = 1.50,
+                    precision = "%.2f",
+                },
             },
             {
                 name = "auto_straighten",

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -984,6 +984,32 @@ function PageBrowserWidget:onHold(arg, ges)
         end
         return true
     end
+    -- Hold on title: do nothing
+    if ges.pos.y < self.title_bar_h then
+        return true
+    end
+    -- If hold on a thumbnail, toggle bookmark on that page
+    for idx=1, self.nb_grid_items do
+        if ges.pos:intersectWith(self.grid[idx].dimen) then
+            local page = self.grid[idx].page_idx
+            if page and self.grid[idx][1][1].is_page_thumbnail then
+                -- Only allow hold on fully displayed thumbnails.
+                -- Also, a thumbnail might be smaller than the original grid
+                -- item dimension. Be sure the hold is on it (otherwise, it's
+                -- a hold in the inter thumbnail margin, that we'd rather not
+                -- handle)
+                local thumb_frame = self.grid[idx][1][1]
+                if ges.pos:intersectWith(thumb_frame.dimen) then
+                    self.ui.bookmark:toggleBookmark(page)
+                    -- Update our cached bookmarks info and ensure the bottom ribbon is redrawn
+                    self.bookmarked_pages = self.ui.bookmark:getBookmarkedPages()
+                    self:updateLayout()
+                    return true
+                end
+            end
+            break
+        end
+    end
     return true
 end
 


### PR DESCRIPTION
#### KOpt: switch page_margin to buttonprogress and fine tuning

Allow for larger margins (which may exhibit other issues that were less noticable with small margins).
See https://github.com/koreader/koreader/issues/4255#issuecomment-1463907821 and next posts for possible caveats with larger margins.
Closes #4255. Closes #7233. Closes #7815.

#### bump crengine: minor fixes, add getPageXPointer()

Includes https://github.com/koreader/crengine/pull/513 :
- Update German hyphenation patterns
- CSS stylesheets cache: also clear it after initial load
- getSurroundingAddedHeight(): use interline_scale_factor
- LVDocView::getNodeByPoint(): tweak again for text selection
- LVDocView::getPageBookmark(): behave as getBookmark()

#### PageBrowser: toggle page bookmark with long-press on thumbnail

See https://github.com/koreader/koreader/issues/10193#issuecomment-1464453447.
Closes #10193.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10208)
<!-- Reviewable:end -->
