### PR TITLE
Frontlight warmth gesture fixed step

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -159,7 +159,7 @@ if Device:hasFrontlight() then
 
         direction, delta_int = calculateGestureDelta(ges, direction, powerd.fl_warmth_min, powerd.fl_warmth_max)
 
-        local warmth = math.floor(powerd.fl_warmth + direction * delta_int * 100 / powerd.fl_warmth_max)
+        local warmth = util.true_round(powerd.fl_warmth + direction * delta_int * 100 / powerd.fl_warmth_max)
         self:onSetFlWarmth(warmth)
         self:onShowWarmth()
         return true

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -1523,4 +1523,18 @@ function util.wrapMethod(target_table, target_field_name, new_func, before_callb
     return wrapped
 end
 
+-- a function to select the same rounding effect when dealing with opposite-sign directions
+-- specifically designed so that frontlight warmth gesture can increment in 5% when set at unit "1"
+function util.true_round(num)
+    under = math.floor(num)
+    upper = math.floor(num) + 1
+    underV = -(under - num)
+    upperV = upper - num
+    if (upperV > underV) then
+        return upper
+    else
+        return under
+    end
+end
+
 return util


### PR DESCRIPTION
Fixes #11220 

It works great on Kindle Scribe when `Increase/Decrease frontlight warmth` is set to `1` in gesture manager.

However, `3` and higher again gives inconsistent results.

Do you guys have a better suggestion for `round` function? There is no built-in regular `round` function, that rounds to lower value if decimal <0.5, and to higher value if >=0.5.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11225)
<!-- Reviewable:end -->
