### PR TITLE
[i18n]KOSync: use already translated "Not available" instead of "Unavailable"

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -94,7 +94,7 @@ end
 
 function KOSync:getSyncPeriod()
     if not self.settings.auto_sync then
-        return _("Unavailable")
+        return _("Not available")
     end
 
     local period = self.settings.pages_before_update


### PR DESCRIPTION
Cf. https://github.com/koreader/koreader/pull/10605#discussion_r1252639047

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10648)
<!-- Reviewable:end -->
