### PR TITLE
Exporter: fix order for Readwise

### DIFF
--- a/plugins/exporter.koplugin/target/readwise.lua
+++ b/plugins/exporter.koplugin/target/readwise.lua
@@ -106,7 +106,7 @@ function ReadwiseExporter:createHighlights(booknotes)
                 category = "books",
                 note = clipping.note,
                 location = clipping.page,
-                location_type = "page",
+                location_type = "order",
                 highlighted_at = os.date("!%Y-%m-%dT%TZ", clipping.time),
             }
             table.insert(highlights, highlight)


### PR DESCRIPTION
Exported highlights are good sorted by position, page numbers could be wrong.
Closes https://github.com/koreader/koreader/issues/10817.

For reference: https://readwise.io/api_deets

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10824)
<!-- Reviewable:end -->
