### PR TITLE
Device:Android: wait until lights dialog is closed

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -499,6 +499,10 @@ function Device:_showLightDialog()
     android.lights.showDialog(title, _("Brightness"), _("Warmth"), _("OK"), _("Cancel"))
 
     local action = android.lights.dialogState()
+    while action == C.ALIGHTS_DIALOG_OPENED do
+        FFIUtil.usleep(250) -- dont pin the CPU
+        action = android.lights.dialogState()
+    end
     if action == C.ALIGHTS_DIALOG_OK then
         self.powerd.fl_intensity = self.powerd:frontlightIntensityHW()
         logger.dbg("Dialog OK, brightness: " .. self.powerd.fl_intensity)


### PR DESCRIPTION
before trying to read return status

like i had said in #10722 i dont really like this implementation, but i am not experienced enough to add a callback into the JNI

re #10722

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10726)
<!-- Reviewable:end -->
