### PR TITLE
History, Collection: title bar in FM style

### DIFF
--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -126,7 +126,7 @@ function FileManagerCollection:onShowColl(collection_name)
         is_borderless = true,
         is_popout = false,
         -- item and book cover thumbnail dimensions in Mosaic and Detailed list display modes
-        -- are equal in File manager, History and Collection windows
+        -- must be equal in File manager, History and Collection windows to avoid image scaling
         title_bar_fm_style = true,
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function() self:showCollDialog() end,

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -125,6 +125,7 @@ function FileManagerCollection:onShowColl(collection_name)
         covers_fullscreen = true, -- hint for UIManager:_repaint()
         is_borderless = true,
         is_popout = false,
+        title_bar_fm_style = true,
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function() self:showCollDialog() end,
         onMenuChoice = self.onMenuChoice,

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -125,6 +125,8 @@ function FileManagerCollection:onShowColl(collection_name)
         covers_fullscreen = true, -- hint for UIManager:_repaint()
         is_borderless = true,
         is_popout = false,
+        -- item and book cover thumbnail dimensions in Mosaic and Detailed list display modes
+        -- are equal in File manager, History and Collection windows
         title_bar_fm_style = true,
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function() self:showCollDialog() end,

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -81,17 +81,13 @@ function FileManagerHistory:updateItemTable()
             self.count[v.status] = self.count[v.status] + 1
         end
     end
-    local title = self.hist_menu_title
-    local filter_title
+    local subtitle
     if self.search_string then
-        filter_title = _("search results")
+        subtitle = T("Search results (%1)", #item_table)
     elseif self.filter ~= "all" then
-        filter_title = filter_text[self.filter]:lower()
+        subtitle = T("Status: %1 (%2)", filter_text[self.filter]:lower(), #item_table)
     end
-    if filter_title then
-        title = title .. T(" (%1: %2)", filter_title, #item_table)
-    end
-    self.hist_menu:switchItemTable(title, item_table, select_number)
+    self.hist_menu:switchItemTable(nil, item_table, select_number, nil, subtitle or "")
 end
 
 function FileManagerHistory:isItemMatch(item)
@@ -223,6 +219,8 @@ function FileManagerHistory:onShowHist(search_info)
         covers_fullscreen = true, -- hint for UIManager:_repaint()
         is_borderless = true,
         is_popout = false,
+        title = self.hist_menu_title,
+        title_bar_fm_style = true,
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function() self:showHistDialog() end,
         onMenuChoice = self.onMenuChoice,

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -221,7 +221,7 @@ function FileManagerHistory:onShowHist(search_info)
         is_popout = false,
         title = self.hist_menu_title,
         -- item and book cover thumbnail dimensions in Mosaic and Detailed list display modes
-        -- are equal in File manager, History and Collection windows
+        -- must be equal in File manager, History and Collection windows to avoid image scaling
         title_bar_fm_style = true,
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function() self:showHistDialog() end,

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -220,6 +220,8 @@ function FileManagerHistory:onShowHist(search_info)
         is_borderless = true,
         is_popout = false,
         title = self.hist_menu_title,
+        -- item and book cover thumbnail dimensions in Mosaic and Detailed list display modes
+        -- are equal in File manager, History and Collection windows
         title_bar_fm_style = true,
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function() self:showHistDialog() end,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -562,7 +562,7 @@ local Menu = FocusManager:extend{
     show_parent = nil,
 
     no_title = false,
-    title = nil,
+    title = "",
     subtitle = nil,
     show_path = nil, -- path in titlebar subtitle
     -- default width and height
@@ -619,7 +619,7 @@ function Menu:_recalculateDimen()
         bottom_height = math.max(self.page_return_arrow:getSize().h, self.page_info_text:getSize().h)
             + 2 * Size.padding.button
     end
-    if not self.no_title then
+    if self.show_path or not self.no_title then
         top_height = self.title_bar:getHeight()
         if not self.title_bar_fm_style then
             top_height = top_height + self.header_padding

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -562,6 +562,7 @@ local Menu = FocusManager:extend{
     show_parent = nil,
 
     title = "No Title",
+    subtitle = nil,
     -- default width and height
     width = nil,
     -- height will be calculated according to item number if not given
@@ -596,6 +597,7 @@ local Menu = FocusManager:extend{
     -- if you want to embed the menu widget into another widget, set
     -- this to false
     is_popout = true,
+    title_bar_fm_style = nil, -- set to true to build increased title bar like in FM
     -- set icon to add title bar left button
     title_bar_left_icon = nil,
     -- close_callback is a function, which is executed when menu is closed
@@ -616,7 +618,10 @@ function Menu:_recalculateDimen()
             + 2 * Size.padding.button
     end
     if self.title_bar and not self.no_title then
-        top_height = self.title_bar:getHeight() + self.header_padding
+        top_height = self.title_bar:getHeight()
+        if not self.title_bar_fm_style then
+            top_height = top_height + self.header_padding
+        end
     end
     height_dim = self.inner_dimen.h - bottom_height - top_height
     local item_height = math.floor(height_dim / self.perpage)
@@ -666,12 +671,16 @@ function Menu:init()
         title_face = self.title_face,
         title_multilines = self.title_multilines,
         title_shrink_font_to_fit = self.title_shrink_font_to_fit,
-        subtitle = self.show_path and BD.directory(filemanagerutil.abbreviate(self.path)),
+        subtitle = self.title_bar_fm_style and "" or (self.show_path and BD.directory(filemanagerutil.abbreviate(self.path))),
         subtitle_truncate_left = self.show_path,
         subtitle_fullwidth = self.show_path,
+        title_top_padding = self.title_bar_fm_style and Screen:scaleBySize(6),
+        button_padding = self.title_bar_fm_style and Screen:scaleBySize(5),
         left_icon = self.title_bar_left_icon,
+        left_icon_size_ratio = self.title_bar_fm_style and 1,
         left_icon_tap_callback = function() self:onLeftButtonTap() end,
         left_icon_hold_callback = function() self:onLeftButtonHold() end,
+        right_icon_size_ratio = self.title_bar_fm_style and 1,
         close_callback = function() self:onClose() end,
         show_parent = self.show_parent or self,
     }
@@ -1127,9 +1136,14 @@ end
     and the page number will be the page containing the first item for
     which item.key = value
 --]]
-function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch)
-    if self.title_bar and new_title then
-        self.title_bar:setTitle(new_title)
+function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch, new_subtitle)
+    if self.title_bar then
+        if new_title then
+            self.title_bar:setTitle(new_title, true)
+        end
+        if new_subtitle then
+            self.title_bar:setSubTitle(new_subtitle, true)
+        end
     end
 
     if itemnumber == nil then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -561,8 +561,10 @@ Widget that displays menu
 local Menu = FocusManager:extend{
     show_parent = nil,
 
-    title = "No Title",
+    no_title = false,
+    title = nil,
     subtitle = nil,
+    show_path = nil, -- path in titlebar subtitle
     -- default width and height
     width = nil,
     -- height will be calculated according to item number if not given
@@ -597,7 +599,7 @@ local Menu = FocusManager:extend{
     -- if you want to embed the menu widget into another widget, set
     -- this to false
     is_popout = true,
-    title_bar_fm_style = nil, -- set to true to build increased title bar like in FM
+    title_bar_fm_style = nil, -- set to true to build increased title bar like in FileManager
     -- set icon to add title bar left button
     title_bar_left_icon = nil,
     -- close_callback is a function, which is executed when menu is closed
@@ -617,7 +619,7 @@ function Menu:_recalculateDimen()
         bottom_height = math.max(self.page_return_arrow:getSize().h, self.page_info_text:getSize().h)
             + 2 * Size.padding.button
     end
-    if self.title_bar and not self.no_title then
+    if not self.no_title then
         top_height = self.title_bar:getHeight()
         if not self.title_bar_fm_style then
             top_height = top_height + self.header_padding
@@ -660,30 +662,39 @@ function Menu:init()
     -----------------------------------
     -- start to set up widget layout --
     -----------------------------------
-    self.title_bar = TitleBar:new{
-        width = self.dimen.w,
-        fullscreen = "true",
-        align = "center",
-        with_bottom_line = self.with_bottom_line,
-        bottom_line_color = self.bottom_line_color,
-        bottom_line_h_padding = self.bottom_line_h_padding,
-        title = self.title,
-        title_face = self.title_face,
-        title_multilines = self.title_multilines,
-        title_shrink_font_to_fit = self.title_shrink_font_to_fit,
-        subtitle = self.title_bar_fm_style and "" or (self.show_path and BD.directory(filemanagerutil.abbreviate(self.path))),
-        subtitle_truncate_left = self.show_path,
-        subtitle_fullwidth = self.show_path,
-        title_top_padding = self.title_bar_fm_style and Screen:scaleBySize(6),
-        button_padding = self.title_bar_fm_style and Screen:scaleBySize(5),
-        left_icon = self.title_bar_left_icon,
-        left_icon_size_ratio = self.title_bar_fm_style and 1,
-        left_icon_tap_callback = function() self:onLeftButtonTap() end,
-        left_icon_hold_callback = function() self:onLeftButtonHold() end,
-        right_icon_size_ratio = self.title_bar_fm_style and 1,
-        close_callback = function() self:onClose() end,
-        show_parent = self.show_parent or self,
-    }
+    if self.show_path or not self.no_title then
+        if self.subtitle == nil then
+            if self.show_path then
+                self.subtitle = BD.directory(filemanagerutil.abbreviate(self.path))
+            elseif self.title_bar_fm_style then
+                self.subtitle = ""
+            end
+        end
+        self.title_bar = TitleBar:new{
+            width = self.dimen.w,
+            fullscreen = "true",
+            align = "center",
+            with_bottom_line = self.with_bottom_line,
+            bottom_line_color = self.bottom_line_color,
+            bottom_line_h_padding = self.bottom_line_h_padding,
+            title = self.title,
+            title_face = self.title_face,
+            title_multilines = self.title_multilines,
+            title_shrink_font_to_fit = self.title_shrink_font_to_fit,
+            subtitle = self.subtitle,
+            subtitle_truncate_left = self.show_path,
+            subtitle_fullwidth = self.show_path,
+            title_top_padding = self.title_bar_fm_style and Screen:scaleBySize(6),
+            button_padding = self.title_bar_fm_style and Screen:scaleBySize(5),
+            left_icon = self.title_bar_left_icon,
+            left_icon_size_ratio = self.title_bar_fm_style and 1,
+            left_icon_tap_callback = function() self:onLeftButtonTap() end,
+            left_icon_hold_callback = function() self:onLeftButtonHold() end,
+            right_icon_size_ratio = self.title_bar_fm_style and 1,
+            close_callback = function() self:onClose() end,
+            show_parent = self.show_parent or self,
+        }
+    end
 
     -- group for items
     self.item_group = VerticalGroup:new{}

--- a/frontend/ui/widget/titlebar.lua
+++ b/frontend/ui/widget/titlebar.lua
@@ -434,21 +434,22 @@ function TitleBar:setTitle(title, no_refresh)
             self.inner_title_group:resetLayout()
         end
         self.title_group:resetLayout()
-        if no_refresh then
-            return
+        if not no_refresh then
+            UIManager:setDirty(self.show_parent, "ui", self.dimen)
         end
-        UIManager:setDirty(self.show_parent, "ui", self.dimen)
     end
 end
 
-function TitleBar:setSubTitle(subtitle)
+function TitleBar:setSubTitle(subtitle, no_refresh)
     if self.subtitle_widget and not self.subtitle_multilines then -- no TextBoxWidget:setText() available
         self.subtitle_widget:setText(subtitle)
         if self.inner_subtitle_group then
             self.inner_subtitle_group:resetLayout()
         end
         self.title_group:resetLayout()
-        UIManager:setDirty(self.show_parent, "ui", self.dimen)
+        if not no_refresh then
+            UIManager:setDirty(self.show_parent, "ui", self.dimen)
+        end
     end
 end
 


### PR DESCRIPTION
Increased height of the title bar in History and Collection pages, equal to FM title bar.
Item dimensions in Classic, Cover, List modes are equal in FM, Hist, Coll.

![1](https://github.com/koreader/koreader/assets/62179190/868903f1-12ae-481a-9a7f-c9d359800ecc)

![2](https://github.com/koreader/koreader/assets/62179190/83218c49-8798-4e55-b73f-1c614c7808a6)

![3](https://github.com/koreader/koreader/assets/62179190/063507bf-f441-4d67-8e2f-1090fd41c256)

![4](https://github.com/koreader/koreader/assets/62179190/2065166a-f91e-4b5d-a2ec-a6a6642a7777)

![5](https://github.com/koreader/koreader/assets/62179190/41d713b3-0a33-4044-9595-c3debdcba6f7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11243)
<!-- Reviewable:end -->
