### PR TITLE
bump crengine, fix images in Wikipedia results and EPUB, View matching CSS tweak

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -946,8 +946,8 @@ function CreDocument:getHTMLFromXPointers(xp0, xp1, flags, from_root_node)
     end
 end
 
-function CreDocument:getStylesheetsMatchingRulesets(node_dataindex)
-    return self._document:getStylesheetsMatchingRulesets(node_dataindex)
+function CreDocument:getStylesheetsMatchingRulesets(node_dataindex, with_main_stylesheet)
+    return self._document:getStylesheetsMatchingRulesets(node_dataindex, with_main_stylesheet)
 end
 
 function CreDocument:getNormalizedXPointer(xp)

--- a/frontend/ui/viewhtml.lua
+++ b/frontend/ui/viewhtml.lua
@@ -353,11 +353,19 @@ function ViewHtml:_handleLongPress(document, css_selectors_offsets, offset_shift
         callback = function()
             self:_showMatchingSelectors(document, ancestors, false)
         end,
+        hold_callback = function()
+            -- skip main stylesheet and style tweaks
+            self:_showMatchingSelectors(document, ancestors, false, false)
+        end,
     }})
     table.insert(copy_buttons, {{
         text = _("Show matched stylesheets rules (all ancestors)"),
         callback = function()
             self:_showMatchingSelectors(document, ancestors, true)
+        end,
+        hold_callback = function()
+            -- skip main stylesheet and style tweaks
+            self:_showMatchingSelectors(document, ancestors, true, false)
         end,
     }})
 
@@ -372,11 +380,11 @@ function ViewHtml:_handleLongPress(document, css_selectors_offsets, offset_shift
     UIManager:show(widget)
 end
 
-function ViewHtml:_showMatchingSelectors(document, ancestors, show_all_ancestors)
+function ViewHtml:_showMatchingSelectors(document, ancestors, show_all_ancestors, with_main_stylesheet)
     local snippets
     if not show_all_ancestors then
         local node_dataindex = ancestors[1][2]
-        snippets = document:getStylesheetsMatchingRulesets(node_dataindex)
+        snippets = document:getStylesheetsMatchingRulesets(node_dataindex, with_main_stylesheet)
     else
         snippets = {}
         local elements = {}
@@ -391,8 +399,11 @@ function ViewHtml:_showMatchingSelectors(document, ancestors, show_all_ancestors
                 table.insert(snippets, "")
             end
             local desc = table.concat(elements, " > ", 1, #ancestors - i + 1)
-            table.insert(snippets, "/* ====== " .. desc .. " */")
-            util.arrayAppend(snippets, document:getStylesheetsMatchingRulesets(node_dataindex))
+            -- We use Unicode solid black blocks to make these really visible
+            table.insert(snippets, "/* \u{259B}" .. ("\u{2580}"):rep(20) .. " */")
+            table.insert(snippets, "/* \u{258C}" .. desc .. " */")
+            table.insert(snippets, "/* \u{2599}" .. ("\u{2584}"):rep(20) .. " */")
+            util.arrayAppend(snippets, document:getStylesheetsMatchingRulesets(node_dataindex, with_main_stylesheet))
         end
     end
 


### PR DESCRIPTION
#### bump crengine: CSS caption-side, SVG, CSS and table fixes

Includes https://github.com/koreader/crengine/pull/524:
- SVG: support embedded base64 images when no doc
- epub.css: hide `<nav hidden="">`
  Closes #10703.
- Tables: fix possible specified width overflow
- Tables: fix caption and table width interactions
- CSS/Tables: add support for "caption-side: top/bottom"
- gatherNodeMatchingRulesets(): avoid messing document cache
- gatherStylesheetsMatchingRulesets(): add with_m_stylesheet param

#### View HTML: Show matched rules: ignore style & tweaks on long-press

On long-press on the "Show matched stylesheets rules" buttons, ignore those from our epub.css/html5.css and from styletweaks, which may make investigating a book style simpler without their noise.
![image](https://github.com/koreader/crengine/assets/24273478/5e675e80-f2ee-4f9f-91b2-49f1ba83c8d8)

I also changed the "markup" for element path, using Unicode solid black blocks, instead of the previous bland `/* ===== DocFragment > body > section > p */`.


#### Wikipedia: handle images in changed Wikipedia HTML

The HTML we get from Wikipedia has recently changed, which has caused images to not be detected and shown in DictQuickLookup, and to be missing or ugly in saved EPUBs. Update our code and CSS to display them again.
See https://github.com/koreader/koreader/pull/5840#issuecomment-1646576070.
Note that their is no longer the (often long) ToC (as nested HTML list items) in our saved EPUBs, as the HTML we get from Wikipedia no longer include it :/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10746)
<!-- Reviewable:end -->
