### PR TITLE
Open with: images

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -275,7 +275,7 @@ function FileManager:setupLayout()
                     callback = function()
                         UIManager:close(self.file_dialog)
                         local one_time_providers = {}
-                        if DocSettings.image_ext[util.getFileNameSuffix(file):lower()] then
+                        if DocumentRegistry:isImageFile(file) then
                             table.insert(one_time_providers, {
                                 provider_name = _("Image viewer"),
                                 callback = function()

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -274,14 +274,26 @@ function FileManager:setupLayout()
                     text = _("Open with…"),
                     callback = function()
                         UIManager:close(self.file_dialog)
-                        local one_time_providers = {
-                            {
-                                provider_name = _("Text viewer"),
+                        local one_time_providers = {}
+                        if DocSettings.image_ext[util.getFileNameSuffix(file):lower()] then
+                            table.insert(one_time_providers, {
+                                provider_name = _("Image viewer"),
                                 callback = function()
-                                    file_manager:openTextViewer(file)
+                                    local ImageViewer = require("ui/widget/imageviewer")
+                                    UIManager:show(ImageViewer:new{
+                                        file = file,
+                                        fullscreen = true,
+                                        with_title_bar = false,
+                                    })
                                 end,
-                            },
-                        }
+                            })
+                        end
+                        table.insert(one_time_providers, {
+                            provider_name = _("Text viewer"),
+                            callback = function()
+                                file_manager:openTextViewer(file)
+                            end,
+                        })
                         if file_manager.texteditor then
                             table.insert(one_time_providers, {
                                 provider_name = _("Text editor"),
@@ -1238,7 +1250,6 @@ function FileManager:onShowFolderMenu()
     end
 
     button_dialog = ButtonDialog:new{
-        width = math.floor(Screen:getWidth() * 0.9),
         shrink_unneeded_width = true,
         buttons = buttons,
         anchor = function()

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -342,7 +342,7 @@ function BookInfo:setCustomBookCover(file, book_props, metadata_updated_caller_c
         local path_chooser = PathChooser:new{
             select_directory = false,
             file_filter = function(filename)
-                return util.arrayContains(DocSettings.cover_ext, util.getFileNameSuffix(filename))
+                return DocSettings.image_ext[util.getFileNameSuffix(filename):lower()]
             end,
             onConfirm = function(image_file)
                 local sidecar_dir
@@ -358,7 +358,7 @@ function BookInfo:setCustomBookCover(file, book_props, metadata_updated_caller_c
                     sidecar_dir = DocSettings:getSidecarDir(file) .. "/"
                     util.makePath(sidecar_dir)
                 end
-                local new_cover_file = sidecar_dir .. "cover." .. util.getFileNameSuffix(image_file)
+                local new_cover_file = sidecar_dir .. "cover." .. util.getFileNameSuffix(image_file):lower()
                 if ffiutil.copyFile(image_file, new_cover_file) == nil then
                     kvp_update()
                 end

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -342,7 +342,7 @@ function BookInfo:setCustomBookCover(file, book_props, metadata_updated_caller_c
         local path_chooser = PathChooser:new{
             select_directory = false,
             file_filter = function(filename)
-                return DocSettings.image_ext[util.getFileNameSuffix(filename):lower()]
+                return DocumentRegistry:isImageFile(filename)
             end,
             onConfirm = function(image_file)
                 local sidecar_dir

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -262,7 +262,8 @@ function ReaderZooming:onReadSettings(config)
                             or G_reader_settings:readSetting("kopt_zoom_overlap_v") or self.zoom_overlap_v
 
     -- update zoom direction parameters
-    local zoom_direction_setting = self.zoom_direction_settings[self.document.configurable.zoom_direction]
+    local zoom_direction_setting = self.zoom_direction_settings[self.document.configurable.zoom_direction
+                                                                or G_reader_settings:readSetting("kopt_zoom_direction") or 7]
     self.zoom_bottom_to_top = zoom_direction_setting.zoom_bottom_to_top
     self.zoom_direction_vertical = zoom_direction_setting.zoom_direction_vertical
 end

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -13,7 +13,15 @@ local logger = require("logger")
 local util = require("util")
 
 local DocSettings = LuaSettings:extend{
-    cover_ext = { "png", "jpg", "jpeg", "gif", "tif", "tiff", "svg" },
+    image_ext = {
+        png  = true,
+        jpg  = true,
+        jpeg = true,
+        gif  = true,
+        tif  = true,
+        tiff = true,
+        svg  = true,
+    },
 }
 
 local HISTORY_DIR = DataStorage:getHistoryDir()
@@ -165,7 +173,7 @@ function DocSettings:_findCoverFileInDir(dir)
     local ok, iter, dir_obj = pcall(lfs.dir, dir)
     if ok then
         for f in iter, dir_obj do
-            for _, ext in ipairs(self.cover_ext) do
+            for ext in pairs(self.image_ext) do
                 if f == "cover." .. ext then
                     return dir .. "/" .. f
                 end

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -12,17 +12,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local util = require("util")
 
-local DocSettings = LuaSettings:extend{
-    image_ext = {
-        png  = true,
-        jpg  = true,
-        jpeg = true,
-        gif  = true,
-        tif  = true,
-        tiff = true,
-        svg  = true,
-    },
-}
+local DocSettings = LuaSettings:extend{}
 
 local HISTORY_DIR = DataStorage:getHistoryDir()
 local DOCSETTINGS_DIR = DataStorage:getDocSettingsDir()
@@ -173,10 +163,8 @@ function DocSettings:_findCoverFileInDir(dir)
     local ok, iter, dir_obj = pcall(lfs.dir, dir)
     if ok then
         for f in iter, dir_obj do
-            for ext in pairs(self.image_ext) do
-                if f == "cover." .. ext then
-                    return dir .. "/" .. f
-                end
+            if util.splitFileNameSuffix(f) == "cover" then
+                return dir .. "/" .. f
             end
         end
     end

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -20,6 +20,7 @@ local DocumentRegistry = {
         svg  = true,
         tif  = true,
         tiff = true,
+        webp = true,
     },
 }
 

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -12,6 +12,15 @@ local DocumentRegistry = {
     providers = {},
     filetype_provider = {},
     mimetype_ext = {},
+    image_ext = {
+        gif  = true,
+        jpeg = true,
+        jpg  = true,
+        png  = true,
+        svg  = true,
+        tif  = true,
+        tiff = true,
+    },
 }
 
 function DocumentRegistry:addProvider(extension, mimetype, provider, weight)
@@ -244,6 +253,10 @@ function DocumentRegistry:getReferenceCount(file)
     else
         return nil
     end
+end
+
+function DocumentRegistry:isImageFile(file)
+    return self.image_ext[util.getFileNameSuffix(file):lower()] and true or false
 end
 
 -- load implementations:

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -94,7 +94,7 @@ function Screensaver:_getRandomImage(dir)
         for f in iter, dir_obj do
             -- Always ignore macOS resource forks, too.
             if lfs.attributes(dir .. f, "mode") == "file" and not util.stringStartsWith(f, "._")
-               and DocumentRegistry:isImageFile(f) then
+                    and DocumentRegistry:isImageFile(f) then
                 i = i + 1
                 pics[i] = f
             end

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -425,7 +425,7 @@ function ImageViewer:_new_image_wg()
         file = self.file,
         image = self.image,
         image_disposable = false, -- we may re-use self.image
-        file_do_cache = self.image and true or false, -- do not cache local files
+        file_do_cache = false,
         alpha = true, -- we might be showing images with an alpha channel (e.g., from Wikipedia)
         width = max_image_w,
         height = max_image_h,

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -271,12 +271,9 @@ function ImageViewer:init()
         end
     end
 
-    if self._images_list then
+    if self._images_list and self._images_list_nb > 1 then
         -- progress bar
-        local percent = 1
-        if self._images_list and self._images_list_nb > 1 then
-            percent = (self._images_list_cur - 1) / (self._images_list_nb - 1)
-        end
+        local percent = (self._images_list_cur - 1) / (self._images_list_nb - 1)
         self.progress_bar = ProgressWidget:new{
             width = self.width - 2*self.button_padding,
             height = Screen:scaleBySize(5),
@@ -346,11 +343,8 @@ function ImageViewer:update()
     -- Image container (we'll insert it once all others are added and we know the height remaining)
     local image_container_idx = #self.frame_elements + 1
     -- Progress bar
-    if self._images_list then
-        local percent = 1
-        if self._images_list_nb > 1 then
-            percent = (self._images_list_cur - 1) / (self._images_list_nb - 1)
-        end
+    if self._images_list and self._images_list_nb > 1 then
+        local percent = (self._images_list_cur - 1) / (self._images_list_nb - 1)
         self.progress_bar:setPercentage(percent)
         table.insert(self.frame_elements, self.progress_container)
     end
@@ -431,6 +425,7 @@ function ImageViewer:_new_image_wg()
         file = self.file,
         image = self.image,
         image_disposable = false, -- we may re-use self.image
+        file_do_cache = self.image and true or false, -- do not cache local files
         alpha = true, -- we might be showing images with an alpha channel (e.g., from Wikipedia)
         width = max_image_w,
         height = max_image_h,
@@ -846,7 +841,7 @@ function ImageViewer:onCloseWidget()
             self.captioned_title_bar:free()
         end
     end
-    if self._images_list then
+    if self._images_list and self._images_list_nb > 1 then
         self.progress_container:free()
     end
     self.button_container:free()

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -22,12 +22,14 @@ Show image from memory example:
 
 local Blitbuffer = require("ffi/blitbuffer")
 local Cache = require("cache")
+local DocumentRegistry = require("document/documentregistry")
 local Geom = require("ui/geometry")
 local RenderImage = require("ui/renderimage")
 local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local Widget = require("ui/widget/widget")
 local logger = require("logger")
+local util = require("util")
 
 -- DPI_SCALE can't change without a restart, so let's compute it now
 local function get_dpi_scale()
@@ -129,9 +131,7 @@ function ImageWidget:_loadimage()
 end
 
 function ImageWidget:_loadfile()
-    local itype = string.lower(string.match(self.file, ".+%.([^.]+)") or "")
-    if itype == "svg" or itype == "png" or itype == "jpg" or itype == "jpeg"
-            or itype == "gif" or itype == "tiff" or itype == "tif" then
+    if DocumentRegistry:isImageFile(self.file) then
         -- In our use cases for files (icons), we either provide width and height,
         -- or just scale_for_dpi, and scale_factor should stay nil.
         -- Other combinations will result in double scaling, and unexpected results.
@@ -159,7 +159,7 @@ function ImageWidget:_loadfile()
             self._bb_disposable = false -- don't touch or free a cached _bb
             self._is_straight_alpha = cached.is_straight_alpha
         else
-            if itype == "svg" then
+            if util.getFileNameSuffix(self.file) == "svg" then
                 local zoom
                 if scale_for_dpi_here then
                     zoom = DPI_SCALE
@@ -399,7 +399,6 @@ function ImageWidget:getScaleFactorExtrema()
 
     -- Compute dynamic limits for the scale factor, based on the screen's area and available memory (if possible).
     -- Extrema eyeballed to be somewhat sensible given our usual screen dimensions and available RAM.
-    local util = require("util")
     local memfree, _ = util.calcFreeMem()
 
     local screen_area = Screen:getWidth() * Screen:getHeight()


### PR DESCRIPTION
(1) Fix crash on opening an image with "Picture Document" provider.

(2) Add "Image viewer" one-time provider.
Benefits: no record in History, better scaling and rotation comparing to open as a book.

ImageViewer internal changes:
-do not show progress bar if number of images in list is 1
-do not cache local files

![1](https://github.com/koreader/koreader/assets/62179190/250e0b64-eae0-4b80-b509-9f2e2bb9ee43)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10561)
<!-- Reviewable:end -->
