### PR TITLE
QuickMenu: keep active when touch input is disabled

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -32,7 +32,6 @@ local CreOptions = require("ui/data/creoptions")
 local KoptOptions = require("ui/data/koptoptions")
 local Device = require("device")
 local Event = require("ui/event")
-local InputContainer = require("ui/widget/container/inputcontainer")
 local Notification = require("ui/widget/notification")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
@@ -1063,7 +1062,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_bold = false,
             callback = function()
                 if quickmenu.is_touch_input_disabled then
-                    InputContainer:onIgnoreTouchInput(true, true)
+                    quickmenu:onIgnoreTouchInput(true, true)
                 end
                 UIManager:close(quickmenu)
                 Dispatcher:execute({[v.key] = settings[v.key]})
@@ -1086,9 +1085,9 @@ function Dispatcher:_showAsMenu(settings, exec_props)
         buttons = buttons,
         anchor = exec_props and exec_props.qm_anchor,
     }
-    if InputContainer:isTouchInputDisabled() then
+    if quickmenu:isTouchInputDisabled() then
         quickmenu.is_touch_input_disabled = true
-        InputContainer:onIgnoreTouchInput(false, true)
+        quickmenu:onIgnoreTouchInput(false, true)
     end
     UIManager:show(quickmenu)
 end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -32,6 +32,7 @@ local CreOptions = require("ui/data/creoptions")
 local KoptOptions = require("ui/data/koptoptions")
 local Device = require("device")
 local Event = require("ui/event")
+local InputContainer = require("ui/widget/container/inputcontainer")
 local Notification = require("ui/widget/notification")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
@@ -1061,6 +1062,9 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_size = 22,
             font_bold = false,
             callback = function()
+                if quickmenu.is_touch_input_disabled then
+                    InputContainer:onIgnoreTouchInput(true, true)
+                end
                 UIManager:close(quickmenu)
                 Dispatcher:execute({[v.key] = settings[v.key]})
             end,
@@ -1082,6 +1086,10 @@ function Dispatcher:_showAsMenu(settings, exec_props)
         buttons = buttons,
         anchor = exec_props and exec_props.qm_anchor,
     }
+    if InputContainer:isTouchInputDisabled() then
+        quickmenu.is_touch_input_disabled = true
+        InputContainer:onIgnoreTouchInput(false, true)
+    end
     UIManager:show(quickmenu)
 end
 

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -304,33 +304,41 @@ end
 --       [1] The most common implementation you'll see is a NOP for ReaderUI modules that defer gesture handling to ReaderUI.
 --           Notification also implements a simple one to dismiss notifications on any user input,
 --           which is something that doesn't impede our goal, which is why we don't need to deal with it.
-function InputContainer:onIgnoreTouchInput(toggle)
+function InputContainer:onIgnoreTouchInput(toggle, no_notify)
     local Notification = require("ui/widget/notification")
     if toggle == false then
         -- Restore the proper onGesture handler if we disabled it
         if InputContainer._onGesture then
             InputContainer.onGesture = InputContainer._onGesture
             InputContainer._onGesture = nil
-            Notification:notify("Restored touch input")
+            if not no_notify then
+                Notification:notify("Restored touch input")
+            end
         end
     elseif toggle == true then
         -- Replace the onGesture handler w/ the minimal one if that's not already the case
         if not InputContainer._onGesture then
             InputContainer._onGesture = InputContainer.onGesture
             InputContainer.onGesture = InputContainer._onGestureFiltered
-            Notification:notify("Disabled touch input")
+            if not no_notify then
+                Notification:notify("Disabled touch input")
+            end
         end
     else
         -- Toggle the current state
         if InputContainer._onGesture then
-            return self:onIgnoreTouchInput(false)
+            return self:onIgnoreTouchInput(false, no_notify)
         else
-            return self:onIgnoreTouchInput(true)
+            return self:onIgnoreTouchInput(true, no_notify)
         end
     end
 
     -- We only affect the base class, once is enough ;).
     return true
+end
+
+function InputContainer:isTouchInputDisabled()
+    return InputContainer._onGesture and true or false
 end
 
 function InputContainer:onResume()


### PR DESCRIPTION
QM is an instance of InputContainer, but touch input is disabled in the base class, hence not very nice direct calls of InputContainer methods.
EDIT: works good on instance.

@offset-torque would be glad https://github.com/koreader/koreader/issues/10812#issuecomment-1678422543.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11119)
<!-- Reviewable:end -->
