### PR TITLE
Kobo: Deal with some more frontlight edge cases on devices with the AW99703 PWM controller

### DIFF
--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -360,6 +360,7 @@ function KoboPowerD:turnOffFrontlightHW(done_callback)
             self:_stopFrontlightRamp()
             -- NOTE: For devices with a ramp_off_delay, we only ramp if we start from > 2%,
             --       otherwise you just see a single delayed step (1%) or two stuttery ones (2%) ;).
+            --       FWIW, modern devices with a different PWM controller deal well with our 2% ramp.
             if self.device.frontlight_settings.ramp_off_delay > 0.0 and self.fl_intensity <= 2 then
                 UIManager:scheduleIn(self.device.frontlight_settings.ramp_delay, self._endRampDown, self, self.fl_min, done_callback)
             else

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -356,9 +356,18 @@ function KoboPowerD:turnOffFrontlightHW(done_callback)
     if UIManager then
         -- We've got nothing to do if we're already ramping down
         if not self.fl_ramp_down_running then
-            self:_stopFrontlightRamp()
-            self:turnOffFrontlightRamp(self.fl_intensity, self.fl_min, done_callback)
-            self.fl_ramp_down_running = true
+            -- NOTE: For devices with a ramp_off_delay, only ramp if we start from > 2%,
+            --       otherwise you just see a single delayed step (1%) or two stuttery ones (2%) ;).
+            if self.fl_intensity > 2 then
+                self:_stopFrontlightRamp()
+                self:turnOffFrontlightRamp(self.fl_intensity, self.fl_min, done_callback)
+                self.fl_ramp_down_running = true
+            else
+                self:setIntensityHW(self.fl_min)
+                if done_callback then
+                    done_callback()
+                end
+            end
         end
     else
         -- If UIManager is not initialized yet, just turn it off immediately
@@ -405,9 +414,17 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
     if UIManager then
         -- We've got nothing to do if we're already ramping up
         if not self.fl_ramp_up_running then
-            self:_stopFrontlightRamp()
-            self:turnOnFrontlightRamp(self.fl_min, self.fl_intensity, done_callback)
-            self.fl_ramp_up_running = true
+            -- Same as when ramping off
+            if self.fl_intensity > 2 then
+                self:_stopFrontlightRamp()
+                self:turnOnFrontlightRamp(self.fl_min, self.fl_intensity, done_callback)
+                self.fl_ramp_up_running = true
+            else
+                self:setIntensityHW(self.fl_intensity)
+                if done_callback then
+                    done_callback()
+                end
+            end
         end
     else
         -- If UIManager is not initialized yet, just turn it on immediately

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -360,7 +360,8 @@ function KoboPowerD:turnOffFrontlightHW(done_callback)
             self:_stopFrontlightRamp()
             -- NOTE: For devices with a ramp_off_delay, we only ramp if we start from > 2%,
             --       otherwise you just see a single delayed step (1%) or two stuttery ones (2%) ;).
-            --       FWIW, modern devices with a different PWM controller deal well with our 2% ramp.
+            -- FWIW, modern devices with a different PWM controller (i.e., with no controller-specific ramp_off_delay workarounds)
+            -- deal with our 2% ramp without stuttering.
             if self.device.frontlight_settings.ramp_off_delay > 0.0 and self.fl_intensity <= 2 then
                 UIManager:scheduleIn(self.device.frontlight_settings.ramp_delay, self._endRampDown, self, self.fl_min, done_callback)
             else


### PR DESCRIPTION
Namely, skip ramping when going to/from <= 2% frontlight, otherwise we just eat the delay for no good reason (1%), or it just stutters and looks bad (2%).

Fix #10970

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10971)
<!-- Reviewable:end -->
