### PR TITLE
Cover browser plugin mosaic mode grid tweaking

### DIFF
--- a/patches/2-mosaic-mode-grid.lua.disabled
+++ b/patches/2-mosaic-mode-grid.lua.disabled
@@ -1,0 +1,6 @@
+-- Tweak these numbers of rows and columns for Mosaic mode in History/Favorites and Filemanager.
+local FileChooser = require("ui/widget/filechooser")
+FileChooser.nb_cols_portrait = 4
+FileChooser.nb_rows_portrait = 5
+FileChooser.nb_cols_landscape = 5
+FileChooser.nb_rows_landscape = 4

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -32,8 +32,8 @@ local _ = require("gettext")
 local Screen = Device.screen
 local T = require("ffi/util").template
 local getMenuText = require("ui/widget/menu").getMenuText
-
 local BookInfoManager = require("bookinfomanager")
+local FileChooser = require("ui/widget/filechooser")
 
 -- Here is the specific UI implementation for "mosaic" display modes
 -- (see covermenu.lua for the generic code)
@@ -861,11 +861,11 @@ function MosaicMenu:_recalculateDimen()
     local portrait_mode = Screen:getWidth() <= Screen:getHeight()
     -- 3 x 3 grid by default if not initially provided (4 x 2 in landscape mode)
     if portrait_mode then
-        self.nb_cols = self.nb_cols_portrait or 3
-        self.nb_rows = self.nb_rows_portrait or 3
+        self.nb_cols = FileChooser.nb_cols_portrait or 3
+        self.nb_rows = FileChooser.nb_rows_portrait or 3
     else
-        self.nb_cols = self.nb_cols_landscape or 4
-        self.nb_rows = self.nb_rows_landscape or 2
+        self.nb_cols = FileChooser.nb_cols_landscape or 4
+        self.nb_rows = FileChooser.nb_rows_landscape or 2
     end
     self.perpage = self.nb_rows * self.nb_cols
     self.page_num = math.ceil(#self.item_table / self.perpage)


### PR DESCRIPTION
Goal: to have configurable number of columns and rows in Mosaic mode (History/Favorites/Filemanager), to fit more content on larger screens.
Tested on: Kindle Scribe (5.16.2)
KOReader version: v2023.10-37
Closes: #11177 (when properly corrected)

This is a non-intrusive CoverBrowser plugin.
Thank you everyone who made this simple tweak possible and everyone who helps find this!

This PR includes first-ever suggested patch.

I am sure you guys won't like this approach, so please guide me how to make this more "built-in" :D 

The perfect method is to make this patch into top menu settings, I don't have enough experience for this yet.

At this stage this is more like a proof of concept, and it works!

Portrait (4x5):
![Reader_2023-12-03_002120](https://github.com/koreader/koreader/assets/6279855/2ceb5c89-28eb-41ca-80e0-7c1b5f2a609d)

Landscape (5x4):
![Reader_2023-12-03_002136](https://github.com/koreader/koreader/assets/6279855/4b9ddac0-ee82-48ac-b518-86c56ed414e3)
