### PR TITLE
Add new PocketBook devices PB-Basic Lux 4 (PB618)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -508,7 +508,7 @@ local PocketBook617 = PocketBook:extend{
 
 -- PocketBook Basic Lux 4 (618)
 local PocketBook618 = PocketBook:extend{
-    model = "PB618",
+    model = "PBBLux4",
     display_dpi = 212,
     isTouchDevice = yes,
     hasDPad = no,

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -506,6 +506,16 @@ local PocketBook617 = PocketBook:extend{
     hasNaturalLight = yes,
 }
 
+-- PocketBook Basic Lux 4 (618)
+local PocketBook618 = PocketBook:extend{
+    model = "PB618",
+    display_dpi = 212,
+    isTouchDevice = yes,
+    hasDPad = no,
+    hasFewKeys = yes,
+    hasFrontlight = yes,
+}
+
 -- PocketBook Touch (622)
 local PocketBook622 = PocketBook:extend{
     model = "PBTouch",
@@ -769,6 +779,8 @@ elseif codename == "PB616" or codename == "PB616W" or
     return PocketBook616
 elseif codename == "PB617" or codename == "PocketBook 617" then
     return PocketBook617
+elseif codename == "PB618" then
+    return PocketBook618
 elseif codename == "PocketBook 622" then
     return PocketBook622
 elseif codename == "PocketBook 623" then

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -510,10 +510,6 @@ local PocketBook617 = PocketBook:extend{
 local PocketBook618 = PocketBook:extend{
     model = "PBBLux4",
     display_dpi = 212,
-    isTouchDevice = yes,
-    hasDPad = no,
-    hasFewKeys = yes,
-    hasFrontlight = yes,
 }
 
 -- PocketBook Touch (622)


### PR DESCRIPTION
I now also own a PB-Basic Lux 4 (PB618) and KOReader runs excellently on it.
[crash.log](https://github.com/koreader/koreader/files/12840018/crash.log)

![IMG_20231008_090913_427](https://github.com/koreader/koreader/assets/84080014/7e399187-7913-4e6d-9350-e6b3fee8ebfa)

![IMG_20231008_090543_351](https://github.com/koreader/koreader/assets/84080014/c137b0ec-c5bf-4e6a-8a16-8f9693420133)

![IMG_20231008_090623_582](https://github.com/koreader/koreader/assets/84080014/d3f738bb-2b9b-4b6e-a869-23fe37318bad)

![IMG_20231008_090654_619](https://github.com/koreader/koreader/assets/84080014/da5bc18e-4de3-4617-b513-a05242a9c2ed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10987)
<!-- Reviewable:end -->
