### PR TITLE
Kobo: Fix the input translation on the Elipsa 2E

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -392,6 +392,20 @@ function Input:adjustABS_SwitchAxesAndMirrorX(ev, max_x)
     end
 end
 
+function Input:adjustABS_SwitchAxesAndMirrorY(ev, max_y)
+    if ev.code == C.ABS_X then
+        ev.code = C.ABS_Y
+        ev.value = max_y - ev.value
+    elseif ev.code == C.ABS_Y then
+        ev.code = C.ABS_X
+    elseif ev.code == C.ABS_MT_POSITION_X then
+        ev.code = C.ABS_MT_POSITION_Y
+        ev.value = max_y - ev.value
+    elseif ev.code == C.ABS_MT_POSITION_Y then
+        ev.code = C.ABS_MT_POSITION_X
+    end
+end
+
 function Input:adjustABS_Translate(ev, by)
     if ev.code == C.ABS_X or ev.code == C.ABS_MT_POSITION_X then
         ev.value = by.x + ev.value


### PR DESCRIPTION
Apparently it mirrors on the Y axis. Or the panel vs. touch rotations are wonkier than expected or ...something.

Brain hurty >_<".

Followup to #10719

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10802)
<!-- Reviewable:end -->
