### PR TITLE
SDL: Keep sdl_window state in sync on the emu

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -172,6 +172,9 @@ function Device:init()
         y = self.window.top,
         is_always_portrait = self.isAlwaysPortrait(),
     }
+    -- Pickup the updated window sizes if they were enforced in S.open (we'll get the coordinates via the inital SDL_WINDOWEVENT_MOVED)...
+    self.window.width = self.screen.w
+    self.window.height = self.screen.h
     self.powerd = require("device/sdl/powerd"):new{device = self}
 
     local ok, re = pcall(self.screen.setWindowIcon, self.screen, "resources/koreader.png")


### PR DESCRIPTION
The emu might enforce window sizes via `EMULATE_READER_W` & `EMULATE_READER_H`, make sure we track those changes.

Requires https://github.com/koreader/koreader-base/pull/1627

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10619)
<!-- Reviewable:end -->
