### PR TITLE
[AutoWarmth] Fix resume and frontlight issue

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -403,9 +403,8 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
         -- We've got nothing to do if we're already ramping up
         if not self.fl_ramp_up_running then
             self:_stopFrontlightRamp()
-            self.fl_ramp_up_running = true
-
             self:turnOnFrontlightRamp(self.fl_min, self.fl_intensity, done_callback)
+            self.fl_ramp_up_running = true
         end
     else
         -- If UIManager is not initialized yet, just turn it on immediately


### PR DESCRIPTION
Fixes a regression introduced in #10426, when suspending during night and resuming during daylight.

see https://github.com/koreader/koreader/blob/fc7181419f4be581635295612d279d20381be699/frontend/device/kobo/powerd.lua#L450

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10557)
<!-- Reviewable:end -->
