### PR TITLE
GestureDetector: Make two_finger pans & swipes report the same sort of data than their standard brethren

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -1102,7 +1102,6 @@ function Contact:handleTwoFingerPan(buddy_contact)
             pos = end_point,
             start_pos = start_point,
             _start_pos = start_point,
-            end_pos = end_point,
             _end_pos = end_point,
             distance = avg_distance,
             direction = tpan_dir,
@@ -1111,12 +1110,9 @@ function Contact:handleTwoFingerPan(buddy_contact)
         if tpan_dir ~= rpan_dir then
             if start_distance > end_distance then
                 ges_ev.ges = "inward_pan"
-                -- Use the end pos
-                ges_ev.pos = ges_ev._end_pos
-                ges_ev._end_pos = nil
-                ges_ev.end_pos = nil
-                ges_ev.start_pos = ges_ev._start_pos
+                -- Use the end pos (this is the default already)
                 ges_ev._start_pos = nil
+                ges_ev._end_pos = nil
             else
                 ges_ev.ges = "outward_pan"
                 -- Use the start pos

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -906,10 +906,12 @@ function Contact:handleSwipe()
     gesture_detector:dropContact(self)
     return {
         ges = ges,
-        -- use first pan tev coordination as swipe start point
-        -- FIXME: Or... don't, and match the pan semantics by using the lift point?
-        -- Except maybe it matters for hit detection... (in which case, just fix the hit detection to use start_pos instead?)
+        -- NOTE: Unlike every other gesture, we use the *contact* point as the gesture's position,
+        --       instead of the *lift* point, mainly because that's what makes the most sense
+        --       from a hit-detection standpoint (c.f., `GestureRange:match` & `InputContainer:onGesture`),
+        --       and that's 99% of the use-cases where the position actually matters for a swipe.
         pos = start_pos,
+        -- And for those rare cases that need it, we provide the lift point separately.
         end_pos = end_pos,
         direction = swipe_direction,
         multiswipe_directions = multiswipe_directions,

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -1114,7 +1114,8 @@ function Contact:handleTwoFingerPan(buddy_contact)
                 ges_ev._end_pos = nil
             else
                 ges_ev.ges = "outward_pan"
-                -- Use the start pos
+                -- Use the start pos, it'll make more sense than the midpoint of the current contacts,
+                -- given the potentially wide span between the two...
                 ges_ev.pos = ges_ev._start_pos
                 ges_ev._start_pos = nil
                 ges_ev.start_pos = nil

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -224,7 +224,6 @@ function GestureDetector:feedEvent(tevs)
         end
         local ges = contact.state(contact)
         if ges then
-            logger.info("GD: Pushed gesture:", ges)
             table.insert(gestures, ges)
         end
     end

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -907,6 +907,7 @@ function Contact:handleSwipe()
         ges = ges,
         -- use first pan tev coordination as swipe start point
         -- FIXME: Or... don't, and match the pan semantics by using the lift point?
+        -- Except maybe it matters for hit detection... (in which case, just fix the hit detection to use start_pos instead?)
         pos = start_pos,
         end_pos = end_pos,
         direction = swipe_direction,

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -1088,10 +1088,10 @@ function Contact:handleTwoFingerPan(buddy_contact)
         -- We'll also want to remember the span between both contacts on start & end for some gestures
         local start_distance = tstart_pos:distance(rstart_pos)
         local end_distance = tend_pos:distance(rend_pos)
-        -- NOTE: "pan" and "hold_pan" use current (end) pos as pos, and provide the relative movement,
-        --       but swipe reports pos as start pos, and provides the end pos separately.
-        --       Since this table will be used for both pans and two_finger_swipe via (via panState),
-        --       we stuff a bunch of extra info in there to swap it around later...
+        -- NOTE: "pan" and "hold_pan" use the current/end point as pos,
+        --       but swipe reports pos as the *starting* point (c.f., `Contact:handleSwipe`).
+        --       Since this table will be used for both pans and two_finger_swipe (via panState),
+        --       we stuff a bunch of extra info in there to swap it around as-needed...
         local ges_ev = {
             ges = "two_finger_pan",
             relative = {

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -1078,6 +1078,7 @@ function Contact:handleTwoFingerPan(buddy_contact)
         local start_distance = tstart_pos:distance(rstart_pos)
         local end_distance = tend_pos:distance(rend_pos)
         -- FIXME: "pan" uses current pos as pos, and reports relative movement instead...
+        --        But swipe does this, and this also happens to be used for swipes (via panState)... -_-"
         local ges_ev = {
             ges = "two_finger_pan",
             pos = start_point,

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -906,6 +906,7 @@ function Contact:handleSwipe()
     return {
         ges = ges,
         -- use first pan tev coordination as swipe start point
+        -- FIXME: Or... don't, and match the pan semantics by using the lift point?
         pos = start_pos,
         end_pos = end_pos,
         direction = swipe_direction,
@@ -1126,7 +1127,7 @@ function Contact:handleTwoFingerPan(buddy_contact)
             -- Some handlers might also want to know the distance between the two contacts on lift & down.
             ges_ev.span = end_distance
             ges_ev.start_span = start_distance
-            -- Drop unnecessary fields
+            -- Drop unnecessary field
             ges_ev.relative = nil
         elseif self.state == Contact.holdState then
             ges_ev.ges = "two_finger_hold_pan"

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -224,6 +224,7 @@ function GestureDetector:feedEvent(tevs)
         end
         local ges = contact.state(contact)
         if ges then
+            logger.info("GD: Pushed gesture:", ges)
             table.insert(gestures, ges)
         end
     end

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -873,6 +873,12 @@ function Contact:handleSwipe()
         w = 0,
         h = 0,
     }
+    local end_pos = Geom:new{
+        x = tev.x,
+        y = tev.y,
+        w = 0,
+        h = 0,
+    }
     local ges = "swipe"
     local multiswipe_directions
 
@@ -895,6 +901,7 @@ function Contact:handleSwipe()
         ges = ges,
         -- use first pan tev coordination as swipe start point
         pos = start_pos,
+        end_pos = end_pos,
         direction = swipe_direction,
         multiswipe_directions = multiswipe_directions,
         distance = swipe_distance,
@@ -1070,9 +1077,11 @@ function Contact:handleTwoFingerPan(buddy_contact)
         -- We'll also want to remember the span between both contacts on start & end for some gestures
         local start_distance = tstart_pos:distance(rstart_pos)
         local end_distance = tend_pos:distance(rend_pos)
+        -- FIXME: "pan" uses current pos as pos, and reports relative movement instead...
         local ges_ev = {
             ges = "two_finger_pan",
             pos = start_point,
+            end_pos = end_point,
             distance = avg_distance,
             direction = tpan_dir,
             time = self.current_tev.timev,
@@ -1130,6 +1139,14 @@ function Contact:handlePanRelease(keep_contact)
 
         logger.dbg("Contact:handlePanRelease: two_finger_pan_release detected")
         pan_ev.ges = "two_finger_pan_release"
+        -- The pan itself uses the midpoint between the two contacts, keep doing that.
+        local buddy_pos = Geom:new{
+            x = buddy_contact.current_tev.x,
+            y = buddy_contact.current_tev.y,
+            w = 0,
+            h = 0,
+        }
+        pan_ev.pos = release_pos:midpoint(buddy_pos)
         -- Don't drop buddy, voidState will handle it
         -- NOTE: This is yet another rotate hack, emanating from voidState into panState.
         if not keep_contact then

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -1170,7 +1170,7 @@ function Contact:handlePanRelease(keep_contact)
 
         logger.dbg("Contact:handlePanRelease: two_finger_pan_release detected")
         pan_ev.ges = "two_finger_pan_release"
-        -- The pan itself uses the midpoint between the two contacts, keep doing that.
+        -- The pan itself used the midpoint between the two contacts, keep doing that.
         local buddy_pos = Geom:new{
             x = buddy_contact.current_tev.x,
             y = buddy_contact.current_tev.y,

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -726,6 +726,7 @@ function Contact:panState(keep_contact)
                             -- Swap from pan semantics to swipe semantics
                             ges_ev.pos = ges_ev._start_pos
                             ges_ev._start_pos = nil
+                            ges_ev.start_pos = nil
                             ges_ev.end_pos = ges_ev._end_pos
                             ges_ev._end_pos = nil
                             ges_ev.relative = nil

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1041,7 +1041,11 @@ function Dispatcher:_showAsMenu(settings, gesture)
         width_factor = 0.8,
         use_info_style = false,
         buttons = buttons,
-        anchor = function() return gesture and gesture.pos end,
+        anchor = function()
+            if gesture then
+                return gesture.end_pos or gesture.pos
+            end
+        end,
     }
     UIManager:show(quickmenu)
 end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1043,6 +1043,7 @@ function Dispatcher:_showAsMenu(settings, gesture)
         buttons = buttons,
         anchor = function()
             if gesture then
+                -- Prefer the lift point if available (e.g., swipes, c.f., `GestureDetector:handleSwipe`)
                 return gesture.end_pos or gesture.pos
             end
         end,

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1041,12 +1041,7 @@ function Dispatcher:_showAsMenu(settings, gesture)
         width_factor = 0.8,
         use_info_style = false,
         buttons = buttons,
-        anchor = function()
-            if gesture then
-                -- Prefer the lift point if available (e.g., swipes, c.f., `GestureDetector:handleSwipe`)
-                return gesture.end_pos or gesture.pos
-            end
-        end,
+        anchor = function() return gesture and gesture.pos end,
     }
     UIManager:show(quickmenu)
 end


### PR DESCRIPTION
In the process of looking over the "swipe reports the *contact* point (i.e., gesture *start*) as `pos` while pretty much everything else reports the *lift* point (i.e., gesture *end*)" for the QuickMenu anchoring thingy, I realized that the two-finger variants of the pans & swipes were doing things... differently (by always using the "swipe" semantics, which effectively means that two_finger_pan reports completely different things than pan).

So, I started looking into best to handle that, and I came up with an ugly mess.

Which leads me to a simple question: why? Wouldn't it be much, much simpler is swipes just behaved like everything else and reported the *lift* point as `pos`?

I don't think we actually care about it much... unless it's used for the tap/gesture zone hit detection, in which case it makes sense to use the start position, dammit (yes, I just thought about that right now :D).

Anyway, RFC, I haven't even started testing this anyway ;D.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10649)
<!-- Reviewable:end -->
