### PR TITLE
TextViewer: font size

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -526,7 +526,6 @@ function ReaderBookmark:onShowBookmark(match_table)
         textviewer = TextViewer:new{
             title = _("Bookmark details"),
             text = bm_view,
-            justified = G_reader_settings:nilOrTrue("dict_justify"),
             buttons_table = {
                 {
                     {

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -891,7 +891,6 @@ function ReaderHighlight:showHighlightNoteOrDialog(page, index, bookmark_note)
             text = bookmark_note,
             width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.8),
             height = math.floor(math.max(Screen:getWidth(), Screen:getHeight()) * 0.4),
-            justified = G_reader_settings:nilOrTrue("dict_justify"),
             buttons_table = {
                 {
                     {

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -197,11 +197,11 @@ When the book's language tag is not among our presets, no specific features will
             -- Text might be too long for InfoMessage
             local status_text = table.concat(lang_infos, "\n")
             local TextViewer = require("ui/widget/textviewer")
-            local Font = require("ui/font")
             UIManager:show(TextViewer:new{
                 title = _("Language tags (and hyphenation dictionaries) used since start up"),
                 text = status_text,
-                text_face = Font:getFace("smallinfont"),
+                text_font_face = "smallinfont",
+                justified = false,
                 height = math.floor(Screen:getHeight() * 0.8),
             })
         end,

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -687,7 +687,6 @@ function Translator:_showTranslation(text, detailed_view, source_lang, target_la
             -- it quite long and wrapped, taking valuable vertical spacing
         text = text_all,
         height = height,
-        justified = G_reader_settings:nilOrTrue("dict_justify"),
         add_default_buttons = true,
         buttons_table = buttons_table,
         close_callback = close_callback,

--- a/frontend/ui/viewhtml.lua
+++ b/frontend/ui/viewhtml.lua
@@ -5,7 +5,6 @@ It it used by ReaderHighlight as an action after text selection.
 
 local BD = require("ui/bidi")
 local Device = require("device")
-local Font = require("ui/font")
 local InfoMessage = require("ui/widget/infomessage")
 local Notification = require("ui/widget/notification")
 local TextViewer = require("ui/widget/textviewer")
@@ -30,7 +29,8 @@ local ViewHtml = {
 
         -- Or additionally show unicode codepoint of each char
         { _("Switch to unicode debug view"), 0xEB5E, true },
-    }
+    },
+    text_font_face = "smallinfont",
 }
 
 -- Main entry point
@@ -124,7 +124,7 @@ function ViewHtml:_viewSelectionHTML(document, selected_text, view, with_css_fil
                     cssviewer = TextViewer:new{
                         title = css_files[i],
                         text = css_text or _("Failed getting CSS content"),
-                        text_face = Font:getFace("smallinfont"),
+                        text_font_face = self.text_font_face,
                         justified = false,
                         para_direction_rtl = false,
                         auto_para_direction = false,
@@ -138,7 +138,7 @@ function ViewHtml:_viewSelectionHTML(document, selected_text, view, with_css_fil
                                     UIManager:show(TextViewer:new{
                                         title = css_files[i],
                                         text = util.prettifyCSS(css_text),
-                                        text_face = Font:getFace("smallinfont"),
+                                        text_font_face = self.text_font_face,
                                         justified = false,
                                         para_direction_rtl = false,
                                         auto_para_direction = false,
@@ -185,7 +185,7 @@ function ViewHtml:_viewSelectionHTML(document, selected_text, view, with_css_fil
     textviewer = TextViewer:new{
         title = _("Selection HTML"),
         text = html,
-        text_face = Font:getFace("smallinfont"),
+        text_font_face = self.text_font_face,
         justified = false,
         para_direction_rtl = false,
         auto_para_direction = false,
@@ -375,8 +375,8 @@ function ViewHtml:_handleLongPress(document, css_selectors_offsets, offset_shift
         end,
     }})
 
-    local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
-    local widget = ButtonDialogTitle:new{
+    local ButtonDialog = require("ui/widget/buttondialog")
+    local widget = ButtonDialog:new{
         title = _("Copy to clipboard:"),
         title_align = "center",
         width_factor = 0.8,
@@ -420,7 +420,7 @@ function ViewHtml:_showMatchingSelectors(document, ancestors, show_all_ancestors
     cssviewer = TextViewer:new{
         title = title,
         text = css_text or _("No matching rulesets"),
-        text_face = Font:getFace("smallinfont"),
+        text_font_face = self.text_font_face,
         justified = false,
         para_direction_rtl = false,
         auto_para_direction = false,
@@ -434,7 +434,7 @@ function ViewHtml:_showMatchingSelectors(document, ancestors, show_all_ancestors
                     UIManager:show(TextViewer:new{
                         title = title,
                         text = util.prettifyCSS(css_text),
-                        text_face = Font:getFace("smallinfont"),
+                        text_font_face = self.text_font_face,
                         justified = false,
                         para_direction_rtl = false,
                         auto_para_direction = false,

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -268,7 +268,6 @@ function KeyValueItem:onShowKeyValue()
         title = self.key,
         title_multilines = true, -- in case it's key/title that is too long
         text = self.value,
-        text_face = Font:getFace("x_smallinfofont", self.font_size),
         lang = self.value_lang,
         width = self.textviewer_width,
         height = self.textviewer_height,

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -46,7 +46,7 @@ local TextViewer = InputContainer:extend{
     -- When used to display more technical text (HTML, CSS,
     -- application logs...), it's best to reset them to false.
     alignment = "left",
-    justified = true,
+    justified = nil,
     lang = nil,
     para_direction_rtl = nil,
     auto_para_direction = true,
@@ -55,7 +55,9 @@ local TextViewer = InputContainer:extend{
     title_face = nil, -- use default from TitleBar
     title_multilines = nil, -- see TitleBar for details
     title_shrink_font_to_fit = nil, -- see TitleBar for details
-    text_face = Font:getFace("x_smallinfofont"),
+
+    text_font_face = nil, -- default "x_smallinfofont"
+    text_font_size = nil,
     fgcolor = Blitbuffer.COLOR_BLACK,
     text_padding = Size.padding.large,
     text_margin = Size.margin.small,
@@ -76,6 +78,16 @@ function TextViewer:init()
     }
     self.width = self.width or Screen:getWidth() - Screen:scaleBySize(30)
     self.height = self.height or Screen:getHeight() - Screen:scaleBySize(30)
+
+    if self.justified == nil then
+        self.justified = G_reader_settings:nilOrTrue("dict_justify")
+    end
+    if self.text_font_face == nil then
+        self.text_font_face = "x_smallinfofont"
+        if self.text_font_size == nil then
+            self.text_font_size = G_reader_settings:readSetting("dict_font_size")
+        end
+    end
 
     self._find_next = false
     self._find_next_button = false
@@ -247,7 +259,7 @@ function TextViewer:init()
 
     self.scroll_text_w = ScrollTextWidget:new{
         text = self.text,
-        face = self.text_face,
+        face = Font:getFace(self.text_font_face, self.text_font_size),
         fgcolor = self.fgcolor,
         width = self.width - 2*self.text_padding - 2*self.text_margin,
         height = textw_height - 2*self.text_padding -2*self.text_margin,

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -3,7 +3,6 @@ local ButtonDialog = require("ui/widget/buttondialog")
 local Cache = require("cache")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DocumentRegistry = require("document/documentregistry")
-local Font = require("ui/font")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local Menu = require("ui/widget/menu")
@@ -688,7 +687,6 @@ function OPDSBrowser:showDownloads(item)
                     title = item.text,
                     title_multilines = true,
                     text = util.htmlToPlainTextIfHtml(item.content),
-                    text_face = Font:getFace("x_smallinfofont", G_reader_settings:readSetting("items_font_size")),
                 })
             end,
         },

--- a/plugins/patchmanagement.koplugin/main.lua
+++ b/plugins/patchmanagement.koplugin/main.lua
@@ -102,7 +102,7 @@ function PatchManagement:getSubMenu(priority)
                                 _("Patches might have changed. Current set of patches will be applied on next restart."))
                         end
                         self.ui.texteditor:quickEditFile(patch_fullpath, done_callback, false)
-                    else -- fallback to show only the first lines
+                    else
                         local file = io.open(patch_fullpath, "rb")
                         if not file then
                             return ""
@@ -114,6 +114,7 @@ function PatchManagement:getSubMenu(priority)
                         textviewer = TextViewer:new{
                             title = patch,
                             text = patch_content,
+                            justified = false,
                         }
                         UIManager:show(textviewer)
                     end


### PR DESCRIPTION
The DictQuickLookup and TextViewer windows are alike, let TextViewer use the same settings `dict_font_size` and `dict_justify`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10911)
<!-- Reviewable:end -->
