### PR TITLE
Device: Don't leave hasSeamlessWifiToggle enabled when hasWifiToggle is disabled

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -285,6 +285,11 @@ function Device:init()
             self.screen:toggleSWDithering(true)
         end
     end
+
+    -- Can't be seamless if you can't do it at all ;)
+    if not self:hasWifiToggle() then
+        self.hasSeamlessWifiToggle = no
+    end
 end
 
 function Device:setScreenDPI(dpi_override)

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -463,6 +463,7 @@ local PocketBook613 = PocketBook:extend{
     display_dpi = 167,
     isTouchDevice = no,
     hasWifiToggle = no,
+    hasSeamlessWifiToggle = no,
     hasFrontlight = no,
     hasDPad = yes,
     hasFewKeys = yes,

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -70,6 +70,7 @@ local Device = Generic:extend{
     hasKeys = yes,
     hasDPad = yes,
     hasWifiToggle = no,
+    hasSeamlessWifiToggle = no,
     isTouchDevice = yes,
     isDefaultFullscreen = no,
     needsScreenRefreshAfterResume = no,


### PR DESCRIPTION
Fix #11059

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11060)
<!-- Reviewable:end -->
