### PR TITLE
remarkable: Update Wi-Fi scripts

### DIFF
--- a/platform/remarkable/disable-wifi.sh
+++ b/platform/remarkable/disable-wifi.sh
@@ -6,7 +6,7 @@ if systemctl is-active -q wpa_supplicant; then
 fi
 
 # stop non-service wpa_supplicant cleanly
-if pidof wpa_supplicant >/dev/null; then
+if pidof wpa_supplicant; then
     wpa_cli terminate
 fi
 

--- a/platform/remarkable/disable-wifi.sh
+++ b/platform/remarkable/disable-wifi.sh
@@ -15,7 +15,7 @@ if ! systemctl is-enabled -q dhcpcd; then
     systemctl stop dhcpcd
 fi
 
-# power down wi-fi interface
+# power down wifi interface
 ifconfig wlan0 down
 
 # unload brcmfmac kernel module

--- a/platform/remarkable/disable-wifi.sh
+++ b/platform/remarkable/disable-wifi.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-# clean stop of wpa_supplicant service, used by xochitl
+# stop wpa_supplicant service cleanly, used by xochitl
 if systemctl is-active -q wpa_supplicant; then
     systemctl stop wpa_supplicant
 fi
 
-# clean stop of non-service wpa_supplicant
+# stop non-service wpa_supplicant cleanly
 if pidof wpa_supplicant >/dev/null; then
     wpa_cli terminate
 fi
@@ -15,7 +15,7 @@ if ! systemctl is-enabled -q dhcpcd; then
     systemctl stop dhcpcd
 fi
 
-# power down wifi interface
+# power down wi-fi interface
 ifconfig wlan0 down
 
 # unload brcmfmac kernel module

--- a/platform/remarkable/disable-wifi.sh
+++ b/platform/remarkable/disable-wifi.sh
@@ -19,6 +19,6 @@ fi
 ifconfig wlan0 down
 
 # unload brcmfmac kernel module
-if lsmod | grep -q brcmfmac; then
+if grep -q "^brcmfmac " "/proc/modules"; then
     modprobe -r brcmfmac
 fi

--- a/platform/remarkable/disable-wifi.sh
+++ b/platform/remarkable/disable-wifi.sh
@@ -6,7 +6,7 @@ if systemctl is-active -q wpa_supplicant; then
 fi
 
 # clean stop of non-service wpa_supplicant
-if pidof wpa_supplicant > /dev/null; then
+if pidof wpa_supplicant >/dev/null; then
     wpa_cli terminate
 fi
 

--- a/platform/remarkable/disable-wifi.sh
+++ b/platform/remarkable/disable-wifi.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 
-# disable wifi and remove modules
+# clean stop of wpa_supplicant service, used by xochitl
+if systemctl is-active -q wpa_supplicant; then
+    systemctl stop wpa_supplicant
+fi
 
-# clean stop (if it's running) of main wpa_supplicant service, used by xochitl
-systemctl stop wpa_supplicant
-# clean stop of non-service wpa_supplicant, if running
-wpa_cli terminate 2>/dev/null
+# clean stop of non-service wpa_supplicant
+if pidof wpa_supplicant > /dev/null; then
+    wpa_cli terminate
+fi
 
 # power down wifi interface
-ifconfig wlan0 down 2>/dev/null
+ifconfig wlan0 down
 
-# remove module
-modprobe -r brcmfmac 2>/dev/null
+# unload brcmfmac kernel module
+if lsmod | grep -q brcmfmac; then
+    modprobe -r brcmfmac
+fi

--- a/platform/remarkable/disable-wifi.sh
+++ b/platform/remarkable/disable-wifi.sh
@@ -10,6 +10,11 @@ if pidof wpa_supplicant > /dev/null; then
     wpa_cli terminate
 fi
 
+# stop dhcpcd if not enabled
+if ! systemctl is-enabled -q dhcpcd; then
+    systemctl stop dhcpcd
+fi
+
 # power down wifi interface
 ifconfig wlan0 down
 

--- a/platform/remarkable/enable-wifi.sh
+++ b/platform/remarkable/enable-wifi.sh
@@ -12,7 +12,7 @@ if systemctl is-active -q wpa_supplicant; then
 fi
 
 # stop non-service wpa_supplicant cleanly
-if pidof wpa_supplicant >/dev/null; then
+if pidof wpa_supplicant; then
     wpa_cli terminate
 fi
 

--- a/platform/remarkable/enable-wifi.sh
+++ b/platform/remarkable/enable-wifi.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # load brcmfmac kernel module
-if ! lsmod | grep -q brcmfmac; then
+if ! grep -q "^brcmfmac " "/proc/modules"; then
     modprobe brcmfmac
     sleep 1
 fi

--- a/platform/remarkable/enable-wifi.sh
+++ b/platform/remarkable/enable-wifi.sh
@@ -12,7 +12,7 @@ if systemctl is-active -q wpa_supplicant; then
 fi
 
 # clean stop of non-service wpa_supplicant
-if pidof wpa_supplicant > /dev/null; then
+if pidof wpa_supplicant >/dev/null; then
     wpa_cli terminate
 fi
 

--- a/platform/remarkable/enable-wifi.sh
+++ b/platform/remarkable/enable-wifi.sh
@@ -1,19 +1,27 @@
 #!/bin/sh
 
-read -r MACHINE_TYPE <"/sys/devices/soc0/machine"
-if [ "reMarkable 2.0" = "${MACHINE_TYPE}" ]; then
-    if ! lsmod | grep -q brcmfmac; then
-        modprobe brcmfmac
-    fi
+# load brcmfmac kernel module
+if ! lsmod | grep -q brcmfmac; then
+    modprobe brcmfmac
+    sleep 1
 fi
 
-# clean stop (if it's running) of main wpa_supplicant service, used by xochitl
-systemctl stop wpa_supplicant
+# clean stop of wpa_supplicant service, used by xochitl
+if systemctl is-active -q wpa_supplicant; then
+    systemctl stop wpa_supplicant
+fi
 
-# clean stop of non-service wpa_supplicant, if running
-wpa_cli terminate 2>/dev/null
+# clean stop of non-service wpa_supplicant
+if pidof wpa_supplicant > /dev/null; then
+    wpa_cli terminate
+fi
 
-sleep 1
-
+# power up wifi interface
 ifconfig wlan0 up
-wpa_supplicant -i wlan0 -C /var/run/wpa_supplicant -B 2>/dev/null
+
+# make sure dhcpcd is running
+if ! systemctl is-active -q dhcpcd; then
+    systemctl start dhcpcd
+fi
+
+wpa_supplicant -i wlan0 -C /var/run/wpa_supplicant -B

--- a/platform/remarkable/enable-wifi.sh
+++ b/platform/remarkable/enable-wifi.sh
@@ -6,12 +6,12 @@ if ! grep -q "^brcmfmac " "/proc/modules"; then
     sleep 1
 fi
 
-# clean stop of wpa_supplicant service, used by xochitl
+# stop wpa_supplicant service cleanly, used by xochitl
 if systemctl is-active -q wpa_supplicant; then
     systemctl stop wpa_supplicant
 fi
 
-# clean stop of non-service wpa_supplicant
+# stop non-service wpa_supplicant cleanly
 if pidof wpa_supplicant >/dev/null; then
     wpa_cli terminate
 fi


### PR DESCRIPTION
Increase the robustness of the reMarkable enable/disable Wi-Fi scripts to support:

- Kernel module unloading not enabled in rM1: https://github.com/koreader/koreader/issues/11257#issuecomment-1868607390
- Future fixes in custom kernels: https://github.com/Etn40ff/linux-remarkable/pull/2
- Future fixes in the upstream kernel: https://github.com/toltec-dev/toltec/issues/803#issuecomment-1870634200
- Current workarounds and minimal setups: https://github.com/toltec-dev/toltec/issues/803#issue-2055903574

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11287)
<!-- Reviewable:end -->
