### PR TITLE
Device: Make sure `input_no_key_repeat` survives a suspend/resume cycle

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -1097,8 +1097,10 @@ end
 -- The common operations that should be performed after resuming the device.
 function Device:_afterResume(inhibit)
     if inhibit ~= false then
-        -- Restore key repeat
-        self:restoreKeyRepeat()
+        -- Restore key repeat if it's not disabled
+        if G_reader_settings:nilOrFalse("input_no_key_repeat") then
+            self:restoreKeyRepeat()
+        end
 
         -- Restore full input handling
         self.input:inhibitInput(false)


### PR DESCRIPTION
I somehow assumed the repeat state snapshot used for restore was taken *after* disabling repeat, but obviously not ;o).

Fix #10902