### PR TITLE
Disabled touch input: always active gestures

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -72,6 +72,8 @@ local settingsList = {
     poweroff = {category="none", event="RequestPowerOff", title=_("Power off"), device=true, condition=Device:canPowerOff(), separator=true},
 
     toggle_hold_corners = {category="none", event="IgnoreHoldCorners", title=_("Toggle hold corners"), device=true},
+    touch_input_on = {category="none", event="IgnoreTouchInput", arg=false, title=_("Enable touch input"), device=true},
+    touch_input_off = {category="none", event="IgnoreTouchInput", arg=true, title=_("Disable touch input"), device=true},
     toggle_touch_input = {category="none", event="IgnoreTouchInput", title=_("Toggle touch input"), device=true, separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
@@ -264,6 +266,8 @@ local dispatcher_menu_order = {
     "poweroff",
 
     "toggle_hold_corners",
+    "touch_input_on",
+    "touch_input_off",
     "toggle_touch_input",
     "toggle_gsensor",
     "rotation_mode",
@@ -944,6 +948,31 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
                     end
                 else
                     location[settings].settings = {["show_as_quickmenu"] = true}
+                end
+                caller.updated = true
+            end
+        end,
+    })
+    table.insert(menu, {
+        text = _("Always active"),
+        checked_func = function()
+            return location[settings] ~= nil
+            and location[settings].settings ~= nil
+            and location[settings].settings.always_active
+        end,
+        callback = function()
+            if location[settings] then
+                if location[settings].settings then
+                    if location[settings].settings.always_active then
+                        location[settings].settings.always_active = nil
+                        if next(location[settings].settings) == nil then
+                            location[settings].settings = nil
+                        end
+                    else
+                        location[settings].settings.always_active = true
+                    end
+                else
+                    location[settings].settings = {["always_active"] = true}
                 end
                 caller.updated = true
             end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -134,7 +134,8 @@ function Gestures:isGestureAlwaysActive(ges, multiswipe_directions)
         end
     end
 
-    return self.gestures[ges] and self.gestures[ges].toggle_touch_input
+    return self.gestures[ges] and (self.gestures[ges].toggle_touch_input or
+        (self.gestures[ges].settings and self.gestures[ges].settings.always_active))
 end
 
 function Gestures:init()

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -134,7 +134,7 @@ function Gestures:isGestureAlwaysActive(ges, multiswipe_directions)
         end
     end
 
-    return self.gestures[ges] and (self.gestures[ges].toggle_touch_input or
+    return self.gestures[ges] and (self.gestures[ges].toggle_touch_input or self.gestures[ges].touch_input_on or
         (self.gestures[ges].settings and self.gestures[ges].settings.always_active))
 end
 

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -121,7 +121,7 @@ Multiswipes allow you to perform complex gestures built up out of multiple swipe
 
 These advanced gestures consist of either straight swipes or diagonal swipes. To ensure accuracy, they can't be mixed.]])
 
--- If the gesture contains the "toggle_touch_input" action,
+-- If the gesture contains "toggle_touch_input" or "touch_input_on" actions, or is set "Always active" manually,
 -- mark it "always active" to make sure that InputContainer won't block it after the IgnoreTouchInput Event.
 function Gestures:isGestureAlwaysActive(ges, multiswipe_directions)
     -- Handle multiswipes properly
@@ -134,8 +134,8 @@ function Gestures:isGestureAlwaysActive(ges, multiswipe_directions)
         end
     end
 
-    return self.gestures[ges] and (self.gestures[ges].toggle_touch_input or self.gestures[ges].touch_input_on or
-        (self.gestures[ges].settings and self.gestures[ges].settings.always_active))
+    local gest = self.gestures[ges]
+    return gest and (gest.toggle_touch_input or gest.touch_input_on or (gest.settings and gest.settings.always_active))
 end
 
 function Gestures:init()


### PR DESCRIPTION
Disabled touch input has become a popular feature. Let's enhance a bit:
-added separate actions "Touch input on", "Touch input off"
-added an option to make a gesture "always active" (even when the touch input is disabled)

![1](https://github.com/koreader/koreader/assets/62179190/d757b64a-0fc8-4a12-a2c2-51c0694ed5f1)

![2](https://github.com/koreader/koreader/assets/62179190/35521bab-a770-4eb0-8808-1eb2de04de69)

This will help in cases like https://github.com/koreader/koreader/issues/10273.

I saw the @NiLuJe 's warning:
https://github.com/koreader/koreader/blob/b8af326836374b82cccdadafef869d1d5decac69/frontend/ui/widget/container/inputcontainer.lua#L296-L306
but couldn't get any errors while testing, at least in a usecase "enable page turns with the bottom edge swipes with disabled touch input".  Maybe I've missed something...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10624)
<!-- Reviewable:end -->
