### PR TITLE
TimeSync: Probe for ntpd/ntpdate dynamically

### DIFF
--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -1,6 +1,14 @@
 local Device = require("device")
 local lfs = require("libs/libkoreader-lfs")
 
+local ffi = require("ffi")
+local C = ffi.C
+require("ffi/posix_h")
+-- We need to be root to be able to set the time (CAP_SYS_TIME)
+if C.getuid() ~= 0 then
+    return { disabled = true, }
+end
+
 local ntp_cmd
 -- Check if we have access to ntpd or ntpdate
 if os.execute("command -v ntpd >/dev/null") == 0 then

--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -1,4 +1,5 @@
 local Device = require("device")
+local lfs = require("libs/libkoreader-lfs")
 
 local command
 --- @todo (hzj-jie): Does pocketbook provide ntpdate?
@@ -44,8 +45,13 @@ local function syncNTP()
         txt = _("Failed to retrieve time from server. Please check your network configuration.")
     else
         txt = currentTime()
+        os.execute("hwclock -u -w")
+
+        -- On Kindle, do it the native way, too..
+        if Device:isKindle() and lfs.attributes("/usr/sbin/setdate", "mode") == "file" then
+            os.execute(string.format("/usr/sbin/setdate '%d'", os.time()))
+        end
     end
-    os.execute("hwclock -u -w")
     UIManager:close(info)
     UIManager:show(InfoMessage:new{
         text = txt,


### PR DESCRIPTION
And, on Kindle, make sure we update the native UI's time, too

Fix #10932

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10935)
<!-- Reviewable:end -->
