### PR TITLE
Fix: Updated legacy directory, which crashed the program

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -334,12 +334,14 @@ end
 function MyClipping:parseHistory()
     local clippings = {}
     local history_dir = DataStorage:getHistoryDir()
-    for f in lfs.dir(history_dir) do
-        local legacy_history_file = ffiutil.joinPath(history_dir, f)
-        if lfs.attributes(legacy_history_file, "mode") == "file" then
-            local doc_file = DocSettings:getFileFromHistory(f)
-            if doc_file then
-                self:parseHistoryFile(clippings, legacy_history_file, doc_file)
+    if lfs.attributes(history_dir, "mode") == "directory" then
+        for f in lfs.dir(history_dir) do
+            local legacy_history_file = ffiutil.joinPath(history_dir, f)
+            if lfs.attributes(legacy_history_file, "mode") == "file" then
+                local doc_file = DocSettings:getFileFromHistory(f)
+                if doc_file then
+                    self:parseHistoryFile(clippings, legacy_history_file, doc_file)
+                end
             end
         end
     end


### PR DESCRIPTION
Fixes #10259

### The problem
The function `exportAllNotes` in the [main.lua](https://github.com/koreader/koreader/blob/master/plugins/exporter.koplugin/main.lua) file of the `exporter` plugin calls `parseHistory` of the [clip.lua](https://github.com/koreader/koreader/blob/master/plugins/exporter.koplugin/clip.lua) file, line 337.

This function tries to access the `history_dir` using `getHistoryDir` function from the [datastorage.lua](https://github.com/koreader/koreader/blob/master/datastorage.lua) module, which it fails to find.

In the `datastorage` module, you can find this snippet of code, starting at line 60:
```lua
local function initDataDir()
    local sub_data_dirs = {
        <some folders>
        -- "history", -- legacy/obsolete sidecar files
        <some other folders>
    }
```

Since the folder is sometimes not present, there should be a protected call so that the program doesn't crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10260)
<!-- Reviewable:end -->
