### PR TITLE
FileChooser: Sort by date

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -844,9 +844,7 @@ function FileManagerMenu:getSortingMenuTable()
     local collates = {
         { _("name"), "strcoll" },
         { _("name (natural sorting)"), "natural" },
-        { _("last read date"), "access" },
-        { _("date added"), "change" },
-        { _("date modified"), "modification" },
+        { _("date modified"), "date" },
         { _("size"), "size" },
         { _("type"), "type" },
         { _("percent – unopened first"), "percent_unopened_first" },

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -7,7 +7,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20230531
+local CURRENT_MIGRATION_DATE = 20230702
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -511,6 +511,15 @@ if last_migration_date < 20230531 then
     if G_reader_settings:readSetting("collate") == "strcoll_mixed" then
         G_reader_settings:saveSetting("collate", "strcoll")
         G_reader_settings:makeTrue("collate_mixed")
+    end
+end
+
+-- 20230702, FileChooser Sort by: one "date" only
+if last_migration_date < 20230702 then
+    logger.info("Performing one-time migration for 20230702")
+    local collate = G_reader_settings:readSetting("collate")
+    if collate == "modification" or collate == "access" or collate == "change" then
+        G_reader_settings:saveSetting("collate", "date")
     end
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
+local datetime = require("datetime")
 local Device = require("device")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
@@ -192,15 +193,7 @@ function FileChooser:getSortingFunction(collate, reverse_collate)
         sorting = function(a, b)
             return natsort(a.text, b.text)
         end
-    elseif collate == "access" then
-        sorting = function(a, b)
-            return a.attr.access > b.attr.access
-        end
-    elseif collate == "change" then
-        sorting = function(a, b)
-            return a.attr.change > b.attr.change
-        end
-    elseif collate == "modification" then
+    elseif collate == "date" then
         sorting = function(a, b)
             return a.attr.modification > b.attr.modification
         end
@@ -347,12 +340,8 @@ function FileChooser:getMenuItemMandatory(item, collate)
     local text
     if collate then -- file
         -- display the sorting parameter in mandatory
-        if collate == "access" then
-            text = os.date("%Y-%m-%d %H:%M", item.attr.access)
-        elseif collate == "change" then
-            text = os.date("%Y-%m-%d %H:%M", item.attr.change)
-        elseif collate == "modification" then
-            text = os.date("%Y-%m-%d %H:%M", item.attr.modification)
+        if collate == "date" then
+            text = datetime.secondsToDateTime(item.attr.modification)
         elseif collate == "percent_unopened_first" or collate == "percent_unopened_last" then
             text = item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
         else


### PR DESCRIPTION
As discussed, "access" and "change" dates are useless.

![1](https://github.com/koreader/koreader/assets/62179190/9c7f8430-cd8b-4242-b6cf-fda631c130c5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10627)
<!-- Reviewable:end -->
