### PR TITLE
ReaderHighlight: delete highlight in view note dialog

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -894,9 +894,10 @@ function ReaderHighlight:showHighlightNoteOrDialog(page, index, bookmark_note)
             buttons_table = {
                 {
                     {
-                        text = _("Close"),
+                        text = _("Delete highlight"),
                         callback = function()
                             UIManager:close(textviewer)
+                            self:deleteHighlight(page, index)
                         end,
                     },
                     {


### PR DESCRIPTION
Changes <kbd>Close</kbd> button to <kbd>Delete highlight</kbd> button.

(1) Other highlight dialogs do not have the Close button.
(2) It is easy to close the note view dialog by tapping outside of it.
(3) Speeds up some workflows:  https://www.mobileread.com/forums/showthread.php?t=356792.

![1](https://github.com/koreader/koreader/assets/62179190/d0608034-82b2-4737-8f53-718c31a7e07b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11039)
<!-- Reviewable:end -->
