### PR TITLE
Minor tweaks or stop-gaps before the release

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -639,7 +639,7 @@ local KindleScribe = Kindle:extend{
     hasGSensor = yes,
     display_dpi = 300,
     touch_dev = "/dev/input/touch",
-    canHWDither = yes,
+    canHWDither = no,
     canDoSwipeAnimation = yes,
 }
 

--- a/frontend/ui/elements/screen_notification_menu_table.lua
+++ b/frontend/ui/elements/screen_notification_menu_table.lua
@@ -1,19 +1,49 @@
 local Notification = require("ui/widget/notification")
 local TextViewer = require("ui/widget/textviewer")
 local UIManager = require("ui/uimanager")
+local logger = require("logger")
 local _ = require("gettext")
 
 local band = bit.band
 local bor = bit.bor
-
-local function setMask(source)
-    G_reader_settings:saveSetting("notification_sources_to_show_mask", source)
-end
+local bnot = bit.bnot
 
 local function getMask()
     return G_reader_settings:readSetting("notification_sources_to_show_mask") or Notification.SOURCE_DEFAULT
 end
 
+local function setMask(source)
+    logger.dbg(string.format("Notification: Updating display mask from %#x to %#x", getMask(), source))
+    G_reader_settings:saveSetting("notification_sources_to_show_mask", source)
+end
+
+local function someEnabled()
+    return band(getMask(), Notification.SOURCE_SOME) == Notification.SOURCE_SOME
+end
+
+-- i.e., MORE - SOME
+local SOURCE_MORE = band(Notification.SOURCE_MORE, bnot(Notification.SOURCE_SOME))
+local function moreEnabled()
+    return band(getMask(), SOURCE_MORE) == SOURCE_MORE
+end
+
+local function dispatcherEnabled()
+    return band(getMask(), Notification.SOURCE_DISPATCHER) == Notification.SOURCE_DISPATCHER
+end
+
+-- i.e., ALL - DEFAULT
+local SOURCE_MISC = band(Notification.SOURCE_ALL, bnot(Notification.SOURCE_DEFAULT))
+local function miscEnabled()
+    return band(getMask(), SOURCE_MISC) == SOURCE_MISC
+end
+
+--[[
+local function allEnabled()
+    return band(getMask(), Notification.SOURCE_ALL) == Notification.SOURCE_ALL
+end
+--]]
+
+-- NOTE: Default is MORE + DISPATCHER
 return {
     text = _("Notifications"),
     help_text = _([[Notification popups may be shown at the top of screen on various occasions.
@@ -26,58 +56,81 @@ This allows selecting which to show or hide.]]),
         {
             text = _("Some notifications from bottom menu"),
             help_text = _("Show notification popups for bottom menu settings with no visual feedback."),
-            checked_func = function()
-                return band(getMask(), Notification.SOURCE_BOTTOM_MENU) == band(Notification.SOURCE_SOME, Notification.SOURCE_BOTTOM_MENU)
-            end,
+            checked_func = someEnabled,
             callback = function()
-                if band(getMask(), Notification.SOURCE_BOTTOM_MENU) == band(Notification.SOURCE_SOME, Notification.SOURCE_BOTTOM_MENU) then
-                    setMask(bor(
-                        Notification.SOURCE_NONE,
-                        band(getMask(), Notification.SOURCE_DISPATCHER)))
+                if someEnabled() then
+                    -- Can't have more without some, so disable more in full
+                    setMask(
+                        band(getMask(), bnot(Notification.SOURCE_MORE)))
                 else
-                    setMask(bor(
-                        band(Notification.SOURCE_SOME, Notification.SOURCE_BOTTOM_MENU),
-                        band(getMask(), Notification.SOURCE_DISPATCHER)))
+                    setMask(
+                        bor(getMask(), Notification.SOURCE_SOME))
                 end
             end,
         },
         {
             text = _("More notifications from bottom menu"),
             help_text = _("Show notification popups for more bottom menu settings."),
-            checked_func = function()
-                return band(getMask(), Notification.SOURCE_BOTTOM_MENU) == band(Notification.SOURCE_DEFAULT, Notification.SOURCE_BOTTOM_MENU)
-            end,
+            checked_func = moreEnabled,
             callback = function()
-                if band(getMask(), Notification.SOURCE_BOTTOM_MENU) == band(Notification.SOURCE_DEFAULT, Notification.SOURCE_BOTTOM_MENU) then
-                    setMask(bor(
-                        Notification.SOURCE_NONE,
-                        band(getMask(), Notification.SOURCE_DISPATCHER)))
+                if moreEnabled() then
+                    -- We *can* keep some without more, so only disable the diff between the two
+                    setMask(
+                        band(getMask(), bnot(SOURCE_MORE)))
                 else
-                    setMask(bor(
-                        band(Notification.SOURCE_DEFAULT, Notification.SOURCE_BOTTOM_MENU),
-                        band(getMask(), Notification.SOURCE_DISPATCHER)))
+                    -- But do enable the full set
+                    setMask(
+                        bor(getMask(), Notification.SOURCE_MORE))
+                end
+            end,
+        },
+        {
+            text = _("Notifications from miscellaneous sources"),
+            help_text = _("Show notification popups for even more bottom menu settings, as well as standalone & misc notifications."),
+            checked_func = miscEnabled,
+            callback = function()
+                if miscEnabled() then
+                    setMask(
+                        band(getMask(), bnot(SOURCE_MISC)))
+                else
+                    setMask(
+                        bor(getMask(), SOURCE_MISC))
                 end
             end,
         },
         {
             text = _("Notifications from gestures and profiles"),
             help_text = _("Show notification popups for changes from gestures and the profiles plugin."),
-            checked_func = function()
-                return band(getMask(), Notification.SOURCE_DISPATCHER) == Notification.SOURCE_DISPATCHER
-            end,
+            checked_func = dispatcherEnabled,
             callback = function()
-                if band(getMask(), Notification.SOURCE_DISPATCHER) == Notification.SOURCE_DISPATCHER then
-                    setMask(bor(
-                        Notification.SOURCE_NONE,
-                        band(getMask(), Notification.SOURCE_BOTTOM_MENU)))
+                if dispatcherEnabled() then
+                    setMask(
+                        band(getMask(), bnot(Notification.SOURCE_DISPATCHER)))
                 else
-                    setMask(bor(
-                        Notification.SOURCE_DISPATCHER,
-                        band(getMask(), Notification.SOURCE_BOTTOM_MENU)))
+                    setMask(
+                        bor(getMask(), Notification.SOURCE_DISPATCHER))
                 end
             end,
             separator = true,
         },
+        --[[
+        {
+            text = _("Notifications from everything"),
+            help_text = _("Show all notification popups, no matter the source. This will flip all of the above at once."),
+            checked_func = allEnabled,
+            radio = true,
+            callback = function()
+                if allEnabled() then
+                    setMask(
+                        band(getMask(), bnot(Notification.SOURCE_ALL)))
+                else
+                    setMask(
+                        bor(getMask(), Notification.SOURCE_ALL))
+                end
+            end,
+            separator = true,
+        },
+        --]]
         {
             text = _("Show past notifications"),
             callback = function()

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -39,11 +39,12 @@ local SOURCE_BOTTOM_MENU = SOURCE_BOTTOM_MENU_ICON +
                            SOURCE_BOTTOM_MENU_PROGRESS
 
 -- these values can be changed here
-local SOURCE_SOME = SOURCE_BOTTOM_MENU_FINE +
-                    SOURCE_DISPATCHER
-local SOURCE_DEFAULT = SOURCE_SOME +
-                       SOURCE_BOTTOM_MENU_MORE +
-                       SOURCE_BOTTOM_MENU_PROGRESS
+local SOURCE_SOME = SOURCE_BOTTOM_MENU_FINE
+local SOURCE_MORE = SOURCE_SOME +
+                    SOURCE_BOTTOM_MENU_MORE +
+                    SOURCE_BOTTOM_MENU_PROGRESS
+local SOURCE_DEFAULT = SOURCE_MORE +
+                       SOURCE_DISPATCHER
 local SOURCE_ALL = SOURCE_BOTTOM_MENU +
                    SOURCE_DISPATCHER +
                    SOURCE_OTHER
@@ -75,6 +76,7 @@ local Notification = InputContainer:extend{
 
     SOURCE_NONE = 0,
     SOURCE_SOME = SOURCE_SOME,
+    SOURCE_MORE = SOURCE_MORE,
     SOURCE_DEFAULT = SOURCE_DEFAULT,
     SOURCE_ALL = SOURCE_ALL,
     _past_messages = {}, -- a static class member to store the N last messages text


### PR DESCRIPTION
* Disable HW dithering on Scribe until we can merge https://github.com/koreader/koreader-base/pull/1718 & #11307 
* Completely random refactor of the Notification setting, because I had to look at it given a report on MR, and I nearly lost my mind trying to follow what the hell was happening in there ;p.

Now looks like this: ![notif_settings](https://github.com/koreader/koreader/assets/111974/ca7ed6f4-1820-4d55-a232-dc4d78313f19)

(Rebase me)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11308)
<!-- Reviewable:end -->
