### PR TITLE
FileChooser: fix show files in bold

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -157,7 +157,7 @@ function FileChooser:getListItem(f, filename, attributes, collate)
         attr = attributes,
     }
     if collate then -- file
-        if G_reader_settings:readSetting("show_file_in_bold") then
+        if G_reader_settings:readSetting("show_file_in_bold") ~= false then
             item.opened = DocSettings:hasSidecarFile(filename)
         end
         if collate == "type" then


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/10294.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10296)
<!-- Reviewable:end -->
