### PR TITLE
BookInfo: add page information

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -101,17 +101,19 @@ function BookInfo:show(file, book_props)
         end
         table.insert(kv_pairs, { prop_text, prop })
     end
-    local lines_nb, words_nb
-    if self.document then
-        lines_nb, words_nb = self:getCurrentPageLinesWordsNumber()
-    end
+    local is_doc = self.document and true or false
     local viewCoverImage = function()
         self:onShowBookCover(file)
     end
-    table.insert(kv_pairs, { _("Cover image:"), _("Tap to display"), callback=viewCoverImage, separator=lines_nb })
+    table.insert(kv_pairs, { _("Cover image:"), _("Tap to display"), callback=viewCoverImage, separator=is_doc })
 
     -- Page section
-    if lines_nb then
+    if is_doc then
+        local lines_nb, words_nb = self:getCurrentPageLinesWordsNumber()
+        if not lines_nb or lines_nb == 0 then
+            lines_nb = _("N/A")
+            words_nb = _("N/A")
+        end
         table.insert(kv_pairs, { _("Current page lines:"), lines_nb })
         table.insert(kv_pairs, { _("Current page words:"), words_nb })
     end

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -108,7 +108,7 @@ function BookInfo:show(file, book_props)
 
     -- Page section
     if is_doc then
-        local lines_nb, words_nb = self:getCurrentPageLinesWordsNumber()
+        local lines_nb, words_nb = self:getCurrentPageLineWordCounts()
         if not lines_nb or lines_nb == 0 then
             lines_nb = _("N/A")
             words_nb = _("N/A")
@@ -255,7 +255,7 @@ function BookInfo:onShowBookCover(file)
     end
 end
 
-function BookInfo:getCurrentPageLinesWordsNumber()
+function BookInfo:getCurrentPageLineWordCounts()
     if self.ui.rolling then
         local Screen = require("device").screen
         local res = self.ui.document._document:getTextFromPositions(0, 0, Screen:getWidth(), Screen:getHeight(),

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -3,11 +3,8 @@ This module provides a way to display book information (filename and book metada
 ]]
 
 local BD = require("ui/bidi")
-local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
-local ImageViewer = require("ui/widget/imageviewer")
 local InfoMessage = require("ui/widget/infomessage")
-local KeyValuePage = require("ui/widget/keyvaluepage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
@@ -16,7 +13,6 @@ local util = require("util")
 local _ = require("gettext")
 
 local BookInfo = WidgetContainer:extend{
-    bookinfo_menu_title = _("Book information"),
 }
 
 function BookInfo:init()
@@ -27,7 +23,7 @@ end
 
 function BookInfo:addToMainMenu(menu_items)
     menu_items.book_info = {
-        text = self.bookinfo_menu_title,
+        text = _("Book information"),
         callback = function()
             self:onShowBookInfo()
         end,
@@ -37,118 +33,88 @@ end
 function BookInfo:show(file, book_props)
     local kv_pairs = {}
 
+    -- File section
     local directory, filename = util.splitFilePathName(file)
-    local filename_without_suffix, filetype = util.splitFileNameSuffix(filename) -- luacheck: no unused
-    if filetype:lower() == "zip" then
-        local filename_without_sub_suffix, sub_filetype = util.splitFileNameSuffix(filename_without_suffix) -- luacheck: no unused
-        sub_filetype = sub_filetype:lower()
-        local supported_sub_filetypes = { "fb2", "htm", "html", "log", "md", "txt" }
-
-        for __, t in ipairs(supported_sub_filetypes) do
-            if sub_filetype == t then
-                filetype = sub_filetype .. "." .. filetype
-                break
-            end
-        end
-    end
-    local file_size = lfs.attributes(file, "size") or 0
-    local file_modification = lfs.attributes(file, "modification") or 0
+    local __, filetype = filemanagerutil.splitFileNameType(filename)
+    local attr = lfs.attributes(file)
+    local file_size = attr.size or 0
     local size_f = util.getFriendlySize(file_size)
     local size_b = util.getFormattedSize(file_size)
-    local size = string.format("%s (%s bytes)", size_f, size_b)
     table.insert(kv_pairs, { _("Filename:"), BD.filename(filename) })
     table.insert(kv_pairs, { _("Format:"), filetype:upper() })
-    table.insert(kv_pairs, { _("Size:"), size })
-    table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", file_modification) })
+    table.insert(kv_pairs, { _("Size:"), string.format("%s (%s bytes)", size_f, size_b) })
+    table.insert(kv_pairs, { _("Last read date:"), os.date("%Y-%m-%d %H:%M:%S", attr.access) })
+    table.insert(kv_pairs, { _("Date modified:"), os.date("%Y-%m-%d %H:%M:%S", attr.modification) })
     table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(directory)), separator = true })
 
+    -- Book section
     -- book_props may be provided if caller already has them available
     -- but it may lack "pages", that we may get from sidecar file
     if not book_props or not book_props.pages then
         book_props = self:getBookProps(file, book_props)
     end
-
-    local title = book_props.title
-    if title == "" or title == nil then title = _("N/A") end
-    table.insert(kv_pairs, { _("Title:"), BD.auto(title) })
-
-    local authors = book_props.authors
-    if authors == "" or authors == nil then
-        authors = _("N/A")
-    elseif authors:find("\n") then -- BD auto isolate each author
-        authors = util.splitToArray(authors, "\n")
-        for i=1, #authors do
-            authors[i] = BD.auto(authors[i])
+    local values_lang
+    local props = {
+        { _("Title:"), "title" },
+        { _("Authors:"), "authors" },
+        { _("Series:"), "series" },
+        { _("Pages:"), "pages" },
+        { _("Language:"), "language" },
+        { _("Keywords:"), "keywords" },
+        { _("Description:"), "description" },
+    }
+    for _, v in ipairs(props) do
+        local prop_text, prop_key = unpack(v)
+        local prop = book_props[prop_key]
+        if prop and prop ~= "" then
+            if prop_key == "title" then
+                prop = BD.auto(prop)
+            elseif prop_key == "authors" or prop_key == "keywords" then
+                if prop:find("\n") then -- BD auto isolate each entry
+                    prop = util.splitToArray(prop, "\n")
+                    for i = 1, #prop do
+                        prop[i] = BD.auto(prop[i])
+                    end
+                    prop = table.concat(prop, "\n")
+                else
+                    prop = BD.auto(prop)
+                end
+            elseif prop_key == "series" then
+                -- If we were fed a BookInfo book_props (e.g., covermenu), series index is in a separate field
+                if book_props.series_index then
+                    -- Here, we're assured that series_index is a Lua number, so round integers are automatically
+                    -- displayed without decimals
+                    prop = prop .. " #" .. book_props.series_index
+                else
+                    -- But here, if we have a plain doc_props series with an index, drop empty decimals from round integers.
+                    prop = prop:gsub("(#%d+)%.0+$", "%1")
+                end
+            elseif prop_key == "language" then
+                -- Get a chance to have title, authors... rendered with alternate
+                -- glyphs for the book language (e.g. japanese book in chinese UI)
+                values_lang = prop
+            elseif prop_key == "description" then
+                -- Description may (often in EPUB, but not always) or may not (rarely in PDF) be HTML
+                prop = util.htmlToPlainTextIfHtml(prop)
+            end
+            table.insert(kv_pairs, { prop_text, prop })
         end
-        authors = table.concat(authors, "\n")
-    else
-        authors = BD.auto(authors)
     end
-    table.insert(kv_pairs, { _("Authors:"), authors })
-
-    local series = book_props.series
-    if series == "" or series == nil then
-        series = _("N/A")
-    else
-        -- If we were fed a BookInfo book_props (e.g., covermenu), series index is in a separate field
-        if book_props.series_index then
-            -- Here, we're assured that series_index is a Lua number, so round integers are automatically displayed without decimals
-            series = book_props.series .. " #" .. book_props.series_index
-        else
-            -- But here, if we have a plain doc_props series with an index, drop empty decimals from round integers.
-            series = book_props.series:gsub("(#%d+)%.0+$", "%1")
-        end
-    end
-    table.insert(kv_pairs, { _("Series:"), BD.auto(series) })
-
-    local pages = book_props.pages
-    if pages == "" or pages == nil then pages = _("N/A") end
-    table.insert(kv_pairs, { _("Pages:"), pages })
-
-    local language = book_props.language
-    if language == "" or language == nil then language = _("N/A") end
-    table.insert(kv_pairs, { _("Language:"), language })
-
-    local keywords = book_props.keywords
-    if keywords == "" or keywords == nil then
-        keywords = _("N/A")
-    elseif keywords:find("\n") then -- BD auto isolate each keywords
-        keywords = util.splitToArray(keywords, "\n")
-        for i=1, #keywords do
-            keywords[i] = BD.auto(keywords[i])
-        end
-        keywords = table.concat(keywords, "\n")
-    else
-        keywords = BD.auto(keywords)
-    end
-    table.insert(kv_pairs, { _("Keywords:"), keywords })
-
-    local description = book_props.description
-    if description == "" or description == nil then
-        description = _("N/A")
-    else
-        -- Description may (often in EPUB, but not always) or may not (rarely
-        -- in PDF) be HTML.
-        description = util.htmlToPlainTextIfHtml(book_props.description)
-    end
-    -- (We don't BD wrap description: it may be multi-lines, and the value we set
-    -- here may be viewed in a TextViewer that has auto_para_direction=true, which
-    -- will show the right thing, that'd we rather not mess with BD wrapping.)
-    table.insert(kv_pairs, { _("Description:"), description })
-
     local viewCoverImage = function()
         self:onShowBookCover(file)
     end
-    table.insert(kv_pairs, { _("Cover image:"), _("Tap to display"), callback=viewCoverImage })
+    table.insert(kv_pairs, { _("Cover image:"), _("Tap to display"), callback=viewCoverImage, separator = true })
 
-    -- Get a chance to have title, authors... rendered with alternate
-    -- glyphs for the book language (e.g. japanese book in chinese UI)
-    local values_lang = nil
-    if book_props.language and book_props.language ~= "" then
-        values_lang = book_props.language
+    -- Page section
+    if self.document then
+        local lines_nb, words_nb = self:getCurrentPageLinesWordsNumber()
+        if lines_nb then
+            table.insert(kv_pairs, { _("Current page lines:"), lines_nb })
+            table.insert(kv_pairs, { _("Current page words:"), words_nb })
+        end
     end
 
-    local widget = KeyValuePage:new{
+    local widget = require("ui/widget/keyvaluepage"):new{
         title = _("Book information"),
         value_overflow_align = "right",
         kv_pairs = kv_pairs,
@@ -158,6 +124,7 @@ function BookInfo:show(file, book_props)
 end
 
 function BookInfo:getBookProps(file, book_props, no_open_document)
+    local DocSettings = require("docsettings")
     if DocSettings:hasSidecarFile(file) then
         local doc_settings = DocSettings:open(file)
         if not book_props then
@@ -269,7 +236,7 @@ function BookInfo:onShowBookCover(file)
     if document then
         local cover_bb = document:getCoverPageImage()
         if cover_bb then
-            local imgviewer = ImageViewer:new{
+            local imgviewer = require("ui/widget/imageviewer"):new{
                 image = cover_bb,
                 with_title_bar = false,
                 fullscreen = true,
@@ -281,6 +248,44 @@ function BookInfo:onShowBookCover(file)
             })
         end
         document:close()
+    end
+end
+
+function BookInfo:getCurrentPageLinesWordsNumber()
+    if self.ui.rolling then
+        local Screen = require("device").screen
+        local res = self.ui.document._document:getTextFromPositions(0, 0, Screen:getWidth(), Screen:getHeight(),
+            false, false) -- do not highlight
+        if not res then return end
+        local lines = self.ui.document:getScreenBoxesFromPositions(res.pos0, res.pos1, true)
+        local words = {}
+        for word in util.gsplit(res.text, "[%s%p]+", false) do
+            if util.hasCJKChar(word) then
+                for char in util.gsplit(word, "[\192-\255][\128-\191]+", true) do
+                    table.insert(words, char)
+                end
+            else
+                table.insert(words, word)
+            end
+        end
+        return #lines, #words
+    else
+        local page_boxes = self.ui.document:getTextBoxes(self.ui:getCurrentPage())
+        if not page_boxes then return end
+        local lines_nb = #page_boxes
+        local words_nb = 0
+        for _, line in ipairs(page_boxes) do
+            if #line == 1 and line[1].word == "" then -- empty line
+                lines_nb = lines_nb - 1
+            else
+                words_nb = words_nb + #line
+                local last_word = line[#line].word
+                if last_word:sub(-1) == "-" and last_word ~= "-" then -- hyphenated
+                    words_nb = words_nb - 1
+                end
+            end
+        end
+        return lines_nb, words_nb
     end
 end
 

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -35,7 +35,7 @@ function BookInfo:show(file, book_props)
     local kv_pairs = {}
 
     -- File section
-    local directory, filename = util.splitFilePathName(file)
+    local folder, filename = util.splitFilePathName(file)
     local __, filetype = filemanagerutil.splitFileNameType(filename)
     local attr = lfs.attributes(file)
     local file_size = attr.size or 0
@@ -44,9 +44,8 @@ function BookInfo:show(file, book_props)
     table.insert(kv_pairs, { _("Filename:"), BD.filename(filename) })
     table.insert(kv_pairs, { _("Format:"), filetype:upper() })
     table.insert(kv_pairs, { _("Size:"), string.format("%s (%s bytes)", size_f, size_b) })
-    table.insert(kv_pairs, { _("Last read date:"), os.date("%Y-%m-%d %H:%M:%S", attr.access) })
-    table.insert(kv_pairs, { _("Date modified:"), os.date("%Y-%m-%d %H:%M:%S", attr.modification) })
-    table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(directory)), separator = true })
+    table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", attr.modification) })
+    table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(folder)), separator = true })
 
     -- Book section
     -- book_props may be provided if caller already has them available

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -64,7 +64,7 @@ function BookInfo:show(file, book_props)
         { _("Keywords:"), "keywords" },
         { _("Description:"), "description" },
     }
-    for __, v in ipairs(props) do
+    for i, v in ipairs(props) do
         local prop_text, prop_key = unpack(v)
         local prop = book_props[prop_key]
         if prop == nil or prop == "" then

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -64,7 +64,7 @@ function BookInfo:show(file, book_props)
         { _("Keywords:"), "keywords" },
         { _("Description:"), "description" },
     }
-    for i, v in ipairs(props) do
+    for _i, v in ipairs(props) do
         local prop_text, prop_key = unpack(v)
         local prop = book_props[prop_key]
         if prop == nil or prop == "" then

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -141,7 +141,8 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
         id = "reset", -- used by covermenu
         enabled = not button_disabled and DocSettings:hasSidecarFile(ffiutil.realpath(file)),
         callback = function()
-            UIManager:show(require("ui/widget/confirmbox"):new{
+            local ConfirmBox = require("ui/widget/confirmbox")
+            local confirmbox = ConfirmBox:new{
                 text = T(_("Reset this document?") .. "\n\n%1\n\n" ..
                     _("Document progress, settings, bookmarks, highlights and notes will be permanently lost."),
                     BD.filepath(file)),
@@ -151,7 +152,8 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
                     require("readhistory"):fileSettingsPurged(file)
                     caller_callback()
                 end,
-            })
+            }
+            UIManager:show(confirmbox)
         end,
     }
 end

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -3,10 +3,8 @@ This module contains miscellaneous helper functions for FileManager
 ]]
 
 local BD = require("ui/bidi")
-local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local DocSettings = require("docsettings")
-local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local ffiutil = require("ffi/util")
 local util = require("util")
@@ -33,6 +31,24 @@ function filemanagerutil.abbreviate(path)
         end
     end
     return path
+end
+
+function filemanagerutil.splitFileNameType(filename)
+    local filename_without_suffix, filetype = util.splitFileNameSuffix(filename)
+    filetype = filetype:lower()
+    if filetype == "zip" then
+        local filename_without_sub_suffix, sub_filetype = util.splitFileNameSuffix(filename_without_suffix)
+        sub_filetype = sub_filetype:lower()
+        local supported_sub_filetypes = { "fb2", "htm", "html", "log", "md", "rtf", "txt", }
+        for _, t in ipairs(supported_sub_filetypes) do
+            if sub_filetype == t then
+                filetype = sub_filetype .. "." .. filetype
+                filename_without_suffix = filename_without_sub_suffix
+                break
+            end
+        end
+    end
+    return filename_without_suffix, filetype
 end
 
 -- Purge doc settings in sidecar directory
@@ -125,7 +141,7 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
         id = "reset", -- used by covermenu
         enabled = not button_disabled and DocSettings:hasSidecarFile(ffiutil.realpath(file)),
         callback = function()
-            UIManager:show(ConfirmBox:new{
+            UIManager:show(require("ui/widget/confirmbox"):new{
                 text = T(_("Reset this document?") .. "\n\n%1\n\n" ..
                     _("Document progress, settings, bookmarks, highlights and notes will be permanently lost."),
                     BD.filepath(file)),
@@ -178,6 +194,7 @@ end
 
 -- Generate "Execute script" file dialog button
 function filemanagerutil.genExecuteScriptButton(file, caller_callback)
+    local InfoMessage = require("ui/widget/infomessage")
     return {
         -- @translators This is the script's programming language (e.g., shell or python)
         text = T(_("Execute %1 script"), util.getScriptType(file)),


### PR DESCRIPTION
(1) Added current page lines and words number (based on https://github.com/koreader/koreader/issues/10231#issuecomment-1477138340)
(2) Do not show empty book props (former "N/A")

<img width="300" alt="01" src="https://user-images.githubusercontent.com/62179190/228251448-1e97c661-3691-4039-aba2-21c4acd8c67a.png">

<img width="300" alt="02" src="https://user-images.githubusercontent.com/62179190/228251476-11707c1e-be03-4cda-9ae7-69dcd123db4d.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10255)
<!-- Reviewable:end -->
