### PR TITLE
[plugin] CoverBrowser: run PRAGMA optimize just before closing db connection

### DIFF
--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -215,6 +215,7 @@ end
 
 function BookInfoManager:closeDbConnection()
     if self.db_conn then
+        self.db_conn:exec("PRAGMA analysis_limit=10000; PRAGMA optimize;")
         self.db_conn:close()
         self.db_conn = nil
     end


### PR DESCRIPTION
Due to <https://github.com/koreader/koreader/pull/10198#issuecomment-1474830282> I browsed the SQLite documentation a bit.

Looking at <https://www.sqlite.org/pragma.html#pragma_optimize>, it says:

> To achieve the best long-term query performance without the need to do a detailed engineering analysis of the application schema and SQL, it is recommended that applications run "PRAGMA optimize" (with no arguments) just before closing each database connection. Long-running applications might also benefit from setting a timer to run "PRAGMA optimize" every few hours.
>
> This pragma is usually a no-op or nearly so and is very fast. However if SQLite feels that performing database optimizations (such as running ANALYZE or creating new indexes) will improve the performance of future queries, then some database I/O may be done. Applications that want to limit the amount of work performed can set a timer that will invoke sqlite3_interrupt() if the pragma goes on for too long. Or, since SQLite 3.32.0, the application can use PRAGMA analysis_limit=N for some small value of N (a few hundred or a few thousand) to limit the depth of analyze.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10219)
<!-- Reviewable:end -->
