### PR TITLE
[doc] Building: minor updates to Debian/Ubuntu prerequisites

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -22,8 +22,8 @@ Install the prerequisites using APT:
 
 ```
 sudo apt-get install build-essential git patch wget unzip \
-gettext autoconf automake cmake libtool nasm ragel luarocks lua5.1 libsdl2-dev \
-libssl-dev libffi-dev libsdl2-dev libc6-dev-i386 xutils-dev linux-libc-dev:i386 zlib1g:i386
+gettext autoconf automake cmake libtool libtool-bin nasm ragel luarocks lua5.1 libsdl2-dev \
+libssl-dev libffi-dev libc6-dev-i386 xutils-dev linux-libc-dev:i386 zlib1g:i386
 ```
 
 ### Fedora/Red Hat

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -23,7 +23,7 @@ Install the prerequisites using APT:
 ```
 sudo apt-get install build-essential git patch wget unzip \
 gettext autoconf automake cmake libtool libtool-bin nasm ragel luarocks lua5.1 libsdl2-dev \
-libssl-dev libffi-dev libc6-dev-i386 xutils-dev linux-libc-dev:i386 zlib1g:i386
+libssl-dev libffi-dev libsdl2-dev libc6-dev-i386 xutils-dev linux-libc-dev:i386 zlib1g:i386
 ```
 
 ### Fedora/Red Hat

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -23,7 +23,7 @@ Install the prerequisites using APT:
 ```
 sudo apt-get install build-essential git patch wget unzip \
 gettext autoconf automake cmake libtool libtool-bin nasm ragel luarocks lua5.1 libsdl2-dev \
-libssl-dev libffi-dev libsdl2-dev libc6-dev-i386 xutils-dev linux-libc-dev:i386 zlib1g:i386
+libssl-dev libffi-dev libc6-dev-i386 xutils-dev linux-libc-dev:i386 zlib1g:i386
 ```
 
 ### Fedora/Red Hat


### PR DESCRIPTION
libtool-bin is something everyone already has installed so it slipped by unnoticed for more than half a decade.

~~SDL 1.2 support was removed 4 years ago: https://github.com/koreader/koreader-base/pull/963~~

Fixes #10896.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10897)
<!-- Reviewable:end -->
