### PR TITLE
Reader: Do less work on same-orientation non-gyro rotations

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -64,6 +64,7 @@ end
 
 FileManagerMenu.onPhysicalKeyboardConnected = FileManagerMenu.registerKeyEvents
 
+-- NOTE: FileManager emits a SetDimensions on init, it's our only caller
 function FileManagerMenu:initGesListener()
     if not Device:isTouchDevice() then return end
 
@@ -962,10 +963,11 @@ function FileManagerMenu:onShowMenu(tab_index)
 end
 
 function FileManagerMenu:onCloseFileManagerMenu()
-    if not self.menu_container then return end
+    if not self.menu_container then return true end
     local last_tab_index = self.menu_container[1].last_index
     G_reader_settings:saveSetting("filemanagermenu_tab_index", last_tab_index)
     UIManager:close(self.menu_container)
+    self.menu_container = nil
     return true
 end
 
@@ -1003,11 +1005,14 @@ function FileManagerMenu:onSwipeShowMenu(ges)
 end
 
 function FileManagerMenu:onSetDimensions(dimen)
-    self:onCloseFileManagerMenu()
-    -- update listening according to new screen dimen
-    if Device:isTouchDevice() then
-        self:initGesListener()
+    -- This widget doesn't support in-place layout updates, so, close & reopen
+    if self.menu_container then
+        self:onCloseFileManagerMenu()
+        self:onShowMenu()
     end
+
+    -- update gesture zones according to new screen dimen
+    self:initGesListener()
 end
 
 function FileManagerMenu:onMenuSearch()

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -158,6 +158,13 @@ function ReaderConfig:onSwipeShowConfigMenu(ges)
     end
 end
 
+-- For some reason, things are fine and dandy without any of this for rotations, but we need it for actual resizes...
+function ReaderConfig:onSetDimensions(dimen)
+    if self.config_dialog then
+        self.config_dialog:init()
+    end
+end
+
 function ReaderConfig:onCloseCallback()
     self.last_panel_index = self.config_dialog.panel_index
     self.config_dialog = nil

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -158,14 +158,6 @@ function ReaderConfig:onSwipeShowConfigMenu(ges)
     end
 end
 
-function ReaderConfig:onSetDimensions(dimen)
-    -- since we cannot redraw config_dialog with new size, we close
-    -- the old one on screen size change
-    if self.config_dialog then
-        self.config_dialog:closeDialog()
-    end
-end
-
 function ReaderConfig:onCloseCallback()
     self.last_panel_index = self.config_dialog.panel_index
     self.config_dialog = nil

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -161,6 +161,7 @@ end
 -- For some reason, things are fine and dandy without any of this for rotations, but we need it for actual resizes...
 function ReaderConfig:onSetDimensions(dimen)
     if self.config_dialog then
+        -- init basically calls update & initGesListener and nothing else, which is exactly what we want.
         self.config_dialog:init()
     end
 end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -181,7 +181,6 @@ end
 
 ReaderMenu.onReaderReady = ReaderMenu.initGesListener
 
-
 function ReaderMenu:setUpdateItemTable()
     for _, widget in pairs(self.registered_widgets) do
         local ok, err = pcall(widget.addToMainMenu, widget, self.menu_items)

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -95,7 +95,7 @@ function ReaderMenu:getPreviousFile()
     return require("readhistory"):getPreviousFile(self.ui.document.file)
 end
 
-function ReaderMenu:onReaderReady()
+function ReaderMenu:initGesListener()
     if not Device:isTouchDevice() then return end
 
     local DTAP_ZONE_MENU = G_defaults:readSetting("DTAP_ZONE_MENU")
@@ -178,6 +178,9 @@ function ReaderMenu:onReaderReady()
         },
     })
 end
+
+ReaderMenu.onReaderReady = ReaderMenu.initGesListener
+
 
 function ReaderMenu:setUpdateItemTable()
     for _, widget in pairs(self.registered_widgets) do
@@ -456,16 +459,24 @@ function ReaderMenu:onShowMenu(tab_index)
 end
 
 function ReaderMenu:onCloseReaderMenu()
-    if self.menu_container then
-        self.last_tab_index = self.menu_container[1].last_index
-        self:onSaveSettings()
-        UIManager:close(self.menu_container)
-    end
+    if not self.menu_container then return true end
+    self.last_tab_index = self.menu_container[1].last_index
+    self:onSaveSettings()
+    UIManager:close(self.menu_container)
+    self.menu_container = nil
     return true
 end
 
 function ReaderMenu:onSetDimensions(dimen)
-    self:onCloseReaderMenu()
+    -- This widget doesn't support in-place layout updates, so, close & reopen
+    if self.menu_container then
+        self:onCloseReaderMenu()
+        self:onShowMenu()
+    end
+
+    -- update gesture zones according to new screen dimen
+    -- (On CRe, this will get called a second time by ReaderReady once the document is reloaded).
+    self:initGesListener()
 end
 
 function ReaderMenu:onCloseDocument()

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -815,7 +815,8 @@ end
 
 function ReaderView:onSetRotationMode(rotation)
     if rotation ~= nil then
-        if rotation == Screen:getRotationMode() then -- no change
+        local old_rotation_mode = Screen:getRotationMode()
+        if rotation == old_rotation_mode then
             return true
         end
 
@@ -826,12 +827,10 @@ function ReaderView:onSetRotationMode(rotation)
             requested_screen_mode = "landscape"
         end
 
-        local old_rotation_mode = Screen:getRotationMode()
-        local old_screen_mode = Screen:getScreenMode()
-        if rotation ~= old_rotation_mode and requested_screen_mode == old_screen_mode then
-            -- We don't need to re-layout anything, so just turn by 180°
+        if rotation ~= old_rotation_mode and requested_screen_mode == Screen:getScreenMode() then
+            -- No layout change, just rotate & repaint with a flash
             Screen:setRotationMode(rotation)
-            UIManager:onRotation()
+            UIManager:setDirty(self.dialog, "full")
             Notification:notify(T(_("Rotation mode set to: %1"), optionsutil:getOptionText("SetRotationMode", rotation)))
             return true
         end
@@ -839,7 +838,7 @@ function ReaderView:onSetRotationMode(rotation)
         Screen:setRotationMode(rotation)
     end
 
-    UIManager:setDirty(self.dialog, "full")
+    UIManager:setDirty(nil, "full") -- SetDimensions will only request a partial, we want a flash
     local new_screen_size = Screen:getSize()
     self.ui:handleEvent(Event:new("SetDimensions", new_screen_size))
     self.ui:onScreenResize(new_screen_size)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -27,8 +27,6 @@ local _ = require("gettext")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
-local framebuffer = require("ffi/framebuffer")
-
 local ReaderView = OverlapGroup:extend{
     document = nil,
     view_modules = nil, -- array
@@ -822,7 +820,7 @@ function ReaderView:onSetRotationMode(rotation)
         end
 
         local requested_screen_mode -- landscape or portrait
-        if rotation == framebuffer.DEVICE_ROTATED_UPRIGHT or rotation == framebuffer.ICE_ROTATED_UPSIDE_DOWN then
+        if rotation == Screen.DEVICE_ROTATED_UPRIGHT or rotation == Screen.ICE_ROTATED_UPSIDE_DOWN then
             requested_screen_mode = "portrait"
         else
             requested_screen_mode = "landscape"

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -820,7 +820,7 @@ function ReaderView:onSetRotationMode(rotation)
         end
 
         local requested_screen_mode -- landscape or portrait
-        if rotation == Screen.DEVICE_ROTATED_UPRIGHT or rotation == Screen.ICE_ROTATED_UPSIDE_DOWN then
+        if rotation == Screen.DEVICE_ROTATED_UPRIGHT or rotation == Screen.DEVICE_ROTATED_UPSIDE_DOWN then
             requested_screen_mode = "portrait"
         else
             requested_screen_mode = "landscape"
@@ -828,8 +828,8 @@ function ReaderView:onSetRotationMode(rotation)
 
         local old_rotation_mode = Screen:getRotationMode()
         local old_screen_mode = Screen:getScreenMode()
-        if rotation and rotation ~= old_rotation_mode and requested_screen_mode == old_screen_mode then
-            -- Cheaper than a full SetRotationMode event, as we don't need to re-layout anything.
+        if rotation ~= old_rotation_mode and requested_screen_mode == old_screen_mode then
+            -- We don't need to re-layout anything, so just turn by 180°
             Screen:setRotationMode(rotation)
             UIManager:onRotation()
             return true

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -832,6 +832,7 @@ function ReaderView:onSetRotationMode(rotation)
             -- We don't need to re-layout anything, so just turn by 180°
             Screen:setRotationMode(rotation)
             UIManager:onRotation()
+            Notification:notify(T(_("Rotation mode set to: %1"), optionsutil:getOptionText("SetRotationMode", rotation)))
             return true
         end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1016,6 +1016,8 @@ function Input:handleMiscGyroEv(ev)
         end
     else
         if rotation_mode and rotation_mode ~= old_rotation_mode then
+            -- NOTE: We do *NOT* send a broadcast manually, and instead rely on the main loop's sendEvent:
+            --       this ensures that only widgets that actually know how to handle a rotation will do so ;).
             return Event:new("SetRotationMode", rotation_mode)
         end
     end

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -897,9 +897,7 @@ function ConfigDialog:init()
     end
 end
 
-function ConfigDialog:updateConfigPanel(index)
-
-end
+function ConfigDialog:updateConfigPanel(index) end
 
 function ConfigDialog:update()
     self:moveFocusTo(1, 1) -- reset selected for re-created layout


### PR DESCRIPTION
Optimize rotation when switching between the 2 variants upside-downside and left-right; quite similar to `G_reader_settings:isTrue("input_lock_gsensor")` in https://github.com/koreader/koreader/blob/63329569eb8afb00a29a723f215c6c5fcc9041aa/frontend/device/input.lua#L986

Tested on the emulator for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11297)
<!-- Reviewable:end -->
