### PR TITLE
File popup dialog buttons

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1,7 +1,6 @@
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonDialog = require("ui/widget/buttondialog")
-local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local CheckButton = require("ui/widget/checkbutton")
 local ConfirmBox = require("ui/widget/confirmbox")
@@ -268,21 +267,7 @@ function FileManager:setupLayout()
             end
             table.insert(buttons, {
                 filemanagerutil.genResetSettingsButton(file, status_button_callback),
-                {
-                    text_func = function()
-                        return ReadCollection:checkItemExist(file)
-                            and _("Remove from favorites") or _("Add to favorites")
-                    end,
-                    enabled = has_provider,
-                    callback = function()
-                        UIManager:close(self.file_dialog)
-                        if ReadCollection:checkItemExist(file) then
-                            ReadCollection:removeItem(file)
-                        else
-                            ReadCollection:addItem(file)
-                        end
-                    end,
-                },
+                filemanagerutil.genAddRemoveFavoritesButton(file, close_dialog_callback, not has_provider),
             })
             table.insert(buttons, {
                 {
@@ -344,7 +329,7 @@ function FileManager:setupLayout()
             })
         end
 
-        self.file_dialog = ButtonDialogTitle:new{
+        self.file_dialog = ButtonDialog:new{
             title = is_file and BD.filename(file:match("([^/]+)$")) or BD.directory(file:match("([^/]+)$")),
             title_align = "center",
             buttons = buttons,
@@ -739,7 +724,7 @@ function FileManager:tapPlus()
         end
     end
 
-    self.file_dialog = ButtonDialogTitle:new{
+    self.file_dialog = ButtonDialog:new{
         title = title,
         title_align = "center",
         buttons = buttons,

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -1,5 +1,6 @@
-local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+local ButtonDialog = require("ui/widget/buttondialog")
 local Device = require("device")
+local DocumentRegistry = require("document/documentregistry")
 local Menu = require("ui/widget/menu")
 local ReadCollection = require("readcollection")
 local UIManager = require("ui/uimanager")
@@ -44,6 +45,10 @@ function FileManagerCollection:onMenuHold(item)
     local function close_dialog_callback()
         UIManager:close(self.collfile_dialog)
     end
+    local function close_dialog_menu_callback()
+        UIManager:close(self.collfile_dialog)
+        self._manager.coll_menu.close_callback()
+    end
     local function status_button_callback()
         UIManager:close(self.collfile_dialog)
         self._manager:updateItemTable()
@@ -67,34 +72,7 @@ function FileManagerCollection:onMenuHold(item)
         },
     })
     table.insert(buttons, {
-        {
-            text = _("Sort favorites"),
-            callback = function()
-                UIManager:close(self.collfile_dialog)
-                local item_table = {}
-                for _, v in ipairs(self._manager.coll_menu.item_table) do
-                    table.insert(item_table, {text = v.text, label = v.file})
-                end
-                local SortWidget = require("ui/widget/sortwidget")
-                local sort_item
-                sort_item = SortWidget:new{
-                    title = _("Sort favorites"),
-                    item_table = item_table,
-                    callback = function()
-                        local new_order_table = {}
-                        for i, v in ipairs(sort_item.item_table) do
-                            table.insert(new_order_table, {
-                                file = v.label,
-                                order = i,
-                            })
-                        end
-                        ReadCollection:writeCollection(new_order_table, self._manager.coll_menu.collection)
-                        self._manager:updateItemTable()
-                    end
-                }
-                UIManager:show(sort_item)
-            end,
-        },
+        filemanagerutil.genShowFolderButton(item.file, close_dialog_menu_callback, item.dim),
         filemanagerutil.genBookInformationButton(item.file, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {
@@ -103,16 +81,12 @@ function FileManagerCollection:onMenuHold(item)
     })
 
     if Device:canExecuteScript(item.file) then
-        local function button_callback()
-            UIManager:close(self.collfile_dialog)
-            self._manager.coll_menu.close_callback()
-        end
         table.insert(buttons, {
-            filemanagerutil.genExecuteScriptButton(item.file, button_callback)
+            filemanagerutil.genExecuteScriptButton(item.file, close_dialog_menu_callback)
         })
     end
 
-    self.collfile_dialog = ButtonDialogTitle:new{
+    self.collfile_dialog = ButtonDialog:new{
         title = item.text:match("([^/]+)$"),
         title_align = "center",
         buttons = buttons,
@@ -142,19 +116,96 @@ function FileManagerCollection:onShowColl(collection)
         covers_fullscreen = true, -- hint for UIManager:_repaint()
         is_borderless = true,
         is_popout = false,
+        title_bar_left_icon = "appbar.menu",
+        onLeftButtonTap = function() self:showCollDialog() end,
         onMenuChoice = self.onMenuChoice,
         onMenuHold = self.onMenuHold,
         onSetRotationMode = self.MenuSetRotationModeHandler,
         _manager = self,
         collection = collection,
     }
-
     self:updateItemTable()
     self.coll_menu.close_callback = function()
         UIManager:close(self.coll_menu)
     end
     UIManager:show(self.coll_menu)
     return true
+end
+
+function FileManagerCollection:showCollDialog()
+    local coll_dialog
+    local is_added = self.ui.document and ReadCollection:checkItemExist(self.ui.document.file)
+    local buttons = {
+        {{
+            text_func = function()
+                return is_added and _("Remove current book from favorites") or _("Add current book to favorites")
+            end,
+            enabled = self.ui.document and true or false,
+            callback = function()
+                UIManager:close(coll_dialog)
+                if is_added then
+                    ReadCollection:removeItem(self.ui.document.file)
+                else
+                    ReadCollection:addItem(self.ui.document.file)
+                end
+                self:updateItemTable()
+            end,
+        }},
+        {{
+            text = _("Add a book to favorites"),
+            callback = function()
+                UIManager:close(coll_dialog)
+                local PathChooser = require("ui/widget/pathchooser")
+                local path_chooser = PathChooser:new{
+                    path = G_reader_settings:readSetting("home_dir"),
+                    select_directory = false,
+                    file_filter = function(file)
+                        return DocumentRegistry:getProviders(file) ~= nil
+                    end,
+                    onConfirm = function(file)
+                        if not ReadCollection:checkItemExist(file) then
+                            ReadCollection:addItem(file)
+                            self:updateItemTable()
+                        end
+                    end,
+                }
+                UIManager:show(path_chooser)
+            end,
+        }},
+        {{
+            text = _("Sort favorites"),
+            callback = function()
+                UIManager:close(coll_dialog)
+                self:sortCollection()
+            end,
+        }},
+    }
+    coll_dialog = ButtonDialog:new{
+        buttons = buttons,
+    }
+    UIManager:show(coll_dialog)
+end
+
+function FileManagerCollection:sortCollection()
+    local item_table = {}
+    for _, v in ipairs(self.coll_menu.item_table) do
+        table.insert(item_table, { text = v.text, label = v.file })
+    end
+    local SortWidget = require("ui/widget/sortwidget")
+    local sort_widget
+    sort_widget = SortWidget:new{
+        title = _("Sort favorites"),
+        item_table = item_table,
+        callback = function()
+            local new_order_table = {}
+            for i, v in ipairs(sort_widget.item_table) do
+                table.insert(new_order_table, { file = v.label, order = i })
+            end
+            ReadCollection:writeCollection(new_order_table, self.coll_menu.collection)
+            self:updateItemTable()
+        end
+    }
+    UIManager:show(sort_widget)
 end
 
 return FileManagerCollection

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -1,5 +1,5 @@
 local BD = require("ui/bidi")
-local ButtonDialog = require("ui/widget/ButtonDialog")
+local ButtonDialog = require("ui/widget/buttondialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -1,5 +1,5 @@
 local BD = require("ui/bidi")
-local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+local ButtonDialog = require("ui/widget/ButtonDialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
@@ -86,6 +86,10 @@ function FileManagerHistory:onMenuHold(item)
     local function close_dialog_callback()
         UIManager:close(self.histfile_dialog)
     end
+    local function close_dialog_menu_callback()
+        UIManager:close(self.histfile_dialog)
+        self._manager.hist_menu.close_callback()
+    end
     local function status_button_callback()
         UIManager:close(self.histfile_dialog)
         if self._manager.filter ~= "all" then
@@ -105,14 +109,7 @@ function FileManagerHistory:onMenuHold(item)
     end
     table.insert(buttons, {
         filemanagerutil.genResetSettingsButton(item.file, status_button_callback, is_currently_opened),
-        {
-            text = _("Remove from history"),
-            callback = function()
-                UIManager:close(self.histfile_dialog)
-                require("readhistory"):removeItem(item)
-                self._manager:updateItemTable()
-            end,
-        },
+        filemanagerutil.genAddRemoveFavoritesButton(item.file, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {
         {
@@ -128,6 +125,17 @@ function FileManagerHistory:onMenuHold(item)
                 FileManager:showDeleteFileDialog(item.file, post_delete_callback)
             end,
         },
+        {
+            text = _("Remove from history"),
+            callback = function()
+                UIManager:close(self.histfile_dialog)
+                require("readhistory"):removeItem(item)
+                self._manager:updateItemTable()
+            end,
+        },
+    })
+    table.insert(buttons, {
+        filemanagerutil.genShowFolderButton(item.file, close_dialog_menu_callback, item.dim),
         filemanagerutil.genBookInformationButton(item.file, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {
@@ -135,7 +143,7 @@ function FileManagerHistory:onMenuHold(item)
         filemanagerutil.genBookDescriptionButton(item.file, close_dialog_callback, item.dim),
     })
 
-    self.histfile_dialog = ButtonDialogTitle:new{
+    self.histfile_dialog = ButtonDialog:new{
         title = BD.filename(item.text:match("([^/]+)$")),
         title_align = "center",
         buttons = buttons,
@@ -243,7 +251,7 @@ function FileManagerHistory:showHistDialog()
             },
         })
     end
-    hist_dialog = ButtonDialogTitle:new{
+    hist_dialog = ButtonDialog:new{
         title = _("Filter by book status"),
         title_align = "center",
         buttons = buttons,

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -164,6 +164,44 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
     }
 end
 
+function filemanagerutil.genAddRemoveFavoritesButton(file, caller_callback, button_disabled)
+    local ReadCollection = require("readcollection")
+    local is_added = ReadCollection:checkItemExist(file)
+    return {
+        text_func = function()
+            return is_added and _("Remove from favorites") or _("Add to favorites")
+        end,
+        enabled = not button_disabled,
+        callback = function()
+            caller_callback()
+            if is_added then
+                ReadCollection:removeItem(file)
+            else
+                ReadCollection:addItem(file)
+            end
+        end,
+    }
+end
+
+function filemanagerutil.genShowFolderButton(file, caller_callback, button_disabled)
+    return {
+        text = _("Show folder"),
+        enabled = not button_disabled,
+        callback = function()
+            caller_callback()
+            local ui = require("apps/filemanager/filemanager").instance
+            if ui then
+                local pathname = util.splitFilePathName(file)
+                ui.file_chooser:changeToPath(pathname, file)
+            else
+                ui = require("apps/reader/readerui").instance
+                ui:onClose()
+                ui:showFileManager(file)
+            end
+        end,
+    }
+end
+
 function filemanagerutil.genBookInformationButton(file, caller_callback, button_disabled)
     return {
         text = _("Book information"),

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -307,7 +307,7 @@ function CoverMenu:updateItems(select_number)
 
                 -- Create the new ButtonDialog, and let UIManager show it
                 -- (all button callback fudging must be done after this block to stick)
-                local ButtonDialog = require("ui/widget/ButtonDialog")
+                local ButtonDialog = require("ui/widget/buttondialog")
                 self.file_dialog = ButtonDialog:new{
                     title = orig_title,
                     title_align = orig_title_align,
@@ -434,7 +434,7 @@ function CoverMenu:onHistoryMenuHold(item)
 
     -- Create the new ButtonDialog, and let UIManager show it
     -- (all button callback replacement must be done after this block to stick)
-    local ButtonDialog = require("ui/widget/ButtonDialog")
+    local ButtonDialog = require("ui/widget/buttondialog")
     self.histfile_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,
@@ -557,7 +557,7 @@ function CoverMenu:onCollectionsMenuHold(item)
 
     -- Create the new ButtonDialog, and let UIManager show it
     -- (all button callback replacement must be done after this block to stick)
-    local ButtonDialog = require("ui/widget/ButtonDialog")
+    local ButtonDialog = require("ui/widget/buttondialog")
     self.collfile_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,
@@ -687,7 +687,7 @@ function CoverMenu:tapPlus()
     })
 
     -- Create the new ButtonDialog, and let UIManager show it
-    local ButtonDialog = require("ui/widget/ButtonDialog")
+    local ButtonDialog = require("ui/widget/buttondialog")
     self.file_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -246,7 +246,7 @@ function CoverMenu:updateItems(select_number)
             -- This causes luacheck warning: "shadowing upvalue argument 'self' on line 34".
             -- Ignoring it (as done in filemanager.lua for the same showFileDialog)
             self.showFileDialog = function(self, file) -- luacheck: ignore
-                -- Call original function: it will create a ButtonDialogTitle
+                -- Call original function: it will create a ButtonDialog
                 -- and store it as self.file_dialog, and UIManager:show() it.
                 self.showFileDialog_orig(self, file)
 
@@ -256,11 +256,11 @@ function CoverMenu:updateItems(select_number)
                     return true
                 end
 
-                -- Remember some of this original ButtonDialogTitle properties
+                -- Remember some of this original ButtonDialog properties
                 local orig_title = self.file_dialog.title
                 local orig_title_align = self.file_dialog.title_align
                 local orig_buttons = self.file_dialog.buttons
-                -- Close original ButtonDialogTitle (it has not yet been painted
+                -- Close original ButtonDialog (it has not yet been painted
                 -- on screen, so we won't see it)
                 UIManager:close(self.file_dialog)
                 -- And clear the rendering stack to avoid inheriting its dirty/refresh queue
@@ -305,17 +305,17 @@ function CoverMenu:updateItems(select_number)
                     },
                 })
 
-                -- Create the new ButtonDialogTitle, and let UIManager show it
+                -- Create the new ButtonDialog, and let UIManager show it
                 -- (all button callback fudging must be done after this block to stick)
-                local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
-                self.file_dialog = ButtonDialogTitle:new{
+                local ButtonDialog = require("ui/widget/ButtonDialog")
+                self.file_dialog = ButtonDialog:new{
                     title = orig_title,
                     title_align = orig_title_align,
                     buttons = orig_buttons,
                 }
 
                 -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-                local button = self.file_dialog.button_table:getButtonById("reset")
+                local button = self.file_dialog:getButtonById("reset")
                 local orig_purge_callback = button.callback
                 button.callback = function()
                     -- Wipe the cache
@@ -326,7 +326,7 @@ function CoverMenu:updateItems(select_number)
 
                 -- Fudge the status change button callbacks to also update the cover_info_cache
                 for _, status in ipairs(book_statuses) do
-                    button = self.file_dialog.button_table:getButtonById(status)
+                    button = self.file_dialog:getButtonById(status)
                     if not button then break end -- status buttons are not shown
                     local orig_status_callback = button.callback
                     button.callback = function()
@@ -338,18 +338,18 @@ function CoverMenu:updateItems(select_number)
                 end
 
                 -- Replace the "Book information" button callback to use directly our bookinfo
-                button = self.file_dialog.button_table:getButtonById("book_information")
+                button = self.file_dialog:getButtonById("book_information")
                 button.callback = function()
                     FileManagerBookInfo:show(file, bookinfo)
                     UIManager:close(self.file_dialog)
                 end
 
-                button = self.file_dialog.button_table:getButtonById("book_cover")
+                button = self.file_dialog:getButtonById("book_cover")
                 if not bookinfo.has_cover then
                     button:disable()
                 end
 
-                button = self.file_dialog.button_table:getButtonById("book_description")
+                button = self.file_dialog:getButtonById("book_description")
                 if bookinfo.description then
                     button.callback = function()
                         UIManager:close(self.file_dialog)
@@ -384,7 +384,7 @@ function CoverMenu:onHistoryMenuHold(item)
         return true
     end
 
-    -- Remember some of this original ButtonDialogTitle properties
+    -- Remember some of this original ButtonDialog properties
     local orig_title = self.histfile_dialog.title
     local orig_title_align = self.histfile_dialog.title_align
     local orig_buttons = self.histfile_dialog.buttons
@@ -434,15 +434,15 @@ function CoverMenu:onHistoryMenuHold(item)
 
     -- Create the new ButtonDialog, and let UIManager show it
     -- (all button callback replacement must be done after this block to stick)
-    local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
-    self.histfile_dialog = ButtonDialogTitle:new{
+    local ButtonDialog = require("ui/widget/ButtonDialog")
+    self.histfile_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,
         buttons = orig_buttons,
     }
 
     -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-    local button = self.histfile_dialog.button_table:getButtonById("reset")
+    local button = self.histfile_dialog:getButtonById("reset")
     local orig_purge_callback = button.callback
     button.callback = function()
         -- Wipe the cache
@@ -453,7 +453,7 @@ function CoverMenu:onHistoryMenuHold(item)
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
     for _, status in ipairs(book_statuses) do
-        button = self.histfile_dialog.button_table:getButtonById(status)
+        button = self.histfile_dialog:getButtonById(status)
         if not button then break end -- status buttons are not shown
         local orig_status_callback = button.callback
         button.callback = function()
@@ -465,7 +465,7 @@ function CoverMenu:onHistoryMenuHold(item)
     end
 
     -- Replace the "Book information" button callback to use directly our bookinfo
-    button = self.histfile_dialog.button_table:getButtonById("book_information")
+    button = self.histfile_dialog:getButtonById("book_information")
     local function when_updated_callback()
         self:updateItems()
     end
@@ -474,12 +474,12 @@ function CoverMenu:onHistoryMenuHold(item)
         UIManager:close(self.histfile_dialog)
     end
 
-    button = self.histfile_dialog.button_table:getButtonById("book_cover")
+    button = self.histfile_dialog:getButtonById("book_cover")
     if not bookinfo.has_cover then
         button:disable()
     end
 
-    button = self.histfile_dialog.button_table:getButtonById("book_description")
+    button = self.histfile_dialog:getButtonById("book_description")
     if bookinfo.description then
         button.callback = function()
             UIManager:close(self.histfile_dialog)
@@ -507,7 +507,7 @@ function CoverMenu:onCollectionsMenuHold(item)
         return true
     end
 
-    -- Remember some of this original ButtonDialogTitle properties
+    -- Remember some of this original ButtonDialog properties
     local orig_title = self.collfile_dialog.title
     local orig_title_align = self.collfile_dialog.title_align
     local orig_buttons = self.collfile_dialog.buttons
@@ -557,15 +557,15 @@ function CoverMenu:onCollectionsMenuHold(item)
 
     -- Create the new ButtonDialog, and let UIManager show it
     -- (all button callback replacement must be done after this block to stick)
-    local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
-    self.collfile_dialog = ButtonDialogTitle:new{
+    local ButtonDialog = require("ui/widget/ButtonDialog")
+    self.collfile_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,
         buttons = orig_buttons,
     }
 
     -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-    local button = self.collfile_dialog.button_table:getButtonById("reset")
+    local button = self.collfile_dialog:getButtonById("reset")
     local orig_purge_callback = button.callback
     button.callback = function()
         -- Wipe the cache
@@ -576,7 +576,7 @@ function CoverMenu:onCollectionsMenuHold(item)
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
     for _, status in ipairs(book_statuses) do
-        button = self.collfile_dialog.button_table:getButtonById(status)
+        button = self.collfile_dialog:getButtonById(status)
         if not button then break end -- status buttons are not shown
         local orig_status_callback = button.callback
         button.callback = function()
@@ -588,7 +588,7 @@ function CoverMenu:onCollectionsMenuHold(item)
     end
 
     -- Replace the "Book information" button callback to use directly our bookinfo
-    button = self.collfile_dialog.button_table:getButtonById("book_information")
+    button = self.collfile_dialog:getButtonById("book_information")
     local function when_updated_callback()
         self:updateItems()
     end
@@ -597,12 +597,12 @@ function CoverMenu:onCollectionsMenuHold(item)
         UIManager:close(self.collfile_dialog)
     end
 
-    button = self.collfile_dialog.button_table:getButtonById("book_cover")
+    button = self.collfile_dialog:getButtonById("book_cover")
     if not bookinfo.has_cover then
         button:disable()
     end
 
-    button = self.collfile_dialog.button_table:getButtonById("book_description")
+    button = self.collfile_dialog:getButtonById("book_description")
     if bookinfo.description then
         button.callback = function()
             UIManager:close(self.collfile_dialog)
@@ -657,16 +657,16 @@ function CoverMenu:onCloseWidget()
 end
 
 function CoverMenu:tapPlus()
-    -- Call original function: it will create a ButtonDialogTitle
+    -- Call original function: it will create a ButtonDialog
     -- and store it as self.file_dialog, and UIManager:show() it.
     CoverMenu._FileManager_tapPlus_orig(self)
     if self.file_dialog.select_mode then return end -- do not change select menu
 
-    -- Remember some of this original ButtonDialogTitle properties
+    -- Remember some of this original ButtonDialog properties
     local orig_title = self.file_dialog.title
     local orig_title_align = self.file_dialog.title_align
     local orig_buttons = self.file_dialog.buttons
-    -- Close original ButtonDialogTitle (it has not yet been painted
+    -- Close original ButtonDialog (it has not yet been painted
     -- on screen, so we won't see it)
     UIManager:close(self.file_dialog)
     UIManager:clearRenderStack()
@@ -686,9 +686,9 @@ function CoverMenu:tapPlus()
         },
     })
 
-    -- Create the new ButtonDialogTitle, and let UIManager show it
-    local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
-    self.file_dialog = ButtonDialogTitle:new{
+    -- Create the new ButtonDialog, and let UIManager show it
+    local ButtonDialog = require("ui/widget/ButtonDialog")
+    self.file_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,
         buttons = orig_buttons,


### PR DESCRIPTION
(1) New file popup dialog buttons:
-History: `Add/remove to/from favorites`
-History, Favorites: `Show folder`

(2) Favorites: new left titlebar menu with
`Add/remove current book to/from favorites`
`Add a book to favorites` - choose a book via PathChooser
`Sort favorites` - previously was in the file popup dialog

Closes https://github.com/koreader/koreader/issues/10343. @ichnilatis-gr

File browser
![01](https://github.com/koreader/koreader/assets/62179190/b501ec54-18f9-4355-8138-e33cb6f02c2f)

History
![02](https://github.com/koreader/koreader/assets/62179190/06f404d2-9a00-46f4-8319-7315f057ca1a)

Favorites
![03](https://github.com/koreader/koreader/assets/62179190/bf63513f-c709-4099-8cb2-fabe511de6c7)

Favorites (called from FM)
![04](https://github.com/koreader/koreader/assets/62179190/80503c19-2176-4fbd-8b6a-a13859ad32cc)

Favorites (called from Reader)
![05](https://github.com/koreader/koreader/assets/62179190/a1bb8019-0ee4-47e9-89ea-5288aaf54b15)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10537)
<!-- Reviewable:end -->
