### PR TITLE
DeviceListener:onToggleFrontlight: add notification of "unchanged"

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -197,7 +197,9 @@ if Device:hasFrontlight() then
         local notif_cb = function()
             Notification:notify(new_text, notif_source)
         end
-        powerd:toggleFrontlight(notif_cb)
+        if not powerd:toggleFrontlight(notif_cb) then
+            Notification:notify(_("Frontlight unchanged."), notif_source)
+        end
     end
 
     function DeviceListener:onShowFlDialog()


### PR DESCRIPTION
add notification when the frontlight is unchanged (no callback is called)

because in `2023.04` a notification would be always be shown (like `Frontlight disabled`) and since `2023.05` no notification would be shown anymore if the frontlight did not change (no intensity change), see

https://github.com/koreader/koreader/blob/d350418367ddf39d752d05e0587e562d7d4af2c4/frontend/device/generic/powerd.lua#L149

re #10722

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10727)
<!-- Reviewable:end -->
