### PR TITLE
Kobo: Yet another attempt at working around the hangs on the latest NXP boards

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -823,12 +823,14 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
     --   followed_link_marker = true: maker shown and not auto removed
     --   followed_link_marker = <number>: removed after <number> seconds
     -- (no real need for a menu item, the default is the finest)
-    local marker_setting
+    local marker_setting = 1
+    --[[
     if G_reader_settings:has("followed_link_marker") then
         marker_setting = G_reader_settings:readSetting("followed_link_marker")
     else
         marker_setting = 1 -- default is: shown and removed after 1 second
     end
+    --]]
 
     if marker_xp and marker_setting then
         -- Show a mark on left side of screen to give a visual feedback of

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -823,14 +823,12 @@ function ReaderRolling:onGotoXPointer(xp, marker_xp)
     --   followed_link_marker = true: maker shown and not auto removed
     --   followed_link_marker = <number>: removed after <number> seconds
     -- (no real need for a menu item, the default is the finest)
-    local marker_setting = 1
-    --[[
+    local marker_setting
     if G_reader_settings:has("followed_link_marker") then
         marker_setting = G_reader_settings:readSetting("followed_link_marker")
     else
         marker_setting = 1 -- default is: shown and removed after 1 second
     end
-    --]]
 
     if marker_xp and marker_setting then
         -- Show a mark on left side of screen to give a visual feedback of

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -2,7 +2,7 @@ local BasePowerD = require("device/generic/powerd")
 local UIManager
 local WakeupMgr = require("device/wakeupmgr")
 local logger = require("logger")
-local util = require("util")
+local ffiUtil = require("ffi/util")
 -- liblipclua, see require below
 
 local KindlePowerD = BasePowerD:new{
@@ -100,12 +100,12 @@ function KindlePowerD:setIntensityHW(intensity)
         -- NOTE: when intensity is 0, we want to *really* kill the light, so do it manually
         -- (asking lipc to set it to 0 would in fact set it to > 0 on ! canTurnFrontlightOff Kindles).
         -- We do *both* to make the fl restore on resume less jarring on devices where lipc 0 != off.
-        util.writeToSysfs(intensity, self.fl_intensity_file)
+        ffiUtil.writeToSysfs(intensity, self.fl_intensity_file)
 
         -- And in case there are two LED groups...
         -- This should never happen as all warmth devices so far canTurnFrontlightOff
         if self.warmth_intensity_file then
-            util.writeToSysfs(intensity, self.warmth_intensity_file)
+            ffiUtil.writeToSysfs(intensity, self.warmth_intensity_file)
         end
     end
 end
@@ -175,7 +175,7 @@ end
 
 function KindlePowerD:onToggleHallSensor()
     local stat = self:isHallSensorEnabled()
-    util.writeToSysfs(stat and 0 or 1, self.hall_file)
+    ffiUtil.writeToSysfs(stat and 0 or 1, self.hall_file)
 end
 
 function KindlePowerD:_readFLIntensity()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -575,12 +575,7 @@ end
 
 function Kobo:init()
     -- Check if we need to disable MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls...
-    local mxcfb_bypass_wait_for
-    if G_reader_settings:has("mxcfb_bypass_wait_for") then
-        mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
-    else
-        mxcfb_bypass_wait_for = not self:hasReliableMxcWaitFor()
-    end
+    local mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
 
     if self:isSunxi() then
         self.screen = require("ffi/framebuffer_sunxi"):new{

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -379,6 +379,10 @@ local KoboStorm = Kobo:extend{
     --       This obviously leads to *terrible* user experience, so, until more is understood about the issue,
     --       bypass this ioctl on this device.
     --       c.f., https://github.com/koreader/koreader/issues/7340
+    -- NOTE: On a possibly related note, on NXP devices (even earlier ones), Nickel will *always* wait for markers in pairs:
+    --       the "expected" marker to wait for, *and* the *previous* one right before that.
+    --       Of course, that first wait will mostly always return early, because it's usually much older and already done.
+    --       This weird quirk was dropped on sunxi & MTK, FWIW.
     hasReliableMxcWaitFor = no,
 }
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -617,7 +617,7 @@ function Kobo:init()
             -- No getter, so, keep track of our own state
             self.hw_night_mode = toggle
             -- Flip the global invert_fb flag
-            util.writeToSysfs(toggle and "night_mode 4" or "night_mode 0", "/proc/hwtcon/cmd")
+            ffiUtil.writeToSysfs(toggle and "night_mode 4" or "night_mode 0", "/proc/hwtcon/cmd")
         end
 
         function self.screen:getHWNightmode()
@@ -1115,7 +1115,7 @@ function Kobo:standby(max_duration)
     logger.dbg("Kobo standby: asking to enter standby . . .")
     local standby_time = time.boottime_or_realtime_coarse()
 
-    local ret = util.writeToSysfs("standby", "/sys/power/state")
+    local ret = ffiUtil.writeToSysfs("standby", "/sys/power/state")
 
     self.last_standby_time = time.boottime_or_realtime_coarse() - standby_time
     self.total_standby_time = self.total_standby_time + self.last_standby_time
@@ -1191,7 +1191,7 @@ function Kobo:suspend()
     -- NOTE: Sets gSleep_Mode_Suspend to 1. Used as a flag throughout the
     --       kernel to suspend/resume various subsystems
     --       c.f., state_extended_store @ kernel/power/main.c
-    local ret = util.writeToSysfs("1", "/sys/power/state-extended")
+    local ret = ffiUtil.writeToSysfs("1", "/sys/power/state-extended")
     if ret then
         logger.dbg("Kobo suspend: successfully asked the kernel to put subsystems to sleep")
     else
@@ -1225,7 +1225,7 @@ function Kobo:suspend()
     logger.dbg("Kobo suspend: asking for a suspend to RAM . . .")
     local suspend_time = time.boottime_or_realtime_coarse()
 
-    ret = util.writeToSysfs("mem", "/sys/power/state")
+    ret = ffiUtil.writeToSysfs("mem", "/sys/power/state")
 
     -- NOTE: At this point, we *should* be in suspend to RAM, as such,
     --       execution should only resume on wakeup...
@@ -1240,7 +1240,7 @@ function Kobo:suspend()
     else
         logger.warn("Kobo suspend: the kernel refused to enter suspend!")
         -- Reset state-extended back to 0 since we are giving up.
-        util.writeToSysfs("0", "/sys/power/state-extended")
+        ffiUtil.writeToSysfs("0", "/sys/power/state-extended")
         if G_reader_settings:isTrue("pm_debug_entry_failure") then
             self:toggleChargingLED(true)
         end
@@ -1289,7 +1289,7 @@ function Kobo:resume()
     --       kernel to suspend/resume various subsystems
     --       cf. kernel/power/main.c @ L#207
     --       Among other things, this sets up the wakeup pins (e.g., resume on input).
-    local ret = util.writeToSysfs("0", "/sys/power/state-extended")
+    local ret = ffiUtil.writeToSysfs("0", "/sys/power/state-extended")
     if ret then
         logger.dbg("Kobo resume: successfully asked the kernel to resume subsystems")
     else
@@ -1305,7 +1305,7 @@ function Kobo:resume()
         -- c.f., neo_ctl @ drivers/input/touchscreen/zforce_i2c.c,
         -- basically, a is wakeup (for activate), d is sleep (for deactivate), and we don't care about s (set res),
         -- and l (led signal level, actually a NOP on NTX kernels).
-        util.writeToSysfs("a", self.hasIRGridSysfsKnob)
+        ffiUtil.writeToSysfs("a", self.hasIRGridSysfsKnob)
     end
 
     -- A full suspend may have toggled the LED off.
@@ -1379,7 +1379,7 @@ function Kobo:_NTXChargingLEDToggle(toggle)
 end
 
 function Kobo:_LinuxChargingLEDToggle(toggle)
-    util.writeToSysfs(toggle and "1" or "0", self.charging_led_sysfs_knob)
+    ffiUtil.writeToSysfs(toggle and "1" or "0", self.charging_led_sysfs_knob)
 end
 
 function Kobo:toggleChargingLED(toggle)
@@ -1427,16 +1427,16 @@ function Kobo:enableCPUCores(amount)
             up = "1"
         end
 
-        util.writeToSysfs(up, path)
+        ffiUtil.writeToSysfs(up, path)
     end
 end
 
 function Kobo:performanceCPUGovernor()
-    util.writeToSysfs("performance", self.cpu_governor_knob)
+    ffiUtil.writeToSysfs("performance", self.cpu_governor_knob)
 end
 
 function Kobo:defaultCPUGovernor()
-    util.writeToSysfs(self.default_cpu_governor, self.cpu_governor_knob)
+    ffiUtil.writeToSysfs(self.default_cpu_governor, self.cpu_governor_knob)
 end
 
 function Kobo:isStartupScriptUpToDate()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -575,7 +575,12 @@ end
 
 function Kobo:init()
     -- Check if we need to disable MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls...
-    local mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
+    local mxcfb_bypass_wait_for
+    if G_reader_settings:has("mxcfb_bypass_wait_for") then
+        mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
+    else
+        mxcfb_bypass_wait_for = not self:hasReliableMxcWaitFor()
+    end
 
     if self:isSunxi() then
         self.screen = require("ffi/framebuffer_sunxi"):new{

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -376,9 +376,9 @@ local KoboStorm = Kobo:extend{
     },
     -- NOTE: The Libra apparently suffers from a mysterious issue where completely innocuous WAIT_FOR_UPDATE_COMPLETE ioctls
     --       will mysteriously fail with a timeout (5s)...
-    --       This obviously leads to *terrible* user experience, so, until more is understood about the issue,
-    --       bypass this ioctl on this device.
-    --       c.f., https://github.com/koreader/koreader/issues/7340
+    --       This obviously leads to *terrible* user experience,
+    --       so we've tried a few things over the years to attempt to deal with it.
+    --       c.f., https://github.com/koreader/koreader/issues/7340 for the genesis of all that.
     -- NOTE: On a possibly related note, on NXP devices (even earlier ones), Nickel will *always* wait for markers in pairs:
     --       the "expected" marker to wait for, *and* the *previous* one right before that.
     --       Of course, that first wait will mostly always return early, because it's usually much older and already done.
@@ -499,7 +499,7 @@ local KoboGoldfinch = Kobo:extend{
     },
     battery_sysfs = "/sys/class/power_supply/battery",
     power_dev = "/dev/input/by-path/platform-bd71828-pwrkey-event",
-    -- Board is eerily similar to the Libra 2, which, unfortunately, means it's also buggy as hell...
+    -- Board is eerily similar to the Libra 2, so, it inherits the same quirks...
     -- c.f., https://github.com/koreader/koreader/issues/9552#issuecomment-1293000313
     hasReliableMxcWaitFor = no,
 }

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -571,12 +571,14 @@ end
 
 function Kobo:init()
     -- Check if we need to disable MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls...
-    local mxcfb_bypass_wait_for
+    local mxcfb_bypass_wait_for = false
+    --[[
     if G_reader_settings:has("mxcfb_bypass_wait_for") then
         mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
     else
         mxcfb_bypass_wait_for = not self:hasReliableMxcWaitFor()
     end
+    --]]
 
     if self:isSunxi() then
         self.screen = require("ffi/framebuffer_sunxi"):new{

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -575,14 +575,12 @@ end
 
 function Kobo:init()
     -- Check if we need to disable MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls...
-    local mxcfb_bypass_wait_for = false
-    --[[
+    local mxcfb_bypass_wait_for
     if G_reader_settings:has("mxcfb_bypass_wait_for") then
         mxcfb_bypass_wait_for = G_reader_settings:isTrue("mxcfb_bypass_wait_for")
     else
         mxcfb_bypass_wait_for = not self:hasReliableMxcWaitFor()
     end
-    --]]
 
     if self:isSunxi() then
         self.screen = require("ffi/framebuffer_sunxi"):new{

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -380,8 +380,8 @@ local KoboStorm = Kobo:extend{
     --       so we've tried a few things over the years to attempt to deal with it.
     --       c.f., https://github.com/koreader/koreader/issues/7340 for the genesis of all that.
     -- NOTE: On a possibly related note, on NXP devices (even earlier ones), Nickel will *always* wait for markers in pairs:
-    --       the "expected" marker to wait for, *and* the *previous* one right before that.
-    --       Of course, that first wait will mostly always return early, because it's usually much older and already done.
+    --       the "expected" marker to wait for, and the *previous* one right before that.
+    --       Of course, that first wait will mostly always return early, because that refresh is usually much older and already dealt with.
     --       This weird quirk was dropped on sunxi & MTK, FWIW.
     hasReliableMxcWaitFor = no,
 }

--- a/frontend/device/sysfs_light.lua
+++ b/frontend/device/sysfs_light.lua
@@ -3,7 +3,7 @@
 -- red and green light LEDs.
 
 local dbg = require("dbg")
-local util = require("util")
+local ffiUtil = require("ffi/util")
 
 local SysfsLight = {
     frontlight_white = nil,
@@ -73,15 +73,15 @@ function SysfsLight:setNaturalBrightness(brightness, warmth)
             if self.frontlight_ioctl then
                 self.frontlight_ioctl:setBrightness(brightness)
             else
-                util.writeToSysfs(brightness, self.frontlight_white)
+                ffiUtil.writeToSysfs(brightness, self.frontlight_white)
             end
         end
         -- The mixer might be using inverted values... (cold is nl_max, warm is nl_min)
         if set_warmth then
             if self.nl_inverted then
-                util.writeToSysfs(self.nl_max - warmth, self.frontlight_mixer)
+                ffiUtil.writeToSysfs(self.nl_max - warmth, self.frontlight_mixer)
             else
-                util.writeToSysfs(warmth, self.frontlight_mixer)
+                ffiUtil.writeToSysfs(warmth, self.frontlight_mixer)
             end
         end
     else
@@ -124,11 +124,11 @@ function SysfsLight:_set_light_value(sysfs_directory, value)
     if not sysfs_directory then return end
     -- bl_power is '31' when the light is turned on, '0' otherwise.
     if (value > 0) then
-        util.writeToSysfs(31, sysfs_directory .. "/bl_power")
+        ffiUtil.writeToSysfs(31, sysfs_directory .. "/bl_power")
     else
-        util.writeToSysfs(0, sysfs_directory .. "/bl_power")
+        ffiUtil.writeToSysfs(0, sysfs_directory .. "/bl_power")
     end
-    util.writeToSysfs(value, sysfs_directory .. "/brightness")
+    ffiUtil.writeToSysfs(value, sysfs_directory .. "/brightness")
 end
 
 return SysfsLight

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -594,10 +594,6 @@ if last_migration_date < 20230731 then
         if not Device:hasReliableMxcWaitFor() then
             G_reader_settings:delSetting("followed_link_marker")
         end
-
-        -- Kill this one unconditionally, as it's user-visible in the dev menu, and I don't want random strays...
-        -- (Will require a restart to take, anyway...)
-        G_reader_settings:delSetting("mxcfb_bypass_wait_for")
     end
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -8,7 +8,7 @@ local logger = require("logger")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20230710
+local CURRENT_MIGRATION_DATE = 20230731
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -582,6 +582,22 @@ if last_migration_date < 20230710 then
             kosync.auto_sync = false
             G_reader_settings:saveSetting("kosync", kosync)
         end
+    end
+end
+
+-- 20230731, aka., "let's kill all those stupid and weird mxcfb workarounds"
+if last_migration_date < 20230731 then
+    logger.info("Performing one-time migration for 20230731")
+
+    local Device = require("device")
+    if Device:isKobo() then
+        if not Device:hasReliableMxcWaitFor() then
+            G_reader_settings:delSetting("followed_link_marker")
+        end
+
+        -- Kill this one unconditionally, as it's user-visible in the dev menu, and I don't want random strays...
+        -- (Will require a restart to take, anyway...)
+        G_reader_settings:delSetting("mxcfb_bypass_wait_for")
     end
 end
 

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -683,9 +683,12 @@ function InputText:onShowKeyboard(ignore_first_hold_release)
 end
 
 function InputText:onCloseKeyboard()
-    UIManager:close(self.keyboard)
     Device:stopTextInput()
-    self.is_keyboard_hidden = true
+
+    if not self.is_keyboard_hidden then
+        UIManager:close(self.keyboard)
+        self.is_keyboard_hidden = true
+    end
 end
 
 function InputText:onCloseWidget()

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -203,11 +203,8 @@ function Notification:onCloseWidget()
 end
 
 function Notification:onShow()
-    -- NOTE: We use the elusive "[ui]" mode solely for the sake of NTX boards flagged as unreliable,
-    --       in the hope that this will save them from an EPDC race that might make them horribly crash.
-    --       c.f., https://github.com/koreader/koreader/issues/9806#issuecomment-1416827447
     UIManager:setDirty(self, function()
-        return "[ui]", self.frame.dimen
+        return "ui", self.frame.dimen
     end)
     if self.timeout then
         UIManager:scheduleIn(self.timeout, function() UIManager:close(self) end)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -933,7 +933,7 @@ function VirtualKeyboard:onShow()
 end
 
 function VirtualKeyboard:onCloseWidget()
-    self:_refresh(false)
+    self:_refresh(true)
 end
 
 function VirtualKeyboard:initLayer(layer)

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -833,26 +833,6 @@ function util.removeFile(file)
     end
 end
 
-function util.writeToSysfs(val, file)
-    -- NOTE: We do things by hand via ffi, because io.write uses fwrite,
-    --       which isn't a great fit for procfs/sysfs (e.g., we lose failure cases like EBUSY,
-    --       as it only reports failures to write to the *stream*, not to the disk/file!).
-    local fd = C.open(file, bit.bor(C.O_WRONLY, C.O_CLOEXEC)) -- procfs/sysfs, we shouldn't need O_TRUNC
-    if fd == -1 then
-        logger.err("Cannot open file `" .. file .. "`:", ffi.string(C.strerror(ffi.errno())))
-        return
-    end
-    val = tostring(val)
-    local bytes = #val
-    local nw = C.write(fd, val, bytes)
-    if nw == -1 then
-        logger.err("Cannot write `" .. val .. "` to file `" .. file .. "`:", ffi.string(C.strerror(ffi.errno())))
-    end
-    C.close(fd)
-    -- NOTE: Allows the caller to possibly handle short writes (not that these should ever happen here).
-    return nw == bytes
-end
-
 -- Gets total, used and available bytes for the mountpoint that holds a given directory.
 -- @string path of the directory
 -- @treturn table with total, used and available bytes

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -5,13 +5,9 @@ This module contains miscellaneous helper functions for the KOReader frontend.
 local BaseUtil = require("ffi/util")
 local Utf8Proc = require("ffi/utf8proc")
 local lfs = require("libs/libkoreader-lfs")
-local logger = require("logger")
 local _ = require("gettext")
 local C_ = _.pgettext
 local T = BaseUtil.template
-local ffi = require("ffi")
-local C = ffi.C
-require("ffi/posix_h")
 
 local lshift = bit.lshift
 local rshift = bit.rshift


### PR DESCRIPTION
* Notification: Drop the fencing from #10083; it never actually helped, and had subtle side-effects we could do without.
* VirtualKeyBoard: Flash on close, otherwise, some of the fast refresh glitches may be burned into the working buffer until a flash. Making sure we flash ourselves prevent it from sticking around on the page ;).
* util: Move `writeToSysfs` to base (i.e., `ffi/util`), as we need it there (and it actually makes more sense there anyway ;p).
* Bump base for https://github.com/koreader/koreader-base/pull/1645, which is where the actual workaround (hopefully) lives.

Re #8414, #9806, #10558

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10771)
<!-- Reviewable:end -->
