### PR TITLE
Add folder check in move-to-archive

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -758,6 +758,11 @@ function util.pathExists(path)
     return lfs.attributes(path, "mode") ~= nil
 end
 
+--- Checks if the given directory exists.
+function util.directoryExists(path)
+  if lfs.attributes(path, "mode") == "directory" then return true end
+end
+
 --- As `mkdir -p`.
 -- Unlike [lfs.mkdir](https://keplerproject.github.io/luafilesystem/manual.html#mkdir)(),
 -- does not error if the directory already exists, and creates intermediate directories as needed.

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -760,7 +760,7 @@ end
 
 --- Checks if the given directory exists.
 function util.directoryExists(path)
-  if lfs.attributes(path, "mode") == "directory" then return true end
+  return lfs.attributes(path, "mode") == "directory"
 end
 
 --- As `mkdir -p`.

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -29,14 +29,6 @@ function MoveToArchive:init()
     self.last_copied_from_dir = self.settings:readSetting("last_copied_from_dir")
 end
 
--- check if the folder exists
-local function dir_exists_v1(path)
-  if (lfs.attributes(path, "mode") == "directory") then
-    return true
-  end
-  return false
-end
-
 function MoveToArchive:addToMainMenu(menu_items)
     menu_items.move_to_archive = {
         text = _("Move to archive"),

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -29,6 +29,14 @@ function MoveToArchive:init()
     self.last_copied_from_dir = self.settings:readSetting("last_copied_from_dir")
 end
 
+-- check if the folder exists
+function dir_exists_v1(path)
+  if (lfs.attributes(path, "mode") == "directory") then
+    return true
+  end
+  return false
+end
+
 function MoveToArchive:addToMainMenu(menu_items)
     menu_items.move_to_archive = {
         text = _("Move to archive"),
@@ -50,7 +58,7 @@ function MoveToArchive:addToMainMenu(menu_items)
             {
                 text = _("Go to archive folder"),
                 callback = function()
-                    if self.archive_dir_path then
+                    if self.archive_dir_path and dir_exists_v1(self.archive_dir_path) then
                         self:openFileBrowser(self.archive_dir_path)
                     else
                         self:showNoArchiveConfirmBox()

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -11,7 +11,6 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local util = require("frontend/util")
 local BaseUtil = require("ffi/util")
 local _ = require("gettext")
-local lfs = require("libs/libkoreader-lfs")
 
 local MoveToArchive = WidgetContainer:extend{
     name = "movetoarchive",
@@ -59,7 +58,7 @@ function MoveToArchive:addToMainMenu(menu_items)
             {
                 text = _("Go to archive folder"),
                 callback = function()
-                    if self.archive_dir_path and dir_exists_v1(self.archive_dir_path) then
+                    if self.archive_dir_path and util.directoryExists(self.archive_dir_path) then
                         self:openFileBrowser(self.archive_dir_path)
                     else
                         self:showNoArchiveConfirmBox()

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -11,6 +11,7 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local util = require("frontend/util")
 local BaseUtil = require("ffi/util")
 local _ = require("gettext")
+local lfs = require("libs/libkoreader-lfs")
 
 local MoveToArchive = WidgetContainer:extend{
     name = "movetoarchive",

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -30,7 +30,7 @@ function MoveToArchive:init()
 end
 
 -- check if the folder exists
-function dir_exists_v1(path)
+local function dir_exists_v1(path)
   if (lfs.attributes(path, "mode") == "directory") then
     return true
   end


### PR DESCRIPTION
First try.
Function is taken from: https://www.geeks3d.com/hacklab/20210901/how-to-check-if-a-directory-exists-in-lua-and-in-python/

Use case:
1) Open KOReader with MoveToArchive plugin enabled, setup folder for it.
2) While KOReader is open, rename that folder to something else.
3) Try to go to that folder from the plugin menu. Now instead of crashing, it should ask about setting a new folder for MoveToArchive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11262)
<!-- Reviewable:end -->
