### PR TITLE
WakeupMgr: kinde: use a 90 sec proximity

### DIFF
--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -227,7 +227,7 @@ function KindlePowerD:checkUnexpectedWakeup()
     -- then we were woken by user input not our alarm.
     if state ~= "screenSaver" and state ~= "suspended" then return end
 
-    if self.device.wakeup_mgr:isWakeupAlarmScheduled() and self.device.wakeup_mgr:wakeupAction() then
+    if self.device.wakeup_mgr:isWakeupAlarmScheduled() and self.device.wakeup_mgr:wakeupAction(90) then
         logger.info("Kindle scheduled wakeup")
     else
         logger.warn("Kindle unscheduled wakeup")


### PR DESCRIPTION
sometimes my kindle fires the rtc alarm a tad too late so use a more generous timeout

the real fix would be to have validateWakeupAlarmByProximity return differently if the alarm is past or in the future, but i am too lazy

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10486)
<!-- Reviewable:end -->
