### PR TITLE
TimeSync: Double-check that ntpd is busybox

### DIFF
--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -14,9 +14,13 @@ local ntp_cmd
 if os.execute("command -v ntpd >/dev/null") == 0 then
     -- Make sure it's actually busybox's implementation, as the syntax may otherwise differ...
     -- (Of particular note, Kobo ships busybox ntpd, but not ntpdate; and Kindle ships ntpdate and !busybox ntpd).
-    local sym = lfs.symlinkattributes("/usr/sbin/ntpd")
-    if sym and sym.mode == "link" and string.sub(sym.target, -7) == "busybox" then
-        ntp_cmd = "ntpd -q -n -p pool.ntp.org"
+    local path = os.getenv("PATH") or ""
+    for p in path:gmatch("([^:]+)") do
+        local sym = lfs.symlinkattributes(p .. "/ntpd")
+        if sym and sym.mode == "link" and string.sub(sym.target, -7) == "busybox" then
+            ntp_cmd = "ntpd -q -n -p pool.ntp.org"
+            break
+        end
     end
 end
 if not ntp_cmd and os.execute("command -v ntpdate >/dev/null") == 0 then

--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -12,8 +12,14 @@ end
 local ntp_cmd
 -- Check if we have access to ntpd or ntpdate
 if os.execute("command -v ntpd >/dev/null") == 0 then
-    ntp_cmd = "ntpd -q -n -p pool.ntp.org"
-elseif os.execute("command -v ntpdate >/dev/null") == 0 then
+    -- Make sure it's actually busybox's implementation, as the syntax may otherwise differ...
+    -- (Of particular note, Kobo ships busybox ntpd, but not ntpdate; and Kindle ships ntpdate and !busybox ntpd).
+    local sym = lfs.symlinkattributes("/usr/sbin/ntpd")
+    if sym and sym.mode == "link" and string.sub(sym.target, -7) == "busybox" then
+        ntp_cmd = "ntpd -q -n -p pool.ntp.org"
+    end
+end
+if not ntp_cmd and os.execute("command -v ntpdate >/dev/null") == 0 then
     ntp_cmd = "ntpdate pool.ntp.org"
 end
 if not ntp_cmd then


### PR DESCRIPTION
Kindle ships another implementation, with incompatible syntax...

Regression since #10935
Thanks to @yparitcher ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10992)
<!-- Reviewable:end -->
