### PR TITLE
Center pdf manual zoom mode

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -725,12 +725,16 @@ function ReaderPaging:getNextPageState(blank_area, offset)
     visible_area = visible_area:shrinkInside(page_area, offset.x, offset.y)
     -- shrink blank area by the height of visible area
     blank_area.h = blank_area.h - visible_area.h
+    local page_offset = Geom:new{x = self.view.state.offset.x, y = 0}
+    if blank_area.w > page_area.w then
+        page_offset:offsetBy((blank_area.w - page_area.w) / 2, 0)
+    end
     return {
         page = self.view.state.page,
         zoom = self.view.state.zoom,
         rotation = self.view.state.rotation,
         gamma = self.view.state.gamma,
-        offset = Geom:new{ x = self.view.state.offset.x, y = 0},
+        offset = page_offset,
         visible_area = visible_area,
         page_area = page_area,
     }
@@ -748,12 +752,16 @@ function ReaderPaging:getPrevPageState(blank_area, offset)
     visible_area = visible_area:shrinkInside(page_area, offset.x, offset.y)
     -- shrink blank area by the height of visible area
     blank_area.h = blank_area.h - visible_area.h
+    local page_offset = Geom:new{x = self.view.state.offset.x, y = 0}
+    if blank_area.w > page_area.w then
+        page_offset:offsetBy((blank_area.w - page_area.w) / 2, 0)
+    end
     return {
         page = self.view.state.page,
         zoom = self.view.state.zoom,
         rotation = self.view.state.rotation,
         gamma = self.view.state.gamma,
-        offset = Geom:new{ x = self.view.state.offset.x, y = 0},
+        offset = page_offset,
         visible_area = visible_area,
         page_area = page_area,
     }

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -714,7 +714,7 @@ function ReaderPaging:onUpdateScrollPageGamma(gamma)
     return true
 end
 
-function ReaderPaging:getNextPageState(blank_area, offset)
+function ReaderPaging:getNextPageState(blank_area, image_offset)
     local page_area = self.view:getPageArea(
         self.view.state.page,
         self.view.state.zoom,
@@ -722,7 +722,7 @@ function ReaderPaging:getNextPageState(blank_area, offset)
     local visible_area = Geom:new{x = 0, y = 0}
     visible_area.w, visible_area.h = blank_area.w, blank_area.h
     visible_area.x, visible_area.y = page_area.x, page_area.y
-    visible_area = visible_area:shrinkInside(page_area, offset.x, offset.y)
+    visible_area = visible_area:shrinkInside(page_area, image_offset.x, image_offset.y)
     -- shrink blank area by the height of visible area
     blank_area.h = blank_area.h - visible_area.h
     local page_offset = Geom:new{x = self.view.state.offset.x, y = 0}
@@ -740,7 +740,7 @@ function ReaderPaging:getNextPageState(blank_area, offset)
     }
 end
 
-function ReaderPaging:getPrevPageState(blank_area, offset)
+function ReaderPaging:getPrevPageState(blank_area, image_offset)
     local page_area = self.view:getPageArea(
         self.view.state.page,
         self.view.state.zoom,
@@ -749,7 +749,7 @@ function ReaderPaging:getPrevPageState(blank_area, offset)
     visible_area.w, visible_area.h = blank_area.w, blank_area.h
     visible_area.x = page_area.x
     visible_area.y = page_area.y + page_area.h - visible_area.h
-    visible_area = visible_area:shrinkInside(page_area, offset.x, offset.y)
+    visible_area = visible_area:shrinkInside(page_area, image_offset.x, image_offset.y)
     -- shrink blank area by the height of visible area
     blank_area.h = blank_area.h - visible_area.h
     local page_offset = Geom:new{x = self.view.state.offset.x, y = 0}


### PR DESCRIPTION
Should fix #9967 
I noticed it was done in a similar way here for paged mode: https://github.com/koreader/koreader/blob/aedb713f82c268abc4edd933f5e0e1408ddc00cf/frontend/apps/reader/modules/readerview.lua#L708-L710

Two things I've noticed, and don't know whether it's intentional, so I didn't touch it:
- when in cont scroll mode, switching to manual zoom resets it back to paged mode
- y page offset is always set to 0. If I'm in cont scroll mode, and 2 pages are displayed on the screen, the second page should have a non 0 y offset I would think