### PR TITLE
Kindle scribe gyro and pen support

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1323,7 +1323,7 @@ function KindleScribe:init()
     -- Enable the so-called "fast" mode, so as to prevent the driver from silently promoting refreshes to REAGL.
     self.screen:_MTK_ToggleFastMode(true)
 
-    -- @fixme The same quirks as on the Oasis 2 and 3 apply ;).
+    --- @fixme The same quirks as on the Oasis 2 and 3 apply ;).
     -- in regular mode, awesome is woken up for a brief moment. In no-framework mode, this works as is.
     local haslipc, lipc = pcall(require, "liblipclua")
     if haslipc and lipc then

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1331,6 +1331,9 @@ function KindleScribe:init()
 
     self.input.open(self.touch_dev)
     self.input.open("fake_events")
+
+    self.input.wacom_protocol = true
+    self.input.open("/dev/input/event4")
 end
 
 function KindleTouch:exit()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -965,8 +965,10 @@ function KindleOasis:init()
 end
 
 -- HAL for gyro orientation switches (EV_ABS:ABS_PRESSURE (?!) w/ custom values to EV_MSC:MSC_GYRO w/ our own custom values)
-local function ZeldaGyroTranslation(this, ev)
-    -- c.f., drivers/input/misc/accel/bma2x2.c
+local function ZeldaBellatrixGyroTranslation(this, ev)
+    -- See source code:
+    -- c.f., drivers/input/misc/accel/bma2x2.c for KOA2/KOA3
+    -- c.f., drivers/input/misc/kx132/kx132.h for KS
     local UPWARD_PORTRAIT_UP_INTERRUPT_HAPPENED     = 15
     local UPWARD_PORTRAIT_DOWN_INTERRUPT_HAPPENED   = 16
     local UPWARD_LANDSCAPE_LEFT_INTERRUPT_HAPPENED  = 17
@@ -1054,7 +1056,7 @@ function KindleOasis2:init()
 
     Kindle.init(self)
 
-    self.input:registerEventAdjustHook(ZeldaGyroTranslation)
+    self.input:registerEventAdjustHook(ZeldaBellatrixGyroTranslation)
     self.input.handleMiscEv = function(this, ev)
         if ev.code == C.MSC_GYRO then
             return this:handleGyroEv(ev)
@@ -1130,7 +1132,7 @@ function KindleOasis3:init()
 
     Kindle.init(self)
 
-    self.input:registerEventAdjustHook(ZeldaGyroTranslation)
+    self.input:registerEventAdjustHook(ZeldaBellatrixGyroTranslation)
     self.input.handleMiscEv = function(this, ev)
         if ev.code == C.MSC_GYRO then
             return this:handleGyroEv(ev)
@@ -1319,7 +1321,7 @@ function KindleScribe:init()
 
     Kindle.init(self)
 
-    self.input:registerEventAdjustHook(ZeldaGyroTranslation)
+    self.input:registerEventAdjustHook(ZeldaBellatrixGyroTranslation)
     self.input.handleMiscEv = function(this, ev)
         if ev.code == C.MSC_GYRO then
             return this:handleGyroEv(ev)

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1326,15 +1326,8 @@ function KindleScribe:init()
         end
     end
 
-    -- Get accelerometer device by looking for EV=9
-    local std_out = io.popen("grep -e 'Handlers\\|EV=' /proc/bus/input/devices | grep -B1 'EV=9' | grep -o 'event[0-9]\\{1,2\\}'", "r")
-    if std_out then
-        local rotation_dev = std_out:read("*line")
-        std_out:close()
-        if rotation_dev then
-            self.input.open("/dev/input/"..rotation_dev)
-        end
-    end
+    -- Get accelerometer device
+    self.input.open("/dev/input/by-path/platform-11007000.i2c-event-joystick")
 
     self.input.open(self.touch_dev)
     self.input.open("fake_events")

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1307,7 +1307,7 @@ end
 function KindleScribe:init()
     -- temporarily wake up awesome
     if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -CONT awesome") 
+        os.execute("killall -CONT awesome")
     end
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1321,7 +1321,7 @@ function KindleScribe:init()
 
     Kindle.init(self)
 
-    -- Setup accelerometer input drivers
+    -- Setup accelerometer rotation input
     self.input:registerEventAdjustHook(KindleGyroTransform)
     self.input.handleMiscEv = function(this, ev)
         if ev.code == C.MSC_GYRO then
@@ -1334,7 +1334,7 @@ function KindleScribe:init()
     self.input.open(self.touch_dev)
     self.input.open("fake_events")
 
-    -- Setup input drivers for pen
+    -- Setup pen input
     self.input.wacom_protocol = true
     self.input.open("/dev/input/event4")
 end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -965,7 +965,7 @@ function KindleOasis:init()
 end
 
 -- HAL for gyro orientation switches (EV_ABS:ABS_PRESSURE (?!) w/ custom values to EV_MSC:MSC_GYRO w/ our own custom values)
-local function ZeldaBellatrixGyroTranslation(this, ev)
+local function KindleGyroTransform(this, ev)
     -- See source code:
     -- c.f., drivers/input/misc/accel/bma2x2.c for KOA2/KOA3
     -- c.f., drivers/input/misc/kx132/kx132.h for KS
@@ -1056,7 +1056,7 @@ function KindleOasis2:init()
 
     Kindle.init(self)
 
-    self.input:registerEventAdjustHook(ZeldaBellatrixGyroTranslation)
+    self.input:registerEventAdjustHook(KindleGyroTransform)
     self.input.handleMiscEv = function(this, ev)
         if ev.code == C.MSC_GYRO then
             return this:handleGyroEv(ev)
@@ -1132,7 +1132,7 @@ function KindleOasis3:init()
 
     Kindle.init(self)
 
-    self.input:registerEventAdjustHook(ZeldaBellatrixGyroTranslation)
+    self.input:registerEventAdjustHook(KindleGyroTransform)
     self.input.handleMiscEv = function(this, ev)
         if ev.code == C.MSC_GYRO then
             return this:handleGyroEv(ev)
@@ -1321,19 +1321,20 @@ function KindleScribe:init()
 
     Kindle.init(self)
 
-    self.input:registerEventAdjustHook(ZeldaBellatrixGyroTranslation)
+    -- Setup accelerometer input drivers
+    self.input:registerEventAdjustHook(KindleGyroTransform)
     self.input.handleMiscEv = function(this, ev)
         if ev.code == C.MSC_GYRO then
             return this:handleGyroEv(ev)
         end
     end
-
     -- Get accelerometer device
     self.input.open("/dev/input/by-path/platform-11007000.i2c-event-joystick")
 
     self.input.open(self.touch_dev)
     self.input.open("fake_events")
 
+    -- Setup input drivers for pen
     self.input.wacom_protocol = true
     self.input.open("/dev/input/event4")
 end


### PR DESCRIPTION
Sorry, I renamed the branch and #11157 got nuked.

This PR adds gyro auto-rotation and basic support to use Kindle Scribe pen as touch input.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11159)
<!-- Reviewable:end -->
