### PR TITLE
persist: fix API

### DIFF
--- a/frontend/dump.lua
+++ b/frontend/dump.lua
@@ -52,7 +52,7 @@ local function _serialize(what, outt, indent, max_lv, history, pairs_func)
     elseif datatype == "boolean" then
         insert(outt, tostring(what))
     elseif datatype == "function" then
-        insert(outt, tostring(what))
+        error("cannot dump functions")
     elseif datatype == "nil" then
         insert(outt, "nil")
     end

--- a/frontend/persist.lua
+++ b/frontend/persist.lua
@@ -29,15 +29,13 @@ local codecs = {
     -- bitser: binary format, fast encode/decode, low size. Not human readable.
     bitser = {
         id = "bitser",
-        reads_from_file = false,
-        writes_to_file = false,
 
         serialize = function(t)
             local ok, str = pcall(bitser.dumps, t)
             if not ok then
                 return nil, "cannot serialize " .. tostring(t) .. " (" .. str .. ")"
             end
-            return str
+            return str, #str
         end,
 
         deserialize = function(str)
@@ -52,15 +50,13 @@ local codecs = {
     --         Slightly larger on-disk representation than bitser, *much* faster to decode, slightly faster to encode.
     luajit = {
         id = "luajit",
-        reads_from_file = false,
-        writes_to_file = false,
 
         serialize = function(t)
             local ok, str = pcall(buffer.encode, t)
             if not ok then
                 return nil, "cannot serialize " .. tostring(t) .. " (" .. str .. ")"
             end
-            return str
+            return str, #str
         end,
 
         deserialize = function(str)
@@ -74,59 +70,22 @@ local codecs = {
     -- zstd: luajit, but compressed w/ zstd ;). Much smaller, at a very small performance cost (decompressing is *fast*).
     zstd = {
         id = "zstd",
-        reads_from_file = true,
-        writes_to_file = true,
 
-        serialize = function(t, as_bytecode, path)
+        serialize = function(t, as_bytecode)
             local ok, str = pcall(buffer.encode, t)
             if not ok then
                 return nil, "cannot serialize " .. tostring(t) .. " (" .. str .. ")"
             end
-            local f = C.fopen(path, "wb")
-            if f == nil then
-                return nil, "fopen: " .. ffi.string(C.strerror(ffi.errno()))
-            end
-            local cbuff, clen = zstd.zstd_compress(str, #str)
-            if C.fwrite(cbuff, 1, clen, f) < clen then
-                C.fclose(f)
-                C.free(cbuff)
-                return nil, "failed to write file"
-            end
-            C.fflush(f)
-            C.fsync(C.fileno(f))
-            C.fclose(f)
-            C.free(cbuff)
-            --- @note: Slight API extension for TileCacheItem, which needs to know the on-disk size, and saves us a :size() call
-            return true, clen
+            local buff, clen = zstd.zstd_compress(str, #str)
+            str = ffi.string(buff, clen)
+            C.free(buff)
+            return str, tonumber(clen)
         end,
 
-        deserialize = function(path)
-            local f = C.fopen(path, "rb")
-            if f == nil then
-                return nil, "fopen: " .. ffi.string(C.strerror(ffi.errno()))
-            end
-            local size = lfs.attributes(path, "size")
-            -- NOTE: In a perfect world, we'd just mmap the file.
-            --       But that's problematic on a portability level: while mmap is POSIX, implementations differ,
-            --       and some old platforms don't support mmap-on-vfat (Legacy Kindle) :'(.
-            local data = C.malloc(size)
-            if data == nil then
-                C.fclose(f)
-                return nil, "failed to allocate read buffer"
-            end
-            if C.fread(data, 1, size, f) < size or C.ferror(f) ~= 0 then
-                C.free(data)
-                C.fclose(f)
-                return nil, "failed to read file"
-            end
-            C.fclose(f)
-
-            local buff, ulen = zstd.zstd_uncompress(data, size)
-            C.free(data)
-
+        deserialize = function(data)
+            local buff, ulen = zstd.zstd_uncompress(data, #data)
             local str = ffi.string(buff, ulen)
             C.free(buff)
-
             local ok, t = pcall(buffer.decode, str)
             if not ok then
                 return nil, "malformed serialized data (" .. t .. ")"
@@ -137,30 +96,26 @@ local codecs = {
     -- dump: human readable, pretty printed, fast enough for most use cases.
     dump = {
         id = "dump",
-        reads_from_file = true,
-        writes_to_file = false,
 
         serialize = function(t, as_bytecode)
-            local content
+            local ok, d = pcall(dump, t)
+            if not ok then
+                return nil, d
+            end
+            d = "return " .. d
             if as_bytecode then
-                local bytecode, err = load("return " .. dump(t))
+                local bytecode, err = load("return " .. d)
                 if not bytecode then
                     logger.warn("cannot convert table to bytecode", err, "fallback to text")
                 else
-                    content = string.dump(bytecode, true)
+                    d = string.dump(bytecode, true)
                 end
             end
-            if not content then
-                content = "return " .. dump(t)
-            end
-            return content
+            return d, #d
         end,
 
         deserialize = function(str)
-            local t, err = loadfile(str)
-            if not t then
-                t, err = loadstring(str)
-            end
+            local t, err = loadstring(str)
             if not t then
                 return nil, err
             end
@@ -171,19 +126,17 @@ local codecs = {
     -- NOTE: if you want pretty printing, pass { sortkeys = true, compact = false, indent = "  " } to serpent's second arg.
     serpent = {
         id = "serpent",
-        reads_from_file = false,
-        writes_to_file = false,
 
         serialize = function(t)
             local ok, str = pcall(serpent.dump, t)
             if not ok then
                 return nil, "cannot serialize " .. tostring(t) .. " (" .. str .. ")"
             end
-            return str
+            return str, #str
         end,
 
         deserialize = function(str)
-            local ok, t = serpent.load(str)
+            local ok, t = serpent.load(str, {safe=false})
             if not ok then
                 return nil, "malformed serialized data (" .. t .. ")"
             end
@@ -219,54 +172,40 @@ function Persist:size()
 end
 
 function Persist:load()
-    local t, err
-    if codecs[self.codec].reads_from_file then
-        t, err = codecs[self.codec].deserialize(self.path)
-    else
-        local str
-        str, err = readFile(self.path)
-        if not str then
-            return nil, err
-        end
-        t, err = codecs[self.codec].deserialize(str)
+    local str, err
+    str, err = readFile(self.path)
+    if not str then
+        return nil, err
     end
+    local t
+    t, err = codecs[self.codec].deserialize(str)
     if not t then
         return nil, err
     end
-
     self.loaded = true
     return t
 end
 
 function Persist:save(t, as_bytecode)
     local ok, err
-    if codecs[self.codec].writes_to_file then
-        ok, err = codecs[self.codec].serialize(t, as_bytecode, self.path)
-        if not ok then
-            return nil, err
-        end
-    else
-        ok, err = codecs[self.codec].serialize(t, as_bytecode)
-        if not ok then
-            return nil, err
-        end
-        local file
-        file, err = io.open(self.path, "wb")
-        if not file then
-            return nil, err
-        end
-        file:write(ok)
-        ffiUtil.fsyncOpenedFile(file)
-        file:close()
+    ok, err = codecs[self.codec].serialize(t, as_bytecode)
+    if not ok then
+        return nil, err
     end
-
+    local file
+    file, err = io.open(self.path, "wb")
+    if not file then
+        return nil, err
+    end
+    file:write(ok)
+    ffiUtil.fsyncOpenedFile(file)
+    file:close()
     -- If we've just created the file, fsync the directory, too
     if not self.loaded then
         ffiUtil.fsyncDirectory(self.path)
         self.loaded = true
     end
-
-    -- c.f., note above, err is the on-disk size when writes_to_file is supported
+    -- note: err is the serialized size
     return true, err
 end
 


### PR DESCRIPTION
- consistency: all codecs' `serialize` implementations return a string (no more `writes_to_file`) and the length of the serialized data (for backward compatible use by the `TileCacheItem` code), and similarly `deserialize` always expect a string.
- fix `dump` codec: serializing functions is not supported
- fix `serpent` codec: correctly deserialize functions