### PR TITLE
[fix] Reintroduce "Start with" default to prevent nil string on startup

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -889,7 +889,7 @@ function FileManagerMenu:getStartWithMenuTable()
     end
     return {
         text_func = function()
-            local start_with = G_reader_settings:readSetting("start_with")
+            local start_with = G_reader_settings:readSetting("start_with") or "filemanager"
             for i, v in ipairs(start_withs) do
                 if v[2] == start_with then
                     return T(_("Start with: %1"), v[1])


### PR DESCRIPTION
Regression from #10198.

Fixes #10368.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10369)
<!-- Reviewable:end -->
