### PR TITLE
pdfdocument: cache page text

### DIFF
--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -103,10 +103,17 @@ function PdfDocument:comparePositions(pos1, pos2)
 end
 
 function PdfDocument:getPageTextBoxes(pageno)
-    local page = self._document:openPage(pageno)
-    local text = page:getPageText()
-    page:close()
-    return text
+    local hash = "textbox|"..self.file.."|"..pageno
+    local cached = DocCache:check(hash)
+    if not cached then
+        local page = self._document:openPage(pageno)
+        local text = page:getPageText()
+        page:close()
+        DocCache:insert(hash, CacheItem:new{text=text, size=text.size})
+        return text
+    else
+        return cached.text
+    end
 end
 
 function PdfDocument:getPanelFromPage(pageno, pos)


### PR DESCRIPTION
Updating the selection queries the same page tens of times per second. This prevents KOReader to keep up high-frequency input event streams.

Fixes #10443. Relies on koreader/koreader-base#1612.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10450)
<!-- Reviewable:end -->
