### PR TITLE
BookMap: visual tweaks and enhancements

### DIFF
--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -68,6 +68,12 @@ function ReaderThumbnail:addToMainMenu(menu_items)
         callback = function()
             self:onShowBookMap()
         end,
+        -- Show the alternative overview mode (which is just a restricted
+        -- variation of the main book map) with long-press (let's avoid
+        -- adding another item in the crowded first menu).
+        hold_callback = function()
+            self:onShowBookMap(true)
+        end,
     }
     menu_items.page_browser = {
         text = _("Page browser"),
@@ -77,10 +83,11 @@ function ReaderThumbnail:addToMainMenu(menu_items)
     }
 end
 
-function ReaderThumbnail:onShowBookMap()
+function ReaderThumbnail:onShowBookMap(overview_mode)
     local BookMapWidget = require("ui/widget/bookmapwidget")
     UIManager:show(BookMapWidget:new{
         ui = self.ui,
+        overview_mode = overview_mode,
     })
     return true
 end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -141,6 +141,7 @@ local settingsList = {
 
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     book_map = {category="none", event="ShowBookMap", title=_("Book map"), reader=true, condition=Device:isTouchDevice()},
+    book_map_overview = {category="none", event="ShowBookMap", arg=true, title=_("Book map (overview)"), reader=true, condition=Device:isTouchDevice()},
     page_browser = {category="none", event="ShowPageBrowser", title=_("Page browser"), reader=true, condition=Device:isTouchDevice()},
     bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), reader=true},
     bookmark_search = {category="none", event="SearchBookmark", title=_("Bookmark search"), reader=true},
@@ -333,6 +334,7 @@ local dispatcher_menu_order = {
 
     "toc",
     "book_map",
+    "book_map_overview",
     "page_browser",
     "bookmarks",
     "bookmark_search",

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -376,7 +376,7 @@ function PageBrowserWidget:update()
     -- Extended separators below the baseline for pages starting thumbnail rows
     local extended_sep_pages = {}
     for p=grid_page_start+self.nb_cols, grid_page_end, self.nb_cols do
-        extended_sep_pages[p] = true
+        extended_sep_pages[p] = BookMapRow.extended_marker.LARGE
     end
 
     -- Show the page number or label at the bottom page slot every N slots, with N


### PR DESCRIPTION
Discussed all along #10433. Closes #10433.

#### PageBrowser: smaller margins if no thumbnail page numbers

Also fix possibly unbalanced left and right margins.

#### BookMap: nicer alignment of the vertical page number

Align page numbers (the vertical ones, on the left of a BookMapRow) on the baseline of the BookMapRow, where page slots rise from.
Also tweak the page number spike below the baseline used in PageBrowser.

#### BookMap: add option "Page browser on tap"

Enabled by default, to get the current behaviour.
Disabling it allows people with small fingers to jump directly to that page in Reader.

#### BookMap: add option "10-page markers"

Allows hairy-boxes amateurs to get small markers (under the baseline) every 10 pages (with -/+ to get small or medium markers, with optionally smaller ones every 5 pages).

#### BookMap: add "Overview" mode

Add a restricted but convenient mode showing BookMap like in initial view, while still allowing chapter levels to be tweaked. This allows getting back to this view with another gesture to see the overall progress in the book, while still having the normal BookMap in flat mode acting as an alternative ToC.
Available as an action to associate to a gesture, and with long-press on the "Book map" menu item.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10530)
<!-- Reviewable:end -->
