### PR TITLE
Re-add file sort by "last date read"

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -844,6 +844,7 @@ function FileManagerMenu:getSortingMenuTable()
     local collates = {
         { _("name"), "strcoll" },
         { _("name (natural sorting)"), "natural" },
+        { _("last read date"), "access" },
         { _("date modified"), "date" },
         { _("size"), "size" },
         { _("type"), "type" },

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -345,7 +345,7 @@ function FileChooser:getMenuItemMandatory(item, collate)
     if collate then -- file
         -- display the sorting parameter in mandatory
         if collate == "access" then
-            text = os.date("%Y-%m-%d %H:%M", item.attr.access)
+            text = datetime.secondsToDateTime(item.attr.access)
         elseif collate == "date" then
             text = datetime.secondsToDateTime(item.attr.modification)
         elseif collate == "percent_unopened_first" or collate == "percent_unopened_last" then

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -193,6 +193,10 @@ function FileChooser:getSortingFunction(collate, reverse_collate)
         sorting = function(a, b)
             return natsort(a.text, b.text)
         end
+    elseif collate == "access" then
+        sorting = function(a, b)
+            return a.attr.access > b.attr.access
+        end
     elseif collate == "date" then
         sorting = function(a, b)
             return a.attr.modification > b.attr.modification
@@ -340,7 +344,9 @@ function FileChooser:getMenuItemMandatory(item, collate)
     local text
     if collate then -- file
         -- display the sorting parameter in mandatory
-        if collate == "date" then
+        if collate == "access" then
+            text = os.date("%Y-%m-%d %H:%M", item.attr.access)
+        elseif collate == "date" then
             text = datetime.secondsToDateTime(item.attr.modification)
         elseif collate == "percent_unopened_first" or collate == "percent_unopened_last" then
             text = item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"


### PR DESCRIPTION
Partial un-do of #10627 : `access` is not the same as `modified`, so we want to keep the "last read date" file sort option in addition to the "date modified" option

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10682)
<!-- Reviewable:end -->
