### PR TITLE
Add color highlight menu

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -558,14 +558,11 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 icon = "texture-box",
                 ok_callback = function()
                     local count = 0
-                    for _, items in pairs(self.view.highlight.saved) do
-                        if items then
-                            count = count + #items
-                            for i = 1, #items do
-                                local item = items[i]
-                                item.drawer = self.view.highlight.saved_drawer
-                                item.color = self.view.highlight.saved_color
-                            end
+                    for _, item in ipairs(self.ui.annotation.annotations) do
+                        if item.drawer then
+                            count = count + 1
+                            item.drawer = self.view.highlight.saved_drawer
+                            item.color = self.view.highlight.saved_color
                         end
                     end
                     if count > 0 then

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -451,7 +451,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     },
                 })
             end
-            UIManager:show(require("ui/widget/radiobuttonwidget"):new{
+            UIManager:show(RadioButtonWidget:new{
                 title_text = _("Highlight color"),
                 width_factor = 0.5,
                 keep_shown_on_apply = false,
@@ -2134,7 +2134,6 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
             },
         })
     end
-    local RadioButtonWidget = require("ui/widget/radiobuttonwidget")
     UIManager:show(RadioButtonWidget:new{
         title_text = _("Highlight color"),
         width_factor = 0.5,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -25,6 +25,7 @@ local T = ffiUtil.template
 local Screen = Device.screen
 
 local ReaderHighlight = InputContainer:extend{
+    -- Matches what is available in BlitBuffer.HIGHLIGHT_COLORS
     highlight_colors = {
         {_("Red"), "red"},
         {_("Orange"), "orange"},
@@ -69,6 +70,7 @@ function ReaderHighlight:init()
     self._current_indicator_pos = nil
     self._previous_indicator_pos = nil
     self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
+    -- NOTE: Unfortunately, yellow tends to look like absolute ass on Kaleido panels...
     self._fallback_color = Screen:isColorEnabled() and "yellow" or "gray"
 
     self:registerKeyEvents()
@@ -552,7 +554,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
         text = _("Apply default style to all highlights"),
         callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
-                text = _("Are you sure you want to edit all highlights."),
+                text = _("Are you sure you want to update all highlights?"),
                 icon = "texture-box",
                 ok_callback = function()
                     local count = 0

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -31,6 +31,7 @@ local ReaderHighlight = InputContainer:extend{
         {_("Yellow"), "yellow"},
         {_("Green"), "green"},
         {_("Blue"), "blue"},
+        {_("Cyan"), "cyan"},
         {_("Purple"), "purple"},
         {_("Gray"), "gray"},
     }

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2052,32 +2052,27 @@ function ReaderHighlight:editHighlightStyle(index)
         UIManager:setDirty(self.dialog, "ui")
         self.ui:handleEvent(Event:new("AnnotationsModified", { item }))
     end
-    self:showHighlightStyleDialog(apply_drawer, item.drawer, page, i)
+    self:showHighlightStyleDialog(apply_drawer, item.drawer, index)
 end
 
-function ReaderHighlight:editHighlightColor(page, i)
-    local item = self.view.highlight.saved[page][i]
+function ReaderHighlight:editHighlightColor(index)
+    local item = self.ui.annotation.annotations[index]
     local apply_color = function(color)
-        self:writePdfAnnotation("delete", page, item)
+        self:writePdfAnnotation("delete", item)
         item.color = color
         if self.ui.paging then
-            self:writePdfAnnotation("save", page, item)
-            local bm_note = self.ui.bookmark:getBookmarkNote(item)
-            if bm_note then
-                self:writePdfAnnotation("content", page, item, bm_note)
+            self:writePdfAnnotation("save", item)
+            if item.note then
+                self:writePdfAnnotation("content", item, item.note)
             end
         end
         UIManager:setDirty(self.dialog, "ui")
-        self.ui:handleEvent(Event:new("BookmarkUpdated",
-                self.ui.bookmark:getBookmarkForHighlight({
-                    page = self.ui.paging and page or item.pos0,
-                    datetime = item.datetime,
-                })))
+        self.ui:handleEvent(Event:new("AnnotationsModified", { item }))
     end
     self:showHighlightColorDialog(apply_color, item.color)
 end
 
-function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, page, i)
+function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, index)
     local default_drawer, keep_shown_on_apply
     if item_drawer then -- called from ReaderHighlight:editHighlightStyle()
         default_drawer = self.view.highlight.saved_drawer or
@@ -2104,17 +2099,17 @@ function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, 
             caller_callback(radio.provider)
         end,
     }
-    if page and i then
+    if index then
         -- called from editHighlightStyle
         ctor.extra_text = _("Highlight color")
         ctor.extra_callback = function(this)
-            local item = self.view.highlight.saved[page][i]
+            local item = self.ui.annotation.annotations[index]
             if item.drawer == "invert" then
                 UIManager:show(InfoMessage:new{ text = _("Colors unavailable when highlight style is set to 'Invert'") })
             else
                 -- Close the style dialog before showing the color dialog
                 this:onClose()
-                self:editHighlightColor(page, i)
+                self:editHighlightColor(index)
             end
         end
     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1,4 +1,5 @@
 local BD = require("ui/bidi")
+local BlitBuffer = require("ffi/blitbuffer")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
@@ -2136,6 +2137,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
             {
                 text = v[1],
                 checked = item_color == v[2],
+                bgcolor = BlitBuffer.colorFromName(v[1]),
                 provider = v[2],
             },
         })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -456,7 +456,6 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     default_provider = default_color,
                     callback = function(radio)
                         self.view.highlight.saved_color = radio.provider
-                        self.ui.doc_settings:saveSetting("highlight_color", self.view.highlight.saved_color)
                         UIManager:setDirty(self.dialog, "ui")
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,
@@ -1899,7 +1898,6 @@ function ReaderHighlight:onCycleHighlightStyle()
         next_style_num = 1
     end
     self.view.highlight.saved_drawer = highlight_style[next_style_num][2]
-    self.ui.doc_settings:saveSetting("highlight_drawer", self.view.highlight.saved_drawer)
     UIManager:show(Notification:new{
         text = T(_("Default highlight style changed to '%1'."), highlight_style[next_style_num][1]),
     })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1143,9 +1143,9 @@ function ReaderHighlight:onShowHighlightDialog(index)
                 end,
             },
             {
-                text = is_auto_text and _("Add note") or _("Edit note"),
+                text = item.note and _("Edit note") or _("Add note"),
                 callback = function()
-                    self:editHighlight(page, index)
+                    self:editHighlight(index)
                     UIManager:close(self.edit_highlight_dialog)
                     self.edit_highlight_dialog = nil
                 end,
@@ -1153,8 +1153,8 @@ function ReaderHighlight:onShowHighlightDialog(index)
             {
                 text = "…",
                 callback = function()
-                    self.selected_text = self.view.highlight.saved[page][index]
-                    self:onShowHighlightMenu(page, index)
+                    self.selected_text = util.tableDeepCopy(item)
+                    self:onShowHighlightMenu(index)
                     UIManager:close(self.edit_highlight_dialog)
                     self.edit_highlight_dialog = nil
                 end,
@@ -2315,7 +2315,7 @@ function ReaderHighlight:onReadSettings(config)
     self.view.highlight.saved_drawer = config:readSetting("highlight_drawer")
         or G_reader_settings:readSetting("highlight_drawing_style") or self.view.highlight.saved_drawer
     self.view.highlight.saved_color = config:readSetting("highlight_color")
-        or G_reader_settings:readSetting("highlight_color") or self.view.highlight.saved_colo
+        or G_reader_settings:readSetting("highlight_color") or self.view.highlight.saved_color
     self.view.highlight.disabled = G_reader_settings:readSetting("default_highlight_action") == "nothing"
 
     self.allow_corner_scroll = G_reader_settings:nilOrTrue("highlight_corner_scroll")

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -30,8 +30,8 @@ local ReaderHighlight = InputContainer:extend{
         {_("Orange"), "orange"},
         {_("Yellow"), "yellow"},
         {_("Green"), "green"},
-        {_("Blue"), "blue"},
         {_("Cyan"), "cyan"},
+        {_("Blue"), "blue"},
         {_("Purple"), "purple"},
         {_("Gray"), "gray"},
     }

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -30,6 +30,7 @@ local ReaderHighlight = InputContainer:extend{
         {_("Orange"), "orange"},
         {_("Yellow"), "yellow"},
         {_("Green"), "green"},
+        {_("Olive"), "olive"},
         {_("Cyan"), "cyan"},
         {_("Blue"), "blue"},
         {_("Purple"), "purple"},

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -423,55 +423,53 @@ function ReaderHighlight:addToMainMenu(menu_items)
             separator = i == #highlight_style,
         })
     end
-    if Screen:isColorScreen() then
-        table.insert(menu_items.highlight_options.sub_item_table, {
-            text_func = function()
-                local saved_color = self.view.highlight.saved_color or "yellow"
-                for __, v in ipairs(self.highlight_colors) do
-                    if v[2] == saved_color then
-                        return T(_("Highlight color: %1"), string.lower(v[1]))
-                    end
+    table.insert(menu_items.highlight_options.sub_item_table, {
+        text_func = function()
+            local saved_color = self.view.highlight.saved_color or "yellow"
+            for __, v in ipairs(self.highlight_colors) do
+                if v[2] == saved_color then
+                    return T(_("Highlight color: %1"), string.lower(v[1]))
                 end
-                return T(_("Highlight color: %1"), saved_color)
-            end,
-            enabled_func = function()
-                return Screen:isColorEnabled() and self.view.highlight.saved_drawer ~= "invert"
-            end,
-            callback = function(touchmenu_instance)
-                local default_color = G_reader_settings:readSetting("highlight_color", "yellow")
-                local saved_color = self.view.highlight.saved_color or "yellow"
-                local radio_buttons = {}
-                for _, v in ipairs(self.highlight_colors) do
-                    table.insert(radio_buttons, {
-                        {
-                            text = v[1],
-                            checked = v[2] == saved_color,
-                            provider = v[2],
-                        },
-                    })
-                end
-                UIManager:show(require("ui/widget/radiobuttonwidget"):new{
-                    title_text = _("Highlight color"),
-                    width_factor = 0.5,
-                    keep_shown_on_apply = false,
-                    radio_buttons = radio_buttons,
-                    default_provider = default_color,
-                    callback = function(radio)
-                        self.view.highlight.saved_color = radio.provider
-                        UIManager:setDirty(self.dialog, "ui")
-                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                    end,
+            end
+            return T(_("Highlight color: %1"), saved_color)
+        end,
+        enabled_func = function()
+            return self.view.highlight.saved_drawer ~= "invert"
+        end,
+        callback = function(touchmenu_instance)
+            local default_color = G_reader_settings:readSetting("highlight_color", "yellow")
+            local saved_color = self.view.highlight.saved_color or "yellow"
+            local radio_buttons = {}
+            for _, v in ipairs(self.highlight_colors) do
+                table.insert(radio_buttons, {
+                    {
+                        text = v[1],
+                        checked = v[2] == saved_color,
+                        provider = v[2],
+                    },
                 })
-            end,
-            hold_callback = function(touchmenu_instance)
-                G_reader_settings:saveSetting("highlight_color", self.view.highlight.saved_color)
-                UIManager:show(Notification:new{
-                    text = T(_("Default highlight color changed to '%1'."), self.view.highlight.saved_color),
-                })
-                if touchmenu_instance then touchmenu_instance:updateItems() end
-            end,
-        })
-    end
+            end
+            UIManager:show(require("ui/widget/radiobuttonwidget"):new{
+                title_text = _("Highlight color"),
+                width_factor = 0.5,
+                keep_shown_on_apply = false,
+                radio_buttons = radio_buttons,
+                default_provider = default_color,
+                callback = function(radio)
+                    self.view.highlight.saved_color = radio.provider
+                    UIManager:setDirty(self.dialog, "ui")
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end,
+            })
+        end,
+        hold_callback = function(touchmenu_instance)
+            G_reader_settings:saveSetting("highlight_color", self.view.highlight.saved_color)
+            UIManager:show(Notification:new{
+                text = T(_("Default highlight color changed to '%1'."), self.view.highlight.saved_color),
+            })
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+        end,
+    })
     table.insert(menu_items.highlight_options.sub_item_table, {
         text_func = function()
             return T(_("Gray highlight opacity: %1"), G_reader_settings:readSetting("highlight_lighten_factor", 0.2))
@@ -544,40 +542,35 @@ function ReaderHighlight:addToMainMenu(menu_items)
             })
         end,
     })
-    if Screen:isColorScreen() then
-        table.insert(menu_items.highlight_options.sub_item_table, {
-            text = _("Apply default style to all highlights"),
-            enabled_func = function()
-                return Screen:isColorEnabled()
-            end,
-            callback = function(touchmenu_instance)
-                UIManager:show(ConfirmBox:new{
-                    text = _("Are you sure you want to edit all highlights."),
-                    icon = "texture-box",
-                    ok_callback = function()
-                        local count = 0
-                        for _, items in pairs(self.view.highlight.saved) do
-                            if items then
-                                count = count + #items
-                                for i = 1, #items do
-                                    local item = items[i]
-                                    item.drawer = self.view.highlight.saved_drawer
-                                    item.color = self.view.highlight.saved_color
-                                end
+    table.insert(menu_items.highlight_options.sub_item_table, {
+        text = _("Apply default style to all highlights"),
+        callback = function(touchmenu_instance)
+            UIManager:show(ConfirmBox:new{
+                text = _("Are you sure you want to edit all highlights."),
+                icon = "texture-box",
+                ok_callback = function()
+                    local count = 0
+                    for _, items in pairs(self.view.highlight.saved) do
+                        if items then
+                            count = count + #items
+                            for i = 1, #items do
+                                local item = items[i]
+                                item.drawer = self.view.highlight.saved_drawer
+                                item.color = self.view.highlight.saved_color
                             end
                         end
-                        if count > 0 then
-                            UIManager:setDirty(self.dialog, "ui")
-                            UIManager:show(Notification:new{
-                                text = T(N_("Applied default style to 1 highlight",
-                                    "Applied default style to %1 highlights", count), count),
-                            })
-                        end
                     end
-                })
-            end,
-        })
-    end
+                    if count > 0 then
+                        UIManager:setDirty(self.dialog, "ui")
+                        UIManager:show(Notification:new{
+                            text = T(N_("Applied default style to 1 highlight",
+                                "Applied default style to %1 highlights", count), count),
+                        })
+                    end
+                end
+            })
+        end,
+    })
     if self.ui.paging then
         menu_items.panel_zoom_options = {
             text = _("Panel zoom (manga/comic)"),
@@ -1129,56 +1122,42 @@ end
 
 function ReaderHighlight:onShowHighlightDialog(index)
     local item = self.ui.annotation.annotations[index]
-    local row = {
-        {
-            text = _("Delete"),
-            callback = function()
-                self:deleteHighlight(index)
-                UIManager:close(self.edit_highlight_dialog)
-                self.edit_highlight_dialog = nil
-            end,
-        },
-        {
-            text = C_("Highlight", "Style"),
-            callback = function()
-                self:editHighlightStyle(index)
-                UIManager:close(self.edit_highlight_dialog)
-                self.edit_highlight_dialog = nil
-            end,
-        },
-    }
-    if Screen:isColorScreen() then
-        table.insert(row, {
-            text = C_("Highlight", "Color"),
-            enabled_func = function()
-                return Screen:isColorEnabled()
-            end,
-            callback = function()
-                self:editHighlightColor(index)
-                UIManager:close(self.edit_highlight_dialog)
-                self.edit_highlight_dialog = nil
-            end,
-        })
-    end
-    table.insert(row, {
-        text = is_auto_text and _("Add note") or _("Edit note"),
-        callback = function()
-            self:editHighlight(index)
-            UIManager:close(self.edit_highlight_dialog)
-            self.edit_highlight_dialog = nil
-        end,
-    })
-    table.insert(row, {
-        text = "…",
-        callback = function()
-            self.selected_text = util.tableDeepCopy(item)
-            self:onShowHighlightMenu(index)
-            UIManager:close(self.edit_highlight_dialog)
-            self.edit_highlight_dialog = nil
-        end,
-    })
     local buttons = {
-        row
+        {
+            {
+                text = _("Delete"),
+                callback = function()
+                    self:deleteHighlight(index)
+                    UIManager:close(self.edit_highlight_dialog)
+                    self.edit_highlight_dialog = nil
+                end,
+            },
+            {
+                text = C_("Highlight", "Style"),
+                callback = function()
+                    self:editHighlightStyle(index)
+                    UIManager:close(self.edit_highlight_dialog)
+                    self.edit_highlight_dialog = nil
+                end,
+            },
+            {
+                text = is_auto_text and _("Add note") or _("Edit note"),
+                callback = function()
+                    self:editHighlight(page, index)
+                    UIManager:close(self.edit_highlight_dialog)
+                    self.edit_highlight_dialog = nil
+                end,
+            },
+            {
+                text = "…",
+                callback = function()
+                    self.selected_text = self.view.highlight.saved[page][index]
+                    self:onShowHighlightMenu(page, index)
+                    UIManager:close(self.edit_highlight_dialog)
+                    self.edit_highlight_dialog = nil
+                end,
+            },
+        },
     }
 
     if self.ui.rolling then
@@ -2071,7 +2050,7 @@ function ReaderHighlight:editHighlightStyle(index)
         UIManager:setDirty(self.dialog, "ui")
         self.ui:handleEvent(Event:new("AnnotationsModified", { item }))
     end
-    self:showHighlightStyleDialog(apply_drawer, item.drawer)
+    self:showHighlightStyleDialog(apply_drawer, item.drawer, page, i)
 end
 
 function ReaderHighlight:editHighlightColor(page, i)
@@ -2096,7 +2075,7 @@ function ReaderHighlight:editHighlightColor(page, i)
     self:showHighlightColorDialog(apply_color, item.color)
 end
 
-function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer)
+function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, page, i)
     local default_drawer, keep_shown_on_apply
     if item_drawer then -- called from ReaderHighlight:editHighlightStyle()
         default_drawer = self.view.highlight.saved_drawer or
@@ -2113,7 +2092,7 @@ function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer)
             },
         })
     end
-    UIManager:show(RadioButtonWidget:new{
+    local ctor = {
         title_text = _("Highlight style"),
         width_factor = 0.5,
         keep_shown_on_apply = keep_shown_on_apply,
@@ -2122,7 +2101,17 @@ function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer)
         callback = function(radio)
             caller_callback(radio.provider)
         end,
-    })
+    }
+    if page and i then
+        -- called from editHighlightStyle
+        ctor.extra_text = _("Highlight color")
+        ctor.extra_callback = function(this)
+            -- Close the style dialog before showing the color dialog
+            this:onClose()
+            self:editHighlightColor(page, i)
+        end
+    end
+    UIManager:show(RadioButtonWidget:new(ctor))
 end
 
 function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -474,7 +474,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
     end
     table.insert(menu_items.highlight_options.sub_item_table, {
         text_func = function()
-            return T(_("Highlight opacity: %1"), G_reader_settings:readSetting("highlight_lighten_factor", 0.2))
+            return T(_("Gray highlight opacity: %1"), G_reader_settings:readSetting("highlight_lighten_factor", 0.2))
         end,
         enabled_func = function()
             return self.view.highlight.saved_drawer == "lighten"
@@ -491,8 +491,8 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 value_hold_step = 0.25,
                 default_value = 0.2,
                 keep_shown_on_apply = true,
-                title_text =  _("Highlight opacity"),
-                info_text = _("The higher the value, the darker the highlight."),
+                title_text =  _("Gray highlight opacity"),
+                info_text = _("The higher the value, the darker the gray."),
                 callback = function(spin)
                     G_reader_settings:saveSetting("highlight_lighten_factor", spin.value)
                     self.view.highlight.lighten_factor = spin.value
@@ -2138,7 +2138,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
             {
                 text = v[1],
                 checked = item_color == v[2],
-                bgcolor = BlitBuffer.colorFromName(v[1]),
+                bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
                 provider = v[2],
             },
         })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2072,7 +2072,7 @@ function ReaderHighlight:editHighlightColor(page, i)
                     datetime = item.datetime,
                 })))
     end
-    self:showHighlightColorDialog(apply_color, item.color)
+    self:showHighlightColorDialog(apply_color, item.color, item.drawer)
 end
 
 function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, page, i)
@@ -2114,7 +2114,7 @@ function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, 
     UIManager:show(RadioButtonWidget:new(ctor))
 end
 
-function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
+function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color, item_drawer)
     local default_color, keep_shown_on_apply
     if item_color then -- called from editHighlightColor
         default_color = self.view.highlight.saved_color or
@@ -2122,13 +2122,23 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
         keep_shown_on_apply = true
     end
     local radio_buttons = {}
-    for _, v in ipairs(self.highlight_colors) do
+    if item_drawer ~= "invert" then
+        for _, v in ipairs(self.highlight_colors) do
+            table.insert(radio_buttons, {
+                {
+                    text = v[1],
+                    checked = item_color == v[2],
+                    bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
+                    provider = v[2],
+                },
+            })
+        end
+    else
+        default_color = nil
         table.insert(radio_buttons, {
             {
-                text = v[1],
-                checked = item_color == v[2],
-                bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
-                provider = v[2],
+                text = _("N/A"),
+                checked = false,
             },
         })
     end
@@ -2140,7 +2150,9 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
         radio_buttons = radio_buttons,
         default_provider = default_color,
         callback = function(radio)
-            caller_callback(radio.provider)
+            if radio.provider then
+                caller_callback(radio.provider)
+            end
         end,
     })
 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2133,6 +2133,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
                 text = v[1],
                 checked = item_color == v[2],
                 bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
+                --bgcolor = Screen:isColorEnabled() and (BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF))) or nil,
                 provider = v[2],
             },
         })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2293,7 +2293,7 @@ end
 function ReaderHighlight:getSavedExtendedHighlightPage(highlight, page, index)
     local item = {
         datetime = highlight.datetime,
-        drawer   = highlight.drawer or self.highlight.saved_drawer,
+        drawer   = highlight.drawer,
         color    = highlight.color or self.highlight.saved_color,
         text     = highlight.text,
         note     = highlight.note,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -446,6 +446,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     {
                         text = v[1],
                         checked = v[2] == saved_color,
+                        bgcolor = BlitBuffer.colorFromName(v[2]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
                         provider = v[2],
                     },
                 })
@@ -2133,7 +2134,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
             {
                 text = v[1],
                 checked = item_color == v[2],
-                bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
+                bgcolor = BlitBuffer.colorFromName(v[2]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
                 provider = v[2],
             },
         })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2072,7 +2072,7 @@ function ReaderHighlight:editHighlightColor(page, i)
                     datetime = item.datetime,
                 })))
     end
-    self:showHighlightColorDialog(apply_color, item.color, item.drawer)
+    self:showHighlightColorDialog(apply_color, item.color)
 end
 
 function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, page, i)
@@ -2114,7 +2114,7 @@ function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, 
     UIManager:show(RadioButtonWidget:new(ctor))
 end
 
-function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color, item_drawer)
+function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
     local default_color, keep_shown_on_apply
     if item_color then -- called from editHighlightColor
         default_color = self.view.highlight.saved_color or
@@ -2122,23 +2122,13 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color, i
         keep_shown_on_apply = true
     end
     local radio_buttons = {}
-    if item_drawer ~= "invert" then
-        for _, v in ipairs(self.highlight_colors) do
-            table.insert(radio_buttons, {
-                {
-                    text = v[1],
-                    checked = item_color == v[2],
-                    bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
-                    provider = v[2],
-                },
-            })
-        end
-    else
-        default_color = nil
+    for _, v in ipairs(self.highlight_colors) do
         table.insert(radio_buttons, {
             {
-                text = _("N/A"),
-                checked = false,
+                text = v[1],
+                checked = item_color == v[2],
+                bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
+                provider = v[2],
             },
         })
     end
@@ -2150,9 +2140,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color, i
         radio_buttons = radio_buttons,
         default_provider = default_color,
         callback = function(radio)
-            if radio.provider then
-                caller_callback(radio.provider)
-            end
+            caller_callback(radio.provider)
         end,
     })
 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2106,9 +2106,14 @@ function ReaderHighlight:showHighlightStyleDialog(caller_callback, item_drawer, 
         -- called from editHighlightStyle
         ctor.extra_text = _("Highlight color")
         ctor.extra_callback = function(this)
-            -- Close the style dialog before showing the color dialog
-            this:onClose()
-            self:editHighlightColor(page, i)
+            local item = self.view.highlight.saved[page][i]
+            if item.drawer == "invert" then
+                UIManager:show(InfoMessage:new{ text = _("Colors unavailable when highlight style is set to 'Invert'") })
+            else
+                -- Close the style dialog before showing the color dialog
+                this:onClose()
+                self:editHighlightColor(page, i)
+            end
         end
     end
     UIManager:show(RadioButtonWidget:new(ctor))

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -451,7 +451,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     },
                 })
             end
-            UIManager:show(RadioButtonWidget:new{
+            local rbw = RadioButtonWidget:new{
                 title_text = _("Highlight color"),
                 width_factor = 0.5,
                 keep_shown_on_apply = false,
@@ -462,7 +462,9 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     UIManager:setDirty(self.dialog, "ui")
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,
-            })
+                dithered = true,
+            }
+            UIManager:show(rbw)
         end,
         hold_callback = function(touchmenu_instance)
             G_reader_settings:saveSetting("highlight_color", self.view.highlight.saved_color)
@@ -2134,7 +2136,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
             },
         })
     end
-    UIManager:show(RadioButtonWidget:new{
+    local rbw = RadioButtonWidget:new{
         title_text = _("Highlight color"),
         width_factor = 0.5,
         keep_shown_on_apply = keep_shown_on_apply,
@@ -2143,7 +2145,17 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
         callback = function(radio)
             caller_callback(radio.provider)
         end,
-    })
+        dithered = true,
+    }
+    -- Mangle the widget's onShow method to swap to a waveform mode that will actually be upgraded to a Kaleido waveform on supported devices...
+    -- (i.e., partial instead of ui)
+    rbw.onShow = function(this)
+        UIManager:setDirty(this, function()
+            return "partial", this.widget_frame.dimen
+        end)
+        return true
+    end
+    UIManager:show(rbw)
 end
 
 function ReaderHighlight:startSelection()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -451,7 +451,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     },
                 })
             end
-            local rbw = RadioButtonWidget:new{
+            UIManager:show(RadioButtonWidget:new{
                 title_text = _("Highlight color"),
                 width_factor = 0.5,
                 keep_shown_on_apply = false,
@@ -463,8 +463,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,
                 dithered = true,
-            }
-            UIManager:show(rbw)
+            })
         end,
         hold_callback = function(touchmenu_instance)
             G_reader_settings:saveSetting("highlight_color", self.view.highlight.saved_color)
@@ -2136,7 +2135,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
             },
         })
     end
-    local rbw = RadioButtonWidget:new{
+    UIManager:show(RadioButtonWidget:new{
         title_text = _("Highlight color"),
         width_factor = 0.5,
         keep_shown_on_apply = keep_shown_on_apply,
@@ -2146,16 +2145,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
             caller_callback(radio.provider)
         end,
         dithered = true,
-    }
-    -- Mangle the widget's onShow method to swap to a waveform mode that will actually be upgraded to a Kaleido waveform on supported devices...
-    -- (i.e., partial instead of ui)
-    rbw.onShow = function(this)
-        UIManager:setDirty(this, function()
-            return "partial", this.widget_frame.dimen
-        end)
-        return true
-    end
-    UIManager:show(rbw)
+    })
 end
 
 function ReaderHighlight:startSelection()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -68,6 +68,7 @@ function ReaderHighlight:init()
     self._current_indicator_pos = nil
     self._previous_indicator_pos = nil
     self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
+    self._fallback_color = Screen:isColorEnabled() and "yellow" or "gray"
 
     self:registerKeyEvents()
 
@@ -425,7 +426,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
     end
     table.insert(menu_items.highlight_options.sub_item_table, {
         text_func = function()
-            local saved_color = self.view.highlight.saved_color or "yellow"
+            local saved_color = self.view.highlight.saved_color or self._fallback_color
             for __, v in ipairs(self.highlight_colors) do
                 if v[2] == saved_color then
                     return T(_("Highlight color: %1"), string.lower(v[1]))
@@ -437,8 +438,8 @@ function ReaderHighlight:addToMainMenu(menu_items)
             return self.view.highlight.saved_drawer ~= "invert"
         end,
         callback = function(touchmenu_instance)
-            local default_color = G_reader_settings:readSetting("highlight_color", "yellow")
-            local saved_color = self.view.highlight.saved_color or "yellow"
+            local default_color = G_reader_settings:readSetting("highlight_color", self._fallback_color)
+            local saved_color = self.view.highlight.saved_color or self._fallback_color
             local radio_buttons = {}
             for _, v in ipairs(self.highlight_colors) do
                 table.insert(radio_buttons, {
@@ -2123,7 +2124,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
     local default_color, keep_shown_on_apply
     if item_color then -- called from editHighlightColor
         default_color = self.view.highlight.saved_color or
-            G_reader_settings:readSetting("highlight_color", "yellow")
+            G_reader_settings:readSetting("highlight_color", self._fallback_color)
         keep_shown_on_apply = true
     end
     local radio_buttons = {}
@@ -2133,7 +2134,6 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
                 text = v[1],
                 checked = item_color == v[2],
                 bgcolor = BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF)),
-                --bgcolor = Screen:isColorEnabled() and (BlitBuffer.colorFromName(v[1]) or BlitBuffer.Color8(bit.bxor(0xFF * self.view.highlight.lighten_factor, 0xFF))) or nil,
                 provider = v[2],
             },
         })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -462,6 +462,8 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     UIManager:setDirty(self.dialog, "ui")
                     if touchmenu_instance then touchmenu_instance:updateItems() end
                 end,
+                -- This ensures the waveform mode will be upgraded to a Kaleido wfm on compatible devices
+                colorful = true,
                 dithered = true,
             })
         end,
@@ -2144,6 +2146,7 @@ function ReaderHighlight:showHighlightColorDialog(caller_callback, item_color)
         callback = function(radio)
             caller_callback(radio.provider)
         end,
+        colorful = true,
         dithered = true,
     })
 end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -609,9 +609,10 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         else
             if bb:getInverse() == 1 then
                 -- MUL doesn't really work on a black background, so, switch to OVER if we're in software nightmode...
-                -- NOTE: We do *not* invert the color here, which means it *will* get inverted by the blitter.
-                --       While not particularly pretty, this will (roughly) match with hardware nightmode, *and* how MuPDF renders highlights...
-                local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF * (self.highlight.lighten_factor or 0.2))
+                -- NOTE: If we do *not* invert the color here, it *will* get inverted by the blitter given that the target bb is inverted.
+                --       While not particularly pretty, this (roughly) matches with hardware nightmode, *and* how MuPDF renders highlights...
+                --       But it's *really* not pretty (https://github.com/koreader/koreader/pull/11044#issuecomment-1902886069), so we'll fix it ;p.
+                local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF * (self.highlight.lighten_factor or 0.2)):invert()
                 bb:blendRectRGB32(x, y, w, h, c)
             else
                 bb:multiplyRectRGB(x, y, w, h, color)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -622,7 +622,9 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         if not color or not Screen:isColorEnabled() then
             color = Blitbuffer.Color8A(0, alpha)
         else
-            color = Blitbuffer.ColorRGB32(color.r, color.g, color.b, alpha)
+            -- FIXME: lighten_factor and lightenRect doing the opposite of what they should mean or some such ;p.
+            -- FIXME: Do we even want a ligthen factor here?
+            color = Blitbuffer.ColorRGB32(color.r, color.g, color.b, bit.bxor(alpha, 0xFF))
         end
         --- @fixme: Use something based on colorblitFrom instead?
         --          (except basically, the invert of it, colorizing the non-covered parts of the alpha map).

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -214,7 +214,8 @@ function ReaderView:paintTo(bb, x, y)
     -- mark last read area of overlapped pages
     if not self.dim_area:isEmpty() and self:isOverlapAllowed() then
         if self.page_overlap_style == "dim" then
-            bb:dimRect(self.dim_area.x, self.dim_area.y, self.dim_area.w, self.dim_area.h)
+            -- NOTE: "dim", as in make black text fainter, e.g., lighten the rect
+            bb:lightenRect(self.dim_area.x, self.dim_area.y, self.dim_area.w, self.dim_area.h)
         else
             -- Paint at the proper y origin depending on whether we paged forward (dim_area.y == 0) or backward
             local paint_y = self.dim_area.y == 0 and self.dim_area.h or self.dim_area.y

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -604,7 +604,7 @@ end
 function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note_mark)
     local x, y, w, h = rect.x, rect.y, rect.w, rect.h
     if drawer == "lighten" then
-        if not color or not Screen:isColorEnabled() then
+        if not color then
             bb:darkenRect(x, y, w, h, self.highlight.lighten_factor)
         else
             if bb:getInverse() == 1 then
@@ -619,7 +619,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
             end
         end
     elseif drawer == "underscore" then
-        if not color or not Screen:isColorEnabled() then
+        if not color then
             color = Blitbuffer.COLOR_GRAY_4
         end
         if Blitbuffer.isColor8(color) then
@@ -628,7 +628,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
             bb:paintRectRGB32(x, y + h - 1, w, Size.line.thick, color)
         end
     elseif drawer == "strikeout" then
-        if not color or not Screen:isColorEnabled() then
+        if not color then
             color = Blitbuffer.COLOR_BLACK
         end
         local line_y = y + math.floor(h / 2) + 1
@@ -644,7 +644,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         bb:invertRect(x, y, w, h)
     end
     if draw_note_mark then
-        if not color or not Screen:isColorEnabled() then
+        if not color then
             color = Blitbuffer.COLOR_BLACK
         end
         if self.highlight.note_mark == "underline" then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -607,7 +607,15 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         if not color or not Screen:isColorEnabled() then
             bb:darkenRect(x, y, w, h, self.highlight.lighten_factor or 0.2)
         else
-            bb:multiplyRectRGB(x, y, w, h, color)
+            if bb:getInverse() == 1 then
+                -- MUL doesn't really work on a black background, so, switch to OVER if we're in software nightmode...
+                -- NOTE: We do *not* invert the color here, which means it *will* get inverted by the blitter.
+                --       While not particularly pretty, this will (roughly) match with hardware nightmode, *and* how MuPDF renders highlights...
+                local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF * (self.highlight.lighten_factor or 0.2))
+                bb:blendRectRGB32(x, y, w, h, c)
+            else
+                bb:multiplyRectRGB(x, y, w, h, color)
+            end
         end
     elseif drawer == "underscore" then
         if not color or not Screen:isColorEnabled() then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -93,10 +93,9 @@ function ReaderView:init()
         lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor", 0.2),
         note_mark = G_reader_settings:readSetting("highlight_note_marker"),
         temp_drawer = "invert",
-        temp_color = "yellow",
         temp = {},
         saved_drawer = "lighten",
-        saved_color = "yellow",
+        saved_color = Screen:isColorEnabled() and "yellow" or "gray",
         indicator = nil, -- geom: non-touch highlight position indicator: {x = 50, y=50}
     }
     self.page_states = {}
@@ -522,7 +521,7 @@ function ReaderView:drawTempHighlight(bb, x, y)
         for i = 1, #boxes do
             local rect = self:pageToScreenTransform(page, boxes[i])
             if rect then
-                self:drawHighlightRect(bb, x, y, rect, self.highlight.temp_drawer, self.highlight.temp_color)
+                self:drawHighlightRect(bb, x, y, rect, self.highlight.temp_drawer)
             end
         end
     end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -659,11 +659,9 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
             color = Blitbuffer.COLOR_BLACK
         end
         if self.highlight.note_mark == "underline" then
-            if Blitbuffer.isColor8(color) then
-                bb:paintRect(x, y + h - 1, w, Size.line.medium, color)
-            else
-                bb:paintRectRGB32(x, y + h - 1, w, Size.line.medium, color)
-            end
+            -- With most annotation styles, we'd risk making this invisible if we used the same color,
+            -- so, always draw this in black.
+            bb:paintRect(x, y + h - 1, w, Size.line.medium, Blitbuffer.COLOR_BLACK)
         else
             local note_mark_pos_x
             if self.ui.paging or

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -621,6 +621,8 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         local alpha = 0xFF*(self.highlight.lighten_factor or 0.5)
         if not color or not Screen:isColorEnabled() then
             color = Blitbuffer.Color8A(0, alpha)
+        else
+            color = Blitbuffer.ColorRGB32(color.r, color.g, color.b, alpha)
         end
         bb:lightenRect(x, y, w, h, color)
     elseif drawer == "underscore" then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -41,15 +41,6 @@ local ReaderView = OverlapGroup:extend{
     note_mark_sign = nil,
     note_mark_pos_x1 = nil, -- page 1
     note_mark_pos_x2 = nil, -- page 2 in two-page mode
-    highlight_colors = {
-        ["red"]    = "#fe4400",
-        ["orange"] = "#ff8800",
-        ["yellow"] = "#fdff32",
-        ["green"]  = "#00ad65",
-        ["blue"]   = "#00f2ff",
-        ["purple"] = "#ee00ff",
-        ["gray"]   = "#808080",
-    },
     -- PDF/DjVu continuous paging
     page_scroll = nil,
     page_bgcolor = Blitbuffer.gray(G_defaults:readSetting("DBACKGROUND_COLOR") * (1/15)),
@@ -508,12 +499,6 @@ function ReaderView:drawScrollView(bb, x, y)
         self.state.pos)
 end
 
---- Converts a color name into a color struct
-function ReaderView:lookupHighlightColor(color_name)
-    local color = self.highlight_colors[color_name]
-    return Blitbuffer.colorFromString(color or "#ffff00")
-end
-
 function ReaderView:drawHighlightIndicator(bb, x, y)
     local rect = self.highlight.indicator
     -- paint big cross line +
@@ -558,7 +543,7 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
         for _, item in ipairs(items) do
             local boxes = self.document:getPageBoxesFromPositions(page, item.pos0, item.pos1)
             if boxes then
-                local color = self:lookupHighlightColor(item.color)
+                local color = Blitbuffer.colorFromName(item.color)
                 local draw_note_mark = item.note and self.highlight.note_mark
                 for _, box in ipairs(boxes) do
                     local rect = self:pageToScreenTransform(page, box)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -547,7 +547,7 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
             local boxes = self.document:getPageBoxesFromPositions(page, item.pos0, item.pos1)
             if boxes then
                 local color = Blitbuffer.colorFromName(item.color)
-                if not Blitbuffer.isColor8(color) then
+                if color and not Blitbuffer.isColor8(color) then
                     colorful = true
                 end
                 local draw_note_mark = item.note and self.highlight.note_mark
@@ -593,7 +593,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
                 local boxes = self.document:getScreenBoxesFromPositions(item.pos0, item.pos1, true) -- get_segments=true
                 if boxes then
                     local color = Blitbuffer.colorFromName(item.color)
-                    if not Blitbuffer.isColor8(color) then
+                    if color and not Blitbuffer.isColor8(color) then
                         colorful = true
                     end
                     local draw_note_mark = item.note and self.highlight.note_mark

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -584,7 +584,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
             if end_pos >= cur_view_top then
                 local boxes = self.document:getScreenBoxesFromPositions(item.pos0, item.pos1, true) -- get_segments=true
                 if boxes then
-                    local color = self:lookupHighlightColor(item.color)
+                    local color = Blitbuffer.colorFromName(item.color)
                     local draw_note_mark = item.note and self.highlight.note_mark
                     for _, box in ipairs(boxes) do
                         if box.h ~= 0 then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -604,9 +604,8 @@ end
 function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note_mark)
     local x, y, w, h = rect.x, rect.y, rect.w, rect.h
     if drawer == "lighten" then
-        local alpha = 0xFF*(self.highlight.lighten_factor or 0.5)
         if not color or not Screen:isColorEnabled() then
-            bb:darkenRect(x, y, w, h, alpha)
+            bb:darkenRect(x, y, w, h, self.highlight.lighten_factor or 0.2)
         else
             bb:multiplyRectRGB(x, y, w, h, color)
         end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -587,7 +587,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
             -- document:getScreenBoxesFromPositions() is expensive, so we
             -- first check if this item is on current page
             local start_pos = self.document:getPosFromXPointer(item.pos0)
-            if start_pos > cur_view_bottom then return end -- this and all next highlights are after the current page
+            if start_pos > cur_view_bottom then return colorful end -- this and all next highlights are after the current page
             local end_pos = self.document:getPosFromXPointer(item.pos1)
             if end_pos >= cur_view_top then
                 local boxes = self.document:getScreenBoxesFromPositions(item.pos0, item.pos1, true) -- get_segments=true

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -605,14 +605,14 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
     local x, y, w, h = rect.x, rect.y, rect.w, rect.h
     if drawer == "lighten" then
         if not color or not Screen:isColorEnabled() then
-            bb:darkenRect(x, y, w, h, self.highlight.lighten_factor or 0.2)
+            bb:darkenRect(x, y, w, h, self.highlight.lighten_factor)
         else
             if bb:getInverse() == 1 then
                 -- MUL doesn't really work on a black background, so, switch to OVER if we're in software nightmode...
                 -- NOTE: If we do *not* invert the color here, it *will* get inverted by the blitter given that the target bb is inverted.
                 --       While not particularly pretty, this (roughly) matches with hardware nightmode, *and* how MuPDF renders highlights...
                 --       But it's *really* not pretty (https://github.com/koreader/koreader/pull/11044#issuecomment-1902886069), so we'll fix it ;p.
-                local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF * (self.highlight.lighten_factor or 0.2)):invert()
+                local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF * self.highlight.lighten_factor):invert()
                 bb:blendRectRGB32(x, y, w, h, c)
             else
                 bb:multiplyRectRGB(x, y, w, h, color)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -605,22 +605,19 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
     if drawer == "lighten" then
         local alpha = 0xFF*(self.highlight.lighten_factor or 0.5)
         if not color or not Screen:isColorEnabled() then
-            color = Blitbuffer.Color8A(0, alpha)
+            bb:darkenRect(x, y, w, h, alpha)
         else
-            -- FIXME: lighten_factor and lightenRect doing the opposite of what they should mean or some such ;p.
-            -- FIXME: Do we even want a ligthen factor here?
-            color = Blitbuffer.ColorRGB32(color.r, color.g, color.b, bit.bxor(alpha, 0xFF))
+            bb:multiplyRectRGB(x, y, w, h, color)
         end
-        --- @fixme: Use something based on colorblitFrom instead?
-        --          (except basically, the invert of it, colorizing the non-covered parts of the alpha map).
-        ---         Might be tricky for non-black text, though...
-        ---         Also potentially annoying with software invert, maybe?
-        bb:lightenRect(x, y, w, h, color)
     elseif drawer == "underscore" then
         if not color or not Screen:isColorEnabled() then
             color = Blitbuffer.COLOR_GRAY_4
         end
-        bb:paintRect(x, y + h - 1, w, Size.line.thick, color)
+        if Blitbuffer.isColor8(color) then
+            bb:paintRect(x, y + h - 1, w, Size.line.thick, color)
+        else
+            bb:paintRectRGB32(x, y + h - 1, w, Size.line.thick, color)
+        end
     elseif drawer == "strikeout" then
         if not color or not Screen:isColorEnabled() then
             color = Blitbuffer.COLOR_BLACK
@@ -629,7 +626,11 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         if self.ui.paging then
             line_y = line_y + 2
         end
-        bb:paintRect(x, line_y, w, Size.line.medium, color)
+        if Blitbuffer.isColor8(color) then
+            bb:paintRect(x, line_y, w, Size.line.medium, color)
+        else
+            bb:paintRectRGB32(x, line_y, w, Size.line.medium, color)
+        end
     elseif drawer == "invert" then
         bb:invertRect(x, y, w, h)
     end
@@ -638,7 +639,11 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
             color = Blitbuffer.COLOR_BLACK
         end
         if self.highlight.note_mark == "underline" then
-            bb:paintRect(x, y + h - 1, w, Size.line.medium, color)
+            if Blitbuffer.isColor8(color) then
+                bb:paintRect(x, y + h - 1, w, Size.line.medium, color)
+            else
+                bb:paintRectRGB32(x, y + h - 1, w, Size.line.medium, color)
+            end
         else
             local note_mark_pos_x
             if self.ui.paging or
@@ -649,7 +654,11 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
                 note_mark_pos_x = self.note_mark_pos_x2
             end
             if self.highlight.note_mark == "sideline" then
-                bb:paintRect(note_mark_pos_x, y, self.note_mark_line_w, h, color)
+                if Blitbuffer.isColor8(color) then
+                    bb:paintRect(note_mark_pos_x, y, self.note_mark_line_w, h, color)
+                else
+                    bb:paintRectRGB32(note_mark_pos_x, y, self.note_mark_line_w, h, color)
+                end
             elseif self.highlight.note_mark == "sidemark" then
                 self.note_mark_sign:paintTo(bb, note_mark_pos_x, y)
             end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -624,6 +624,10 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         else
             color = Blitbuffer.ColorRGB32(color.r, color.g, color.b, alpha)
         end
+        --- @fixme: Use something based on colorblitFrom instead?
+        --          (except basically, the invert of it, colorizing the non-covered parts of the alpha map).
+        ---         Might be tricky for non-black text, though...
+        ---         Also potentially annoying with software invert, maybe?
         bb:lightenRect(x, y, w, h, color)
     elseif drawer == "underscore" then
         if not color or not Screen:isColorEnabled() then

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -253,6 +253,8 @@ function PdfDocument:saveHighlight(pageno, item)
     elseif item.drawer == "strikeout" then
         annot_type = C.PDF_ANNOT_STRIKE_OUT
     end
+    -- NOTE: For highlights, display style may differ compared to ReaderView:drawHighlightRect...
+    --       (e.g., we do a MUL blend, MuPDF currently appears to do an OVER blend).
     page:addMarkupAnnotation(quadpoints, n, annot_type, annot_color) -- may update/adjust quadpoints
     -- Update pboxes with the possibly adjusted coordinates (this will have it updated
     -- in self.view.highlight.saved[page])

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -1,3 +1,4 @@
+local BlitBuffer = require("ffi/blitbuffer")
 local CacheItem = require("cacheitem")
 local CanvasContext = require("document/canvascontext")
 local DocCache = require("document/doccache")
@@ -244,7 +245,7 @@ function PdfDocument:saveHighlight(pageno, item)
     local quadpoints, n = _quadpointsFromPboxes(item.pboxes)
     local page = self._document:openPage(pageno)
     local annot_type = C.PDF_ANNOT_HIGHLIGHT
-    local annot_color =  Blitbuffer.colorFromString(item.color)
+    local annot_color =  BlitBuffer.colorFromString(item.color)
     if item.drawer == "lighten" then
         annot_type = C.PDF_ANNOT_HIGHLIGHT
     elseif item.drawer == "underscore" then

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -244,6 +244,7 @@ function PdfDocument:saveHighlight(pageno, item)
     local quadpoints, n = _quadpointsFromPboxes(item.pboxes)
     local page = self._document:openPage(pageno)
     local annot_type = C.PDF_ANNOT_HIGHLIGHT
+    local annot_color =  Blitbuffer.colorFromString(item.color)
     if item.drawer == "lighten" then
         annot_type = C.PDF_ANNOT_HIGHLIGHT
     elseif item.drawer == "underscore" then
@@ -251,7 +252,7 @@ function PdfDocument:saveHighlight(pageno, item)
     elseif item.drawer == "strikeout" then
         annot_type = C.PDF_ANNOT_STRIKE_OUT
     end
-    page:addMarkupAnnotation(quadpoints, n, annot_type) -- may update/adjust quadpoints
+    page:addMarkupAnnotation(quadpoints, n, annot_type, annot_color) -- may update/adjust quadpoints
     -- Update pboxes with the possibly adjusted coordinates (this will have it updated
     -- in self.view.highlight.saved[page])
     item.pboxes = _quadpointsToPboxes(quadpoints, n)

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -245,7 +245,7 @@ function PdfDocument:saveHighlight(pageno, item)
     local quadpoints, n = _quadpointsFromPboxes(item.pboxes)
     local page = self._document:openPage(pageno)
     local annot_type = C.PDF_ANNOT_HIGHLIGHT
-    local annot_color =  BlitBuffer.colorFromString(item.color)
+    local annot_color =  BlitBuffer.colorFromName(item.color)
     if item.drawer == "lighten" then
         annot_type = C.PDF_ANNOT_HIGHLIGHT
     elseif item.drawer == "underscore" then

--- a/frontend/ui/widget/checkbutton.lua
+++ b/frontend/ui/widget/checkbutton.lua
@@ -67,11 +67,14 @@ function CheckButton:initCheckButton(checked)
             show_parent = self.show_parent or self,
         }
     end
+    local fgcolor = self.fgcolor or Blitbuffer.COLOR_BLACK
     self._textwidget = TextBoxWidget:new{
         text = self.text,
         face = self.face,
         width = (self.width or self.parent:getAddedWidgetAvailableWidth()) - self._checkmark.dimen.w,
-        fgcolor = self.enabled and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_DARK_GRAY,
+        bold = self.bold,
+        fgcolor = self.enabled and fgcolor or Blitbuffer.COLOR_DARK_GRAY,
+        bgcolor = self.bgcolor,
     }
     local textbox_shift = math.max(0, self._checkmark.baseline - self._textwidget:getBaseline())
     self._verticalgroup = VerticalGroup:new{

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -160,7 +160,7 @@ function FrameContainer:paintTo(bb, x, y)
             container_height - 2*self.bordersize)
     end
     if self.dim then
-        bb:dimRect(x + self.bordersize, y + self.bordersize,
+        bb:lightenRect(x + self.bordersize, y + self.bordersize,
             container_width - 2*self.bordersize,
             container_height - 2*self.bordersize)
     end

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -578,7 +578,7 @@ function ImageWidget:paintTo(bb, x, y)
     ---        This would require the *original* transparent icon, not the flattened one in the cache.
     ---        c.f., https://github.com/koreader/koreader/pull/6937#issuecomment-748372429 for a PoC
     if self.dim then
-        bb:dimRect(x, y, size.w, size.h)
+        bb:lightenRect(x, y, size.w, size.h)
     end
     -- In night mode, invert all rendered images, so the original is
     -- displayed when the whole screen is inverted by night mode.

--- a/frontend/ui/widget/radiobuttontable.lua
+++ b/frontend/ui/widget/radiobuttontable.lua
@@ -66,6 +66,10 @@ function RadioButtonTable:init()
                 radio = true,
                 provider = btn_entry.provider,
 
+                bold = btn_entry.bold,
+                fgcolor = btn_entry.fgcolor,
+                bgcolor = btn_entry.bgcolor,
+
                 width = (self.width - sizer_space) / column_cnt,
                 bordersize = 0,
                 margin = 0,

--- a/frontend/ui/widget/radiobuttonwidget.lua
+++ b/frontend/ui/widget/radiobuttonwidget.lua
@@ -64,12 +64,11 @@ local RadioButtonWidget = FocusManager:extend{
     default_provider = nil,
     extra_text = nil,
     extra_callback = nil,
+    colorful = false, -- should be set to true if any of the buttons' text is colorful
     -- output
     provider = nil, -- provider of the checked button
     row = nil, -- row of the checked button
     col = nil, -- column of the checked button
-    -- for internal use
-    colorful = false, -- used to change waveform mode if any of our text is colorful
 }
 
 function RadioButtonWidget:init()
@@ -95,6 +94,8 @@ function RadioButtonWidget:init()
     }
 
     -- Check if any of our buttons use color text...
+    -- NOTE: There are so few callers that require this, that we just let them set the colorful field themselves...
+    --[[
     for row, t in ipairs(self.radio_buttons) do
         for col, w in ipairs(t) do
             if w.fgcolor and not Blitbuffer.isColor8(w.fgcolor) then
@@ -110,6 +111,8 @@ function RadioButtonWidget:init()
             break
         end
     end
+    --]]
+
     self:update()
 end
 

--- a/frontend/ui/widget/radiobuttonwidget.lua
+++ b/frontend/ui/widget/radiobuttonwidget.lua
@@ -68,6 +68,8 @@ local RadioButtonWidget = FocusManager:extend{
     provider = nil, -- provider of the checked button
     row = nil, -- row of the checked button
     col = nil, -- column of the checked button
+    -- for internal use
+    colorful = false, -- used to change waveform mode if any of our text is colorful
 }
 
 function RadioButtonWidget:init()
@@ -91,6 +93,23 @@ function RadioButtonWidget:init()
             }
         },
     }
+
+    -- Check if any of our buttons use color text...
+    for row, t in ipairs(self.radio_buttons) do
+        for col, w in ipairs(t) do
+            if w.fgcolor and not Blitbuffer.isColor8(w.fgcolor) then
+                self.colorful = true
+                break
+            end
+            if w.bgcolor and not Blitbuffer.isColor8(w.bgcolor) then
+                self.colorful = true
+                break
+            end
+        end
+        if self.colorful then
+            break
+        end
+    end
     self:update()
 end
 
@@ -215,7 +234,7 @@ function RadioButtonWidget:update()
         self.movable,
     }
     UIManager:setDirty(self, function()
-        return "ui", self.widget_frame.dimen
+        return self.colorful and "partial" or "ui", self.widget_frame.dimen
     end)
 end
 
@@ -242,7 +261,7 @@ end
 
 function RadioButtonWidget:onShow()
     UIManager:setDirty(self, function()
-        return "ui", self.widget_frame.dimen
+        return self.colorful and "partial" or "ui", self.widget_frame.dimen
     end)
     return true
 end

--- a/frontend/ui/widget/radiobuttonwidget.lua
+++ b/frontend/ui/widget/radiobuttonwidget.lua
@@ -236,8 +236,14 @@ function RadioButtonWidget:update()
         },
         self.movable,
     }
+
+    -- If the device doesn't support Kaleido wfm, or color is disabled, don't bother tweaking the wfm
+    if self.colorful and not (Screen:isColorEnabled() and Device:hasKaleidoWfm()) then
+        self.colorful = false
+    end
+
     UIManager:setDirty(self, function()
-        return self.colorful and "partial" or "ui", self.widget_frame.dimen
+        return self.colorful and "full" or "ui", self.widget_frame.dimen
     end)
 end
 
@@ -264,7 +270,7 @@ end
 
 function RadioButtonWidget:onShow()
     UIManager:setDirty(self, function()
-        return self.colorful and "partial" or "ui", self.widget_frame.dimen
+        return self.colorful and "full" or "ui", self.widget_frame.dimen
     end)
     return true
 end

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -836,11 +836,12 @@ function TextBoxWidget:_renderText(start_row_idx, end_row_idx)
     h = h + self.line_glyph_extra_height
     if self._bb then self._bb:free() end
     local bbtype = nil
-    if (self.line_num_to_image and self.line_num_to_image[start_row_idx]) or not Blitbuffer.isColor8(self.bgcolor) then
+    local colorful_bg_pen = not Blitbuffer.isColor8(self.bgcolor)
+    if (self.line_num_to_image and self.line_num_to_image[start_row_idx]) or colorful_bg_pen then
         bbtype = Screen:isColorEnabled() and Blitbuffer.TYPE_BBRGB32 or Blitbuffer.TYPE_BB8
     end
     self._bb = Blitbuffer.new(self.width, h, bbtype)
-    if Blitbuffer.isColor8(self.bgcolor) then
+    if not colorful_bg_pen then
         self._bb:fill(self.bgcolor)
     else
         self._bb:paintRectRGB32(0, 0, self._bb:getWidth(), self._bb:getHeight(), self.bgcolor)

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -836,12 +836,14 @@ function TextBoxWidget:_renderText(start_row_idx, end_row_idx)
     h = h + self.line_glyph_extra_height
     if self._bb then self._bb:free() end
     local bbtype = nil
-    local colorful_bg_pen = not Blitbuffer.isColor8(self.bgcolor)
-    if (self.line_num_to_image and self.line_num_to_image[start_row_idx]) or colorful_bg_pen then
+    local color_fg = not Blitbuffer.isColor8(self.fgcolor)
+    local color_bg = not Blitbuffer.isColor8(self.bgcolor)
+    -- Color, whether from images or fg or bg, means we'll need an RGB32 buffer (if it makes sense, e.g., on a color screen).
+    if (self.line_num_to_image and self.line_num_to_image[start_row_idx]) or color_fg or color_bg then
         bbtype = Screen:isColorEnabled() and Blitbuffer.TYPE_BBRGB32 or Blitbuffer.TYPE_BB8
     end
     self._bb = Blitbuffer.new(self.width, h, bbtype)
-    if not colorful_bg_pen then
+    if not color_bg then
         self._bb:fill(self.bgcolor)
     else
         self._bb:paintRectRGB32(0, 0, self._bb:getWidth(), self._bb:getHeight(), self.bgcolor)
@@ -880,10 +882,17 @@ function TextBoxWidget:_renderText(start_row_idx, end_row_idx)
                         if self._alt_color_for_rtl then
                             color = xglyph.is_rtl and Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_BLACK
                         end
-                        self._bb:colorblitFrom(glyph.bb,
-                                    xglyph.x0 + glyph.l + xglyph.x_offset,
-                                    y - glyph.t - xglyph.y_offset,
-                                    0, 0, glyph.bb:getWidth(), glyph.bb:getHeight(), color)
+                        if not color_fg then
+                            self._bb:colorblitFrom(glyph.bb,
+                                        xglyph.x0 + glyph.l + xglyph.x_offset,
+                                        y - glyph.t - xglyph.y_offset,
+                                        0, 0, glyph.bb:getWidth(), glyph.bb:getHeight(), color)
+                        else
+                            self._bb:colorblitFromRGB32(glyph.bb,
+                                        xglyph.x0 + glyph.l + xglyph.x_offset,
+                                        y - glyph.t - xglyph.y_offset,
+                                        0, 0, glyph.bb:getWidth(), glyph.bb:getHeight(), color)
+                        end
                     end
                 end
             end

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -836,11 +836,15 @@ function TextBoxWidget:_renderText(start_row_idx, end_row_idx)
     h = h + self.line_glyph_extra_height
     if self._bb then self._bb:free() end
     local bbtype = nil
-    if self.line_num_to_image and self.line_num_to_image[start_row_idx] then
+    if (self.line_num_to_image and self.line_num_to_image[start_row_idx]) or not Blitbuffer.isColor8(self.bgcolor) then
         bbtype = Screen:isColorEnabled() and Blitbuffer.TYPE_BBRGB32 or Blitbuffer.TYPE_BB8
     end
     self._bb = Blitbuffer.new(self.width, h, bbtype)
-    self._bb:fill(self.bgcolor)
+    if Blitbuffer.isColor8(self.bgcolor) then
+        self._bb:fill(self.bgcolor)
+    else
+        self._bb:paintRectRGB32(0, 0, self._bb:getWidth(), self._bb:getHeight(), self.bgcolor)
+    end
 
     local y = self.line_glyph_baseline
     if self.use_xtext then

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -58,7 +58,7 @@ end
 -- So sorry for the Tolinos with (Android 4.4.x).
 -- Maybe https://f-droid.org/de/packages/jackpal.androidterm/ could be an alternative then.
 if (Device:isAndroid() and Device.firmware_rev < 21) or not check_prerequisites() then
-    logger.warn("Terminal: Device doesn't meet some of the plugin's prerequisites")
+    logger.warn("Terminal: Device doesn't meet some of the plugin's requirements")
     return { disabled = true, }
 end
 


### PR DESCRIPTION
Pass a configurable ColorRGB32 to bb:paintRect / bb:lightenRect.
If isColorEnabled is unset then original B&W Color8/uint8_t is passed in.

Requires corresponding Cbb patch.
https://github.com/koreader/koreader-base/pull/1680

Fix #9024 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11044)
<!-- Reviewable:end -->
