### PR TITLE
Translate page: fix translate page with a title

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1452,8 +1452,7 @@ end
 function ReaderHighlight:onTranslateCurrentPage()
     local x0, y0, x1, y1, page, is_reflow
     if self.ui.rolling then
-        x0 = 0
-        y0 = 0
+        y0, x0 = self.ui.document:getScreenPositionFromXPointer(self.ui.document:getXPointer())
         x1 = Screen:getWidth()
         y1 = Screen:getHeight()
     else


### PR DESCRIPTION
Use actual screen position of the text starting point instead of (0,0).
Closes https://github.com/koreader/koreader/issues/10505.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10506)
<!-- Reviewable:end -->
