### PR TITLE
VirtualKeyboard: Revamp visibility handling

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -920,10 +920,10 @@ function ReaderStyleTweak:editBookTweak(touchmenu_instance)
                 end
             end
         end,
-        -- Set/save view and cursor position callback
+        -- Store/retrieve view and cursor position callback
         view_pos_callback = function(top_line_num, charpos)
-            -- This same callback is called with no argument to get initial position,
-            -- and with arguments to give back final position when closed.
+            -- This same callback is called with no arguments on init to retrieve the stored initial position,
+            -- and with arguments to store the final position on close.
             if top_line_num and charpos then
                 self.book_style_tweak_last_edit_pos = {top_line_num, charpos}
             else

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -543,8 +543,6 @@ UIManager:setDirty(self.widget, function() return "ui", self.someelement.dimen e
 @bool refreshdither `true` if widget requires dithering (optional)
 ]]
 function UIManager:setDirty(widget, refreshtype, refreshregion, refreshdither)
-    logger.info("UIManager:setDirty", tostring(widget), refreshtype, refreshregion, refreshdither)
-    print(debug.traceback())
     local widget_name
     if widget then
         widget_name = widget.name or widget.id or tostring(widget)

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -543,6 +543,8 @@ UIManager:setDirty(self.widget, function() return "ui", self.someelement.dimen e
 @bool refreshdither `true` if widget requires dithering (optional)
 ]]
 function UIManager:setDirty(widget, refreshtype, refreshregion, refreshdither)
+    logger.info("UIManager:setDirty", tostring(widget), refreshtype, refreshregion, refreshdither)
+    print(debug.traceback())
     local widget_name
     if widget then
         widget_name = widget.name or widget.id or tostring(widget)

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -543,14 +543,14 @@ function InputDialog:toggleKeyboard(force_toggle)
     -- Remember the *current* visibility, as the following close will reset it
     local visible = self:isKeyboardVisible()
 
+    self.input = self:getInputText() -- re-init with up-to-date text
+    self:onClose() -- will close keyboard and save view position
+    self:free()
+
     if force_toggle == false and not visible then
         -- Already hidden, bye!
         return
     end
-
-    self.input = self:getInputText() -- re-init with up-to-date text
-    self:onClose() -- will close keyboard and save view position
-    self:free()
 
     -- Init needs to know the keyboard's visibility state *before* the widget actually exists...
     if force_toggle == true then

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -366,7 +366,6 @@ function InputDialog:init()
         scroll_by_pan = self.scroll_by_pan,
         cursor_at_end = self.cursor_at_end,
         readonly = self.readonly,
-        manage_keyboard_state = not self.add_nav_bar, -- we handle keyboard toggle ourselve if nav_bar
         parent = self,
         is_text_edited = self._text_modified,
         top_line_num = self._top_line_num,

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -475,6 +475,7 @@ function InputDialog:getAddedWidgetAvailableWidth()
     return self._input_widget.width
 end
 
+-- Close the keyboard if we tap anywhere outside of the keyboard (that isn't an input field, where it would be caught via InputText:onTapTextBox)
 function InputDialog:onTap()
     -- This is slightly more fine-grained than VK's own visibility lock, hence the duplication...
     if self.deny_keyboard_hiding then

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -640,7 +640,7 @@ function InputDialog:onClose()
     self._top_line_num = self._input_widget.top_line_num
     self._charpos = self._input_widget.charpos
     if self.view_pos_callback then
-        -- Let the widget store the current top line num and cursor position
+        -- This lets the caller store/process the current top line num and cursor position via this callback
         self.view_pos_callback(self._top_line_num, self._charpos)
     end
     self:onCloseKeyboard()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -545,6 +545,7 @@ function InputDialog:lockKeyboard(toggle)
 end
 
 -- NOTE: Only called by fullscreen and/or add_nav_bar codepaths
+--       We do not currently have !fullscreen add_nav_bar callers...
 function InputDialog:toggleKeyboard(force_toggle)
     -- Remember the *current* visibility, as the following close will reset it
     local visible = self:isKeyboardVisible()
@@ -578,6 +579,7 @@ function InputDialog:toggleKeyboard(force_toggle)
     end
     self:init()
 
+    -- NOTE: If we ever have non-fullscreen add_nav_bar callers, it might make sense *not* to lock the keyboard there?
     if self.keyboard_visible then
         self:lockKeyboard(false)
         self:onShowKeyboard()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -544,12 +544,17 @@ function InputDialog:toggleKeyboard(force_hide)
     self.input = self:getInputText() -- re-init with up-to-date text
     self:onClose() -- will close keyboard and save view position
     self:free()
+
+    -- Init needs to know the keyboard's visibility state *before* the widget actually exists...
+    self.keyboard_visible = not visible
     self:init()
 
-    if visible then
-        self:onCloseKeyboard()
-    else
+    if self.keyboard_visible then
         self:onShowKeyboard()
+    else
+        self:onCloseKeyboard()
+        -- Prevent InputText:onTapTextBox from opening the keyboard back up on top of our buttons
+        self.
     end
 end
 
@@ -567,8 +572,11 @@ function InputDialog:onKeyboardHeightChanged()
     self:free()
     -- Restore original text_height (or reset it if none to force recomputing it)
     self.text_height = self.orig_text_height or nil
+
+    -- Same deal as in toggleKeyboard...
+    self.keyboard_visible = visible
     self:init()
-    if visible then
+    if self.keyboard_visible then
         self:onShowKeyboard()
     end
     -- Our position on screen has probably changed, so have the full screen refreshed

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -445,6 +445,11 @@ function InputDialog:init()
             self:addWidget(widget, true)
         end
     end
+
+    -- If we're fullscreen without a keyboard, make sure only the toggle button can show the keyboard...
+    if self.fullscreen and not self.keyboard_visible then
+        self:lockKeyboard(true)
+    end
 end
 
 function InputDialog:addWidget(widget, re_init)
@@ -539,6 +544,7 @@ function InputDialog:lockKeyboard(toggle)
     return self._input_widget:lockKeyboard(toggle)
 end
 
+-- NOTE: Only called by fullscreen and/or add_nav_bar codepaths
 function InputDialog:toggleKeyboard(force_toggle)
     -- Remember the *current* visibility, as the following close will reset it
     local visible = self:isKeyboardVisible()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -163,7 +163,7 @@ local InputDialog = FocusManager:extend{
 
     -- For use by TextEditor plugin:
     view_pos_callback = nil, -- Called with no args on init to retrieve top_line_num/charpos (however the caller chooses to do so, e.g., some will store it in a LuaSettings),
-                             -- called with (top_line_num, charpos) on close to let the widget do its thing so that the no args branch spits back useful data..
+                             -- called with (top_line_num, charpos) on close to let the callback do its thing so that the no args branch spits back useful data..
 
     -- Set to false if movable gestures conflicts with subwidgets gestures
     is_movable = true,

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -536,6 +536,10 @@ function InputDialog:isKeyboardVisible()
     return self._input_widget:isKeyboardVisible()
 end
 
+function InputDialog:lockKeyboard(toggle)
+    return self._input_widget:lockKeyboard(toggle)
+end
+
 function InputDialog:toggleKeyboard(force_hide)
     if force_hide and not self:isKeyboardVisible() then return end
     -- Remember the *current* visibility, as the following close will reset it
@@ -550,11 +554,12 @@ function InputDialog:toggleKeyboard(force_hide)
     self:init()
 
     if self.keyboard_visible then
+        self:lockKeyboard(false)
         self:onShowKeyboard()
     else
         self:onCloseKeyboard()
         -- Prevent InputText:onTapTextBox from opening the keyboard back up on top of our buttons
-        self.
+        self:lockKeyboard(true)
     end
 end
 

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -120,8 +120,6 @@ local T = require("ffi/util").template
 local util = require("util")
 local _ = require("gettext")
 
-local logger = require("logger")
-
 local InputDialog = FocusManager:extend{
     is_always_active = true,
     title = "",
@@ -543,17 +541,13 @@ function InputDialog:lockKeyboard(toggle)
 end
 
 function InputDialog:toggleKeyboard(force_toggle)
-    logger.info("InputDialog:toggleKeyboard", force_toggle)
     -- Remember the *current* visibility, as the following close will reset it
     local visible = self:isKeyboardVisible()
-    logger.info("visible", visible)
-    logger.info("was visible", self._keyboard_was_visible)
-    print(debug.traceback())
 
     -- When we forcibly close the keyboard, remember its current visiblity state, so that we can properly restore it later.
     -- (This is used by some buttons in fullscreen mode, where we might want to keep the original keyboard hidden when popping up a new one for another InputDialog).
     if force_toggle == false then
-        -- NOTE: visible will be nil between init and show, which is precisely what happens when the *hide* the keyboard.
+        -- NOTE: visible will be nil between our own init and a show of the keyboard, which is precisely what happens when the *hide* the keyboard.
         self._keyboard_was_visible = visible == true
     end
 

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -562,7 +562,7 @@ function InputDialog:toggleKeyboard(force_toggle)
     -- When we forcibly close the keyboard, remember its current visiblity state, so that we can properly restore it later.
     -- (This is used by some buttons in fullscreen mode, where we might want to keep the original keyboard hidden when popping up a new one for another InputDialog).
     if force_toggle == false then
-        -- NOTE: visible will be nil between our own init and a show of the keyboard, which is precisely what happens when the *hide* the keyboard.
+        -- NOTE: visible will be nil between our own init and a show of the keyboard, which is precisely what happens when we *hide* the keyboard.
         self._keyboard_was_visible = visible == true
     end
 

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -531,6 +531,9 @@ function InputDialog:onCloseWidget()
 end
 
 function InputDialog:onShowKeyboard(ignore_first_hold_release)
+    -- NOTE: There's no VirtualKeyboard widget instantiated at all when readonly,
+    --       and our input widget handles that itself, so we don't need any guards here.
+    --       (In which case, isKeyboardVisible will return `nil`, same as if we had a VK instantiated but *never* shown).
     self._input_widget:onShowKeyboard(ignore_first_hold_release)
     -- There's a bit of a chicken or egg issue in init where we would like to check the actual keyboard's visibility state,
     -- but the widget might not exist or be shown yet, so we'll just have to keep this in sync...

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -18,8 +18,6 @@ local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
 
-local logger = require("logger")
-
 local Keyboard -- Conditional instantiation
 local FocusManagerInstance -- Delayed instantiation
 
@@ -696,7 +694,6 @@ function InputText:onCloseKeyboard()
 end
 
 function InputText:isKeyboardVisible()
-    logger.info("InputText:isKeyboardVisible")
     if self.keyboard then
         return self.keyboard:isVisible()
     end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -53,7 +53,7 @@ local InputText = InputContainer:extend{
     auto_para_direction = false,
     alignment_strict = false,
 
-    readonly = nil, -- without a VirtualKeyboard if true
+    readonly = nil, -- will not support a Keyboard widget if true
 
     -- for internal use
     keyboard = nil, -- Keyboard widget (either VirtualKeyboard or PhysicalKeyboard)

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -707,7 +707,6 @@ end
 
 function InputText:onCloseWidget()
     if self.keyboard then
-        self.keyboard:onClose()
         self.keyboard:free()
     end
     self:free()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -699,6 +699,12 @@ function InputText:isKeyboardVisible()
     end
 end
 
+function InputText:lockKeyboard(toggle)
+    if self.keyboard then
+        return self.keyboard:lockVisibility(toggle)
+    end
+end
+
 function InputText:onCloseWidget()
     if self.keyboard then
         self.keyboard:onClose()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -18,6 +18,8 @@ local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
 
+local logger = require("logger")
+
 local Keyboard -- Conditional instantiation
 local FocusManagerInstance -- Delayed instantiation
 
@@ -694,6 +696,7 @@ function InputText:onCloseKeyboard()
 end
 
 function InputText:isKeyboardVisible()
+    logger.info("InputText:isKeyboardVisible")
     if self.keyboard then
         return self.keyboard:isVisible()
     end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -693,6 +693,12 @@ function InputText:onCloseKeyboard()
     end
 end
 
+function InputText:isKeyboardVisible()
+    if self.keyboard then
+        return self.keyboard:isVisible()
+    end
+end
+
 function InputText:onCloseWidget()
     if self.keyboard then
         self.keyboard:onClose()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -18,8 +18,6 @@ local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
 
-local logger = require("logger")
-
 local Keyboard -- Conditional instantiation
 local FocusManagerInstance -- Delayed instantiation
 
@@ -34,7 +32,7 @@ local InputText = InputContainer:extend{
     focused = true,
     parent = nil, -- parent dialog that will be set dirty
     edit_callback = nil, -- called with true when text modified, false on init or text re-set
-    scroll_callback = nil, -- called with (low, high) when view is scrolled (cf ScrollTextWidget)
+    scroll_callback = nil, -- called with (low, high) when view is scrolled (c.f., ScrollTextWidget)
     scroll_by_pan = false, -- allow scrolling by lines with Pan (needs scroll=true)
 
     width = nil,
@@ -75,6 +73,11 @@ local InputText = InputContainer:extend{
 function InputText:initEventListener() end
 function InputText:onFocus() end
 function InputText:onUnfocus() end
+
+-- Resync our position state with our text widget's actual state
+function InputText:resyncPos()
+    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+end
 
 local function initTouchEvents()
     if Device:isTouchDevice() then
@@ -147,7 +150,7 @@ local function initTouchEvents()
                 local x = ges.pos.x - self._frame_textwidget.dimen.x - textwidget_offset
                 local y = ges.pos.y - self._frame_textwidget.dimen.y - textwidget_offset
                 self.text_widget:moveCursorToXY(x, y, true) -- restrict_to_view=true
-                self.charpos, self.top_line_num = self.text_widget:getCharPos()
+                self:resyncPos()
             end
             return true
         end
@@ -515,7 +518,7 @@ function InputText:initTextBox(text, char_added)
         }
     end
     -- Get back possibly modified charpos and virtual_line_num
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 
     self._frame_textwidget = FrameContainer:new{
         bordersize = self.bordersize,
@@ -540,7 +543,6 @@ function InputText:initTextBox(text, char_added)
     --- @fixme self.parent is not always in the widget stack (BookStatusWidget)
     -- Don't even try to refresh dummy widgets used for text height computations...
     if not self.for_measurement_only then
-        logger.info("InputText:initTextBox")
         UIManager:setDirty(self.parent, function()
             return "ui", self.dimen
         end)
@@ -886,71 +888,71 @@ end
 function InputText:leftChar()
     if self.charpos == 1 then return end
     self.text_widget:moveCursorLeft()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:rightChar()
     if self.charpos > #self.charlist then return end
     self.text_widget:moveCursorRight()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:goToStartOfLine()
     local new_pos = select(1, self:getStringPos({"\n", "\r"}, {"\n", "\r"}))
     self.text_widget:moveCursorToCharPos(new_pos)
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:goToEndOfLine()
     local new_pos = select(2, self:getStringPos({"\n", "\r"}, {"\n", "\r"})) + 1
     self.text_widget:moveCursorToCharPos(new_pos)
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:goToHome()
     self.text_widget:moveCursorHome()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:goToEnd()
     self.text_widget:moveCursorEnd()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:moveCursorToCharPos(char_pos)
     self.text_widget:moveCursorToCharPos(char_pos)
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:upLine()
     self.text_widget:moveCursorUp()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:downLine()
     if #self.charlist == 0 then return end -- Avoid cursor moving within a hint.
     self.text_widget:moveCursorDown()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:scrollDown()
     self.text_widget:scrollDown()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:scrollUp()
     self.text_widget:scrollUp()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:scrollToTop()
     self.text_widget:scrollToTop()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:scrollToBottom()
     self.text_widget:scrollToBottom()
-    self.charpos, self.top_line_num = self.text_widget:getCharPos()
+    self:resyncPos()
 end
 
 function InputText:clear()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -682,8 +682,6 @@ dbg:guard(InputText, "onTextInput",
     end)
 
 function InputText:onShowKeyboard(ignore_first_hold_release)
-    Device:startTextInput()
-
     if self.keyboard then
         self.keyboard:showKeyboard(ignore_first_hold_release)
     end
@@ -691,8 +689,6 @@ function InputText:onShowKeyboard(ignore_first_hold_release)
 end
 
 function InputText:onCloseKeyboard()
-    Device:stopTextInput()
-
     if self.keyboard then
         self.keyboard:hideKeyboard()
     end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -18,6 +18,8 @@ local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
 
+local logger = require("logger")
+
 local Keyboard -- Conditional instantiation
 local FocusManagerInstance -- Delayed instantiation
 
@@ -538,6 +540,7 @@ function InputText:initTextBox(text, char_added)
     --- @fixme self.parent is not always in the widget stack (BookStatusWidget)
     -- Don't even try to refresh dummy widgets used for text height computations...
     if not self.for_measurement_only then
+        logger.info("InputText:initTextBox")
         UIManager:setDirty(self.parent, function()
             return "ui", self.dimen
         end)

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -218,6 +218,9 @@ end
 function MultiInputDialog:onSwitchFocus(inputbox)
     -- unfocus current inputbox
     self._input_widget:unfocus()
+    -- and close its existing keyboard
+    self._input_widget:onCloseKeyboard()
+
     UIManager:setDirty(nil, function()
         return "ui", self.dialog_frame.dimen
     end)
@@ -226,7 +229,7 @@ function MultiInputDialog:onSwitchFocus(inputbox)
     self._input_widget = inputbox
     self._input_widget:focus()
 
-    -- Make sure we have a visible KeyBoard
+    -- Make sure we have a (new) visible keyboard
     self._input_widget:onShowKeyboard()
 end
 

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -218,7 +218,6 @@ end
 function MultiInputDialog:onSwitchFocus(inputbox)
     -- unfocus current inputbox
     self._input_widget:unfocus()
-    self._input_widget:onCloseKeyboard()
     UIManager:setDirty(nil, function()
         return "ui", self.dialog_frame.dimen
     end)
@@ -226,6 +225,8 @@ function MultiInputDialog:onSwitchFocus(inputbox)
     -- focus new inputbox
     self._input_widget = inputbox
     self._input_widget:focus()
+
+    -- Make sure we have a visible KeyBoard
     self._input_widget:onShowKeyboard()
 end
 

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -218,8 +218,8 @@ end
 function MultiInputDialog:onSwitchFocus(inputbox)
     -- unfocus current inputbox
     self._input_widget:unfocus()
-    -- and close its existing keyboard
-    self._input_widget:onCloseKeyboard()
+    -- and close its existing keyboard (via InputDialog's thin wrapper around _input_widget's own method)
+    self:onCloseKeyboard()
 
     UIManager:setDirty(nil, function()
         return "ui", self.dialog_frame.dimen
@@ -230,7 +230,7 @@ function MultiInputDialog:onSwitchFocus(inputbox)
     self._input_widget:focus()
 
     -- Make sure we have a (new) visible keyboard
-    self._input_widget:onShowKeyboard()
+    self:onShowKeyboard()
 end
 
 return MultiInputDialog

--- a/frontend/ui/widget/physicalkeyboard.lua
+++ b/frontend/ui/widget/physicalkeyboard.lua
@@ -170,6 +170,7 @@ function PhysicalKeyboard:setupNumericMappingUI()
 end
 
 -- Match VirtualKeyboard's API to ease caller's life
+function PhysicalKeyboard:lockVisibility() end
 function PhysicalKeyboard:setVisibility() end
 function PhysicalKeyboard:isVisible() return true end
 function PhysicalKeyboard:showKeyboard() end

--- a/frontend/ui/widget/physicalkeyboard.lua
+++ b/frontend/ui/widget/physicalkeyboard.lua
@@ -169,4 +169,10 @@ function PhysicalKeyboard:setupNumericMappingUI()
     self.dimen = keyboard_frame:getSize()
 end
 
+-- Match VirtualKeyboard's API to ease caller's life
+function PhysicalKeyboard:setVisibility() end
+function PhysicalKeyboard:isVisible() return true end
+function PhysicalKeyboard:showKeyboard() end
+function PhysicalKeyboard:hideKeyboard() end
+
 return PhysicalKeyboard

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -755,6 +755,7 @@ end
 
 local VirtualKeyboard = FocusManager:extend{
     name = "VirtualKeyboard",
+    visible = nil,
     covers_footer = true,
     modal = true,
     disable_double_tap = true,
@@ -929,11 +930,38 @@ end
 
 function VirtualKeyboard:onShow()
     self:_refresh(true)
+    self.visible = true
     return true
 end
 
 function VirtualKeyboard:onCloseWidget()
     self:_refresh(true)
+    self.visible = false
+end
+
+function VirtualKeyboard:setVisibility(toggle)
+    if toggle then
+        UIManager:show(self)
+    else
+        self:onClose()
+    end
+end
+
+function VirtualKeyboard:isVisible()
+    return self.visible
+end
+
+function VirtualKeyboard:showKeyboard(ignore_first_hold_release)
+    if not self:isVisible() then
+        self.ignore_first_hold_release = ignore_first_hold_release
+        self:setVisibility(true)
+    end
+end
+
+function VirtualKeyboard:hideKeyboard()
+    if self:isVisible() then
+        self:setVisibility(false)
+    end
 end
 
 function VirtualKeyboard:initLayer(layer)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -930,12 +930,15 @@ function VirtualKeyboard:_refresh(want_flash, fullscreen)
 end
 
 function VirtualKeyboard:onShow()
+    logger.info("VirtualKeyboard:onShow", tostring(self))
     self:_refresh(true)
     self.visible = true
     return true
 end
 
 function VirtualKeyboard:onCloseWidget()
+    logger.info("VirtualKeyboard:onCloseWidget", tostring(self))
+    print(debug.traceback())
     self:_refresh(true)
     self.visible = false
 end
@@ -957,6 +960,7 @@ function VirtualKeyboard:setVisibility(toggle)
 end
 
 function VirtualKeyboard:isVisible()
+    logger.info("VirtualKeyboard:isVisible", tostring(self), self.visible)
     return self.visible
 end
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -930,15 +930,12 @@ function VirtualKeyboard:_refresh(want_flash, fullscreen)
 end
 
 function VirtualKeyboard:onShow()
-    logger.info("VirtualKeyboard:onShow", tostring(self))
     self:_refresh(true)
     self.visible = true
     return true
 end
 
 function VirtualKeyboard:onCloseWidget()
-    logger.info("VirtualKeyboard:onCloseWidget", tostring(self))
-    print(debug.traceback())
     self:_refresh(true)
     self.visible = false
 end
@@ -960,7 +957,6 @@ function VirtualKeyboard:setVisibility(toggle)
 end
 
 function VirtualKeyboard:isVisible()
-    logger.info("VirtualKeyboard:isVisible", tostring(self), self.visible)
     return self.visible
 end
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -756,6 +756,7 @@ end
 local VirtualKeyboard = FocusManager:extend{
     name = "VirtualKeyboard",
     visible = nil,
+    lock_visibility = false,
     covers_footer = true,
     modal = true,
     disable_double_tap = true,
@@ -939,7 +940,15 @@ function VirtualKeyboard:onCloseWidget()
     self.visible = false
 end
 
+function VirtualKeyboard:lockVisibility(toggle)
+    self.lock_visibility = toggle
+end
+
 function VirtualKeyboard:setVisibility(toggle)
+    if self.lock_visibility then
+        return
+    end
+
     if toggle then
         UIManager:show(self)
     else

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -951,8 +951,10 @@ function VirtualKeyboard:setVisibility(toggle)
 
     if toggle then
         UIManager:show(self)
+        Device:startTextInput()
     else
         self:onClose()
+        Device:stopTextInput()
     end
 end
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -932,12 +932,14 @@ end
 function VirtualKeyboard:onShow()
     self:_refresh(true)
     self.visible = true
+    Device:startTextInput()
     return true
 end
 
 function VirtualKeyboard:onCloseWidget()
     self:_refresh(true)
     self.visible = false
+    Device:stopTextInput()
 end
 
 function VirtualKeyboard:lockVisibility(toggle)
@@ -951,10 +953,8 @@ function VirtualKeyboard:setVisibility(toggle)
 
     if toggle then
         UIManager:show(self)
-        Device:startTextInput()
     else
         self:onClose()
-        Device:stopTextInput()
     end
 end
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -939,6 +939,9 @@ end
 function VirtualKeyboard:onCloseWidget()
     self:_refresh(true)
     self.visible = false
+    -- NOTE: This effectively stops SDL text input when a keyboard is hidden (... but navigational stuff still works).
+    --       If you instead wanted it to be enabled as long as an input dialog is displayed, regardless of VK's state,
+    --       this should be moved to InputDialog's onShow/onCloseWidget handlers (but, it would allow input on unfocused fields).
     Device:stopTextInput()
 end
 

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -941,7 +941,9 @@ function VirtualKeyboard:onCloseWidget()
     self.visible = false
     -- NOTE: This effectively stops SDL text input when a keyboard is hidden (... but navigational stuff still works).
     --       If you instead wanted it to be enabled as long as an input dialog is displayed, regardless of VK's state,
-    --       this should be moved to InputDialog's onShow/onCloseWidget handlers (but, it would allow input on unfocused fields).
+    --       this could be moved to InputDialog's onShow/onCloseWidget handlers (but, it would allow input on unfocused fields).
+    -- NOTE: But something more complex, possibly based on an in-class ref count would have to be implemented in order to be able to deal
+    --       with multiple InputDialogs being shown and closed in asymmetric fashion... Ugh.
     Device:stopTextInput()
 end
 

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -545,7 +545,7 @@ function TextEditor:editFile(file_path, readonly)
         cursor_at_end = false,
         readonly = readonly,
         add_nav_bar = true,
-        keyboard_hidden = not self.show_keyboard_on_start,
+        keyboard_visible = self.show_keyboard_on_start,
         scroll_by_pan = true,
         buttons = {buttons_first_row},
         -- Set/save view and cursor position callback
@@ -641,7 +641,9 @@ Do you want to keep this file as empty, or do you prefer to delete it?
 
     }
     UIManager:show(input)
-    input:onShowKeyboard()
+    if self.show_keyboard_on_start then
+        input:onShowKeyboard()
+    end
     -- Note about self.readonly:
     -- We might have liked to still show keyboard even if readonly, just
     -- to use the arrow keys for line by line scrolling with cursor.

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -641,10 +641,10 @@ Do you want to keep this file as empty, or do you prefer to delete it?
 
     }
     UIManager:show(input)
-    if self.show_keyboard_on_start and not self.readonly then
+    if self.show_keyboard_on_start and not readonly then
         input:onShowKeyboard()
     end
-    -- Note about self.readonly:
+    -- Note about readonly:
     -- We might have liked to still show keyboard even if readonly, just
     -- to use the arrow keys for line by line scrolling with cursor.
     -- But it's easier to just let InputDialog and InputText do their

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -548,10 +548,10 @@ function TextEditor:editFile(file_path, readonly)
         keyboard_visible = self.show_keyboard_on_start,
         scroll_by_pan = true,
         buttons = {buttons_first_row},
-        -- Set/save view and cursor position callback
+        -- Store/retrieve view and cursor position callback
         view_pos_callback = function(top_line_num, charpos)
-            -- This same callback is called with no argument to get initial position,
-            -- and with arguments to give back final position when closed.
+            -- This same callback is called with no arguments on init to retrieve the stored initial position,
+            -- and with arguments to store the final position on close.
             if top_line_num and charpos then
                 self.last_view_pos[file_path] = {top_line_num, charpos}
             else

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -545,7 +545,7 @@ function TextEditor:editFile(file_path, readonly)
         cursor_at_end = false,
         readonly = readonly,
         add_nav_bar = true,
-        keyboard_visible = self.show_keyboard_on_start,
+        keyboard_visible = self.show_keyboard_on_start, -- InputDialog will enforce false if readonly
         scroll_by_pan = true,
         buttons = {buttons_first_row},
         -- Store/retrieve view and cursor position callback

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -572,7 +572,7 @@ function TextEditor:editFile(file_path, readonly)
         end,
         -- File saving callback
         save_callback = function(content, closing) -- Will add Save/Close buttons
-            if self.readonly then
+            if readonly then
                 -- We shouldn't be called if read-only, but just in case
                 return false, _("File is read only")
             end

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -643,9 +643,6 @@ Do you want to keep this file as empty, or do you prefer to delete it?
     UIManager:show(input)
     if self.show_keyboard_on_start then
         input:onShowKeyboard()
-    else
-        -- Should only be shown via the dedicated button
-        input:lockKeyboard(true)
     end
     -- Note about self.readonly:
     -- We might have liked to still show keyboard even if readonly, just

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -643,6 +643,9 @@ Do you want to keep this file as empty, or do you prefer to delete it?
     UIManager:show(input)
     if self.show_keyboard_on_start then
         input:onShowKeyboard()
+    else
+        -- Should only be shown via the dedicated button
+        input:lockKeyboard(true)
     end
     -- Note about self.readonly:
     -- We might have liked to still show keyboard even if readonly, just

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -641,7 +641,7 @@ Do you want to keep this file as empty, or do you prefer to delete it?
 
     }
     UIManager:show(input)
-    if self.show_keyboard_on_start then
+    if self.show_keyboard_on_start and not self.readonly then
         input:onShowKeyboard()
     end
     -- Note about self.readonly:


### PR DESCRIPTION
Move as much of the state tracking as possible inside VirtualKeyboard itself.
InputDialog unfortunately needs an internal tracking of this state because it needs to know about it *before* the VK is shown, so we have to keep a bit of duplication in there, although we do try much harder to keep everything in sync (at least at function call edges), and to keep the damage contained to, essentially, the toggle button's handler.

(Followup to #10803 & #10850)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10852)
<!-- Reviewable:end -->
