### PR TITLE
Bundle of misc fixes

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -792,12 +792,16 @@ function Device:retrieveNetworkInfo()
                             else
                                 local essid_on = iwr.u.data.flags
                                 if essid_on ~= 0 then
+                                    -- Knowing the token index may be fun, bit it isn't in fact, super interesting...
+                                    --[[
                                     local token_index = bit.band(essid_on, C.IW_ENCODE_INDEX)
                                     if token_index > 1 then
                                         table.insert(results, T(_("SSID: \"%1\" [%2]"), ffi.string(essid), token_index))
                                     else
                                         table.insert(results, T(_("SSID: \"%1\""), ffi.string(essid)))
                                     end
+                                    --]]
+                                    table.insert(results, T(_("SSID: \"%1\""), ffi.string(essid)))
                                 else
                                     table.insert(results, _("SSID: off/any"))
                                 end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -432,11 +432,6 @@ local KoboCadmus = Kobo:extend{
         nl_min = 0,
         nl_max = 10,
         nl_inverted = false,
-        --- @note: The Sage natively ramps when setting the frontlight intensity.
-        ---        A side-effect of this behavior is that if you queue a series of intensity changes ending at 0,
-        ---        it won't ramp *at all*, and jump straight to zero.
-        ---        So we delay the final ramp off step to prevent (both) the native and our ramping from being optimized out
-        ramp_off_delay = 0.5,
     },
     boot_rota = C.FB_ROTATE_CW,
     battery_sysfs = "/sys/class/power_supply/battery",
@@ -637,6 +632,14 @@ function Kobo:init()
             -- Sage w/ a BD71828 PMIC
             self.power_dev = "/dev/input/by-path/platform-bd71828-pwrkey.4.auto-event"
         end
+    end
+
+    -- NOTE: Devices with an AW99703 frontlight PWM controller feature a hardware smooth ramp when setting the frontlight intensity.
+    ---      A side-effect of this behavior is that if you queue a series of intensity changes ending at 0,
+    ---      it won't ramp *at all*, jumping straight to zero instead.
+    ---      So we delay the final ramp off step to prevent (both) the native and our ramping from being optimized out.
+    if self:hasNaturalLight() and self.frontlight_settings.frontlight_mixer:find("aw99703", 12, true) then
+        self.frontlight_settings.ramp_off_delay = 0.5
     end
 
     -- NOTE: i.MX5 devices have a wonky RTC that doesn't like alarms set further away that UINT16_MAX seconds from now...


### PR DESCRIPTION
* OTA: Unbreak the first OTA on a fresh install (via https://github.com/koreader/koreader-base/pull/1643); Regression since #10162)
* NetworkInfo: Never show the token index next to the SSID
* Kobo: Apply the smooth ramp-off fix to all devices with an AW99703 PWM controller.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10728)
<!-- Reviewable:end -->
