### PR TITLE
Add translation button to dictionary lookup modal

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -466,6 +466,18 @@ function DictQuickLookup:init()
             },
             {
                 {
+                    id = "translate",
+                    text_func = function()
+                        return _("Translate")
+                    end,
+                    callback = function()
+                        UIManager:scheduleIn(0.1, function()
+                            Translator:showTranslation(self.word, true, nil, nil, true)
+                        end)
+                    end,
+                },
+                --
+                {
                     id = "wikipedia",
                     -- if dictionary result, do the same search on wikipedia
                     -- if already wiki, get the full page for the current result


### PR DESCRIPTION
There might be the case that a word could not be found in the dictionary or, if found, the dictionary entry isn't sufficient.
In that case it would be great if one could easily translate the word as a fallback.

Therefore I added a "Translate" button to the dictionary lookup modal.

<img width="497" alt="Screenshot 2023-07-12 at 15 41 58" src="https://github.com/koreader/koreader/assets/7283097/e56ca67b-e8c1-4784-ad5e-c2b03b305ccd">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10684)
<!-- Reviewable:end -->
