### PR TITLE
Custom metadata: fixes 2

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -177,6 +177,12 @@ function BookInfo:show(file, book_props)
     UIManager:show(self.kvp_widget)
 end
 
+function BookInfo.getCustomProp(prop_key, filepath)
+    local custom_metadata_file = DocSettings:getCustomMetadataFile(filepath)
+    return custom_metadata_file
+        and DocSettings:openCustomMetadata(custom_metadata_file):readSetting("custom_props")[prop_key]
+end
+
 -- Returns extended and customized metadata.
 function BookInfo.extendProps(original_props, filepath)
     -- do not customize if filepath is not passed (eg from covermenu)
@@ -355,7 +361,6 @@ function BookInfo:updateBookInfo(file, book_props, prop_updated, prop_value_old)
         doc_props = book_props,
         metadata_key_updated = prop_updated,
         metadata_value_old = prop_value_old,
-        metadata_value_new = book_props[prop_updated],
     }
     self.kvp_widget:onClose()
     self:show(file, book_props)
@@ -428,10 +433,14 @@ function BookInfo:setCustomMetadata(file, book_props, prop_key, prop_value)
 end
 
 function BookInfo:showCustomEditDialog(file, book_props, prop_key)
+    local prop = book_props[prop_key]
+    if prop and prop_key == "description" then
+        prop = util.htmlToPlainTextIfHtml(prop)
+    end
     local input_dialog
     input_dialog = InputDialog:new{
         title = _("Edit book metadata:") .. " " .. self.prop_text[prop_key]:gsub(":", ""),
-        input = book_props[prop_key],
+        input = prop,
         input_type = prop_key == "series_index" and "number",
         allow_newline = prop_key == "authors" or prop_key == "keywords" or prop_key == "description",
         buttons = {

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -777,8 +777,8 @@ end
 function ReaderTypography:onPreRenderDocument(config)
     -- This is called after the document has been loaded,
     -- when we know and can access the document language.
-    local props = self.ui.document:getProps()
-    local doc_language = FileManagerBookInfo.extendProps(props, self.ui.document.file).language
+    local doc_language = FileManagerBookInfo.getCustomProp("language", self.ui.document.file)
+                      or self.ui.document:getProps().language
     self.book_lang_tag = self:fixLangTag(doc_language)
 
     local is_known_lang_tag = self.book_lang_tag and LANG_TAG_TO_LANG_NAME[self.book_lang_tag] ~= nil


### PR DESCRIPTION
(1) Optimize getting custom prop if only one prop is needed.
(2) Pass plain text to the custom edit dialog.
(3) Remove unused `metadata_value_new` in the event arg.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10919)
<!-- Reviewable:end -->
