### PR TITLE
Add 'Content-Length' header to WebDAV upload request

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -7,6 +7,7 @@ local socketutil = require("socketutil")
 local util = require("util")
 local _ = require("gettext")
 local logger = require("logger")
+local lfs = require("libs/libkoreader-lfs")
 
 local WebDavApi = {
 }
@@ -207,7 +208,8 @@ function WebDavApi:uploadFile(file_url, user, pass, local_path, etag)
         user     = user,
         password = pass,
         headers = {
-            ["If-Match"] = etag
+            ["Content-Length"] = lfs.attributes(local_path, "size"),
+            ["If-Match"] = etag,
         }
     })
     socketutil:reset_timeout()


### PR DESCRIPTION
To avoid problems with 0 bytes files on upload from device to cloud I suggest to add 'Content-Length' header to upload function. Tested by manually changed `koreader/frontend/apps/cloudstorage/webdavapi.lua` file on Kobo Clara HD. Works fine.

https://github.com/koreader/koreader/issues/10564

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10567)
<!-- Reviewable:end -->
