### PR TITLE
Reader: do not apply line spacing out of range

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -69,9 +69,9 @@ function ReaderCoptListener:onReadSettings(config)
 end
 
 function ReaderCoptListener:onConfigChange(option_name, option_value)
-    -- font_size is historically and sadly shared by both mupdf and cre reader modules,
+    -- font_size and line_spacing are historically and sadly shared by both mupdf and cre reader modules,
     -- but fortunately they can be distinguished by their different ranges
-    if option_name == "font_size" and option_value < 5 then return end
+    if (option_name == "font_size" or option_name == "line_spacing") and option_value < 5 then return end
     self.document.configurable[option_name] = option_value
     self.ui:handleEvent(Event:new("StartActivityIndicator"))
     return true

--- a/frontend/apps/reader/modules/readerkoptlistener.lua
+++ b/frontend/apps/reader/modules/readerkoptlistener.lua
@@ -72,9 +72,9 @@ function ReaderKoptListener:onDocLangUpdate(lang)
 end
 
 function ReaderKoptListener:onConfigChange(option_name, option_value)
-    -- font_size is historically and sadly shared by both mupdf and cre reader modules,
+    -- font_size and line_spacing are historically and sadly shared by both mupdf and cre reader modules,
     -- but fortunately they can be distinguished by their different ranges
-    if option_name == "font_size" and option_value > 5 then return end
+    if (option_name == "font_size" or option_name == "line_spacing") and option_value > 5 then return end
     self.document.configurable[option_name] = option_value
     self.ui:handleEvent(Event:new("StartActivityIndicator"))
     UIManager:setDirty("all", "partial")

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -387,7 +387,7 @@ Note that your selected font size is not affected by this setting.]]),
                 more_options = true,
                 more_options_param = {
                   value_min = 50,
-                  value_max = 300,
+                  value_max = 200,
                   value_step = 1,
                   value_hold_step = 5,
                   unit = "%",


### PR DESCRIPTION
Continue of https://github.com/koreader/koreader/pull/10295, discussed at https://github.com/koreader/koreader/pull/10295#issuecomment-1495648088 and further.

cre limits:
https://github.com/koreader/koreader/blob/34c2dab54b479b7f11f898976476bb647497afc4/frontend/apps/reader/modules/readerfont.lua#L263-L264


pdf limits:
https://github.com/koreader/koreader/blob/34c2dab54b479b7f11f898976476bb647497afc4/defaults.lua#L84
https://github.com/koreader/koreader/blob/34c2dab54b479b7f11f898976476bb647497afc4/frontend/ui/data/koptoptions.lua#L366-L369

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10307)
<!-- Reviewable:end -->
