### PR TITLE
Feature: Added the possibility to export using kindle's myClippings f…

### DIFF
--- a/plugins/exporter.koplugin/base.lua
+++ b/plugins/exporter.koplugin/base.lua
@@ -93,7 +93,7 @@ function BaseExporter:getFilePath(t)
     if not self.is_remote then
         local filename = string.format("%s-%s.%s",
             self:getTimeStamp(),
-            #t == 1 and t[1].output_filename or "all-books",
+            #t == 1 and t[1].output_filename or self.all_books_title or "all-books",
             self.extension)
         return self.clipping_dir .. "/" .. getSafeFilename(filename)
     end

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -38,7 +38,7 @@ local _ = require("gettext")
 
 -- migrate settings from old "evernote.koplugin" or from previous (monolithic) "exporter.koplugin"
 local function migrateSettings()
-    local formats = { "html", "joplin", "json", "readwise", "text" }
+    local formats = { "html", "joplin", "json", "readwise", "text", "my_clippings" }
 
     local settings = G_reader_settings:readSetting("exporter")
     if not settings then
@@ -104,6 +104,7 @@ local Exporter = WidgetContainer:extend{
         markdown = require("target/markdown"),
         readwise = require("target/readwise"),
         text = require("target/text"),
+        my_clippings = require("target/my_clippings"),
     },
 }
 

--- a/plugins/exporter.koplugin/target/my_clippings.lua
+++ b/plugins/exporter.koplugin/target/my_clippings.lua
@@ -7,6 +7,7 @@ local ClippingsExporter = require("base"):new {
     name = "myClippings",
     extension = "txt",
     mimetype = "text/plain",
+    all_books_title = "myClippings"
 }
 
 local function format(booknotes)

--- a/plugins/exporter.koplugin/target/my_clippings.lua
+++ b/plugins/exporter.koplugin/target/my_clippings.lua
@@ -1,0 +1,51 @@
+local util = require("ffi/util")
+local T = util.template
+local _ = require("gettext")
+
+-- myClippings exporter
+local ClippingsExporter = require("base"):new {
+    name = "myClippings",
+    extension = "txt",
+    mimetype = "text/plain",
+}
+
+local function format(booknotes)
+    local content = ""
+    for ___, entry in ipairs(booknotes) do
+        for ____, clipping in ipairs(entry) do
+            if booknotes.title and clipping.text then
+                content = content .. booknotes.title .. "\n"
+                local header = T(_("- Your Highlight on page %1 | Added on %2\n\n"), clipping.page, os.date("%A, %B %d, %Y %I:%M:%S %p", clipping.time))
+                content = content .. header
+                content = content .. clipping.text
+                content = content .. "\n==========\n"
+                if clipping.note then
+                    content = content .. booknotes.title .. "\n"
+                    header = T(_("- Your Note on page %1 | Added on %2\n\n"), clipping.page, os.date("%A, %B %d, %Y %I:%M:%S %p", clipping.time))
+                    content = content .. header .. clipping.note
+                    content = content .. "\n==========\n"
+                end
+            end
+        end
+    end
+    return content
+end
+
+function ClippingsExporter:export(t)
+    local path = self:getFilePath(t)
+    local file = io.open(path, "a")
+    if not file then return false end
+    for __, booknotes in ipairs(t) do
+        local content = format(booknotes)
+        file:write(content)
+    end
+    file:close()
+    return true
+end
+
+function ClippingsExporter:share(t)
+    local content = format(t)
+    self:shareText(content)
+end
+
+return ClippingsExporter


### PR DESCRIPTION
Solves FR #10262

This adds the "MyClippings" option when exporting your highlights.
The code of `target/myClippings.lua` is similar to that of `target/text.lua`.

Also updated `main.lua` to show the new option.

This formatting is recognized as a kindle's `myClippings.txt` file.

![image](https://user-images.githubusercontent.com/98263539/228367271-d5950938-136c-4ad2-b35b-18b5716b30a2.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10263)
<!-- Reviewable:end -->
