### PR TITLE
i18n: Don't use Lua unicode escapes

### DIFF
--- a/frontend/ui/elements/screen_notification_menu_table.lua
+++ b/frontend/ui/elements/screen_notification_menu_table.lua
@@ -52,8 +52,8 @@ This allows selecting which to show or hide.]]),
     sub_item_table = {
         genMenuItem(Notification.SOURCE_BOTTOM_MENU_ICON, _("From bottom menu icons")),
         genMenuItem(Notification.SOURCE_BOTTOM_MENU_TOGGLE, _("From bottom menu toggles")),
-        genMenuItem(Notification.SOURCE_BOTTOM_MENU_FINE, _("From bottom menu \u{00b1} buttons")), -- Poor man's +/- w/ \u{207a}\u{2044}\u{208b} doesn't look too great because subscript minus sits on the baseline in most fonts...
-        genMenuItem(Notification.SOURCE_BOTTOM_MENU_MORE, _("From bottom menu \u{22ee} buttons")), -- vertical ellipsis
+        genMenuItem(Notification.SOURCE_BOTTOM_MENU_FINE, _("From bottom menu ± buttons")), -- Poor man's +/- w/ \u{207a}\u{2044}\u{208b} doesn't look too great because subscript minus sits on the baseline in most fonts...
+        genMenuItem(Notification.SOURCE_BOTTOM_MENU_MORE, _("From bottom menu ⋮ buttons")), -- vertical ellipsis
         genMenuItem(Notification.SOURCE_BOTTOM_MENU_PROGRESS, _("From bottom menu progress bars")),
         genMenuItem(Notification.SOURCE_DISPATCHER, _("From gestures and profiles")),
         genMenuItem(Notification.SOURCE_OTHER, _("From all other sources"), nil, true),

--- a/frontend/ui/elements/screen_notification_menu_table.lua
+++ b/frontend/ui/elements/screen_notification_menu_table.lua
@@ -53,7 +53,7 @@ This allows selecting which to show or hide.]]),
         genMenuItem(Notification.SOURCE_BOTTOM_MENU_ICON, _("From bottom menu icons")),
         genMenuItem(Notification.SOURCE_BOTTOM_MENU_TOGGLE, _("From bottom menu toggles")),
         genMenuItem(Notification.SOURCE_BOTTOM_MENU_FINE, _("From bottom menu ± buttons")), -- Poor man's +/- w/ \u{207a}\u{2044}\u{208b} doesn't look too great because subscript minus sits on the baseline in most fonts...
-        genMenuItem(Notification.SOURCE_BOTTOM_MENU_MORE, _("From bottom menu ⋮ buttons")), -- vertical ellipsis
+        genMenuItem(Notification.SOURCE_BOTTOM_MENU_MORE, _("From bottom menu ⋮ buttons")),
         genMenuItem(Notification.SOURCE_BOTTOM_MENU_PROGRESS, _("From bottom menu progress bars")),
         genMenuItem(Notification.SOURCE_DISPATCHER, _("From gestures and profiles")),
         genMenuItem(Notification.SOURCE_OTHER, _("From all other sources"), nil, true),


### PR DESCRIPTION
Something in the gettext/weblate pipeline doesn't like it...

These are real unicode codepoints, not custom nerdfont ones, so just render the actual glyph instead of escaping it.

Fix #11328

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11330)
<!-- Reviewable:end -->
