### PR TITLE
Autowarmth: Change strings "set" and "unset" to "turn on" / "turn off" where appropriate

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -995,7 +995,7 @@ function AutoWarmth:getWarmthMenu()
                 else
                     UIManager:show(ConfirmBox:new{
                         text = _("Night mode"),
-                        ok_text = _("Set"),
+                        ok_text = _("Turn on"),
                         ok_callback = function()
                             self.warmth[num] = 110
                             self.warmth[#self.warmth - num + 1] = 110
@@ -1003,7 +1003,7 @@ function AutoWarmth:getWarmthMenu()
                             self:scheduleMidnightUpdate()
                             if touchmenu_instance then self:updateItems(touchmenu_instance) end
                         end,
-                        cancel_text = _("Unset"),
+                        cancel_text = _("Turn off"),
                         cancel_callback = function()
                             self.warmth[num] = 0
                             self.warmth[#self.warmth - num + 1] = 0


### PR DESCRIPTION
At least for that case i think `Activate` and `Deactivate` are more appropriate (especially for translations)

for example currently in german they are translated to:
`Set` -> `Setzen` (literally `place` / `set`)
`Unset` -> `Löschen` (literally `delete`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10733)
<!-- Reviewable:end -->
