### PR TITLE
Add esperanto-english dictionary

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -2859,6 +2859,14 @@ local dictionaries = {
         license = "Open Vietnamese Dictionary Project, https://sourceforge.net/projects/ovdp/",
         url = "https://khoicandev.github.io/ovdp-mirror/vi-ru.tar.gz"
     },
+    {
+        name = "Esperanto-English dictionary by Paul Denisowski",
+        lang_in = "eto",
+        lang_out = "eng",
+        entries = 63728,
+        license = "Creative Commons Attribution 3.0 Unported License",
+        url = "https://github.com/jmthackett/en-eo-stardict/releases/download/latest/dictionary.tar.gz"
+    },
 }
 
 return dictionaries


### PR DESCRIPTION
Might have got the languages the wrong way around - to be clear, the words are Esperanto and the definitions are in English!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10297)
<!-- Reviewable:end -->
