### PR TITLE
frontend: remarkable: Support the mainline touchscreen

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -143,13 +143,6 @@ function Remarkable:init()
         wacom_protocol = true,
     }
 
-    self.input.open(self.input_wacom) -- Wacom
-    self.input.open(self.input_ts) -- Touchscreen
-    self.input.open(self.input_buttons) -- Buttons
-
-    local scalex = screen_width / self.mt_width
-    local scaley = screen_height / self.mt_height
-
     -- Assume input stuff is saner on mainline kernels...
     -- (c.f., https://github.com/koreader/koreader/issues/10012)
     local is_mainline = false
@@ -164,6 +157,18 @@ function Remarkable:init()
             is_mainline = true
         end
     end
+
+    if is_mainline then
+        self.input_ts = "/dev/input/touchscreen0"
+    end
+
+    self.input.open(self.input_wacom) -- Wacom
+    self.input.open(self.input_ts) -- Touchscreen
+    self.input.open(self.input_buttons) -- Buttons
+
+    local scalex = screen_width / self.mt_width
+    local scaley = screen_height / self.mt_height
+
     if is_mainline then
         -- NOTE: The panel sends *both* ABS_MT_ & ABS_ coordinates, while the pen only sends ABS_ coordinates.
         --       Since we have to apply *different* mangling to each of them,

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -159,6 +159,8 @@ function Remarkable:init()
     end
 
     if is_mainline then
+        self.input_wacom = "/dev/input/by-path/platform-30a20000.i2c-event-mouse"
+        self.input_buttons = "/dev/input/by-path/platform-30370000.snvs:snvs-powerkey-event"
         self.input_ts = "/dev/input/touchscreen0"
     end
 


### PR DESCRIPTION
As discussed in https://github.com/koreader/koreader/issues/10012#issuecomment-1591810200 the mainline kernel doesn't use `/dev/input/event2`. Let's use the correct path instead.

Unfortunately I'm unable to test against the shipping kernel to know if this path works, but I suspect it doesn't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10585)
<!-- Reviewable:end -->
