### PR TITLE
Collections: fix crash on showing deleted file entry

### DIFF
--- a/frontend/readcollection.lua
+++ b/frontend/readcollection.lua
@@ -42,7 +42,7 @@ function ReadCollection:prepareList(collection_name)
             file = file_path,
             text = v.file:gsub(".*/", ""),
             dim = not file_exists,
-            mandatory = file_exists and util.getFriendlySize(lfs.attributes(file_path, "size") or 0),
+            mandatory = file_exists and util.getFriendlySize(lfs.attributes(file_path, "size") or 0) or "",
             select_enabled = file_exists,
         })
     end


### PR DESCRIPTION
If a file has been deleted outside of KOReader, its entry remains in Collection list and in coverbrowser bookinfo sql.
So listmenu tries to build the full entry with the mandatory containing filesize (which is `false`).
After this fix the file entry will be displayed dimmed (as for deleted files), with metadata but without filesize.
Then a user should take care of this entry manually:
-remove it from the Collection, or
-refresh cached book info (after that listmenu will show the filename only with a hint (deleted))
Closes https://github.com/koreader/koreader/issues/10487.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10488)
<!-- Reviewable:end -->
