### PR TITLE
Folder shortcuts: speed up

### DIFF
--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -120,7 +120,7 @@ function FileManagerShortcuts:editShortcut(folder, post_callback)
                     if item then
                         item.text = new_name
                     else
-                        self.folder_shortcuts[folder] = { text = new_name }
+                        self.folder_shortcuts[folder] = { text = new_name, time = os.time() }
                         if post_callback then
                             post_callback()
                         end

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -16,35 +16,21 @@ local FileManagerShortcuts = WidgetContainer:extend{
 
 function FileManagerShortcuts:updateItemTable()
     local item_table = {}
-    for _, item in ipairs(self.folder_shortcuts) do
+    for folder, item in pairs(self.folder_shortcuts) do
         table.insert(item_table, {
-            text = string.format("%s (%s)", item.text, item.folder),
-            folder = item.folder,
+            text = string.format("%s (%s)", item.text, folder),
+            folder = folder,
             name = item.text,
         })
     end
     table.sort(item_table, function(l, r)
         return l.text < r.text
     end)
-
-    -- try to stay on current page
-    local select_number
-    if self.shortcuts_menu.page and self.shortcuts_menu.perpage and self.shortcuts_menu.page > 0 then
-        select_number = (self.shortcuts_menu.page - 1) * self.shortcuts_menu.perpage + 1
-    end
-    self.shortcuts_menu:switchItemTable(nil, item_table, select_number)
-end
-
-function FileManagerShortcuts:_getIndex(folder)
-    for i, v in ipairs(self.folder_shortcuts) do
-        if v.folder == folder then
-            return i
-        end
-    end
+    self.shortcuts_menu:switchItemTable(nil, item_table, -1)
 end
 
 function FileManagerShortcuts:hasFolderShortcut(folder)
-    return self:_getIndex(folder) and true or false
+    return self.folder_shortcuts[folder] and true or false
 end
 
 function FileManagerShortcuts:onMenuChoice(item)
@@ -81,9 +67,7 @@ function FileManagerShortcuts:onMenuHold(item)
                 end
             },
         },
-    }
-    if self._manager.ui.file_chooser and self._manager.ui.clipboard then
-        table.insert(buttons, {
+        self._manager.ui.file_chooser and self._manager.ui.clipboard and {
             {
                 text = _("Paste to folder"),
                 callback = function()
@@ -91,9 +75,8 @@ function FileManagerShortcuts:onMenuHold(item)
                     self._manager.ui:pasteFileFromClipboard(item.folder)
                 end
             },
-        })
-    end
-
+        },
+    }
     dialog = ButtonDialog:new{
         title = item.name .. "\n" .. BD.dirpath(item.folder),
         title_align = "center",
@@ -104,8 +87,7 @@ function FileManagerShortcuts:onMenuHold(item)
 end
 
 function FileManagerShortcuts:removeShortcut(folder)
-    local index = self:_getIndex(folder)
-    table.remove(self.folder_shortcuts, index)
+    self.folder_shortcuts[folder] = nil
     if self.shortcuts_menu then
         self.fm_updated = true
         self:updateItemTable()
@@ -113,13 +95,8 @@ function FileManagerShortcuts:removeShortcut(folder)
 end
 
 function FileManagerShortcuts:editShortcut(folder, post_callback)
-    local index = self:_getIndex(folder)
-    local item, name
-    if index then -- rename
-        item = self.folder_shortcuts[index]
-        name = item.text
-    end
-
+    local item = self.folder_shortcuts[folder]
+    local name = item and item.text -- rename
     local input_dialog
     input_dialog = InputDialog:new {
         title = _("Enter folder shortcut name"),
@@ -143,10 +120,7 @@ function FileManagerShortcuts:editShortcut(folder, post_callback)
                     if item then
                         item.text = new_name
                     else
-                        table.insert(self.folder_shortcuts, {
-                            text = new_name,
-                            folder = folder,
-                        })
+                        self.folder_shortcuts[folder] = { text = new_name }
                         if post_callback then
                             post_callback()
                         end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20230901
+local CURRENT_MIGRATION_DATE = 20231212
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -629,6 +629,20 @@ if last_migration_date < 20230901 then
     local contrast = G_reader_settings:readSetting("kopt_contrast")
     if contrast then
         G_reader_settings:saveSetting("kopt_contrast", 1 / contrast)
+    end
+end
+
+-- 20231212, change folder_shortcuts setting from array to hash table
+if last_migration_date < 20231212 then
+    logger.info("Performing one-time migration for 20231212")
+
+    local shortcuts = G_reader_settings:readSetting("folder_shortcuts")
+    if shortcuts and shortcuts[1] ~= nil then
+        local new_shortcuts = {}
+        for _, item in ipairs(shortcuts) do
+            new_shortcuts[item.folder] = { text = item.text }
+        end
+        G_reader_settings:saveSetting("folder_shortcuts", new_shortcuts)
     end
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -638,9 +638,10 @@ if last_migration_date < 20231212 then
 
     local shortcuts = G_reader_settings:readSetting("folder_shortcuts")
     if shortcuts and shortcuts[1] ~= nil then
+        local now = os.time()
         local new_shortcuts = {}
-        for _, item in ipairs(shortcuts) do
-            new_shortcuts[item.folder] = { text = item.text }
+        for i, item in ipairs(shortcuts) do
+            new_shortcuts[item.folder] = { text = item.text, time = now + i }
         end
         G_reader_settings:saveSetting("folder_shortcuts", new_shortcuts)
     end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20231212
+local CURRENT_MIGRATION_DATE = 20231217
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -632,9 +632,9 @@ if last_migration_date < 20230901 then
     end
 end
 
--- 20231212, change folder_shortcuts setting from array to hash table
-if last_migration_date < 20231212 then
-    logger.info("Performing one-time migration for 20231212")
+-- 20231217, change folder_shortcuts setting from array to hash table
+if last_migration_date < 20231217 then
+    logger.info("Performing one-time migration for 20231217")
 
     local shortcuts = G_reader_settings:readSetting("folder_shortcuts")
     if shortcuts and shortcuts[1] ~= nil then


### PR DESCRIPTION
Since we show an indicator in the file browser, the check must be accelerated as much as possible, so - hash table.

https://github.com/koreader/koreader/blob/dbaef37b275a75bb7989b871f6a342af526394aa/frontend/apps/filemanager/filemanagershortcuts.lua#L32-L34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11221)
<!-- Reviewable:end -->
