### PR TITLE
NaturalLightWidget: Fallback to previous values instead of `nil` if InputText is empty

### DIFF
--- a/frontend/ui/widget/naturallightwidget.lua
+++ b/frontend/ui/widget/naturallightwidget.lua
@@ -115,6 +115,13 @@ function NaturalLightWidget:adaptableNumber(initial, step)
     table.insert(minus_number_plus, button_minus)
     table.insert(minus_number_plus, input_text)
     table.insert(minus_number_plus, button_plus)
+
+    -- Sanitize the returned value so as not to upset sysfs_light...
+    function input_text:getText()
+        -- Also, while we're here, make sure we actually return a number, because InputText doesn't for... reasons.
+        return tonumber(self.text) or initial
+    end
+
     return minus_number_plus
 end
 


### PR DESCRIPTION
The backend code makes rather strong assumptions that it'll *always* get a number of of it ;).

Fix #10352

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10425)
<!-- Reviewable:end -->
