### PR TITLE
Button related tweaks, add menu to Book map and Page browser

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -771,6 +771,16 @@ local BOOK_TWEAK_INPUT_HINT = T([[
 
 %2]], _("You can add CSS snippets which will be applied only to this book."), BOOK_TWEAK_SAMPLE_CSS)
 
+local CSS_SUGGESTIONS = {
+    { "-cr-hint: footnote-inpage;", _("When set on a block element containing the target id of a href, this block element will be shown as an in-page footnote.")},
+    { "-cr-hint: non-linear-combining;", _("Can be set on some specific DocFragments (ie. DocFragment[id*=16]) to ignore them in the linear pages flow.")},
+    { "-cr-hint: toc-level1;", _("When set on an element, its text can be used to build the alternative table of contents.")},
+    { "display: run-in !important,", _("When set on a block element, this element content will be inlined with the next block element.")},
+    { "font-size: 1rem !important;", _("1rem will enforce your main font size")},
+    { "hyphens: none !important", _("Disables hyphenation inside the targeted elements.")},
+    { "text-indent: 1.2em !important;", _("1.2em is our default text indentation.")},
+}
+
 function ReaderStyleTweak:editBookTweak(touchmenu_instance)
     local InputDialog = require("ui/widget/inputdialog")
     local editor -- our InputDialog instance
@@ -823,7 +833,7 @@ function ReaderStyleTweak:editBookTweak(touchmenu_instance)
         add_nav_bar = true,
         scroll_by_pan = true,
         buttons = {{
-            -- First button on first row (row will be completed with Reset|Save|Close)
+            -- First buttons on first row (row will be completed with Reset|Save|Close)
             {
                 id = tweak_button_id,
                 text_func = function()
@@ -839,6 +849,40 @@ function ReaderStyleTweak:editBookTweak(touchmenu_instance)
                         editor:setInputText(css_text, true)
                         toggle_tweak_button()
                     end
+                end,
+            },
+            {
+                id = "css_suggestions_button_id",
+                text = "CSS \u{2261}",
+                callback = function()
+                    local suggestions_popup_widget
+                    local buttons = {}
+                    for _, suggestion in ipairs(CSS_SUGGESTIONS) do
+                        table.insert(buttons, {{
+                            text = suggestion[1],
+                            align = "left",
+                            callback = function()
+                                UIManager:close(suggestions_popup_widget)
+                                editor._input_widget:addChars(suggestion[1])
+                            end,
+                            hold_callback = suggestion[2] and function()
+                                UIManager:show(InfoMessage:new{ text = suggestion[2] })
+                            end or nil
+                        }})
+                    end
+                    local ButtonDialog = require("ui/widget/buttondialog")
+                    suggestions_popup_widget = ButtonDialog:new{
+                        modal = true, -- needed when keyboard is shown
+                        width = math.floor(Screen:getWidth() * 0.9), -- max width, will get smaller
+                        shrink_unneeded_width = true,
+                        buttons = buttons,
+                        anchor = function()
+                            -- we return prefers_pop_down=true so it pops over the keyboard
+                            -- instead of the text if it can
+                            return editor.button_table:getButtonById("css_suggestions_button_id").dimen, true
+                        end,
+                    }
+                    UIManager:show(suggestions_popup_widget)
                 end,
             },
         }},

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
+local ButtonDialog = require("ui/widget/buttondialog")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
 local Font = require("ui/font")
@@ -609,8 +610,8 @@ function BookMapWidget:init()
     self.title_bar = TitleBar:new{
         fullscreen = true,
         title = self.title,
-        left_icon = "info",
-        left_icon_tap_callback = function() self:showHelp() end,
+        left_icon = "appbar.menu",
+        left_icon_tap_callback = function() self:showMenu() end,
         left_icon_hold_callback = function()
             self:toggleDefaultSettings() -- toggle between user settings and default view
         end,
@@ -1018,14 +1019,119 @@ function BookMapWidget:update()
 end
 
 
-function BookMapWidget:showHelp()
+function BookMapWidget:showMenu()
+    local button_dialog
+    -- Width of our -/+ buttons, so it looks fine with Button's default font size of 20
+    local plus_minus_width = Screen:scaleBySize(60)
+    local buttons = {
+        {{
+            text = _("About book map"),
+            align = "left",
+            callback = function()
+                self:showAbout()
+            end,
+        }},
+        {{
+            text = _("Available gestures"),
+            align = "left",
+            callback = function()
+                self:showGestures()
+            end,
+        }},
+        {{
+            text = _("Switch current/initial views"),
+            align = "left",
+            enabled_func = function() return self.toc_depth > 0 end,
+            callback = function()
+                self:toggleDefaultSettings()
+            end,
+        }},
+        {{
+            text = _("Switch grid/flat views"),
+            align = "left",
+            enabled_func = function() return self.toc_depth > 0 end,
+            callback = function()
+                self.flat_map = not self.flat_map
+                self:saveSettings()
+                self:update()
+            end,
+        }},
+        {
+            {
+                text = _("Chapters"),
+                callback = function() end,
+                align = "left",
+            },
+            {
+                text = "\u{2796}", -- Heavy minus sign
+                enabled_func = function() return self.toc_depth > 0 end,
+                callback = function()
+                    if self:updateTocDepth(self.flat_map and 1 or -1, nil) then
+                        self:update()
+                    end
+                end,
+                width = plus_minus_width,
+            },
+            {
+                text = "\u{2795}", -- Heavy plus sign
+                enabled_func = function() return self.toc_depth < self.max_toc_depth end,
+                callback = function()
+                    if self:updateTocDepth(self.flat_map and -1 or 1, nil) then
+                        self:update()
+                    end
+                end,
+                width = plus_minus_width,
+            }
+        },
+        {
+            {
+                text = _("Page slot width"),
+                callback = function() end,
+                align = "left",
+                -- Below, minus increases page per row and plus decreases it.
+                -- It feels more natural this way: + will make everything (page slots and the grid) bigger.
+            },
+            {
+                text = "\u{2796}", -- Heavy minus sign
+                enabled_func = function() return self.pages_per_row < self.max_pages_per_row end,
+                callback = function()
+                    if self:updatePagesPerRow(10, true) then
+                        self:update()
+                    end
+                end,
+                width = plus_minus_width,
+            },
+            {
+                text = "\u{2795}", -- Heavy plus sign
+                enabled_func = function() return self.pages_per_row > self.min_pages_per_row end,
+                callback = function()
+                    if self:updatePagesPerRow(-10, true) then
+                        self:update()
+                    end
+                end,
+                width = plus_minus_width,
+            }
+        },
+    }
+    button_dialog = ButtonDialog:new{
+        -- width = math.floor(Screen:getWidth() / 2),
+        width = math.floor(Screen:getWidth() * 0.9), -- max width, will get smaller
+        shrink_unneeded_width = true,
+        buttons = buttons,
+        anchor = function()
+            return self.title_bar.left_button.image.dimen
+        end,
+    }
+    UIManager:show(button_dialog)
+end
+function BookMapWidget:showAbout()
     UIManager:show(InfoMessage:new{
         text = _([[
 Book map displays an overview of the book content.
 
-If statistics are enabled, black bars are shown for already read pages (gray for pages read in the current reading session). Their heights vary with the time spent reading the page.
-Chapters are shown above their pages.
-Under the pages can be found some indicators:
+If statistics are enabled, black bars are shown for already read pages (gray for pages read in the current reading session). Their heights vary depending on the time spent reading the page.
+Chapters are shown above the pages they encompass.
+Under the pages, these indicators may be shown:
 ▲ current page
 ❶ ❷ … previous locations
 ▒ highlighted text
@@ -1033,14 +1139,24 @@ Under the pages can be found some indicators:
  bookmarked page
 ▢ focused page when coming from Pages browser
 
-Tap on a location in the book to browse thumbnails of the pages there.
-Swipe along the left screen edge to change the level of chapters to include in the book map, and the type of book map (grid or flat) when crossing the level 0.
-Swipe along the bottom screen edge to change the width of page slots.
-Swipe or pan vertically on content to scroll.
-Any multiswipe will close the book map.
+On a newly opened book, the book map will start in grid mode showing all chapter levels, fitting on a single screen, to give the best initial overview of the book's content.]]),
+    })
+end
 
-On a newly opened book, the book map will start in grid mode showing all chapter levels, fitting on a single screen, to give the best initial overview of the book's content.
-Long-press on ⓘ to switch between current and initial views.]]),
+function BookMapWidget:showGestures()
+    UIManager:show(InfoMessage:new{
+        text = _([[
+Tap on a location in the book to browse thumbnails of the pages there.
+
+Swipe along the left screen edge to change the level of chapters to include in the book map, and the type of book map (grid or flat) when crossing the level 0.
+
+Swipe along the bottom screen edge to change the width of page slots.
+
+Swipe or pan vertically on content to scroll.
+
+Long-press on ≡ to switch between current and initial views.
+
+Any multiswipe will close the book map.]]),
     })
 end
 

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -85,6 +85,12 @@ function Button:init()
 
     local outer_pad_width = 2*self.padding_h + 2*self.margin + 2*self.bordersize -- unscaled_size_check: ignore
 
+    -- If this button could be made smaller while still not needing truncation
+    -- or a smaller font size, we'll set this: it may allow an upper widget to
+    -- resize/relayout itself to look more compact/nicer (as this size would
+    -- depends on translations)
+    self._min_needed_width = nil
+
     if self.text then
         local max_width = self.max_width or self.width
         if max_width then
@@ -97,6 +103,9 @@ function Button:init()
             bold = self.text_font_bold,
             face = Font:getFace(self.text_font_face, self.text_font_size)
         }
+        if not self.label_widget:isTruncated() then
+            self._min_needed_width = self.label_widget:getSize().w + outer_pad_width
+        end
         self.did_truncation_tweaks = false
         if self.avoid_text_truncation and self.label_widget:isTruncated() then
             self.did_truncation_tweaks = true
@@ -146,6 +155,7 @@ function Button:init()
             width = self.icon_width,
             height = self.icon_height,
         }
+        self._min_needed_width = self.icon_width + outer_pad_width
     end
     local widget_size = self.label_widget:getSize()
     local inner_width
@@ -210,6 +220,12 @@ function Button:init()
             },
         }
     }
+end
+
+function Button:getMinNeededWidth()
+    if self._min_needed_width and self._min_needed_width < self.width then
+        return self._min_needed_width
+    end
 end
 
 function Button:setText(text, width)

--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -252,6 +252,9 @@ function Button:enable()
     if not self.enabled then
         if self.text then
             self.label_widget.fgcolor = Blitbuffer.COLOR_BLACK
+            if self.label_widget.update then -- using a TextBoxWidget
+                self.label_widget:update() -- needed to redraw with the new color
+            end
         else
             self.label_widget.dim = false
         end
@@ -263,6 +266,9 @@ function Button:disable()
     if self.enabled then
         if self.text then
             self.label_widget.fgcolor = Blitbuffer.COLOR_DARK_GRAY
+            if self.label_widget.update then
+                self.label_widget:update()
+            end
         else
             self.label_widget.dim = true
         end
@@ -287,6 +293,14 @@ function Button:enableDisable(enable)
     else
         self:disable()
     end
+end
+
+function Button:paintTo(bb, x, y)
+    if self.enabled_func then
+        -- state may change because of outside factors, so check it on each painting
+        self:enableDisable(self.enabled_func())
+    end
+    InputContainer.paintTo(self, bb, x, y)
 end
 
 function Button:hide()

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -88,6 +88,7 @@ function ButtonDialog:init()
     end
     self.movable = MovableContainer:new{
             alpha = self.alpha,
+            anchor = self.anchor,
             FrameContainer:new{
                 ButtonTable:new{
                     buttons = self.buttons,

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -55,11 +55,19 @@ local Screen = require("device").screen
 
 local ButtonDialog = InputContainer:extend{
     buttons = nil,
+    width = nil,
+    width_factor = nil, -- number between 0 and 1, factor to the smallest of screen width and height
     tap_close_callback = nil,
     alpha = nil, -- passed to MovableContainer
 }
 
 function ButtonDialog:init()
+    if not self.width then
+        if not self.width_factor then
+            self.width_factor = 0.9 -- default if no width specified
+        end
+        self.width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * self.width_factor)
+    end
     if Device:hasKeys() then
         local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
         self.key_events.Close = { { close_keys } }
@@ -81,6 +89,7 @@ function ButtonDialog:init()
             FrameContainer:new{
                 ButtonTable:new{
                     buttons = self.buttons,
+                    width = self.width - 2*Size.border.window - 2*Size.padding.button,
                     show_parent = self,
                 },
                 background = Blitbuffer.COLOR_WHITE,

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -57,6 +57,8 @@ local ButtonDialog = InputContainer:extend{
     buttons = nil,
     width = nil,
     width_factor = nil, -- number between 0 and 1, factor to the smallest of screen width and height
+    shrink_unneeded_width = false, -- have 'width' meaning 'max_width'
+    shrink_min_width = nil, -- default to ButtonTable's default
     tap_close_callback = nil,
     alpha = nil, -- passed to MovableContainer
 }
@@ -90,6 +92,8 @@ function ButtonDialog:init()
                 ButtonTable:new{
                     buttons = self.buttons,
                     width = self.width - 2*Size.border.window - 2*Size.padding.button,
+                    shrink_unneeded_width = self.shrink_unneeded_width,
+                    shrink_min_width = self.shrink_min_width,
                     show_parent = self,
                 },
                 background = Blitbuffer.COLOR_WHITE,

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -61,12 +61,29 @@ function ButtonDialogTitle:init()
             }
         end
     end
+
     self.button_table = ButtonTable:new{
-        width = self.width,
+        width = self.width - 2*Size.border.window - 2*Size.padding.button,
         buttons = self.buttons,
         zero_sep = true,
         show_parent = self,
     }
+
+    local title_padding = self.use_info_style and self.info_padding or self.title_padding
+    local title_margin = self.use_info_style and self.info_margin or self.title_margin
+    local title_width = self.width - 2 * (Size.border.window + Size.padding.button + title_padding + title_margin)
+    local title_widget = FrameContainer:new{
+        padding = title_padding,
+        margin = title_margin,
+        bordersize = 0,
+        TextBoxWidget:new{
+            text = self.title,
+            width = title_width,
+            face = self.use_info_style and self.info_face or self.title_face,
+            alignment = self.title_align or "left",
+        },
+    }
+
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),
         ignore_if_over = "height",
@@ -74,17 +91,7 @@ function ButtonDialogTitle:init()
             FrameContainer:new{
                 VerticalGroup:new{
                     align = "center",
-                    FrameContainer:new{
-                        padding = self.use_info_style and self.info_padding or self.title_padding,
-                        margin = self.use_info_style and self.info_margin or self.title_margin,
-                        bordersize = 0,
-                        TextBoxWidget:new{
-                            text = self.title,
-                            width = math.floor(self.width * 0.9),
-                            face = self.use_info_style and self.info_face or self.title_face,
-                            alignment = self.title_align or "left",
-                        },
-                    },
+                    title_widget,
                     VerticalSpan:new{ width = Size.span.vertical_default },
                     self.button_table,
                 },

--- a/frontend/ui/widget/buttondialogtitle.lua
+++ b/frontend/ui/widget/buttondialogtitle.lua
@@ -88,6 +88,7 @@ function ButtonDialogTitle:init()
         dimen = Screen:getSize(),
         ignore_if_over = "height",
         MovableContainer:new{
+            anchor = self.anchor,
             FrameContainer:new{
                 VerticalGroup:new{
                     align = "center",

--- a/frontend/ui/widget/buttonprogresswidget.lua
+++ b/frontend/ui/widget/buttonprogresswidget.lua
@@ -73,7 +73,7 @@ function ButtonProgressWidget:update()
         buttons_count = buttons_count + 1
         span_count = span_count + 1
     end
-    local button_width_real = (self.width - span_count * self.horizontal_span_width) / buttons_count - 2*button_padding - 2*button_margin - 2*button_bordersize
+    local button_width_real = (self.width - span_count * self.horizontal_span_width) / buttons_count
     local button_width = math.floor(button_width_real)
     local button_width_adjust = button_width_real - button_width
     local button_width_to_add = 0
@@ -81,16 +81,14 @@ function ButtonProgressWidget:update()
     -- Minus button on the left
     if self.fine_tune then
         button_width_to_add = button_width_to_add + button_width_adjust
-        local margin = button_margin
-        local extra_border_size = 0
         local button = Button:new{
             text = "−",
             radius = 0,
-            margin = margin,
+            margin = button_margin,
             padding = button_padding,
-            bordersize = button_bordersize + extra_border_size,
+            bordersize = button_bordersize,
             enabled = true,
-            width = button_width - 2*extra_border_size,
+            width = button_width,
             preselect = false,
             text_font_face = self.font_face,
             text_font_size = self.font_size,
@@ -122,6 +120,7 @@ function ButtonProgressWidget:update()
         local margin = button_margin
         if self.thin_grey_style and highlighted then
             margin = 0 -- moved outside button so it's not inverted
+            real_button_width = real_button_width - 2*button_margin
         end
         local extra_border_size = 0
         if not self.thin_grey_style and is_default then
@@ -135,7 +134,7 @@ function ButtonProgressWidget:update()
             padding = button_padding,
             bordersize = button_bordersize + extra_border_size,
             enabled = true,
-            width = real_button_width - 2*extra_border_size,
+            width = real_button_width,
             preselect = highlighted,
             text_font_face = self.font_face,
             text_font_size = self.font_size,
@@ -183,16 +182,14 @@ function ButtonProgressWidget:update()
             real_button_width = button_width + math.floor(button_width_to_add)
             button_width_to_add = button_width_to_add - math.floor(button_width_to_add)
         end
-        local margin = button_margin
-        local extra_border_size = 0
         local button = Button:new{
             text = "＋",
             radius = 0,
-            margin = margin,
+            margin = button_margin,
             padding = button_padding,
-            bordersize = button_bordersize + extra_border_size,
+            bordersize = button_bordersize,
             enabled = true,
-            width = real_button_width - 2*extra_border_size,
+            width = real_button_width,
             preselect = false,
             text_font_face = self.font_face,
             text_font_size = self.font_size,
@@ -218,16 +215,14 @@ function ButtonProgressWidget:update()
             -- One pixel wider to better align the entire widget
             real_button_width = button_width + math.floor(button_width_to_add)
         end
-        local margin = button_margin
-        local extra_border_size = 0
         local button = Button:new{
             text = "⋮",
             radius = 0,
-            margin = margin,
+            margin = button_margin,
             padding = button_padding,
-            bordersize = button_bordersize + extra_border_size,
+            bordersize = button_bordersize,
             enabled = true,
-            width = real_button_width - 2*extra_border_size,
+            width = real_button_width,
             preselect = false,
             text_font_face = self.font_face,
             text_font_size = self.font_size,

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -19,8 +19,6 @@ local ButtonTable = FocusManager:extend{
         },
     },
     sep_width = Size.line.medium,
-    padding = Size.padding.default,
-
     zero_sep = false,
 }
 
@@ -65,11 +63,11 @@ function ButtonTable:init()
                 allow_hold_when_disabled = btn_entry.allow_hold_when_disabled,
                 vsync = btn_entry.vsync,
                 width = math.ceil((self.width - sizer_space)/column_cnt),
-                max_width = math.ceil((self.width - sizer_space)/column_cnt - 2*self.sep_width - 2*self.padding),
                 bordersize = 0,
                 margin = 0,
                 padding = Size.padding.buttontable, -- a bit taller than standalone buttons, for easier tap
-                padding_h = 0, -- allow text to take more of the horizontal space
+                padding_h = btn_entry.align == "left" and Size.padding.large or 0,
+                    -- allow text to take more of the horizontal space if centered
                 text_font_face = btn_entry.font_face,
                 text_font_size = btn_entry.font_size,
                 text_font_bold = btn_entry.font_bold,

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -42,7 +42,17 @@ function ButtonTable:init()
         local horizontal_group = HorizontalGroup:new{}
         local row = self.buttons[i]
         local column_cnt = #row
-        local sizer_space = self.sep_width * (column_cnt - 1) + 2
+        local available_width = self.width - self.sep_width * (column_cnt - 1)
+        local unspecified_width_buttons = 0
+        for j = 1, column_cnt do
+            local btn_entry = row[j]
+            if btn_entry.width then
+                available_width = available_width - btn_entry.width
+            else
+                unspecified_width_buttons = unspecified_width_buttons + 1
+            end
+        end
+        local default_button_width = math.floor(available_width / unspecified_width_buttons)
         for j = 1, column_cnt do
             local btn_entry = row[j]
             local button = Button:new{
@@ -63,7 +73,7 @@ function ButtonTable:init()
                 hold_callback = btn_entry.hold_callback,
                 allow_hold_when_disabled = btn_entry.allow_hold_when_disabled,
                 vsync = btn_entry.vsync,
-                width = math.ceil((self.width - sizer_space)/column_cnt),
+                width = btn_entry.width or default_button_width,
                 bordersize = 0,
                 margin = 0,
                 padding = Size.padding.buttontable, -- a bit taller than standalone buttons, for easier tap

--- a/frontend/ui/widget/buttontable.lua
+++ b/frontend/ui/widget/buttontable.lua
@@ -53,6 +53,7 @@ function ButtonTable:init()
                 icon_height = btn_entry.icon_height,
                 align = btn_entry.align,
                 enabled = btn_entry.enabled,
+                enabled_func = btn_entry.enabled_func,
                 callback = function()
                     if self.show_parent and self.show_parent.movable then
                         self.show_parent.movable:resetEventState()

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -288,8 +288,8 @@ function ConfigOption:init()
                 local name_widget_width = math.floor(name_align * Screen:getWidth())
                 -- We don't remove default_option_hpadding from name_text_max_width
                 -- to give more to text and avoid truncation: as it is right aligned,
-                -- the text can grow on the left, padding_small is enough.
-                local name_text_max_width = name_widget_width - 2*padding_small
+                -- the text can grow on the left.
+                local name_text_max_width = name_widget_width
                 local face = Font:getFace(name_font_face, name_font_size)
                 local option_name_container = RightContainer:new{
                     dimen = Geom:new{ w = name_widget_width, h = option_height},

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -42,6 +42,8 @@ function FrontLightWidget:init()
     self.screen_height = Screen:getHeight()
     self.span = Math.round(self.screen_height * 0.01)
     self.width = math.floor(self.screen_width * 0.95)
+    self.inner_width = self.width - 2 * Size.padding.large
+    self.button_width = math.floor(self.inner_width / 4)
 
     -- State constants
     self.powerd = Device:getPowerDevice()
@@ -134,7 +136,7 @@ function FrontLightWidget:layout()
     end
 
     self.fl_progress = ProgressWidget:new{
-        width = math.floor(self.screen_width * 0.9),
+        width = self.inner_width,
         height = Size.item.height_big,
         percentage = self.fl.cur / self.fl.max,
         ticks = ticks,
@@ -145,14 +147,12 @@ function FrontLightWidget:layout()
         text = _("Brightness"),
         face = self.medium_font_face,
         bold = true,
-        max_width = math.floor(self.screen_width * 0.95),
+        max_width = self.inner_width,
     }
     self.fl_minus = Button:new{
         text = "−",
-        margin = Size.margin.small,
-        radius = 0,
         enabled = self.fl.cur ~= self.fl.min,
-        width = math.floor(self.screen_width * 0.2),
+        width = self.button_width,
         show_parent = self,
         callback = function()
             self:setBrightness(self.fl.cur - 1)
@@ -160,10 +160,8 @@ function FrontLightWidget:layout()
     }
     self.fl_plus = Button:new{
         text = "＋",
-        margin = Size.margin.small,
-        radius = 0,
         enabled = self.fl.cur ~= self.fl.max,
-        width = math.floor(self.screen_width * 0.2),
+        width = self.button_width,
         show_parent = self,
         callback = function()
             self:setBrightness(self.fl.cur + 1)
@@ -172,7 +170,7 @@ function FrontLightWidget:layout()
     self.fl_level = TextWidget:new{
         text = tostring(self.fl.cur),
         face = self.medium_font_face,
-        max_width = math.floor(self.screen_width * 0.95 - 1.275 * (self.fl_minus.width + self.fl_plus.width)),
+        max_width = self.inner_width - 2*self.button_width,
     }
     local fl_level_container = CenterContainer:new{
         dimen = Geom:new{
@@ -183,10 +181,8 @@ function FrontLightWidget:layout()
     }
     local fl_min = Button:new{
         text = C_("Extrema", "Min"),
-        margin = Size.margin.small,
-        radius = 0,
         enabled = true,
-        width = math.floor(self.screen_width * 0.2),
+        width = self.button_width,
         show_parent = self,
         callback = function()
             self:setBrightness(self.fl.min + 1)
@@ -194,10 +190,8 @@ function FrontLightWidget:layout()
     }
     local fl_max = Button:new{
         text = C_("Extrema", "Max"),
-        margin = Size.margin.small,
-        radius = 0,
         enabled = true,
-        width = math.floor(self.screen_width * 0.2),
+        width = self.button_width,
         show_parent = self,
         callback = function()
             self:setBrightness(self.fl.max)
@@ -205,17 +199,15 @@ function FrontLightWidget:layout()
     }
     local fl_toggle = Button:new{
         text = _("Toggle"),
-        margin = Size.margin.small,
-        radius = 0,
         enabled = true,
-        width = math.floor(self.screen_width * 0.2),
+        width = self.button_width,
         show_parent = self,
         callback = function()
             self:setBrightness(self.fl.min)
         end,
     }
     local fl_spacer = HorizontalSpan:new{
-        width = math.floor((self.screen_width * 0.95 - 1.2 * (self.fl_minus.width + self.fl_plus.width + fl_toggle.width)) / 2),
+        width = math.floor((self.inner_width - 3 * self.button_width) / 2)
     }
     local fl_buttons_above = HorizontalGroup:new{
         align = "center",
@@ -257,7 +249,7 @@ function FrontLightWidget:layout()
         local nl_group_below = HorizontalGroup:new{ align = "center" }
 
         self.nl_progress = ButtonProgressWidget:new{
-            width = math.floor(self.screen_width * 0.9),
+            width = self.inner_width,
             font_size = 20, -- match Button's default
             padding = 0,
             thin_grey_style = false,
@@ -276,24 +268,20 @@ function FrontLightWidget:layout()
             text = _("Warmth"),
             face = self.medium_font_face,
             bold = true,
-            max_width = math.floor(self.screen_width * 0.95),
+            max_width = self.inner_width,
         }
         self.nl_minus = Button:new{
             text = "−",
-            margin = Size.margin.small,
-            radius = 0,
             enabled = self.nl.cur ~= self.nl.min,
-            width = math.floor(self.screen_width * 0.2),
+            width = self.button_width,
             show_parent = self,
             callback = function()
                 self:setWarmth(self.nl.cur - 1, true) end,
         }
         self.nl_plus = Button:new{
             text = "＋",
-            margin = Size.margin.small,
-            radius = 0,
             enabled = self.nl.cur ~= self.nl.max,
-            width = math.floor(self.screen_width * 0.2),
+            width = self.button_width,
             show_parent = self,
             callback = function()
                 self:setWarmth(self.nl.cur + 1, true) end,
@@ -301,7 +289,7 @@ function FrontLightWidget:layout()
         self.nl_level = TextWidget:new{
             text = tostring(self.nl.cur),
             face = self.medium_font_face,
-            max_width = math.floor(self.screen_width * 0.95 - 1.275 * (self.nl_minus.width + self.nl_plus.width)),
+            max_width = self.inner_width - 2*self.button_width,
         }
         local nl_level_container = CenterContainer:new{
             dimen = Geom:new{
@@ -312,10 +300,8 @@ function FrontLightWidget:layout()
         }
         local nl_min = Button:new{
             text = C_("Extrema", "Min"),
-            margin = Size.margin.small,
-            radius = 0,
             enabled = true,
-            width = math.floor(self.screen_width * 0.2),
+            width = self.button_width,
             show_parent = self,
             callback = function()
                 self:setWarmth(self.nl.min, true)
@@ -323,17 +309,31 @@ function FrontLightWidget:layout()
         }
         local nl_max = Button:new{
             text = C_("Extrema", "Max"),
-            margin = Size.margin.small,
-            radius = 0,
             enabled = true,
-            width = math.floor(self.screen_width * 0.2),
+            width = self.button_width,
             show_parent = self,
             callback = function()
                 self:setWarmth(self.nl.max, true)
             end,
         }
+        local nl_setup
+        local nl_spacer_width
+        -- Aura One R/G/B widget
+        if not self.has_nl_mixer and not self.has_nl_api then
+            nl_setup =  Button:new{
+                text = _("Configure"),
+                width = self.button_width,
+                show_parent = self,
+                callback = function()
+                    UIManager:show(NaturalLight:new{fl_widget = self})
+                end,
+            }
+            nl_spacer_width = math.floor((self.inner_width - 3 * self.button_width) / 2)
+        else
+            nl_spacer_width = self.inner_width - 2 * self.button_width
+        end
         local nl_spacer = HorizontalSpan:new{
-            width = math.floor((self.screen_width * 0.95 - 1.2 * (self.nl_minus.width + self.nl_plus.width)) / 2),
+            width = nl_spacer_width
         }
         local nl_buttons_above = HorizontalGroup:new{
             align = "center",
@@ -342,13 +342,19 @@ function FrontLightWidget:layout()
             self.nl_plus,
         }
         self.layout[3] = {self.nl_minus, self.nl_plus}
+        self:mergeLayoutInVertical(self.nl_progress) -- move it as self.layout[4]
         local nl_buttons_below = HorizontalGroup:new{
             align = "center",
             nl_min,
             nl_spacer,
             nl_max,
         }
-        self.layout[4] = {nl_min, nl_max}
+        self.layout[5] = {nl_min, nl_max}
+        if nl_setup then
+            table.insert(nl_buttons_below, 3, nl_setup)
+            table.insert(nl_buttons_below, 4, nl_spacer)
+            table.insert(self.layout[5], 2, nl_setup)
+        end
 
         table.insert(main_group, nl_span)
         table.insert(main_group, nl_header)
@@ -363,21 +369,6 @@ function FrontLightWidget:layout()
         table.insert(main_group, nl_group_below)
         table.insert(main_group, nl_padding_span)
 
-        -- Aura One R/G/B widget
-        if not self.has_nl_mixer and not self.has_nl_api then
-            local nl_setup =  Button:new{
-                text = _("Configure"),
-                margin = Size.margin.small,
-                radius = 0,
-                width = math.floor(self.screen_width * 0.2),
-                show_parent = self,
-                callback = function()
-                    UIManager:show(NaturalLight:new{fl_widget = self})
-                end,
-            }
-            table.insert(main_group, nl_setup)
-            self.layout[5] = {nl_setup}
-        end
     end
 
     table.insert(main_container, main_group)

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -236,7 +236,6 @@ function NumberPickerWidget:init()
         text_font_face = self.spinner_face.font,
         text_font_size = self.spinner_face.orig_size,
         width = self.width,
-        max_width = self.width,
         show_parent = self.show_parent,
         callback = callback_input,
     }

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
+local ButtonDialog = require("ui/widget/buttondialog")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Device = require("device")
 local Event = require("ui/event")
@@ -106,11 +107,11 @@ function PageBrowserWidget:init()
     self.title_bar = TitleBar:new{
         fullscreen = true,
         title = self.title,
-        left_icon = "info",
-        left_icon_tap_callback = function() self:showHelp() end,
+        left_icon = "appbar.menu",
+        left_icon_tap_callback = function() self:showMenu() end,
         left_icon_hold_callback = function()
             -- Cycle nb of toc span levels shown in bottom row
-            if self:updateNbTocSpans(-1, true) then
+            if self:updateNbTocSpans(-1, true, true) then
                 self:updateLayout()
             end
         end,
@@ -613,19 +614,152 @@ function PageBrowserWidget:showTile(grid_idx, page, tile, do_refresh)
     end
 end
 
-function PageBrowserWidget:showHelp()
+function PageBrowserWidget:showMenu()
+    local button_dialog
+    -- Width of our -/+ buttons, so it looks fine with Button's default font size of 20
+    local plus_minus_width = Screen:scaleBySize(60)
+    local buttons = {
+        {{
+            text = _("About page browser"),
+            align = "left",
+            callback = function()
+                self:showAbout()
+            end,
+        }},
+        {{
+            text = _("Available gestures"),
+            align = "left",
+            callback = function()
+                self:showGestures()
+            end,
+        }},
+        {
+            {
+                text = _("Thumbnail columns"),
+                callback = function() end,
+                align = "left",
+            },
+            {
+                text = "\u{2796}", -- Heavy minus sign
+                enabled_func = function() return self.nb_cols > self.min_nb_cols end,
+                callback = function()
+                    if self:updateNbCols(-1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                width = plus_minus_width,
+            },
+            {
+                text = "\u{2795}", -- Heavy plus sign
+                enabled_func = function() return self.nb_cols < self.max_nb_cols end,
+                callback = function()
+                    if self:updateNbCols(1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                width = plus_minus_width,
+            }
+        },
+        {
+            {
+                text = _("Thumbnail rows"),
+                callback = function() end,
+                align = "left",
+            },
+            {
+                text = "\u{2796}", -- Heavy minus sign
+                enabled_func = function() return self.nb_rows > self.min_nb_rows end,
+                callback = function()
+                    if self:updateNbRows(-1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                width = plus_minus_width,
+            },
+            {
+                text = "\u{2795}", -- Heavy plus sign
+                enabled_func = function() return self.nb_rows < self.max_nb_rows end,
+                callback = function()
+                    if self:updateNbRows(1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                width = plus_minus_width,
+            }
+        },
+        {
+            {
+                text = _("Chapters in bottom ribbon"),
+                callback = function() end,
+                align = "left",
+            },
+            {
+                text = "\u{2796}", -- Heavy minus sign
+                enabled_func = function() return self.nb_toc_spans > 0 end,
+                callback = function()
+                    if self:updateNbTocSpans(-1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                width = plus_minus_width,
+            },
+            {
+                text = "\u{2795}", -- Heavy plus sign
+                enabled_func = function() return self.nb_toc_spans < self.max_toc_depth end,
+                callback = function()
+                    if self:updateNbTocSpans(1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                width = plus_minus_width,
+            }
+        },
+    }
+    button_dialog = ButtonDialog:new{
+        -- width = math.floor(Screen:getWidth() / 2),
+        width = math.floor(Screen:getWidth() * 0.9), -- max width, will get smaller
+        shrink_unneeded_width = true,
+        buttons = buttons,
+        anchor = function()
+            return self.title_bar.left_button.image.dimen
+        end,
+    }
+    UIManager:show(button_dialog)
+end
+
+function PageBrowserWidget:showAbout()
     UIManager:show(InfoMessage:new{
         text = _([[
 Page browser shows thumbnails of pages.
 
-The bottom ribbon displays an extract of the book map around the shown pages: see the book map help for details.
+The bottom ribbon displays an extract of the book map around the pages displayed:
 
+If statistics are enabled, black bars are shown for already read pages (gray for pages read in the current reading session). Their heights vary depending on the time spent reading the page.
+Chapters are shown above the pages they encompass.
+Under the pages, these indicators may be shown:
+▲ current page
+❶ ❷ … previous locations
+▒ highlighted text
+ highlighted text with notes
+ bookmarked page]]),
+    })
+end
+
+function PageBrowserWidget:showGestures()
+    UIManager:show(InfoMessage:new{
+        text = _([[
 Swipe along the top or left screen edge to change the number of columns or rows of thumbnails.
-Swipe vertically to move one row, horizontally to move one page.
+
+Swipe vertically to move one row, horizontally to move one screen.
+
 Swipe horizontally in the bottom ribbon to move by the full stripe.
+
 Tap in the bottom ribbon on a page to focus thumbnails on this page.
+
 Tap on a thumbnail to read this page.
-Long-press on ⓘ to decrease or reset the number of chapter levels shown in the bottom ribbon.
+
+Long-press on ≡ to decrease or reset the number of chapter levels shown in the bottom ribbon.
+
 Any multiswipe will close the page browser.]]),
     })
 end
@@ -681,19 +815,26 @@ function PageBrowserWidget:saveSettings(reset)
     G_reader_settings:saveSetting("page_browser_nb_cols", self.nb_cols)
 end
 
-function PageBrowserWidget:updateNbTocSpans(value, relative)
+function PageBrowserWidget:updateNbTocSpans(value, relative, rollover)
     local new_nb_toc_spans
     if relative then
         new_nb_toc_spans = self.nb_toc_spans + value
     else
         new_nb_toc_spans = value
     end
-    -- We don't cap, we cycle
     if new_nb_toc_spans < 0 then
-        new_nb_toc_spans = self.max_toc_depth
+        if rollover then
+            new_nb_toc_spans = self.max_toc_depth
+        else
+            new_nb_toc_spans = 0
+        end
     end
     if new_nb_toc_spans > self.max_toc_depth then
-        new_nb_toc_spans = 0
+        if rollover then
+            new_nb_toc_spans = 0
+        else
+            new_nb_toc_spans = self.max_toc_depth
+        end
     end
     if new_nb_toc_spans == self.nb_toc_spans then
         return false

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -55,7 +55,6 @@ function SkimToWidget:init()
     local larger_span_units = 3 -- 3 x small span width
     local nb_span_units = 2 + 2*larger_span_units
     local button_width = math.floor( (inner_width - nb_span_units * button_span_unit_width) * (1/5))
-    local button_inner_width = button_width - 2 * (Size.border.button + Size.padding.button)
     -- Update inner_width (possibly smaller because of math.floor())
     inner_width = button_width * 5 + nb_span_units * button_span_unit_width
 
@@ -79,7 +78,7 @@ function SkimToWidget:init()
         text = "-1",
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -90,7 +89,7 @@ function SkimToWidget:init()
         text = "-10",
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -101,7 +100,7 @@ function SkimToWidget:init()
         text = "+1",
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -112,7 +111,7 @@ function SkimToWidget:init()
         text = "+10",
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -131,7 +130,7 @@ function SkimToWidget:init()
         padding = 0,
         bordersize = 0,
         enabled = true,
-        width = button_width, -- no border/padding: use outer button width
+        width = button_width,
         show_parent = self,
         callback = function()
             self.callback_switch_to_goto()
@@ -153,7 +152,7 @@ function SkimToWidget:init()
         text = chapter_next_text,
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -170,7 +169,7 @@ function SkimToWidget:init()
         text = chapter_prev_text,
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -187,7 +186,7 @@ function SkimToWidget:init()
         text = bookmark_next_text,
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -202,7 +201,7 @@ function SkimToWidget:init()
         text = bookmark_prev_text,
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         vsync = true,
         callback = function()
@@ -219,7 +218,7 @@ function SkimToWidget:init()
         end,
         radius = 0,
         enabled = true,
-        width = button_inner_width,
+        width = button_width,
         show_parent = self,
         callback = function()
             self.ui:handleEvent(Event:new("ToggleBookmark"))

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -532,7 +532,6 @@ function WordInfoDialog:init()
     self.book_title_button = Button:new{
         text = self.book_title .. book_title_triangle,
         width = width,
-        max_width = width,
         text_font_face = "NotoSans-Italic.ttf",
         text_font_size = 14,
         text_font_bold = false,
@@ -755,7 +754,6 @@ function VocabItemWidget:initItemWidget()
         self.forgot_button = Button:new{
             text = _("Forgot"),
             width = self.review_button_width,
-            max_width = self.review_button_width,
             radius = Size.radius.button,
             callback = function()
                 self:onForgot()
@@ -770,7 +768,6 @@ function VocabItemWidget:initItemWidget()
                 self:onGotIt()
             end,
             width = self.review_button_width,
-            max_width = self.review_button_width,
             show_parent = self,
         }
         right_widget = HorizontalGroup:new{
@@ -1359,7 +1356,7 @@ function VocabularyBuilderWidget:refreshFooter()
     local sync_size = TextWidget:getFontSizeToFitHeight("cfont", footer_height, Size.padding.buttontable*2)
     self.footer_sync = Button:new{
         text = "⇅",
-        width = self.footer_left_corner_width - Size.padding.large * 2,
+        width = self.footer_left_corner_width,
         text_font_size = sync_size,
         text_font_bold = false,
         bordersize = 0,


### PR DESCRIPTION
Easier to review commit by commit.
Fixes some issues noticed at https://github.com/koreader/koreader/pull/9526#issuecomment-1464903837.
Implement ideas discussed at https://github.com/koreader/koreader/issues/10056#issuecomment-1458833625

#### Button: handle 'width' as the final outer width

All our widgets are considering their provided 'width' as the outer width, except Button which considered it as some 'inner width', to which padding/border/margin were added. Let's have them all consistent.
Some other widgets using Button had tweaks to account for that odd behaviour: fix and simplify them.
Also fix Button layout when text is left aligned.

#### FrontLightWidget: cleanup buttons layout

Properly compute Button and separator widths, instead of using magic numbers (which lost their magic over the years :)
Ensure buttons and progress widgets are properly aligned on the sides.
Move the optional Warmth "Configure" button in the middle of Warmth Min and Max.
Fix keyboard navigation layout, which was not working on devices with Warmth.

Button and layout should look now better aligned (no idea why it goes with 2 different progress widget, but I don't care).
![image](https://user-images.githubusercontent.com/24273478/226438646-b192dc55-a24e-45d3-bec5-c4bfc3f35933.png)

#### Button: fix enableDisable when multilines

Also add support for a enabled_func() property, and ensure its enable/disable state on each repaint.

#### ButtonTable: allow buttons to request a fixed width

It is expected some button(s) in a row do not specify such a width, so they get distributed the remaining space from the ButtonTable specified width.
This is to allow building these -/+ buttons:
![image](https://user-images.githubusercontent.com/24273478/226441056-a8e43b21-4595-4b2f-9e47-57c50adcd4d5.png)

#### ButtonDialog/ButtonDialogTitle: consistent 'width' handling

Make these 2 widget behave similarly, and don't rely on ButtonTable default width for their own default width.
ButtonDialogTitle: also properly size its title.

#### ButtonTable: allow shrinking uneeded width

If buttons and their text would fit in a smaller width, reduce the whole ButtonTable width.
May be used for properly sized context menus with ButtonDialog, with the width required depending on the translations for a language.

#### MovableContainer: add support for anchoring initial position

When passing as 'anchor' a Geom object (ie. a widget dimen or a ges.pos), or a function returning such an object, a MovableContainer will be initially positionned near this point/widget, instead of being centered on the screen.
Allow that for ButtonDialog and ButtonDialogTitle, so we can make them behave as context menus (ie. for a titlebar top left/right icons).

#### Book map, Page browser: add top left menu

Split original very long help text (which was very slow to display) into 2 parts: About... and Available gestures.
Also add -/+ buttons to change things (which can already and more practically be done with swipes along the edges) to give a bit of meat to these menus.
I also modified a bit the wording (ie. my pompous "Under xxx can be found yyy...").

![image](https://user-images.githubusercontent.com/24273478/226439510-8debb5f1-88a6-41de-831b-fe738ffa3fef.png)

![image](https://user-images.githubusercontent.com/24273478/226439590-44fdbbd6-9262-4faf-9f90-44cdf37ddbbc.png)

![image](https://user-images.githubusercontent.com/24273478/226439640-076536cc-4b32-4690-8df5-6229c426543f.png)
(in there, I went with adding a blank line between each sentence, makes it easier to read to me, is that ok?).

![image](https://user-images.githubusercontent.com/24273478/226439908-04c65d58-8174-4998-af66-8595a6fb9546.png)

![image](https://user-images.githubusercontent.com/24273478/226439970-26db3531-8b67-43fc-8880-ffaffcc1e4a3.png)

![image](https://user-images.githubusercontent.com/24273478/226440027-826568a8-094e-464a-a15b-76b4ac0b3ad7.png)

#### Book style tweak: add button with CSS suggestions

Mostly non-standard CSS declarations (so, possibly unknown to users) that can be useful for solving certain issues.
Long-press on them show a little help_text.

![image](https://user-images.githubusercontent.com/24273478/226440313-bddb40fc-8f9a-4eff-a652-d487f407795e.png)

I think one or two of these should go, because it gets a bit too tall and get shifted and in the way.
I added the text-indent, font-size and margins one early to have something a bit consistent, and later added more -cr-hint. Which of these brings less knowledge and can go ?

#### bump crengine: fix parsing of multibytes encodings

Includes https://github.com/koreader/crengine/pull/515 : 
- LVTextFileBase: fix parsing of multibytes encodings
Closes #10218. Closes #561.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10230)
<!-- Reviewable:end -->
