### PR TITLE
File browser: show Folder Menu on long-press on Home icon

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -119,8 +119,8 @@ function FileManager:setupLayout()
         button_padding = Screen:scaleBySize(5),
         left_icon = "home",
         left_icon_size_ratio = 1,
-        left_icon_tap_callback = function() self:onShowFolderMenu() end,
-        left_icon_hold_callback = false, -- propagate long-press to dispatcher
+        left_icon_tap_callback = function() self:goHome() end,
+        left_icon_hold_callback = function() self:onShowFolderMenu() end,
         right_icon = "plus",
         right_icon_size_ratio = 1,
         right_icon_tap_callback = function() self:onShowPlusMenu() end,

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -405,7 +405,7 @@ function FileChooser:changeToPath(path, focused_path)
         end
         if not unreadable_dir_content[path][focused_path] then
             unreadable_dir_content[path][focused_path] = {
-                text = focused_path:sub(#path+2),
+                text = focused_path:sub(#path > 1 and #path+2 or 2),
                 fullpath = focused_path,
                 attr = lfs.attributes(focused_path),
             }

--- a/plugins/gestures.koplugin/defaults.lua
+++ b/plugins/gestures.koplugin/defaults.lua
@@ -7,7 +7,7 @@ return {
         tap_top_right_corner = nil,
         tap_right_bottom_corner = nil,
         tap_left_bottom_corner = Device:hasFrontlight() and {toggle_frontlight = true,} or nil,
-        hold_top_left_corner = {filemanager = true,},
+        hold_top_left_corner = nil,
         hold_top_right_corner = {refresh_content = true,},
         hold_bottom_left_corner = nil,
         hold_bottom_right_corner = nil,


### PR DESCRIPTION
Also fixes unreadable folder name in root (https://github.com/koreader/koreader/pull/10275#issuecomment-1493404186).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10298)
<!-- Reviewable:end -->
