### PR TITLE
do not allow clipboard to be nil

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -98,7 +98,7 @@ local linux_evdev_rep_code_map = {
     [C.REP_PERIOD] = "REP_PERIOD",
 }
 
-local _internal_clipboard_text = nil -- holds the last copied text
+local _internal_clipboard_text = "" -- holds the last copied text
 
 local Input = {
     -- must point to the device implementation when instantiating
@@ -190,13 +190,13 @@ local Input = {
 
     -- simple internal clipboard implementation, can be overidden to use system clipboard
     hasClipboardText = function()
-        return _internal_clipboard_text ~= nil and _internal_clipboard_text ~= ""
+        return _internal_clipboard_text ~= ""
     end,
     getClipboardText = function()
         return _internal_clipboard_text
     end,
     setClipboardText = function(text)
-        _internal_clipboard_text = text
+        _internal_clipboard_text = text or ""
     end,
 }
 

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -179,7 +179,7 @@ local function initTouchEvents()
                     end
                 end
                 local clipboard_value = Device.input.getClipboardText()
-                local is_clipboard_empty = clipboard_value == nil or clipboard_value == ""
+                local is_clipboard_empty = clipboard_value == ""
                 local clipboard_dialog
                 clipboard_dialog = require("ui/widget/textviewer"):new{
                     title = _("Clipboard"),


### PR DESCRIPTION
we use it as text anyway and test if it is the empty string also.

this fixes a crash in viewhtml when holding a selector with an empty clipboard, we try to concatenate getClipboardText which is nil (on !SDL & !Android)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10780)
<!-- Reviewable:end -->
