### PR TITLE
ReaderHighlight: fix translation

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1383,10 +1383,17 @@ dbg:guard(ReaderHighlight, "translate",
             "translate must not be called with nil selected_text!")
     end)
 
-function ReaderHighlight:onTranslateText(text, page, index)
+function ReaderHighlight:getDocumentLanguage()
     local doc_props = self.ui.doc_settings:readSetting("doc_props")
     local doc_lang = doc_props and doc_props.language
-    Translator:showTranslation(text, true, doc_lang, nil, true, page, index)
+    if doc_lang == "" then
+        doc_lang = nil
+    end
+    return doc_lang
+end
+
+function ReaderHighlight:onTranslateText(text, page, index)
+    Translator:showTranslation(text, true, self:getDocumentLanguage(), nil, true, page, index)
 end
 
 function ReaderHighlight:onTranslateCurrentPage()
@@ -1413,9 +1420,7 @@ function ReaderHighlight:onTranslateCurrentPage()
         self.ui.document.configurable.text_wrap = is_reflow
     end
     if res and res.text then
-        local doc_props = self.ui.doc_settings:readSetting("doc_props")
-        local doc_lang = doc_props and doc_props.language
-        Translator:showTranslation(res.text, false, doc_lang)
+        Translator:showTranslation(res.text, false, self:getDocumentLanguage())
     end
 end
 


### PR DESCRIPTION
Fix translation for books without "language" in properties (it is "", Translator expects `nil`).
Regression after https://github.com/koreader/koreader/pull/10438.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10451)
<!-- Reviewable:end -->
