### PR TITLE
Add G-sensor and Pen support for Kindle Scribe

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1331,6 +1331,9 @@ function KindleScribe:init()
 
     self.input.open(self.touch_dev)
     self.input.open("fake_events")
+
+    self.input.wacom_protocol = true
+    self.input.open("/dev/input/event4")
 end
 
 function KindleTouch:exit()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1326,15 +1326,8 @@ function KindleScribe:init()
         end
     end
 
-    -- Get accelerometer device by looking for EV=9
-    local std_out = io.popen("grep -e 'Handlers\\|EV=' /proc/bus/input/devices | grep -B1 'EV=9' | grep -o 'event[0-9]\\{1,2\\}'", "r")
-    if std_out then
-        local rotation_dev = std_out:read("*line")
-        std_out:close()
-        if rotation_dev then
-            self.input.open("/dev/input/"..rotation_dev)
-        end
-    end
+    -- Get accelerometer device
+    self.input.open("/dev/input/by-path/platform-11007000.i2c-event-joystick")
 
     self.input.open(self.touch_dev)
     self.input.open("fake_events")


### PR DESCRIPTION
After this, Top menu - Gear - Screen - Rotation - you should see accelerometer settings.




Tested on Kindle Scribe with 5.16.2, auto-rotation works great!

However, gestures called "Rotation 90 deg CW" and "Rotation 90 deg CCW" don't work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11157)
<!-- Reviewable:end -->
