### PR TITLE
File search, FileChooser and others

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -36,10 +36,6 @@ DCREREADER_VIEW_MODE = "page",
 -- default to false
 DSHOWOVERLAP = false,
 
--- show hidden files in filemanager
--- default to false
-DSHOWHIDDENFILES = false,
-
 -- landscape clockwise rotation
 -- default to true, set to false for counterclockwise rotation
 DLANDSCAPE_CLOCKWISE_ROTATION = true,

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -65,6 +65,9 @@ function FileManagerHistory:updateItemTable()
     local item_table = {}
     for _, v in ipairs(require("readhistory").hist) do
         if self.filter == "all" or v.status == self.filter then
+            if self.is_frozen and v.status == "complete" then
+                v.mandatory_dim = true
+            end
             table.insert(item_table, v)
         end
         if self.statuses_fetched then
@@ -190,7 +193,8 @@ function FileManagerHistory:onShowHist()
     }
 
     self.filter = G_reader_settings:readSetting("history_filter", "all")
-    if self.filter ~= "all" then
+    self.is_frozen = G_reader_settings:isTrue("history_freeze_finished_books")
+    if self.filter ~= "all" or self.is_frozen then
         self:fetchStatuses(false)
     end
     self:updateItemTable()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -143,6 +143,7 @@ function FileManagerMenu:onOpenLastDoc()
 end
 
 function FileManagerMenu:setUpdateItemTable()
+    local FileChooser = self.ui.file_chooser
 
     -- setting tab
     self.menu_items.filebrowser_settings = {
@@ -150,18 +151,18 @@ function FileManagerMenu:setUpdateItemTable()
         sub_item_table = {
             {
                 text = _("Show finished books"),
-                checked_func = function() return self.ui.file_chooser.show_finished end,
-                callback = function() self.ui:toggleFinishedBooks() end,
+                checked_func = function() return FileChooser.show_finished end,
+                callback = function() FileChooser:toggleShowFilesMode("show_finished") end,
             },
             {
                 text = _("Show hidden files"),
-                checked_func = function() return self.ui.file_chooser.show_hidden end,
-                callback = function() self.ui:toggleHiddenFiles() end,
+                checked_func = function() return FileChooser.show_hidden end,
+                callback = function() FileChooser:toggleShowFilesMode("show_hidden") end,
             },
             {
                 text = _("Show unsupported files"),
-                checked_func = function() return self.ui.file_chooser.show_unsupported end,
-                callback = function() self.ui:toggleUnsupportedFiles() end,
+                checked_func = function() return FileChooser.show_unsupported end,
+                callback = function() FileChooser:toggleShowFilesMode("show_unsupported") end,
                 separator = true,
             },
             {
@@ -439,7 +440,7 @@ To:
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("reverse_collate")
-            self.ui.file_chooser:refreshPath()
+            FileChooser:refreshPath()
         end,
     }
     self.menu_items.sort_mixed = {
@@ -461,7 +462,7 @@ To:
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("collate_mixed")
-            self.ui.file_chooser:refreshPath()
+            FileChooser:refreshPath()
         end,
     }
     self.menu_items.start_with = self:getStartWithMenuTable()

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -54,43 +54,45 @@ local settingsList = {
     history = {category="none", event="ShowHist", title=_("History"), general=true},
     favorites = {category="none", event="ShowColl", arg="favorites", title=_("Favorites"), general=true},
     filemanager = {category="none", event="Home", title=_("File browser"), general=true, separator=true},
-
+    --
     dictionary_lookup = {category="none", event="ShowDictionaryLookup", title=_("Dictionary lookup"), general=true},
-    wikipedia_lookup = {category="none", event="ShowWikipediaLookup", title=_("Wikipedia lookup"), general=true},
-    fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), general=true},
-    file_search = {category="none", event="ShowFileSearch", title=_("File search"), general=true, separator=true},
-
+    wikipedia_lookup = {category="none", event="ShowWikipediaLookup", title=_("Wikipedia lookup"), general=true, separator=true},
+    --
     show_menu = {category="none", event="ShowMenu", title=_("Show menu"), general=true},
     menu_search = {category="none", event="MenuSearch", title=_("Menu search"), general=true},
     screenshot = {category="none", event="Screenshot", title=_("Screenshot"), general=true, separator=true},
+    --
 
-    -- Device settings
+    -- Device
     exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit screensaver"), device=true},
     suspend = {category="none", event="RequestSuspend", title=_("Suspend"), device=true, condition=Device:canSuspend()},
-    exit = {category="none", event="Exit", title=_("Exit KOReader"), device=true},
     restart = {category="none", event="Restart", title=_("Restart KOReader"), device=true, condition=Device:canRestart()},
     reboot = {category="none", event="RequestReboot", title=_("Reboot the device"), device=true, condition=Device:canReboot()},
-    poweroff = {category="none", event="RequestPowerOff", title=_("Power off"), device=true, condition=Device:canPowerOff(), separator=true},
-
+    poweroff = {category="none", event="RequestPowerOff", title=_("Power off"), device=true, condition=Device:canPowerOff()},
+    exit = {category="none", event="Exit", title=_("Exit KOReader"), device=true, separator=true},
+    --
     toggle_hold_corners = {category="none", event="IgnoreHoldCorners", title=_("Toggle hold corners"), device=true},
     touch_input_on = {category="none", event="IgnoreTouchInput", arg=false, title=_("Enable touch input"), device=true},
     touch_input_off = {category="none", event="IgnoreTouchInput", arg=true, title=_("Disable touch input"), device=true},
     toggle_touch_input = {category="none", event="IgnoreTouchInput", title=_("Toggle touch input"), device=true, separator=true},
+    --
     swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
+    --
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
     iterate_rotation = {category="none", event="IterateRotation", title=_("Rotate by 90° CW"), device=true},
     iterate_rotation_ccw = {category="none", event="IterateRotation", arg=true, title=_("Rotate by 90° CCW"), device=true, separator=true},
-
+    --
     wifi_on = {category="none", event="InfoWifiOn", title=_("Turn on Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     wifi_off = {category="none", event="InfoWifiOff", title=_("Turn off Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     toggle_fullscreen = {category="none", event="ToggleFullscreen", title=_("Toggle Fullscreen"), device=true, condition=not Device:isAlwaysFullscreen()},
     show_network_info = {category="none", event="ShowNetworkInfo", title=_("Show network info"), device=true, separator=true},
+    --
 
-    -- Screen & Lights
+    -- Screen and lights
     show_frontlight_dialog = {category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), screen=true, condition=Device:hasFrontlight()},
     toggle_frontlight = {category="none", event="ToggleFrontlight", title=_("Toggle frontlight"), screen=true, condition=Device:hasFrontlight()},
     set_frontlight = {category="absolutenumber", event="SetFlIntensity", min=0, max=Device:getPowerDevice().fl_max, title=_("Set frontlight brightness"), screen=true, condition=Device:hasFrontlight()},
@@ -99,9 +101,9 @@ local settingsList = {
     set_frontlight_warmth = {category="absolutenumber", event="SetFlWarmth", min=0, max=100, title=_("Set frontlight warmth"), screen=true, condition=Device:hasNaturalLight()},
     increase_frontlight_warmth = {category="incrementalnumber", event="IncreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Increase frontlight warmth"), screen=true, condition=Device:hasNaturalLight()},
     decrease_frontlight_warmth = {category="incrementalnumber", event="DecreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Decrease frontlight warmth"), screen=true, condition=Device:hasNaturalLight(), separator=true},
-
     night_mode = {category="none", event="ToggleNightMode", title=_("Toggle night mode"), screen=true},
     set_night_mode = {category="string", event="SetNightMode", title=_("Set night mode"), screen=true, args={true, false}, toggle={_("on"), _("off")}, separator=true},
+    --
     full_refresh = {category="none", event="FullRefresh", title=_("Full screen refresh"), screen=true},
     set_refresh_rate = {category="absolutenumber", event="SetBothRefreshRates", min=-1, max=200, title=_("Full refresh rate (always)"), screen=true, condition=Device:hasEinkScreen()},
     set_day_refresh_rate = {category="absolutenumber", event="SetDayRefreshRate", min=-1, max=200, title=_("Full refresh rate (not in night mode)"), screen=true, condition=Device:hasEinkScreen()},
@@ -109,23 +111,28 @@ local settingsList = {
     set_flash_on_chapter_boundaries = {category="string", event="SetFlashOnChapterBoundaries", title=_("Always flash on chapter boundaries"), screen=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("on"), _("off")}},
     toggle_flash_on_chapter_boundaries = {category="none", event="ToggleFlashOnChapterBoundaries", title=_("Toggle flashing on chapter boundaries"), screen=true, condition=Device:hasEinkScreen()},
     set_no_flash_on_second_chapter_page = {category="string", event="SetNoFlashOnSecondChapterPage", title=_("Never flash on chapter's 2nd page"), screen=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("on"), _("off")}},
-    toggle_no_flash_on_second_chapter_page = {category="none", event="ToggleNoFlashOnSecondChapterPage", title=_("Toggle flashing on chapter's 2nd page"), screen=true, condition=Device:hasEinkScreen(), separator=true},
+    toggle_no_flash_on_second_chapter_page = {category="none", event="ToggleNoFlashOnSecondChapterPage", title=_("Toggle flashing on chapter's 2nd page"), screen=true, condition=Device:hasEinkScreen()},
     set_flash_on_pages_with_images = {category="string", event="SetFlashOnPagesWithImages", title=_("Always flash on pages with images"), screen=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("on"), _("off")}},
-    toggle_flash_on_pages_with_images = {category="none", event="ToggleFlashOnPagesWithImages", title=_("Toggle flashing on pages with images"), screen=true, condition=Device:hasEinkScreen()},
+    toggle_flash_on_pages_with_images = {category="none", event="ToggleFlashOnPagesWithImages", title=_("Toggle flashing on pages with images"), screen=true, condition=Device:hasEinkScreen(), separator=true},
+    --
 
-    -- filemanager settings
+    -- File browser
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
     show_plus_menu = {category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true},
     toggle_select_mode = {category="none", event="ToggleSelectMode", title=_("Toggle select mode"), filemanager=true},
     refresh_content = {category="none", event="RefreshContent", title=_("Refresh content"), filemanager=true},
-    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, separator=true},
+    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true},
+    file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true, separator=true},
+    --
+    -- go_to
+    -- back
 
-    -- reader settings
+    -- Reader
     open_next_document_in_folder = {category="none", event="OpenNextDocumentInFolder", title=_("Open next document in folder"), reader=true, separator=true},
-
+    --
     show_config_menu = {category="none", event="ShowConfigMenu", title=_("Show bottom menu"), reader=true},
     toggle_status_bar = {category="none", event="ToggleFooterMode", title=_("Toggle status bar"), reader=true, separator=true},
-
+    --
     prev_chapter = {category="none", event="GotoPrevChapter", title=_("Previous chapter"), reader=true},
     next_chapter = {category="none", event="GotoNextChapter", title=_("Next chapter"), reader=true},
     first_page = {category="none", event="GoToBeginning", title=_("First page"), reader=true},
@@ -138,6 +145,7 @@ local settingsList = {
     first_bookmark = {category="none", event="GotoFirstBookmark", title=_("First bookmark"), reader=true},
     last_bookmark = {category="none", event="GotoLastBookmark", title=_("Last bookmark"), reader=true},
     latest_bookmark = {category="none", event="GoToLatestBookmark", title=_("Latest bookmark"), reader=true, separator=true},
+    --
     back = {category="none", event="Back", title=_("Back"), filemanager=true, reader=true},
     previous_location = {category="none", event="GoBackLink", arg=true, title=_("Back to previous location"), reader=true},
     next_location = {category="none", event="GoForwardLink", arg=true, title=_("Forward to next location"), reader=true},
@@ -145,72 +153,77 @@ local settingsList = {
     follow_nearest_internal_link = {category="arg", event="GoToInternalPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest internal link"), reader=true},
     add_location_to_history = {category="none", event="AddCurrentLocationToStack", arg=true, title=_("Add current location to history"), reader=true},
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
-
+    --
+    fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), reader=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     book_map = {category="none", event="ShowBookMap", title=_("Book map"), reader=true, condition=Device:isTouchDevice()},
     book_map_overview = {category="none", event="ShowBookMap", arg=true, title=_("Book map (overview)"), reader=true, condition=Device:isTouchDevice()},
     page_browser = {category="none", event="ShowPageBrowser", title=_("Page browser"), reader=true, condition=Device:isTouchDevice()},
     bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), reader=true},
-    bookmark_search = {category="none", event="SearchBookmark", title=_("Bookmark search"), reader=true, separator=true},
-
+    bookmark_search = {category="none", event="SearchBookmark", title=_("Bookmark search"), reader=true},
+    toggle_bookmark = {category="none", event="ToggleBookmark", title=_("Toggle bookmark"), reader=true, separator=true},
+    --
     book_status = {category="none", event="ShowBookStatus", title=_("Book status"), reader=true},
     book_info = {category="none", event="ShowBookInfo", title=_("Book information"), reader=true},
     book_description = {category="none", event="ShowBookDescription", title=_("Book description"), reader=true},
     book_cover = {category="none", event="ShowBookCover", title=_("Book cover"), reader=true, separator=true},
-
+    --
     translate_page = {category="none", event="TranslateCurrentPage", title=_("Translate current page"), reader=true, separator=true},
+    --
+    toggle_page_change_animation = {category="none", event="TogglePageChangeAnimation", title=_("Toggle page turn animations"), reader=true, condition=Device:canDoSwipeAnimation()},
+    toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), reader=true},
+    toggle_handmade_toc = {category="none", event="ToggleHandmadeToc", title=_("Toggle custom TOC"), reader=true},
+    toggle_handmade_flows = {category="none", event="ToggleHandmadeFlows", title=_("Toggle custom hidden flows"), reader=true, separator=true},
+    --
+    set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args_func=ReaderHighlight.getHighlightActions, reader=true},
+    cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
+    cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true, separator=true},
+    --
+    flush_settings = {category="none", event="FlushSettings", arg=true, title=_("Save book metadata"), reader=true, separator=true},
+    --
 
-    -- rolling reader settings
+    -- Reflowable documents
     set_font = {category="string", event="SetFont", title=_("Set font"), rolling=true, args_func=require("fontlist").getFontArgFunc,},
     increase_font = {category="incrementalnumber", event="IncreaseFontSize", min=0.5, max=255, step=0.5, title=_("Increase font size"), rolling=true},
     decrease_font = {category="incrementalnumber", event="DecreaseFontSize", min=0.5, max=255, step=0.5, title=_("Decrease font size"), rolling=true},
-    --
 
-    toggle_bookmark = {category="none", event="ToggleBookmark", title=_("Toggle bookmark"), reader=true},
-    toggle_page_change_animation = {category="none", event="TogglePageChangeAnimation", title=_("Toggle page turn animations"), reader=true, condition=Device:canDoSwipeAnimation()},
-
-    -- paging reader settings
+    -- Page layout documents
     toggle_page_flipping = {category="none", event="TogglePageFlipping", title=_("Toggle page flipping"), paging=true},
     toggle_bookmark_flipping = {category="none", event="ToggleBookmarkFlipping", title=_("Toggle bookmark flipping"), paging=true},
     toggle_reflow = {category="none", event="ToggleReflow", title=_("Toggle reflow"), paging=true},
     zoom = {category="string", event="SetZoomMode", title=_("Zoom mode"), args_func=ReaderZooming.getZoomModeActions, paging=true},
     zoom_factor_change = {category="none", event="ZoomFactorChange", title=_("Change zoom factor"), paging=true, separator=true},
     --
-
-    toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), reader=true},
-    toggle_handmade_toc = {category="none", event="ToggleHandmadeToc", title=_("Toggle custom TOC"), reader=true},
-    toggle_handmade_flows = {category="none", event="ToggleHandmadeFlows", title=_("Toggle custom hidden flows"), reader=true, separator=true},
-
-    set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args_func=ReaderHighlight.getHighlightActions, reader=true},
-    cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
-    cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true, separator=true},
-    flush_settings = {category="none", event="FlushSettings", arg=true, title=_("Save book metadata"), reader=true, separator=true},
     panel_zoom_toggle = {category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), paging=true, separator=true},
+    --
 
     -- parsed from CreOptions
-    -- the rest of the table elements are built from their counterparts in CreOptions
     rotation_mode = {category="string", device=true},
+    font_size = {category="absolutenumber", title=_("Set font size"), rolling=true, step=0.5},
+    word_spacing = {category="string", rolling=true},
+    word_expansion = {category="string", rolling=true},
+    font_gamma = {category="string", rolling=true},
+    font_base_weight = {category="string", rolling=true},
+    font_hinting = {category="string", rolling=true},
+    font_kerning = {category="string", rolling=true, separator=true},
+    --
     visible_pages = {category="string", rolling=true, separator=true},
+    --
     h_page_margins = {category="string", rolling=true},
     sync_t_b_page_margins = {category="string", rolling=true},
     t_page_margin = {category="absolutenumber", rolling=true},
     b_page_margin = {category="absolutenumber", rolling=true, separator=true},
+    --
     view_mode = {category="string", rolling=true},
     block_rendering_mode = {category="string", rolling=true},
     render_dpi = {category="string", title=_("Zoom"), rolling=true},
     line_spacing = {category="absolutenumber", rolling=true, separator=true},
-    font_size = {category="absolutenumber", title=_("Set font size"), rolling=true, step=0.5},
-    font_base_weight = {category="string", rolling=true},
-    word_spacing = {category="string", rolling=true},
-    word_expansion = {category="string", rolling=true},
-    font_gamma = {category="string", rolling=true},
-    font_hinting = {category="string", rolling=true},
-    font_kerning = {category="string", rolling=true, separator=true},
+    --
     status_line = {category="string", rolling=true},
     embedded_css = {category="string", rolling=true},
     embedded_fonts = {category="string", rolling=true},
     smooth_scaling = {category="string", rolling=true},
-    nightmode_images = {category="string", rolling=true, separator=true},
+    nightmode_images = {category="string", rolling=true},
 
     -- parsed from KoptOptions
     kopt_trim_page = {category="string", paging=true},
@@ -218,7 +231,7 @@ local settingsList = {
     kopt_zoom_overlap_h = {category="absolutenumber", paging=true},
     kopt_zoom_overlap_v = {category="absolutenumber", paging=true},
     kopt_zoom_mode_type = {category="string", paging=true},
-    kopt_zoom_range_number = {category="string", paging=true},
+    -- kopt_zoom_range_number = {category="string", paging=true},
     kopt_zoom_factor = {category="string", paging=true},
     kopt_zoom_mode_genus = {category="string", paging=true},
     kopt_zoom_direction = {category="string", paging=true},
@@ -249,34 +262,36 @@ local settingsList = {
 
 -- array for item order in menu
 local dispatcher_menu_order = {
-    -- device
+    -- General
     "reading_progress",
     "open_previous_document",
     "history",
     "favorites",
     "filemanager",
-
+    --
     "dictionary_lookup",
     "wikipedia_lookup",
-    "fulltext_search",
-    "file_search",
-
+    --
     "show_menu",
     "menu_search",
     "screenshot",
+    --
 
+    -- Device
     "exit_screensaver",
     "suspend",
-    "exit",
     "restart",
     "reboot",
     "poweroff",
-
+    "exit",
+    --
     "toggle_hold_corners",
     "touch_input_on",
     "touch_input_off",
     "toggle_touch_input",
+    --
     "swap_page_turn_buttons",
+    --
     "toggle_key_repeat",
     "toggle_gsensor",
     "rotation_mode",
@@ -284,13 +299,15 @@ local dispatcher_menu_order = {
     "invert_rotation",
     "iterate_rotation",
     "iterate_rotation_ccw",
-
+    --
     "wifi_on",
     "wifi_off",
     "toggle_wifi",
     "toggle_fullscreen",
     "show_network_info",
+    --
 
+    -- Screen and lights
     "show_frontlight_dialog",
     "toggle_frontlight",
     "set_frontlight",
@@ -299,10 +316,9 @@ local dispatcher_menu_order = {
     "set_frontlight_warmth",
     "increase_frontlight_warmth",
     "decrease_frontlight_warmth",
-
     "night_mode",
     "set_night_mode",
-
+    --
     "full_refresh",
     "set_refresh_rate",
     "set_day_refresh_rate",
@@ -313,20 +329,25 @@ local dispatcher_menu_order = {
     "toggle_no_flash_on_second_chapter_page",
     "set_flash_on_pages_with_images",
     "toggle_flash_on_pages_with_images",
+    --
 
-    -- filemanager
+    -- File browser
     "folder_up",
     "show_plus_menu",
     "toggle_select_mode",
     "refresh_content",
     "folder_shortcuts",
+    "file_search",
+    --
+    -- "go_to"
+    -- "back"
 
-    -- reader
+    -- Reader
     "open_next_document_in_folder",
-
+    --
     "show_config_menu",
     "toggle_status_bar",
-
+    --
     "prev_chapter",
     "next_chapter",
     "first_page",
@@ -339,6 +360,7 @@ local dispatcher_menu_order = {
     "first_bookmark",
     "last_bookmark",
     "latest_bookmark",
+    --
     "back",
     "previous_location",
     "next_location",
@@ -346,21 +368,36 @@ local dispatcher_menu_order = {
     "follow_nearest_internal_link",
     "add_location_to_history",
     "clear_location_history",
-
+    --
+    "fulltext_search",
     "toc",
     "book_map",
     "book_map_overview",
     "page_browser",
     "bookmarks",
     "bookmark_search",
-
+    "toggle_bookmark",
+    --
     "book_status",
     "book_info",
     "book_description",
     "book_cover",
-
+    --
     "translate_page",
+    --
+    "toggle_page_change_animation",
+    "toggle_inverse_reading_order",
+    "toggle_handmade_toc",
+    "toggle_handmade_flows",
+    --
+    "set_highlight_action",
+    "cycle_highlight_action",
+    "cycle_highlight_style",
+    --
+    "flush_settings",
+    --
 
+    -- Reflowable documents
     "set_font",
     "increase_font",
     "decrease_font",
@@ -371,44 +408,37 @@ local dispatcher_menu_order = {
     "font_base_weight",
     "font_hinting",
     "font_kerning",
-
-    "toggle_bookmark",
-    "toggle_page_change_animation",
-    "toggle_page_flipping",
-    "toggle_bookmark_flipping",
-    "toggle_reflow",
-    "toggle_inverse_reading_order",
-    "toggle_handmade_toc",
-    "toggle_handmade_flows",
-    "zoom",
-    "zoom_factor_change",
-    "set_highlight_action",
-    "cycle_highlight_action",
-    "cycle_highlight_style",
-    "flush_settings",
-    "panel_zoom_toggle",
-
+    --
     "visible_pages",
-
+    --
     "h_page_margins",
     "sync_t_b_page_margins",
     "t_page_margin",
     "b_page_margin",
-
+    --
     "view_mode",
     "block_rendering_mode",
     "render_dpi",
     "line_spacing",
-
+    --
     "status_line",
     "embedded_css",
     "embedded_fonts",
     "smooth_scaling",
     "nightmode_images",
+    --
 
+    -- Fixed layout documents
+    "toggle_page_flipping",
+    "toggle_bookmark_flipping",
+    "toggle_reflow",
+    "zoom",
+    "zoom_factor_change",
+    --
+    "panel_zoom_toggle",
+    --
     "kopt_trim_page",
     "kopt_page_margin",
-
     "kopt_zoom_overlap_h",
     "kopt_zoom_overlap_v",
     "kopt_zoom_mode_type",
@@ -416,24 +446,20 @@ local dispatcher_menu_order = {
     "kopt_zoom_factor",
     "kopt_zoom_mode_genus",
     "kopt_zoom_direction",
-
     "kopt_page_scroll",
     "kopt_page_gap_height",
     "kopt_full_screen",
     "kopt_line_spacing",
     "kopt_justification",
-
     "kopt_font_size",
     "kopt_font_fine_tune",
     "kopt_word_spacing",
     "kopt_text_wrap",
-
     "kopt_contrast",
     "kopt_page_opt",
     "kopt_hw_dithering",
     "kopt_sw_dithering",
     "kopt_quality",
-
     "kopt_doc_language",
     "kopt_forced_ocr",
     "kopt_writing_direction",
@@ -996,12 +1022,13 @@ end
 function Dispatcher:isActionEnabled(action)
     local disabled = true
     if action and (action.condition == nil or action.condition == true) then
+        local for_fm_only = action["filemanager"] and not action["reader"]
         local ui = require("apps/reader/readerui").instance
         local context = ui and (ui.paging and "paging" or "rolling")
         if context == "paging" then
-            disabled = action["rolling"]
+            disabled = action["rolling"] or for_fm_only
         elseif context == "rolling" then
-            disabled = action["paging"]
+            disabled = action["paging"] or for_fm_only
         else -- FM
             disabled = (action["reader"] or action["rolling"] or action["paging"]) and not action["filemanager"]
         end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -54,14 +54,14 @@ local settingsList = {
     history = {category="none", event="ShowHist", title=_("History"), general=true},
     favorites = {category="none", event="ShowColl", arg="favorites", title=_("Favorites"), general=true},
     filemanager = {category="none", event="Home", title=_("File browser"), general=true, separator=true},
-    --
+    ----
     dictionary_lookup = {category="none", event="ShowDictionaryLookup", title=_("Dictionary lookup"), general=true},
     wikipedia_lookup = {category="none", event="ShowWikipediaLookup", title=_("Wikipedia lookup"), general=true, separator=true},
-    --
+    ----
     show_menu = {category="none", event="ShowMenu", title=_("Show menu"), general=true},
     menu_search = {category="none", event="MenuSearch", title=_("Menu search"), general=true},
     screenshot = {category="none", event="Screenshot", title=_("Screenshot"), general=true, separator=true},
-    --
+    ----
 
     -- Device
     exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit screensaver"), device=true},
@@ -70,27 +70,27 @@ local settingsList = {
     reboot = {category="none", event="RequestReboot", title=_("Reboot the device"), device=true, condition=Device:canReboot()},
     poweroff = {category="none", event="RequestPowerOff", title=_("Power off"), device=true, condition=Device:canPowerOff()},
     exit = {category="none", event="Exit", title=_("Exit KOReader"), device=true, separator=true},
-    --
+    ----
     toggle_hold_corners = {category="none", event="IgnoreHoldCorners", title=_("Toggle hold corners"), device=true},
     touch_input_on = {category="none", event="IgnoreTouchInput", arg=false, title=_("Enable touch input"), device=true},
     touch_input_off = {category="none", event="IgnoreTouchInput", arg=true, title=_("Disable touch input"), device=true},
     toggle_touch_input = {category="none", event="IgnoreTouchInput", title=_("Toggle touch input"), device=true, separator=true},
-    --
+    ----
     swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
-    --
+    ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
     iterate_rotation = {category="none", event="IterateRotation", title=_("Rotate by 90° CW"), device=true},
     iterate_rotation_ccw = {category="none", event="IterateRotation", arg=true, title=_("Rotate by 90° CCW"), device=true, separator=true},
-    --
+    ----
     wifi_on = {category="none", event="InfoWifiOn", title=_("Turn on Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     wifi_off = {category="none", event="InfoWifiOff", title=_("Turn off Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     toggle_wifi = {category="none", event="ToggleWifi", title=_("Toggle Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     toggle_fullscreen = {category="none", event="ToggleFullscreen", title=_("Toggle Fullscreen"), device=true, condition=not Device:isAlwaysFullscreen()},
     show_network_info = {category="none", event="ShowNetworkInfo", title=_("Show network info"), device=true, separator=true},
-    --
+    ----
 
     -- Screen and lights
     show_frontlight_dialog = {category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), screen=true, condition=Device:hasFrontlight()},
@@ -103,7 +103,7 @@ local settingsList = {
     decrease_frontlight_warmth = {category="incrementalnumber", event="DecreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Decrease frontlight warmth"), screen=true, condition=Device:hasNaturalLight(), separator=true},
     night_mode = {category="none", event="ToggleNightMode", title=_("Toggle night mode"), screen=true},
     set_night_mode = {category="string", event="SetNightMode", title=_("Set night mode"), screen=true, args={true, false}, toggle={_("on"), _("off")}, separator=true},
-    --
+    ----
     full_refresh = {category="none", event="FullRefresh", title=_("Full screen refresh"), screen=true},
     set_refresh_rate = {category="absolutenumber", event="SetBothRefreshRates", min=-1, max=200, title=_("Full refresh rate (always)"), screen=true, condition=Device:hasEinkScreen()},
     set_day_refresh_rate = {category="absolutenumber", event="SetDayRefreshRate", min=-1, max=200, title=_("Full refresh rate (not in night mode)"), screen=true, condition=Device:hasEinkScreen()},
@@ -114,7 +114,7 @@ local settingsList = {
     toggle_no_flash_on_second_chapter_page = {category="none", event="ToggleNoFlashOnSecondChapterPage", title=_("Toggle flashing on chapter's 2nd page"), screen=true, condition=Device:hasEinkScreen()},
     set_flash_on_pages_with_images = {category="string", event="SetFlashOnPagesWithImages", title=_("Always flash on pages with images"), screen=true, condition=Device:hasEinkScreen(), args={true, false}, toggle={_("on"), _("off")}},
     toggle_flash_on_pages_with_images = {category="none", event="ToggleFlashOnPagesWithImages", title=_("Toggle flashing on pages with images"), screen=true, condition=Device:hasEinkScreen(), separator=true},
-    --
+    ----
 
     -- File browser
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
@@ -123,16 +123,16 @@ local settingsList = {
     refresh_content = {category="none", event="RefreshContent", title=_("Refresh content"), filemanager=true},
     folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true},
     file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true, separator=true},
-    --
+    ----
     -- go_to
     -- back
 
     -- Reader
     open_next_document_in_folder = {category="none", event="OpenNextDocumentInFolder", title=_("Open next document in folder"), reader=true, separator=true},
-    --
+    ----
     show_config_menu = {category="none", event="ShowConfigMenu", title=_("Show bottom menu"), reader=true},
     toggle_status_bar = {category="none", event="ToggleFooterMode", title=_("Toggle status bar"), reader=true, separator=true},
-    --
+    ----
     prev_chapter = {category="none", event="GotoPrevChapter", title=_("Previous chapter"), reader=true},
     next_chapter = {category="none", event="GotoNextChapter", title=_("Next chapter"), reader=true},
     first_page = {category="none", event="GoToBeginning", title=_("First page"), reader=true},
@@ -145,7 +145,7 @@ local settingsList = {
     first_bookmark = {category="none", event="GotoFirstBookmark", title=_("First bookmark"), reader=true},
     last_bookmark = {category="none", event="GotoLastBookmark", title=_("Last bookmark"), reader=true},
     latest_bookmark = {category="none", event="GoToLatestBookmark", title=_("Latest bookmark"), reader=true, separator=true},
-    --
+    ----
     back = {category="none", event="Back", title=_("Back"), filemanager=true, reader=true},
     previous_location = {category="none", event="GoBackLink", arg=true, title=_("Back to previous location"), reader=true},
     next_location = {category="none", event="GoForwardLink", arg=true, title=_("Forward to next location"), reader=true},
@@ -153,7 +153,7 @@ local settingsList = {
     follow_nearest_internal_link = {category="arg", event="GoToInternalPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest internal link"), reader=true},
     add_location_to_history = {category="none", event="AddCurrentLocationToStack", arg=true, title=_("Add current location to history"), reader=true},
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
-    --
+    ----
     fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), reader=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     book_map = {category="none", event="ShowBookMap", title=_("Book map"), reader=true, condition=Device:isTouchDevice()},
@@ -162,25 +162,25 @@ local settingsList = {
     bookmarks = {category="none", event="ShowBookmark", title=_("Bookmarks"), reader=true},
     bookmark_search = {category="none", event="SearchBookmark", title=_("Bookmark search"), reader=true},
     toggle_bookmark = {category="none", event="ToggleBookmark", title=_("Toggle bookmark"), reader=true, separator=true},
-    --
+    ----
     book_status = {category="none", event="ShowBookStatus", title=_("Book status"), reader=true},
     book_info = {category="none", event="ShowBookInfo", title=_("Book information"), reader=true},
     book_description = {category="none", event="ShowBookDescription", title=_("Book description"), reader=true},
     book_cover = {category="none", event="ShowBookCover", title=_("Book cover"), reader=true, separator=true},
-    --
+    ----
     translate_page = {category="none", event="TranslateCurrentPage", title=_("Translate current page"), reader=true, separator=true},
-    --
+    ----
     toggle_page_change_animation = {category="none", event="TogglePageChangeAnimation", title=_("Toggle page turn animations"), reader=true, condition=Device:canDoSwipeAnimation()},
     toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), reader=true},
     toggle_handmade_toc = {category="none", event="ToggleHandmadeToc", title=_("Toggle custom TOC"), reader=true},
     toggle_handmade_flows = {category="none", event="ToggleHandmadeFlows", title=_("Toggle custom hidden flows"), reader=true, separator=true},
-    --
+    ----
     set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args_func=ReaderHighlight.getHighlightActions, reader=true},
     cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
     cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true, separator=true},
-    --
+    ----
     flush_settings = {category="none", event="FlushSettings", arg=true, title=_("Save book metadata"), reader=true, separator=true},
-    --
+    ----
 
     -- Reflowable documents
     set_font = {category="string", event="SetFont", title=_("Set font"), rolling=true, args_func=require("fontlist").getFontArgFunc,},
@@ -193,9 +193,9 @@ local settingsList = {
     toggle_reflow = {category="none", event="ToggleReflow", title=_("Toggle reflow"), paging=true},
     zoom = {category="string", event="SetZoomMode", title=_("Zoom mode"), args_func=ReaderZooming.getZoomModeActions, paging=true},
     zoom_factor_change = {category="none", event="ZoomFactorChange", title=_("Change zoom factor"), paging=true, separator=true},
-    --
+    ----
     panel_zoom_toggle = {category="none", event="TogglePanelZoomSetting", title=_("Toggle panel zoom"), paging=true, separator=true},
-    --
+    ----
 
     -- parsed from CreOptions
     rotation_mode = {category="string", device=true},
@@ -206,19 +206,19 @@ local settingsList = {
     font_base_weight = {category="string", rolling=true},
     font_hinting = {category="string", rolling=true},
     font_kerning = {category="string", rolling=true, separator=true},
-    --
+    ----
     visible_pages = {category="string", rolling=true, separator=true},
-    --
+    ----
     h_page_margins = {category="string", rolling=true},
     sync_t_b_page_margins = {category="string", rolling=true},
     t_page_margin = {category="absolutenumber", rolling=true},
     b_page_margin = {category="absolutenumber", rolling=true, separator=true},
-    --
+    ----
     view_mode = {category="string", rolling=true},
     block_rendering_mode = {category="string", rolling=true},
     render_dpi = {category="string", title=_("Zoom"), rolling=true},
     line_spacing = {category="absolutenumber", rolling=true, separator=true},
-    --
+    ----
     status_line = {category="string", rolling=true},
     embedded_css = {category="string", rolling=true},
     embedded_fonts = {category="string", rolling=true},
@@ -268,14 +268,14 @@ local dispatcher_menu_order = {
     "history",
     "favorites",
     "filemanager",
-    --
+    ----
     "dictionary_lookup",
     "wikipedia_lookup",
-    --
+    ----
     "show_menu",
     "menu_search",
     "screenshot",
-    --
+    ----
 
     -- Device
     "exit_screensaver",
@@ -284,14 +284,14 @@ local dispatcher_menu_order = {
     "reboot",
     "poweroff",
     "exit",
-    --
+    ----
     "toggle_hold_corners",
     "touch_input_on",
     "touch_input_off",
     "toggle_touch_input",
-    --
+    ----
     "swap_page_turn_buttons",
-    --
+    ----
     "toggle_key_repeat",
     "toggle_gsensor",
     "rotation_mode",
@@ -299,13 +299,13 @@ local dispatcher_menu_order = {
     "invert_rotation",
     "iterate_rotation",
     "iterate_rotation_ccw",
-    --
+    ----
     "wifi_on",
     "wifi_off",
     "toggle_wifi",
     "toggle_fullscreen",
     "show_network_info",
-    --
+    ----
 
     -- Screen and lights
     "show_frontlight_dialog",
@@ -318,7 +318,7 @@ local dispatcher_menu_order = {
     "decrease_frontlight_warmth",
     "night_mode",
     "set_night_mode",
-    --
+    ----
     "full_refresh",
     "set_refresh_rate",
     "set_day_refresh_rate",
@@ -329,7 +329,7 @@ local dispatcher_menu_order = {
     "toggle_no_flash_on_second_chapter_page",
     "set_flash_on_pages_with_images",
     "toggle_flash_on_pages_with_images",
-    --
+    ----
 
     -- File browser
     "folder_up",
@@ -338,16 +338,16 @@ local dispatcher_menu_order = {
     "refresh_content",
     "folder_shortcuts",
     "file_search",
-    --
+    ----
     -- "go_to"
     -- "back"
 
     -- Reader
     "open_next_document_in_folder",
-    --
+    ----
     "show_config_menu",
     "toggle_status_bar",
-    --
+    ----
     "prev_chapter",
     "next_chapter",
     "first_page",
@@ -360,7 +360,7 @@ local dispatcher_menu_order = {
     "first_bookmark",
     "last_bookmark",
     "latest_bookmark",
-    --
+    ----
     "back",
     "previous_location",
     "next_location",
@@ -368,7 +368,7 @@ local dispatcher_menu_order = {
     "follow_nearest_internal_link",
     "add_location_to_history",
     "clear_location_history",
-    --
+    ----
     "fulltext_search",
     "toc",
     "book_map",
@@ -377,25 +377,25 @@ local dispatcher_menu_order = {
     "bookmarks",
     "bookmark_search",
     "toggle_bookmark",
-    --
+    ----
     "book_status",
     "book_info",
     "book_description",
     "book_cover",
-    --
+    ----
     "translate_page",
-    --
+    ----
     "toggle_page_change_animation",
     "toggle_inverse_reading_order",
     "toggle_handmade_toc",
     "toggle_handmade_flows",
-    --
+    ----
     "set_highlight_action",
     "cycle_highlight_action",
     "cycle_highlight_style",
-    --
+    ----
     "flush_settings",
-    --
+    ----
 
     -- Reflowable documents
     "set_font",
@@ -408,25 +408,24 @@ local dispatcher_menu_order = {
     "font_base_weight",
     "font_hinting",
     "font_kerning",
-    --
+    ----
     "visible_pages",
-    --
+    ----
     "h_page_margins",
     "sync_t_b_page_margins",
     "t_page_margin",
     "b_page_margin",
-    --
+    ----
     "view_mode",
     "block_rendering_mode",
     "render_dpi",
     "line_spacing",
-    --
+    ----
     "status_line",
     "embedded_css",
     "embedded_fonts",
     "smooth_scaling",
     "nightmode_images",
-    --
 
     -- Fixed layout documents
     "toggle_page_flipping",
@@ -434,9 +433,9 @@ local dispatcher_menu_order = {
     "toggle_reflow",
     "zoom",
     "zoom_factor_change",
-    --
+    ----
     "panel_zoom_toggle",
-    --
+    ----
     "kopt_trim_page",
     "kopt_page_margin",
     "kopt_zoom_overlap_h",

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -22,10 +22,10 @@ local FileChooser = Menu:extend{
     path = lfs.currentdir(),
     show_path = true,
     parent = nil,
-    show_hidden = false, -- set to true to show folders/files starting with "."
+    show_finished    = G_reader_settings:readSetting("show_finished", true), -- books marked as finished
+    show_hidden      = G_reader_settings:readSetting("show_hidden", false), -- folders/files starting with "."
+    show_unsupported = G_reader_settings:readSetting("show_unsupported", false), -- set to true to ignore file_filter
     file_filter = nil, -- function defined in the caller, returns true for files to be shown
-    show_unsupported = false, -- set to true to ignore file_filter
-    show_finished = true, -- show all books
     -- NOTE: Input is *always* a relative entry name
     exclude_dirs = { -- const
         -- KOReader / Kindle
@@ -101,7 +101,6 @@ end
 
 function FileChooser:init()
     self.path_items = {}
-    self.width = Screen:getWidth()
     self.item_table = self:genItemTableFromPath(self.path)
     Menu.init(self) -- call parent's init()
 end
@@ -121,7 +120,7 @@ function FileChooser:getList(path, collate)
                     if attributes.mode == "directory" and f ~= "." and f ~= ".." then
                         if self:show_dir(f) then
                             if collate then -- when collate == nil count only to display in folder mandatory
-                                item = self:getListItem(f, filename, attributes)
+                                item = FileChooser.getListItem(f, filename, attributes)
                             end
                             table.insert(dirs, item)
                         end
@@ -129,7 +128,7 @@ function FileChooser:getList(path, collate)
                     elseif attributes.mode == "file" and not util.stringStartsWith(f, "._") then
                         if self:show_file(f, filename) then
                             if collate then -- when collate == nil count only to display in folder mandatory
-                                item = self:getListItem(f, filename, attributes, collate)
+                                item = FileChooser.getListItem(f, filename, attributes, collate)
                             end
                             table.insert(files, item)
                         end
@@ -140,7 +139,7 @@ function FileChooser:getList(path, collate)
     else -- error, probably "permission denied"
         if unreadable_dir_content[path] then
             -- Add this dummy item that will be replaced with a message by genItemTable()
-            table.insert(dirs, self:getListItem("./.", path, lfs.attributes(path)))
+            table.insert(dirs, FileChooser.getListItem("./.", path, lfs.attributes(path)))
             -- If we knew about some content (if we had come up from them
             -- to this directory), have them shown
             for k, v in pairs(unreadable_dir_content[path]) do
@@ -155,7 +154,7 @@ function FileChooser:getList(path, collate)
     return dirs, files
 end
 
-function FileChooser:getListItem(f, filename, attributes, collate)
+function FileChooser.getListItem(f, filename, attributes, collate)
     local item = {
         text = f,
         fullpath = filename,
@@ -454,18 +453,12 @@ function FileChooser:changePageToPath(path)
     end
 end
 
-function FileChooser:toggleFinishedBooks()
-    self.show_finished = not self.show_finished
-    self:refreshPath()
-end
-
-function FileChooser:toggleHiddenFiles()
-    self.show_hidden = not self.show_hidden
-    self:refreshPath()
-end
-
-function FileChooser:toggleUnsupportedFiles()
-    self.show_unsupported = not self.show_unsupported
+function FileChooser:toggleShowFilesMode(mode)
+    -- modes: "show_finished", "show_hidden", "show_unsupported"
+    local setting = not self[mode]
+    self[mode] = setting
+    FileChooser[mode] = setting
+    G_reader_settings:saveSetting(mode, setting)
     self:refreshPath()
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -455,10 +455,8 @@ end
 
 function FileChooser:toggleShowFilesMode(mode)
     -- modes: "show_finished", "show_hidden", "show_unsupported"
-    local setting = not self[mode]
-    self[mode] = setting
-    FileChooser[mode] = setting
-    G_reader_settings:saveSetting(mode, setting)
+    FileChooser[mode] = not FileChooser[mode]
+    G_reader_settings:saveSetting(mode, FileChooser[mode])
     self:refreshPath()
 end
 

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -1,6 +1,5 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
-local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
 local Device = require("device")
 local Event = require("ui/event")
 local FileChooser = require("ui/widget/filechooser")
@@ -36,9 +35,11 @@ function PathChooser:init()
             self.title = _("Long-press to choose")
         end
     end
-    self.show_hidden = G_reader_settings:isTrue("show_hidden")
     if not self.show_files then
         self.file_filter = function() return false end -- filter out regular files
+    end
+    if self.file_filter then
+        self.show_unsupported = false -- honour file_filter
     end
     if self.select_directory then
         -- Let FileChooser display "Long-press to choose current folder"
@@ -127,7 +128,7 @@ function PathChooser:onMenuHold(item)
         title = T(_("Choose this path?\n\n%1"), BD.path(path))
     end
     local onConfirm = self.onConfirm
-    self.button_dialog = ButtonDialogTitle:new{
+    self.button_dialog = ButtonDialog:new{
         title = title,
         buttons = {
             {

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -316,12 +316,14 @@ function CoverMenu:updateItems(select_number)
 
                 -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
                 local button = self.file_dialog:getButtonById("reset")
-                local orig_purge_callback = button.callback
-                button.callback = function()
-                    -- Wipe the cache
-                    self:updateCache(file)
-                    -- And then purge the sidecar folder as expected
-                    orig_purge_callback()
+                if button then
+                    local orig_purge_callback = button.callback
+                    button.callback = function()
+                        -- Wipe the cache
+                        self:updateCache(file)
+                        -- And then purge the sidecar folder as expected
+                        orig_purge_callback()
+                    end
                 end
 
                 -- Fudge the status change button callbacks to also update the cover_info_cache
@@ -345,18 +347,20 @@ function CoverMenu:updateItems(select_number)
                 end
 
                 button = self.file_dialog:getButtonById("book_cover")
-                if not bookinfo.has_cover then
+                if button and not bookinfo.has_cover then
                     button:disable()
                 end
 
                 button = self.file_dialog:getButtonById("book_description")
-                if bookinfo.description then
-                    button.callback = function()
-                        UIManager:close(self.file_dialog)
-                        FileManagerBookInfo:onShowBookDescription(bookinfo.description)
+                if button then
+                    if bookinfo.description then
+                        button.callback = function()
+                            UIManager:close(self.file_dialog)
+                            FileManagerBookInfo:onShowBookDescription(bookinfo.description)
+                        end
+                    else
+                        button:disable()
                     end
-                else
-                    button:disable()
                 end
 
                 UIManager:show(self.file_dialog)
@@ -443,12 +447,14 @@ function CoverMenu:onHistoryMenuHold(item)
 
     -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
     local button = self.histfile_dialog:getButtonById("reset")
-    local orig_purge_callback = button.callback
-    button.callback = function()
-        -- Wipe the cache
-        self:updateCache(file)
-        -- And then purge the sidecar folder as expected
-        orig_purge_callback()
+    if button then
+        local orig_purge_callback = button.callback
+        button.callback = function()
+            -- Wipe the cache
+            self:updateCache(file)
+            -- And then purge the sidecar folder as expected
+            orig_purge_callback()
+        end
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
@@ -472,18 +478,20 @@ function CoverMenu:onHistoryMenuHold(item)
     end
 
     button = self.histfile_dialog:getButtonById("book_cover")
-    if not bookinfo.has_cover then
+    if button and not bookinfo.has_cover then
         button:disable()
     end
 
     button = self.histfile_dialog:getButtonById("book_description")
-    if bookinfo.description then
-        button.callback = function()
-            UIManager:close(self.histfile_dialog)
-            FileManagerBookInfo:onShowBookDescription(bookinfo.description)
+    if button then
+        if bookinfo.description then
+            button.callback = function()
+                UIManager:close(self.histfile_dialog)
+                FileManagerBookInfo:onShowBookDescription(bookinfo.description)
+            end
+        else
+            button:disable()
         end
-    else
-        button:disable()
     end
 
     UIManager:show(self.histfile_dialog)
@@ -563,12 +571,14 @@ function CoverMenu:onCollectionsMenuHold(item)
 
     -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
     local button = self.collfile_dialog:getButtonById("reset")
-    local orig_purge_callback = button.callback
-    button.callback = function()
-        -- Wipe the cache
-        self:updateCache(file)
-        -- And then purge the sidecar folder as expected
-        orig_purge_callback()
+    if button then
+        local orig_purge_callback = button.callback
+        button.callback = function()
+            -- Wipe the cache
+            self:updateCache(file)
+            -- And then purge the sidecar folder as expected
+            orig_purge_callback()
+        end
     end
 
     -- Fudge the status change button callbacks to also update the cover_info_cache
@@ -592,18 +602,20 @@ function CoverMenu:onCollectionsMenuHold(item)
     end
 
     button = self.collfile_dialog:getButtonById("book_cover")
-    if not bookinfo.has_cover then
+    if button and not bookinfo.has_cover then
         button:disable()
     end
 
     button = self.collfile_dialog:getButtonById("book_description")
-    if bookinfo.description then
-        button.callback = function()
-            UIManager:close(self.collfile_dialog)
-            FileManagerBookInfo:onShowBookDescription(bookinfo.description)
+    if button then
+        if bookinfo.description then
+            button.callback = function()
+                UIManager:close(self.collfile_dialog)
+                FileManagerBookInfo:onShowBookDescription(bookinfo.description)
+            end
+        else
+            button:disable()
         end
-    else
-        button:disable()
     end
 
     UIManager:show(self.collfile_dialog)


### PR DESCRIPTION
All is cross-bound, hence the combined PR.

(1) **File search**
File search now is available in the file browser only.
Standard file dialog pop-up buttons added. Closes https://github.com/koreader/koreader/issues/10991.

![1](https://github.com/koreader/koreader/assets/62179190/b59676c5-5239-4e18-b619-c76b6260ba05)

(2) **File manager**
Unapplicable pop-up buttons in the file dialog are hidden (previously they were disabled).

Supported file
![2](https://github.com/koreader/koreader/assets/62179190/7a8a2893-1736-4d8b-a2a9-79c5f332489f)

Unsupported file
![3](https://github.com/koreader/koreader/assets/62179190/2dffda7f-1238-4adb-bb22-c86b84aaad19)

(3) **FileChooser**
"Show" settings (finished books, hidden files, unsupported files) are centralized in FileChooser.
Optimization: do not init the settings every time when FM is launched.

(4) **Dispatcher**
"File search" is moved from General to File browser section.
"Fulltext search" is moved from General to Reader section.
Tidy: lines of code are ordered in accordance with the action menu order, comments fixed/added.

(5) **History**
Finished books timestamp is dimmed if "Freeze last read date of finished books" is enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10994)
<!-- Reviewable:end -->
