### PR TITLE
Android: improve kodev run

### DIFF
--- a/kodev
+++ b/kodev
@@ -110,8 +110,6 @@ function setup_env() {
     SETUP_ENV_GREP_COMMAND="grep -z -v debug"
     if [ -n "${KODEBUG}" ]; then
         SETUP_ENV_GREP_COMMAND="grep -z debug"
-        # for android adb install
-        KODEBUG_SUFFIX=-debug
     fi
     local files=()
     while IFS= read -r -d $'\0'; do
@@ -811,16 +809,18 @@ TARGET:
                     kodev-release --ignore-translation android
                     assert_ret_zero $?
                 fi
-                setup_env
+                if [ -n "${KODEBUG}" ]; then
+                    KODEBUG_SUFFIX=-debug
+                fi
                 # clear logcat to get rid of useless cruft
                 adb logcat -c
                 # uninstall existing package to make sure *everything* is gone from memory
                 # no assert_ret_zero; uninstall is allowed to fail if there's nothing to uninstall
-                adb uninstall "org.koreader.launcher"
+                adb uninstall "org.koreader.launcher${KODEBUG_SUFFIX/-/.}"
                 adb install "koreader-android-${ANDROID_ARCH}${KODEBUG_SUFFIX}-${VERSION}.apk"
                 assert_ret_zero $?
                 # there's no adb run so we do this…
-                adb shell monkey -p org.koreader.launcher -c android.intent.category.LAUNCHER 1
+                adb shell monkey -p org.koreader.launcher${KODEBUG_SUFFIX/-/.} -c android.intent.category.LAUNCHER 1
                 assert_ret_zero $?
                 adb logcat KOReader:V luajit-launcher:V "*:E"
             } || echo "Failed to find adb in PATH to interact with Android device."


### PR DESCRIPTION
launch & unistall the correct version

do not rely on setup_env

When paired with wireless debugging, this makes android debugging not such a pain.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10418)
<!-- Reviewable:end -->
