### PR TITLE
Folder shortcuts: new markers, buttons

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -112,7 +112,7 @@ end
 function FileManager:updateTitleBarPath(path)
     path = path or self.file_chooser.path
     local text = BD.directory(filemanagerutil.abbreviate(path))
-    if FileManagerShortcuts:isShortcutAdded(path) then
+    if FileManagerShortcuts:hasFolderShortcut(path) then
         text = "☆ " .. text
     end
     self.title_bar:setSubTitle(text)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -359,8 +359,7 @@ function FileManagerMenu:setUpdateItemTable()
                         end,
                         callback = function()
                             G_reader_settings:flipNilOrTrue("shorten_home_dir")
-                            local FileManager = require("apps/filemanager/filemanager")
-                            if FileManager.instance then FileManager.instance:reinit() end
+                            self.ui:updateTitleBarPath()
                         end,
                         help_text = _([[
 "Shorten home folder" will display the home folder itself as "Home" instead of its full path.

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -2,7 +2,6 @@ local BD = require("ui/bidi")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
-local Event = require("ui/event")
 local FFIUtil = require("ffi/util")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local PluginLoader = require("pluginloader")
@@ -785,7 +784,7 @@ The sorting order is the same as in filemanager.
 
 Tap a book in the search results to open it.]]),
         callback = function()
-            self.ui:handleEvent(Event:new("ShowFileSearch"))
+            self.ui.filesearcher:onShowFileSearch()
         end
     }
 

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -43,7 +43,7 @@ function FileManagerShortcuts:_getIndex(folder)
     end
 end
 
-function FileManagerShortcuts:isShortcutAdded(folder)
+function FileManagerShortcuts:hasFolderShortcut(folder)
     return self:_getIndex(folder) and true or false
 end
 
@@ -67,10 +67,10 @@ function FileManagerShortcuts:onMenuHold(item)
     local buttons = {
         {
             {
-                text = _("Delete shortcut"),
+                text = _("Remove shortcut"),
                 callback = function()
                     UIManager:close(dialog)
-                    self._manager:deleteShortcut(item.folder)
+                    self._manager:removeShortcut(item.folder)
                 end
             },
             {
@@ -103,7 +103,7 @@ function FileManagerShortcuts:onMenuHold(item)
     return true
 end
 
-function FileManagerShortcuts:deleteShortcut(folder)
+function FileManagerShortcuts:removeShortcut(folder)
     local index = self:_getIndex(folder)
     table.remove(self.folder_shortcuts, index)
     if self.shortcuts_menu then
@@ -170,7 +170,7 @@ function FileManagerShortcuts:addShortcut()
         select_file = false,
         path = self.ui.file_chooser and self.ui.file_chooser.path or self.ui:getLastDirFile(),
         onConfirm = function(path)
-            if self:isShortcutAdded(path) then
+            if self:hasFolderShortcut(path) then
                 UIManager:show(InfoMessage:new{
                     text = _("Shortcut already exists."),
                 })
@@ -193,12 +193,12 @@ function FileManagerShortcuts:genShowFolderShortcutsButton(pre_callback)
 end
 
 function FileManagerShortcuts:genAddRemoveShortcutButton(folder, pre_callback, post_callback)
-    if self:isShortcutAdded(folder) then
+    if self:hasFolderShortcut(folder) then
         return {
             text = _("Remove from folder shortcuts"),
             callback = function()
                 pre_callback()
-                self:deleteShortcut(folder)
+                self:removeShortcut(folder)
                 post_callback()
             end,
         }

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -7,199 +7,210 @@ local Screen = require("device").screen
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local lfs = require("libs/libkoreader-lfs")
-local util = require("ffi/util")
 local _ = require("gettext")
-local T = util.template
 
 local FileManagerShortcuts = WidgetContainer:extend{
+    title = _("Folder shortcuts"),
     folder_shortcuts = G_reader_settings:readSetting("folder_shortcuts", {}),
 }
 
-function FileManagerShortcuts:updateItemTable(select_callback)
+function FileManagerShortcuts:updateItemTable()
     local item_table = {}
     for _, item in ipairs(self.folder_shortcuts) do
         table.insert(item_table, {
             text = string.format("%s (%s)", item.text, item.folder),
             folder = item.folder,
-            friendly_name = item.text,
-            deletable = true,
-            editable = true,
-            callback = function()
-                UIManager:close(self.fm_bookmark)
-
-                local folder = item.folder
-                if folder ~= nil and lfs.attributes(folder, "mode") == "directory" then
-                    if select_callback then
-                        select_callback(folder)
-                    else
-                        if self.ui.file_chooser then
-                            self.ui.file_chooser:changeToPath(folder)
-                        else -- called from Reader
-                            self.ui:onClose()
-                            self.ui:showFileManager(folder .. "/")
-                        end
-                    end
-                end
-            end,
+            name = item.text,
         })
     end
-
     table.sort(item_table, function(l, r)
         return l.text < r.text
     end)
 
     -- try to stay on current page
     local select_number
-
-    if self.fm_bookmark.page and self.fm_bookmark.perpage and self.fm_bookmark.page > 0 then
-        select_number = (self.fm_bookmark.page - 1) * self.fm_bookmark.perpage + 1
+    if self.shortcuts_menu.page and self.shortcuts_menu.perpage and self.shortcuts_menu.page > 0 then
+        select_number = (self.shortcuts_menu.page - 1) * self.shortcuts_menu.perpage + 1
     end
-
-    self.fm_bookmark:switchItemTable(nil,
-                                     item_table, select_number)
+    self.shortcuts_menu:switchItemTable(nil, item_table, select_number)
 end
 
-function FileManagerShortcuts:addNewFolder()
+function FileManagerShortcuts:_getIndex(folder)
+    for i, v in ipairs(self.folder_shortcuts) do
+        if v.folder == folder then
+            return i
+        end
+    end
+end
+
+function FileManagerShortcuts:isShortcutAdded(folder)
+    return self:_getIndex(folder) and true or false
+end
+
+function FileManagerShortcuts:onMenuChoice(item)
+    local folder = item.folder
+    if lfs.attributes(folder, "mode") ~= "directory" then return end
+    if self.select_callback then
+        self.select_callback(folder)
+    else
+        if self._manager.ui.file_chooser then
+            self._manager.ui.file_chooser:changeToPath(folder)
+        else -- called from Reader
+            self._manager.ui:onClose()
+            self._manager.ui:showFileManager(folder .. "/")
+        end
+    end
+end
+
+function FileManagerShortcuts:onMenuHold(item)
+    local dialog
+    local buttons = {
+        {
+            {
+                text = _("Delete shortcut"),
+                callback = function()
+                    UIManager:close(dialog)
+                    self._manager:deleteShortcut(item.folder)
+                end
+            },
+            {
+                text = _("Rename shortcut"),
+                callback = function()
+                    UIManager:close(dialog)
+                    self._manager:editShortcut(item.folder)
+                end
+            },
+        },
+    }
+    if self._manager.ui.file_chooser and self._manager.ui.clipboard then
+        table.insert(buttons, {
+            {
+                text = _("Paste to folder"),
+                callback = function()
+                    UIManager:close(dialog)
+                    self._manager.ui:pasteHere(item.folder)
+                end
+            },
+        })
+    end
+
+    dialog = ButtonDialog:new{
+        title = item.name .. "\n" .. BD.dirpath(item.folder),
+        title_align = "center",
+        buttons = buttons,
+    }
+    UIManager:show(dialog)
+    return true
+end
+
+function FileManagerShortcuts:deleteShortcut(folder)
+    local index = self:_getIndex(folder)
+    table.remove(self.folder_shortcuts, index)
+    if self.shortcuts_menu then
+        self.fm_updated = true
+        self:updateItemTable()
+    end
+end
+
+function FileManagerShortcuts:editShortcut(folder, post_callback)
+    local index = self:_getIndex(folder)
+    local item, name
+    if index then -- rename
+        item = self.folder_shortcuts[index]
+        name = item.text
+    end
+
+    local input_dialog
+    input_dialog = InputDialog:new {
+        title = _("Enter folder shortcut name"),
+        input = name,
+        description = BD.dirpath(folder),
+        buttons = {{
+            {
+                text = _("Cancel"),
+                id = "close",
+                callback = function()
+                    UIManager:close(input_dialog)
+                end,
+            },
+            {
+                text = _("Save"),
+                is_enter_default = true,
+                callback = function()
+                    local new_name = input_dialog:getInputText()
+                    if new_name == "" or new_name == name then return end
+                    UIManager:close(input_dialog)
+                    if item then
+                        item.text = new_name
+                    else
+                        table.insert(self.folder_shortcuts, {
+                            text = new_name,
+                            folder = folder,
+                        })
+                        if post_callback then
+                            post_callback()
+                        end
+                    end
+                    if self.shortcuts_menu then
+                        self.fm_updated = true
+                        self:updateItemTable()
+                    end
+                end,
+            },
+        }},
+    }
+    UIManager:show(input_dialog)
+    input_dialog:onShowKeyboard()
+end
+
+function FileManagerShortcuts:addShortcut()
     local PathChooser = require("ui/widget/pathchooser")
     local path_chooser = PathChooser:new{
         select_directory = true,
         select_file = false,
-        path = self.fm_bookmark.curr_path,
+        path = self.ui.file_chooser and self.ui.file_chooser.path or self.ui:getLastDirFile(),
         onConfirm = function(path)
-            local add_folder_input
-            local friendly_name = util.basename(path) or _("my folder")
-            add_folder_input = InputDialog:new{
-                title = _("Enter friendly name"),
-                input = friendly_name,
-                description = T(_("Title for selected folder:\n%1"), BD.dirpath(path)),
-                buttons = {
-                    {
-                        {
-                            text = _("Cancel"),
-                            id = "close",
-                            callback = function()
-                                UIManager:close(add_folder_input)
-                            end,
-                        },
-                        {
-                            text = _("Add"),
-                            is_enter_default = true,
-                            callback = function()
-                                self:addFolderFromInput(add_folder_input:getInputValue(), path)
-                                UIManager:close(add_folder_input)
-                            end,
-                        },
-                    }
-                },
-            }
-            UIManager:show(add_folder_input)
-            add_folder_input:onShowKeyboard()
-        end
+            if self:isShortcutAdded(path) then
+                UIManager:show(InfoMessage:new{
+                    text = _("Shortcut already exists."),
+                })
+            else
+                self:editShortcut(path)
+            end
+        end,
     }
     UIManager:show(path_chooser)
 end
 
-function FileManagerShortcuts:addFolderFromInput(friendly_name, folder)
-    for __, item in ipairs(self.folder_shortcuts) do
-        if item.text == friendly_name and item.folder == folder then
-            UIManager:show(InfoMessage:new{
-                text = _("A shortcut to this folder already exists."),
-            })
-            return
-        end
-    end
-    table.insert(self.folder_shortcuts, {
-        text = friendly_name,
-        folder = folder,
-    })
-    self:updateItemTable()
-end
-
-function FileManagerShortcuts:onMenuHold(item)
-    if item.deletable or item.editable then
-        local folder_shortcuts_dialog
-        folder_shortcuts_dialog = ButtonDialog:new{
-            buttons = {
-                {
-                    {
-                        text = _("Paste file"),
-                        enabled = (self._manager.ui.file_chooser and self._manager.ui.clipboard) and true or false,
-                        callback = function()
-                            UIManager:close(folder_shortcuts_dialog)
-                            self._manager.ui:pasteHere(item.folder)
-                        end
-                    },
-                    {
-                        text = _("Edit"),
-                        enabled = item.editable,
-                        callback = function()
-                            UIManager:close(folder_shortcuts_dialog)
-                            self._manager:editFolderShortcut(item)
-                        end
-                    },
-                    {
-                        text = _("Delete"),
-                        enabled = item.deletable,
-                        callback = function()
-                            UIManager:close(folder_shortcuts_dialog)
-                            self._manager:deleteFolderShortcut(item)
-                        end
-                    },
-                },
-            }
-        }
-        UIManager:show(folder_shortcuts_dialog)
-        return true
-    end
-end
-
-function FileManagerShortcuts:editFolderShortcut(item)
-    local edit_folder_input
-    edit_folder_input = InputDialog:new {
-        title = _("Edit friendly name"),
-        input = item.friendly_name,
-        description = T(_("Rename title for selected folder:\n%1"), BD.dirpath(item.folder)),
-        buttons = {
-            {
-                {
-                    text = _("Cancel"),
-                    id = "close",
-                    callback = function()
-                        UIManager:close(edit_folder_input)
-                    end,
-                },
-                {
-                    text = _("Apply"),
-                    is_enter_default = true,
-                    callback = function()
-                        self:renameFolderShortcut(item, edit_folder_input:getInputText())
-                        UIManager:close(edit_folder_input)
-                    end,
-                },
-            }
-        },
+function FileManagerShortcuts:genShowFolderShortcutsButton(pre_callback)
+    return {
+        text = self.title,
+        callback = function()
+            pre_callback()
+            self:onShowFolderShortcutsDialog()
+        end,
     }
-    UIManager:show(edit_folder_input)
-    edit_folder_input:onShowKeyboard()
 end
 
-function FileManagerShortcuts:renameFolderShortcut(item, new_name)
-    for _, element in ipairs(self.folder_shortcuts) do
-        if element.text == item.friendly_name and element.folder == item.folder then
-            element.text = new_name
-        end
+function FileManagerShortcuts:genAddRemoveShortcutButton(folder, pre_callback, post_callback)
+    if self:isShortcutAdded(folder) then
+        return {
+            text = _("Remove from folder shortcuts"),
+            callback = function()
+                pre_callback()
+                self:deleteShortcut(folder)
+                post_callback()
+            end,
+        }
+    else
+        return {
+            text = _("Add to folder shortcuts"),
+            callback = function()
+                pre_callback()
+                self:editShortcut(folder, post_callback)
+            end,
+        }
     end
-    self:updateItemTable()
-end
-
-function FileManagerShortcuts:deleteFolderShortcut(item)
-    for i = #self.folder_shortcuts, 1, -1 do
-        local element = self.folder_shortcuts[i]
-        if element.text == item.friendly_name and element.folder == item.folder then
-            table.remove(self.folder_shortcuts, i)
-        end
-    end
-    self:updateItemTable()
 end
 
 function FileManagerShortcuts:onSetDimensions(dimen)
@@ -208,7 +219,7 @@ end
 
 function FileManagerShortcuts:MenuSetRotationModeHandler(rotation)
     if rotation ~= nil and rotation ~= Screen:getRotationMode() then
-        UIManager:close(self._manager.fm_bookmark)
+        UIManager:close(self._manager.shortcuts_menu)
         if self._manager.ui.view and self._manager.ui.view.onSetRotationMode then
             self._manager.ui.view:onSetRotationMode(rotation)
         elseif self._manager.ui.onSetRotationMode then
@@ -222,23 +233,33 @@ function FileManagerShortcuts:MenuSetRotationModeHandler(rotation)
 end
 
 function FileManagerShortcuts:onShowFolderShortcutsDialog(select_callback)
-    self.fm_bookmark = Menu:new{
-        title = _("Folder shortcuts"),
+    self.shortcuts_menu = Menu:new{
+        title = self.title,
         show_parent = self.ui,
-        no_title = false,
-        parent = nil,
-        is_popout = false,
+        covers_fullscreen = true,
         is_borderless = true,
-        curr_path = self.ui.file_chooser and self.ui.file_chooser.path or self.ui:getLastDirFile(),
+        is_popout = false,
+        select_callback = select_callback, -- called from PathChooser titlebar left button
+        title_bar_left_icon = not select_callback and "plus" or nil,
+        onLeftButtonTap = function() self:addShortcut() end,
+        onMenuChoice = self.onMenuChoice,
         onMenuHold = not select_callback and self.onMenuHold or nil,
         onSetRotationMode = self.MenuSetRotationModeHandler,
-        title_bar_left_icon = not select_callback and "plus" or nil,
-        onLeftButtonTap = function() self:addNewFolder() end,
         _manager = self,
     }
-
-    self:updateItemTable(select_callback)
-    UIManager:show(self.fm_bookmark)
+    self.shortcuts_menu.close_callback = function()
+        UIManager:close(self.shortcuts_menu)
+        if self.fm_updated then
+            if self.ui.file_chooser then
+                self.ui.file_chooser:refreshPath()
+                self.ui:updateTitleBarPath()
+            end
+            self.fm_updated = nil
+        end
+        self.shortcuts_menu = nil
+    end
+    self:updateItemTable()
+    UIManager:show(self.shortcuts_menu)
 end
 
 return FileManagerShortcuts

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -3,6 +3,7 @@ local datetime = require("datetime")
 local Device = require("device")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
+local FileManagerShortcuts = require("apps/filemanager/filemanagershortcuts")
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
@@ -361,6 +362,9 @@ function FileChooser:getMenuItemMandatory(item, collate)
         text = T("%1 \u{F016}", #dir_files)
         if #sub_dirs > 0 then
             text = T("%1 \u{F114} ", #sub_dirs) .. text
+        end
+        if FileManagerShortcuts:isShortcutAdded(item.fullpath) then
+            text = "☆ " .. text
         end
     end
     return text

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -363,7 +363,7 @@ function FileChooser:getMenuItemMandatory(item, collate)
         if #sub_dirs > 0 then
             text = T("%1 \u{F114} ", #sub_dirs) .. text
         end
-        if FileManagerShortcuts:isShortcutAdded(item.fullpath) then
+        if FileManagerShortcuts:hasFolderShortcut(item.fullpath) then
             text = "☆ " .. text
         end
     end


### PR DESCRIPTION
(1) A marker in the mandatory to indicate the folder is added to Folder shortcuts.
(2) A marker in the TitleBar path to indicate the current folder is added to Folder shortcuts. 
(3) A button in the Plus menu to add/remove current folder to/from Folder shortcuts.
(4) A button in the folder popup dialog to add/remove the folder to/from Folder shortcuts.
(5) New wordings in the Folder shortcuts popup dialog buttons.

Classic
![1](https://github.com/koreader/koreader/assets/62179190/a42dee00-b752-4a25-8e55-99ac79143987)

Mosaic
![2](https://github.com/koreader/koreader/assets/62179190/d8dc76c3-9130-49c4-88ee-007fa9b2a244)

Detailed list
![3](https://github.com/koreader/koreader/assets/62179190/fedbd806-95c2-4e55-90e7-be8642a8afea)

Plus menu
![4](https://github.com/koreader/koreader/assets/62179190/0e45c2c4-5e8c-46fa-9e2b-ea3850439d1e)

Popup dialog
![5](https://github.com/koreader/koreader/assets/62179190/d2c691a4-d69b-4f1a-ad95-5ade9e4fe024)

Folder shortcuts
![6](https://github.com/koreader/koreader/assets/62179190/4e9864fa-3f0f-4ee7-9498-dba48c82f7ab)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11108)
<!-- Reviewable:end -->
