### PR TITLE
KOSync: Assume Android will handle Wi-Fi on its own

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -50,6 +50,9 @@ local CHECKSUM_METHOD = {
 -- Debounce push/pull attempts
 local API_CALL_DEBOUNCE_DELAY = time.s(25)
 
+-- Android shouldn't really be flagged hasWifiToggle, as it happens *outside* of KOReader, requiring a focus switch *and* user interaction...
+local hasSaneWifiToggle = Device:hasWifiToggle() and not Device:isAndroid()
+
 -- NOTE: This is used in a migration script by ui/data/onetime_migration,
 --       which is why it's public.
 KOSync.default_settings = {
@@ -84,7 +87,7 @@ function KOSync:init()
     self.device_id = G_reader_settings:readSetting("device_id")
 
     -- Disable auto-sync if beforeWifiAction was reset to "prompt" behind our back...
-    if self.settings.auto_sync and Device:hasWifiToggle() and G_reader_settings:readSetting("wifi_enable_action") ~= "turn_on" then
+    if self.settings.auto_sync and hasSaneWifiToggle and G_reader_settings:readSetting("wifi_enable_action") ~= "turn_on" then
         self.settings.auto_sync = false
         logger.warn("KOSync: Automatic sync has been disabled because wifi_enable_action is *not* turn_on")
     end
@@ -229,7 +232,7 @@ function KOSync:addToMainMenu(menu_items)
                 help_text = _([[This may lead to nagging about toggling WiFi on document close and suspend/resume, depending on the device's connectivity.]]),
                 callback = function()
                     -- Actively recommend switching the before wifi action to "turn_on" instead of prompt, as prompt will just not be practical (or even plain usable) here.
-                    if Device:hasWifiToggle() and G_reader_settings:readSetting("wifi_enable_action") ~= "turn_on" and not self.settings.auto_sync then
+                    if hasSaneWifiToggle and G_reader_settings:readSetting("wifi_enable_action") ~= "turn_on" and not self.settings.auto_sync then
                         UIManager:show(InfoMessage:new{ text = _("You will have to switch the 'Action when Wi-Fi is off' Network setting to 'turn on' to be able to enable this feature!") })
                         return
                     end


### PR DESCRIPTION
i.e., behave as if it were *not* flagged hasWifiToggle (because it really shouldn't be).

A case could be made to just nip this in the bud and stop flagging it entirely, but there are a *few* nice to have things hidden behind that capcheck, so, for now, just special-case this one...

Fix https://github.com/koreader/koreader/issues/10790#issuecomment-1699138570

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10862)
<!-- Reviewable:end -->
