### PR TITLE
Statistics: keep rows ordered during sync insert

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -3226,6 +3226,7 @@ function ReaderStatistics.onSync(local_path, cached_path, income_path)
             INNER JOIN book_id_map as map
             ON id_book = map.iid
             WHERE map.mid IS NOT null
+            ORDER BY start_time
         ON CONFLICT(id_book, page, start_time) DO UPDATE SET
         duration = MAX(duration, excluded.duration);
 


### PR DESCRIPTION
Honestly, I might be literally the only person who cares about this.

During the Statistics sync, if new rows are inserted then they're not added to the database in any particular order. That creates absolutely no problems for anything within KOReader itself.
But if you have more than one reader and you sync each of them at semi-regular intervals, then if you do a sqlite `.dump` of the databases and `diff` those text files, the lines are in scrambled order from each other.

So this PR has zero effect on any visible behavior within KOReader. It only helps weirdos like me doing obscure text processing on dumps of the statistics database :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10952)
<!-- Reviewable:end -->
