### PR TITLE
Calendar view and Page browser tweaks

### DIFF
--- a/frontend/ui/widget/datetimewidget.lua
+++ b/frontend/ui/widget/datetimewidget.lua
@@ -211,7 +211,7 @@ function DateTimeWidget:createLayout()
             value = self.min,
             value_min = self.min_min or 0,
             value_max = self.min_max or 59,
-            value_step = 1,
+            value_step = self.min_step or 1,
             value_hold_step = self.min_hold_step or 10,
             width = number_picker_widgets_width,
         }

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -893,11 +893,31 @@ function PageBrowserWidget:updateFocusPage(value, relative)
     else
         new_focus_page = value
     end
-    if new_focus_page < 1 then
-        new_focus_page = 1
-    end
-    if new_focus_page > self.nb_pages then
-        new_focus_page = self.nb_pages
+    -- Handle scroll by row or page a bit differently, so we dont constrain and
+    -- readjust the focus page: when later scrolling in the other direction,
+    -- we'll find exactly the view as it was (this means that we allow a single
+    -- thumbnail in the view, but it's less confusing this way).
+    if relative and (value == -self.nb_grid_items or value == -self.nb_cols) then
+        -- Going back one page or row. If first thumbnail is page 1 (or less if
+        -- blank), don't move. Otherwise, go ahead without any check as we'll
+        -- have something to display.
+        if self.focus_page - self.focus_page_shift <= 1 then
+            return
+        end
+    elseif relative and (value == self.nb_grid_items or value == self.nb_cols) then
+        -- Going forward one page or row. If last thumbnail is last page (or more if
+        -- blank), don't move. Otherwise, go ahead without any check as we'll
+        -- have something to display.
+        if self.focus_page - self.focus_page_shift + self.nb_grid_items - 1 >= self.nb_pages then
+            return
+        end
+    else
+        if new_focus_page < 1 then
+            new_focus_page = 1
+        end
+        if new_focus_page > self.nb_pages then
+            new_focus_page = self.nb_pages
+        end
     end
     if new_focus_page == self.focus_page then
         return false

--- a/plugins/statistics.koplugin/calendarview.lua
+++ b/plugins/statistics.koplugin/calendarview.lua
@@ -911,11 +911,21 @@ function CalendarDayView:refreshTimeline()
         })
     end
     -- Horizontal lines
+    local idx_00h00
+    if self.reader_statistics.settings.calendar_day_start_hour and self.reader_statistics.settings.calendar_day_start_hour ~= 0 then
+        idx_00h00 = 24 - self.reader_statistics.settings.calendar_day_start_hour
+    end
     for i=0, 24 do
         local offset_y = self.timeline_offset + self.hour_height * i
+        local height = Size.border.default
+        if idx_00h00 and i == idx_00h00 then
+            -- Thicker separator between 23:00 and 00:00
+            offset_y = offset_y - math.floor(height/2) -- shift it a bit up
+            height = height * 2
+        end
         table.insert(self.timeline, FrameContainer:new{
             width = self.timeline_width,
-            height = Size.border.default,
+            height = height,
             background = Blitbuffer.COLOR_LIGHT_GRAY,
             bordersize = 0,
             padding = 0,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1088,7 +1088,9 @@ The max value ensures a page you stay on for a long time (because you fell aslee
                             local start_of_day_widget = DateTimeWidget:new{
                                 hour = self.settings.calendar_day_start_hour or 0,
                                 min = self.settings.calendar_day_start_minute or 0,
-                                hour_max = 6,
+                                min_max = 50,
+                                min_step = 10, -- we have vertical lines every 10mn, keep them meaningful
+                                min_hold_step = 30,
                                 ok_text = _("Set time"),
                                 title_text = _("Daily timeline starts at"),
                                 info_text =_([[


### PR DESCRIPTION
#### Calendar view's day view: thicker separator at 00:00

When using the new option "Daily timeline starts at", make the separator line between 23:00 and 00:00 thicker.
Also tweak time picker to pick minutes by units of 10, and remove max hour (06:00) limitation.
See https://github.com/koreader/koreader/pull/10254#issuecomment-1493073148.

#### PageBrowser: tweak scrolling behaviour at book start/end

Handle scroll by row or page a bit differently, so we dont constrain and readjust the focus page when reaching book start or end: when later scrolling in the other direction, we'll find exactly the view as it was (this means that we allow a single thumbnail in the view, but it's less confusing this way).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10289)
<!-- Reviewable:end -->
