### PR TITLE
Limit size of crash.log during run (mainly for developers)

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -501,7 +501,7 @@ To:
                     end
                 end,
             },
-        }
+        },
     }
     if Device:isKobo() and not Device:isSunxi() then
         table.insert(self.menu_items.developer_options.sub_item_table, {


### PR DESCRIPTION
I sometimes had the problem, that crash.log is growing too much during a run of KOReader (esp. the file is not limited on a restart). Despite the disk usage, on the next real start KOReader needs some noticeable time to trim the file.
This PR should reduce the disk usage and startup time.

The main audience for this PR are developers, users might not notice the difference.

So this tiny bit of software hooks itself into the `developer options` menu entry and allows trimming the content of `crash.log` to the hard coded size of 500000 bytes if the size exceeds the hard coded size by a defined factor (hard coded to 2).
This trimming will happen: never, on suspend, every 30min, every hour  or every 6 hours.

Draft by now so ... please no nitpicking,


General feedback about the idea, place in the UI, naming and so on is welcomed ...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10227)
<!-- Reviewable:end -->
