### PR TITLE
PM: Minor refactor to suspend/resume code flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ else
 	cp -f $(KOR_BASE)/ev_replay.py $(INSTALL_DIR)/koreader/
 	@echo "[*] create symlink instead of copying files in development mode"
 	cd $(INSTALL_DIR)/koreader && \
-		bash -O extglob -c "ln -sf ../../$(KOR_BASE)/$(OUTPUT_DIR)/!(cache) ."
+		bash -O extglob -c "ln -sf ../../$(KOR_BASE)/$(OUTPUT_DIR)/!(cache|history) ."
 	@echo "[*] install front spec only for the emulator"
 	cd $(INSTALL_DIR)/koreader/spec && test -e front || \
 		ln -sf ../../../../spec ./front

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -540,7 +540,6 @@ end
 
 function Device:install()
     local ConfirmBox = require("ui/widget/confirmbox")
-    local Event = require("ui/event")
     UIManager:show(ConfirmBox:new{
         text = _("Update is ready. Install it now?"),
         ok_text = _("Install"),

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -1,4 +1,6 @@
 local BasePowerD = require("device/generic/powerd")
+local Event = require("ui/event")
+local UIManager
 local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
@@ -8,9 +10,7 @@ local AndroidPowerD = BasePowerD:new{
 
 -- Let the footer know of the change
 local function broadcastLightChanges()
-    if package.loaded["ui/uimanager"] ~= nil then
-        local Event = require("ui/event")
-        local UIManager = require("ui/uimanager")
+    if UIManager then
         UIManager:broadcastEvent(Event:new("FrontlightStateChanged"))
     end
 end
@@ -81,6 +81,10 @@ function AndroidPowerD:turnOnFrontlightHW()
 
     self.is_fl_on = true
     broadcastLightChanges()
+end
+
+function AndroidPowerD:UIManagerReadyHW(uimgr)
+    UIManager = uimgr
 end
 
 return AndroidPowerD

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -250,7 +250,7 @@ function Cervantes:setEventHandlers(UIManager)
         -- NOTE: Plug/unplug events will wake the device up, which is why we put it back to sleep.
         if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
-        else
+        elseif not self.screen_saver_lock then
             -- Potentially start an USBMS session
             local MassStorage = require("ui/elements/mass_storage")
             MassStorage:start()
@@ -262,7 +262,7 @@ function Cervantes:setEventHandlers(UIManager)
         self:_afterNotCharging()
         if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
-        else
+        elseif not self.screen_saver_lock then
             -- Potentially dismiss the USBMS ConfirmBox
             local MassStorage = require("ui/elements/mass_storage")
             MassStorage:dismiss()

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -232,7 +232,7 @@ function Cervantes:setEventHandlers(UIManager)
     UIManager.event_handlers.Charging = function()
         self:_beforeCharging()
         -- NOTE: Plug/unplug events will wake the device up, which is why we put it back to sleep.
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
            UIManager.event_handlers.Suspend()
         end
     end
@@ -240,7 +240,7 @@ function Cervantes:setEventHandlers(UIManager)
         -- We need to put the device into suspension, other things need to be done before it.
         self:usbPlugOut()
         self:_afterNotCharging()
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
            UIManager.event_handlers.Suspend()
         end
     end
@@ -248,7 +248,7 @@ function Cervantes:setEventHandlers(UIManager)
     UIManager.event_handlers.UsbPlugIn = function()
         self:_beforeCharging()
         -- NOTE: Plug/unplug events will wake the device up, which is why we put it back to sleep.
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
         else
             -- Potentially start an USBMS session
@@ -260,7 +260,7 @@ function Cervantes:setEventHandlers(UIManager)
         -- We need to put the device into suspension, other things need to be done before it.
         self:usbPlugOut()
         self:_afterNotCharging()
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
         else
             -- Potentially dismiss the USBMS ConfirmBox

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -200,16 +200,10 @@ function Cervantes:setEventHandlers(UIManager)
     -- suspend. So let's unschedule it when suspending, and restart it after
     -- resume. Done via the plugin's onSuspend/onResume handlers.
     UIManager.event_handlers.Suspend = function()
-        self:_beforeSuspend()
         self:onPowerEvent("Suspend")
     end
     UIManager.event_handlers.Resume = function()
-        -- MONOTONIC doesn't tick during suspend,
-        -- invalidate the last battery capacity pull time so that we get up to date data immediately.
-        self:getPowerDevice():invalidateCapacityCache()
-
         self:onPowerEvent("Resume")
-        self:_afterResume()
     end
     UIManager.event_handlers.PowerPress = function()
         -- Always schedule power off.
@@ -222,10 +216,7 @@ function Cervantes:setEventHandlers(UIManager)
             -- resume if we were suspended
             if self.screen_saver_mode then
                 if self.screen_saver_lock then
-                    logger.dbg("Pressed power while awake in screen saver mode, going back to suspend...")
-                    self:_beforeSuspend()
-                    self.powerd:beforeSuspend() -- this won't be run by onPowerEvent because we're in screen_saver_mode
-                    self:onPowerEvent("Suspend")
+                    UIManager.event_handlers.Suspend()
                 else
                     UIManager.event_handlers.Resume()
                 end

--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -143,7 +143,7 @@ end
 
 function CervantesPowerD:afterResume()
     if self.fl then
-        -- just re-set it to self.hw_intensity that we haven't change on Suspend
+        -- just re-set it to self.hw_intensity that we haven't changed on Suspend
         if not self.device:hasNaturalLight() then
             self.fl:setBrightness(self.hw_intensity)
         else
@@ -151,8 +151,6 @@ function CervantesPowerD:afterResume()
         end
     end
 
-    -- MONOTONIC doesn't tick during suspend,
-    -- invalidate the last battery capacity pull time so that we get up to date data immediately.
     self:invalidateCapacityCache()
 
     -- Restore user input and emit the Resume event.

--- a/frontend/device/cervantes/powerd.lua
+++ b/frontend/device/cervantes/powerd.lua
@@ -132,19 +132,31 @@ function CervantesPowerD:isChargingHW()
 end
 
 function CervantesPowerD:beforeSuspend()
-    if self.fl == nil then return end
-    -- just turn off frontlight without remembering its state
-    self.fl:setBrightness(0)
+    -- Inhibit user input and emit the Suspend event.
+    self.device:_beforeSuspend()
+
+    if self.fl then
+        -- just turn off frontlight without remembering its state
+        self.fl:setBrightness(0)
+    end
 end
 
 function CervantesPowerD:afterResume()
-    if self.fl == nil then return end
-    -- just re-set it to self.hw_intensity that we haven't change on Suspend
-    if not self.device:hasNaturalLight() then
-        self.fl:setBrightness(self.hw_intensity)
-    else
-        self.fl:setNaturalBrightness(self.hw_intensity, self.fl_warmth)
+    if self.fl then
+        -- just re-set it to self.hw_intensity that we haven't change on Suspend
+        if not self.device:hasNaturalLight() then
+            self.fl:setBrightness(self.hw_intensity)
+        else
+            self.fl:setNaturalBrightness(self.hw_intensity, self.fl_warmth)
+        end
     end
+
+    -- MONOTONIC doesn't tick during suspend,
+    -- invalidate the last battery capacity pull time so that we get up to date data immediately.
+    self:invalidateCapacityCache()
+
+    -- Restore user input and emit the Resume event.
+    self.device:_afterResume()
 end
 
 return CervantesPowerD

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -259,6 +259,8 @@ function Device:getPowerDevice()
 end
 
 function Device:rescheduleSuspend()
+    logger.warn("!! Device:rescheduleSuspend !!")
+    print(debug.traceback())
     local UIManager = require("ui/uimanager")
     UIManager:unschedule(self.suspend)
     UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend, self)
@@ -266,6 +268,11 @@ end
 
 -- Only used on platforms where we handle suspend ourselves.
 function Device:onPowerEvent(ev)
+    logger.warn("** Device:onPowerEvent **", ev)
+    logger.dbg("self.screen_saver_mode", self.screen_saver_mode)
+    logger.dbg("self.screen_saver_lock", self.screen_saver_lock)
+    logger.dbg("self.is_cover_closed", self.is_cover_closed)
+    print(debug.traceback())
     local Screensaver = require("ui/screensaver")
     if self.screen_saver_mode then
         if ev == "Power" or ev == "Resume" then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -7,7 +7,7 @@ This module defines stubs for common methods.
 local DataStorage = require("datastorage")
 local Event = require("ui/event")
 local Geom = require("ui/geometry")
-local UIManager -- will be updated when available
+local UIManager -- Updated on UIManager init
 local logger = require("logger")
 local ffi = require("ffi")
 local time = require("ui/time")

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -962,7 +962,6 @@ function Device:UIManagerReady(uimgr) end
 
 -- Set device event handlers common to all devices
 function Device:_setEventHandlers(uimgr)
-    print("Device:_setEventHandlers", uimgr)
     if self:canReboot() then
         UIManager.event_handlers.Reboot = function(message_text)
             local ConfirmBox = require("ui/widget/confirmbox")
@@ -1017,18 +1016,11 @@ function Device:_setEventHandlers(uimgr)
     end
 
     -- Let implementations expand on that
-    print("Calling setEventHandlers")
-    print("self", self)
-    print("Device", Device)
-    print("package.loaded.device", package.loaded.device)
-    print("require('device')", require("device"))
-    print("package.loaded['device/generic/device']", package.loaded['device/generic/device'])
     self:setEventHandlers(uimgr)
 end
 
 -- Devices can add additional event handlers by overwriting this method.
 function Device:setEventHandlers(uimgr)
-    print("Device:setEventHandlers", uimgr)
     -- These will be most probably overwritten in the device specific `setEventHandlers`
     UIManager.event_handlers.Suspend = function()
         self.powerd:beforeSuspend()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -940,7 +940,7 @@ function Device:untar(archive, extract_to, with_stripped_root)
     return os.execute(cmd:format(archive, extract_to))
 end
 
--- Update our UIManager reference once its ready
+-- Update our UIManager reference once it's ready
 function Device:_UIManagerReady(uimgr)
     -- Our own ref
     UIManager = uimgr
@@ -1019,9 +1019,9 @@ function Device:_setEventHandlers(uimgr)
     self:setEventHandlers(uimgr)
 end
 
--- Devices can add additional event handlers by overwriting this method.
+-- Devices can add additional event handlers by implementing this method.
 function Device:setEventHandlers(uimgr)
-    -- These will be most probably overwritten in the device specific `setEventHandlers`
+    -- These will most probably be overwritten by device-specific `setEventHandlers` implementations
     UIManager.event_handlers.Suspend = function()
         self.powerd:beforeSuspend()
     end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -1009,10 +1009,10 @@ end
 function Device:setEventHandlers(UIManager)
     -- These will be most probably overwritten in the device specific `setEventHandlers`
     UIManager.event_handlers.Suspend = function()
-        self.device:beforeSuspend()
+        self.powerd:beforeSuspend()
     end
     UIManager.event_handlers.Resume = function()
-        self.device:afterResume()
+        self.powerd:afterResume()
     end
 end
 

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -261,19 +261,12 @@ function Device:getPowerDevice()
 end
 
 function Device:rescheduleSuspend()
-    logger.warn("!! Device:rescheduleSuspend !!")
-    print(debug.traceback())
     UIManager:unschedule(self.suspend)
     UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend, self)
 end
 
 -- Only used on platforms where we handle suspend ourselves.
 function Device:onPowerEvent(ev)
-    logger.warn("** Device:onPowerEvent **", ev)
-    logger.dbg("self.screen_saver_mode", self.screen_saver_mode)
-    logger.dbg("self.screen_saver_lock", self.screen_saver_lock)
-    logger.dbg("self.is_cover_closed", self.is_cover_closed)
-    print(debug.traceback())
     local Screensaver = require("ui/screensaver")
     if self.screen_saver_mode then
         if ev == "Power" or ev == "Resume" then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -299,9 +299,9 @@ function Device:onPowerEvent(ev)
                 self.powerd:afterResume()
             end
         elseif ev == "Suspend" then
-            -- Already in screen saver mode, no need to update UI/state before
-            -- suspending the hardware. This usually happens when sleep cover
-            -- is closed after the device was sent to suspend state.
+            -- Already in screen saver mode, no need to update the UI (and state, usually) before suspending again.
+            -- This usually happens when the sleep cover is closed on an already sleeping device,
+            -- (e.g., it was previously suspended via the Power button).
             if self.screen_saver_lock then
                 -- This can only happen when some sort of screensaver_delay is set,
                 -- and the user presses the Power button *after* already having woken up the device.

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -997,10 +997,10 @@ end
 function Device:setEventHandlers(UIManager)
     -- These will be most probably overwritten in the device specific `setEventHandlers`
     UIManager.event_handlers.Suspend = function()
-        self:_beforeSuspend(false)
+        self.device:beforeSuspend()
     end
     UIManager.event_handlers.Resume = function()
-        self:_afterResume(false)
+        self.device:afterResume()
     end
 end
 

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -301,7 +301,18 @@ function Device:onPowerEvent(ev)
             -- Already in screen saver mode, no need to update UI/state before
             -- suspending the hardware. This usually happens when sleep cover
             -- is closed after the device was sent to suspend state.
-            logger.dbg("Already in screen saver mode, going back to suspend...")
+            if self.screen_saver_lock then
+                -- This can only happen when some sort of screensaver_delay is set,
+                -- and the user presses the Power button *after* already having woken up the device.
+                -- In this case, we want to go back to suspend *without* affecting the screensaver,
+                -- so we simply mimic our own behavior when *not* in screen_saver_mode ;).
+                logger.dbg("Pressed power while awake in screen saver mode, going back to suspend...")
+                -- Basically, this is the only difference.
+                -- We need it because we're actually in a sane post-Resume event state right now.
+                self.powerd:beforeSuspend()
+            else
+                logger.dbg("Already in screen saver mode, going back to suspend...")
+            end
             -- Much like the real suspend codepath below, in case we got here via screen_saver_lock,
             -- make sure we murder WiFi again (because restore WiFi on resume could have kicked in).
             if self:hasWifiToggle() then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -277,7 +277,8 @@ function Device:onPowerEvent(ev)
     if self.screen_saver_mode then
         if ev == "Power" or ev == "Resume" then
             if self.is_cover_closed then
-                -- don't let power key press wake up device when the cover is in closed state.
+                -- Don't let power key press wake up device when the cover is in closed state.
+                logger.dbg("Pressed power while asleep in screen saver mode with a closed sleepcover, going back to suspend...")
                 self:rescheduleSuspend()
             else
                 logger.dbg("Resuming...")

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -7,7 +7,7 @@ This module defines stubs for common methods.
 local DataStorage = require("datastorage")
 local Event = require("ui/event")
 local Geom = require("ui/geometry")
-local UIManager = nil -- will be updated when available
+local UIManager -- will be updated when available
 local logger = require("logger")
 local ffi = require("ffi")
 local time = require("ui/time")

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -962,6 +962,7 @@ function Device:UIManagerReady(uimgr) end
 
 -- Set device event handlers common to all devices
 function Device:_setEventHandlers(uimgr)
+    print("Device:_setEventHandlers", uimgr)
     if self:canReboot() then
         UIManager.event_handlers.Reboot = function(message_text)
             local ConfirmBox = require("ui/widget/confirmbox")
@@ -1016,11 +1017,18 @@ function Device:_setEventHandlers(uimgr)
     end
 
     -- Let implementations expand on that
+    print("Calling setEventHandlers")
+    print("self", self)
+    print("Device", Device)
+    print("package.loaded.device", package.loaded.device)
+    print("require('device')", require("device"))
+    print("package.loaded['device/generic/device']", package.loaded['device/generic/device'])
     self:setEventHandlers(uimgr)
 end
 
 -- Devices can add additional event handlers by overwriting this method.
 function Device:setEventHandlers(uimgr)
+    print("Device:setEventHandlers", uimgr)
     -- These will be most probably overwritten in the device specific `setEventHandlers`
     UIManager.event_handlers.Suspend = function()
         self.powerd:beforeSuspend()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -950,6 +950,9 @@ function Device:_UIManagerReady(uimgr)
     -- Forward that to PowerD
     self.powerd:UIManagerReady(uimgr)
 
+    -- And to Input
+    self.input:UIManagerReady(uimgr)
+
     -- Setup PM event handlers
     -- NOTE: We keep forwarding the uimgr reference because some implementations don't actually have a module-local UIManager ref to update
     self:_setEventHandlers(uimgr)

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,6 +1,6 @@
 local Event = require("ui/event")
 local Math = require("optmath")
-local UIManager = nil -- will be updated when available
+local UIManager -- will be updated when available
 local logger = require("logger")
 local time = require("ui/time")
 local BasePowerD = {

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -77,7 +77,7 @@ function BasePowerD:afterResume()
     self.device:_afterResume(false)
 end
 
--- Update our UIManager reference once its ready
+-- Update our UIManager reference once it's ready
 function BasePowerD:UIManagerReady(uimgr)
     -- Our own ref
     UIManager = uimgr

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -69,7 +69,13 @@ function BasePowerD:beforeSuspend() self.device:_beforeSuspend(false) end
 -- Anything that needs to be done after doing a real hardware resume.
 -- (Such as restoring front light state).
 -- Do *not* omit calling Device's _afterResume method!
-function BasePowerD:afterResume() self.device:_afterResume(false) end
+function BasePowerD:afterResume()
+    -- MONOTONIC doesn't tick during suspend,
+    -- invalidate the last battery capacity pull time so that we get up to date data immediately.
+    self:invalidateCapacityCache()
+
+    self.device:_afterResume(false)
+end
 
 -- Update our UIManager reference once its ready
 function BasePowerD:UIManagerReady(uimgr)

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -69,10 +69,12 @@ function BasePowerD:frontlightWarmthHW() return 0 end
 function BasePowerD:readyUIHW(uimgr) end
 -- Anything that needs to be done before doing a real hardware suspend.
 -- (Such as turning the front light off).
-function BasePowerD:beforeSuspend() end
+-- Do *not* omit calling Device's _beforeSuspend method! This default implementation passes `false` so as *not* to disable input events during PM.
+function BasePowerD:beforeSuspend() self.device:_beforeSuspend(false) end
 -- Anything that needs to be done after doing a real hardware resume.
--- (Such as restoring front light state. Do *not* omit calling Device's _afterResume method!).
-function BasePowerD:afterResume() self.device:_afterResume() end
+-- (Such as restoring front light state).
+-- Do *not* omit calling Device's _afterResume method!
+function BasePowerD:afterResume() self.device:_afterResume(false) end
 
 function BasePowerD:isFrontlightOn()
     return self.is_fl_on

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -71,8 +71,8 @@ function BasePowerD:readyUIHW(uimgr) end
 -- (Such as turning the front light off).
 function BasePowerD:beforeSuspend() end
 -- Anything that needs to be done after doing a real hardware resume.
--- (Such as restoring front light state).
-function BasePowerD:afterResume() end
+-- (Such as restoring front light state. Do *not* omit calling Device's _afterResume method!).
+function BasePowerD:afterResume() self.device:_afterResume() end
 
 function BasePowerD:isFrontlightOn()
     return self.is_fl_on

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,6 +1,6 @@
 local Event = require("ui/event")
 local Math = require("optmath")
-local UIManager -- will be updated when available
+local UIManager
 local logger = require("logger")
 local time = require("ui/time")
 local BasePowerD = {

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -7,7 +7,7 @@ local DEBUG = require("dbg")
 local Event = require("ui/event")
 local GestureDetector = require("device/gesturedetector")
 local Key = require("device/key")
-local UIManager = nil -- will be updated when available
+local UIManager -- will be updated when available
 local framebuffer = require("ffi/framebuffer")
 local input = require("ffi/input")
 local logger = require("logger")

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -7,7 +7,7 @@ local DEBUG = require("dbg")
 local Event = require("ui/event")
 local GestureDetector = require("device/gesturedetector")
 local Key = require("device/key")
-local UIManager -- will be updated when available
+local UIManager
 local framebuffer = require("ffi/framebuffer")
 local input = require("ffi/input")
 local logger = require("logger")

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1,4 +1,5 @@
 local Generic = require("device/generic/device")
+local UIManager -- will be updated when available
 local time = require("ui/time")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
@@ -177,7 +178,6 @@ function Kindle:initNetworkManager(NetworkMgr)
         kindleEnableWifi(0)
         -- NOTE: Same here, except disconnect is simpler, so a dumb delay will do...
         if complete_callback then
-            local UIManager = require("ui/uimanager")
             UIManager:scheduleIn(2, complete_callback)
         end
     end
@@ -301,7 +301,6 @@ function Kindle:outofScreenSaver()
         if self:supportsScreensaver() then
             local Screensaver = require("ui/screensaver")
             local widget_was_closed = Screensaver:close()
-            local UIManager = require("ui/uimanager")
             if widget_was_closed then
                 -- And redraw everything in case the framework managed to screw us over...
                 UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
@@ -339,7 +338,6 @@ function Kindle:outofScreenSaver()
             elseif os.getenv("CVM_STOPPED") == "yes" then
                 os.execute("killall -STOP cvm")
             end
-            local UIManager = require("ui/uimanager")
             -- NOTE: We redraw after a slightly longer delay to take care of the potentially dynamic ad screen...
             --       This is obviously brittle as all hell. Tested on a slow-ass PW1.
             UIManager:scheduleIn(3, function() UIManager:setDirty("all", "full") end)
@@ -371,7 +369,11 @@ function Kindle:untar(archive, extract_to)
     return os.execute(("./tar --no-same-permissions --no-same-owner -xf %q -C %q"):format(archive, extract_to))
 end
 
-function Kindle:setEventHandlers(UIManager)
+function Kindle:UIManagerReady(uimgr)
+    UIManager = uimgr
+end
+
+function Kindle:setEventHandlers(uimgr)
     UIManager.event_handlers.Suspend = function()
         self.powerd:toggleSuspend()
     end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -291,8 +291,9 @@ function Kindle:intoScreenSaver()
             -- so that we do the right thing on resume ;).
             self.screen_saver_mode = true
         end
+
+        self.powerd:beforeSuspend()
     end
-    self.powerd:beforeSuspend()
 end
 
 function Kindle:outofScreenSaver()
@@ -345,8 +346,9 @@ function Kindle:outofScreenSaver()
             -- Flip the switch again
             self.screen_saver_mode = false
         end
+
+        self.powerd:afterResume()
     end
-    self.powerd:afterResume()
 end
 
 function Kindle:usbPlugOut()
@@ -374,12 +376,10 @@ function Kindle:setEventHandlers(UIManager)
         self.powerd:toggleSuspend()
     end
     UIManager.event_handlers.IntoSS = function()
-        self:_beforeSuspend()
         self:intoScreenSaver()
     end
     UIManager.event_handlers.OutOfSS = function()
         self:outofScreenSaver()
-        self:_afterResume()
     end
     UIManager.event_handlers.Charging = function()
         self:_beforeCharging()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1,5 +1,5 @@
 local Generic = require("device/generic/device")
-local UIManager -- will be updated when available
+local UIManager
 local time = require("ui/time")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -1,5 +1,5 @@
 local BasePowerD = require("device/generic/powerd")
-local UIManager -- will be updated when available
+local UIManager
 local WakeupMgr = require("device/wakeupmgr")
 local logger = require("logger")
 local util = require("util")

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -289,6 +289,8 @@ function KindlePowerD:beforeSuspend()
 end
 
 function KindlePowerD:afterResume()
+    self:invalidateCapacityCache()
+
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
 end

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -1,4 +1,5 @@
 local BasePowerD = require("device/generic/powerd")
+local UIManager -- will be updated when available
 local WakeupMgr = require("device/wakeupmgr")
 local logger = require("logger")
 local util = require("util")
@@ -185,7 +186,6 @@ function KindlePowerD:afterResume()
     if not self.device:hasFrontlight() then
         return
     end
-    local UIManager = require("ui/uimanager")
     if self:isFrontlightOn() then
         -- The Kindle framework should turn the front light back on automatically.
         -- The following statement ensures consistency of intensity, but should basically always be redundant,
@@ -249,7 +249,6 @@ function KindlePowerD:initWakeupMgr()
         -- This filters out user input resumes -> device will resume to active
         -- Also the Kindle stays in Ready to suspend for 10 seconds
         -- so the alarm may fire 10 seconds early
-        local UIManager = require("ui/uimanager")
         UIManager:scheduleIn(15, self.checkUnexpectedWakeup, self)
     end
 
@@ -292,6 +291,10 @@ end
 function KindlePowerD:afterResume()
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
+end
+
+function KindlePowerD:UIManagerReadyHW(uimgr)
+    UIManager = uimgr
 end
 
 --- @fixme: This won't ever fire on its own, as KindlePowerD is already a metatable on a plain table.

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -284,6 +284,16 @@ function KindlePowerD:resetT1Timeout()
     end
 end
 
+function KindlePowerD:beforeSuspend()
+    -- Inhibit user input and emit the Suspend event.
+    self.device:_beforeSuspend()
+end
+
+function KindlePowerD:afterResume()
+    -- Restore user input and emit the Resume event.
+    self.device:_afterResume()
+end
+
 --- @fixme: This won't ever fire on its own, as KindlePowerD is already a metatable on a plain table.
 function KindlePowerD:__gc()
     if self.lipc_handle then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -501,11 +501,6 @@ local KoboGoldfinch = Kobo:extend{
     hasReliableMxcWaitFor = no,
 }
 
-function Kobo:_UIManagerReady(uimgr)
-    -- NOTE: We've already done this earlier via setEventHandlers ;).
-    UIManager = uimgr
-end
-
 function Kobo:setupChargingLED()
     if G_reader_settings:nilOrTrue("enable_charging_led") then
         if self:hasAuxBattery() and self.powerd:isAuxBatteryConnected() then
@@ -1376,10 +1371,11 @@ function Kobo:isStartupScriptUpToDate()
     return md5.sumFile(current_script) == md5.sumFile(new_script)
 end
 
-function Kobo:setEventHandlers(uimgr)
-    -- Update our module-local
+function Kobo:UIManagerReady(uimgr)
     UIManager = uimgr
+end
 
+function Kobo:setEventHandlers(uimgr)
     -- We do not want auto suspend procedure to waste battery during
     -- suspend. So let's unschedule it when suspending, and restart it after
     -- resume. Done via the plugin's onSuspend/onResume handlers.

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1388,7 +1388,6 @@ function Kobo:setEventHandlers(uimgr)
         self:getPowerDevice():invalidateCapacityCache()
 
         self:onPowerEvent("Resume")
-        self:_afterResume()
     end
     UIManager.event_handlers.PowerPress = function()
         -- Always schedule power off.

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1,6 +1,6 @@
 local Generic = require("device/generic/device")
 local Geom = require("ui/geometry")
-local UIManager -- Updated on UIManager init
+local UIManager
 local WakeupMgr = require("device/wakeupmgr")
 local time = require("ui/time")
 local ffiUtil = require("ffi/util")

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1379,14 +1379,9 @@ function Kobo:setEventHandlers(uimgr)
     -- suspend. So let's unschedule it when suspending, and restart it after
     -- resume. Done via the plugin's onSuspend/onResume handlers.
     UIManager.event_handlers.Suspend = function()
-        self:_beforeSuspend()
         self:onPowerEvent("Suspend")
     end
     UIManager.event_handlers.Resume = function()
-        -- MONOTONIC doesn't tick during suspend,
-        -- invalidate the last battery capacity pull time so that we get up to date data immediately.
-        self:getPowerDevice():invalidateCapacityCache()
-
         self:onPowerEvent("Resume")
     end
     UIManager.event_handlers.PowerPress = function()
@@ -1405,7 +1400,6 @@ function Kobo:setEventHandlers(uimgr)
                     -- In this case, we want to go back to suspend *without* affecting the screensaver,
                     -- so we mimic UIManager.event_handlers.Suspend's behavior when *not* in screen_saver_mode ;).
                     logger.dbg("Pressed power while awake in screen saver mode, going back to suspend...")
-                    self:_beforeSuspend()
                     self.powerd:beforeSuspend() -- this won't be run by onPowerEvent because we're in screen_saver_mode
                     self:onPowerEvent("Suspend")
                 else

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1376,6 +1376,7 @@ function Kobo:UIManagerReady(uimgr)
 end
 
 function Kobo:setEventHandlers(uimgr)
+    print("Kobo:setEventHandlers", uimgr)
     -- We do not want auto suspend procedure to waste battery during
     -- suspend. So let's unschedule it when suspending, and restart it after
     -- resume. Done via the plugin's onSuspend/onResume handlers.

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1376,7 +1376,6 @@ function Kobo:UIManagerReady(uimgr)
 end
 
 function Kobo:setEventHandlers(uimgr)
-    print("Kobo:setEventHandlers", uimgr)
     -- We do not want auto suspend procedure to waste battery during
     -- suspend. So let's unschedule it when suspending, and restart it after
     -- resume. Done via the plugin's onSuspend/onResume handlers.

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -983,8 +983,6 @@ end
 
 -- NOTE: We overload this to make sure checkUnexpectedWakeup doesn't trip *before* the newly scheduled suspend
 function Kobo:rescheduleSuspend()
-    logger.warn("** Kobo:rescheduleSuspend **")
-    print(debug.traceback())
     UIManager:unschedule(self.suspend)
     UIManager:unschedule(self.checkUnexpectedWakeup)
     UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend, self)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1430,7 +1430,7 @@ function Kobo:setEventHandlers(uimgr)
         -- NOTE: Plug/unplug events will wake the device up, which is why we put it back to sleep.
         if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
-        else
+        elseif not self.screen_saver_lock then
             -- Potentially start an USBMS session
             local MassStorage = require("ui/elements/mass_storage")
             MassStorage:start()
@@ -1442,7 +1442,7 @@ function Kobo:setEventHandlers(uimgr)
         self:_afterNotCharging()
         if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
-        else
+        elseif not self.screen_saver_lock then
             -- Potentially dismiss the USBMS ConfirmBox
             local MassStorage = require("ui/elements/mass_storage")
             MassStorage:dismiss()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -983,6 +983,8 @@ end
 
 -- NOTE: We overload this to make sure checkUnexpectedWakeup doesn't trip *before* the newly scheduled suspend
 function Kobo:rescheduleSuspend()
+    logger.warn("** Kobo:rescheduleSuspend **")
+    print(debug.traceback())
     UIManager:unschedule(self.suspend)
     UIManager:unschedule(self.checkUnexpectedWakeup)
     UIManager:scheduleIn(self.suspend_wait_timeout, self.suspend, self)

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1395,13 +1395,7 @@ function Kobo:setEventHandlers(uimgr)
             -- resume if we were suspended
             if self.screen_saver_mode then
                 if self.screen_saver_lock then
-                    -- This can only happen when some sort of screensaver_delay is set,
-                    -- and the user presses the Power button *after* already having woken up the device.
-                    -- In this case, we want to go back to suspend *without* affecting the screensaver,
-                    -- so we mimic UIManager.event_handlers.Suspend's behavior when *not* in screen_saver_mode ;).
-                    logger.dbg("Pressed power while awake in screen saver mode, going back to suspend...")
-                    self.powerd:beforeSuspend() -- this won't be run by onPowerEvent because we're in screen_saver_mode
-                    self:onPowerEvent("Suspend")
+                    UIManager.event_handlers.Suspend()
                 else
                     UIManager.event_handlers.Resume()
                 end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -501,6 +501,11 @@ local KoboGoldfinch = Kobo:extend{
     hasReliableMxcWaitFor = no,
 }
 
+function Kobo:_UIManagerReady(uimgr)
+    -- NOTE: We've already done this earlier via setEventHandlers ;).
+    UIManager = uimgr
+end
+
 function Kobo:setupChargingLED()
     if G_reader_settings:nilOrTrue("enable_charging_led") then
         if self:hasAuxBattery() and self.powerd:isAuxBatteryConnected() then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1411,7 +1411,7 @@ function Kobo:setEventHandlers(uimgr)
     UIManager.event_handlers.Charging = function()
         self:_beforeCharging()
         -- NOTE: Plug/unplug events will wake the device up, which is why we put it back to sleep.
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
            UIManager.event_handlers.Suspend()
         end
     end
@@ -1419,7 +1419,7 @@ function Kobo:setEventHandlers(uimgr)
         -- We need to put the device into suspension, other things need to be done before it.
         self:usbPlugOut()
         self:_afterNotCharging()
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
            UIManager.event_handlers.Suspend()
         end
     end
@@ -1427,7 +1427,7 @@ function Kobo:setEventHandlers(uimgr)
     UIManager.event_handlers.UsbPlugIn = function()
         self:_beforeCharging()
         -- NOTE: Plug/unplug events will wake the device up, which is why we put it back to sleep.
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
         else
             -- Potentially start an USBMS session
@@ -1439,7 +1439,7 @@ function Kobo:setEventHandlers(uimgr)
         -- We need to put the device into suspension, other things need to be done before it.
         self:usbPlugOut()
         self:_afterNotCharging()
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
             UIManager.event_handlers.Suspend()
         else
             -- Potentially dismiss the USBMS ConfirmBox

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -2,7 +2,7 @@ local BasePowerD = require("device/generic/powerd")
 local Math = require("optmath")
 local NickelConf = require("device/kobo/nickel_conf")
 local SysfsLight = require ("device/sysfs_light")
-local UIManager -- will be updated when available
+local UIManager
 local RTC = require("ffi/rtc")
 
 -- Here, we only deal with the real hw intensity.

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -424,7 +424,9 @@ function KoboPowerD:beforeSuspend()
         -- Remember the current frontlight state
         self.fl_was_on = self.is_fl_on
         -- Turn off the frontlight
-        self:turnOffFrontlight()
+        -- NOTE: Funky delay mainly to yield to the EPDC's refresh on UP systems.
+        --       (Neither yieldToEPDC nor nextTick & friends quite cut it here)...
+        UIManager:scheduleIn(0.001, self.turnOffFrontlight, self)
     end
 end
 
@@ -444,7 +446,7 @@ function KoboPowerD:afterResume()
         -- Don't bother if the light was already off on suspend
         if self.fl_was_on then
             -- Turn the frontlight back on
-            -- NOTE: Funky delay mainly to yield to the EPDC's refresh (yieldToEPDC doesn't quite cut it here)...
+            -- NOTE: There's quite likely *more* resource contention than on suspend here :/.
             UIManager:scheduleIn(0.001, self.turnOnFrontlight, self)
         end
     end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -430,16 +430,6 @@ end
 
 -- Restore front light state after resume.
 function KoboPowerD:afterResume()
-    -- There's a whole bunch of stuff happening before us in Generic:onPowerEvent,
-    -- so this may not be as smooth as on suspend...
-    if self.fl then
-        -- Don't bother if the light was already off on suspend
-        if self.fl_was_on then
-            -- Turn the frontlight back on
-            self:turnOnFrontlight()
-        end
-    end
-
     -- Set the system clock to the hardware clock's time.
     RTC:HCToSys()
 
@@ -447,6 +437,17 @@ function KoboPowerD:afterResume()
 
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
+
+    -- There's a whole bunch of stuff happening before us in Generic:onPowerEvent,
+    -- so we'll delay this ever so slightly so as to appear as smooth as possible...
+    if self.fl then
+        -- Don't bother if the light was already off on suspend
+        if self.fl_was_on then
+            -- Turn the frontlight back on
+            -- NOTE: Funky delay mainly to yield to the EPDC's refresh (yieldToEPDC doesn't quite cut it here)...
+            UIManager:scheduleIn(0.001, self.turnOnFrontlight, self)
+        end
+    end
 end
 
 function KoboPowerD:UIManagerReadyHW(uimgr)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -418,6 +418,8 @@ function KoboPowerD:beforeSuspend()
     -- Inhibit user input and emit the Suspend event.
     self.device:_beforeSuspend()
 
+    -- Handle the frontlight last,
+    -- to prevent as many thing as we can froma interfering with the smoothness of the ramp
     if self.fl then
         -- Remember the current frontlight state
         self.fl_was_on = self.is_fl_on
@@ -428,14 +430,6 @@ end
 
 -- Restore front light state after resume.
 function KoboPowerD:afterResume()
-    if self.fl then
-        -- Don't bother if the light was already off on suspend
-        if self.fl_was_on then
-            -- Turn the frontlight back on
-            self:turnOnFrontlight()
-        end
-    end
-
     -- Set the system clock to the hardware clock's time.
     RTC:HCToSys()
 
@@ -443,6 +437,16 @@ function KoboPowerD:afterResume()
 
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
+
+    -- Much like on suspend, deal with the frontlight last.
+    -- (Except that unlike on suspend, the resume refresh isn't fenced)
+    if self.fl then
+        -- Don't bother if the light was already off on suspend
+        if self.fl_was_on then
+            -- Turn the frontlight back on
+            self:turnOnFrontlight()
+        end
+    end
 end
 
 function KoboPowerD:UIManagerReadyHW(uimgr)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -447,7 +447,7 @@ function KoboPowerD:afterResume()
     self.device:_afterResume()
 end
 
-function KoboPowerD:readyUIHW(uimgr)
+function KoboPowerD:UIManagerReadyHW(uimgr)
     UIManager = uimgr
 end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -1,8 +1,8 @@
-local UIManager -- will be updated when available
 local BasePowerD = require("device/generic/powerd")
 local Math = require("optmath")
 local NickelConf = require("device/kobo/nickel_conf")
 local SysfsLight = require ("device/sysfs_light")
+local UIManager -- will be updated when available
 local RTC = require("ffi/rtc")
 
 -- Here, we only deal with the real hw intensity.

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -439,8 +439,6 @@ function KoboPowerD:afterResume()
     -- Set the system clock to the hardware clock's time.
     RTC:HCToSys()
 
-    -- MONOTONIC doesn't tick during suspend,
-    -- invalidate the last battery capacity pull time so that we get up to date data immediately.
     self:invalidateCapacityCache()
 
     -- Restore user input and emit the Resume event.

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -1,4 +1,4 @@
-local UIManager = nil -- will be updated when available
+local UIManager -- will be updated when available
 local BasePowerD = require("device/generic/powerd")
 local Math = require("optmath")
 local NickelConf = require("device/kobo/nickel_conf")

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -430,16 +430,8 @@ end
 
 -- Restore front light state after resume.
 function KoboPowerD:afterResume()
-    -- Set the system clock to the hardware clock's time.
-    RTC:HCToSys()
-
-    self:invalidateCapacityCache()
-
-    -- Restore user input and emit the Resume event.
-    self.device:_afterResume()
-
-    -- Much like on suspend, deal with the frontlight last.
-    -- (Except that unlike on suspend, the resume refresh isn't fenced)
+    -- There's a whole bunch of stuff happening before us in Generic:onPowerEvent,
+    -- so this may not be as smooth as on suspend...
     if self.fl then
         -- Don't bother if the light was already off on suspend
         if self.fl_was_on then
@@ -447,6 +439,14 @@ function KoboPowerD:afterResume()
             self:turnOnFrontlight()
         end
     end
+
+    -- Set the system clock to the hardware clock's time.
+    RTC:HCToSys()
+
+    self:invalidateCapacityCache()
+
+    -- Restore user input and emit the Resume event.
+    self.device:_afterResume()
 end
 
 function KoboPowerD:UIManagerReadyHW(uimgr)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -419,7 +419,7 @@ function KoboPowerD:beforeSuspend()
     self.device:_beforeSuspend()
 
     -- Handle the frontlight last,
-    -- to prevent as many thing as we can from interfering with the smoothness of the ramp
+    -- to prevent as many things as we can from interfering with the smoothness of the ramp
     if self.fl then
         -- Remember the current frontlight state
         self.fl_was_on = self.is_fl_on

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -432,6 +432,10 @@ function KoboPowerD:afterResume()
 
     -- Set the system clock to the hardware clock's time.
     RTC:HCToSys()
+
+    -- Don't forget to call generic's handler, too,
+    -- as it's responsible for restoring user input and emitting the Resume event!
+    BasePowerD.afterResume(self)
 end
 
 function KoboPowerD:readyUIHW(uimgr)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -419,7 +419,7 @@ function KoboPowerD:beforeSuspend()
     self.device:_beforeSuspend()
 
     -- Handle the frontlight last,
-    -- to prevent as many thing as we can froma interfering with the smoothness of the ramp
+    -- to prevent as many thing as we can from interfering with the smoothness of the ramp
     if self.fl then
         -- Remember the current frontlight state
         self.fl_was_on = self.is_fl_on

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -389,10 +389,10 @@ end
 function PocketBook:setEventHandlers(UIManager)
     -- Only fg/bg state plugin notifiers, not real power event.
     UIManager.event_handlers.Suspend = function()
-        self:_beforeSuspend()
+        self.powerd:beforeSuspend()
     end
     UIManager.event_handlers.Resume = function()
-        self:_afterResume()
+        self.powerd:afterResume()
     end
     UIManager.event_handlers.Exit = function()
         local Event = require("ui/event")

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -1,4 +1,5 @@
 local Generic = require("device/generic/device") -- <= look at this file!
+local UIManager
 local logger = require("logger")
 local ffi = require("ffi")
 local C = ffi.C
@@ -333,8 +334,6 @@ function PocketBook:reboot()
 end
 
 function PocketBook:initNetworkManager(NetworkMgr)
-    local UIManager = require("ui/uimanager")
-
     local function keepWifiAlive()
         -- Make sure only one wifiKeepAlive is scheduled
         UIManager:unschedule(keepWifiAlive)
@@ -386,7 +385,11 @@ function PocketBook:getDefaultCoverPath()
     return "/mnt/ext1/system/logo/offlogo/cover.bmp"
 end
 
-function PocketBook:setEventHandlers(UIManager)
+function PocketBook:UIManagerReady(uimgr)
+    UIManager = uimgr
+end
+
+function PocketBook:setEventHandlers(uimgr)
     -- Only fg/bg state plugin notifiers, not real power event.
     UIManager.event_handlers.Suspend = function()
         self.powerd:beforeSuspend()

--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -79,6 +79,8 @@ function PocketBookPowerD:beforeSuspend()
 end
 
 function PocketBookPowerD:afterResume()
+    self:invalidateCapacityCache()
+
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
 end

--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -73,4 +73,14 @@ function PocketBookPowerD:isChargingHW()
     end
 end
 
+function PocketBookPowerD:beforeSuspend()
+    -- Inhibit user input and emit the Suspend event.
+    self.device:_beforeSuspend()
+end
+
+function PocketBookPowerD:afterResume()
+    -- Restore user input and emit the Resume event.
+    self.device:_afterResume()
+end
+
 return PocketBookPowerD

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -268,12 +268,10 @@ end
 
 function Remarkable:setEventHandlers(UIManager)
     UIManager.event_handlers.Suspend = function()
-        self:_beforeSuspend()
         self:onPowerEvent("Suspend")
     end
     UIManager.event_handlers.Resume = function()
         self:onPowerEvent("Resume")
-        self:_afterResume()
     end
     UIManager.event_handlers.PowerPress = function()
         UIManager:scheduleIn(2, UIManager.poweroff_action)
@@ -284,10 +282,7 @@ function Remarkable:setEventHandlers(UIManager)
             -- resume if we were suspended
             if self.screen_saver_mode then
                 if self.screen_saver_lock then
-                    logger.dbg("Pressed power while awake in screen saver mode, going back to suspend...")
-                    self:_beforeSuspend()
-                    self.powerd:beforeSuspend() -- this won't be run by onPowerEvent because we're in screen_saver_mode
-                    self:onPowerEvent("Suspend")
+                    UIManager.event_handlers.Suspend()
                 else
                     UIManager.event_handlers.Resume()
                 end

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -22,4 +22,14 @@ function Remarkable_PowerD:isChargingHW()
     return self:read_str_file(self.status_file) == "Charging"
 end
 
+function Remarkable_PowerD:beforeSuspend()
+    -- Inhibit user input and emit the Suspend event.
+    self.device:_beforeSuspend()
+end
+
+function Remarkable_PowerD:afterResume()
+    -- Restore user input and emit the Resume event.
+    self.device:_afterResume()
+end
+
 return Remarkable_PowerD

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -28,6 +28,8 @@ function Remarkable_PowerD:beforeSuspend()
 end
 
 function Remarkable_PowerD:afterResume()
+    self:invalidateCapacityCache()
+
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
 end

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -363,7 +363,11 @@ function Device:setEventHandlers(uimgr)
     UIManager.event_handlers.PowerRelease = function()
         -- Resume if we were suspended
         if self.screen_saver_mode then
-            UIManager.event_handlers.Resume()
+            if self.screen_saver_lock then
+                UIManager.event_handlers.Suspend()
+            else
+                UIManager.event_handlers.Resume()
+            end
         else
             UIManager.event_handlers.Suspend()
         end

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -350,12 +350,10 @@ function Device:setEventHandlers(UIManager)
     end
 
     UIManager.event_handlers.Suspend = function()
-        self:_beforeSuspend()
         self:simulateSuspend()
     end
     UIManager.event_handlers.Resume = function()
         self:simulateResume()
-        self:_afterResume()
     end
     UIManager.event_handlers.PowerRelease = function()
         -- Resume if we were suspended
@@ -385,11 +383,15 @@ function Emulator:simulateSuspend()
     local Screensaver = require("ui/screensaver")
     Screensaver:setup()
     Screensaver:show()
+
+    self.powerd:beforeSuspend()
 end
 
 function Emulator:simulateResume()
     local Screensaver = require("ui/screensaver")
     Screensaver:close()
+
+    self.powerd:afterResume()
 end
 
 -- fake network manager for the emulator

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -1,5 +1,7 @@
 local Event = require("ui/event")
+local Geom = require("ui/geometry")
 local Generic = require("device/generic/device")
+local UIManager
 local SDL = require("ffi/SDL2_0")
 local ffi = require("ffi")
 local logger = require("logger")
@@ -180,8 +182,7 @@ function Device:init()
         device = self,
         event_map = require("device/sdl/event_map_sdl2"),
         handleSdlEv = function(device_input, ev)
-            local Geom = require("ui/geometry")
-            local UIManager = require("ui/uimanager")
+
 
             -- SDL events can remain cdata but are almost completely transparent
             local SDL_TEXTINPUT = 771
@@ -342,7 +343,11 @@ function Device:toggleFullscreen()
     end
 end
 
-function Device:setEventHandlers(UIManager)
+function Device:UIManagerReady(uimgr)
+    UIManager = uimgr
+end
+
+function Device:setEventHandlers(uimgr)
     if not self:canSuspend() then
         -- If we can't suspend, we have no business even trying to, as we may not have overloaded `Device:simulateResume`.
         -- Instead, rely on the Generic Suspend/Resume handlers.
@@ -396,7 +401,6 @@ end
 
 -- fake network manager for the emulator
 function Emulator:initNetworkManager(NetworkMgr)
-    local UIManager = require("ui/uimanager")
     local connectionChangedEvent = function()
         if G_reader_settings:nilOrTrue("emulator_fake_wifi_connected") then
             UIManager:broadcastEvent(Event:new("NetworkConnected"))

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -37,4 +37,15 @@ function SDLPowerD:isChargingHW()
     return false
 end
 
+function SDLPowerD:beforeSuspend()
+    -- Inhibit user input and emit the Suspend event.
+    self.device:_beforeSuspend()
+end
+
+-- Restore front light state after resume.
+function SDLPowerD:afterResume()
+    -- Restore user input and emit the Resume event.
+    self.device:_afterResume()
+end
+
 return SDLPowerD

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -43,6 +43,8 @@ function SDLPowerD:beforeSuspend()
 end
 
 function SDLPowerD:afterResume()
+    self:invalidateCapacityCache()
+
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
 end

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -42,7 +42,6 @@ function SDLPowerD:beforeSuspend()
     self.device:_beforeSuspend()
 end
 
--- Restore front light state after resume.
 function SDLPowerD:afterResume()
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -233,12 +233,6 @@ function SonyPRSTUX:setEventHandlers(uimgr)
     UIManager.event_handlers.UsbPlugOut = function()
         self:usbPlugOut()
     end
-    UIManager.event_handlers.__default__ = function(input_event)
-        -- Same as in Kobo: we want to ignore keys during suspension
-        if not self.screen_saver_mode then
-            UIManager:sendEvent(input_event)
-        end
-    end
 end
 
 -- For Sony PRS-T2

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -192,14 +192,12 @@ end
 
 function SonyPRSTUX:setEventHandlers(UIManager)
     UIManager.event_handlers.Suspend = function()
-        self:_beforeSuspend()
         self:intoScreenSaver()
         self:suspend()
     end
     UIManager.event_handlers.Resume = function()
         self:resume()
         self:outofScreenSaver()
-        self:_afterResume()
     end
     UIManager.event_handlers.PowerPress = function()
         UIManager:scheduleIn(2, UIManager.poweroff_action)
@@ -225,7 +223,6 @@ function SonyPRSTUX:setEventHandlers(UIManager)
         if self.screen_saver_mode then
             self:resume()
             self:outofScreenSaver()
-            self:_afterResume()
         end
         self:usbPlugIn()
     end

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -211,7 +211,11 @@ function SonyPRSTUX:setEventHandlers(uimgr)
             UIManager:unschedule(UIManager.poweroff_action)
             -- resume if we were suspended
             if self.screen_saver_mode then
-                UIManager.event_handlers.Resume()
+                if self.screen_saver_lock then
+                    UIManager.event_handlers.Suspend()
+                else
+                    UIManager.event_handlers.Resume()
+                end
             else
                 UIManager.event_handlers.Suspend()
             end
@@ -224,7 +228,7 @@ function SonyPRSTUX:setEventHandlers(uimgr)
         self:_afterNotCharging()
     end
     UIManager.event_handlers.UsbPlugIn = function()
-        if self.screen_saver_mode then
+        if self.screen_saver_mode and not self.screen_saver_lock then
             self:resume()
             self:outofScreenSaver()
         end

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -1,5 +1,6 @@
 local Generic = require("device/generic/device") -- <= look at this file!
 local PluginShare = require("pluginshare")
+local UIManager
 local ffi = require("ffi")
 local logger = require("logger")
 
@@ -102,7 +103,6 @@ function SonyPRSTUX:outofScreenSaver()
     if self.screen_saver_mode then
         local Screensaver = require("ui/screensaver")
         Screensaver:close()
-        local UIManager = require("ui/uimanager")
         UIManager:nextTick(function() UIManager:setDirty("all", "full") end)
     end
     self.powerd:afterResume()
@@ -190,7 +190,11 @@ function SonyPRSTUX:getDeviceModel()
     return ffi.string("PRS-T2")
 end
 
-function SonyPRSTUX:setEventHandlers(UIManager)
+function SonyPRSTUX:UIManagerReady(uimgr)
+    UIManager = uimgr
+end
+
+function SonyPRSTUX:setEventHandlers(uimgr)
     UIManager.event_handlers.Suspend = function()
         self:intoScreenSaver()
         self:suspend()

--- a/frontend/device/sony-prstux/powerd.lua
+++ b/frontend/device/sony-prstux/powerd.lua
@@ -34,6 +34,8 @@ function SonyPRSTUX_PowerD:beforeSuspend()
 end
 
 function SonyPRSTUX_PowerD:afterResume()
+    self:invalidateCapacityCache()
+
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
 end

--- a/frontend/device/sony-prstux/powerd.lua
+++ b/frontend/device/sony-prstux/powerd.lua
@@ -33,7 +33,6 @@ function SonyPRSTUX_PowerD:beforeSuspend()
     self.device:_beforeSuspend()
 end
 
--- Restore front light state after resume.
 function SonyPRSTUX_PowerD:afterResume()
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()

--- a/frontend/device/sony-prstux/powerd.lua
+++ b/frontend/device/sony-prstux/powerd.lua
@@ -28,4 +28,15 @@ function SonyPRSTUX_PowerD:isChargingHW()
     return self:read_str_file(self.status_file) == "Charging"
 end
 
+function SonyPRSTUX_PowerD:beforeSuspend()
+    -- Inhibit user input and emit the Suspend event.
+    self.device:_beforeSuspend()
+end
+
+-- Restore front light state after resume.
+function SonyPRSTUX_PowerD:afterResume()
+    -- Restore user input and emit the Resume event.
+    self.device:_afterResume()
+end
+
 return SonyPRSTUX_PowerD

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -102,7 +102,8 @@ function UIManager:init()
         end)
     end
 
-    Device:_setEventHandlers(self)
+    -- Tell Device that we're now available, so that it can setup PM event handlers
+    Device:_UIManagerReady(self)
 
     -- A simple wrapper for UIManager:quit()
     -- This may be overwritten by setRunForeverMode(); for testing purposes
@@ -1550,9 +1551,6 @@ This is the main loop of the UI controller.
 It is intended to manage input events and delegate them to dialogs.
 --]]
 function UIManager:run()
-    -- Tell Device that we're ready
-    Device:UIManagerReady(self)
-
     self:initLooper()
     -- currently there is no Turbo support for Windows
     -- use our own main loop

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -103,7 +103,6 @@ function UIManager:init()
     end
 
     -- Tell Device that we're now available, so that it can setup PM event handlers
-    print("UIM Device", Device)
     Device:_UIManagerReady(self)
 
     -- A simple wrapper for UIManager:quit()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1550,8 +1550,8 @@ This is the main loop of the UI controller.
 It is intended to manage input events and delegate them to dialogs.
 --]]
 function UIManager:run()
-    -- Tell PowerD that we're ready
-    Device:getPowerDevice():readyUI()
+    -- Tell Device that we're ready
+    Device:UIManagerReady(self)
 
     self:initLooper()
     -- currently there is no Turbo support for Windows

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -103,6 +103,7 @@ function UIManager:init()
     end
 
     -- Tell Device that we're now available, so that it can setup PM event handlers
+    print("UIM Device", Device)
     Device:_UIManagerReady(self)
 
     -- A simple wrapper for UIManager:quit()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -405,9 +405,9 @@ function UIManager:unschedule(action)
     local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then
+            logger.info("Removing task scheduled in", self._task_queue[i].time - time.now(), "@ index", i)
             table.remove(self._task_queue, i)
             removed = true
-            logger.info("Removed task @ index", i)
         end
     end
     return removed

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -401,11 +401,9 @@ UIManager:scheduleIn(10.5, self.anonymousFunction)
 UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
-    logger.dbg("UIManager:unschedule", tostring(action))
     local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then
-            logger.info("Removing task scheduled in", self._task_queue[i].time - time.now(), "@ index", i)
             table.remove(self._task_queue, i)
             removed = true
         end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -400,11 +400,13 @@ UIManager:scheduleIn(10.5, self.anonymousFunction)
 UIManager:unschedule(self.anonymousFunction)
 ]]
 function UIManager:unschedule(action)
+    logger.dbg("UIManager:unschedule", tostring(action))
     local removed = false
     for i = #self._task_queue, 1, -1 do
         if self._task_queue[i].action == action then
             table.remove(self._task_queue, i)
             removed = true
+            logger.info("Removed task @ index", i)
         end
     end
     return removed

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -470,6 +470,32 @@ describe("device module", function()
             Device.screen_saver_mode = false
             readerui:onClose()
         end)
+
+        it("SDL", function()
+            local Device = require("device/sdl/device")
+            stub(Device, "initNetworkManager")
+            stub(Device, "suspend")
+            Device:init()
+            package.loaded.device = Device
+
+            local UIManager = require("ui/uimanager")
+            UIManager:init()
+
+            local sample_pdf = "spec/front/unit/data/tall.pdf"
+            local ReaderUI = require("apps/reader/readerui")
+            ReaderUI:doShowReader(sample_pdf)
+            local readerui = ReaderUI._getRunningInstance()
+            stub(readerui, "onFlushSettings")
+            -- UIManager.event_handlers.PowerPress() -- We only fake a Release event on the Emu
+            UIManager.event_handlers.PowerRelease()
+            assert.stub(readerui.onFlushSettings).was_called()
+
+            Device.initNetworkManager:revert()
+            Device.suspend:revert()
+            readerui.onFlushSettings:revert()
+            Device.screen_saver_mode = false
+            readerui:onClose()
+        end)
     end)
     -- luacheck: pop
 end)

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -333,7 +333,8 @@ describe("device module", function()
             end)
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/kobo/device"):init()
+            local Device = require("device/kobo/device")
+            Device:init()
 
             local UIManager = require("ui/uimanager")
             stub(Device, "suspend")
@@ -369,7 +370,8 @@ describe("device module", function()
 
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/cervantes/device"):init()
+            local Device = require("device/cervantes/device")
+            Device:init()
 
             local UIManager = require("ui/uimanager")
 
@@ -393,7 +395,8 @@ describe("device module", function()
         it("SDL", function()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/sdl/device"):init()
+            local Device = require("device/sdl/device")
+            Device:init()
 
             local UIManager = require("ui/uimanager")
 
@@ -436,7 +439,8 @@ describe("device module", function()
             end
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/remarkable/device"):init()
+            local Device = require("device/remarkable/device")
+            Device:init()
 
             local UIManager = require("ui/uimanager")
 

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -359,13 +359,13 @@ describe("device module", function()
             Device.powerd.fl = nil
             package.loaded.device = Device
 
-            local ReaderUI = require("apps/reader/readerui")
             local UIManager = require("ui/uimanager")
             -- Generic's onPowerEvent may request a repaint, but we can't do that
             stub(UIManager, "forceRePaint")
             UIManager:init()
 
             local sample_pdf = "spec/front/unit/data/tall.pdf"
+            local ReaderUI = require("apps/reader/readerui")
             ReaderUI:doShowReader(sample_pdf)
             local readerui = ReaderUI._getRunningInstance()
             stub(readerui, "onFlushSettings")
@@ -402,12 +402,12 @@ describe("device module", function()
             Device.powerd.fl = nil
             package.loaded.device = Device
 
-            local ReaderUI = require("apps/reader/readerui")
             local UIManager = require("ui/uimanager")
             stub(UIManager, "forceRePaint")
             UIManager:init()
 
             local sample_pdf = "spec/front/unit/data/tall.pdf"
+            local ReaderUI = require("apps/reader/readerui")
             ReaderUI:doShowReader(sample_pdf)
             local readerui = ReaderUI._getRunningInstance()
             stub(readerui, "onFlushSettings")
@@ -444,18 +444,18 @@ describe("device module", function()
                 end
             end
             local Device = require("device/remarkable/device")
-            package.loaded.device = Device
             stub(Device, "initNetworkManager")
+            stub(Device, "suspend")
             Device:init()
-            local sample_pdf = "spec/front/unit/data/tall.pdf"
-            local ReaderUI = require("apps/reader/readerui")
+            Device.powerd.fl = nil
+            package.loaded.device = Device
 
             local UIManager = require("ui/uimanager")
-
-            stub(Device, "suspend")
-
+            stub(UIManager, "forceRePaint")
             UIManager:init()
 
+            local sample_pdf = "spec/front/unit/data/tall.pdf"
+            local ReaderUI = require("apps/reader/readerui")
             ReaderUI:doShowReader(sample_pdf)
             local readerui = ReaderUI._getRunningInstance()
             stub(readerui, "onFlushSettings")
@@ -463,6 +463,7 @@ describe("device module", function()
             UIManager.event_handlers.PowerRelease()
             assert.stub(readerui.onFlushSettings).was_called()
 
+            UIManager.forceRePaint:revert()
             Device.initNetworkManager:revert()
             Device.suspend:revert()
             readerui.onFlushSettings:revert()

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -333,15 +333,11 @@ describe("device module", function()
             end)
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local device_to_test = require("device/kobo/device")
-            local Device = require("device")
-            Device.setEventHandlers = device_to_test.setEventHandlers
+            local Device = require("device/kobo/device"):init()
 
             local UIManager = require("ui/uimanager")
             stub(Device, "suspend")
-            stub(Device, "isKobo")
 
-            Device.isKobo.returns(true)
             UIManager:init()
 
             ReaderUI:doShowReader(sample_pdf)
@@ -352,7 +348,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.isKobo:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
             readerui:onClose()
@@ -374,16 +369,12 @@ describe("device module", function()
 
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device")
-            local device_to_test = require("device/cervantes/device")
-            Device.setEventHandlers = device_to_test.setEventHandlers
+            local Device = require("device/cervantes/device"):init()
 
             local UIManager = require("ui/uimanager")
 
             stub(Device, "suspend")
-            stub(Device, "isCervantes")
 
-            Device.isCervantes.returns(true)
             UIManager:init()
 
             ReaderUI:doShowReader(sample_pdf)
@@ -394,7 +385,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.isCervantes:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
             readerui:onClose()
@@ -403,16 +393,12 @@ describe("device module", function()
         it("SDL", function()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device")
-            local device_to_test = require("device/sdl/device")
-            Device.setEventHandlers = device_to_test.setEventHandlers
+            local Device = require("device/sdl/device"):init()
 
             local UIManager = require("ui/uimanager")
 
             stub(Device, "suspend")
-            stub(Device, "isSDL")
 
-            Device.isSDL.returns(true)
             UIManager:init()
 
             ReaderUI:doShowReader(sample_pdf)
@@ -423,7 +409,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.isSDL:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
             readerui:onClose()
@@ -451,16 +436,12 @@ describe("device module", function()
             end
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device")
-            local device_to_test = require("device/remarkable/device")
-            Device.setEventHandlers = device_to_test.setEventHandlers
+            local Device = require("device/remarkable/device"):init()
 
             local UIManager = require("ui/uimanager")
 
             stub(Device, "suspend")
-            stub(Device, "isRemarkable")
 
-            Device.isRemarkable.returns(true)
             UIManager:init()
 
             ReaderUI:doShowReader(sample_pdf)
@@ -471,7 +452,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.isRemarkable:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
             readerui:onClose()

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -7,17 +7,20 @@ describe("device module", function()
     local ffi, C
 
     setup(function()
+        local fb = require("ffi/framebuffer")
         mock_fb = {
             new = function()
                 return {
                     getRawSize = function() return {w = 600, h = 800} end,
                     getWidth = function() return 600 end,
+                    getHeight = function() return 800 end,
                     getDPI = function() return 72 end,
                     setViewport = function() end,
                     getRotationMode = function() return 0 end,
                     getScreenMode = function() return "portrait" end,
                     setRotationMode = function() end,
-                    scaleByDPI = function(this, dp) return math.ceil(dp * this:getDPI() / 160) end,
+                    scaleByDPI = fb.scaleByDPI,
+                    scaleBySize = fb.scaleBySize,
                 }
             end
         }

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -11,6 +11,7 @@ describe("device module", function()
         mock_fb = {
             new = function()
                 return {
+                    device = package.loaded.device,
                     bb = require("ffi/blitbuffer").new(600, 800, 1),
                     getRawSize = function() return {w = 600, h = 800} end,
                     getWidth = function() return 600 end,
@@ -347,15 +348,13 @@ describe("device module", function()
             stub(Device, "suspend")
             Device:init()
             package.loaded.device = Device
-            print("Kobo:", Device)
+
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
             local UIManager = require("ui/uimanager")
             UIManager:init()
-            print("whee")
 
             ReaderUI:doShowReader(sample_pdf)
-            print("whoop")
             local readerui = ReaderUI._getRunningInstance()
             stub(readerui, "onFlushSettings")
             UIManager.event_handlers.PowerPress()

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -337,6 +337,8 @@ describe("device module", function()
             -- Bypass frontend/device probeDevice, while making sure that it points to the right implementation
             local Device = require("device/kobo/device")
             package.loaded.device = Device
+            -- Apparently common isn't setup properly in the testsuite, so we can't have nice things
+            stub(Device, "initNetworkManager")
             Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
@@ -353,6 +355,7 @@ describe("device module", function()
             UIManager.event_handlers.PowerRelease()
             assert.stub(readerui.onFlushSettings).was_called()
 
+            Device.initNetworkManager:revert()
             Device.suspend:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
@@ -375,6 +378,7 @@ describe("device module", function()
 
             local Device = require("device/cervantes/device")
             package.loaded.device = Device
+            stub(Device, "initNetworkManager")
             Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
@@ -392,6 +396,7 @@ describe("device module", function()
             UIManager.event_handlers.PowerRelease()
             assert.stub(readerui.onFlushSettings).was_called()
 
+            Device.initNetworkManager:revert()
             Device.suspend:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
@@ -401,6 +406,7 @@ describe("device module", function()
         it("SDL", function()
             local Device = require("device/sdl/device")
             package.loaded.device = Device
+            stub(Device, "initNetworkManager")
             Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
@@ -418,6 +424,7 @@ describe("device module", function()
             UIManager.event_handlers.PowerRelease()
             assert.stub(readerui.onFlushSettings).was_called()
 
+            Device.initNetworkManager:revert()
             Device.suspend:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
@@ -446,6 +453,7 @@ describe("device module", function()
             end
             local Device = require("device/remarkable/device")
             package.loaded.device = Device
+            stub(Device, "initNetworkManager")
             Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
@@ -463,6 +471,7 @@ describe("device module", function()
             UIManager.event_handlers.PowerRelease()
             assert.stub(readerui.onFlushSettings).was_called()
 
+            Device.initNetworkManager:revert()
             Device.suspend:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -423,34 +423,6 @@ describe("device module", function()
             readerui:onClose()
         end)
 
-        it("SDL", function()
-            local Device = require("device/sdl/device")
-            package.loaded.device = Device
-            stub(Device, "initNetworkManager")
-            Device:init()
-            local sample_pdf = "spec/front/unit/data/tall.pdf"
-            local ReaderUI = require("apps/reader/readerui")
-
-            local UIManager = require("ui/uimanager")
-
-            stub(Device, "suspend")
-
-            UIManager:init()
-
-            ReaderUI:doShowReader(sample_pdf)
-            local readerui = ReaderUI._getRunningInstance()
-            stub(readerui, "onFlushSettings")
-            UIManager.event_handlers.PowerPress()
-            UIManager.event_handlers.PowerRelease()
-            assert.stub(readerui.onFlushSettings).was_called()
-
-            Device.initNetworkManager:revert()
-            Device.suspend:revert()
-            readerui.onFlushSettings:revert()
-            Device.screen_saver_mode = false
-            readerui:onClose()
-        end)
-
         it("Remarkable", function()
             io.open = function(filename, mode)
                 if filename == "/usr/bin/xochitl" then

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -339,7 +339,6 @@ describe("device module", function()
 
             local UIManager = require("ui/uimanager")
             stub(Device, "suspend")
-            stub(Device.powerd, "beforeSuspend")
             stub(Device, "isKobo")
 
             Device.isKobo.returns(true)
@@ -353,7 +352,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.powerd.beforeSuspend:revert()
             Device.isKobo:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
@@ -383,7 +381,6 @@ describe("device module", function()
             local UIManager = require("ui/uimanager")
 
             stub(Device, "suspend")
-            stub(Device.powerd, "beforeSuspend")
             stub(Device, "isCervantes")
 
             Device.isCervantes.returns(true)
@@ -397,7 +394,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.powerd.beforeSuspend:revert()
             Device.isCervantes:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
@@ -414,7 +410,6 @@ describe("device module", function()
             local UIManager = require("ui/uimanager")
 
             stub(Device, "suspend")
-            stub(Device.powerd, "beforeSuspend")
             stub(Device, "isSDL")
 
             Device.isSDL.returns(true)
@@ -428,7 +423,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.powerd.beforeSuspend:revert()
             Device.isSDL:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false
@@ -464,7 +458,6 @@ describe("device module", function()
             local UIManager = require("ui/uimanager")
 
             stub(Device, "suspend")
-            stub(Device.powerd, "beforeSuspend")
             stub(Device, "isRemarkable")
 
             Device.isRemarkable.returns(true)
@@ -478,7 +471,6 @@ describe("device module", function()
             assert.stub(readerui.onFlushSettings).was_called()
 
             Device.suspend:revert()
-            Device.powerd.beforeSuspend:revert()
             Device.isRemarkable:revert()
             readerui.onFlushSettings:revert()
             Device.screen_saver_mode = false

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -11,6 +11,8 @@ describe("device module", function()
         mock_fb = {
             new = function()
                 return {
+                    device = package.loaded.device,
+                    bb = require("ffi/blitbuffer").new(600, 800, 1),
                     getRawSize = function() return {w = 600, h = 800} end,
                     getWidth = function() return 600 end,
                     getHeight = function() return 800 end,

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -331,10 +331,12 @@ describe("device module", function()
                     return osgetenv(key)
                 end
             end)
+            -- Bypass frontend/device probeDevice, while making sure that it points to the right implementation
+            local Device = require("device/kobo/device")
+            package.loaded.device = Device
+            Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/kobo/device")
-            Device:init()
 
             local UIManager = require("ui/uimanager")
             stub(Device, "suspend")
@@ -368,10 +370,11 @@ describe("device module", function()
                 end
             end
 
+            local Device = require("device/cervantes/device")
+            package.loaded.device = Device
+            Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/cervantes/device")
-            Device:init()
 
             local UIManager = require("ui/uimanager")
 
@@ -393,10 +396,11 @@ describe("device module", function()
         end)
 
         it("SDL", function()
+            local Device = require("device/sdl/device")
+            package.loaded.device = Device
+            Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/sdl/device")
-            Device:init()
 
             local UIManager = require("ui/uimanager")
 
@@ -437,10 +441,11 @@ describe("device module", function()
                     return iopen(filename, mode)
                 end
             end
+            local Device = require("device/remarkable/device")
+            package.loaded.device = Device
+            Device:init()
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
-            local Device = require("device/remarkable/device")
-            Device:init()
 
             local UIManager = require("ui/uimanager")
 

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -347,11 +347,15 @@ describe("device module", function()
             stub(Device, "initNetworkManager")
             stub(Device, "suspend")
             Device:init()
+            -- Don't poke the RTC
+            Device.wakeup_mgr = require("device/wakeupmgr"):new{rtc = require("device/kindle/mockrtc")}
             package.loaded.device = Device
 
             local sample_pdf = "spec/front/unit/data/tall.pdf"
             local ReaderUI = require("apps/reader/readerui")
             local UIManager = require("ui/uimanager")
+            -- Generic's onPowerEvent may request a repaint, but we can't do that
+            stub(UIManager, "forceRePaint")
             UIManager:init()
 
             ReaderUI:doShowReader(sample_pdf)
@@ -361,6 +365,7 @@ describe("device module", function()
             UIManager.event_handlers.PowerRelease()
             assert.stub(readerui.onFlushSettings).was_called()
 
+            UIManager.forceRePaint:revert()
             Device.initNetworkManager:revert()
             Device.suspend:revert()
             readerui.onFlushSettings:revert()


### PR DESCRIPTION
Make sure we only send Suspend/Resume events when we *actually* suspend/resume. This is done via the Device `_beforeSuspend`/`_afterResume` methods, and those were called by the *input handlers*, not the PM logic; which means they would fire, while the PM logic could actually take a smarter decision and *not* do what the event just sent implied ;).

(i.e., sleep with a cover -> suspend + actual suspend, OK; but if you then resume with a button -> input assumes resume, but PM will actually suspend again!).

Existing design issue made more apparent by #9448 ;).

Also fixes/generalizes a few corner-cases related to screen_saver_lock handling (e.g., don't allow USBMS during a lock).

And deal with the fallout of the main change to the Kobo frontlight ramp behavior ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10426)
<!-- Reviewable:end -->
