### PR TITLE
Device:Android: call "_decideFrontlightState" to keep "is_fl_on" in sync

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -501,6 +501,7 @@ function Device:_showLightDialog()
     local action = android.lights.dialogState()
     if action == C.ALIGHTS_DIALOG_OK then
         self.powerd.fl_intensity = self.powerd:frontlightIntensityHW()
+        self.powerd:_decideFrontlightState()
         logger.dbg("Dialog OK, brightness: " .. self.powerd.fl_intensity)
         if android.isWarmthDevice() then
             self.powerd.fl_warmth = self.powerd:frontlightWarmthHW()
@@ -510,6 +511,7 @@ function Device:_showLightDialog()
     elseif action == C.ALIGHTS_DIALOG_CANCEL then
         logger.dbg("Dialog Cancel, brightness: " .. self.powerd.fl_intensity)
         self.powerd:setIntensityHW(self.powerd.fl_intensity)
+        self.powerd:_decideFrontlightState()
         if android.isWarmthDevice() then
             logger.dbg("Dialog Cancel, warmth: " .. self.powerd.fl_warmth)
             self.powerd:setWarmth(self.powerd.fl_warmth)


### PR DESCRIPTION
re #10725

This PR is so that variable `is_fl_on` is also kept in-sync when `fl_intensity` is being set, this *could* maybe be de-duplicated by always calling it after the both `if`'s.

Why?

because thing that depend on `is_fl_on` do not work correctly after just `fl_intensity` being set, like `BasePowerD:isFrontlightOn` (by extension also `BasePowerD:isFrontlightOff`) and so in turn things like `BasePowerD:toggleFrontlight` call the wrong function.

Example:
(assuming #10726 is merged, makes it easier to explain)

initial state:
fl_intensity: 50
is_fl_on: true

then you go to the lights dialog, change `brightness` to `0` (fronlight being off) and then just `fl_intensity` is set to `0`, but `is_fl_on` stays `true` - which is wrong, and so if you then do something like event `ToggleFrontlight` it will go the path of `Frontlight Disabled`, even though the frontlight was already disabled

@pazos i hope this examples makes it more clear what i meant with https://github.com/koreader/koreader/pull/10725#issuecomment-1646616900, i have go the path of `or to use powerd:_decideFrontlightState()`
to make it less forgettable in the future maybe refactor this with one of the other options listed in the mentioned comment (like adding a helper function for only internal state)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10731)
<!-- Reviewable:end -->
