### PR TITLE
Fix: exporting Markdown with missing authors doesn't crash anymore

### DIFF
--- a/plugins/exporter.koplugin/template/md.lua
+++ b/plugins/exporter.koplugin/template/md.lua
@@ -39,7 +39,8 @@ local function prepareBookContent(book, formatting_options, highlight_formatting
     local content = ""
     local current_chapter = nil
     content = content .. "# " .. book.title .. "\n"
-    content = content .. "##### " .. book.author:gsub("\n", ", ") .. "\n\n"
+    local author = book.author or _("N/A")
+    content = content .. "##### " .. author:gsub("\n", ", ") .. "\n\n"
     for _, note in ipairs(book) do
         local entry = note[1]
         if entry.chapter ~= current_chapter then


### PR DESCRIPTION
Solves #10070 and maybe #10072

The previous version would crash due to author missing in the book's metadata.
```lua
-- line 38
local function prepareBookContent(book, formatting_options, highlight_formatting)
    [..........]
    content = content .. "##### " .. book.author:gsub("\n", ", ") .. "\n\n"
    [.........]
```

Added a conditional that sets the book author to a default `(Author not found in book's metadata)`, so that the user can still have a feedback on missing metadata, while successfully exporting their notes.
The fix works both with export one file and export all files.

![image](https://user-images.githubusercontent.com/98263539/229288205-e652ec6f-0328-4d32-8754-e6614ce5f4ac.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10278)
<!-- Reviewable:end -->
