### PR TITLE
Translator: explicite wording above each section, fix minor View HTML/CSS issues

### DIFF
--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -588,7 +588,8 @@ function Translator:_showTranslation(text, detailed_view, source_lang, target_la
     if detailed_view then
         if is_result_valid(result[6]) then
             -- Alternative translations:
-            table.insert(output, "________")
+            table.insert(output, "")
+            table.insert(output, _("Alternate translations:"))
             for i, r in ipairs(result[6]) do
                 if type(r[3]) == "table" then
                     local s = type(r[1]) == "string" and r[1]:gsub("\n", "") or ""
@@ -604,7 +605,8 @@ function Translator:_showTranslation(text, detailed_view, source_lang, target_la
         end
         if is_result_valid(result[13]) then
             -- Definition(word)
-            table.insert(output, "________")
+            table.insert(output, "")
+            table.insert(output, _("Definition:"))
             for i, r in ipairs(result[13]) do
                 if r[2] and type(r[2]) == "table" then
                     local symbol = util.unicodeCodepointToUtf8(10101 + (i < 10 and i or 10))

--- a/frontend/ui/viewhtml.lua
+++ b/frontend/ui/viewhtml.lua
@@ -92,7 +92,7 @@ function ViewHtml:_viewSelectionHTML(document, selected_text, view, with_css_fil
         -- pages to get to the HTML content on the initial view.)
     end
     if massage_html or hide_stylesheet_elem_content then
-        replace_in_html("<stylesheet[^>]*>(.-)</stylesheet>", function(s)
+        replace_in_html("<stylesheet[^>]*>.-</stylesheet>", function(s)
             local pre, css_text, post = s:match("(<stylesheet[^>]*>)%s*(.-)%s*(</stylesheet>)")
             if hide_stylesheet_elem_content then
                 return pre .. "[...]" .. post
@@ -101,8 +101,8 @@ function ViewHtml:_viewSelectionHTML(document, selected_text, view, with_css_fil
         end)
     end
     -- Make sure we won't get wrapped just after our indentation if there is no break opportunity later
-    replace_in_html("\n( *)", function(s)
-        return "\n" .. ("\u{00A0}"):rep(#s)
+    replace_in_html("\n *", function(s)
+        return "\n" .. ("\u{00A0}"):rep(#s - 1)
     end)
 
     local textviewer

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -1249,6 +1249,8 @@ function util.prettifyCSS(css_text, condensed)
         css_text = css_text:gsub("\n *([^\n]+){", "\n%1{") -- remove leading spaces on a standalone one
         -- Make sure { is on the same line with the selector it follows
         css_text = css_text:gsub("%s*\n *{", " {")
+        -- Make sure we have a newline after our }
+        css_text = css_text:gsub("\n} *([^\n]+)", "\n}\n%1")
         -- Restore all protected chars
         css_text = css_text:gsub("\v", ",")
         css_text = css_text:gsub("\f", ":")


### PR DESCRIPTION
`View HTML & CSS: fix minor spacing issues`

Fix one space indentation too much, and wrap after `}` when `h1 {...} h2 {...}` on a single line.

`Translator: explicite wording above each section`

Closes #10787.

@Frenzie : there are some translated strings - so up to you if this should go in v2023.08 or v2023.09.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10799)
<!-- Reviewable:end -->
