### PR TITLE
Notification: NOP conflicting event handlers from our base class

### DIFF
--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -323,9 +323,9 @@ function InputContainer:onIgnoreTouchInput(toggle)
     else
         -- Toggle the current state
         if InputContainer._onGesture then
-            self:onIgnoreTouchInput(false)
+            return self:onIgnoreTouchInput(false)
         else
-            self:onIgnoreTouchInput(true)
+            return self:onIgnoreTouchInput(true)
         end
     end
 

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -251,4 +251,13 @@ function Notification:onGesture(ev)
     return InputContainer.onGesture(self, ev)
 end
 
+-- Since toasts do *not* prevent event propagation, if we let this go through to InputContainer, shit happens...
+function Notification:onIgnoreTouchInput(toggle)
+    return true
+end
+-- Do the same for other Events caught by our base class
+Notification.onResume = Notification.onIgnoreTouchInput
+Notification.onPhysicalKeyboardDisconnected = Notification.onIgnoreTouchInput
+Notification.onInput = Notification.onIgnoreTouchInput
+
 return Notification


### PR DESCRIPTION
Notification is a toast, so it doesn't stop event propagation. If we don't disable those handlers inside Notification, we get spurious duplicate handlers being fired ;).

Fix #10461

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10471)
<!-- Reviewable:end -->
