### PR TITLE
Fix frontlight toggle not ramping, but immediately turning off on Sage

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -192,9 +192,12 @@ if Device:hasFrontlight() then
         else
             new_text = _("Frontlight enabled.")
         end
-        -- We display the notification first, with a forced refresh *now*, in order to make sure the refresh fencing will not to affect the ramp on devices where we handle both the ramp and the fencing ourselves...
-        Notification:notify(new_text, nil, true)
-        powerd:toggleFrontlight()
+        -- We defer displaying the Notification to PowerD, as the toggle may be a ramp, and we both want to make sure the refresh fencing won't affect it, and that we only display the Notification at the end...
+        local notif_source = Notification.notify_source
+        local notif_cb = function()
+            Notification:notify(new_text, notif_source)
+        end
+        powerd:toggleFrontlight(notif_cb)
     end
 
     function DeviceListener:onShowFlDialog()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -186,14 +186,15 @@ if Device:hasFrontlight() then
 
     function DeviceListener:onToggleFrontlight()
         local powerd = Device:getPowerDevice()
-        powerd:toggleFrontlight()
         local new_text
         if powerd.is_fl_on then
-            new_text = _("Frontlight enabled.")
-        else
             new_text = _("Frontlight disabled.")
+        else
+            new_text = _("Frontlight enabled.")
         end
-        Notification:notify(new_text)
+        -- We display the notification first, with a forced refresh *now*, in order to make sure the refresh fencing will not to affect the ramp on devices where we handle both the ramp and the fencing ourselves...
+        Notification:notify(new_text, nil, true)
+        powerd:toggleFrontlight()
     end
 
     function DeviceListener:onShowFlDialog()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -308,7 +308,6 @@ function Device:onPowerEvent(ev)
         end
     -- else we were not in screensaver mode
     elseif ev == "Power" or ev == "Suspend" then
-        self.powerd:beforeSuspend()
         local UIManager = require("ui/uimanager")
         logger.dbg("Suspending...")
         -- Add the current state of the SleepCover flag...
@@ -325,28 +324,25 @@ function Device:onPowerEvent(ev)
         if self:needsScreenRefreshAfterResume() then
             self.screen:refreshFull()
         end
-        -- NOTE: In the same vein as above, this is delayed to make sure we update the screen first.
-        --       (This, unfortunately, means we can't just move this to Device:_beforeSuspend :/).
-        UIManager:scheduleIn(0.1, function()
-            -- NOTE: This side of the check needs to be laxer, some platforms can handle Wi-Fi without WifiManager ;).
-            if self:hasWifiToggle() then
-                local network_manager = require("ui/network/manager")
-                -- NOTE: wifi_was_on does not necessarily mean that Wi-Fi is *currently* on! It means *we* enabled it.
-                --       This is critical on Kobos (c.f., #3936), where it might still be on from KSM or Nickel,
-                --       without us being aware of it (i.e., wifi_was_on still unset or false),
-                --       because suspend will at best fail, and at worst deadlock the system if Wi-Fi is on,
-                --       regardless of who enabled it!
-                if network_manager:isWifiOn() then
-                    network_manager:releaseIP()
-                    network_manager:turnOffWifi()
-                end
+        -- NOTE: In the same vein as above, make sure we update the screen *now*, before dealing with Wi-Fi.
+        UIManager:forceRePaint()
+        -- NOTE: This side of the check needs to be laxer, some platforms can handle Wi-Fi without WifiManager ;).
+        if self:hasWifiToggle() then
+            local network_manager = require("ui/network/manager")
+            -- NOTE: wifi_was_on does not necessarily mean that Wi-Fi is *currently* on! It means *we* enabled it.
+            --       This is critical on Kobos (c.f., #3936), where it might still be on from KSM or Nickel,
+            --       without us being aware of it (i.e., wifi_was_on still unset or false),
+            --       because suspend will at best fail, and at worst deadlock the system if Wi-Fi is on,
+            --       regardless of who enabled it!
+            if network_manager:isWifiOn() then
+                network_manager:releaseIP()
+                network_manager:turnOffWifi()
             end
-            -- Only actually schedule suspension if we're still supposed to go to sleep,
-            -- because the Wi-Fi stuff above may have blocked for a significant amount of time...
-            if self.screen_saver_mode then
-                self:rescheduleSuspend()
-            end
-        end)
+        end
+        -- Only turn off the frontlight *after* we've displayed the screensaver and dealt with Wi-Fi,
+        -- to prevent that from affecting the smoothness of the frontlight ramp down.
+        self.powerd:beforeSuspend()
+        self:rescheduleSuspend()
     end
 end
 

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -43,7 +43,7 @@ end
 
 function BasePowerD:readyUI()
     UIManager = require("ui/uimanager")
-    self:readyUIHW()
+    self:readyUIHW(UIManager)
 end
 
 function BasePowerD:init() end
@@ -66,7 +66,7 @@ function BasePowerD:isFrontlightOnHW() return self.fl_intensity > self.fl_min en
 function BasePowerD:turnOffFrontlightHW() self:setIntensityHW(self.fl_min) end
 function BasePowerD:turnOnFrontlightHW() self:setIntensityHW(self.fl_intensity) end --- @fixme: what if fl_intensity == fl_min (c.f., kindle)?
 function BasePowerD:frontlightWarmthHW() return 0 end
-function BasePowerD:readyUIHW() end
+function BasePowerD:readyUIHW(uimgr) end
 -- Anything that needs to be done before doing a real hardware suspend.
 -- (Such as turning the front light off).
 function BasePowerD:beforeSuspend() end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,4 +1,3 @@
-local UIManager -- will be updated when available
 local Math = require("optmath")
 local logger = require("logger")
 local time = require("ui/time")
@@ -17,6 +16,7 @@ local BasePowerD = {
     last_aux_capacity_pull_time = time.s(-61),  -- timestamp of last pull
 
     is_fl_on = false,                 -- whether the frontlight is on
+    UIManager = nil -- will be updated when available
 }
 
 function BasePowerD:new(o)
@@ -42,7 +42,7 @@ function BasePowerD:new(o)
 end
 
 function BasePowerD:readyUI()
-    UIManager = require("ui/uimanager")
+    self.UIManager = require("ui/uimanager")
 end
 
 function BasePowerD:init() end
@@ -210,8 +210,8 @@ function BasePowerD:getCapacity()
     -- BasePowerD is loaded before UIManager.
     -- Nothing *currently* calls this before UIManager is actually loaded, but future-proof this anyway.
     local now
-    if UIManager then
-        now = UIManager:getElapsedTimeSinceBoot()
+    if self.UIManager then
+        now = self.UIManager:getElapsedTimeSinceBoot()
     else
         -- Add time the device was in standby and suspend
         now = time.now() + self.device.total_standby_time + self.device.total_suspend_time
@@ -235,8 +235,8 @@ end
 function BasePowerD:getAuxCapacity()
     local now
 
-    if UIManager then
-        now = UIManager:getElapsedTimeSinceBoot()
+    if self.UIManager then
+        now = self.UIManager:getElapsedTimeSinceBoot()
     else
         -- Add time the device was in standby and suspend
         now = time.now() + self.device.total_standby_time + self.device.total_suspend_time
@@ -272,9 +272,9 @@ end
 
 function BasePowerD:stateChanged()
     -- BasePowerD is loaded before UIManager. So we cannot broadcast events before UIManager has been loaded.
-    if UIManager then
+    if self.UIManager then
         local Event = require("ui/event")
-        UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))
+        self.UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))
     end
 end
 

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -63,8 +63,8 @@ function BasePowerD:isAuxChargingHW() return false end
 function BasePowerD:isAuxChargedHW() return false end
 function BasePowerD:frontlightIntensityHW() return 0 end
 function BasePowerD:isFrontlightOnHW() return self.fl_intensity > self.fl_min end
-function BasePowerD:turnOffFrontlightHW() self:setIntensityHW(self.fl_min) end
-function BasePowerD:turnOnFrontlightHW() self:setIntensityHW(self.fl_intensity) end --- @fixme: what if fl_intensity == fl_min (c.f., kindle)?
+function BasePowerD:turnOffFrontlightHW(done_callback) self:setIntensityHW(self.fl_min) end
+function BasePowerD:turnOnFrontlightHW(done_callback) self:setIntensityHW(self.fl_intensity) end --- @fixme: what if fl_intensity == fl_min (c.f., kindle)?
 function BasePowerD:frontlightWarmthHW() return 0 end
 function BasePowerD:readyUIHW(uimgr) end
 -- Anything that needs to be done before doing a real hardware suspend.
@@ -96,29 +96,29 @@ function BasePowerD:frontlightIntensity()
     return self.fl_intensity
 end
 
-function BasePowerD:toggleFrontlight()
+function BasePowerD:toggleFrontlight(done_callback)
     if not self.device:hasFrontlight() then return false end
     if self:isFrontlightOn() then
-        return self:turnOffFrontlight()
+        return self:turnOffFrontlight(done_callback)
     else
-        return self:turnOnFrontlight()
+        return self:turnOnFrontlight(done_callback)
     end
 end
 
-function BasePowerD:turnOffFrontlight()
+function BasePowerD:turnOffFrontlight(done_callback)
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOff() then return false end
-    self:turnOffFrontlightHW()
+    self:turnOffFrontlightHW(done_callback)
     self.is_fl_on = false
     self:stateChanged()
     return true
 end
 
-function BasePowerD:turnOnFrontlight()
+function BasePowerD:turnOnFrontlight(done_callback)
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOn() then return false end
     if self.fl_intensity == self.fl_min then return false end  --- @fixme what the hell?
-    self:turnOnFrontlightHW()
+    self:turnOnFrontlightHW(done_callback)
     self.is_fl_on = true
     self:stateChanged()
     return true

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -166,7 +166,10 @@ local Kobo = Generic:extend{
     -- Device ships with various hardware revisions under the same device code, requirign automatic hardware detection...
     automagic_sysfs = false,
 
-    unexpected_wakeup_count = 0
+    unexpected_wakeup_count = 0,
+    frontlight_settings = {
+        wait_before_turn_off_s = 0.0, -- time to wait before turning FL off.
+    },
 }
 
 local KoboTrilogyA = Kobo:extend{
@@ -449,6 +452,7 @@ local KoboCadmus = Kobo:extend{
         nl_min = 0,
         nl_max = 10,
         nl_inverted = false,
+        wait_before_turn_off_s = 0.5, -- time to wait before turning FL off.
     },
     boot_rota = C.FB_ROTATE_CW,
     battery_sysfs = "/sys/class/power_supply/battery",

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -449,7 +449,11 @@ local KoboCadmus = Kobo:extend{
         nl_min = 0,
         nl_max = 10,
         nl_inverted = false,
-        ramp_off_delay = 0.5, -- delay the final ramp off step to prevent the whole ramp from being optimized out
+        --- @note: The Sage natively ramps when setting the frontlight intensity.
+        ---        A side-effect of this behavior is that if you queue a series of intensity changes ending at 0,
+        ---        it won't ramp *at all*, and jump straight to zero.
+        ---        So we delay the final ramp off step to prevent (both) the native and our ramping from being optimized out
+        ramp_off_delay = 0.5,
     },
     boot_rota = C.FB_ROTATE_CW,
     battery_sysfs = "/sys/class/power_supply/battery",

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -449,6 +449,7 @@ local KoboCadmus = Kobo:extend{
         nl_min = 0,
         nl_max = 10,
         nl_inverted = false,
+        ramp_delay = 0.025,
         ramp_off_delay = 0.5, -- delay the final ramp off step to prevent the whole ramp from being optimized out
     },
     boot_rota = C.FB_ROTATE_CW,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -449,7 +449,6 @@ local KoboCadmus = Kobo:extend{
         nl_min = 0,
         nl_max = 10,
         nl_inverted = false,
-        ramp_delay = 0.025,
         ramp_off_delay = 0.5, -- delay the final ramp off step to prevent the whole ramp from being optimized out
     },
     boot_rota = C.FB_ROTATE_CW,

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -167,9 +167,6 @@ local Kobo = Generic:extend{
     automagic_sysfs = false,
 
     unexpected_wakeup_count = 0,
-    frontlight_settings = {
-        wait_before_turn_off_s = 0.0, -- time to wait before turning FL off.
-    },
 }
 
 local KoboTrilogyA = Kobo:extend{
@@ -452,7 +449,7 @@ local KoboCadmus = Kobo:extend{
         nl_min = 0,
         nl_max = 10,
         nl_inverted = false,
-        wait_before_turn_off_s = 0.5, -- time to wait before turning FL off.
+        ramp_off_delay = 0.5, -- delay the final ramp off step to prevent the whole ramp from being optimized out
     },
     boot_rota = C.FB_ROTATE_CW,
     battery_sysfs = "/sys/class/power_supply/battery",

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -138,8 +138,6 @@ function KoboPowerD:init()
         self.device.frontlight_settings.ramp_off_delay = self.device.frontlight_settings.ramp_off_delay or 0.0
         --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so we only really need a delay on older devices.
         self.device.frontlight_settings.ramp_delay = self.device.frontlight_settings.ramp_delay or (self.device:hasNaturalLight() and 0.0 or 0.025)
-        --- FIXME: Drop me.
-        print("Ramp delay is", self.device.frontlight_settings.ramp_delay)
 
         -- If this device has natural light (currently only KA1 & Forma)
         -- Use the SysFS interface, and ioctl otherwise.
@@ -253,8 +251,6 @@ function KoboPowerD:isFrontlightOnHW()
 end
 
 function KoboPowerD:_setIntensityHW(intensity)
-    -- FIXME: Drop me!
-    print("KoboPowerD:_setIntensityHW", intensity)
     if self.fl == nil then return end
     if self.fl_warmth == nil or self.device:hasNaturalLightMixer() then
         -- We either don't have NL, or we have a mixer: we only want to set the intensity (c.f., #5429)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -350,16 +350,6 @@ function KoboPowerD:turnOffFrontlightHW()
             self:_stopFrontlightRamp()
             self:turnOffFrontlightRamp(self.fl_intensity, self.fl_min)
             self.fl_ramp_down_running = true
-
-            -- NOTE: This is essentially what setIntensityHW does, except we don't actually touch the FL,
-            --       we only sync the state of the main process with the final state of what we're doing in the forks.
-            -- And update hw_intensity in our actual process ;).
-            self.hw_intensity = self.fl_min
-            -- NOTE: And don't forget to update sysfs_light, too, as a real setIntensityHW would via setBrightness
-            if self.fl then
-                self.fl.current_brightness = self.fl_min
-            end
-            self:_decideFrontlightState()
         end
     else -- if UIManager is not initialized yet, default to "off" immediately
         self:setIntensityHW(self.fl_min)
@@ -400,16 +390,6 @@ function KoboPowerD:turnOnFrontlightHW()
             self.fl_ramp_up_running = true
 
             self:turnOnFrontlightRamp(self.fl_min, self.fl_intensity)
-
-            -- NOTE: This is essentially what setIntensityHW does, except we don't actually touch the FL,
-            --       we only sync the state of the main process with the final state of what we're doing in the forks.
-            -- And update hw_intensity in our actual process ;).
-            self.hw_intensity = self.fl_intensity
-            -- NOTE: And don't forget to update sysfs_light, too, as a real setIntensityHW would via setBrightness
-            if self.fl then
-                self.fl.current_brightness = self.fl_intensity
-            end
-            self:_decideFrontlightState()
         end
     else -- if UIManager is not initialized yes, default to "on" with no ramp
         self:setIntensityHW(self.fl_intensity)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -253,6 +253,7 @@ function KoboPowerD:isFrontlightOnHW()
 end
 
 function KoboPowerD:_setIntensityHW(intensity)
+    -- FIXME: Drop me!
     print("KoboPowerD:_setIntensityHW", intensity)
     if self.fl == nil then return end
     if self.fl_warmth == nil or self.device:hasNaturalLightMixer() then
@@ -374,7 +375,7 @@ function KoboPowerD:turnOnFrontlightRamp(curr_ramp_intensity, end_intensity, don
     if curr_ramp_intensity == 0 then
         curr_ramp_intensity = 1
     else
-        curr_ramp_intensity = math.ceil(math.min(curr_ramp_intensity * 1.25, self.fl_max))
+        curr_ramp_intensity = math.ceil(math.min(curr_ramp_intensity * 1.5, self.fl_max))
     end
 
     if curr_ramp_intensity < end_intensity then

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -133,6 +133,7 @@ function KoboPowerD:init()
     self.initial_is_fl_on = true
 
     if self.device:hasFrontlight() then
+        self.device.frontlight_settings = self.device.frontlight_settings or {}
         -- Does this device require non-standard ramping behavior?
         self.device.frontlight_settings.ramp_off_delay = self.device.frontlight_settings.ramp_off_delay or 0.0
         -- FIXME: See if !hasNaturalLight still requires a higher delay

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -136,8 +136,10 @@ function KoboPowerD:init()
         self.device.frontlight_settings = self.device.frontlight_settings or {}
         -- Does this device require non-standard ramping behavior?
         self.device.frontlight_settings.ramp_off_delay = self.device.frontlight_settings.ramp_off_delay or 0.0
-        -- FIXME: See if !hasNaturalLight still requires a higher delay
-        self.device.frontlight_settings.ramp_delay = self.device.frontlight_settings.ramp_delay or 0.025
+        --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so we only really need a delay on older devices.
+        self.device.frontlight_settings.ramp_delay = self.device.frontlight_settings.ramp_delay or (self.device:hasNaturalLight() and 0.0 or 0.035)
+        --- FIXME: Drop me.
+        print("Ramp delay is", self.device.frontlight_settings.ramp_delay)
 
         -- If this device has natural light (currently only KA1 & Forma)
         -- Use the SysFS interface, and ioctl otherwise.

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -339,7 +339,7 @@ function KoboPowerD:turnOffFrontlightRamp(curr_ramp_intensity, end_intensity, do
     curr_ramp_intensity = math.floor(math.max(curr_ramp_intensity * .75, 0))
 
     if curr_ramp_intensity > end_intensity then
-        self:_setIntensityHW(math.floor(curr_ramp_intensity))
+        self:_setIntensityHW(curr_ramp_intensity)
         UIManager:scheduleIn(self.device.frontlight_settings.ramp_delay, self.turnOffFrontlightRamp, self, curr_ramp_intensity, end_intensity, done_callback)
     else
         -- Some devices require delaying the final step, to prevent them from jumping straight to zero and messing up the ramp.
@@ -373,7 +373,7 @@ function KoboPowerD:turnOnFrontlightRamp(curr_ramp_intensity, end_intensity, don
     curr_ramp_intensity = math.floor(math.min(curr_ramp_intensity + end_intensity/5, end_intensity))
 
     if curr_ramp_intensity < end_intensity then
-        self:setIntensityHW(curr_ramp_intensity)
+        self:_setIntensityHW(curr_ramp_intensity)
         UIManager:scheduleIn(self.device.frontlight_settings.ramp_delay, self.turnOnFrontlightRamp, self, curr_ramp_intensity, end_intensity, done_callback)
     else
         self:_setIntensityHW(end_intensity)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -137,7 +137,7 @@ function KoboPowerD:init()
         -- Does this device require non-standard ramping behavior?
         self.device.frontlight_settings.ramp_off_delay = self.device.frontlight_settings.ramp_off_delay or 0.0
         --- @note: Newer devices appear to block slightly longer on FL ioctls/sysfs, so we only really need a delay on older devices.
-        self.device.frontlight_settings.ramp_delay = self.device.frontlight_settings.ramp_delay or (self.device:hasNaturalLight() and 0.0 or 0.035)
+        self.device.frontlight_settings.ramp_delay = self.device.frontlight_settings.ramp_delay or (self.device:hasNaturalLight() and 0.0 or 0.025)
         --- FIXME: Drop me.
         print("Ramp delay is", self.device.frontlight_settings.ramp_delay)
 

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -156,7 +156,7 @@ end
 function Notification:notify(arg, source, refresh_after)
     source = source or self.notify_source
     local mask = G_reader_settings:readSetting("notification_sources_to_show_mask") or self.SOURCE_DEFAULT
-    if source and band(mask, self.notify_source) ~= 0 then
+    if source and band(mask, source) ~= 0 then
         UIManager:show(Notification:new{
             text = arg,
          })


### PR DESCRIPTION
On my Sage toggling Frontlight on gives a smooth brightness ramp; but toggling it off is a jump in brightness.

This PR fixes that behavioir:
*) Toggling FL on is not changed
*) Toggling FL of does a ramp (with an exponential decay, to make it smooth :) as the observer should like. Anyway not tested on other devices as a Sage). 

More infos are in the comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10305)
<!-- Reviewable:end -->
