### PR TITLE
Add new PocketBook InkPad Color 3 (743K3)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -702,6 +702,24 @@ function PocketBook743C._fb_init(fb, finfo, vinfo)
     vinfo.bits_per_pixel = 24
 end
 
+-- PocketBook InkPad Color 3 (743K3)
+local PocketBook743K3 = PocketBook:extend{
+    model = "PBInkPadColor3",
+    display_dpi = 300,
+    color_saturation = 1.5,
+    hasColorScreen = yes,
+    canHWDither = yes, -- Adjust color saturation with inkview
+    canUseCBB = no, -- 24bpp
+    isAlwaysPortrait = yes,
+    usingForcedRotation = landscape_ccw,
+    hasNaturalLight = yes,
+}
+
+function PocketBook743K3._fb_init(fb, finfo, vinfo)
+    -- Pocketbook Color Lux reports bits_per_pixel = 8, but actually uses an RGB24 framebuffer
+    vinfo.bits_per_pixel = 24
+end
+
 -- PocketBook InkPad 4 (743G/743g)
 local PocketBook743G = PocketBook:extend{
     model = "PBInkPad4",
@@ -821,6 +839,8 @@ elseif codename == "PB741" then
     return PocketBook741
 elseif codename == "PB743C" then
     return PocketBook743C
+elseif codename == "PB743K3" then
+    return PocketBook743K3
 elseif codename == "PB743G" or codename == "PB743g" or codename == "PocketBook 743G" or codename == "PocketBook 743g" then
     return PocketBook743G
 elseif codename == "PocketBook 840" or codename == "Reader InkPad" then


### PR DESCRIPTION
To add the new PocketBook InkPad Color 3 (743K3) with E Ink Kaleido™ 3 screen.

[crash.log(1).txt](https://github.com/koreader/koreader/files/13258960/crash.log.1.txt)

[crash.log(2).txt](https://github.com/koreader/koreader/files/13258962/crash.log.2.txt)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11079)
<!-- Reviewable:end -->
