### PR TITLE
Kindle: Frontlight fixes & Gestures: Make the edge swipe zones configurable

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -69,6 +69,10 @@ DTAP_ZONE_BOTTOM_LEFT = {x = 0, y = 7/8, w = 1/8, h = 1/8},
 DTAP_ZONE_BOTTOM_RIGHT = {x = 7/8, y = 7/8, w = 1/8, h = 1/8},
 DDOUBLE_TAP_ZONE_NEXT_CHAPTER = {x = 1/4, y = 0, w = 3/4, h = 1},
 DDOUBLE_TAP_ZONE_PREV_CHAPTER = {x = 0, y = 0, w = 1/4, h = 1},
+DSWIPE_ZONE_LEFT_EDGE = { x = 0, y = 0, w = 1/8, h = 1},
+DSWIPE_ZONE_RIGHT_EDGE = { x = 7/8, y = 0, w = 1/8, h = 1},
+DSWIPE_ZONE_TOP_EDGE = { x = 0, y = 0, w = 1, h = 1/8},
+DSWIPE_ZONE_BOTTOM_EDGE = { x = 0, y = 7/8, w = 1, h = 1/8},
 
 -- koptreader config defaults
 DKOPTREADER_CONFIG_FONT_SIZE = 1.0,        -- range from 0.1 to 3.0

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -60,7 +60,7 @@ function AndroidPowerD:turnOffFrontlightHW()
     android.setScreenBrightness(self.fl_min)
 end
 
-function AndroidPowerD:turnOnFrontlightHW()
+function AndroidPowerD:turnOnFrontlightHW(done_callback)
     if self:isFrontlightOn() and self:isFrontlightOnHW() then
         return
     end
@@ -68,6 +68,8 @@ function AndroidPowerD:turnOnFrontlightHW()
     android.enableFrontlightSwitch()
 
     android.setScreenBrightness(math.floor(self.fl_intensity * self.bright_diff / self.fl_max))
+
+    return false
 end
 
 return AndroidPowerD

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -187,7 +187,7 @@ if Device:hasFrontlight() then
     function DeviceListener:onToggleFrontlight()
         local powerd = Device:getPowerDevice()
         local new_text
-        if powerd.is_fl_on then
+        if powerd:isFrontlightOn() then
             new_text = _("Frontlight disabled.")
         else
             new_text = _("Frontlight enabled.")

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -43,7 +43,10 @@ function BasePowerD:new(o)
 end
 
 function BasePowerD:init() end
-function BasePowerD:setIntensityHW(intensity) end
+--- @note: This should *always* call self:_decideFrontlightState() in its coda (unless you have a custom isFrontlightOn implementation)!
+function BasePowerD:setIntensityHW(intensity)
+    self:_decideFrontlightState()
+end
 --- @note: Unlike the "public" setWarmth, this one takes a value in the *native* scale!
 function BasePowerD:setWarmthHW(warmth) end
 function BasePowerD:getCapacityHW() return 0 end
@@ -207,7 +210,6 @@ function BasePowerD:setIntensity(intensity)
     if not self.device:hasFrontlight() then return false end
     if intensity == self:frontlightIntensity() then return false end
     self.fl_intensity = self:normalizeIntensity(intensity)
-    self:_decideFrontlightState()
     logger.dbg("set light intensity", self.fl_intensity)
     self:setIntensityHW(self.fl_intensity)
     self:stateChanged()

--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -41,6 +41,9 @@ function PocketBookPowerD:setIntensityHW(intensity)
     else
         inkview.SetFrontlightState(intensity)
     end
+
+    -- We have a custom isFrontlightOn implementation, so this is redundant
+    self:_decideFrontlightState()
 end
 
 function PocketBookPowerD:isFrontlightOn()

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -18,6 +18,7 @@ end
 function SDLPowerD:setIntensityHW(intensity)
     require("logger").info("set brightness to", intensity)
     self.hw_intensity = intensity or self.hw_intensity
+    self:_decideFrontlightState()
 end
 
 function SDLPowerD:frontlightWarmthHW()

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -784,21 +784,33 @@ function Gestures:setupGesture(ges)
         ratio_w = 1, ratio_h = 1,
     }
 
+    local dswipe_zone_left_edge = G_defaults:readSetting("DSWIPE_ZONE_LEFT_EDGE")
     local zone_left_edge = {
-        ratio_x = 0, ratio_y = 0,
-        ratio_w = 1/8, ratio_h = 1,
+        ratio_x = dswipe_zone_left_edge.x,
+        ratio_y = dswipe_zone_left_edge.y,
+        ratio_w = dswipe_zone_left_edge.w,
+        ratio_h = dswipe_zone_left_edge.h,
     }
+    local dswipe_zone_right_edge = G_defaults:readSetting("DSWIPE_ZONE_RIGHT_EDGE")
     local zone_right_edge = {
-        ratio_x = 7/8, ratio_y = 0,
-        ratio_w = 1/8, ratio_h = 1,
+        ratio_x = dswipe_zone_right_edge.x,
+        ratio_y = dswipe_zone_right_edge.y,
+        ratio_w = dswipe_zone_right_edge.w,
+        ratio_h = dswipe_zone_right_edge.h,
     }
+    local dswipe_zone_top_edge = G_defaults:readSetting("DSWIPE_ZONE_TOP_EDGE")
     local zone_top_edge = {
-        ratio_x = 0, ratio_y = 0,
-        ratio_w = 1, ratio_h = 1/8,
+        ratio_x = dswipe_zone_top_edge.x,
+        ratio_y = dswipe_zone_top_edge.y,
+        ratio_w = dswipe_zone_top_edge.w,
+        ratio_h = dswipe_zone_top_edge.h,
     }
+    local dswipe_zone_bottom_edge = G_defaults:readSetting("DSWIPE_ZONE_BOTTOM_EDGE")
     local zone_bottom_edge = {
-        ratio_x = 0, ratio_y = 7/8,
-        ratio_w = 1, ratio_h = 1/8,
+        ratio_x = dswipe_zone_bottom_edge.x,
+        ratio_y = dswipe_zone_bottom_edge.y,
+        ratio_w = dswipe_zone_bottom_edge.w,
+        ratio_h = dswipe_zone_bottom_edge.h,
     }
 
     local dtap_zone_top_left = G_defaults:readSetting("DTAP_ZONE_TOP_LEFT")

--- a/spec/unit/frontlight_spec.lua
+++ b/spec/unit/frontlight_spec.lua
@@ -23,6 +23,7 @@ describe("Frontlight function in PowerD", function()
         end
         PowerD.setIntensityHW = function(self, intensity)
             self.frontlight = intensity
+            self:_decideFrontlightState()
         end
     end)
 


### PR DESCRIPTION
As "global defaults" (i.e., "advanced settings" in the UI).

These were the only zones not available there, for some reason (probably they were new and we try to avoid adding new defaults).

Fix #11142

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11158)
<!-- Reviewable:end -->
