### PR TITLE
Exporter: fix XMNote export, add author field

### DIFF
--- a/plugins/exporter.koplugin/target/xmnote.lua
+++ b/plugins/exporter.koplugin/target/xmnote.lua
@@ -79,6 +79,7 @@ end
 function XMNoteExporter:createRequestBody(booknotes)
     local book = {
         title = booknotes.title or "",
+        author = booknotes.author or "",
         type = 1,
         locationUnit = 1,
     }
@@ -151,10 +152,13 @@ end
 
 
 function XMNoteExporter:isReadyToExport()
-    return true
+    if self.settings.ip then return true end
+    return false
 end
 
 function XMNoteExporter:export(t)
+    if not self:isReadyToExport() then return false end
+
     for _, booknotes in ipairs(t) do
         local ok = self:createHighlights(booknotes)
         if not ok then return false end


### PR DESCRIPTION
Optimize #11087 :

1. In `isReadyToExport`, check if the ip is set. If not, then the user cannot enable xmnote export.
2. Add author field in highlights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11134)
<!-- Reviewable:end -->
