### PR TITLE
coverbrowser: make showing some metadata fields optional

### DIFF
--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -315,6 +315,12 @@ function BookInfoManager:saveSetting(key, value, db_conn, skip_reload)
     end
 end
 
+function BookInfoManager:toggleSetting(key)
+    local value = not self:getSetting(key)
+    self:saveSetting(key, value)
+    return value
+end
+
 -- Bookinfo management
 function BookInfoManager:getBookInfo(filepath, get_cover)
     local directory, filename = util.splitFilePathName(filepath)

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -191,6 +191,46 @@ function CoverBrowser:addToMainMenu(menu_items)
                 end,
             },
             {
+                text = _("Progress"),
+                sub_item_table = {
+                    {
+                        text = _("Show progress"),
+                        checked_func = function() return
+                            not BookInfoManager:getSetting("hide_page_info")
+                        end,
+                        callback = function()
+                            BookInfoManager:toggleSetting("hide_page_info")
+                            self:refreshFileManagerInstance()
+                        end,
+                    },
+                    {
+                        text = _("Show progress % in mosaic mode"),
+                        checked_func = function() return BookInfoManager:getSetting("show_progress_in_mosaic") end,
+                        callback = function()
+                            BookInfoManager:toggleSetting("show_progress_in_mosaic")
+                            self:refreshFileManagerInstance()
+                        end,
+                    },
+                    {
+                        text = _("Show number of pages read instead of progress %"),
+                        checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,
+                        callback = function()
+                            BookInfoManager:toggleSetting("show_pages_read_as_progress")
+                            self:refreshFileManagerInstance()
+                        end,
+                    },
+                    {
+                        text = _("Show number of pages left to read"),
+                        checked_func = function() return BookInfoManager:getSetting("show_pages_left_in_progress") end,
+                        callback = function()
+                            BookInfoManager:toggleSetting("show_pages_left_in_progress")
+                            self:refreshFileManagerInstance()
+                        end,
+                        separator = true,
+                    },
+                },
+            },
+            {
                 text = _("Display hints"),
                 sub_item_table = {
                     {
@@ -265,29 +305,14 @@ function CoverBrowser:addToMainMenu(menu_items)
                 separator = true
             },
             {
-                text = _("Show progress % in mosaic mode"),
-                checked_func = function() return BookInfoManager:getSetting("show_progress_in_mosaic") end,
+                text = _("Show file properties"),
+                checked_func = function()
+                    return not BookInfoManager:getSetting("hide_file_info")
+                end,
                 callback = function()
-                    BookInfoManager:toggleSetting("show_progress_in_mosaic")
+                    BookInfoManager:toggleSetting("hide_file_info")
                     self:refreshFileManagerInstance()
                 end,
-            },
-            {
-                text = _("Show number of pages read instead of progress %"),
-                checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,
-                callback = function()
-                    BookInfoManager:toggleSetting("show_pages_read_as_progress")
-                    self:refreshFileManagerInstance()
-                end,
-            },
-            {
-                text = _("Show number of pages left to read"),
-                checked_func = function() return BookInfoManager:getSetting("show_pages_left_in_progress") end,
-                callback = function()
-                    BookInfoManager:toggleSetting("show_pages_left_in_progress")
-                    self:refreshFileManagerInstance()
-                end,
-                separator = true,
             },
             {
                 text = _("Book info cache management"),

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -133,9 +133,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             return BookInfoManager:getSetting("unified_display_mode")
         end,
         callback = function()
-            local do_sync = not BookInfoManager:getSetting("unified_display_mode")
-            BookInfoManager:saveSetting("unified_display_mode", do_sync)
-            if do_sync then
+            if BookInfoManager:toggleSetting("unified_display_mode") then
                 self:setupHistoryDisplayMode(filemanager_display_mode)
                 self:setupCollectionDisplayMode(filemanager_display_mode)
             end
@@ -199,11 +197,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                         text = _("Show hint for books with description"),
                         checked_func = function() return not BookInfoManager:getSetting("no_hint_description") end,
                         callback = function()
-                            if BookInfoManager:getSetting("no_hint_description") then
-                                BookInfoManager:saveSetting("no_hint_description", false)
-                            else
-                                BookInfoManager:saveSetting("no_hint_description", true)
-                            end
+                            BookInfoManager:toggleSetting("no_hint_description")
                             self:refreshFileManagerInstance()
                         end,
                     },
@@ -211,11 +205,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                         text = _("Show hint for book status in history"),
                         checked_func = function() return BookInfoManager:getSetting("history_hint_opened") end,
                         callback = function()
-                            if BookInfoManager:getSetting("history_hint_opened") then
-                                BookInfoManager:saveSetting("history_hint_opened", false)
-                            else
-                                BookInfoManager:saveSetting("history_hint_opened", true)
-                            end
+                            BookInfoManager:toggleSetting("history_hint_opened")
                             self:refreshFileManagerInstance()
                         end,
                     },
@@ -223,11 +213,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                         text = _("Show hint for book status in favorites"),
                         checked_func = function() return BookInfoManager:getSetting("collections_hint_opened") end,
                         callback = function()
-                            if BookInfoManager:getSetting("collections_hint_opened") then
-                                BookInfoManager:saveSetting("collections_hint_opened", false)
-                            else
-                                BookInfoManager:saveSetting("collections_hint_opened", true)
-                            end
+                            BookInfoManager:toggleSetting("collections_hint_opened")
                             self:refreshFileManagerInstance()
                         end,
                     }
@@ -282,11 +268,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                 text = _("Show progress % in mosaic mode"),
                 checked_func = function() return BookInfoManager:getSetting("show_progress_in_mosaic") end,
                 callback = function()
-                    if BookInfoManager:getSetting("show_progress_in_mosaic") then
-                        BookInfoManager:saveSetting("show_progress_in_mosaic", false)
-                    else
-                        BookInfoManager:saveSetting("show_progress_in_mosaic", true)
-                    end
+                    BookInfoManager:toggleSetting("show_progress_in_mosaic")
                     self:refreshFileManagerInstance()
                 end,
             },
@@ -294,11 +276,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                 text = _("Show number of pages read instead of progress %"),
                 checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,
                 callback = function()
-                    if BookInfoManager:getSetting("show_pages_read_as_progress") then
-                        BookInfoManager:saveSetting("show_pages_read_as_progress", false)
-                    else
-                        BookInfoManager:saveSetting("show_pages_read_as_progress", true)
-                    end
+                    BookInfoManager:toggleSetting("show_pages_read_as_progress")
                     self:refreshFileManagerInstance()
                 end,
             },
@@ -306,11 +284,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                 text = _("Show number of pages left to read"),
                 checked_func = function() return BookInfoManager:getSetting("show_pages_left_in_progress") end,
                 callback = function()
-                    if BookInfoManager:getSetting("show_pages_left_in_progress") then
-                        BookInfoManager:saveSetting("show_pages_left_in_progress", false)
-                    else
-                        BookInfoManager:saveSetting("show_pages_left_in_progress", true)
-                    end
+                    BookInfoManager:toggleSetting("show_pages_left_in_progress")
                     self:refreshFileManagerInstance()
                 end,
                 separator = true,


### PR DESCRIPTION
Showing the page / progress info and the file size / type can now be disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10941)
<!-- Reviewable:end -->
