### PR TITLE
Check for Noto Emoji font in UI fallback fonts

### DIFF
--- a/frontend/ui/elements/font_ui_fallbacks.lua
+++ b/frontend/ui/elements/font_ui_fallbacks.lua
@@ -39,7 +39,8 @@ local genFallbackCandidates = function()
         local fontinfo = FontList.fontinfo[font_path] -- (NotoColorEmoji.tff happens to get no fontinfo)
         if fontinfo and #fontinfo == 1 then -- Ignore font files with multiple faces
             fontinfo = fontinfo[1]
-            if util.stringStartsWith(fontinfo.name, "Noto Sans ") and
+            if (util.stringStartsWith(fontinfo.name, "Noto Sans ") or
+                        fontinfo.name == "Noto Emoji") and
                         not fontinfo.bold and not fontinfo.italic and
                         not fontinfo.serif and not fontinfo.mono then
                 fallback_candidates[fontinfo.name] = fontinfo


### PR DESCRIPTION
After discussion with @NiLuJe in (on?) Gitter.

<details> 
<summary>Screenshot</summary>

![FileManager_2023-09-17_193044](https://github.com/koreader/koreader/assets/2306085/47cfa725-d52f-440d-80de-84a5a6524981)

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10908)
<!-- Reviewable:end -->
