### PR TITLE
macOS: We ship our own webp, don't pull brew's

### DIFF
--- a/platform/mac/do_mac_bundle.sh
+++ b/platform/mac/do_mac_bundle.sh
@@ -146,18 +146,13 @@ done
 # Brew has a tendency to infiltrate our builds and take over some of the dependencies...
 BREW="$(brew --prefix)/opt"
 # So, because it made us pick those up, ship 'em
-cp "${BREW}/gettext/lib/libintl.8.dylib" "${BREW}/webp/lib/libwebp.7.dylib" "${BREW}/webp/lib/libsharpyuv.0.dylib" "${BREW}/libsodium/lib/libsodium.23.dylib" libs
-chmod 777 libs/libintl.8.dylib libs/libwebp.7.dylib libs/libsharpyuv.0.dylib libs/libsodium.23.dylib
+cp "${BREW}/gettext/lib/libintl.8.dylib" "${BREW}/libsodium/lib/libsodium.23.dylib" libs
+chmod 777 libs/libintl.8.dylib libs/libsodium.23.dylib
 # Update their name
 install_name_tool -id libintl.8.dylib libs/libintl.8.dylib
-install_name_tool -id libwebp.7.dylib libs/libwebp.7.dylib
-install_name_tool -id libsharpyuv.0.dylib libs/libsharpyuv.0.dylib
 install_name_tool -id libsodium.23.dylib libs/libsodium.23.dylib
 # And make sure anything that depends on them points to ours
 install_name_tool -change "${BREW}/gettext/lib/libintl.8.dylib" libs/libintl.8.dylib libs/libglib-2.0.dylib
-install_name_tool -change "${BREW}/webp/lib/libsharpyuv.0.dylib" libs/libsharpyuv.0.dylib libs/libwebp.7.dylib
-install_name_tool -change "${BREW}/webp/lib/libwebp.7.dylib" libs/libwebp.7.dylib libs/liblept.5.dylib
-install_name_tool -change "${BREW}/webp/lib/libwebp.7.dylib" libs/libwebp.7.dylib libs/libtesseract.3.dylib
 install_name_tool -change "${BREW}/libsodium/lib/libsodium.23.dylib" libs/libsodium.23.dylib libs/libczmq.1.dylib
 install_name_tool -change "${BREW}/libsodium/lib/libsodium.23.dylib" libs/libsodium.23.dylib libs/libfmq.1.dylib
 install_name_tool -change "${BREW}/libsodium/lib/libsodium.23.dylib" libs/libsodium.23.dylib libs/libzmq.4.dylib


### PR DESCRIPTION
c.f., https://github.com/koreader/koreader/pull/10687#issuecomment-1633450159

----

I'm not actually sure why we were pulling webp itself, since we build it? Perhaps this predates that fact?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10690)
<!-- Reviewable:end -->
