### PR TITLE
ConfirmBox: add widgets

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1136,15 +1136,16 @@ function ReaderBookmark:onSearchBookmark(bm_menu)
         parent = input_dialog,
     }
     input_dialog:addWidget(check_button_case)
+    local separator_width = input_dialog:getAddedWidgetAvailableWidth()
     separator = CenterContainer:new{
         dimen = Geom:new{
-            w = input_dialog._input_widget.width,
+            w = separator_width,
             h = 2 * Size.span.vertical_large,
         },
         LineWidget:new{
             background = Blitbuffer.COLOR_DARK_GRAY,
             dimen = Geom:new{
-                w = input_dialog._input_widget.width,
+                w = separator_width,
                 h = Size.line.medium,
             }
         },

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -38,8 +38,8 @@ local CheckButton = InputContainer:extend{
     background = Blitbuffer.COLOR_WHITE,
     text = nil,
     parent = nil, -- parent widget, must be set by the caller
-    width = nil, -- default value: parent widget's input widget width
-    -- If the parent widget has no input widget, the width must be set by the caller.
+    width = nil, -- default value: parent widget's added widgets available width
+    -- If the parent widget has no getAddedWidgetAvailableWidth() method, the width must be set by the caller.
 }
 
 function CheckButton:init()
@@ -70,7 +70,7 @@ function CheckButton:initCheckButton(checked)
     self._textwidget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = (self.width or self.parent._input_widget.width) - self._checkmark.dimen.w,
+        width = (self.width or self.parent:getAddedWidgetAvailableWidth()) - self._checkmark.dimen.w,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
     }
     local textbox_shift = math.max(0, self._checkmark.baseline - self._textwidget:getBaseline())

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -70,7 +70,7 @@ function CheckButton:initCheckButton(checked)
     self._textwidget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = (self.width or self.parent._input_widget.width) - self._checkmark.dimen.w,
+        width = (self.width or self.parent.added_widgets_width) - self._checkmark.dimen.w,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
     }
     local textbox_shift = math.max(0, self._checkmark.baseline - self._textwidget:getBaseline())

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -70,7 +70,7 @@ function CheckButton:initCheckButton(checked)
     self._textwidget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = (self.width or self.parent.added_widgets_width) - self._checkmark.dimen.w,
+        width = (self.width or self.parent._input_widget.width) - self._checkmark.dimen.w,
         fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
     }
     local textbox_shift = math.max(0, self._checkmark.baseline - self._textwidget:getBaseline())

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -77,15 +77,15 @@ function ConfirmBox:init()
         end
     end
 
-    -- Named so for consistency with other widgets that use addWidget()
-    self._input_widget = TextBoxWidget:new{
+    self.text_widget_width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 2/3)
+    local text_widget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 2/3),
+        width = self.text_widget_width,
     }
     self.text_group = VerticalGroup:new{
         align = "left",
-        self._input_widget,
+        text_widget,
     }
     if self._added_widgets then
         table.insert(self.text_group, VerticalSpan:new{ width = Size.padding.large })
@@ -173,9 +173,9 @@ function ConfirmBox:init()
     -- Reduce font size until widget fit screen height if needed
     local cur_size = frame:getSize()
     if cur_size and cur_size.h > 0.95 * Screen:getHeight() then
-        local orig_font = self._input_widget.face.orig_font
-        local orig_size = self._input_widget.face.orig_size
-        local real_size = self._input_widget.face.size
+        local orig_font = text_widget.face.orig_font
+        local orig_size = text_widget.face.orig_size
+        local real_size = text_widget.face.size
         if orig_size > 10 then -- don't go too small
             while true do
                 orig_size = orig_size - 1
@@ -213,6 +213,10 @@ function ConfirmBox:_preserveAddedWidgets()
     for i = 1, #self._added_widgets do
         table.remove(self.text_group)
     end
+end
+
+function ConfirmBox:getAddedWidgetAvailableWidth()
+    return self.text_widget_width
 end
 
 function ConfirmBox:onShow()

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -83,14 +83,14 @@ function ConfirmBox:init()
         face = self.face,
         width = self.added_widgets_width,
     }
-    local text_group = VerticalGroup:new{
+    self.text_group = VerticalGroup:new{
         align = "left",
         text_widget,
     }
     if self._added_widgets then
-        table.insert(text_group, VerticalSpan:new{ width = Size.padding.large })
+        table.insert(self.text_group, VerticalSpan:new{ width = Size.padding.large })
         for _, widget in ipairs(self._added_widgets) do
-            table.insert(text_group, widget)
+            table.insert(self.text_group, widget)
         end
     end
     local content = HorizontalGroup:new{
@@ -100,7 +100,7 @@ function ConfirmBox:init()
             alpha = true,
         },
         HorizontalSpan:new{ width = Size.span.horizontal_default },
-        text_group,
+        self.text_group,
     }
 
     local buttons = {{ -- single row
@@ -188,6 +188,9 @@ function ConfirmBox:init()
                 end
             end
             -- re-init this widget
+            if self._added_widgets then
+                self:_preserveAddedWidgets()
+            end
             self:free()
             self:init()
         end
@@ -195,12 +198,23 @@ function ConfirmBox:init()
 end
 
 function ConfirmBox:addWidget(widget)
-    if not self._added_widgets then
+    if self._added_widgets then
+        self:_preserveAddedWidgets()
+    else
         self._added_widgets = {}
     end
     table.insert(self._added_widgets, widget)
+    self:free()
     self:init()
 end
+
+function ConfirmBox:_preserveAddedWidgets()
+    -- remove added widgets to preserve their TextBoxWidget from being free'ed
+    for i = 1, #self._added_widgets do
+        table.remove(self.text_group)
+    end
+end
+
 
 function ConfirmBox:onShow()
     UIManager:setDirty(self, function()

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -77,15 +77,15 @@ function ConfirmBox:init()
         end
     end
 
-    self.added_widgets_width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 2/3)
-    local text_widget = TextBoxWidget:new{
+    -- Named so for consistency with other widgets that use addWidget()
+    self._input_widget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
-        width = self.added_widgets_width,
+        width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 2/3),
     }
     self.text_group = VerticalGroup:new{
         align = "left",
-        text_widget,
+        self._input_widget,
     }
     if self._added_widgets then
         table.insert(self.text_group, VerticalSpan:new{ width = Size.padding.large })
@@ -173,9 +173,9 @@ function ConfirmBox:init()
     -- Reduce font size until widget fit screen height if needed
     local cur_size = frame:getSize()
     if cur_size and cur_size.h > 0.95 * Screen:getHeight() then
-        local orig_font = text_widget.face.orig_font
-        local orig_size = text_widget.face.orig_size
-        local real_size = text_widget.face.size
+        local orig_font = self._input_widget.face.orig_font
+        local orig_size = self._input_widget.face.orig_size
+        local real_size = self._input_widget.face.size
         if orig_size > 10 then -- don't go too small
             while true do
                 orig_size = orig_size - 1

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -209,12 +209,11 @@ function ConfirmBox:addWidget(widget)
 end
 
 function ConfirmBox:_preserveAddedWidgets()
-    -- remove added widgets to preserve their TextBoxWidget from being free'ed
+    -- remove added widgets to preserve their subwidgets from being free'ed
     for i = 1, #self._added_widgets do
         table.remove(self.text_group)
     end
 end
-
 
 function ConfirmBox:onShow()
     UIManager:setDirty(self, function()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -469,6 +469,10 @@ function InputDialog:addWidget(widget, re_init)
     table.insert(self.vgroup, #self.vgroup-1, widget)
 end
 
+function InputDialog:getAddedWidgetAvailableWidth()
+    return self._input_widget.width
+end
+
 function InputDialog:onTap()
     if self.deny_keyboard_hiding then
         return

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -215,6 +215,7 @@ function InputDialog:init()
     else
         self.text_width = self.text_width or math.floor(self.width * 0.9)
     end
+    self.added_widgets_width = self.text_width
     if self.readonly then -- hide keyboard if we can't edit
         self.keyboard_hidden = true
     end

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -215,7 +215,6 @@ function InputDialog:init()
     else
         self.text_width = self.text_width or math.floor(self.width * 0.9)
     end
-    self.added_widgets_width = self.text_width
     if self.readonly then -- hide keyboard if we can't edit
         self.keyboard_hidden = true
     end

--- a/frontend/ui/widget/openwithdialog.lua
+++ b/frontend/ui/widget/openwithdialog.lua
@@ -43,7 +43,6 @@ function OpenWithDialog:init()
     }
     self.layout = {self.layout[#self.layout]} -- keep bottom buttons
     self:mergeLayoutInVertical(self.radio_button_table, #self.layout) -- before bottom buttons
-    self._input_widget = self.radio_button_table
 
     local vertical_span = VerticalSpan:new{
         width = Size.padding.large,


### PR DESCRIPTION
In the same way as InputDialog does.

1 widget added

<img width="300" alt="2" src="https://user-images.githubusercontent.com/62179190/234761918-d10794e0-43e4-482c-a2ad-aa7218ae5af6.png">

4 widgets added (line, span, 2 checkbuttons)

<img width="300" alt="3" src="https://user-images.githubusercontent.com/62179190/234761946-aa13fa94-077f-46d9-995b-8fbf44092d2f.png">

(Also minor code cleanup)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10364)
<!-- Reviewable:end -->
