### PR TITLE
Page browser: show nightmode thumbnails when in nightmode

### DIFF
--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -250,6 +250,10 @@ end
 function ReaderThumbnail:getPageThumbnail(page, width, height, batch_id, when_generated_callback)
     self:setupCache()
     self.current_target_size_tag = string.format("w%d_h%d", width, height)
+    if self.ui.rolling and Screen.night_mode and self.ui.document.configurable.nightmode_images == 1 then
+        -- We'll get a different bb in this case: it needs it own cache hash
+        self.current_target_size_tag = self.current_target_size_tag .. "_ni"
+    end
     local hash = string.format("p%d-%s", page, self.current_target_size_tag)
     local tile = self.tile_cache and self.tile_cache:check(hash)
     if tile then
@@ -431,7 +435,7 @@ function ReaderThumbnail:_getPageImage(page)
             self.ui.document:setGammaIndex(30) -- as downscaling will make text grayer
         end
         self.ui.document:setImageScaling(false) -- No need for smooth scaling as all will be downscaled
-        self.ui.document:setNightmodeImages(false) -- We don't invert page images even if nightmode set: keep images as-is
+        -- (We keep "nighmode_images" as it was set: we may get and cache a different bb whether nightmode is on or off)
         self.ui.view.state.page = page -- Be on requested page
         self.ui.document:gotoPage(page) -- Current xpointer needs to be updated for some of what follows
         self.ui.bookmark:onPageUpdate(page) -- Update dogear state for this page

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -251,8 +251,8 @@ function ReaderThumbnail:getPageThumbnail(page, width, height, batch_id, when_ge
     self:setupCache()
     self.current_target_size_tag = string.format("w%d_h%d", width, height)
     if self.ui.rolling and Screen.night_mode and self.ui.document.configurable.nightmode_images == 1 then
-        -- We'll get a different bb in this case: it needs it own cache hash
-        self.current_target_size_tag = self.current_target_size_tag .. "_ni"
+        -- We'll get a different bb in this case: it needs its own cache hash
+        self.current_target_size_tag = self.current_target_size_tag .. "_nm"
     end
     local hash = string.format("p%d-%s", page, self.current_target_size_tag)
     local tile = self.tile_cache and self.tile_cache:check(hash)

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -74,6 +74,7 @@ local ImageWidget = Widget:extend{
     dim = nil,
     alpha = false, -- honors alpha values from the image
     is_icon = false, -- set to true by sub-class IconWidget
+    original_in_nightmode = true, -- defaults to display the original image colors in nightmode
 
     -- When rotation_angle is not 0, native image is rotated by this angle
     -- before scaling.
@@ -578,7 +579,7 @@ function ImageWidget:paintTo(bb, x, y)
     ---        but we currently don't, as we don't really trickle down
     ---        a way to discriminate them from the B&W ones.
     ---        Currently, this is *only* the KOReader icon in Help, AFAIK.
-    if Screen.night_mode and not self.is_icon then
+    if Screen.night_mode and self.original_in_nightmode and not self.is_icon then
         bb:invertRect(x, y, size.w, size.h)
     end
 end

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -749,6 +749,7 @@ function PageBrowserWidget:showTile(grid_idx, page, tile, do_refresh)
         ImageWidget:new{
             image = tile.bb,
             image_disposable = false,
+            original_in_nightmode = false, -- we want our page thumbnail nightmode'd when in nighmtmode
         },
     }
     item_container[1] = thumb_frame


### PR DESCRIPTION
Just prevent page thumbnails ImageWidgets to be nightmode inverted, unlike all other ones which are expected to be double inverted to get their original colors shown.
The same thumbnail can be used and cached in both day and night modes, unless "nightmode_images" is enabled and have crengine itself invert images, making thumbnails different.

(Had a hard time writing that commit message :) was initially mentionning "triple inverting"... hard to put into words what's happening in nightmode and the simple tweaks there).

See https://github.com/koreader/koreader/issues/10811#issuecomment-1785943242

Pinging @NiLuJe for your OK the the ImageWidget `original_in_nightmode = true` idea/wording.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11091)
<!-- Reviewable:end -->
