### PR TITLE
tests: fix EPUB test

### DIFF
--- a/spec/unit/document_spec.lua
+++ b/spec/unit/document_spec.lua
@@ -72,20 +72,9 @@ describe("EPUB document module", function()
         assert.is_equal(doc:fastDigest(), "59d481d168cca6267322f150c5f6a2a3")
     end)
     it("should register droid sans fallback", function()
-        local fonts_registry = {
-            "Droid Sans Mono",
-            "FreeSans",
-            "FreeSerif",
-            "Noto Naskh Arabic",
-            "Noto Sans",
-            "Noto Sans Arabic UI",
-            "Noto Sans Bengali UI",
-            "Noto Sans CJK SC",
-            "Noto Sans Devanagari UI",
-            "Noto Serif",
-        }
         local face_list = cre.getFontFaces()
-        assert.are.same(fonts_registry, face_list)
+        assert.is_equal(face_list[1], "Droid Sans Mono")
+        assert.is_true(#face_list >= 10)
     end)
     it("should close document", function()
         doc:close()


### PR DESCRIPTION
Otherwise the test fail in my environment because of some user fonts:
```
./spec/front/unit/document_spec.lua:88: Expected objects to be the same.
Passed in:
(table: 0x7f20c448b498) {
  [1] = 'Droid Sans Mono'
 *[2] = 'EB Garamond Absinthe'
  [3] = 'Fira Code'
  [4] = 'Fira Sans'
  [5] = 'FiraCode Nerd Font'
  [6] = 'FreeSans'
  [7] = 'FreeSerif'
  [8] = 'Noto Naskh Arabic'
  [9] = 'Noto Sans'
  [10] = 'Noto Sans Arabic UI'
  [11] = 'Noto Sans Bengali UI'
  [12] = 'Noto Sans CJK SC'
  [13] = 'Noto Sans Devanagari UI'
  [14] = 'Noto Serif' }
Expected:
(table: 0x7f20c448b3c0) {
  [1] = 'Droid Sans Mono'
 *[2] = 'FreeSans'
  [3] = 'FreeSerif'
  [4] = 'Noto Naskh Arabic'
  [5] = 'Noto Sans'
  [6] = 'Noto Sans Arabic UI'
  [7] = 'Noto Sans Bengali UI'
  [8] = 'Noto Sans CJK SC'
  [9] = 'Noto Sans Devanagari UI'
  [10] = 'Noto Serif' }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10566)
<!-- Reviewable:end -->
