### PR TITLE
KOSync: Set sane socket timeouts properly

### DIFF
--- a/frontend/socketutil.lua
+++ b/frontend/socketutil.lua
@@ -51,7 +51,7 @@ function socketutil:set_timeout(block_timeout, total_timeout)
 
     -- Also update the actual LuaSocket & LuaSec constants, because:
     -- 1. LuaSocket's `open` does a `settimeout` *after* create with this constant
-    -- 2. Rogue code might be attemptng to enforce them
+    -- 2. Rogue code might be attempting to enforce them
     http.TIMEOUT = self.block_timeout
     https.TIMEOUT = self.block_timeout
 end

--- a/frontend/socketutil.lua
+++ b/frontend/socketutil.lua
@@ -51,7 +51,7 @@ function socketutil:set_timeout(block_timeout, total_timeout)
 
     -- Also update the actual LuaSocket & LuaSec constants, because:
     -- 1. LuaSocket's `open` does a `settimeout` *after* create with this constant
-    -- 2. KOSync updates it to a stupidly low value
+    -- 2. Rogue code might be attemptng to enforce them
     http.TIMEOUT = self.block_timeout
     https.TIMEOUT = self.block_timeout
 end

--- a/plugins/kosync.koplugin/KOSyncClient.lua
+++ b/plugins/kosync.koplugin/KOSyncClient.lua
@@ -1,5 +1,5 @@
 local UIManager = require("ui/uimanager")
-local DEBUG = require("dbg")
+local logger = require("logger")
 local socketutil = require("socketutil")
 
 local KOSyncClient = {
@@ -70,7 +70,7 @@ function KOSyncClient:register(username, password)
     if ok then
         return res.status == 201, res.body
     else
-        DEBUG(ok, res)
+        logger.dbg("KOSyncClient:register failure:", res)
         return false, res.body
     end
 end
@@ -89,7 +89,7 @@ function KOSyncClient:authorize(username, password)
     if ok then
         return res.status == 200, res.body
     else
-        DEBUG("err:", res)
+        logger.dbg("KOSyncClient:authorize failure:", res)
         return false, res.body
     end
 end
@@ -125,7 +125,7 @@ function KOSyncClient:update_progress(
         if ok then
             callback(res.status == 200, res.body)
         else
-            DEBUG("err:", res)
+            logger.dbg("KOSyncClient:update_progress failure:", res)
             callback(false, res.body)
         end
     end)
@@ -157,7 +157,7 @@ function KOSyncClient:get_progress(
         if ok then
             callback(res.status == 200, res.body)
         else
-            DEBUG("err:", res)
+            logger.dbg("KOSyncClient:get_progress failure:", res)
             callback(false, res.body)
         end
     end)

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -637,10 +637,8 @@ function KOSync:updateProgress(ensure_networking, interactive, refresh_on_succes
         return
     end
 
-    local last_push = self.push_timestamp
     local now = UIManager:getElapsedTimeSinceBoot()
-    self.push_timestamp = now
-    if not interactive and now - last_push <= API_CALL_DEBOUNCE_DELAY then
+    if not interactive and now - self.push_timestamp <= API_CALL_DEBOUNCE_DELAY then
         logger.dbg("KOSync: We've already pushed progress less than 25s ago!")
         return
     end
@@ -697,6 +695,8 @@ function KOSync:updateProgress(ensure_networking, interactive, refresh_on_succes
             end
         end
     end
+
+    self.push_timestamp = now
 end
 
 function KOSync:getProgress(ensure_networking, interactive)
@@ -707,10 +707,8 @@ function KOSync:getProgress(ensure_networking, interactive)
         return
     end
 
-    local last_pull = self.pull_timestamp
     local now = UIManager:getElapsedTimeSinceBoot()
-    self.pull_timestamp = now
-    if not interactive and now - last_pull <= API_CALL_DEBOUNCE_DELAY then
+    if not interactive and now - self.pull_timestamp <= API_CALL_DEBOUNCE_DELAY then
         logger.dbg("KOSync: We've already pulled progress less than 25s ago!")
         return
     end
@@ -827,6 +825,8 @@ function KOSync:getProgress(ensure_networking, interactive)
         if interactive then showSyncError() end
         if err then logger.dbg("err:", err) end
     end
+
+    self.pull_timestamp = now
 end
 
 function KOSync:_onCloseDocument()

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -637,8 +637,10 @@ function KOSync:updateProgress(ensure_networking, interactive, refresh_on_succes
         return
     end
 
+    local last_push = self.push_timestamp
     local now = UIManager:getElapsedTimeSinceBoot()
-    if not interactive and now - self.push_timestamp <= API_CALL_DEBOUNCE_DELAY then
+    self.push_timestamp = now
+    if not interactive and now - last_push <= API_CALL_DEBOUNCE_DELAY then
         logger.dbg("KOSync: We've already pushed progress less than 25s ago!")
         return
     end
@@ -695,8 +697,6 @@ function KOSync:updateProgress(ensure_networking, interactive, refresh_on_succes
             end
         end
     end
-
-    self.push_timestamp = now
 end
 
 function KOSync:getProgress(ensure_networking, interactive)
@@ -707,8 +707,10 @@ function KOSync:getProgress(ensure_networking, interactive)
         return
     end
 
+    local last_pull = self.pull_timestamp
     local now = UIManager:getElapsedTimeSinceBoot()
-    if not interactive and now - self.pull_timestamp <= API_CALL_DEBOUNCE_DELAY then
+    self.pull_timestamp = now
+    if not interactive and now - last_pull <= API_CALL_DEBOUNCE_DELAY then
         logger.dbg("KOSync: We've already pulled progress less than 25s ago!")
         return
     end
@@ -825,8 +827,6 @@ function KOSync:getProgress(ensure_networking, interactive)
         if interactive then showSyncError() end
         if err then logger.dbg("err:", err) end
     end
-
-    self.pull_timestamp = now
 end
 
 function KOSync:_onCloseDocument()


### PR DESCRIPTION
An attempt was made in the original code, but the whole thing was designed in the hope of actually switching to turbo, so it was super janky without it.
Anyway, we now actually have a sane way to set socket timeouts, so, use that, and set them very tight for now.

This is fairly critical right now, because the server is down, and the default timeouts are ~30s. That happens to be *above* the debounce threshold, so you can't even hope for that to help you. Meaning, right now, you get a 2 * 30s block on resume with auto sync. That's... Very Not Good(TM).

That becomes a single 2s one after this.

Exercised the timeouts thanks to the main server being down right now, and also tested successfully with a custom sync server (but, granted, one that's actually much closer to me than koreader.rocks), so, timings might need some more tinkering later...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10835)
<!-- Reviewable:end -->
