### PR TITLE
FileChooser: fix crash on "unreadable content"

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -405,7 +405,7 @@ function FileChooser:changeToPath(path, focused_path)
         end
         if not unreadable_dir_content[path][focused_path] then
             unreadable_dir_content[path][focused_path] = {
-                name = focused_path:sub(#path+2),
+                text = focused_path:sub(#path+2),
                 fullpath = focused_path,
                 attr = lfs.attributes(focused_path),
             }


### PR DESCRIPTION
Reported in https://github.com/koreader/koreader/pull/10275#issuecomment-1492955156.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10283)
<!-- Reviewable:end -->
