### PR TITLE
Kindle: toggle cover events

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -726,6 +726,7 @@ function KindlePaperWhite2:init()
         fl_intensity_file = "/sys/class/backlight/max77696-bl/brightness",
         batt_capacity_file = "/sys/devices/system/wario_battery/wario_battery0/battery_capacity",
         is_charging_file = "/sys/devices/system/wario_charger/wario_charger0/charging",
+        hall_file = "/sys/devices/system/wario_hall/wario_hall0/hall_enable",
     }
 
     Kindle.init(self)
@@ -740,6 +741,7 @@ function KindleBasic:init()
         device = self,
         batt_capacity_file = "/sys/devices/system/wario_battery/wario_battery0/battery_capacity",
         is_charging_file = "/sys/devices/system/wario_charger/wario_charger0/charging",
+        hall_file = "/sys/devices/system/wario_hall/wario_hall0/hall_enable",
     }
 
     Kindle.init(self)
@@ -755,6 +757,7 @@ function KindleVoyage:init()
         fl_intensity_file = "/sys/class/backlight/max77696-bl/brightness",
         batt_capacity_file = "/sys/devices/system/wario_battery/wario_battery0/battery_capacity",
         is_charging_file = "/sys/devices/system/wario_charger/wario_charger0/charging",
+        hall_file = "/sys/devices/system/wario_hall/wario_hall0/hall_enable",
     }
     self.input = require("device/input"):new{
         device = self,
@@ -814,6 +817,7 @@ function KindlePaperWhite3:init()
         fl_intensity_file = "/sys/class/backlight/max77696-bl/brightness",
         batt_capacity_file = "/sys/devices/system/wario_battery/wario_battery0/battery_capacity",
         is_charging_file = "/sys/devices/system/wario_charger/wario_charger0/charging",
+        hall_file = "/sys/devices/system/wario_hall/wario_hall0/hall_enable",
     }
 
     Kindle.init(self)
@@ -870,6 +874,7 @@ function KindleOasis:init()
         -- NOTE: Points to the embedded battery. The one in the cover is codenamed "soda".
         batt_capacity_file = "/sys/devices/system/wario_battery/wario_battery0/battery_capacity",
         is_charging_file = "/sys/devices/system/wario_charger/wario_charger0/charging",
+        hall_file = "/sys/devices/system/wario_hall/wario_hall0/hall_enable",
     }
 
     self.input = require("device/input"):new{
@@ -1130,6 +1135,7 @@ function KindleBasic2:init()
         batt_capacity_file = "/sys/class/power_supply/bd7181x_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd7181x_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd7181x_bat/status",
+        hall_file = "/sys/devices/system/heisenberg_hall/heisenberg_hall0/hall_enable",
     }
 
     Kindle.init(self)
@@ -1146,6 +1152,7 @@ function KindlePaperWhite4:init()
         batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd71827_bat/status",
+        hall_file = "/sys/bus/platform/drivers/hall_sensor/rex_hall/hall_enable",
     }
 
     Kindle.init(self)
@@ -1172,6 +1179,7 @@ function KindleBasic3:init()
         batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd71827_bat/status",
+        hall_file = "/sys/bus/platform/drivers/hall_sensor/rex_hall/hall_enable",
     }
 
     Kindle.init(self)
@@ -1193,6 +1201,7 @@ function KindlePaperWhite5:init()
         batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd71827_bat/status",
+        hall_file = "/sys/devices/platform/eink_hall/hall_enable",
     }
 
     -- Enable the so-called "fast" mode, so as to prevent the driver from silently promoting refreshes to REAGL.

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -1,6 +1,7 @@
 local BasePowerD = require("device/generic/powerd")
 local WakeupMgr = require("device/wakeupmgr")
 local logger = require("logger")
+local util = require("util")
 -- liblipclua, see require below
 
 local KindlePowerD = BasePowerD:new{
@@ -98,11 +99,12 @@ function KindlePowerD:setIntensityHW(intensity)
         -- NOTE: when intensity is 0, we want to *really* kill the light, so do it manually
         -- (asking lipc to set it to 0 would in fact set it to > 0 on ! canTurnFrontlightOff Kindles).
         -- We do *both* to make the fl restore on resume less jarring on devices where lipc 0 != off.
-        os.execute("printf '%s' ".. intensity .." > " .. self.fl_intensity_file)
+        util.writeToSysfs(intensity, self.fl_intensity_file)
 
         -- And in case there are two LED groups...
+        -- This should never happen as all warmth devices so far canTurnFrontlightOff
         if self.warmth_intensity_file then
-            os.execute("printf '%s' ".. intensity .." > " .. self.warmth_intensity_file)
+            util.writeToSysfs(intensity, self.warmth_intensity_file)
         end
     end
 end
@@ -159,6 +161,20 @@ function KindlePowerD:isChargedHW()
     end
 
     return false
+end
+
+function KindlePowerD:hasHallSensor()
+    return self.hall_file ~= nil
+end
+
+function KindlePowerD:isHallSensorEnabled()
+    local int = self:read_int_file(self.hall_file)
+    return int == 1
+end
+
+function KindlePowerD:onToggleHallSensor()
+    local stat = self:isHallSensorEnabled()
+    util.writeToSysfs(stat and 0 or 1, self.hall_file)
 end
 
 function KindlePowerD:_readFLIntensity()

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -241,7 +241,7 @@ if Device:isKindle() and PowerD:hasHallSensor() then
     common_settings.cover_events = {
         text = _("Disable Kindle cover events"),
         help_text = _([[Toggle the Hall effect sensor.
-This is used to detect if the cover is closed to auto sleep and wake the device. If there is no cover present the sensor may cause spurious wakeups when located next to a magnetic source.]]),
+This is used to detect if the cover is closed, which will automatically sleep and wake the device. If there is no cover present the sensor may cause spurious wakeups when located next to a magnetic source.]]),
         keep_menu_open = true,
         checked_func = function() return not PowerD:isHallSensorEnabled() end,
         callback = function() PowerD:onToggleHallSensor() end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -4,6 +4,7 @@ local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local Language = require("ui/language")
 local NetworkMgr = require("ui/network/manager")
+local PowerD = Device:getPowerDevice()
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 local N_ = _.ngettext
@@ -233,6 +234,17 @@ if Device:isKobo() then
             G_reader_settings:makeFalse("ignore_power_sleepcover")
             UIManager:askForRestart()
         end
+    }
+end
+
+if Device:isKindle() and PowerD:hasHallSensor() then
+    common_settings.cover_events = {
+        text = _("Disable Kindle cover events"),
+        help_text = _([[Toggle the Hall effect sensor.
+This is used to detect if the cover is closed to auto sleep and wake the device. If there is no cover present the sensor may cause spurious wakeups when located next to a magnetic source.]]),
+        keep_menu_open = true,
+        checked_func = function() return not PowerD:isHallSensorEnabled() end,
+        callback = function() PowerD:onToggleHallSensor() end,
     }
 end
 

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -58,6 +58,7 @@ local order = {
         "autoshutdown",
         "ignore_sleepcover",
         "ignore_open_sleepcover",
+        "cover_events",
         "ignore_battery_optimizations",
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -102,6 +102,7 @@ local order = {
         "autoshutdown",
         "ignore_sleepcover",
         "ignore_open_sleepcover",
+        "cover_events",
         "ignore_battery_optimizations",
         "mass_storage_settings", -- if Device:canToggleMassStorage()
         "file_ext_assoc",

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -5,9 +5,13 @@ This module contains miscellaneous helper functions for the KOReader frontend.
 local BaseUtil = require("ffi/util")
 local Utf8Proc = require("ffi/utf8proc")
 local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
 local _ = require("gettext")
 local C_ = _.pgettext
 local T = BaseUtil.template
+local ffi = require("ffi")
+local C = ffi.C
+require("ffi/posix_h")
 
 local lshift = bit.lshift
 local rshift = bit.rshift
@@ -827,6 +831,26 @@ function util.removeFile(file)
     else
         return nil, "file is nil"
     end
+end
+
+function util.writeToSysfs(val, file)
+    -- NOTE: We do things by hand via ffi, because io.write uses fwrite,
+    --       which isn't a great fit for procfs/sysfs (e.g., we lose failure cases like EBUSY,
+    --       as it only reports failures to write to the *stream*, not to the disk/file!).
+    local fd = C.open(file, bit.bor(C.O_WRONLY, C.O_CLOEXEC)) -- procfs/sysfs, we shouldn't need O_TRUNC
+    if fd == -1 then
+        logger.err("Cannot open file `" .. file .. "`:", ffi.string(C.strerror(ffi.errno())))
+        return
+    end
+    val = tostring(val)
+    local bytes = #val
+    local nw = C.write(fd, val, bytes)
+    if nw == -1 then
+        logger.err("Cannot write `" .. val .. "` to file `" .. file .. "`:", ffi.string(C.strerror(ffi.errno())))
+    end
+    C.close(fd)
+    -- NOTE: Allows the caller to possibly handle short writes (not that these should ever happen here).
+    return nw == bytes
 end
 
 -- Gets total, used and available bytes for the mountpoint that holds a given directory.

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -40,7 +40,6 @@ describe("device module", function()
     after_each(function()
         mock_input.open:revert()
         os.getenv:revert()
-        os.execute:revert()
 
         os.getenv = osgetenv
         io.open = iopen
@@ -278,8 +277,6 @@ describe("device module", function()
             assert.is.same(kindle_dev.powerd.fl_intensity, 5)
 
             kindle_dev.powerd:toggleFrontlight()
-            assert.stub(os.execute).was_called_with(
-                "printf '%s' 0 > /sys/class/backlight/max77696-bl/brightness")
             -- Here be shenanigans: we don't override powerd's fl_intensity when we turn the light off,
             -- so that we can properly turn it back on at the previous intensity ;)
             assert.is.same(kindle_dev.powerd.fl_intensity, 5)


### PR DESCRIPTION
~~used on kindle but can be extended to other devices~~

Allow disabling the hall efect sensor via the sysfs knob, so the kindle system wont sleep & wake the device

for those of use that stay in koreader, are caseless and get spurious wakeups

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10363)
<!-- Reviewable:end -->
