### PR TITLE
NetworkManager: Bypass isOnline on !hasWifiToggle platforms

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -396,6 +396,11 @@ function NetworkMgr:afterWifiAction(callback)
 end
 
 function NetworkMgr:isOnline()
+    -- For the same reasons as isWifiOn and isConnected above, bypass this on !hasWifiToggle platforms.
+    if not Device:hasWifiToggle() then
+        return true
+    end
+
     local socket = require("socket")
     -- Microsoft uses `dns.msftncsi.com` for Windows, see
     -- <https://technet.microsoft.com/en-us/library/ee126135#BKMK_How> for


### PR DESCRIPTION
Followup to #10669, fix #10694

While this one *should* technically be sound in and of itself, it failing would trip up the beforeWifiAction framework, so, just let whatever needs network connectivity fall on its face later; at worst, that'll provide more helpful logging than this failing would (because spoiler alert: it doesn't log anything :D).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10697)
<!-- Reviewable:end -->
