### PR TITLE
Widgets: Unschedule timeouts on early close

### DIFF
--- a/frontend/ui/trapper.lua
+++ b/frontend/ui/trapper.lua
@@ -179,8 +179,10 @@ function Trapper:info(text, fast_refresh)
                 return false
             end
             if self.current_widget then
-                -- Re-show current widget that was dismissed
-                -- (this is fine for our simple InfoMessage)
+                -- Resurect a dead widget. This should only be performed by trained Necromancers.
+                -- Do NOT do this at home, kids.
+                -- Some state *might* be lost, but the basics should survive...
+                self.current_widget:init()
                 UIManager:show(self.current_widget)
             end
             UIManager:forceRePaint()

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -217,6 +217,7 @@ function InfoMessage:onCloseWidget()
     -- If we were closed early, drop the scheduled timeout
     if self._timeout_func then
         UIManager:unschedule(self._timeout_func)
+        self._timeout_func = nil
     end
     if self.invisible then
         -- Still invisible, no setDirty needed

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -206,6 +206,12 @@ function InfoMessage:init()
 end
 
 function InfoMessage:onCloseWidget()
+    -- If we were closed early, drop the scheduled timeout
+    if self._timeout_func then
+        UIManager:unschedule(self._timeout_func)
+        self._timeout_func = nil
+    end
+
     if self._delayed_show_action then
         UIManager:unschedule(self._delayed_show_action)
         self._delayed_show_action = nil
@@ -214,11 +220,7 @@ function InfoMessage:onCloseWidget()
         self.dismiss_callback()
         self.dismiss_callback = nil
     end
-    -- If we were closed early, drop the scheduled timeout
-    if self._timeout_func then
-        UIManager:unschedule(self._timeout_func)
-        self._timeout_func = nil
-    end
+
     if self.invisible then
         -- Still invisible, no setDirty needed
         return

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -218,7 +218,10 @@ function InfoMessage:onCloseWidget()
     end
     if self.dismiss_callback then
         self.dismiss_callback()
-        self.dismiss_callback = nil
+        -- NOTE: Dirty hack for Trapper, which needs to pull a Lazarus on dead widgets while preserving the callback's integrity ;).
+        if not self.is_infomessage then
+            self.dismiss_callback = nil
+        end
     end
 
     if self.invisible then

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -57,6 +57,7 @@ local Notification = InputContainer:extend{
     margin = Size.margin.default,
     padding = Size.padding.default,
     timeout = 2, -- default to 2 seconds
+    _timeout_func = nil,
     toast = true, -- closed on any event, and let the event propagate to next top widget
 
     _shown_list = {}, -- actual static class member, array of stacked notifications (value is show (well, init) time or false).
@@ -200,6 +201,10 @@ function Notification:onCloseWidget()
     UIManager:setDirty(nil, function()
         return "ui", self.frame.dimen
     end)
+    -- If we were closed early, drop the scheduled timeout
+    if self._timeout_func then
+        UIManager:unschedule(self._timeout_func)
+    end
 end
 
 function Notification:onShow()
@@ -207,7 +212,11 @@ function Notification:onShow()
         return "ui", self.frame.dimen
     end)
     if self.timeout then
-        UIManager:scheduleIn(self.timeout, function() UIManager:close(self) end)
+        self._timeout_func = function()
+            self._timeout_func = nil
+            UIManager:close(self)
+        end
+        UIManager:scheduleIn(self.timeout, self._timeout_func)
     end
 
     if #self._past_messages >= MAX_NB_PAST_MESSAGES then

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -204,6 +204,7 @@ function Notification:onCloseWidget()
     -- If we were closed early, drop the scheduled timeout
     if self._timeout_func then
         UIManager:unschedule(self._timeout_func)
+        self._timeout_func = nil
     end
 end
 

--- a/frontend/ui/widget/qrmessage.lua
+++ b/frontend/ui/widget/qrmessage.lua
@@ -92,6 +92,7 @@ function QRMessage:onCloseWidget()
 
     if self.dismiss_callback then
         self.dismiss_callback()
+        self.dismiss_callback = nil
     end
 end
 

--- a/frontend/ui/widget/qrmessage.lua
+++ b/frontend/ui/widget/qrmessage.lua
@@ -87,6 +87,7 @@ function QRMessage:onCloseWidget()
     -- If we were closed early, drop the scheduled timeout
     if self._timeout_func then
         UIManager:unschedule(self._timeout_func)
+        self._timeout_func = nil
     end
 
     if self.dismiss_callback then

--- a/frontend/ui/widget/qrmessage.lua
+++ b/frontend/ui/widget/qrmessage.lua
@@ -37,7 +37,7 @@ local QRMessage = InputContainer:extend{
     text = nil,  -- The text to encode.
     width = nil,  -- The width. Keep it nil to use original width.
     height = nil,  -- The height. Keep it nil to use original height.
-    dismiss_callback = function() end,
+    dismiss_callback = nil,
     alpha = nil,
     scale_factor = 1,
 }
@@ -88,6 +88,10 @@ function QRMessage:onCloseWidget()
     if self._timeout_func then
         UIManager:unschedule(self._timeout_func)
     end
+
+    if self.dismiss_callback then
+        self.dismiss_callback()
+    end
 end
 
 function QRMessage:onShow()
@@ -106,7 +110,6 @@ function QRMessage:onShow()
 end
 
 function QRMessage:onTapClose()
-    self.dismiss_callback()
     UIManager:close(self)
 end
 QRMessage.onAnyKeyPressed = QRMessage.onTapClose


### PR DESCRIPTION
Affects Notification, InfoMessage & QRMessage

Mostly harmless in practice, except for InfoMessage with a dismiss_callback, as it would have effectively ran twice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11126)
<!-- Reviewable:end -->
