### PR TITLE
Refactor FileManager collation for easier patching

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -124,7 +124,7 @@ function FileSearcher:getList()
         ["/proc"] = true,
         ["/sys"] = true,
     }
-    local collate = G_reader_settings:readSetting("collate")
+    local collate = FileChooser:getCollate()
     local search_string = self.search_string
     if search_string ~= "*" then -- one * to show all files
         if not self.case_sensitive then

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -161,14 +161,14 @@ function FileSearcher:getList()
                             table.insert(new_dirs, fullpath)
                         end
                         if self:isFileMatch(f, fullpath, search_string) then
-                            table.insert(dirs, FileChooser.getListItem(f, fullpath, attributes))
+                            table.insert(dirs, FileChooser:getListItem(nil, f, fullpath, attributes))
                         end
                     -- Always ignore macOS resource forks, too.
                     elseif attributes.mode == "file" and not util.stringStartsWith(f, "._")
                             and (FileChooser.show_unsupported or DocumentRegistry:hasProvider(fullpath))
                             and FileChooser:show_file(f) then
                         if self:isFileMatch(f, fullpath, search_string, true) then
-                            table.insert(files, FileChooser.getListItem(f, fullpath, attributes, collate))
+                            table.insert(files, FileChooser:getListItem(nil, f, fullpath, attributes, collate))
                         end
                     end
                 end

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -161,7 +161,7 @@ function FileSearcher:getList()
                             table.insert(new_dirs, fullpath)
                         end
                         if self:isFileMatch(f, fullpath, search_string) then
-                            table.insert(dirs, FileChooser:getListItem(nil, f, fullpath, attributes))
+                            table.insert(dirs, FileChooser:getListItem(nil, f, fullpath, attributes, collate))
                         end
                     -- Always ignore macOS resource forks, too.
                     elseif attributes.mode == "file" and not util.stringStartsWith(f, "._")

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -148,7 +148,6 @@ local FileChooser = Menu:extend{
             end,
             item_func = function(item)
                 item.suffix = util.getFileNameSuffix(item.text)
-                return item
             end,
         },
         percent_unopened_first = {
@@ -174,7 +173,6 @@ local FileChooser = Menu:extend{
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 item.percent_finished = percent_finished or 0
-                return item
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
@@ -203,7 +201,6 @@ local FileChooser = Menu:extend{
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 item.percent_finished = percent_finished or 0
-                return item
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
@@ -269,7 +266,7 @@ function FileChooser:getList(path, collate)
     else -- error, probably "permission denied"
         if unreadable_dir_content[path] then
             -- Add this dummy item that will be replaced with a message by genItemTable()
-            table.insert(dirs, FileChooser.getListItem(path, "./.", path, lfs.attributes(path)))
+            table.insert(dirs, FileChooser:getListItem(path, "./.", path, lfs.attributes(path)), collate)
             -- If we knew about some content (if we had come up from them
             -- to this directory), have them shown
             for k, v in pairs(unreadable_dir_content[path]) do
@@ -307,7 +304,7 @@ function FileChooser:getListItem(dirpath, f, fullpath, attributes, collate)
         item.dim = self.filemanager and self.filemanager.selected_files
                    and self.filemanager.selected_files[item.path]
         if collate.item_func ~= nil then
-            item = collate.item_func(item)
+            collate.item_func(item)
         end
         item.mandatory = self:getMenuItemMandatory(item, collate)
     else -- folder
@@ -317,7 +314,7 @@ function FileChooser:getListItem(dirpath, f, fullpath, attributes, collate)
             item.text = item.text.."/"
             item.bidi_wrap_func = BD.directory
             if collate.can_collate_mixed and collate.item_func ~= nil then
-                item = collate.item_func(item)
+                collate.item_func(item)
             end
             if dirpath then -- file browser or PathChooser
                 item.mandatory = self:getMenuItemMandatory(item)


### PR DESCRIPTION
This PR extracts the collation related code from FileChooser and FileManager, to make it easier to add new sorting algorithms through user patches.

I also noticed a slight difference between which items got sorted depending on whether the `collate_mixed` option was set. Since the collation related code is now 'further away', I attempted to make it more consistent and predictable.

As an example, this is the user patch that I have been using: https://gist.github.com/wfdewith/978e4f8e09f481a480cb1bf645e8d518

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11150)
<!-- Reviewable:end -->
