### PR TITLE
fix dictionary link

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -2729,7 +2729,7 @@ local dictionaries = {
         lang_out = "fas",
         entries = 145075,
         license = "MIT, https://github.com/hossein1376/English-Persian-Kindle-Custom-Dictionary",
-        url = "https://github.com/Monirzadeh/English-Persian-Kindle-Custom-Dictionary/raw/koreader/English Persian Dictionary.tar.gz"
+        url = "https://github.com/hossein1376/English-Persian-Kindle-Custom-Dictionary/raw/main/English%20Persian%20Dictionary.tar.gz"
     },
     {
         name = "Vietnamese-English dictionary",

--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -2724,6 +2724,14 @@ local dictionaries = {
         url = "https://khoicandev.github.io/ovdp-mirror/en-vi.tar.gz"
     },
     {
+        name = "English-Persian dictionary",
+        lang_in = "eng",
+        lang_out = "fas",
+        entries = 145075,
+        license = "MIT, https://github.com/hossein1376/English-Persian-Kindle-Custom-Dictionary",
+        url = "https://github.com/Monirzadeh/English-Persian-Kindle-Custom-Dictionary/raw/koreader/English Persian Dictionary.tar.gz"
+    },
+    {
         name = "Vietnamese-English dictionary",
         lang_in = "vie",
         lang_out = "eng",


### PR DESCRIPTION
koreader can't download dictionary file if that have space in the url (it should change to `%20`)
and update links for persian dictionary too.
sorry for my mistake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11165)
<!-- Reviewable:end -->
