### PR TITLE
Profiles: disable inapplicable actions in QuickMenu

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -131,7 +131,7 @@ local settingsList = {
     prev_bookmark = {category="none", event="GotoPreviousBookmarkFromPage", title=_("Previous bookmark"), reader=true},
     next_bookmark = {category="none", event="GotoNextBookmarkFromPage", title=_("Next bookmark"), reader=true},
     latest_bookmark = {category="none", event="GoToLatestBookmark", title=_("Go to latest bookmark"), reader=true},
-    back = {category="none", event="Back", title=_("Back"), reader=true},
+    back = {category="none", event="Back", title=_("Back"), filemanager=true, reader=true},
     previous_location = {category="none", event="GoBackLink", arg=true, title=_("Back to previous location"), reader=true},
     next_location = {category="none", event="GoForwardLink", arg=true, title=_("Forward to next location"), reader=true},
     follow_nearest_link = {category="arg", event="GoToPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest link"), reader=true},
@@ -970,19 +970,19 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
 end
 
 function Dispatcher:isActionEnabled(action)
-    local not_enabled = true
-    if action.condition == nil or action.condition == true then
+    local disabled = true
+    if action and (action.condition == nil or action.condition == true) then
         local ui = require("apps/reader/readerui").instance
         local context = ui and (ui.paging and "paging" or "rolling")
         if context == "paging" then
-            not_enabled = action["rolling"]
+            disabled = action["rolling"]
         elseif context == "rolling" then
-            not_enabled = action["paging"]
+            disabled = action["paging"]
         else -- FM
-            not_enabled = action["reader"] or action["rolling"] or action["paging"]
+            disabled = (action["reader"] or action["rolling"] or action["paging"]) and not action["filemanager"]
         end
     end
-    return not not_enabled
+    return not disabled
 end
 
 function Dispatcher:_showAsMenu(settings)
@@ -1033,7 +1033,7 @@ function Dispatcher:execute(settings, gesture)
             k = v
             v = settings[k]
         end
-        if settingsList[k] ~= nil and Dispatcher:isActionEnabled(settingsList[k]) then
+        if Dispatcher:isActionEnabled(settingsList[k]) then
             Notification:setNotifySource(Notification.SOURCE_DISPATCHER)
             if settingsList[k].configurable then
                 local value = v

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -970,12 +970,24 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
 end
 
 function Dispatcher:_showAsMenu(settings)
+    local ui = require("apps/reader/readerui").instance
+    local state = ui and (ui.paging and "paging" or "rolling")
+    local function action_disabled(action)
+        if state == "paging" then
+            return action["rolling"]
+        elseif state == "rolling" then
+            return action["paging"]
+        else -- FM
+            return action["reader"] or action["rolling"] or action["paging"]
+        end
+    end
     local display_list = Dispatcher:getDisplayList(settings)
     local quickmenu
     local buttons = {}
     for _, v in ipairs(display_list) do
         table.insert(buttons, {{
             text = v.text,
+            enabled = not action_disabled(settingsList[v.key]),
             align = "left",
             font_face = "smallinfofont",
             font_size = 22,


### PR DESCRIPTION
The PR is discussible, maybe a user should take care of his profiles himself? @yparitcher

The same profile with mixed actions in:

FM
![1](https://github.com/koreader/koreader/assets/62179190/706f2134-29c1-4cc1-8a55-65b4fbc70157)

cre
![2](https://github.com/koreader/koreader/assets/62179190/83c3592f-0e04-4aaf-9c32-b8e768f4872a)

pdf
![3](https://github.com/koreader/koreader/assets/62179190/d20f2351-2d0d-470c-8f2b-947190f97208)

Closes https://github.com/koreader/koreader/issues/10493.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10500)
<!-- Reviewable:end -->
