### PR TITLE
FileManager: truncate left in selected files list

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1269,7 +1269,10 @@ end
 function FileManager:showSelectedFilesList()
     local selected_files = {}
     for file in pairs(self.selected_files) do
-        table.insert(selected_files, { text = file })
+        table.insert(selected_files, {
+            text = file,
+            bidi_wrap_func = BD.filepath,
+        })
     end
     local function sorting(a, b)
         local a_path, a_name = util.splitFilePathName(a.text)

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1287,6 +1287,7 @@ function FileManager:showSelectedFilesList()
     local menu = Menu:new{
         is_borderless = true,
         is_popout = false,
+        truncate_left = true,
         show_parent = menu_container,
         onMenuSelect = function(_, item)
             UIManager:close(menu_container)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -224,13 +224,17 @@ function MenuItem:init()
             text = text,
             face = self.face,
             bold = self.bold,
+            truncate_left = self.truncate_left,
             fgcolor = self.dim and Blitbuffer.COLOR_DARK_GRAY or nil,
         }
         local w = item_name:getWidth()
         if w > available_width then
-            -- We give it a little more room if truncated for better visual
+            local text_max_width_if_ellipsis = available_width
+            -- We give it a little more room if truncated at the right for better visual
             -- feeling (which might make it no more truncated, but well...)
-            local text_max_width_if_ellipsis = available_width + text_mandatory_padding - text_ellipsis_mandatory_padding
+            if not self.truncate_left then
+                text_max_width_if_ellipsis = text_max_width_if_ellipsis + text_mandatory_padding - text_ellipsis_mandatory_padding
+            end
             item_name:setMaxWidth(text_max_width_if_ellipsis)
         else
             if self.with_dots then
@@ -1063,6 +1067,7 @@ function Menu:updateItems(select_number)
                 linesize = self.linesize,
                 single_line = self.single_line,
                 multilines_show_more_text = multilines_show_more_text,
+                truncate_left = self.truncate_left,
                 align_baselines = self.align_baselines,
                 with_dots = self.with_dots,
                 line_color = self.line_color,


### PR DESCRIPTION
Truncate the path to view the filename in full. Closes https://github.com/koreader/koreader/issues/10760.

![1](https://github.com/koreader/koreader/assets/62179190/b9cfce91-0956-48b2-b086-58b85bac2a32)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10783)
<!-- Reviewable:end -->
