### PR TITLE
CoverBrowser: fix getting cached info

### DIFF
--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -61,7 +61,7 @@ function CoverMenu:updateCache(file, status, do_create, pages)
         status = summary and summary.status
         local highlight = doc_settings:readSetting("highlight")
         local has_highlight = highlight and next(highlight) and true
-        self.cover_info_cache[file] = {pages, percent_finished, status, has_highlight}
+        self.cover_info_cache[file] = table.pack(pages, percent_finished, status, has_highlight) -- may be a sparse array
     else
         if self.cover_info_cache and self.cover_info_cache[file] then
             if status then

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -372,7 +372,10 @@ function ListMenuItem:update()
             if DocSettings:hasSidecarFile(self.filepath) then
                 self.been_opened = true
                 self.menu:updateCache(self.filepath, nil, true, pages) -- create new cache entry if absent
-                pages, percent_finished, status, has_highlight = unpack(self.menu.cover_info_cache[self.filepath])
+                pages            = self.menu.cover_info_cache[self.filepath][1]
+                percent_finished = self.menu.cover_info_cache[self.filepath][2]
+                status           = self.menu.cover_info_cache[self.filepath][3]
+                has_highlight    = self.menu.cover_info_cache[self.filepath][4]
             end
             -- right widget, first line
             local directory, filename = util.splitFilePathName(self.filepath) -- luacheck: no unused

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -372,10 +372,8 @@ function ListMenuItem:update()
             if DocSettings:hasSidecarFile(self.filepath) then
                 self.been_opened = true
                 self.menu:updateCache(self.filepath, nil, true, pages) -- create new cache entry if absent
-                pages            = self.menu.cover_info_cache[self.filepath][1]
-                percent_finished = self.menu.cover_info_cache[self.filepath][2]
-                status           = self.menu.cover_info_cache[self.filepath][3]
-                has_highlight    = self.menu.cover_info_cache[self.filepath][4]
+                pages, percent_finished, status, has_highlight =
+                    unpack(self.menu.cover_info_cache[self.filepath], 1, self.menu.cover_info_cache[self.filepath].n)
             end
             -- right widget, first line
             local directory, filename = util.splitFilePathName(self.filepath) -- luacheck: no unused

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -577,7 +577,8 @@ function MosaicMenuItem:update()
             if DocSettings:hasSidecarFile(self.filepath) then
                 self.been_opened = true
                 self.menu:updateCache(self.filepath, nil, true, bookinfo.pages) -- create new cache entry if absent
-                dummy, percent_finished, status = unpack(self.menu.cover_info_cache[self.filepath])
+                percent_finished = self.menu.cover_info_cache[self.filepath][2]
+                status           = self.menu.cover_info_cache[self.filepath][3]
             end
             self.percent_finished = percent_finished
             self.status = status

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -577,8 +577,8 @@ function MosaicMenuItem:update()
             if DocSettings:hasSidecarFile(self.filepath) then
                 self.been_opened = true
                 self.menu:updateCache(self.filepath, nil, true, bookinfo.pages) -- create new cache entry if absent
-                percent_finished = self.menu.cover_info_cache[self.filepath][2]
-                status           = self.menu.cover_info_cache[self.filepath][3]
+                dummy, percent_finished, status =
+                    unpack(self.menu.cover_info_cache[self.filepath], 1, self.menu.cover_info_cache[self.filepath].n)
             end
             self.percent_finished = percent_finished
             self.status = status


### PR DESCRIPTION
Some values of the cache array can be `nil`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10346)
<!-- Reviewable:end -->
