### PR TITLE
NetworkManager: Always flip wifi_was_on when interactively tearing down Wi-Fi

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -266,7 +266,7 @@ function NetworkMgr:enableWifi(wifi_cb, connectivity_cb, connectivity_widget, in
     return true
 end
 
-function NetworkMgr:disableWifi(cb)
+function NetworkMgr:disableWifi(cb, interactive)
     local complete_callback = function()
         UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         if cb then
@@ -275,6 +275,11 @@ function NetworkMgr:disableWifi(cb)
     end
     UIManager:broadcastEvent(Event:new("NetworkDisconnecting"))
     self:turnOffWifi(complete_callback)
+
+    if interactive then
+        self.wifi_was_on = false
+        G_reader_settings:makeFalse("wifi_was_on")
+    end
 end
 
 function NetworkMgr:toggleWifiOn(complete_callback, long_press, interactive)
@@ -284,8 +289,6 @@ function NetworkMgr:toggleWifiOn(complete_callback, long_press, interactive)
     UIManager:show(toggle_im)
     UIManager:forceRePaint()
 
-    self.wifi_was_on = true
-    G_reader_settings:makeTrue("wifi_was_on")
     self.wifi_toggle_long_press = long_press
 
     self:enableWifi(complete_callback, nil, nil, interactive)
@@ -293,17 +296,14 @@ function NetworkMgr:toggleWifiOn(complete_callback, long_press, interactive)
     UIManager:close(toggle_im)
 end
 
-function NetworkMgr:toggleWifiOff(complete_callback)
+function NetworkMgr:toggleWifiOff(complete_callback, interactive)
     local toggle_im = InfoMessage:new{
         text = _("Turning off Wi-Fi…"),
     }
     UIManager:show(toggle_im)
     UIManager:forceRePaint()
 
-    self.wifi_was_on = false
-    G_reader_settings:makeFalse("wifi_was_on")
-
-    self:disableWifi(complete_callback)
+    self:disableWifi(complete_callback, interactive)
 
     UIManager:close(toggle_im)
 end
@@ -335,7 +335,7 @@ function NetworkMgr:promptWifi(complete_callback, long_press, interactive)
         text = _("Wi-Fi is enabled, but you're currently not connected to a network.\nHow would you like to proceed?"),
         choice1_text = _("Turn Wi-Fi off"),
         choice1_callback = function()
-            self:toggleWifiOff(complete_callback)
+            self:toggleWifiOff(complete_callback, interactive)
         end,
         choice2_text = _("Connect"),
         choice2_callback = function()
@@ -683,7 +683,7 @@ function NetworkMgr:getWifiToggleMenuTable()
             touchmenu_instance:updateItems()
         end -- complete_callback()
         if fully_connected then
-            self:toggleWifiOff(complete_callback)
+            self:toggleWifiOff(complete_callback, true)
         elseif self.is_wifi_on and not self.is_connected then
             -- ask whether user wants to connect or turn off wifi
             self:promptWifi(complete_callback, long_press, true)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -757,7 +757,8 @@ end
 function NetworkMgr:getRestoreMenuTable()
     return {
         text = _("Restore Wi-Fi connection on resume"),
-        help_text = _([[This will attempt to automatically and silently re-connect to Wi-Fi on startup or on resume if Wi-Fi used to be enabled the last time you used KOReader.]]),
+        -- i.e., *everything* flips wifi_was_on true, but only direct user interaction (i.e., Menu & Gestures) will flip it off.
+        help_text = _([[This will attempt to automatically and silently re-connect to Wi-Fi on startup or on resume if Wi-Fi used to be enabled the last time you used KOReader, and you did not explicitly disable it.]]),
         checked_func = function() return G_reader_settings:isTrue("auto_restore_wifi") end,
         enabled_func = function() return Device:hasWifiRestore() end,
         callback = function() G_reader_settings:flipNilOrFalse("auto_restore_wifi") end,

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -205,8 +205,8 @@ function NetworkListener:onSuspend()
     logger.dbg("NetworkListener: onSuspend")
 
     -- If we haven't already (e.g., via Generic's onPowerEvent), kill Wi-Fi.
-    -- Except on Android, where turnOnWifi/turnOffWifi are *interactive*... :/
-    if Device:hasWifiToggle() and NetworkMgr:isWifiOn() and not Device:isAndroid() then
+    -- Do so only on devices where we have explicit management of Wi-Fi: assume the host system does things properly elsewhere.
+    if Device:hasWifiManager() and NetworkMgr:isWifiOn() then
         NetworkMgr:disableWifi()
     end
 

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -26,7 +26,7 @@ local function enableWifi()
     -- NB Normal widgets should use NetworkMgr:promptWifiOn()
     -- (or, better yet, the NetworkMgr:beforeWifiAction wrappers: NetworkMgr:runWhenOnline() & co.)
     -- This is specifically the toggle Wi-Fi action, so consent is implied.
-    NetworkMgr:enableWifi(nil, nil, nil, true) -- flag it as interactive, though
+    NetworkMgr:enableWifi(nil, nil, nil, true) -- flag it as interactive
 
     UIManager:close(toggle_im)
 end
@@ -38,7 +38,7 @@ local function disableWifi()
     UIManager:show(toggle_im)
     UIManager:forceRePaint()
 
-    NetworkMgr:disableWifi()
+    NetworkMgr:disableWifi(nil, true) -- flag it as interactive
 
     UIManager:close(toggle_im)
     UIManager:show(InfoMessage:new{


### PR DESCRIPTION
Fix #10823

(For reference, we *enable* wifi_was_on no matter *how* wifi is enabled, but we only toggle it off when it's killed by a *direct* user interaction, the intent being that if *something* non-interactive enabled wifi, you'll probably silently need it on resume too).

(Rebase me).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10825)
<!-- Reviewable:end -->
