### PR TITLE
ArchiveViewer: view files

### DIFF
--- a/plugins/archiveviewer.koplugin/main.lua
+++ b/plugins/archiveviewer.koplugin/main.lua
@@ -2,6 +2,7 @@ local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local DocumentRegistry = require("document/documentregistry")
+local InfoMessage = require("ui/widget/infomessage")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -177,17 +178,17 @@ function ArchiveViewer:showFileDialog(arcfile, filepath)
     local buttons = {
         {
             {
-                text = _("View"),
-                callback = function()
-                    UIManager:close(dialog)
-                    self:viewFile(arcfile, filepath)
-                end,
-            },
-            {
                 text = _("Extract"),
                 callback = function()
                     UIManager:close(dialog)
                     self:extractFile(arcfile, filepath)
+                end,
+            },
+            {
+                text = _("View"),
+                callback = function()
+                    UIManager:close(dialog)
+                    self:viewFile(arcfile, filepath)
                 end,
             },
         },
@@ -208,6 +209,10 @@ function ArchiveViewer:viewFile(arcfile, filepath)
             content = std_out:read("*all")
             std_out:close()
         else
+            UIManager:show(InfoMessage:new{
+                text = _("Cannot extract file content."),
+                icon = "notice-warning",
+            })
             return
         end
     else


### PR DESCRIPTION
View archived files content (without extraction to a file).
ImageViewer is used for supported image files, TextViewer for all other types.

![1](https://github.com/koreader/koreader/assets/62179190/aee4c62f-6845-4b4c-b989-8e6fe2ff3c0d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10683)
<!-- Reviewable:end -->
