### PR TITLE
bump crengine: various optimizations and fixes

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -786,9 +786,9 @@ local CSS_SUGGESTIONS = {
     { "-cr-hint: footnote-inpage;", _("When set on a block element containing the target id of a href, this block element will be shown as an in-page footnote.")},
     { "-cr-hint: non-linear-combining;", _("Can be set on some specific DocFragments (ie. DocFragment[id*=16]) to ignore them in the linear pages flow.")},
     { "-cr-hint: toc-level1;", _("When set on an element, its text can be used to build the alternative table of contents.")},
-    { "display: run-in !important,", _("When set on a block element, this element content will be inlined with the next block element.")},
-    { "font-size: 1rem !important;", _("1rem will enforce your main font size")},
-    { "hyphens: none !important", _("Disables hyphenation inside the targeted elements.")},
+    { "display: run-in !important;", _("When set on a block element, this element content will be inlined with the next block element.")},
+    { "font-size: 1rem !important;", _("1rem will enforce your main font size.")},
+    { "hyphens: none !important;", _("Disables hyphenation inside the targeted elements.")},
     { "text-indent: 1.2em !important;", _("1.2em is our default text indentation.")},
 }
 


### PR DESCRIPTION
Includes:
- Avoid unnecessary string modifications https://github.com/koreader/crengine/pull/543
- remove unused lang_name https://github.com/koreader/crengine/pull/537
- extract SniffBOM()
- Optimize LVHTMLParser::CheckFormat()
- LVHTMLParser::CheckFormat() bugfixes
- Don't fillCharbuffer in Reset()
- lvfntman: fix stupid mistake https://github.com/koreader/crengine/pull/546
- css: mark const member functions https://github.com/koreader/crengine/pull/545
- css: clarify LVCssSelectorRule ownership
- css: speedup class matching
- fb2.css: empty paragraphs should have some line height https://github.com/koreader/crengine/pull/547
  Closes #11173.
- CJK: fix bad ruby drawing on last paragraph line https://github.com/koreader/crengine/pull/548
  Closes #11021.

Also includes:
ReaderStyleTweak: minor CSS suggestions popup fixes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11191)
<!-- Reviewable:end -->
