### PR TITLE
otamanager: fix OTA model name for Android x86_64

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -83,7 +83,7 @@ function OTAManager:getOTAModel()
             return "android-arm64"
         elseif arch == "x86" then
             return "android-x86"
-        elseif arch == "x86_64" then
+        elseif arch == "x64" then
             return "android-x86_64"
         end
         return "android"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/10997)
<!-- Reviewable:end -->
