### PR TITLE
File manager: fix height of menu widget

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -619,7 +619,7 @@ function Menu:_recalculateDimen()
         bottom_height = math.max(self.page_return_arrow:getSize().h, self.page_info_text:getSize().h)
             + 2 * Size.padding.button
     end
-    if self.show_path or not self.no_title then
+    if self.title_bar and not self.no_title then
         top_height = self.title_bar:getHeight()
         if not self.title_bar_fm_style then
             top_height = top_height + self.header_padding


### PR DESCRIPTION
Wrong height of file manager content in classic mode.
Bug in https://github.com/koreader/koreader/pull/11243.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11251)
<!-- Reviewable:end -->
