### PR TITLE
QuickMenu: keep open on apply

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -943,6 +943,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         {"rolling", _("Reflowable documents (epub, fb2, txt…)")},
         {"paging", _("Fixed layout documents (pdf, djvu, pics…)")},
     }
+    menu.max_per_page = 1 + #section_list -- settings in page 2
     for _, section in ipairs(section_list) do
         local submenu = {}
         Dispatcher:_addItem(caller, submenu, location, settings, section[1])
@@ -1018,6 +1019,31 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
             end
         end,
     })
+    table.insert(menu, {
+        text = _("Keep QuickMenu open on apply"),
+        checked_func = function()
+            return location[settings] ~= nil
+            and location[settings].settings ~= nil
+            and location[settings].settings.keep_open_on_apply
+        end,
+        callback = function()
+            if location[settings] then
+                if location[settings].settings then
+                    if location[settings].settings.keep_open_on_apply then
+                        location[settings].settings.keep_open_on_apply = nil
+                        if next(location[settings].settings) == nil then
+                            location[settings].settings = nil
+                        end
+                    else
+                        location[settings].settings.keep_open_on_apply = true
+                    end
+                else
+                    location[settings].settings = {["keep_open_on_apply"] = true}
+                end
+                caller.updated = true
+            end
+        end,
+    })
 end
 
 function Dispatcher:isActionEnabled(action)
@@ -1037,6 +1063,8 @@ function Dispatcher:isActionEnabled(action)
 end
 
 function Dispatcher:_showAsMenu(settings, exec_props)
+    local title = settings.settings.name or _("QuickMenu")
+    local keep_open_on_apply = settings.settings.keep_open_on_apply
     local display_list = Dispatcher:getDisplayList(settings)
     local quickmenu
     local buttons = {}
@@ -1063,6 +1091,10 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             callback = function()
                 UIManager:close(quickmenu)
                 Dispatcher:execute({[v.key] = settings[v.key]})
+                if keep_open_on_apply then
+                    quickmenu:setTitle(title)
+                    UIManager:show(quickmenu)
+                end
             end,
             hold_callback = function()
                 if v.key:sub(1, 13) == "profile_exec_" then
@@ -1074,7 +1106,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
     end
     local ButtonDialog = require("ui/widget/buttondialog")
     quickmenu = ButtonDialog:new{
-        title = settings.settings.name or _("QuickMenu"),
+        title = title,
         title_align = "center",
         shrink_unneeded_width = true,
         shrink_min_width = math.floor(0.6 * Screen:getWidth()),

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1020,7 +1020,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         end,
     })
     table.insert(menu, {
-        text = _("Keep QuickMenu open on apply"),
+        text = _("Keep QuickMenu open"),
         checked_func = function()
             return location[settings] ~= nil
             and location[settings].settings ~= nil
@@ -1091,7 +1091,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             callback = function()
                 UIManager:close(quickmenu)
                 Dispatcher:execute({[v.key] = settings[v.key]})
-                if keep_open_on_apply then
+                if keep_open_on_apply and not util.stringStartsWith(v.key, "touch_input") then
                     quickmenu:setTitle(title)
                     UIManager:show(quickmenu)
                 end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -244,6 +244,7 @@ function Gestures:genMenu(ges)
         end,
     })
     Dispatcher:addSubMenu(self, sub_items, self.gestures, ges)
+    sub_items.max_per_page = nil -- restore default, settings in page 2
     table.insert(sub_items, {
         text = _("Anchor QuickMenu to gesture position"),
         checked_func = function()


### PR DESCRIPTION
(1) Closes https://github.com/koreader/koreader/issues/11131.
(2) Adjustable actions menu length to place settings in page 2.

Gestures

![1](https://github.com/koreader/koreader/assets/62179190/ca42f7d6-b96d-4d9b-9edd-51a5c91ce2a0)
![2](https://github.com/koreader/koreader/assets/62179190/8996bd5f-5e36-4311-94d2-39a296189cae)

Profiles

![3](https://github.com/koreader/koreader/assets/62179190/cc2a1879-4390-4e73-997c-4810ddb4a7e5)
![4](https://github.com/koreader/koreader/assets/62179190/f0be36b9-42dd-4b77-97dc-1413f2f748b1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11135)
<!-- Reviewable:end -->
