### PR TITLE
Fix "Move current book to archive"

### DIFF
--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -103,8 +103,8 @@ function MoveToArchive:onMoveToArchive(do_copy)
     else
         text = _("Book moved.\nDo you want to open it from the archive folder?")
         FileManager:moveFile(document_full_path, self.archive_dir_path)
-        require("readhistory"):updateItemByPath(document_full_path, dest_file) -- (will update "lastfile" if needed)
-        require("readcollection"):updateItemByPath(document_full_path, dest_file)
+        require("readhistory"):updateItem(document_full_path, dest_file) -- (will update "lastfile" if needed)
+        require("readcollection"):updateItem(document_full_path, dest_file)
     end
     DocSettings.updateLocation(document_full_path, dest_file, do_copy)
     UIManager:show(ConfirmBox:new{


### PR DESCRIPTION
updateItemByPath has recently been replaced with updateItem in both readhistory and readcollection.

Fixes: aabd6d7a2602 ("File browser, Collection: improve group actions (#11178)")
Fixes: https://github.com/koreader/koreader/issues/11320

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11321)
<!-- Reviewable:end -->
