### PR TITLE
Chore: Make sure we always pass a rect to `fb:refreshFull`

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -326,7 +326,7 @@ function Device:onPowerEvent(ev)
                 self:resume()
                 local widget_was_closed = Screensaver:close()
                 if widget_was_closed and self:needsScreenRefreshAfterResume() then
-                    UIManager:scheduleIn(1, function() self.screen:refreshFull() end)
+                    UIManager:scheduleIn(1, function() self.screen:refreshFull(0, 0, self.screen:getWidth(), self.screen:getHeight()) end)
                 end
                 self.powerd:afterResume()
             end
@@ -371,7 +371,7 @@ function Device:onPowerEvent(ev)
         --       and on platforms where we defer to a system tool, it'd probably suspend too early!
         --       c.f., #6676
         if self:needsScreenRefreshAfterResume() then
-            self.screen:refreshFull()
+            self.screen:refreshFull(0, 0, self.screen:getWidth(), self.screen:getHeight())
         end
         -- NOTE: In the same vein as above, make sure we update the screen *now*, before dealing with Wi-Fi.
         UIManager:forceRePaint()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -639,7 +639,7 @@ local KindleScribe = Kindle:extend{
     hasGSensor = yes,
     display_dpi = 300,
     touch_dev = "/dev/input/touch",
-    canHWDither = no,
+    canHWDither = yes,
     canDoSwipeAnimation = yes,
 }
 

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -529,7 +529,7 @@ function Screensaver:show()
             if self:withBackground() then
                 Screen:clear()
             end
-            Screen:refreshFull()
+            Screen:refreshFull(0, 0, Screen:getWidth(), Screen:getHeight())
 
             -- On Kobo, on sunxi SoCs with a recent kernel, wait a tiny bit more to avoid weird refresh glitches...
             if Device:isKobo() and Device:isSunxi() then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1170,7 +1170,7 @@ function UIManager:_refresh(mode, region, dither)
     end
 
     -- if no region is specified, use the screen's dimensions
-    region = region or Geom:new{w=Screen:getWidth(), h=Screen:getHeight()}
+    region = region or Geom:new{x = 0, y = 0, w = Screen:getWidth(), h = Screen:getHeight()}
 
     -- if no dithering hint was specified, don't request dithering
     dither = dither or false


### PR DESCRIPTION
The API was unclear and the low-level functions had nil guards in place, but, in fact, our main caller, UIManager, ensures that can never happen.

A matching base PR (https://github.com/koreader/koreader-base/pull/1718) will drop those safety nets, so ensure we're safe.

Fix: #11303 (and re-enables HW dithering on the Kindle Scribe).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11307)
<!-- Reviewable:end -->
