### PR TITLE
Fix connection bug with non-ASCII SSIDs in wpa_supplicant

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1067,7 +1067,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
             end
             UIManager:show(InfoMessage:new{
                 tag = "NetworkMgr", -- for crazy KOSync purposes
-                text = T(_("Connected to network %1"), BD.wrap(self.decodeSSID(ssid))),
+                text = T(_("Connected to network %1"), BD.wrap(util.fixUtf8(ssid, "�"))),
                 timeout = 3,
             })
         else
@@ -1117,23 +1117,6 @@ end
 
 function NetworkMgr:setWirelessBackend(name, options)
     require("ui/network/"..name).init(self, options)
-end
-
-function NetworkMgr.decodeSSID(text)
-    local decode = function(b)
-        local c = string.char(tonumber(b, 16))
-        -- This is a hack that allows us to make sure that any decoded backslash
-        -- does not get replaced in the step that replaces double backslashes.
-        if c == "\\" then
-            return "\\\\"
-        else
-            return c
-        end
-    end
-
-    local decoded = text:gsub("%f[\\]\\x(%x%x)", decode)
-    decoded = decoded:gsub("\\\\", "\\")
-    return util.fixUtf8(decoded, "�")
 end
 
 -- set network proxy if global variable G_defaults:readSetting("NETWORK_PROXY") is defined

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -56,6 +56,7 @@ local OverlapGroup = require("ui/widget/overlapgroup")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
+local util = require("util")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local Widget = require("ui/widget/widget")
 local _ = require("gettext")
@@ -106,7 +107,7 @@ local NetworkItem = InputContainer:extend{
     icon_size = Screen:scaleBySize(32),
     width = nil,
     info = nil,
-    decoded_ssid = nil,
+    display_ssid = nil,
     background = Blitbuffer.COLOR_WHITE,
 }
 
@@ -115,7 +116,7 @@ function NetworkItem:init()
     if not self.info.ssid then
         self.info.ssid = "[hidden]"
     end
-    self.decoded_ssid = NetworkMgr.decodeSSID(self.info.ssid)
+    self.display_ssid = util.fixUtf8(self.info.ssid, "�")
 
     local wifi_icon
     if string.find(self.info.flags, "WPA") then
@@ -151,7 +152,7 @@ function NetworkItem:init()
                 },
                 horizontal_space,
                 TextWidget:new{
-                    text = self.decoded_ssid,
+                    text = self.display_ssid,
                     face = Font:getFace("cfont"),
                 },
             },
@@ -285,7 +286,7 @@ end
 function NetworkItem:onEditNetwork()
     local password_input
     password_input = InputDialog:new{
-        title = self.decoded_ssid,
+        title = self.display_ssid,
         input = self.info.password,
         input_hint = _("password (leave empty for open networks)"),
         input_type = "text",
@@ -328,7 +329,7 @@ end
 function NetworkItem:onAddNetwork()
     local password_input
     password_input = InputDialog:new{
-        title = self.decoded_ssid,
+        title = self.display_ssid,
         input = "",
         input_hint = _("password (leave empty for open networks)"),
         input_type = "text",
@@ -490,7 +491,7 @@ function NetworkSetting:init()
                 UIManager:close(self, "ui", self.dimen)
             end
             UIManager:show(InfoMessage:new{
-                text = T(_("Connected to network %1"), BD.wrap(connected_item.decoded_ssid)),
+                text = T(_("Connected to network %1"), BD.wrap(connected_item.display_ssid)),
                 timeout = 3,
             })
             if self.connect_callback then

--- a/spec/unit/network_manager_spec.lua
+++ b/spec/unit/network_manager_spec.lua
@@ -73,30 +73,6 @@ describe("network_manager module", function()
         assert.is.same(release_ip_called, 0)
     end)
 
-    describe("decodeSSID()", function()
-        local NetworkMgr = require("ui/network/manager")
-
-        it("should correctly unescape emoji", function()
-            assert.is_equal("📚", NetworkMgr.decodeSSID("\\xf0\\x9f\\x93\\x9a"))
-        end)
-
-        it("should correctly unescape multiple characters", function()
-            assert.is_equal("神舟五号", NetworkMgr.decodeSSID("\\xe7\\xa5\\x9e\\xe8\\x88\\x9f\\xe4\\xba\\x94\\xe5\\x8f\\xb7"))
-        end)
-
-        it("should ignore escaped backslashes", function()
-            assert.is_equal("\\x61", NetworkMgr.decodeSSID("\\\\x61"))
-        end)
-
-        it("should not remove encoded backslashes", function()
-            assert.is_equal("\\\\", NetworkMgr.decodeSSID("\\x5c\\"))
-        end)
-
-        it("should deal with invalid UTF-8 (relatively) gracefully", function()
-            assert.is_equal("��", NetworkMgr.decodeSSID("\\xe2\\x82"))
-        end)
-    end)
-
     teardown(function()
         function Device:initNetworkManager() end
         function Device:hasWifiRestore() return false end


### PR DESCRIPTION
Connecting to non-ASCII SSIDs does not work, and I did not actually if #10864 fixed it. It turns out that it didn't, so here is a PR that actually fixes it.

The UTF-8 decoding of SSIDs is specific to wpa_supplicant. In this patch, we move all of this decoding logic to the wpa_supplicant module. We expose the raw bytes of the SSID to the NetworkMgr code, and make sure to always fix bad UTF-8 before we display the SSID to the user.

Within the wpa_supplicant module, we replace the call to the wpa_passphrase binary to get the PSK with a direct function call to OpenSSL. This allows us to calculate the PSK over any arbitrary bytes, including UTF-8. In the same vein, we use the hex-encoded SSID to communicate with wpa_supplicant when setting up the network to support arbitrary bytes in the SSID.

Unfortunately, we also remove the tests, as there is no way to unit test local functions.

This PR depends on koreader/koreader-base#1693 and cannot be merged before base has been updated to reflect those changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11089)
<!-- Reviewable:end -->
