### PR TITLE
New menu option and filemanager filter to hide finished books #7158

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -128,6 +128,7 @@ function FileManager:setupLayout()
         right_icon_hold_callback = false, -- propagate long-press to dispatcher
     }
 
+    local show_finished = G_reader_settings:nilOrTrue("show_finished")
     local show_hidden = G_reader_settings:isTrue("show_hidden") or G_defaults:readSetting("DSHOWHIDDENFILES")
     local show_unsupported = G_reader_settings:isTrue("show_unsupported")
     local file_chooser = FileChooser:new{
@@ -138,6 +139,7 @@ function FileManager:setupLayout()
         height = Screen:getHeight() - self.title_bar:getHeight(),
         is_popout = false,
         is_borderless = true,
+        show_finished = show_finished,
         show_hidden = show_hidden,
         show_unsupported = show_unsupported,
         file_filter = function(filename)
@@ -778,6 +780,11 @@ end
 
 function FileManager:getCurrentDir()
     return FileManager.instance and FileManager.instance.file_chooser.path
+end
+
+function FileManager:toggleFinishedBooks()
+    self.file_chooser:toggleFinishedBooks()
+    G_reader_settings:saveSetting("show_finished", self.file_chooser.show_finished)
 end
 
 function FileManager:toggleHiddenFiles()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -149,6 +149,11 @@ function FileManagerMenu:setUpdateItemTable()
         text = _("Settings"),
         sub_item_table = {
             {
+                text = _("Show finished books"),
+                checked_func = function() return self.ui.file_chooser.show_finished end,
+                callback = function() self.ui:toggleFinishedBooks() end,
+            },
+            {
                 text = _("Show hidden files"),
                 checked_func = function() return self.ui.file_chooser.show_hidden end,
                 callback = function() self.ui:toggleHiddenFiles() end,

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -4,6 +4,7 @@ local datetime = require("datetime")
 local Device = require("device")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
+local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local Menu = require("ui/widget/menu")
 local OpenWithDialog = require("ui/widget/openwithdialog")
 local UIManager = require("ui/uimanager")
@@ -88,11 +89,13 @@ function FileChooser:show_dir(dirname)
     return true
 end
 
-function FileChooser:show_file(filename)
+function FileChooser:show_file(filename, fullpath)
     for _, pattern in ipairs(self.exclude_files) do
         if filename:match(pattern) then return false end
     end
-    return self.show_unsupported or self.file_filter == nil or self.file_filter(filename)
+    if not self.show_unsupported and self.file_filter ~= nil and not self.file_filter(filename) then return false end
+    if not self.show_finished and fullpath ~= nil and filemanagerutil.getStatus(fullpath) == "complete" then return false end
+    return true
 end
 
 function FileChooser:init()
@@ -123,7 +126,7 @@ function FileChooser:getList(path, collate)
                         end
                     -- Always ignore macOS resource forks.
                     elseif attributes.mode == "file" and not util.stringStartsWith(f, "._") then
-                        if self:show_file(f) then
+                        if self:show_file(f, filename) then
                             if collate then -- when collate == nil count only to display in folder mandatory
                                 item = self:getListItem(f, filename, attributes, collate)
                             end
@@ -448,6 +451,11 @@ function FileChooser:changePageToPath(path)
             break
         end
     end
+end
+
+function FileChooser:toggleFinishedBooks()
+    self.show_finished = not self.show_finished
+    self:refreshPath()
 end
 
 function FileChooser:toggleHiddenFiles()

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -25,6 +25,7 @@ local FileChooser = Menu:extend{
     show_hidden = false, -- set to true to show folders/files starting with "."
     file_filter = nil, -- function defined in the caller, returns true for files to be shown
     show_unsupported = false, -- set to true to ignore file_filter
+    show_finished = true, -- show all books
     -- NOTE: Input is *always* a relative entry name
     exclude_dirs = { -- const
         -- KOReader / Kindle


### PR DESCRIPTION
Fixes issue #7158

The default behavior is to display the finished books (no change on upgrade). For consistency with the two similar options, it represented by a checkbox "Show hidden books" that is checked by default.

The implementation is straightforward, meaning that, when the option is unchecked, each file will require a call to `filemanagerutil.getStatus` that checks its status.

For clarity, the code uses the "finished books" expression because the condition is relevant to the *book* metadata, while the other settings are about *file* attributes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10895)
<!-- Reviewable:end -->
