### PR TITLE
History: shorten date/time field

### DIFF
--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -222,14 +222,14 @@ function FileManagerHistory:showHistDialog()
         }
     end
     table.insert(buttons, {
-        genFilterButton("reading"),
-        genFilterButton("abandoned"),
-        genFilterButton("complete"),
-    })
-    table.insert(buttons, {
         genFilterButton("all"),
         genFilterButton("new"),
         genFilterButton("deleted"),
+    })
+    table.insert(buttons, {
+        genFilterButton("reading"),
+        genFilterButton("abandoned"),
+        genFilterButton("complete"),
     })
     if self.count.deleted > 0 then
         table.insert(buttons, {}) -- separator

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -264,6 +264,17 @@ function FileManagerMenu:setUpdateItemTable()
                 text = _("History settings"),
                 sub_item_table = {
                     {
+                        text = _("Shorten date/time"),
+                        checked_func = function()
+                            return G_reader_settings:isTrue("history_datetime_short")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrFalse("history_datetime_short")
+                            require("readhistory"):reload(true)
+                        end,
+                        separator = true,
+                    },
+                    {
                         text = _("Clear history of deleted files"),
                         callback = function()
                             UIManager:show(ConfirmBox:new{

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -24,7 +24,8 @@ local function buildEntry(input_time, input_file)
         file = file_path,
         text = input_file:gsub(".*/", ""),
         dim = not file_exists,
-        mandatory = datetime.secondsToDateTime(input_time),
+        mandatory = G_reader_settings:isTrue("history_datetime_short")
+            and datetime.secondsToDate(input_time):sub(3) or datetime.secondsToDateTime(input_time),
         select_enabled = file_exists,
     }
 end


### PR DESCRIPTION
To give more room for a title. Applicable in Classic and List display modes.

![0](https://github.com/koreader/koreader/assets/62179190/02deacb4-0f7e-4129-b3dd-e3195bf2090b)

![1](https://github.com/koreader/koreader/assets/62179190/e217a8a0-7280-4aa5-b74d-6d0fb9ced4f4)

![2](https://github.com/koreader/koreader/assets/62179190/1285ac42-b9e9-4611-ad68-08da455d940e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10594)
<!-- Reviewable:end -->
