### PR TITLE
ReaderPaging: do not store zeroes in page_positions

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -226,7 +226,7 @@ book, the page view will be roughly the same.
 --]]
 function ReaderPaging:setPagePosition(page, pos)
     logger.dbg("set page position", pos)
-    self.page_positions[page] = pos
+    self.page_positions[page] = pos ~= 0 and pos or nil
     self.ui:handleEvent(Event:new("PagePositionUpdated"))
 end
 


### PR DESCRIPTION
The `page_positions` array is saved to sdr. The purpose of it is:
https://github.com/koreader/koreader/blob/45428dda49aefdab68cc232e0798ce030c33d531/frontend/apps/reader/modules/readerpaging.lua#L220-L231
In my library I have found a pdf book of 300 pages with all page_positions equal to zero, and this array of 300 zero entries is saved to sdr.
Page_position value depends on the view mode parameters, but we can assume that zero is a frequent case.
So let do not store zeroes in sdr. Nils are handled well already (line 242):
https://github.com/koreader/koreader/blob/45428dda49aefdab68cc232e0798ce030c33d531/frontend/apps/reader/modules/readerpaging.lua#L233-L243

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10602)
<!-- Reviewable:end -->
