### PR TITLE
ImageViewer: set preferred rotation and auto rotation

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -36,10 +36,6 @@ DCREREADER_VIEW_MODE = "page",
 -- default to false
 DSHOWOVERLAP = false,
 
--- landscape clockwise rotation
--- default to true, set to false for counterclockwise rotation
-DLANDSCAPE_CLOCKWISE_ROTATION = true,
-
 -- default minimum screen height for reading with 2 pages in landscape mode
 DCREREADER_TWO_PAGE_THRESHOLD = 7,
 

--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -85,6 +85,43 @@ When unchecked, the default rotation of the file browser and the default/saved r
             table.insert(rotation_table, genMenuItem(C_("Rotation", "↓ 180°"), Screen.DEVICE_ROTATED_UPSIDE_DOWN))
         end
 
+        rotation_table[#rotation_table].separator = true
+        table.insert(rotation_table, {
+            text = _("Image viewer rotation"),
+            sub_item_table = {
+                {
+                    text = _("Clockwise (when in portrait)") .. "  \u{EB67}",
+                    radio = true,
+                    checked_func = function()
+                        return G_reader_settings:nilOrTrue("imageviewer_rotate_clockwise")
+                    end,
+                    callback = function()
+                        G_reader_settings:makeTrue("imageviewer_rotate_clockwise")
+                    end,
+                },
+                {
+                    text = _("Counter-clockwise (when in portrait)") .. "  \u{EB65}",
+                    radio = true,
+                    checked_func = function()
+                        return G_reader_settings:isFalse("imageviewer_rotate_clockwise")
+                    end,
+                    callback = function()
+                        G_reader_settings:makeFalse("imageviewer_rotate_clockwise")
+                    end,
+                    separator = true,
+                },
+                {
+                    text = _("Auto-rotate for best fit"),
+                    help_text = _("Auto-rotate the image to best match screen and image aspect ratios on image viewer launch (ie. if in portrait mode, a landscape image will be rotated).");
+                    checked_func = function()
+                        return G_reader_settings:isTrue("imageviewer_rotate_auto_for_best_fit")
+                    end,
+                    callback = function()
+                        G_reader_settings:flipTrue("imageviewer_rotate_auto_for_best_fit")
+                    end,
+                }
+            }
+        })
         return rotation_table
     end,
 }

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -156,6 +156,10 @@ function ImageViewer:init()
         self.image = self._scaled_image_func(1) -- native image size, that we need to know
     end
 
+    if G_reader_settings:isTrue("imageviewer_rotate_auto_for_best_fit") then
+        self.rotated = (Screen:getWidth() > Screen:getHeight()) ~= (self.image:getWidth() > self.image:getHeight())
+    end
+
     -- Widget layout
     if self._scale_to_fit == nil then -- initialize our toggle
         self._scale_to_fit = self.scale_factor == 0
@@ -398,16 +402,15 @@ function ImageViewer:_new_image_wg()
 
     local rotation_angle = 0
     if self.rotated then
-        -- in portrait mode, rotate according to this global setting so we are
-        -- like in landscape mode
-        -- NOTE: This is the sole user of this legacy global left!
-        local rotate_clockwise = G_defaults:readSetting("DLANDSCAPE_CLOCKWISE_ROTATION")
+        -- The default is to rotate clockwise when in portrait mode, so right handed users
+        -- get to hold the device's bottom in their right hand.
+        local rotate_clockwise = G_reader_settings:nilOrTrue("imageviewer_rotate_clockwise")
         if Screen:getWidth() > Screen:getHeight() then
-            -- in landscape mode, counter-rotate landscape rotation so we are
+            -- in landscape mode, counter-rotate this rotation so we are
             -- back like in portrait mode
             rotate_clockwise = not rotate_clockwise
         end
-        rotation_angle = rotate_clockwise and 90 or 270
+        rotation_angle = rotate_clockwise and 270 or 90
     end
 
     if self._scaled_image_func then


### PR DESCRIPTION
Add option to set the preferred rotation in ImageViewer, defaults to the most natural rotation for right handed users.
Remove the obsolete setting, that used to be used for more things, but ended up being used only by ImageViewer (no migration, its name and its effect were contradictory).
Add option to auto-rotate for best fit on launch, so landscape images are auto-rotated to the preferred rotation.

Discussed in (and supersedes) #10540.

As previously with the bottom menu, it's not obvious to express a rotation in icons and words :) (And we can't use the nice icons we made for the bottom menu in our TouchMenu).
It's a bit less critical here, as there's only 2 choices and once people have tested it or choosen the other, they'll be done.
![image](https://github.com/koreader/koreader/assets/24273478/f210ae70-30e7-490f-bbee-e8a6230a8d35)

Not sure what @stelzch meant at https://github.com/koreader/koreader/pull/10540#issuecomment-1602774805 : 
> However, I am still having issues if the device screen rotation is changed, in this case the image rotation does not follow the cw/ccw setting.

I guess it is that when in landscape, the rotation was inverted - which is the expected behaviour. We actually chose the prefered orientation for when we turn the device in lanscape - the prefered orientation when in portrait is fixed/hardcoded: it's the natural one. (No idea what happens with Android tablets with kickstatnds that are naturally used in landscape... Don't want to think about that :))
And when reading in landscape mode, the rotation is inverted so we get to the natural portait orientation.
Confusing to explain :)
There's not much symbols in Unicode to express this. I found these 2 ones in our nerdfont that may express something - actually, lucky the arrow are in the clockwise rotation express with the words :) But they don't say if the black thingy is the image or the device.
It can make sense if you think of it as a landscape image displayed in portrait mode: small - and getting bigger when you rotate it, the side of the image following the way of the arrow is where it will be once the image is rotated (but you have to rotate your device the other way :).... confusing.)
Dunno if the symbols should be inverted when the menu is displayed in lanscape... and/or if I should get rid of "(when in portrait)", or include the symbol in the parens (harder/clumy for the translators).

Anyway, better ideas for the wording and symbols welcome.
("Counter clockwise" or "Anti clockwise" if we're going with "clockwise" ? With a hyphen or a space in between ?)