### PR TITLE
getProps: centralize and deduplicate

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -73,7 +73,7 @@ function BookInfo:show(file, book_props, metadata_updated_caller_callback)
         if prop == nil or prop == "" then
             prop = _("N/A")
         elseif prop_key == "title" then
-            prop = BD.auto(prop)
+            prop = book_props.title_from_filename and _("N/A") or BD.auto(prop)
         elseif prop_key == "authors" or prop_key == "keywords" then
             if prop:find("\n") then -- BD auto isolate each entry
                 prop = util.splitToArray(prop, "\n")

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -84,16 +84,8 @@ function BookInfo:show(file, book_props, metadata_updated_caller_callback)
             else
                 prop = BD.auto(prop)
             end
-        elseif prop_key == "series" then
-            -- If we were fed a BookInfo book_props (e.g., covermenu), series index is in a separate field
-            if book_props.series_index then
-                -- Here, we're assured that series_index is a Lua number, so round integers are automatically
-                -- displayed without decimals
-                prop = prop .. " #" .. book_props.series_index
-            else
-                -- But here, if we have a plain doc_props series with an index, drop empty decimals from round integers.
-                prop = prop:gsub("(#%d+)%.0+$", "%1")
-            end
+        elseif prop_key == "series" and book_props.series_index then
+            prop = prop .. " #" .. book_props.series_index
         elseif prop_key == "language" then
             -- Get a chance to have title, authors... rendered with alternate
             -- glyphs for the book language (e.g. japanese book in chinese UI)

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -938,12 +938,6 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, 
     end
 
     local book_title = self.ui.doc_settings and self.ui.doc_settings:readSetting("doc_props").title or _("Dictionary lookup")
-    if book_title == "" then -- no or empty metadata title
-        if self.ui.document and self.ui.document.file then
-            local directory, filename = util.splitFilePathName(self.ui.document.file) -- luacheck: no unused
-            book_title = util.splitFileNameSuffix(filename)
-        end
-    end
 
     -- Event for plugin to catch lookup with book title
     self.ui:handleEvent(Event:new("WordLookedUp", word, book_title))

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -370,8 +370,8 @@ function ReaderWikipedia:initLanguages(word)
             end
         end
         -- use book and UI languages
-        if self.view then
-            addLanguage(self.view.document:getProps().language)
+        if self.ui.doc_settings then
+            addLanguage(self.ui.doc_settings:readSetting("doc_props").language)
         end
         addLanguage(G_reader_settings:readSetting("language"))
         if #self.wiki_languages == 0 and word then
@@ -428,12 +428,6 @@ function ReaderWikipedia:lookupWikipedia(word, is_sane, box, get_fullpage, force
 
     if not self.disable_history then
         local book_title = self.ui.doc_settings and self.ui.doc_settings:readSetting("doc_props").title or _("Wikipedia lookup")
-        if book_title == "" then -- no or empty metadata title
-            if self.ui.document and self.ui.document.file then
-                local directory, filename = util.splitFilePathName(self.ui.document.file) -- luacheck: no unused
-                book_title = util.splitFileNameSuffix(filename)
-            end
-        end
         wikipedia_history:addTableItem("wikipedia_history", {
             book_title = book_title,
             time = os.time(),

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -657,13 +657,7 @@ function ReaderUI:doShowReader(file, provider, seamless)
     }
 
     local title = reader.doc_settings:readSetting("doc_props").title
-
-    if title ~= "" then
-        Screen:setWindowTitle(title)
-    else
-        local _, filename = util.splitFilePathName(file)
-        Screen:setWindowTitle(filename)
-    end
+    Screen:setWindowTitle(title)
     Device:notifyBookState(title, document)
 
     -- This is mostly for the few callers that bypass the coroutine shenanigans and call doShowReader directly,

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -213,6 +213,10 @@ function CreDocument:getDocumentFormat()
     return self._document:getDocumentFormat()
 end
 
+function CreDocument:getDocumentProps()
+    return self._document:getDocumentProps()
+end
+
 function CreDocument:setupDefaultView()
     if self.loaded then
         -- Don't apply defaults if the document has already been loaded

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -51,23 +51,6 @@ function DjvuDocument:updateColorRendering()
     end
 end
 
-function DjvuDocument:getProps()
-    local props = self._document:getMetadata()
-    local _, _, docname = self.file:find(".*/(.*)")
-    docname = docname or self.file
-
-    -- According to djvused(1), the convention is that
-    -- BibTex keys are always lowercase and DocInfo capitalized
-    props.title = props.title or props.Title or docname:match("(.*)%.")
-    props.authors = props.author or props.Author
-    props.series = props.series or props.Series
-    props.language = props.language or props.Language
-    props.keywords = props.keywords or props.Keywords
-    props.description = props.description or props.Description
-
-    return props
-end
-
 function DjvuDocument:comparePositions(pos1, pos2)
     return self.koptinterface:comparePositions(self, pos1, pos2)
 end

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -207,8 +207,55 @@ function Document:getNativePageDimensions(pageno)
     return page_size
 end
 
+function Document:getDocumentProps()
+    -- pdfdocument, djvudocument
+    return self._document:getMetadata()
+    -- credocument, picdocument - overridden by a document implementation
+end
+
 function Document:getProps()
-    return self._document:getDocumentProps()
+    local function makeNilIfEmpty(str)
+        if str == "" then
+            return nil
+        end
+        return str
+    end
+    local props = self:getDocumentProps()
+    local title, authors, series, series_index, language, keywords, description
+    title = makeNilIfEmpty(props.title or props.Title)
+    if not title then -- file name without extension
+        local _, _, docname = self.file:find(".*/(.*)")
+        title = (docname or self.file):match("(.*)%.")
+    end
+    authors = makeNilIfEmpty(props.authors or props.author or props.Author)
+    series = makeNilIfEmpty(props.series or props.Series)
+    if series and string.find(series, "#") then
+        -- If there's a series index in there, split it off to series_index, and only store the name in series.
+        -- This property is currently only set by:
+        --   * DjVu, for which I couldn't find a real standard for metadata fields
+        --     (we currently use Series for this field, c.f., https://exiftool.org/TagNames/DjVu.html).
+        --   * CRe, which could offer us a split getSeriesName & getSeriesNumber...
+        --     except getSeriesNumber does an atoi, so it'd murder decimal values.
+        --     So, instead, parse how it formats the whole thing as a string ;).
+        local series_name
+        series_name, series_index = series:match("(.*) #(%d+%.?%d-)$")
+        if series_index then
+            series = series_name
+            series_index = tonumber(series_index)
+        end
+    end
+    language = makeNilIfEmpty(props.language or props.Language)
+    keywords = makeNilIfEmpty(props.keywords or props.Keywords)
+    description = makeNilIfEmpty(props.description or props.Description or props.subject)
+    return {
+        title        = title,
+        authors      = authors,
+        series       = series,
+        series_index = series_index,
+        language     = language,
+        keywords     = keywords,
+        description  = description,
+    }
 end
 
 function Document:_readMetadata()

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -221,11 +221,12 @@ function Document:getProps()
         return str
     end
     local props = self:getDocumentProps()
-    local title, authors, series, series_index, language, keywords, description
-    title = makeNilIfEmpty(props.title or props.Title)
-    if not title then -- file name without extension
+    local title, title_from_filename, authors, series, series_index, language, keywords, description
+    title = props.title or props.Title
+    if title == nil or title == "" then -- file name without extension
         local _, _, docname = self.file:find(".*/(.*)")
         title = (docname or self.file):match("(.*)%.")
+        title_from_filename = true
     end
     authors = makeNilIfEmpty(props.authors or props.author or props.Author)
     series = makeNilIfEmpty(props.series or props.Series)
@@ -248,13 +249,14 @@ function Document:getProps()
     keywords = makeNilIfEmpty(props.keywords or props.Keywords)
     description = makeNilIfEmpty(props.description or props.Description or props.subject)
     return {
-        title        = title,
-        authors      = authors,
-        series       = series,
-        series_index = series_index,
-        language     = language,
-        keywords     = keywords,
-        description  = description,
+        title               = title,
+        title_from_filename = title_from_filename,
+        authors             = authors,
+        series              = series,
+        series_index        = series_index,
+        language            = language,
+        keywords            = keywords,
+        description         = description,
     }
 end
 

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -313,24 +313,6 @@ function PdfDocument:close()
     Document.close(self)
 end
 
-function PdfDocument:getProps()
-    local props = self._document:getMetadata()
-    if props.title == "" then
-        local startPos = util.lastIndexOf(self.file, "%/")
-        if startPos > 0  then
-            props.title = string.sub(self.file, startPos + 1, -5) --remove extension .pdf
-        else
-            props.title = string.sub(self.file, 0, -5)
-        end
-    end
-    props.authors = props.author
-    props.series = ""
-    props.language = ""
-    props.keywords = props.keywords
-    props.description = props.subject
-    return props
-end
-
 function PdfDocument:getLinkFromPosition(pageno, pos)
     return self.koptinterface:getLinkFromPosition(self, pageno, pos)
 end

--- a/frontend/document/picdocument.lua
+++ b/frontend/document/picdocument.lua
@@ -42,12 +42,8 @@ function PicDocument:getUsedBBox(pageno)
     return { x0 = 0, y0 = 0, x1 = self._document.width, y1 = self._document.height }
 end
 
-function PicDocument:getProps()
-    local _, _, docname = self.file:find(".*/(.*)")
-    docname = docname or self.file
-    return {
-        title = docname:match("(.*)%."),
-    }
+function PicDocument:getDocumentProps()
+    return {}
 end
 
 function PicDocument:getCoverPageImage()

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -154,6 +154,7 @@ function Screensaver:expandSpecial(message, fallback)
     local time_left_chapter = _("N/A")
     local time_left_document = _("N/A")
     local batt_lvl = _("N/A")
+    local props
 
     local ReaderUI = require("apps/reader/readerui")
     local ui = ReaderUI.instance
@@ -173,12 +174,7 @@ function Screensaver:expandSpecial(message, fallback)
             time_left_document = self:_calcAverageTimeForPages(doc:getTotalPagesLeft(currentpage))
         end
         percent = Math.round((currentpage * 100) / totalpages)
-        local props = doc:getProps()
-        if props then
-            title = props.title and props.title ~= "" and props.title or title
-            authors = props.authors and props.authors ~= "" and props.authors or authors
-            series = props.series and props.series ~= "" and props.series or series
-        end
+        props = doc:getProps()
     elseif DocSettings:hasSidecarFile(lastfile) then
         -- If there's no ReaderUI instance, but the file has sidecar data, use that
         local doc_settings = DocSettings:open(lastfile)
@@ -186,13 +182,20 @@ function Screensaver:expandSpecial(message, fallback)
         percent = doc_settings:readSetting("percent_finished") or percent
         currentpage = Math.round(percent * totalpages)
         percent = Math.round(percent * 100)
-        local doc_props = doc_settings:readSetting("doc_props")
-        if doc_props then
-            title = doc_props.title and doc_props.title ~= "" and doc_props.title or title
-            authors = doc_props.authors and doc_props.authors ~= "" and doc_props.authors or authors
-            series = doc_props.series and doc_props.series ~= "" and doc_props.series or series
-        end
+        props = doc_settings:readSetting("doc_props")
         -- Unable to set time_left_chapter and time_left_document without ReaderUI, so leave N/A
+    end
+    if props then
+        title = props.title
+        if props.authors then
+            authors = props.authors
+        end
+        if props.series then
+            series = props.series
+            if props.series_index then
+                series = series .. " #" .. props.series_index
+            end
+        end
     end
     if Device:hasBattery() then
         local powerd = Device:getPowerDevice()

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -308,14 +308,10 @@ end
 
 function Translator:getDocumentLanguage()
     local ui = require("apps/reader/readerui").instance
-    if not ui or not ui.document then
+    local lang = ui and ui.doc_settings and ui.doc_settings:readSetting("doc_props").language
+    if not lang then
         return
     end
-    local props = ui.document:getProps()
-    if not props or not props.language or props.language == "" then
-        return
-    end
-    local lang = props.language
     lang = lang:match("(.*)-") or lang
     lang = lang:lower()
     local name, supported = self:getLanguageName(lang, "")

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -493,36 +493,10 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
         if loaded then
             dbrow.pages = pages
             local props = document:getProps()
-            if next(props) then -- there's at least one item
-                dbrow.has_meta = 'Y'
+            dbrow.has_meta = 'Y' -- title always exists
+            for k, v in pairs(props) do
+                dbrow[k] = v
             end
-            if props.title and props.title ~= "" then dbrow.title = props.title end
-            if props.authors and props.authors ~= "" then dbrow.authors = props.authors end
-            if props.series and props.series ~= "" then
-                -- NOTE: If there's a series index in there, split it off to series_index, and only store the name in series.
-                --       This property is currently only set by:
-                --         * DjVu, for which I couldn't find a real standard for metadata fields
-                --           (we currently use Series for this field, c.f., https://exiftool.org/TagNames/DjVu.html).
-                --         * CRe, which could offer us a split getSeriesName & getSeriesNumber...
-                --           except getSeriesNumber does an atoi, so it'd murder decimal values.
-                --           So, instead, parse how it formats the whole thing as a string ;).
-                if string.find(props.series, "#") then
-                    dbrow.series, dbrow.series_index = props.series:match("(.*) #(%d+%.?%d-)$")
-                    if dbrow.series_index then
-                        -- We're inserting via a bind method, so make sure we feed it a Lua number, because it's a REAL in the db.
-                        dbrow.series_index = tonumber(dbrow.series_index)
-                    else
-                        -- If the index pattern didn't match (e.g., nothing after the octothorp, or a string),
-                        -- restore the full thing as the series name.
-                        dbrow.series = props.series
-                    end
-                else
-                    dbrow.series = props.series
-                end
-            end
-            if props.language and props.language ~= "" then dbrow.language = props.language end
-            if props.keywords and props.keywords ~= "" then dbrow.keywords = props.keywords end
-            if props.description and props.description ~= "" then dbrow.description = props.description end
             if cover_specs then
                 local spec_sizetag = cover_specs.sizetag
                 local spec_max_cover_w = cover_specs.max_cover_w

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -37,7 +37,7 @@ local BOOKINFO_DB_SCHEMA = [[
         in_progress         INTEGER,  -- 0 (done), >0 : nb of tries (to avoid retrying failed extractions forever)
         unsupported         TEXT,     -- NULL if supported / reason for being unsupported
         cover_fetched       TEXT,     -- NULL / 'Y' = we tried to fetch a cover (but we may not have gotten one)
-        has_meta            TEXT,     -- NULL / 'Y' = has metadata (title, authors...)
+        has_meta            TEXT,     -- NULL / 'Y'('T') = has metadata (title, authors...) ('T' title from filename)
         has_cover           TEXT,     -- NULL / 'Y' = has cover image (cover_*)
         cover_sizetag       TEXT,     -- 'M' (Medium, MosaicMenuItem) / 's' (small, ListMenuItem)
 
@@ -493,7 +493,7 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
         if loaded then
             dbrow.pages = pages
             local props = document:getProps()
-            dbrow.has_meta = 'Y' -- title always exists
+            dbrow.has_meta = props.title_from_filename and 'T' or 'Y'
             for k, v in pairs(props) do
                 dbrow[k] = v
             end

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -255,6 +255,7 @@ function CoverMenu:updateItems(select_number)
                     -- If no bookinfo (yet) about this file, or it's a directory, let the original dialog be
                     return true
                 end
+                bookinfo.title_from_filename = bookinfo.has_meta == 'T'
 
                 -- Remember some of this original ButtonDialog properties
                 local orig_title = self.file_dialog.title

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -629,7 +629,7 @@ function MosaicMenuItem:update()
                         bookinfo.series = BD.auto(bookinfo.series)
                     end
                     if series_mode == "append_series_to_title" then
-                        if bookinfo.title then
+                        if bookinfo.title and bookinfo.has_meta ~= 'T' then
                             title_add = " - " .. bookinfo.series
                         else
                             title_add = bookinfo.series
@@ -661,7 +661,7 @@ function MosaicMenuItem:update()
                         height = dimen.h,
                         bordersize = border_size,
                         filename = self.text,
-                        title = not bookinfo.ignore_meta and bookinfo.title,
+                        title = not bookinfo.ignore_meta and bookinfo.has_meta ~= 'T' and bookinfo.title,
                         authors = not bookinfo.ignore_meta and bookinfo.authors,
                         title_add = not bookinfo.ignore_meta and title_add,
                         authors_add = not bookinfo.ignore_meta and authors_add,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -174,23 +174,18 @@ function ReaderStatistics:initData()
     if not self.data then
         self.data = { performance_in_pages= {} }
     end
-    local book_properties = self:getBookProperties()
+    local book_properties = self.ui.doc_settings:readSetting("doc_props")
     self.data.title = book_properties.title
-    if self.data.title == nil or self.data.title == "" then
-        self.data.title = self.document.file:match("^.+/(.+)$")
+    self.data.authors = book_properties.authors or "N/A"
+    self.data.language = book_properties.language or "N/A"
+    local series
+    if book_properties.series then
+        series = book_properties.series
+        if book_properties.series_index then
+            series = series .. " #" .. book_properties.series_index
+        end
     end
-    self.data.authors = book_properties.authors
-    if self.data.authors == nil or self.data.authors == "" then
-        self.data.authors = "N/A"
-    end
-    self.data.language = book_properties.language
-    if self.data.language == nil or self.data.language == "" then
-        self.data.language = "N/A"
-    end
-    self.data.series = book_properties.series
-    if self.data.series == nil or self.data.series == "" then
-        self.data.series = "N/A"
-    end
+    self.data.series = series or "N/A"
 
     self.data.pages = self.view.document:getPageCount()
     if not self.data.md5 then
@@ -919,15 +914,6 @@ function ReaderStatistics:getPageTimeTotalStats(id_book)
         total_time = 0
     end
     return total_pages, total_time
-end
-
-function ReaderStatistics:getBookProperties()
-    local props = self.view.document:getProps()
-    if props.title == "No document" or props.title == "" then
-        --- @fixme Sometimes crengine returns "No document", try one more time.
-        props = self.view.document:getProps()
-    end
-    return props
 end
 
 function ReaderStatistics:getStatisticEnabledMenuItem()

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -78,13 +78,6 @@ local function resetButtonOnLookupWindow()
                 font_bold = false,
                 callback = function()
                     local book_title = obj.ui.doc_settings and obj.ui.doc_settings:readSetting("doc_props").title or _("Dictionary lookup")
-                    if book_title == "" then -- no or empty metadata title
-                        if obj.ui.document and obj.ui.document.file then
-                            local util = require("util")
-                            local directory, filename = util.splitFilePathName(obj.ui.document.file) -- luacheck: no unused
-                            book_title = util.splitFileNameSuffix(filename)
-                        end
-                    end
                     obj.ui:handleEvent(Event:new("WordLookedUp", obj.word, book_title, true)) -- is_manual: true
                     local button = obj.button_table.button_by_id["vocabulary"]
                     if button then


### PR DESCRIPTION
In props:
-`title` always exists
-no more `key = ""`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10826)
<!-- Reviewable:end -->
