### PR TITLE
FileChooser: fix reverse sorting of folders

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -446,18 +446,11 @@ To:
         text = _("Folders and files mixed"),
         enabled_func = function()
             local collate = G_reader_settings:readSetting("collate")
-            return collate ~= "size" and
-                   collate ~= "type" and
-                   collate ~= "percent_unopened_first" and
-                   collate ~= "percent_unopened_last"
+            return not FileChooser.isCollateNotForMixed(collate)
         end,
         checked_func = function()
             local collate = G_reader_settings:readSetting("collate")
-            return G_reader_settings:isTrue("collate_mixed") and
-                   collate ~= "size" and
-                   collate ~= "type" and
-                   collate ~= "percent_unopened_first" and
-                   collate ~= "percent_unopened_last"
+            return not FileChooser.isCollateNotForMixed(collate) and G_reader_settings:isTrue("collate_mixed")
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("collate_mixed")

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -242,19 +242,21 @@ function FileChooser:genItemTableFromPath(path)
     return self:genItemTable(dirs, files, path)
 end
 
+function FileChooser.isCollateNotForMixed(collate)
+    return collate == "size" or collate == "type"
+        or collate == "percent_unopened_first" or collate == "percent_unopened_last"
+end
+
 function FileChooser:genItemTable(dirs, files, path)
     local collate = G_reader_settings:readSetting("collate")
-    local collate_not_for_mixed = collate == "size" or
-                                  collate == "type" or
-                                  collate == "percent_unopened_first" or
-                                  collate == "percent_unopened_last"
     local collate_mixed = G_reader_settings:isTrue("collate_mixed")
     local reverse_collate = G_reader_settings:isTrue("reverse_collate")
     local sorting = self:getSortingFunction(collate, reverse_collate)
+    local collate_not_for_mixed = self.isCollateNotForMixed(collate)
     if collate_not_for_mixed or not collate_mixed then
         table.sort(files, sorting)
-        if collate_not_for_mixed then
-            sorting = self:getSortingFunction("strcoll", reverse_collate)
+        if collate_not_for_mixed then -- keep folders sorted by name not reversed
+            sorting = self:getSortingFunction("strcoll")
         end
         table.sort(dirs, sorting)
     end


### PR DESCRIPTION
Minor fix: in sorting modes unapplicable to folders (size, type, percentage), folders remain sorted by name.
In that modes the reverse sorting should not affect folders.

Minor deduplicating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11093)
<!-- Reviewable:end -->
