### PR TITLE
Exporter: selected files

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -328,6 +328,16 @@ function MyClipping:parseHistory()
     return clippings
 end
 
+function MyClipping:parseFiles(files)
+    local clippings = {}
+    for file in pairs(files) do
+        if DocSettings:hasSidecarFile(file) then
+            self:getClippingsFromBook(clippings, file)
+        end
+    end
+    return clippings
+end
+
 function MyClipping:getProps(file)
     local document = DocumentRegistry:openDocument(file)
     local book_props = nil

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -171,6 +171,18 @@ function Exporter:exportAllNotes()
     self:exportClippings(clippings)
 end
 
+function Exporter:exportFilesNotes(files)
+-- @table files {[file_path] = true}
+    local clippings = self.parser:parseFiles(files)
+    for title, booknotes in pairs(clippings) do
+        -- chapter number is zero
+        if #booknotes == 0 then
+            clippings[title] = nil
+        end
+    end
+    self:exportClippings(clippings)
+end
+
 function Exporter:exportClippings(clippings)
     if type(clippings) ~= "table" then return end
     local exportables = {}


### PR DESCRIPTION
Export highlights for selected files.
Having a button "Select all files in folder", it is easy to export the whole folder.
So, closes https://github.com/koreader/koreader/issues/10402.

To keep even number of buttons, added a feature "Show selected files list". May be useful to check selections before an operation. Just a sorted list, no titlebar or popup menu, tapping a file jumps to its folder.

![01](https://github.com/koreader/koreader/assets/62179190/8b28f649-86b8-423e-a137-b731e88ee8fe)

![02](https://github.com/koreader/koreader/assets/62179190/3d753721-e2de-465f-ab1a-92b50fa26ef5)
