### PR TITLE
Properly toggle warmth on OnyxWarmthController devices as well

### DIFF
--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -76,9 +76,8 @@ function AndroidPowerD:turnOnFrontlightHW(done_callback)
 
     -- Devices using OnyxWarmthController also need to turn on warmth
     if android.hasStandaloneWarmth() then
-        -- Due to AndroidPowerD:frontlightWarmthHW() above,
-        -- we need to divide by self.warm_diff,
-        -- otherwise self.warm_diff is too large is discarded by the controller.
+        -- Due to AndroidPowerD:frontlightWarmthHW() above, we need to divide by self.warm_diff,
+        -- otherwise self.warm_diff is too large and gets discarded by the controller.
         android.setScreenWarmth(math.floor(self.fl_warmth / self.warm_diff)) -- e.g. 160 out of 255
     end
     return false

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -11,7 +11,7 @@ function AndroidPowerD:frontlightIntensityHW()
 end
 
 function AndroidPowerD:setIntensityHW(intensity)
-    -- if frontlight switch was toggled of, turn it on
+    -- If the frontlight switch was off, turn it on.
     android.enableFrontlightSwitch()
 
     self.fl_intensity = intensity
@@ -58,6 +58,11 @@ function AndroidPowerD:turnOffFrontlightHW()
         return
     end
     android.setScreenBrightness(self.fl_min)
+    
+    -- Devices using OnyxWarmthController also need to turn off Warmth
+    if android.hasStandaloneWarmth then
+        android.setScreenWarmth(self.fl_warmth_min)
+    end
 end
 
 function AndroidPowerD:turnOnFrontlightHW(done_callback)

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -74,9 +74,7 @@ function AndroidPowerD:turnOnFrontlightHW(done_callback)
     android.setScreenBrightness(math.floor(self.fl_intensity * self.bright_diff / self.fl_max))
 
     if android.hasStandaloneWarmth() then
-        -- Due to AndroidPowerD:frontlightWarmthHW() above, we need to divide by self.warm_diff,
-        -- otherwise self.warm_diff is too large and gets discarded by the controller.
-        android.setScreenWarmth(math.floor(self.fl_warmth / self.warm_diff)) -- e.g. 160 out of 255
+        android.setScreenWarmth(math.floor(self.fl_warmth / self.warm_diff))
     end
     return false
 end

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -59,8 +59,8 @@ function AndroidPowerD:turnOffFrontlightHW()
     end
     android.setScreenBrightness(self.fl_min)
 
-    -- Devices using OnyxWarmthController also need to turn off Warmth
-    if android.hasStandaloneWarmth then
+    -- Devices using OnyxWarmthController also need to turn off warmth
+    if android.hasStandaloneWarmth() then
         android.setScreenWarmth(self.fl_warmth_min)
     end
 end
@@ -74,6 +74,13 @@ function AndroidPowerD:turnOnFrontlightHW(done_callback)
 
     android.setScreenBrightness(math.floor(self.fl_intensity * self.bright_diff / self.fl_max))
 
+    -- Devices using OnyxWarmthController also need to turn on warmth
+    if android.hasStandaloneWarmth() then
+        -- Due to AndroidPowerD:frontlightWarmthHW() above,
+        -- we need to divide by self.warm_diff,
+        -- otherwise self.warm_diff is too large is discarded by the controller.
+        android.setScreenWarmth(math.floor(self.fl_warmth / self.warm_diff)) -- e.g. 160 out of 255
+    end
     return false
 end
 

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -59,7 +59,6 @@ function AndroidPowerD:turnOffFrontlightHW()
     end
     android.setScreenBrightness(self.fl_min)
 
-    -- Devices using OnyxWarmthController also need to turn off warmth
     if android.hasStandaloneWarmth() then
         android.setScreenWarmth(self.fl_warmth_min)
     end
@@ -74,7 +73,6 @@ function AndroidPowerD:turnOnFrontlightHW(done_callback)
 
     android.setScreenBrightness(math.floor(self.fl_intensity * self.bright_diff / self.fl_max))
 
-    -- Devices using OnyxWarmthController also need to turn on warmth
     if android.hasStandaloneWarmth() then
         -- Due to AndroidPowerD:frontlightWarmthHW() above, we need to divide by self.warm_diff,
         -- otherwise self.warm_diff is too large and gets discarded by the controller.

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -58,7 +58,7 @@ function AndroidPowerD:turnOffFrontlightHW()
         return
     end
     android.setScreenBrightness(self.fl_min)
-    
+
     -- Devices using OnyxWarmthController also need to turn off Warmth
     if android.hasStandaloneWarmth then
         android.setScreenWarmth(self.fl_warmth_min)


### PR DESCRIPTION
Depends on https://github.com/koreader/android-luajit-launcher/pull/426

Fixing old issue on Onyx devices that also need warmth to be turned off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11275)
<!-- Reviewable:end -->
