### PR TITLE
QuickMenu: add long-press on profile

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1045,10 +1045,11 @@ end
 Calls the events in a settings list
 arguments are:
     1) the settings table
-    2) execution management table: { qm_show = true|false} - forcibly show QM / run
+    2) optionally a `gestures` object
+    3) execution management table: { qm_show = true|false} - forcibly show QM / run
                                    { qm_anchor = ges.pos } - anchor position
 --]]--
-function Dispatcher:execute(settings, exec_props)
+function Dispatcher:execute(settings, gesture, exec_props)
     if ((exec_props == nil or exec_props.qm_show == nil) and settings.settings and settings.settings.show_as_quickmenu)
             or (exec_props and exec_props.qm_show) then
         return Dispatcher:_showAsMenu(settings, exec_props)

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1058,6 +1058,7 @@ function Dispatcher:execute(settings, exec_props)
     if has_many then
         UIManager:broadcastEvent(Event:new("BatchedUpdate"))
     end
+    local gesture = exec_props and exec_props.gesture
     for k, v in iter_func(settings) do
         if type(k) == "number" then
             k = v
@@ -1074,29 +1075,25 @@ function Dispatcher:execute(settings, exec_props)
                 end
                 UIManager:sendEvent(Event:new("ConfigChange", settingsList[k].configurable.name, value))
             end
-            if settingsList[k].category == "none" then
-                if settingsList[k].arg ~= nil then
-                    UIManager:sendEvent(Event:new(settingsList[k].event, settingsList[k].arg, exec_props))
-                else
-                    UIManager:sendEvent(Event:new(settingsList[k].event))
-                end
-            end
-            if settingsList[k].category == "absolutenumber"
-                or settingsList[k].category == "string"
-            then
-                UIManager:sendEvent(Event:new(settingsList[k].event, v))
-            end
 
-            local gesture = exec_props and exec_props.gesture
-            -- the event can accept a gesture object or an argument
-            if settingsList[k].category == "arg" then
+            local category = settingsList[k].category
+            local event = settingsList[k].event
+            if category == "none" then
+                if settingsList[k].arg ~= nil then
+                    UIManager:sendEvent(Event:new(event, settingsList[k].arg, exec_props))
+                else
+                    UIManager:sendEvent(Event:new(event))
+                end
+            elseif category == "absolutenumber" or category == "string" then
+                UIManager:sendEvent(Event:new(event, v))
+            elseif category == "arg" then
+                -- the event can accept a gesture object or an argument
                 local arg = gesture or settingsList[k].arg
-                UIManager:sendEvent(Event:new(settingsList[k].event, arg))
-            end
-            -- the event can accept a gesture object or a number
-            if settingsList[k].category == "incrementalnumber" then
+                UIManager:sendEvent(Event:new(event, arg))
+            elseif category == "incrementalnumber" then
+                -- the event can accept a gesture object or a number
                 local arg = v ~= 0 and v or gesture or 0
-                UIManager:sendEvent(Event:new(settingsList[k].event, arg))
+                UIManager:sendEvent(Event:new(event, arg))
             end
         end
         Notification:resetNotifySource()

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1004,7 +1004,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_size = 22,
             callback = function()
                 UIManager:close(quickmenu)
-                Dispatcher:execute(settings, { qm_show = false })
+                Dispatcher:execute(settings, nil, { qm_show = false })
             end,
         }})
     end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1004,7 +1004,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_size = 22,
             callback = function()
                 UIManager:close(quickmenu)
-                Dispatcher:execute(settings, nil, { qm_show = false })
+                Dispatcher:execute(settings, { qm_show = false })
             end,
         }})
     end
@@ -1045,11 +1045,11 @@ end
 Calls the events in a settings list
 arguments are:
     1) the settings table
-    2) optionally a `gestures` object
-    3) execution management table: { qm_show = true|false} - forcibly show QM / run
+    2) execution management table: { qm_show = true|false} - forcibly show QM / run
                                    { qm_anchor = ges.pos } - anchor position
+                                   { gesture = ges } - a `gestures` object
 --]]--
-function Dispatcher:execute(settings, gesture, exec_props)
+function Dispatcher:execute(settings, exec_props)
     if ((exec_props == nil or exec_props.qm_show == nil) and settings.settings and settings.settings.show_as_quickmenu)
             or (exec_props and exec_props.qm_show) then
         return Dispatcher:_showAsMenu(settings, exec_props)
@@ -1086,6 +1086,8 @@ function Dispatcher:execute(settings, gesture, exec_props)
             then
                 UIManager:sendEvent(Event:new(settingsList[k].event, v))
             end
+
+            local gesture = exec_props and exec_props.gesture
             -- the event can accept a gesture object or an argument
             if settingsList[k].category == "arg" then
                 local arg = gesture or settingsList[k].arg

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -1153,11 +1153,11 @@ function Gestures:gestureAction(action, ges)
         return
     else
         self.ui:handleEvent(Event:new("HandledAsSwipe"))
-        local exec_props
+        local exec_props = { gesture = ges }
         if action_list.settings and action_list.settings.anchor_quickmenu then
-            exec_props = { qm_anchor = ges.end_pos or ges.pos }
+            exec_props.qm_anchor = ges.end_pos or ges.pos
         end
-        Dispatcher:execute(action_list, ges, exec_props)
+        Dispatcher:execute(action_list, exec_props)
     end
     return true
 end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -1153,8 +1153,11 @@ function Gestures:gestureAction(action, ges)
         return
     else
         self.ui:handleEvent(Event:new("HandledAsSwipe"))
-        ges.anchor_quickmenu = action_list.settings and action_list.settings.anchor_quickmenu
-        Dispatcher:execute(action_list, ges)
+        local exec_props
+        if action_list.settings and action_list.settings.anchor_quickmenu then
+            exec_props = { qm_anchor = ges.end_pos or ges.pos }
+        end
+        Dispatcher:execute(action_list, exec_props)
     end
     return true
 end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -1157,7 +1157,7 @@ function Gestures:gestureAction(action, ges)
         if action_list.settings and action_list.settings.anchor_quickmenu then
             exec_props = { qm_anchor = ges.end_pos or ges.pos }
         end
-        Dispatcher:execute(action_list, exec_props)
+        Dispatcher:execute(action_list, ges, exec_props)
     end
     return true
 end

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -124,14 +124,14 @@ function Profiles:getSubMenuItems()
                 text = _("Execute"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    self:onProfileExecute(k, false, false)
+                    self:onProfileExecute(k, { qm_show = false })
                 end,
             },
             {
                 text = _("Show as QuickMenu"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    self:onProfileExecute(k, false, true)
+                    self:onProfileExecute(k, { qm_show = true })
                 end,
             },
             {
@@ -253,8 +253,8 @@ function Profiles:getSubMenuItems()
     return sub_item_table
 end
 
-function Profiles:onProfileExecute(name, gesture, show_as_quickmenu)
-    Dispatcher:execute(self.data[name], gesture, show_as_quickmenu)
+function Profiles:onProfileExecute(name, exec_props)
+    Dispatcher:execute(self.data[name], exec_props)
 end
 
 function Profiles:editProfileName(editCallback, old_name)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -254,7 +254,7 @@ function Profiles:getSubMenuItems()
 end
 
 function Profiles:onProfileExecute(name, exec_props)
-    Dispatcher:execute(self.data[name], exec_props)
+    Dispatcher:execute(self.data[name], nil, exec_props)
 end
 
 function Profiles:editProfileName(editCallback, old_name)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -254,7 +254,7 @@ function Profiles:getSubMenuItems()
 end
 
 function Profiles:onProfileExecute(name, exec_props)
-    Dispatcher:execute(self.data[name], nil, exec_props)
+    Dispatcher:execute(self.data[name], exec_props)
 end
 
 function Profiles:editProfileName(editCallback, old_name)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -124,20 +124,14 @@ function Profiles:getSubMenuItems()
                 text = _("Execute"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    local show_as_quickmenu = v.settings.show_as_quickmenu
-                    self.data[k].settings.show_as_quickmenu = nil
-                    self:onProfileExecute(k)
-                    self.data[k].settings.show_as_quickmenu = show_as_quickmenu
+                    self:onProfileExecute(k, false, false)
                 end,
             },
             {
                 text = _("Show as QuickMenu"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    local show_as_quickmenu = v.settings.show_as_quickmenu
-                    self.data[k].settings.show_as_quickmenu = true
-                    self:onProfileExecute(k)
-                    self.data[k].settings.show_as_quickmenu = show_as_quickmenu
+                    self:onProfileExecute(k, false, true)
                 end,
             },
             {
@@ -259,8 +253,8 @@ function Profiles:getSubMenuItems()
     return sub_item_table
 end
 
-function Profiles:onProfileExecute(name, gesture)
-    Dispatcher:execute(self.data[name], gesture)
+function Profiles:onProfileExecute(name, gesture, show_as_quickmenu)
+    Dispatcher:execute(self.data[name], gesture, show_as_quickmenu)
 end
 
 function Profiles:editProfileName(editCallback, old_name)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -382,7 +382,7 @@ function Profiles:updateGestures(action_old_name, action_new_name)
                                 table.remove(gesture_loaded.settings.order, i)
                                 if #gesture.settings.order == 0 then
                                     gesture.settings.order = nil
-                                    if #gesture.settings == 0 then
+                                    if next(gesture.settings) == nil then
                                         gesture.settings = nil
                                     end
                                 end
@@ -397,7 +397,7 @@ function Profiles:updateGestures(action_old_name, action_new_name)
                     gesture[action_new_name] = true
                     gesture_loaded[action_new_name] = true
                 else
-                    if #gesture == 0 then
+                    if next(gesture) == nil then
                         all_gestures.data[section][gesture_name] = nil
                     end
                 end


### PR DESCRIPTION
Fixes https://github.com/koreader/koreader/issues/10668#issuecomment-1627806785.

Long-press on a profile entry in a QuickMenu calls a new QM with the content of the profile and "Execute all" button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10671)
<!-- Reviewable:end -->
