### PR TITLE
Exporter: correct access to doc settings

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -2,7 +2,6 @@ local DocumentRegistry = require("document/documentregistry")
 local DocSettings = require("docsettings")
 local ffiutil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
-local logger = require("logger")
 local md5 = require("ffi/sha2").md5
 local util = require("util")
 local _ = require("gettext")

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -1,7 +1,6 @@
 local DocumentRegistry = require("document/documentregistry")
 local DocSettings = require("docsettings")
 local ffiutil = require("ffi/util")
-local lfs = require("libs/libkoreader-lfs")
 local md5 = require("ffi/sha2").md5
 local util = require("util")
 local _ = require("gettext")

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -1,4 +1,3 @@
-local DataStorage = require("datastorage")
 local DocumentRegistry = require("document/documentregistry")
 local DocSettings = require("docsettings")
 local ffiutil = require("ffi/util")
@@ -303,52 +302,29 @@ function MyClipping:parseHighlight(highlights, bookmarks, book)
     end
 end
 
-function MyClipping:parseHistoryFile(clippings, history_file, doc_file)
-    if lfs.attributes(history_file, "mode") ~= "file"
-    or not history_file:find(".+%.lua$") then
-        return
-    end
-    if lfs.attributes(doc_file, "mode") ~= "file" then return end
-    local ok, stored = pcall(dofile, history_file)
-    if ok then
-        if not stored then
-            logger.warn("An empty history file ",
-                        history_file,
-                        "has been found. The book associated is ",
-                        doc_file)
-            return
-        elseif not stored.highlight then
-            return
-        end
-        local _, docname = util.splitFilePathName(doc_file)
-        local parsed_title, parsed_author = self:parseTitleFromPath(util.splitFileNameSuffix(docname), doc_file)
-        clippings[parsed_title] = {
-            file = doc_file,
-            title = stored.stats.title or parsed_title,
-            author = stored.stats.authors or parsed_author,
-        }
-        self:parseHighlight(stored.highlight, stored.bookmarks, clippings[parsed_title])
-    end
+function MyClipping:getClippingsFromBook(clippings, doc_path)
+    local doc_settings = DocSettings:open(doc_path)
+    local highlights = doc_settings:readSetting("highlight")
+    if not highlights then return end
+    local bookmarks = doc_settings:readSetting("bookmarks")
+    local stats = doc_settings:readSetting("stats")
+    local title = stats and stats.title
+    local author = stats and stats.authors
+    local _, doc_name = util.splitFilePathName(doc_path)
+    local parsed_title, parsed_author = self:parseTitleFromPath(util.splitFileNameSuffix(doc_name))
+    clippings[parsed_title] = {
+        file = doc_path,
+        title = title or parsed_title,
+        author = author or parsed_author,
+    }
+    self:parseHighlight(highlights, bookmarks, clippings[parsed_title])
 end
 
 function MyClipping:parseHistory()
     local clippings = {}
-    local history_dir = DataStorage:getHistoryDir()
-    if lfs.attributes(history_dir, "mode") == "directory" then
-        for f in lfs.dir(history_dir) do
-            local legacy_history_file = ffiutil.joinPath(history_dir, f)
-            if lfs.attributes(legacy_history_file, "mode") == "file" then
-                local doc_file = DocSettings:getFileFromHistory(f)
-                if doc_file then
-                    self:parseHistoryFile(clippings, legacy_history_file, doc_file)
-                end
-            end
-        end
-    end
     for _, item in ipairs(require("readhistory").hist) do
-        if not item.dim then
-            self:parseHistoryFile(clippings, DocSettings:getSidecarFile(item.file, "doc"), item.file)
-            self:parseHistoryFile(clippings, DocSettings:getSidecarFile(item.file, "dir"), item.file)
+        if not item.dim and DocSettings:hasSidecarFile(item.file) then
+            self:getClippingsFromBook(clippings, item.file)
         end
     end
     return clippings


### PR DESCRIPTION
Also avoid double-reading the legacy history (`readhistory` takes care of it).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10407)
<!-- Reviewable:end -->
