### PR TITLE
Fix: title from filename is now used only as fallback when exporting

### DIFF
--- a/plugins/exporter.koplugin/base.lua
+++ b/plugins/exporter.koplugin/base.lua
@@ -93,7 +93,7 @@ function BaseExporter:getFilePath(t)
     if not self.is_remote then
         local filename = string.format("%s-%s.%s",
             self:getTimeStamp(),
-            #t == 1 and t[1].exportable_title or "all-books",
+            #t == 1 and t[1].output_filename or "all-books",
             self.extension)
         return self.clipping_dir .. "/" .. getSafeFilename(filename)
     end

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -394,8 +394,8 @@ function MyClipping:getDocMeta(view)
     end
     return {
         title = title,
-        -- To make sure that export doesn't fail due to unsupported charchters.
-        exportable_title = parsed_title,
+        -- Replaces characters that are invalid in filenames.
+        output_filename = util.getSafeFilename(title),
         author = author,
         number_of_pages = number_of_pages,
         file = view.document.file,


### PR DESCRIPTION
Solves #10281

The current implementation of the naming system for single imports automatically uses a fallback to avoid illegal characters.

The fix implements a way to check if the title from the metadata does have illegal characters before using the original filename as a fallback.

I think this was the original intent, as signaled from the comment in the function (see in changes).

This allows for more consistency across the export plugin and uses the original filename only when metadata is missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10282)
<!-- Reviewable:end -->
