### PR TITLE
OTM: Don't keep it in scope forever.

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -190,7 +190,9 @@ CanvasContext:init(Device)
 Version:updateVersionLog(Device.model)
 
 -- Handle one time migration stuff (settings, deprecation, ...) in case of an upgrade...
-require("ui/data/onetime_migration")
+do
+    dofile("frontend/ui/data/onetime_migration.lua")
+end
 
 -- UI mirroring for RTL languages, and text shaping configuration
 local Bidi = require("ui/bidi")


### PR DESCRIPTION
First, don't require it so as not to pin it in package.loaded; just use dofile
And, second, do that in an explicitly scoped block because nothing in there should persist, when we named it "one time", we meant it ;p.

Followup to #10775

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10776)
<!-- Reviewable:end -->
