### PR TITLE
Input: Be more thorough in resetState

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -506,6 +506,15 @@ function Input:resetState()
         self.gesture_detector:resetClockSource()
     end
     self:clearTimeouts()
+
+    -- Drop the slots on our end, too
+    self:newFrame()
+    self.cur_slot = self.main_finger_slot
+    self.ev_slots = {
+        [self.main_finger_slot] = {
+            slot = self.main_finger_slot,
+        },
+    }
 end
 
 function Input:handleKeyBoardEv(ev)


### PR DESCRIPTION
Drop the actual slot data storage, in addition to the active references (i.e., drop Input's state in addition to GestureManager's).

Re: #10571

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10612)
<!-- Reviewable:end -->
