### PR TITLE
 coverbrowser: don't override the CRE cache

### DIFF
--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -623,7 +623,6 @@ function CoverMenu:onCloseWidget()
     logger.dbg("CoverMenu:onCloseWidget: terminating jobs if needed")
     BookInfoManager:terminateBackgroundJobs()
     BookInfoManager:closeDbConnection() -- sqlite connection no more needed
-    BookInfoManager:cleanUp() -- clean temporary resources
 
     -- Cancel any still scheduled update
     if self.items_update_action then


### PR DESCRIPTION
Caching is not used, as documents are no fully loaded (metadata only), and no rendering is done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10940)
<!-- Reviewable:end -->
