### PR TITLE
Don't use shellcheck on thirdparty scripts

### DIFF
--- a/kodev
+++ b/kodev
@@ -994,7 +994,7 @@ function kodev-check() {
     check_submodules
 
     # shellcheck disable=2016
-    mapfile -t shellscript_locations < <({ git -c submodule.recurse=0 grep -lE '^#!(/usr)?/bin/(env )?(bash|sh)' && git submodule --quiet foreach '[ "$path" = "base" -o "$path" = "platform/android/luajit-launcher" ] || git grep -lE "^#!(/usr)?/bin/(env )?(bash|sh)" | sed "s|^|$path/|"' && git ls-files ./*.sh; } | sort | uniq)
+    mapfile -t shellscript_locations < <({ git grep -lE '^#!(/usr)?/bin/(env )?(bash|sh)' | sed "/^plugins\/terminal.koplugin\/shfm$/d" && git submodule --quiet foreach '[ "$path" = "base" -o "$path" = "platform/android/luajit-launcher" ] || git grep -lE "^#!(/usr)?/bin/(env )?(bash|sh)" | sed "s|^|$path/|"' && git ls-files ./*.sh; } | sort | uniq)
 
     SHFMT_OPTIONS="-i 4 -ci"
 


### PR DESCRIPTION
Currently,  `./kodev check` spits out a lot of warnings on `shfm`. `shfm` is a third-party file.

This PR adds a method to skip certain files from being shellchecked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10344)
<!-- Reviewable:end -->
