### PR TITLE
[i18n] Revert Unicode escape sequence to utf-8 bytes for translation

### DIFF
--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -150,7 +150,7 @@ function datetime.secondsToHClock(seconds, withoutSeconds, hmsFormat, withDays, 
                 if compact then
                     return T(C_("Time", "%1s"), string.format("%d", seconds))
                 else
-                    return T(C_("Time", "%1m\u{2009}%2s"), "0", string.format("%d", seconds)) -- use a thin space
+                    return T(C_("Time", "%1m\xE2\x80\x89%2s"), "0", string.format("%d", seconds)) -- use a thin space
                 end
             else
                 if compact then


### PR DESCRIPTION
Cf. <https://github.com/koreader/koreader/discussions/10774#discussioncomment-6618167>, reverts #10769 for direct use in translations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10845)
<!-- Reviewable:end -->
