### PR TITLE
[RFC] Fix: use metadata for author and title when exporting all notes

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -321,13 +321,13 @@ function MyClipping:parseHistoryFile(clippings, history_file, doc_file)
             return
         end
         local _, docname = util.splitFilePathName(doc_file)
-        local title, author = self:parseTitleFromPath(util.splitFileNameSuffix(docname), doc_file)
-        clippings[title] = {
+        local parsed_title, parsed_author = self:parseTitleFromPath(util.splitFileNameSuffix(docname), doc_file)
+        clippings[parsed_title] = {
             file = doc_file,
-            title = title,
-            author = author,
+            title = stored.stats.title or parsed_title,
+            author = stored.stats.authors or parsed_author,
         }
-        self:parseHighlight(stored.highlight, stored.bookmarks, clippings[title])
+        self:parseHighlight(stored.highlight, stored.bookmarks, clippings[parsed_title])
     end
 end
 


### PR DESCRIPTION
Fixes #10279

The fix makes it so that `parseHistoryFile` uses the stored metadata from the history file to define title and author, instead of the `doc_file` (book) filename.
This makes the results coming form `export all books` and `export current book` the same.

The current solution still keeps the author and title from the filename as fallbacks, but could be removed or changed with some other default (for example, "(Missing author in book's metadata)"), if we want the users to have feedback on missing metadata and have them fix it.

This are the files post-fix (reference before fix in the issue), left is all-books and right is current book export.
![image](https://user-images.githubusercontent.com/98263539/229292801-bf022785-72f6-45bf-86de-48dcd423c2ac.png)

The filename still uses the wrong title (grokking instead of Grokking Algorithms), not sure if I should fix it here or in another issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10280)
<!-- Reviewable:end -->
