### PR TITLE
Device:Android: use more correct intensity setting function

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -500,7 +500,7 @@ function Device:_showLightDialog()
 
     local action = android.lights.dialogState()
     if action == C.ALIGHTS_DIALOG_OK then
-        self.powerd.fl_intensity = self.powerd:frontlightIntensityHW()
+        self.powerd.setIntensityHW(self.powerd:frontlightIntensityHW())
         logger.dbg("Dialog OK, brightness: " .. self.powerd.fl_intensity)
         if android.isWarmthDevice() then
             self.powerd.fl_warmth = self.powerd:frontlightWarmthHW()


### PR DESCRIPTION
instead of manually setting the variable

i think `setIntensity` (no `HW`) would be more correct, but this should at least make both paths consistent

re #10722

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10725)
<!-- Reviewable:end -->
