### PR TITLE
Statistics plugin sync: fix bloated null id_books

### DIFF
--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20230727
+local CURRENT_MIGRATION_DATE = 20230802
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -587,9 +587,9 @@ if last_migration_date < 20230710 then
     end
 end
 
--- 20230727, Statistics plugin null id_book in page_stat_data
-if last_migration_date < 20230727 then
-    logger.info("Performing one-time migration for 20230727")
+-- 20230802, Statistics plugin null id_book in page_stat_data
+if last_migration_date < 20230802 then
+    logger.info("Performing one-time migration for 20230802")
     local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
     if util.fileExists(db_location) then
         local conn = SQ3.open(db_location)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -6,6 +6,7 @@ local DataStorage = require("datastorage")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local SQ3 = require("lua-ljsqlite3/init")
+local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
@@ -589,17 +590,22 @@ end
 -- 20230727, Statistics plugin null id_book in page_stat_data
 if last_migration_date < 20230727 then
     logger.info("Performing one-time migration for 20230727")
-    local conn = SQ3.open(DataStorage:getSettingsDir() .. "/statistics.sqlite3")
-    local ok, value = pcall(conn.exec, conn, "PRAGMA table_info('page_stat_data')")
-    if ok and value then
-        -- Has table
-        conn:exec("DELETE FROM page_stat_data WHERE id_book IS null;")
-        local ok2, errmsg = pcall(conn.exec, conn, "VACUUM;")
-        if not ok2 then
-            logger.warn("Failed compacting statistics database when fixing null id_book:", errmsg)
+    local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
+    if util.fileExists(db_location) then
+        local conn = SQ3.open(db_location)
+        local ok, value = pcall(conn.exec, conn, "PRAGMA table_info('page_stat_data')")
+        if ok and value then
+            -- Has table
+            conn:exec("DELETE FROM page_stat_data WHERE id_book IS null;")
+            local ok2, errmsg = pcall(conn.exec, conn, "VACUUM;")
+            if not ok2 then
+                logger.warn("Failed compacting statistics database when fixing null id_book:", errmsg)
+            end
+        else
+            logger.warn("db not compatible when performing onetime migration:", ok, value)
         end
     else
-        logger.warn("db not compatible when performing onetime migration:", ok, value)
+        logger.info("statistics.sqlite3 not found.")
     end
 end
 

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -428,14 +428,6 @@ Please wait…
             end
         end
     end
-    if not self.settings.fixed_null_idbook then
-        self.settings.fixed_null_idbook = true
-        conn:exec("DELETE FROM page_stat_data WHERE id_book IS null;")
-        local ok, errmsg = pcall(conn.exec, conn, "VACUUM;")
-        if not ok then
-            logger.warn("Failed compacting statistics database when fixing null id_book:", errmsg)
-        end
-    end
     conn:close()
 end
 


### PR DESCRIPTION
This PR is an attempt to fix #10342 and #10656. According to https://github.com/koreader/koreader/issues/10656#issuecomment-1650991464, the bug could be `null id_books` in `page_stat_data`. I didn't really find out why that happened from the sync code but still added some "fail-proofs". 
Also it would be great if @libelle1995 and @xsdjt could try out this solution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10749)
<!-- Reviewable:end -->
