### PR TITLE
bump LunaSVG, crengine: add support for .docm

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -823,6 +823,9 @@ function ReaderUI:dealWithLoadDocumentFailure()
                 coroutine.resume(_coroutine, false)
             end,
         })
+        -- Restore input, so can catch the InfoMessage dismiss and exit
+        Device:setIgnoreInput(false)
+        Input:inhibitInputUntil(0.2)
         coroutine.yield() -- pause till InfoMessage is dismissed
     end
     -- We have to error and exit the coroutine anyway to avoid any segfault

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1509,6 +1509,7 @@ function CreDocument:register(registry)
     registry:addProvider("chm", "application/vnd.ms-htmlhelp", self, 90)
     registry:addProvider("doc", "application/msword", self, 90)
     registry:addProvider("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", self, 90)
+    registry:addProvider("docm", "application/vnd.ms-word.document.macroEnabled.12", self, 90)
     registry:addProvider("epub", "application/epub+zip", self, 100)
     registry:addProvider("epub", "application/epub", self, 100) -- Alternative mimetype for OPDS.
     registry:addProvider("epub3", "application/epub+zip", self, 100)


### PR DESCRIPTION
Includes:
- bump LunaSVG: intermediate upstream bump, cleanup https://github.com/koreader/koreader-base/pull/1640
- bump LunaSVG: minor upstream tweaks

crengine https://github.com/koreader/crengine/pull/523 :
- DocX: add support for similar DocM format
- LVStyleSheet: fix LVCssDeclaration::getHash()
- CSS parsing: accept Unicode values for ID and classnames
- update for Harfbuzz 8, fix some compiler warning

Also fix input not restored when loading failed, and KOReader not able to exit (showing an InfoMessage "KOReader will exit not." and waiting for a dismiss tap - which did never happen as input was not restored :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10702)
<!-- Reviewable:end -->
