### PR TITLE
cre doc_settings: do not duplicate copt_ settings

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -180,48 +180,48 @@ function ReaderFont:onReadSettings(config)
                          or self.ui.document.header_font
     self.ui.document:setHeaderFont(self.header_font_face)
 
-    self.font_size = config:readSetting("font_size")
+    self.font_size = config:readSetting("copt_font_size")
                   or G_reader_settings:readSetting("copt_font_size")
                   or G_defaults:readSetting("DCREREADER_CONFIG_DEFAULT_FONT_SIZE")
                   or 22
     self.ui.document:setFontSize(Screen:scaleBySize(self.font_size))
 
-    self.font_base_weight = config:readSetting("font_base_weight")
+    self.font_base_weight = config:readSetting("copt_font_base_weight")
                       or G_reader_settings:readSetting("copt_font_base_weight")
                       or 0
     self.ui.document:setFontBaseWeight(self.font_base_weight)
 
-    self.font_hinting = config:readSetting("font_hinting")
+    self.font_hinting = config:readSetting("copt_font_hinting")
                      or G_reader_settings:readSetting("copt_font_hinting")
                      or 2 -- auto (default in cre.cpp)
     self.ui.document:setFontHinting(self.font_hinting)
 
-    self.font_kerning = config:readSetting("font_kerning")
+    self.font_kerning = config:readSetting("copt_font_kerning")
                      or G_reader_settings:readSetting("copt_font_kerning")
                      or 3 -- harfbuzz (slower, but needed for proper arabic)
     self.ui.document:setFontKerning(self.font_kerning)
 
-    self.word_spacing = config:readSetting("word_spacing")
+    self.word_spacing = config:readSetting("copt_word_spacing")
                      or G_reader_settings:readSetting("copt_word_spacing")
                      or {95, 75}
     self.ui.document:setWordSpacing(self.word_spacing)
 
-    self.word_expansion = config:readSetting("word_expansion")
+    self.word_expansion = config:readSetting("copt_word_expansion")
                        or G_reader_settings:readSetting("copt_word_expansion")
                        or 0
     self.ui.document:setWordExpansion(self.word_expansion)
 
-    self.cjk_width_scaling = config:readSetting("cjk_width_scaling")
+    self.cjk_width_scaling = config:readSetting("copt_cjk_width_scaling")
                        or G_reader_settings:readSetting("copt_cjk_width_scaling")
                        or 100
     self.ui.document:setCJKWidthScaling(self.cjk_width_scaling)
 
-    self.line_space_percent = config:readSetting("line_space_percent")
+    self.line_space_percent = config:readSetting("copt_line_spacing")
                            or G_reader_settings:readSetting("copt_line_spacing")
                            or G_defaults:readSetting("DCREREADER_CONFIG_LINE_SPACE_PERCENT_MEDIUM")
     self.ui.document:setInterlineSpacePercent(self.line_space_percent)
 
-    self.gamma_index = config:readSetting("gamma_index")
+    self.gamma_index = config:readSetting("copt_font_gamma")
                     or G_reader_settings:readSetting("copt_font_gamma")
                     or 15 -- gamma = 1.0
     self.ui.document:setGammaIndex(self.gamma_index)
@@ -354,15 +354,6 @@ end
 function ReaderFont:onSaveSettings()
     self.ui.doc_settings:saveSetting("font_face", self.font_face)
     self.ui.doc_settings:saveSetting("header_font_face", self.header_font_face)
-    self.ui.doc_settings:saveSetting("font_size", self.font_size)
-    self.ui.doc_settings:saveSetting("font_base_weight", self.font_base_weight)
-    self.ui.doc_settings:saveSetting("font_hinting", self.font_hinting)
-    self.ui.doc_settings:saveSetting("font_kerning", self.font_kerning)
-    self.ui.doc_settings:saveSetting("word_spacing", self.word_spacing)
-    self.ui.doc_settings:saveSetting("word_expansion", self.word_expansion)
-    self.ui.doc_settings:saveSetting("cjk_width_scaling", self.cjk_width_scaling)
-    self.ui.doc_settings:saveSetting("line_space_percent", self.line_space_percent)
-    self.ui.doc_settings:saveSetting("gamma_index", self.gamma_index)
     self.ui.doc_settings:saveSetting("font_family_fonts", self.font_family_fonts)
 end
 

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -79,7 +79,7 @@ function ReaderTypeset:onReadSettings(config)
     self:setBlockRenderingMode(self.block_rendering_mode)
 
     -- set render DPI
-    self.render_dpi = config:readSetting("render_dpi")
+    self.render_dpi = config:readSetting("copt_render_dpi")
                    or G_reader_settings:readSetting("copt_render_dpi")
                    or 96
     self:setRenderDPI(self.render_dpi)
@@ -127,7 +127,6 @@ function ReaderTypeset:onSaveSettings()
     self.ui.doc_settings:saveSetting("css", self.css)
     self.ui.doc_settings:saveSetting("embedded_css", self.embedded_css)
     self.ui.doc_settings:saveSetting("embedded_fonts", self.embedded_fonts)
-    self.ui.doc_settings:saveSetting("render_dpi", self.render_dpi)
 end
 
 function ReaderTypeset:onToggleEmbeddedStyleSheet(toggle)

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -110,22 +110,16 @@ function ReaderTypeset:onReadSettings(config)
                          or 1
     self:toggleTxtPreFormatted(self.txt_preformatted)
 
-    -- default to disable smooth scaling for now.
-    if config:has("smooth_scaling") then
-        self.smooth_scaling = config:isTrue("smooth_scaling")
-    else
-        local global = G_reader_settings:readSetting("copt_smooth_scaling")
-        self.smooth_scaling = global == 1 and true or false
-    end
+    -- default to disable smooth scaling for now
+    local setting = config:readSetting("copt_smooth_scaling")
+                 or G_reader_settings:readSetting("copt_smooth_scaling")
+    self.smooth_scaling = setting == 1
     self:toggleImageScaling(self.smooth_scaling)
 
     -- default to automagic nightmode-friendly handling of images
-    if config:has("nightmode_images") then
-        self.nightmode_images = config:isTrue("nightmode_images")
-    else
-        local global = G_reader_settings:readSetting("copt_nightmode_images")
-        self.nightmode_images = (global == nil or global == 1) and true or false
-    end
+    setting = config:readSetting("copt_nightmode_images")
+           or G_reader_settings:readSetting("copt_nightmode_images")
+    self.nightmode_images = setting == 1 or setting == nil
     self:toggleNightmodeImages(self.nightmode_images)
 end
 
@@ -134,8 +128,6 @@ function ReaderTypeset:onSaveSettings()
     self.ui.doc_settings:saveSetting("embedded_css", self.embedded_css)
     self.ui.doc_settings:saveSetting("embedded_fonts", self.embedded_fonts)
     self.ui.doc_settings:saveSetting("render_dpi", self.render_dpi)
-    self.ui.doc_settings:saveSetting("smooth_scaling", self.smooth_scaling)
-    self.ui.doc_settings:saveSetting("nightmode_images", self.nightmode_images)
 end
 
 function ReaderTypeset:onToggleEmbeddedStyleSheet(toggle)

--- a/frontend/ui/data/settings_migration.lua
+++ b/frontend/ui/data/settings_migration.lua
@@ -43,11 +43,6 @@ function SettingsMigration:migrateSettings(config)
         local space_condensing = config:readSetting("copt_space_condensing")
         logger.info("Migrating old", cfg_class, "CRe space condensing:", space_condensing)
         config:saveSetting("copt_word_spacing", { 100, space_condensing })
-        if cfg_class == "book" then
-            -- a bit messy that some settings are saved twice in DocSettings, with
-            -- and without a copt_ prefix, and they must be in sync
-            config:saveSetting("word_spacing", { 100, space_condensing })
-        end
     end
 
 end


### PR DESCRIPTION
All configurable settings are saved as `copt_` settings. Do not duplicate them in sdr.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10763)
<!-- Reviewable:end -->
