### PR TITLE
Statistics: Also skip hidden flows stuff in continuous mode

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1618,7 +1618,7 @@ function ReaderStatistics:getCurrentStat()
     local total_pages
     local page_progress_string
     local percent_read
-    if (self.document:hasHiddenFlows()) then
+    if self.document:hasHiddenFlows() and self.view.state.page then
         local flow = self.document:getPageFlow(self.view.state.page)
         current_page = self.document:getPageNumberInFlow(self.view.state.page)
         total_pages = self.document:getTotalPagesInFlow(flow)


### PR DESCRIPTION
Followup to #11279

(ReaderFooter does it this way, and I don't have a testcase on hand anyway).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11284)
<!-- Reviewable:end -->
