### PR TITLE
PageBrowser: show page number alongside thumbnails

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -21,6 +21,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
 local LanguageSupport = require("languagesupport")
+local Notification = require("ui/widget/notification")
 local PluginLoader = require("pluginloader")
 local ReaderActivityIndicator = require("apps/reader/modules/readeractivityindicator")
 local ReaderBack = require("apps/reader/modules/readerback")
@@ -742,8 +743,12 @@ function ReaderUI:saveSettings()
     G_reader_settings:flush()
 end
 
-function ReaderUI:onFlushSettings()
+function ReaderUI:onFlushSettings(show_notification)
     self:saveSettings()
+    if show_notification then
+        -- Invoked from dispatcher to explicitely flush settings
+        Notification:notify(_("Book metadata saved."))
+    end
 end
 
 function ReaderUI:closeDocument()

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -144,7 +144,8 @@ local settingsList = {
     swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page turn buttons"), reader=true, condition=Device:hasKeys(), separator=true},
     set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args_func=ReaderHighlight.getHighlightActions, reader=true},
     cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
-    cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true},
+    cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true, separator=true},
+    flush_settings = {category="none", event="FlushSettings", arg=true, title=_("Save book metadata"), reader=true, separator=true},
     page_jmp = {category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Turn pages"), reader=true},
     panel_zoom_toggle = {category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), paging=true, separator=true},
 
@@ -347,6 +348,7 @@ local dispatcher_menu_order = {
     "set_highlight_action",
     "cycle_highlight_action",
     "cycle_highlight_style",
+    "flush_settings",
     "panel_zoom_toggle",
 
     "visible_pages",

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -304,6 +304,7 @@ function BookMapRow:init()
     self.indicators = {}
     self.bottom_texts = {}
     local prev_page_was_read = true -- avoid one at start of row
+    local extended_marker_h = math.ceil(self.span_height * 0.3)
     local unread_marker_h = math.ceil(self.span_height * 0.05)
     local read_min_h = math.max(math.ceil(self.span_height * 0.1), unread_marker_h+Size.line.thick)
     if self.page_slot_width >= 5 * unread_marker_h then
@@ -358,6 +359,35 @@ function BookMapRow:init()
                 })
             end
             prev_page_was_read = false
+        end
+        -- Extended separators below the baseline if requested (by PageBrowser
+        -- to show the start of thumbnail rows)
+        if self.extended_sep_pages and self.extended_sep_pages[page] then
+            local w = Size.line.thin
+            local x
+            if _mirroredUI then
+                x = self:getPageX(page, true) - w
+            else
+                x = self:getPageX(page)
+            end
+            local y = self.pages_frame_height - self.pages_frame_border
+            table.insert(self.pages_markers, {
+                x = x, y = y,
+                w = w, h = extended_marker_h,
+                color = Blitbuffer.COLOR_BLACK,
+            })
+        end
+        -- Add a little spike below the baseline above each page number displayed, so we
+        -- can more easily associate the (possibly wider) page number to its page slot.
+        if self.page_texts and self.page_texts[page] then
+            local w = Screen:scaleBySize(2)
+            local x = math.floor((self:getPageX(page) + self:getPageX(page, true) + 0.5)/2 - w/2)
+            local y = self.pages_frame_height - self.pages_frame_border + 2
+            table.insert(self.pages_markers, {
+                x = x, y = y,
+                w = w, h = math.ceil(w*1.5),
+                color = Blitbuffer.COLOR_BLACK,
+            })
         end
         -- Indicator for bookmark/highlight type, and current page
         if self.bookmarked_pages[page] then


### PR DESCRIPTION
#### Dispatcher: add "Save book metadata"

Closes #10277.
Note: in dispatcher.lua, the action definitions (with separators) and the ordering are in 2 different lists, and their ordering is different, which makes it tedious to properly update and figuring out where to insert/update separators.

#### PageBrowser: show page number alongside thumbnails

Add a top left menu item -/+ to show none, only on the first thumbnail of a row, or on all thumbnails.
Also make the page slot separator longer in the bottom ribbon before pages that start a thumbnails row.
Also show a little spike in the bottom ribbon below page slots that get their page number displayed, to ease figuring out the connection.
Discussed all along #10320. Closes #10320.

![image](https://user-images.githubusercontent.com/24273478/235301630-f7767229-229e-4d0c-ba25-43d5ba5ac393.png)

![image](https://user-images.githubusercontent.com/24273478/235301766-12bae61a-8809-476d-b855-2af9ef09a926.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10370)
<!-- Reviewable:end -->
