### PR TITLE
ReaderHighlight: fix translator auto lang for fragment

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1393,7 +1393,7 @@ function ReaderHighlight:getDocumentLanguage()
 end
 
 function ReaderHighlight:onTranslateText(text, page, index)
-    Translator:showTranslation(text, true, self:getDocumentLanguage(), nil, true, page, index)
+    Translator:showTranslation(text, true, nil, nil, true, page, index)
 end
 
 function ReaderHighlight:onTranslateCurrentPage()


### PR DESCRIPTION
Regression after https://github.com/koreader/koreader/pull/10438.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10469)
<!-- Reviewable:end -->
