### PR TITLE
History: fix book info buttons disable

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -140,6 +140,42 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
     }
 end
 
+function filemanagerutil.genBookInformationButton(file, dialog, button_disabled)
+    return {
+        text = _("Book information"),
+        id = "book_information", -- used by covermenu
+        enabled = not button_disabled,
+        callback = function()
+            UIManager:close(dialog)
+            require("apps/filemanager/filemanagerbookinfo"):show(file)
+        end,
+    }
+end
+
+function filemanagerutil.genBookDescriptionButton(file, dialog, button_disabled)
+    return {
+        text = _("Book description"),
+        id = "book_description", -- used by covermenu
+        enabled = not button_disabled,
+        callback = function()
+            UIManager:close(dialog)
+            require("apps/filemanager/filemanagerbookinfo"):onShowBookDescription(nil, file)
+        end,
+    }
+end
+
+function filemanagerutil.genBookCoverButton(file, dialog, button_disabled)
+    return {
+        text = _("Book cover"),
+        id = "book_cover", -- used by covermenu
+        enabled = not button_disabled,
+        callback = function()
+            UIManager:close(dialog)
+            require("apps/filemanager/filemanagerbookinfo"):onShowBookCover(file)
+        end,
+    }
+end
+
 -- Generate "Execute script" file dialog button
 function filemanagerutil.genExecuteScriptButton(file, caller_callback)
     return {

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -18,14 +18,14 @@ local ReadHistory = {
 
 local function buildEntry(input_time, input_file)
     local file_path = realpath(input_file) or input_file -- keep orig file path of deleted files
-    local is_file_deleted = lfs.attributes(file_path, "mode") ~= "file"
+    local file_exists = lfs.attributes(file_path, "mode") == "file"
     return {
         time = input_time,
         file = file_path,
         text = input_file:gsub(".*/", ""),
-        dim = is_file_deleted,
+        dim = not file_exists,
         mandatory = datetime.secondsToDateTime(input_time),
-        select_enabled = not is_file_deleted,
+        select_enabled = file_exists,
     }
 end
 

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -16,11 +16,6 @@ local ReadHistory = {
     last_read_time = 0,
 }
 
-local function selectCallback(path)
-    local ReaderUI = require("apps/reader/readerui")
-    ReaderUI:showReader(path)
-end
-
 local function buildEntry(input_time, input_file)
     local file_path = realpath(input_file) or input_file -- keep orig file path of deleted files
     local is_file_deleted = lfs.attributes(file_path, "mode") ~= "file"
@@ -31,9 +26,6 @@ local function buildEntry(input_time, input_file)
         dim = is_file_deleted,
         mandatory = datetime.secondsToDateTime(input_time),
         select_enabled = not is_file_deleted,
-        callback = function()
-            selectCallback(input_file)
-        end,
     }
 end
 
@@ -196,9 +188,6 @@ function ReadHistory:updateItemByPath(old_path, new_path)
     if index then
         self.hist[index].file = new_path
         self.hist[index].text = new_path:gsub(".*/", "")
-        self.hist[index].callback = function()
-            selectCallback(new_path)
-        end
         self:_flush()
         self:reload(true)
     end


### PR DESCRIPTION
Forgot to disable Book cover and Book description buttons for deleted files:

<img width="250" alt="01" src="https://user-images.githubusercontent.com/62179190/227704949-c586026b-9248-45f0-93ce-7954f2e0535d.png">

Minor optimization:
-readhistory: do not store the same callback in each item
-filemanagerutil: the same book info buttons will be used in other modules

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10244)
<!-- Reviewable:end -->
