### PR TITLE
Device:Android: always call "_decideFrontlightState" in "setIntensityHW"

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -515,7 +515,6 @@ function Device:_showLightDialog()
     elseif action == C.ALIGHTS_DIALOG_CANCEL then
         logger.dbg("Dialog Cancel, brightness: " .. self.powerd.fl_intensity)
         self.powerd:setIntensityHW(self.powerd.fl_intensity)
-        self.powerd:_decideFrontlightState()
         if android.isWarmthDevice() then
             logger.dbg("Dialog Cancel, warmth: " .. self.powerd.fl_warmth)
             self.powerd:setWarmth(self.powerd.fl_warmth)

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -16,6 +16,7 @@ function AndroidPowerD:setIntensityHW(intensity)
 
     self.fl_intensity = intensity
     android.setScreenBrightness(math.floor(intensity * self.bright_diff / self.fl_max))
+    self:_decideFrontlightState()
 end
 
 function AndroidPowerD:init()


### PR DESCRIPTION
re https://github.com/koreader/koreader/pull/10731#discussion_r1271505121

This PR changes so that androids implementation of `setIntensityHW` always calls `_decideFrontlightState`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10737)
<!-- Reviewable:end -->
