### PR TITLE
Exporter: choose folder

### DIFF
--- a/plugins/exporter.koplugin/base.lua
+++ b/plugins/exporter.koplugin/base.lua
@@ -63,6 +63,9 @@ Loads settings for the exporter
 function BaseExporter:loadSettings()
     local plugin_settings = G_reader_settings:readSetting("exporter") or {}
     self.settings = plugin_settings[self.name] or {}
+    if plugin_settings.clipping_dir then
+        self.clipping_dir = plugin_settings.clipping_dir
+    end
 end
 
 --[[--

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -263,7 +263,7 @@ function Exporter:addToMainMenu(menu_items)
                 sub_item_table = submenu,
             },
             {
-                text = _("Choose exporting folder"),
+                text = _("Choose export folder"),
                 keep_menu_open = true,
                 callback = function()
                     self:chooseFolder()
@@ -298,7 +298,7 @@ function Exporter:chooseFolder()
     local clipping_dir = settings.clipping_dir or clipping_dir_default
     local MultiConfirmBox = require("ui/widget/multiconfirmbox")
     local confirm_box = MultiConfirmBox:new{
-        text = T(_("Exporting folder is set to:\n%1\n\nChoose new exporting folder?"), clipping_dir),
+        text = T(_("Export folder is set to:\n%1\n\nChoose new export folder?"), clipping_dir),
         choice1_text = _("Use default"),
         choice1_callback = function()
             settings.clipping_dir = nil

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -96,7 +96,6 @@ end
 
 local Exporter = WidgetContainer:extend{
     name = "exporter",
-    clipping_dir = DataStorage:getDataDir() .. "/clipboard",
     targets = {
         html = require("target/html"),
         joplin = require("target/joplin"),
@@ -262,7 +261,13 @@ function Exporter:addToMainMenu(menu_items)
             {
                 text = _("Choose formats and services"),
                 sub_item_table = submenu,
-                separator = true,
+            },
+            {
+                text = _("Choose exporting folder"),
+                keep_menu_open = true,
+                callback = function()
+                    self:chooseFolder()
+                end,
             },
         }
     }
@@ -280,6 +285,43 @@ function Exporter:addToMainMenu(menu_items)
         })
     end
     menu_items.exporter = menu
+end
+
+function Exporter:chooseFolder()
+    local function set_targets_clipping_dir(dir)
+        for k in pairs(self.targets) do
+            self.targets[k].clipping_dir = dir
+        end
+    end
+    local clipping_dir_default = DataStorage:getFullDataDir() .. "/clipboard"
+    local settings = G_reader_settings:readSetting("exporter") or {}
+    local clipping_dir = settings.clipping_dir or clipping_dir_default
+    local MultiConfirmBox = require("ui/widget/multiconfirmbox")
+    local confirm_box = MultiConfirmBox:new{
+        text = T(_("Exporting folder is set to:\n%1\n\nChoose new exporting folder?"), clipping_dir),
+        choice1_text = _("Use default"),
+        choice1_callback = function()
+            settings.clipping_dir = nil
+            G_reader_settings:saveSetting("exporter", settings)
+            set_targets_clipping_dir(clipping_dir_default)
+        end,
+        choice2_text = _("Choose folder"),
+        choice2_callback = function()
+            local PathChooser = require("ui/widget/pathchooser")
+            local path_chooser = PathChooser:new{
+                select_file = false,
+                show_files = false,
+                path = clipping_dir,
+                onConfirm = function(new_path)
+                    settings.clipping_dir = new_path
+                    G_reader_settings:saveSetting("exporter", settings)
+                    set_targets_clipping_dir(new_path)
+                end
+            }
+            UIManager:show(path_chooser)
+        end,
+    }
+    UIManager:show(confirm_box)
 end
 
 return Exporter


### PR DESCRIPTION
Default is still `koreader/clipboard`.

![01](https://github.com/koreader/koreader/assets/62179190/2d47b086-9c81-475e-a3f4-22717d5ad4ff)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10448)
<!-- Reviewable:end -->
