### PR TITLE
Font list menu: allow sorting by more recently set

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -101,10 +101,7 @@ function ReaderFont:setupFaceMenuTable()
                     text = text .. "   �"
                 end
                 if newly_added_fonts[v] then
-                    -- No real "new" symbol found in Unicode or nerdfont, so let's use
-                    -- this nerdfont small and superscripted "down arrow".
-                    -- (As it includes some left padding, no need for a leading space.)
-                    text = text .. "\u{F479}"
+                    text = text .. "  \u{EA93}" -- "NEW" in a black square, from nerdfont
                 end
                 return text
             end,

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -101,7 +101,10 @@ function ReaderFont:setupFaceMenuTable()
                     text = text .. "   �"
                 end
                 if newly_added_fonts[v] then
-                    text = text .. "  *" -- (no real "new" symbol found in Unicode or nerdfont)
+                    -- No real "new" symbol found in Unicode or nerdfont, so let's use
+                    -- this nerdfont small and superscripted "down arrow".
+                    -- (As it includes some left padding, no need for a leading space.)
+                    text = text .. "\u{F479}"
                 end
                 return text
             end,

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -798,6 +798,11 @@ end
 function TouchMenu:backToUpperMenu(no_close)
     if #self.item_table_stack ~= 0 then
         self.item_table = table.remove(self.item_table_stack)
+        -- Allow a menu table to refresh itself when going up (ie. from
+        -- a setting submenu that may want to update this menu).
+        if self.item_table.needs_refresh and self.item_table.refresh_func then
+            self.item_table = self.item_table.refresh_func()
+        end
         self.page = 1
         if self.parent_id then
             self:_recalculatePageLayout() -- we need an accurate self.perpage

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -798,8 +798,8 @@ end
 function TouchMenu:backToUpperMenu(no_close)
     if #self.item_table_stack ~= 0 then
         self.item_table = table.remove(self.item_table_stack)
-        -- Allow a menu table to refresh itself when going up (ie. from
-        -- a setting submenu that may want to update this menu).
+        -- Allow a menu table to refresh itself when going up (ie. from a setting
+        -- submenu that may want to have its parent menu updated).
         if self.item_table.needs_refresh and self.item_table.refresh_func then
             self.item_table = self.item_table.refresh_func()
         end


### PR DESCRIPTION
- Add a toggle in Font settings> allowing showing font ordered by most recently selected (long-press on it allows clearing this history).
- Keep in G_reader_settings a list of known fonts, so we can notice newly added user fonts, and put them at the start of the most recently selected. Show these new fonts with a symbol in the menu.
- TouchMenu: allows for a flag to trigger menu refresh when going up.

This is possibly a simpler alternative solution to #10613, so: Closes #10613.

@jonnyl2 : from https://github.com/koreader/koreader/issues/10613#issuecomment-1625468452

> Would this be an array of all fonts or just a defined number of recently selected ones? I would suggest that newly installed fonts also get in front of the line for easy selection after installation. But of course if the array is only 10 fonts and you install 10 new fonts at once it would wipe out all recent selections, so then nevermind...

Didn't think about newly installed fonts, but went with it. To be able to notice them, I need to keep a list of all fonts seen in `settings.reader.lua` (not fond of that, I like my settings tidy :) and this adds 1 or 2 KB to its size, but ok.... if this is fine with other devs ?)
So, with that full list, where I just remove from the middle and put a font at start when you select it, there is no "10 font history".

Not heavily tested, I probably won't use it, and I don't really know how usable it is with items moving around. @jonnyl2 : can you test it ? I think you now know how to pick files from a PR, but if not, I can provide you a zip.

One question: when should we put a font at the start of the recent list ? Only when tapping in the menu ? Or anytime we set the font, ie. via a gesture or a profile (which is what is done currently by this PR). I don't update it with the book main font when you switch to another book though (should we ?)

Long-press is a bit strange, it should act as a help_text but also allows clearing the history.
Rewording suggestions welcome (also for the code, dunno if "recently set" is the most clear wording, "recently selected" ?)
![image](https://github.com/koreader/koreader/assets/24273478/3f9015aa-3998-40cb-84aa-36096f28f9c0)

Couldn't find a "new" icon in Unicode or our nerdfont... This `[+]` icon is a bit dumb... But we won't see it after the next KOReader restart :) as fonts are considered new only for the session they got noticed as new.
![image](https://github.com/koreader/koreader/assets/24273478/8e60afd5-b5a6-4d59-8449-b51f14d6d7a2)

(My first candidate was U+2668 "Hot Springs"...: ![image](https://github.com/koreader/koreader/assets/24273478/30adff5e-6be9-44e9-8031-ed5b29327230) )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10662)
<!-- Reviewable:end -->
