### PR TITLE
QuickMenu: anchor to gesture position 2

### DIFF
--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -108,7 +108,13 @@ function ButtonDialog:init()
         end
     end
 
-    local content_width = self.width - 2*Size.border.window - 2*Size.padding.button
+    self.buttontable = ButtonTable:new{
+        buttons = self.buttons,
+        width = self.width - 2*Size.border.window - 2*Size.padding.button,
+        shrink_unneeded_width = self.shrink_unneeded_width,
+        shrink_min_width = self.shrink_min_width,
+        show_parent = self,
+    }
 
     local title_widget, title_widget_height
     if self.title then
@@ -128,7 +134,7 @@ function ButtonDialog:init()
             bordersize = 0,
             TextBoxWidget:new{
                 text = self.title,
-                width = content_width - 2 * (title_padding + title_margin),
+                width = self.buttontable.width - 2 * (title_padding + title_margin),
                 face = title_face,
                 alignment = self.title_align,
             },
@@ -139,13 +145,6 @@ function ButtonDialog:init()
         title_widget_height = 0
     end
 
-    self.buttontable = ButtonTable:new{
-        buttons = self.buttons,
-        width = content_width,
-        shrink_unneeded_width = self.shrink_unneeded_width,
-        shrink_min_width = self.shrink_min_width,
-        show_parent = self,
-    }
     -- If the ButtonTable ends up being taller than the screen, wrap it inside a ScrollableContainer.
     -- Ensure some small top and bottom padding, so the scrollbar stand out, and some outer margin
     -- so the this dialog does not take the full height and stand as a popup.
@@ -199,7 +198,7 @@ function ButtonDialog:init()
         separator = LineWidget:new{
             background = Blitbuffer.COLOR_GRAY,
             dimen = Geom:new{
-                w = content_width + (scrollbar_width or 0),
+                w = self.buttontable.width + (scrollbar_width or 0),
                 h = Size.line.medium,
             },
         }

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -118,7 +118,7 @@ function Profiles:getSubMenuItems()
     }
     for k, v in FFIUtil.orderedPairs(self.data) do
         local edit_actions_sub_items = {}
-        Dispatcher:addSubMenu(self, edit_actions_sub_items, self.data, k)
+        Dispatcher:addSubMenu(self, edit_actions_sub_items, self.data, k, true)
         local sub_items = {
             {
                 text = _("Execute"),
@@ -259,8 +259,8 @@ function Profiles:getSubMenuItems()
     return sub_item_table
 end
 
-function Profiles:onProfileExecute(name, gesture)
-    Dispatcher:execute(self.data[name], gesture)
+function Profiles:onProfileExecute(name, gesture, anchor_quickmenu)
+    Dispatcher:execute(self.data[name], gesture, anchor_quickmenu)
 end
 
 function Profiles:editProfileName(editCallback, old_name)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -259,8 +259,8 @@ function Profiles:getSubMenuItems()
     return sub_item_table
 end
 
-function Profiles:onProfileExecute(name)
-    Dispatcher:execute(self.data[name])
+function Profiles:onProfileExecute(name, gesture)
+    Dispatcher:execute(self.data[name], gesture)
 end
 
 function Profiles:editProfileName(editCallback, old_name)
@@ -271,6 +271,7 @@ function Profiles:editProfileName(editCallback, old_name)
         buttons = {{
             {
                 text = _("Cancel"),
+                id = "close",
                 callback = function()
                     UIManager:close(name_input)
                 end,


### PR DESCRIPTION
Follow up to https://github.com/koreader/koreader/pull/10636.

(1) Enable anchoring for profiles
(2) Anchoring is optional
(3) QuickMenu width is adjustable, not less than 0.5 of the screen width.

In Gestures manager:

![1](https://github.com/koreader/koreader/assets/62179190/03becbc8-a0b4-4720-8a82-fb0f41cd09d2)

In Profiles:

![2](https://github.com/koreader/koreader/assets/62179190/6ff7b0bc-2de4-457d-8498-9a9317ee5841)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10641)
<!-- Reviewable:end -->
