### PR TITLE
InputDialog: tap outside to close dialog if keyboard is hidden

### DIFF
--- a/frontend/apps/reader/modules/readerhandmade.lua
+++ b/frontend/apps/reader/modules/readerhandmade.lua
@@ -484,6 +484,7 @@ function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, sele
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(dialog)
                     end,

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -267,16 +267,18 @@ function ButtonDialog:onCloseWidget()
     end)
 end
 
-function ButtonDialog:onTapClose()
-    UIManager:close(self)
+function ButtonDialog:onClose()
     if self.tap_close_callback then
         self.tap_close_callback()
     end
+    UIManager:close(self)
     return true
 end
 
-function ButtonDialog:onClose()
-    self:onTapClose()
+function ButtonDialog:onTapClose(arg, ges)
+    if ges.pos:notIntersectWith(self.movable.dimen) then
+        self:onClose()
+    end
     return true
 end
 

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -483,7 +483,7 @@ end
 
 -- Tap outside of inputbox to hide the keyboard (inside the inputbox it is caught via InputText:onTapTextBox).
 -- If the keyboard is hidden, tap outside of the dialog to close the dialog.
-function InputDialog:onTap()
+function InputDialog:onTap(arg, ges)
     -- This is slightly more fine-grained than VK's own visibility lock, hence the duplication...
     if self.deny_keyboard_hiding then
         return
@@ -491,7 +491,9 @@ function InputDialog:onTap()
     if self:isKeyboardVisible() then
         self:onCloseKeyboard()
     else
-        self:onCloseDialog()
+        if ges.pos:notIntersectWith(self.dialog_frame.dimen) then
+            self:onCloseDialog()
+        end
     end
 end
 

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -436,7 +436,10 @@ function InputDialog:init()
         self.ges_events.Tap = {
             GestureRange:new{
                 ges = "tap",
-                range = self[1].dimen, -- screen above the keyboard
+                range = Geom:new{
+                    w = self.screen_width,
+                    h = self.screen_height,
+                },
             },
         }
     end
@@ -478,13 +481,18 @@ function InputDialog:getAddedWidgetAvailableWidth()
     return self._input_widget.width
 end
 
--- Close the keyboard if we tap anywhere outside of the keyboard (that isn't an input field, where it would be caught via InputText:onTapTextBox)
+-- Tap outside of inputbox to hide the keyboard (inside the inputbox it is caught via InputText:onTapTextBox).
+-- If the keyboard is hidden, tap outside of the dialog to close the dialog.
 function InputDialog:onTap()
     -- This is slightly more fine-grained than VK's own visibility lock, hence the duplication...
     if self.deny_keyboard_hiding then
         return
     end
-    self:onCloseKeyboard()
+    if self:isKeyboardVisible() then
+        self:onCloseKeyboard()
+    else
+        self:onCloseDialog()
+    end
 end
 
 function InputDialog:getInputText()

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -724,6 +724,7 @@ function Menu:init()
         {
             {
                 text = _("Cancel"),
+                id = "close",
                 callback = function()
                     self.page_info_text:closeInputDialog()
                 end,

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -441,6 +441,7 @@ function TextViewer:findDialog()
             {
                 {
                     text = _("Cancel"),
+                    id = "close",
                     callback = function()
                         UIManager:close(input_dialog)
                     end,


### PR DESCRIPTION
Have tried and found useful. Closes https://github.com/koreader/koreader/issues/11092.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11094)
<!-- Reviewable:end -->
