### PR TITLE
[ota]: deprecation check & notice

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -450,6 +450,10 @@ function Device:info()
     return common_text..platform_text..eink_text..wakelocks_text
 end
 
+function Device:isDeprecated()
+    return self.firmware_rev < 18
+end
+
 function Device:test()
     android.runTest()
 end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -48,6 +48,7 @@ local Device = {
     hasWifiManager = no,
     isDefaultFullscreen = yes,
     isHapticFeedbackEnabled = no,
+    isDeprecated = no, -- device no longer receive OTA updates
     isTouchDevice = no,
     hasFrontlight = no,
     hasNaturalLight = no, -- FL warmth implementation specific to NTX boards (Kobo, Cervantes)

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -153,6 +153,8 @@ function OTAManager:getZsyncFilename()
 end
 
 function OTAManager:checkUpdate()
+    if Device:isDeprecated() then return -1 end
+
     local http = require("socket.http")
     local ltn12 = require("ltn12")
     local socket = require("socket")
@@ -226,6 +228,10 @@ function OTAManager:fetchAndProcessUpdate()
     if ota_version == 0 then
         UIManager:show(InfoMessage:new{
             text = _("KOReader is up to date."),
+        })
+    elseif ota_version == -1 then
+        UIManager:show(InfoMessage:new{
+            text = _("Device no longer supported.\n\nPlease check https://github.com/koreader/koreader/wiki/deprecated-devices"),
         })
     elseif ota_version == nil then
         local channel = ota_channels[OTAManager:getOTAChannel()]

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -231,7 +231,7 @@ function OTAManager:fetchAndProcessUpdate()
         })
     elseif ota_version == -1 then
         UIManager:show(InfoMessage:new{
-            text = _("Device no longer supported.\n\nPlease check https://github.com/koreader/koreader/wiki/deprecated-devices"),
+            text = T(_("Device no longer supported.\n\nPlease check %1."), "https://github.com/koreader/koreader/wiki/deprecated-devices")
         })
     elseif ota_version == nil then
         local channel = ota_channels[OTAManager:getOTAChannel()]

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -231,7 +231,7 @@ function OTAManager:fetchAndProcessUpdate()
         })
     elseif ota_version == -1 then
         UIManager:show(InfoMessage:new{
-            text = T(_("Device no longer supported.\n\nPlease check %1."), "https://github.com/koreader/koreader/wiki/deprecated-devices")
+            text = T(_("Device no longer supported.\n\nPlease check %1"), "https://github.com/koreader/koreader/wiki/deprecated-devices")
         })
     elseif ota_version == nil then
         local channel = ota_channels[OTAManager:getOTAChannel()]


### PR DESCRIPTION
Poor man implementation since we cannot fullfit https://github.com/koreader/koreader/pull/10610#issuecomment-1608462530

>> EOL devices running the last supported version receive a "you're up to date" while checking updates.
>> EOL devices on previous versions receive an update to last supported version.

So instead, we merge something like this a few days/weeks *before* real deprecation and warn users with EOL devices that the source of trust is in https://github.com/koreader/koreader/wiki/deprecated-devices.

Other platforms can implement their own `isDeprecated` override on the future.

A better approach is very welcome. The same for a future proof client-server implementation.

This one is trivial and tries to prevent some tickets :)

No worries, at some point in 2024 somebody will try to update from v2021.02 and we will get a ticket :p

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10639)
<!-- Reviewable:end -->
