### PR TITLE
Revert "Kobo: Disable HW inversion on MTK (#10841)"

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -647,10 +647,6 @@ function Kobo:init()
 
     -- So far, MTK kernels do not export a per-request inversion flag
     if self:isMTK() then
-        --- @fixme: Apparently, that doesn't quite work, at least on the Elipsa 2E, so, disable HW inversion...
-        ---         c.f., https://github.com/koreader/koreader/pull/10719#issuecomment-1693425726
-        self.canHWInvert = no
-        --[[
         -- Instead, there's a global flag that we can *set* (but not *get*) via a procfs knob...
         -- Overload the HWNightMode stuff to implement that properly, like we do on Kindle
         function self.screen:setHWNightmode(toggle)
@@ -665,7 +661,6 @@ function Kobo:init()
             -- (We want to disable this on exit, always, as it will never be used by Nickel, which does SW inversion).
             return self.hw_night_mode == true
         end
-        --]]
     end
 
     -- Automagic sysfs discovery


### PR DESCRIPTION
This reverts commit e7e0d2edb6af95bced95ce88d90a9e08f49fcf7a.

Whatever's actually going on with nightmode, this isn't it. This was independently confirmed to behave as expected, and the issue that prompted this was *not* fixed by this commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10928)
<!-- Reviewable:end -->
