### PR TITLE
Auto crop fix

### DIFF
--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -527,7 +527,7 @@ function ReaderZooming:getZoom(pageno)
         local ubbox_dimen = self.ui.document:getUsedBBoxDimensions(pageno, 1)
         -- if bbox is larger than the native page dimension render the full page
         -- See discussion in koreader/koreader#970.
-        if ubbox_dimen.w <= page_size.w and ubbox_dimen.h <= page_size.h or self.ui.document.configurable.trim_page == 1 then
+        if (ubbox_dimen.w <= page_size.w and ubbox_dimen.h <= page_size.h) or (self.ui.document.configurable.trim_page == 1) then
             page_size = ubbox_dimen
             self.view:onBBoxUpdate(ubbox_dimen)
         else


### PR DESCRIPTION
After some tests with the said document from https://github.com/koreader/koreader/issues/970 it seems like that the visual defect occurs for only semi-auto and manual crop modes.

I've removed auto-crop from the rule so https://github.com/koreader/koreader/issues/4106 can be fixed when using auto-crop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11194)
<!-- Reviewable:end -->
