### PR TITLE
Extended addition of PocketBook InkPad 4 (PB743G)/(PB743g)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -646,8 +646,8 @@ function PocketBook741._fb_init(fb, finfo, vinfo)
     vinfo.bits_per_pixel = 24
 end
 
--- PocketBook InkPad 4 (743g)
-local PocketBook743g = PocketBook:extend{
+-- PocketBook InkPad 4 (743G/743g)
+local PocketBook743G = PocketBook:extend{
     model = "PBInkPad4",
     display_dpi = 300,
     isAlwaysPortrait = yes,
@@ -757,8 +757,8 @@ elseif codename == "PB740-2" or codename == "PB740-3" then
     return PocketBook740_2
 elseif codename == "PB741" then
     return PocketBook741
-elseif codename == "PB743g" or codename == "PocketBook 743g" then
-    return PocketBook743g
+elseif codename == "PB743G" or codename == "PB743g" or codename == "PocketBook 743G" or codename == "PocketBook 743g" then
+    return PocketBook743G
 elseif codename == "PocketBook 840" or codename == "Reader InkPad" then
     return PocketBook840
 elseif codename == "PB970" then


### PR DESCRIPTION
Extended addition of PocketBook InkPad 4 with firmware later U743g.6.8.885 (PB743G) because its device ID was corrected from PB743g to PB743G by firmware U743g.6.8.1719.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10655)
<!-- Reviewable:end -->
