### PR TITLE
Statistics.koplugin: Calendar day with custom start time

### DIFF
--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -222,12 +222,13 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
     if self.extra_text then
         table.insert(buttons, {
             {
+                id = "extra_text_button",
                 text = self.extra_text,
                 callback = function()
                     if self.extra_callback then
                         self.extra_callback(left_widget:getValue(), right_widget:getValue())
                     end
-                    if not self.keep_shown_on_apply then -- assume extra wants it same as ok
+                    if not self.keep_shown_on_apply and not self.keep_shown_on_extra then
                         self:onClose()
                     end
                 end,
@@ -270,6 +271,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         show_parent = self,
     }
     self:mergeLayoutInVertical(button_table)
+    self.button_table = button_table
 
     self.widget_frame = FrameContainer:new{
         radius = Size.radius.window,

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -222,13 +222,12 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
     if self.extra_text then
         table.insert(buttons, {
             {
-                id = "extra_text_button",
                 text = self.extra_text,
                 callback = function()
                     if self.extra_callback then
                         self.extra_callback(left_widget:getValue(), right_widget:getValue())
                     end
-                    if not self.keep_shown_on_apply and not self.keep_shown_on_extra then
+                    if not self.keep_shown_on_apply then -- assume extra wants it same as ok
                         self:onClose()
                     end
                 end,
@@ -271,7 +270,6 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         show_parent = self,
     }
     self:mergeLayoutInVertical(button_table)
-    self.button_table = button_table
 
     self.widget_frame = FrameContainer:new{
         radius = Size.radius.window,

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -766,18 +766,14 @@ end
 
 function CalendarDayView:onNextPage()
     if not self:nextPage() and self.day_ts + 82800 < os.time() then
-        local next_day_ts = self.day_ts + 86400 + 10800 -- make sure it's the next day
+        local current_day_ts = self.day_ts - (self.reader_statistics.settings.calendar_day_start_hour or 0) * 3600
+                                           - (self.reader_statistics.settings.calendar_day_start_minute or 0) * 60
+        local next_day_ts = current_day_ts + 86400 + 10800 -- make sure it's the next day
         local next_day_date = os.date("*t", next_day_ts)
         next_day_ts = os.time({
             year = next_day_date.year,
             month = next_day_date.month,
             day = next_day_date.day,
-        })
-        local current_day_date = os.date("*t", self.day_ts)
-        local current_day_ts = os.time({
-            year = current_day_date.year,
-            month = current_day_date.month,
-            day = current_day_date.day,
         })
         local current_day_length = next_day_ts - current_day_ts
         if self.day_ts + current_day_length < os.time() then
@@ -791,18 +787,14 @@ end
 
 function CalendarDayView:onPrevPage()
     if not self:prevPage() and self.day_ts - 82800 >= self.min_ts then
-        local previous_day_ts = self.day_ts - 86400 + 10800 -- make sure it's the previous day
+        local current_day_ts = self.day_ts - (self.reader_statistics.settings.calendar_day_start_hour or 0) * 3600
+                                           - (self.reader_statistics.settings.calendar_day_start_minute or 0) * 60
+        local previous_day_ts = current_day_ts - 86400 + 10800 -- make sure it's the previous day
         local previous_day_date = os.date("*t", previous_day_ts)
         previous_day_ts = os.time({
             year = previous_day_date.year,
             month = previous_day_date.month,
             day = previous_day_date.day,
-        })
-        local current_day_date = os.date("*t", self.day_ts)
-        local current_day_ts = os.time({
-            year = current_day_date.year,
-            month = current_day_date.month,
-            day = current_day_date.day,
         })
         local previous_day_length = current_day_ts - previous_day_ts
         if self.day_ts - previous_day_length >= self.min_ts then

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -774,6 +774,8 @@ function CalendarDayView:onNextPage()
             year = next_day_date.year,
             month = next_day_date.month,
             day = next_day_date.day,
+            hour = 0,
+            min = 0,
         })
         local current_day_length = next_day_ts - current_day_ts
         if self.day_ts + current_day_length < os.time() then
@@ -795,6 +797,8 @@ function CalendarDayView:onPrevPage()
             year = previous_day_date.year,
             month = previous_day_date.month,
             day = previous_day_date.day,
+            hour = 0,
+            min = 0,
         })
         local previous_day_length = current_day_ts - previous_day_ts
         if self.day_ts - previous_day_length >= self.min_ts then

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -765,19 +765,51 @@ function CalendarDayView:goToPage(page)
 end
 
 function CalendarDayView:onNextPage()
-    if not self:nextPage() and self.day_ts + 86400 < os.time() then
-        -- go to next day
-        self.day_ts = self.day_ts + 86400
-        self:setupView()
+    if not self:nextPage() and self.day_ts + 82800 < os.time() then
+        local next_day_ts = self.day_ts + 86400 + 10800 -- make sure it's the next day
+        local next_day_date = os.date("*t", next_day_ts)
+        next_day_ts = os.time({
+            year = next_day_date.year,
+            month = next_day_date.month,
+            day = next_day_date.day,
+        })
+        local current_day_date = os.date("*t", self.day_ts)
+        local current_day_ts = os.time({
+            year = current_day_date.year,
+            month = current_day_date.month,
+            day = current_day_date.day,
+        })
+        local current_day_length = next_day_ts - current_day_ts
+        if self.day_ts + current_day_length < os.time() then
+            -- go to next day
+            self.day_ts = self.day_ts + current_day_length
+            self:setupView()
+        end
     end
     return true
 end
 
 function CalendarDayView:onPrevPage()
-    if not self:prevPage() and self.day_ts - 86400 >= self.min_ts then
-        -- go to previous day
-        self.day_ts = self.day_ts - 86400
-        self:setupView()
+    if not self:prevPage() and self.day_ts - 82800 >= self.min_ts then
+        local previous_day_ts = self.day_ts - 86400 + 10800 -- make sure it's the previous day
+        local previous_day_date = os.date("*t", previous_day_ts)
+        previous_day_ts = os.time({
+            year = previous_day_date.year,
+            month = previous_day_date.month,
+            day = previous_day_date.day,
+        })
+        local current_day_date = os.date("*t", self.day_ts)
+        local current_day_ts = os.time({
+            year = current_day_date.year,
+            month = current_day_date.month,
+            day = current_day_date.day,
+        })
+        local previous_day_length = current_day_ts - previous_day_ts
+        if self.day_ts - previous_day_length >= self.min_ts then
+            -- go to previous day
+            self.day_ts = self.day_ts - previous_day_length
+            self:setupView()
+        end
     end
     return true
 end

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -699,7 +699,7 @@ function CalendarDayView:setupView()
         end
         kv.checked = true
     end
-    table.sort(self.kv_pairs, function(a,b) return a[2] > b[2] end) --sort by value
+    table.sort(self.kv_pairs, function(a,b) return a.duration > b.duration end) --sort by value
     self.title = self:title_callback()
 
     self.show_page = 1

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2793,7 +2793,7 @@ function ReaderStatistics:getReadBookByDay(month)
                                   AND strftime('%s', ?, 'utc', '+33 days', 'start of month', '-1 second')
         )
         GROUP  BY
-            strftime('%Y-%m-%d', start_time , 'unixepoch', 'localtime'),
+            strftime('%Y-%m-%d', start_time, 'unixepoch', 'localtime'),
             id_book,
             title
         ORDER BY day, durations desc, book_id, book_title;

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2780,7 +2780,7 @@ function ReaderStatistics:getReadBookByDay(month)
         FROM   page_stat
         JOIN   book ON book.id = page_stat.id_book
         WHERE  start_time BETWEEN strftime('%s', ?, 'utc') + ?
-                              AND strftime('%s', ?, 'utc', '+33 days', 'start of month') + ?
+                              AND strftime('%s', ?, 'utc', '+33 days', 'start of month', '-1 second') + ?
         GROUP  BY
             strftime('%Y-%m-%d', start_time - ?, 'unixepoch', 'localtime'),
             id_book,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1035,6 +1035,44 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                     },
                     {
                         text_func = function()
+                            -- @translators %1 is the hour and %2 is the minute, units for h and m will be automatically added
+                            return T(_("Calendar days start at %1 %2"),
+                                T(C_("Time", "%1h"), self.settings.calendar_day_start_hour or 0),
+                                T(C_("Time", "%1m"), self.settings.calendar_day_start_minute or 0)
+                            )
+                        end,
+                        callback = function(touchmenu_instance)
+                            local DoubleSpinWidget = require("/ui/widget/doublespinwidget")
+                            local start_of_day_widget = DoubleSpinWidget:new{
+                                left_text = C_("Time", "h"),
+                                left_value = self.settings.calendar_day_start_hour or 0,
+                                left_default = 0,
+                                left_min = 0,
+                                left_max = 6,
+                                left_step = 1,
+                                left_hold_step = 3,
+                                right_text = C_("Time", "m"),
+                                right_value = self.settings.calendar_day_start_minute or 0,
+                                right_default = 0,
+                                right_min = 0,
+                                right_max = 59,
+                                right_step = 1,
+                                right_hold_step = 10,
+                                is_range = false,
+                                title_text = _("Starting time of a day"),
+                                info_text = _("Set starting time of a day to be used in statistics, so that readings past 00:00 would be counted to the previous day."),
+                                callback = function(hour, minute)
+                                    self.settings.calendar_day_start_hour = hour
+                                    self.settings.calendar_day_start_minute = minute
+                                    touchmenu_instance:updateItems()
+                                end,
+                            }
+                            UIManager:show(start_of_day_widget)
+                        end,
+                        keep_menu_open = true,
+                    },
+                    {
+                        text_func = function()
                             return T(_("Books per calendar day: %1"), self.settings.calendar_nb_book_spans)
                         end,
                         callback = function(touchmenu_instance)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1089,11 +1089,11 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                                 min = self.settings.calendar_day_start_minute or 0,
                                 hour_max = 6,
                                 ok_text = _("Set time"),
-                                title_text = _("Set starting time of a day"),
+                                title_text = _("Daily timeline starts at"),
                                 info_text =_([[
-Set the time when the day timeline should start.
+Set the time when the daily timeline should start.
 
-If you read past midnight, and wish this reading to appear with the previous evening's reading, you can set this to 04:00 for example.
+If you read past midnight, and would like this reading session to be displayed on the same screen with your previous evening reading sessions, use a value such as 04:00.
 
 Time is in hours and minutes.]]),
                                 callback = function(time)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1077,7 +1077,7 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                     {
                         text_func = function()
                             -- @translators %1 is the time in the format 00:00
-                            return T(_("Calendar days start at %1 "),
+                            return T(_("Daily timeline starts at %1"),
                                 string.format("%02d:%02d", self.settings.calendar_day_start_hour or 0,
                                                            self.settings.calendar_day_start_minute or 0)
                             )
@@ -1097,15 +1097,9 @@ If you read past midnight, and wish this reading to appear with the previous eve
 
 Time is in hours and minutes.]]),
                                 callback = function(time)
-                                    if time.hour and time.min then
-                                        self.settings.calendar_day_start_hour = time.hour
-                                        self.settings.calendar_day_start_minute = time.min
-                                        touchmenu_instance:updateItems()
-                                    else
-                                        UIManager:show(InfoMessage:new{
-                                            text = _("Time couldn't be set"),
-                                        })
-                                    end
+                                    self.settings.calendar_day_start_hour = time.hour
+                                    self.settings.calendar_day_start_minute = time.min
+                                    touchmenu_instance:updateItems()
                                 end
                             }
                             UIManager:show(start_of_day_widget)


### PR DESCRIPTION
Closes #10250.

Made two commits, one is on the calendar day view and the other the calendar weeks view. The latter is quite ugly because in the sql commands, the offset is inserted in multiple places.

I tried another way with the sqls though, something like:`select *** from (select start_time - offset as start_time, *** from page_stat) as page_stat ***` so the `start_time` is first modified then compared but somehow it doesn't work.

Still, I find it too confusing to just leave it if the two views are out of sync. Maybe there's a better way to do the sqls?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10254)
<!-- Reviewable:end -->
