### PR TITLE
Inputtext: select text without affecting MovableContainer

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -175,12 +175,14 @@ local function initTouchEvents()
                         })
                         self.selection_start_pos = nil
                         self.do_select = false
+                        self._hold_handled = true
                         return true
                     else -- select start
                         self.selection_start_pos = self.charpos
                         UIManager:show(Notification:new{
-                            text = _("Set cursor to end of selection, then hold."),
+                            text = _("Set cursor to end of selection, then hold in the text box."),
                         })
+                        self._hold_handled = true
                         return true
                     end
                 end
@@ -243,7 +245,7 @@ local function initTouchEvents()
                                 callback = function()
                                     UIManager:close(clipboard_dialog)
                                     UIManager:show(Notification:new{
-                                        text = _("Set cursor to start of selection, then hold."),
+                                        text = _("Set cursor to start of selection, then hold in the text box."),
                                     })
                                     self.do_select = true
                                 end,


### PR DESCRIPTION
HoldRelease events in selecting text for clipboard mode to be consumed by Inputtext itself, rather than its parent MovableContainer.

prevents the side effect of changing the state of MovableContainer; holdreleases outside Inputtext area work as usual.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11169)
<!-- Reviewable:end -->
