### PR TITLE
InputText/InputDialog: fix keyboard issue

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -368,6 +368,7 @@ function InputDialog:init()
         scroll_by_pan = self.scroll_by_pan,
         cursor_at_end = self.cursor_at_end,
         readonly = self.readonly,
+        manage_keyboard_state = not self.add_nav_bar, -- we handle keyboard toggle ourselve if nav_bar
         parent = self,
         is_text_edited = self._text_modified,
         top_line_num = self._top_line_num,

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -34,6 +34,7 @@ local InputText = InputContainer:extend{
     edit_callback = nil, -- called with true when text modified, false on init or text re-set
     scroll_callback = nil, -- called with (low, high) when view is scrolled (cf ScrollTextWidget)
     scroll_by_pan = false, -- allow scrolling by lines with Pan (needs scroll=true)
+    manage_keyboard_state = true, -- manage keyboard hidden/shown state
 
     width = nil,
     height = nil, -- when nil, will be set to original text height (possibly
@@ -132,7 +133,7 @@ local function initTouchEvents()
             if self.parent.onSwitchFocus then
                 self.parent:onSwitchFocus(self)
             else
-                if self.is_keyboard_hidden then
+                if self.is_keyboard_hidden and self.manage_keyboard_state then
                     self:onShowKeyboard()
                 end
             end
@@ -677,7 +678,7 @@ dbg:guard(InputText, "onTextInput",
 function InputText:onShowKeyboard(ignore_first_hold_release)
     Device:startTextInput()
 
-    if self.is_keyboard_hidden then
+    if self.is_keyboard_hidden or not self.manage_keyboard_state then
         self.keyboard.ignore_first_hold_release = ignore_first_hold_release
         UIManager:show(self.keyboard)
         self.is_keyboard_hidden = false
@@ -688,7 +689,7 @@ end
 function InputText:onCloseKeyboard()
     Device:stopTextInput()
 
-    if not self.is_keyboard_hidden then
+    if not self.is_keyboard_hidden or not self.manage_keyboard_state then
         UIManager:close(self.keyboard)
         self.is_keyboard_hidden = true
     end


### PR DESCRIPTION
Fix issue introduced by 976aaf5f: with full screen text editor and hiding the keyboard, a tap in the text area would show a new keyboard hiding the button allowing to save/close the text editor, getting us stuck there.
See https://github.com/koreader/koreader/pull/10803#issuecomment-1694483616

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10850)
<!-- Reviewable:end -->
