### PR TITLE
Kindle Scribe: fix touch input

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -638,7 +638,7 @@ local KindleScribe = Kindle:extend{
     hasLightSensor = yes,
     hasGSensor = yes,
     display_dpi = 300,
-    touch_dev = "/dev/input/by-path/platform-1001e000.i2c-event",
+    touch_dev = "/dev/input/touch",
     -- NOTE: TBC whether dithering actually works on Bellatrix3...
     canHWDither = no,
     canDoSwipeAnimation = yes,


### PR DESCRIPTION
Closes #11199 , that reported about touch input unresponsiveness if KOReader was started very soon after a fresh Kindle reboot, both via KUAL and KOL.

Context: the old touch device was in fact a Wacom Digitizer (`event3`).
The new `touch` device is the true touch device, `event2`.

Why the old input device worked in all other cases (at all!) is still a lab126 mistery. My suspicion is that down the road of startup, Wacom Digitizer is then duplicated as a touch. However, this transition doesn't seem to have enough time to kick in, and probably gets murdered among other stuff that `koreader.sh` needs to murder during its startup.

Thank you @NiLuJe !

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11285)
<!-- Reviewable:end -->
