### PR TITLE
OPDS Catalog: Improve server connection dialog

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -128,9 +128,9 @@ function OPDSBrowser:addEditCatalog(item, is_calibre)
         fields[1].hint = _("OPDS host")
         fields[2].text = self.calibre_opds.port and tostring(self.calibre_opds.port) or "8080"
         fields[2].hint = _("OPDS port")
-		fields[3].text = self.calibre_opds.path or "opds"
-		fields[3].hint = _("OPDS path")
-		fields[3].description = _("If you're connecting to a local calibre library, set the path to 'opds'.")
+        fields[3].text = self.calibre_opds.path or "opds"
+        fields[3].hint = _("OPDS path")
+        fields[3].description = _("If you're connecting to a local calibre library, set the path to 'opds'.")
         fields[4].text = self.calibre_opds.username
         fields[5].text = self.calibre_opds.password
     else

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -61,7 +61,7 @@ local OPDSBrowser = Menu:extend{
             url = "https://gallica.bnf.fr/opds",
         },
     }),
-    calibre_name = _("Local calibre library"),
+    calibre_name = _("Local OPDS Catalog"),
     calibre_opds = G_reader_settings:readSetting("calibre_opds", {}),
 
     catalog_type         = "application/atom%+xml",
@@ -100,7 +100,7 @@ function OPDSBrowser:genItemTableFromRoot()
         {   -- calibre is the first and non-deletable item
             text       = self.calibre_name,
             url        = self.calibre_opds.host and self.calibre_opds.port and
-                         string.format("http://%s:%d/opds", self.calibre_opds.host, self.calibre_opds.port),
+                         string.format("http://%s:%d/%s", self.calibre_opds.host, self.calibre_opds.port, self.calibre_opds.path),
             username   = self.calibre_opds.username,
             password   = self.calibre_opds.password,
             searchable = false,
@@ -121,15 +121,18 @@ end
 -- Shows dialog to edit properties of the new/existing catalog
 function OPDSBrowser:addEditCatalog(item, is_calibre)
     local title
-    local fields = {{}, {}, {}, {}}
+    local fields = {{}, {}, {}, {}, {}}
     if is_calibre then
-        title = _("Edit local calibre host and port")
+        title = _("Edit local OPDS host, port, and path")
         fields[1].text = self.calibre_opds.host or "192.168.1.1"
-        fields[1].hint = _("calibre host")
+        fields[1].hint = _("OPDS host")
         fields[2].text = self.calibre_opds.port and tostring(self.calibre_opds.port) or "8080"
-        fields[2].hint = _("calibre port")
-        fields[3].text = self.calibre_opds.username
-        fields[4].text = self.calibre_opds.password
+        fields[2].hint = _("OPDS port")
+		fields[3].text = self.calibre_opds.path or "opds"
+		fields[3].hint = _("OPDS path")
+		fields[3].description = _("If you're connecting to a local calibre library, set the path to 'opds'.")
+        fields[4].text = self.calibre_opds.username
+        fields[5].text = self.calibre_opds.password
     else
         fields[1].hint = _("Catalog name")
         fields[2].hint = _("Catalog URL")
@@ -137,15 +140,15 @@ function OPDSBrowser:addEditCatalog(item, is_calibre)
             title = _("Edit OPDS catalog")
             fields[1].text = item.text
             fields[2].text = item.url
-            fields[3].text = item.username
-            fields[4].text = item.password
+            fields[4].text = item.username
+            fields[5].text = item.password
         else
             title = _("Add OPDS catalog")
         end
     end
-    fields[3].hint = _("Username (optional)")
-    fields[4].hint = _("Password (optional)")
-    fields[4].text_type = "password"
+    fields[4].hint = _("Username (optional)")
+    fields[5].hint = _("Password (optional)")
+    fields[5].text_type = "password"
 
     local dialog
     dialog = MultiInputDialog:new{
@@ -228,8 +231,8 @@ function OPDSBrowser:editCatalogFromInput(fields, item, no_init)
     end
     new_server.title    = fields[1]
     new_server.url      = fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2]
-    new_server.username = fields[3] ~= "" and fields[3] or nil
-    new_server.password = fields[4]
+    new_server.username = fields[4] ~= "" and fields[4] or nil
+    new_server.password = fields[5]
     if not item then
         table.insert(self.opds_servers, new_server)
     end
@@ -244,8 +247,8 @@ function OPDSBrowser:editCalibreFromInput(fields)
     if tonumber(fields[2]) then
         self.calibre_opds.port = fields[2]
     end
-    self.calibre_opds.username = fields[3] ~= "" and fields[3] or nil
-    self.calibre_opds.password = fields[4]
+    self.calibre_opds.username = fields[4] ~= "" and fields[4] or nil
+    self.calibre_opds.password = fields[5]
     self:init()
 end
 


### PR DESCRIPTION
## Changes

* Updated the "Local calibre library" → "Edit" dialog to allow the user to provide a path to the OPDS service (default value is set to the originally hardcoded "opds")
* Updated the field and dialog names from "calibre" specifically to "OPDS" generally, to align with the "OPDS catalog" name in the magnifying glass menu, and to express support for other OPDS implementations besides Calibre Content Server

## Comparisons

Old                        |  New
:-------------------------:|:-------------------------:
![FileManager_2023-06-29_200454](https://github.com/koreader/koreader/assets/13406729/73589b82-7837-4ebe-9eb5-429aeebaf00c) |  ![FileManager_2023-06-29_195953](https://github.com/koreader/koreader/assets/13406729/0b2a6cb4-d07d-4093-8b71-e1924ec81510)
![FileManager_2023-06-29_200432](https://github.com/koreader/koreader/assets/13406729/a7a75e42-87c5-4df4-b3fd-d776dad9984f) |  ![FileManager_2023-06-29_200007](https://github.com/koreader/koreader/assets/13406729/a25ca968-f495-41eb-9117-b74f1c32d4d5)

## Reasoning

The OPDS plugin seemed to only work when connecting to Calibre Content Server. It turns out `opdsbrowser.lua` was hardcoding the OPDS URL path to `/opds`, which is what Calibre Content Server advertises on. But Ubooquity advertises OPDS catalogs on `/opds-books` and `/opds-comics`, and Kavita advertises them on `/api/opds/<long-hash>`. This change allows users to specify a path, which makes it work with other OPDS server implementations now. (I only tested Ubooquity.)

## My Use Case

I have a large collection of PDFs and ePUBs on a NAS that's frequently updated. I wanted to advertise a local OPDS catalog of that collection that's refreshed daily, but I could only get KOReader to connect to Calibre, and I wasn't able to make Calibre work with my setup. I made this change so I could use Ubooquity to advertise a new catalog each day, and download files onto my Kobo over WiFi. It's working great for me now, so hopefully it will help other people who were having a similar issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10623)
<!-- Reviewable:end -->
