### PR TITLE
Finished books: freeze history timestamp and statistics

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -272,6 +272,15 @@ function FileManagerMenu:setUpdateItemTable()
                             G_reader_settings:flipNilOrFalse("history_datetime_short")
                             require("readhistory"):reload(true)
                         end,
+                    },
+                    {
+                        text = _("Preserve finished books timestamp"),
+                        checked_func = function()
+                            return G_reader_settings:isTrue("history_preserve_finished_books")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrFalse("history_preserve_finished_books")
+                        end,
                         separator = true,
                     },
                     {

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -274,12 +274,12 @@ function FileManagerMenu:setUpdateItemTable()
                         end,
                     },
                     {
-                        text = _("Preserve finished books timestamp"),
+                        text = _("Freeze last read date of finished books"),
                         checked_func = function()
-                            return G_reader_settings:isTrue("history_preserve_finished_books")
+                            return G_reader_settings:isTrue("history_freeze_finished_books")
                         end,
                         callback = function()
-                            G_reader_settings:flipNilOrFalse("history_preserve_finished_books")
+                            G_reader_settings:flipNilOrFalse("history_freeze_finished_books")
                         end,
                         separator = true,
                     },

--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -311,19 +311,9 @@ end
 ---- @string "YYYY-MM-DD HH:MM:SS", time may be absent
 ---- @treturn seconds
 function datetime.stringToSeconds(datetime_string)
-    if not datetime_string:match("%d+:%d+:%d+") then
-        datetime_string = datetime_string .. " 00:00:00"
-    end
-    local year, month, day, hour, min, sec = datetime_string:match("(%d+)-(%d+)-(%d+) (%d+):(%d+):(%d+)")
-    local dateTimeTable = {
-        year  = year,
-        month = month,
-        day   = day,
-        hour  = hour,
-        min   = min,
-        sec   = sec,
-    }
-    return os.time(dateTimeTable)
+    local year, month, day = datetime_string:match("(%d+)-(%d+)-(%d+)")
+    local hour, min, sec   = datetime_string:match("(%d+):(%d+):(%d+)")
+    return os.time({ year = year, month = month, day = day, hour = hour or 0, min = min or 0, sec = sec or 0 })
 end
 
 return datetime

--- a/frontend/datetime.lua
+++ b/frontend/datetime.lua
@@ -307,4 +307,23 @@ function datetime.secondsToDateTime(seconds, twelve_hour_clock, use_locale)
     return message_text
 end
 
+--- Converts a date+time string to seconds
+---- @string "YYYY-MM-DD HH:MM:SS", time may be absent
+---- @treturn seconds
+function datetime.stringToSeconds(datetime_string)
+    if not datetime_string:match("%d+:%d+:%d+") then
+        datetime_string = datetime_string .. " 00:00:00"
+    end
+    local year, month, day, hour, min, sec = datetime_string:match("(%d+)-(%d+)-(%d+) (%d+):(%d+):(%d+)")
+    local dateTimeTable = {
+        year  = year,
+        month = month,
+        day   = day,
+        hour  = hour,
+        min   = min,
+        sec   = sec,
+    }
+    return os.time(dateTimeTable)
+end
+
 return datetime

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -260,7 +260,7 @@ function ReadHistory:addItem(file, ts, no_flush)
             if ts and self.hist[index].time == ts then
                 return -- legacy item already added
             end
-            if not ts and G_reader_settings:isTrue("history_preserve_finished_books")
+            if not ts and G_reader_settings:isTrue("history_freeze_finished_books")
                       and filemanagerutil.getStatus(file) == "complete" then
                 return -- book marked as finished, do not update timestamps of item and file
             end

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -3,6 +3,7 @@ local DocSettings = require("docsettings")
 local datetime = require("datetime")
 local dump = require("dump")
 local ffiutil = require("ffi/util")
+local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local util = require("util")
 local joinPath = ffiutil.joinPath
 local lfs = require("libs/libkoreader-lfs")
@@ -255,8 +256,14 @@ end
 function ReadHistory:addItem(file, ts, no_flush)
     if file ~= nil and lfs.attributes(file, "mode") == "file" then
         local index = self:getIndexByFile(realpath(file))
-        if ts and index and self.hist[index].time == ts then
-            return -- this legacy item is in the history already
+        if index then -- book is in the history already
+            if ts and self.hist[index].time == ts then
+                return -- legacy item already added
+            end
+            if not ts and G_reader_settings:isTrue("history_preserve_finished_books")
+                      and filemanagerutil.getStatus(file) == "complete" then
+                return -- book marked as finished, do not update timestamps of item and file
+            end
         end
         local now = ts or os.time()
         local mtime = lfs.attributes(file, "modification")

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -92,10 +92,10 @@ ReaderStatistics.default_settings = {
 }
 
 function ReaderStatistics:onDispatcherRegisterActions()
-    Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), general=true, separator=false})
-    Dispatcher:registerAction("stats_calendar_day_view", {category="none", event="ShowCalendarDayView", title=_("Statistics today's timeline"), general=true, separator=true})
-    Dispatcher:registerAction("book_statistics", {category="none", event="ShowBookStats", title=_("Book statistics"), reader=true, separator=false})
-    Dispatcher:registerAction("stats_sync", {category="none", event="SyncBookStats", title=_("Synchronize book statistics"), reader=true, separator=true})
+    Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), general=true})
+    Dispatcher:registerAction("stats_calendar_day_view", {category="none", event="ShowCalendarDayView", title=_("Statistics today's timeline"), general=true})
+    Dispatcher:registerAction("stats_sync", {category="none", event="SyncBookStats", title=_("Synchronize book statistics"), general=true, separator=true})
+    Dispatcher:registerAction("book_statistics", {category="none", event="ShowBookStats", title=_("Book statistics"), reader=true})
 end
 
 function ReaderStatistics:init()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local BookStatusWidget = require("ui/widget/bookstatuswidget")
+local ButtonDialog = require("ui/widget/buttondialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -1296,7 +1297,7 @@ Time is in hours and minutes.]]),
                                 end
                             }
                             local type = server.type == "dropbox" and " (DropBox)" or " (WebDAV)"
-                            dialogue = require("ui/widget/buttondialogtitle"):new{
+                            dialogue = ButtonDialog:new{
                                 title = T(_("Cloud storage:\n%1\n\nFolder path:\n%2\n\nSet up the same cloud folder on each device to sync across your devices."),
                                              server.name.." "..type, SyncService.getReadablePath(server)),
                                 buttons = {


### PR DESCRIPTION
Separate settings for History and Statistics.
If enabled in History settings: after opening the finished book will not pop up in History, will not be saved as Last document, will not pop up in the file browser with Sort by last read date.
Doesn't depend on the way of opening (from FM, History, Collections, random book etc.).
Closes https://github.com/koreader/koreader/issues/10962.
EDIT: closes https://github.com/koreader/koreader/issues/10984.

![1](https://github.com/koreader/koreader/assets/62179190/88411fd8-7f44-42e7-befd-09df1dadbc46)

![2](https://github.com/koreader/koreader/assets/62179190/d1f72796-eb57-43d5-a1e0-59a7b8e9e42b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10968)
<!-- Reviewable:end -->
