### PR TITLE
Exporter: memos, replace space with underscore for # tag creation

### DIFF
--- a/plugins/exporter.koplugin/target/memos.lua
+++ b/plugins/exporter.koplugin/target/memos.lua
@@ -135,7 +135,7 @@ function MemosExporter:createHighlights(booknotes)
             if clipping.note then
                 highlight = highlight .. clipping.note .. "\n\n"
             end
-            highlight =  highlight .. booknotes.title .. " (page: " .. clipping.page .. "）\n\n #" .. booknotes.title .. " #koreader"
+            highlight =  highlight .. booknotes.title .. " (page: " .. clipping.page .. "）\n\n #" .. booknotes.title:gsub("%s+", "_") .. " #koreader"
             local result, err = makeRequest("POST", { content = highlight }, self.settings.api, self.settings.token)
             if not result then
                 logger.warn("error creating highlights", err)


### PR DESCRIPTION
@fierceX (author of the plugin) FYI

Creating tags on memos looked like "#This is a book title" meaning only "#This" would become a Tag. Replacing spaces with underscore to be more usable so that the following tag would be created "#This_is_a_book_title"

and thanks a lot to @fierceX, very useful plugin!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11107)
<!-- Reviewable:end -->
