### PR TITLE
Profiles: fix showing some bad values

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -568,7 +568,7 @@ function Dispatcher:getNameFromItem(item, settings, dont_show_value)
             display_value = tostring(value)
         end
         if display_value then
-            if settingsList[item].unit and tonumber(display_value) then
+            if settingsList[item].unit and (type(value) == "table" or tonumber(display_value)) then
                 display_value = display_value .. " " .. settingsList[item].unit
             end
             title = title .. ": " .. display_value

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -562,13 +562,13 @@ function Dispatcher:getNameFromItem(item, settings, dont_show_value)
                     settingsList[item].args, settingsList[item].toggle = settingsList[item].args_func()
                 end
                 local value_num = util.arrayContains(settingsList[item].args, value)
-                display_value = settingsList[item].toggle[value_num]
+                display_value = settingsList[item].toggle[value_num] or string.format("%.1f", value)
             end
         elseif category == "absolutenumber" or category == "incrementalnumber" then
             display_value = tostring(value)
         end
         if display_value then
-            if settingsList[item].unit then
+            if settingsList[item].unit and tonumber(display_value) then
                 display_value = display_value .. " " .. settingsList[item].unit
             end
             title = title .. ": " .. display_value


### PR DESCRIPTION
Fix showing action values:
-when an action has both a toggle and a spinwidget, and the value is not equal to any arg of the toggle
-when an action has a toggle and a unit, and the toggle is not a number

Before / after

![11](https://github.com/koreader/koreader/assets/62179190/307960ba-dabc-4c04-bcfd-77a49f600103)

![12](https://github.com/koreader/koreader/assets/62179190/fdea61b0-932b-40e6-8e0f-c4e730a72b07)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10495)
<!-- Reviewable:end -->
