### PR TITLE
Kindle: Log the suspend/wakeup source (& a bunch of fixes)

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2208,8 +2208,10 @@ function ReaderHighlight:onSaveSettings()
 end
 
 function ReaderHighlight:onClose()
-    UIManager:close(self.highlight_dialog)
-    self.highlight_dialog = nil
+    if self.highlight_dialog then
+        UIManager:close(self.highlight_dialog)
+        self.highlight_dialog = nil
+    end
     -- clear highlighted text
     self:clear()
 end

--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -38,7 +38,10 @@ function ReaderStatus:onEndOfBook()
     local QuickStart = require("ui/quickstart")
     local last_file = G_reader_settings:readSetting("lastfile")
     if last_file == QuickStart.quickstart_filename then
-        self:openFileBrowser()
+        -- Like onOpenNextDocumentInFolder, delay this so as not to break instance lifecycle
+        UIManager:nextTick(function()
+            self:openFileBrowser()
+        end)
         return
     end
 
@@ -59,15 +62,15 @@ function ReaderStatus:onEndOfBook()
                         return self.summary.status == "complete" and _("Mark as reading") or _("Mark as finished")
                     end,
                     callback = function()
-                        self:onMarkBook()
                         UIManager:close(button_dialog)
+                        self:onMarkBook()
                     end,
                 },
                 {
                     text = _("Book status"),
                     callback = function()
-                        self:onShowBookStatus()
                         UIManager:close(button_dialog)
+                        self:onShowBookStatus()
                     end,
                 },
 
@@ -76,16 +79,16 @@ function ReaderStatus:onEndOfBook()
                 {
                     text = _("Go to beginning"),
                     callback = function()
-                        self.ui:handleEvent(Event:new("GoToBeginning"))
                         UIManager:close(button_dialog)
+                        self.ui:handleEvent(Event:new("GoToBeginning"))
                     end,
                 },
                 {
                     text = _("Open next file"),
                     enabled = next_file_enabled,
                     callback = function()
-                        self:onOpenNextDocumentInFolder()
                         UIManager:close(button_dialog)
+                        self:onOpenNextDocumentInFolder()
                     end,
                 },
             },
@@ -93,15 +96,18 @@ function ReaderStatus:onEndOfBook()
                 {
                     text = _("Delete file"),
                     callback = function()
-                        self:deleteFile()
                         UIManager:close(button_dialog)
+                        self:deleteFile()
                     end,
                 },
                 {
                     text = _("File browser"),
                     callback = function()
-                        self:openFileBrowser()
                         UIManager:close(button_dialog)
+                        -- Ditto
+                        UIManager:nextTick(function()
+                            self:openFileBrowser()
+                        end)
                     end,
                 },
             },
@@ -123,11 +129,7 @@ function ReaderStatus:onEndOfBook()
             UIManager:show(info)
             UIManager:forceRePaint()
             UIManager:close(info)
-            -- Delay until the next tick, as this will destroy the Document instance,
-            -- but we may not be the final Event caught by said Document...
-            UIManager:nextTick(function()
-                self:onOpenNextDocumentInFolder()
-            end)
+            self:onOpenNextDocumentInFolder()
         else
             UIManager:show(InfoMessage:new{
                 text = _("Could not open next file. Sort by last read date does not support this feature."),
@@ -172,7 +174,11 @@ function ReaderStatus:onOpenNextDocumentInFolder()
     local FileChooser = require("ui/widget/filechooser")
     local next_file = FileChooser:getNextFile(self.document.file)
     if next_file then
-        self.ui:switchDocument(next_file)
+        -- Delay until the next tick, as this will destroy the Document instance,
+        -- but we may not be the final Event caught by said Document...
+        UIManager:nextTick(function()
+            self.ui:switchDocument(next_file)
+        end)
     else
         UIManager:show(InfoMessage:new{
             text = _("This is the last file in the current folder. No next file to open."),

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -280,7 +280,18 @@ function Kindle:usbPlugIn()
     -- NOTE: If the device is put in USBNet mode before we even start, everything's peachy, though :).
 end
 
-function Kindle:intoScreenSaver()
+-- Hopefully, the event sources are fairly portable...
+-- c.f., https://github.com/koreader/koreader/pull/11174#issuecomment-1830064445
+-- NOTE: There's no distinction between real button presses and powerd_test -p or lipc-set-prop -i com.lab126.powerd powerButton 1
+local POWERD_EVENT_SOURCES = {
+    [1] = "BUTTON_WAKEUP",  -- outOfScreenSaver 1
+    [2] = "BUTTON_SUSPEND", -- goingToScreenSaver 2
+    [4] = "HALL_SUSPEND",   -- goingToScreenSaver 4
+    [6] = "HALL_WAKEUP",    -- outOfScreenSaver 6
+}
+
+function Kindle:intoScreenSaver(source)
+    logger.dbg("Kindle:intoScreenSaver via", POWERD_EVENT_SOURCES[source] or string.format("UNKNOWN_SUSPEND (%d)", source or -1))
     if not self.screen_saver_mode then
         if self:supportsScreensaver() then
             -- NOTE: Meaning this is not a SO device ;)
@@ -304,7 +315,8 @@ function Kindle:intoScreenSaver()
     self.powerd:beforeSuspend()
 end
 
-function Kindle:outofScreenSaver()
+function Kindle:outofScreenSaver(source)
+    logger.dbg("Kindle:outofScreenSaver via", POWERD_EVENT_SOURCES[source] or string.format("UNKNOWN_WAKEUP (%d)", source or -1))
     if self.screen_saver_mode then
         if self:supportsScreensaver() then
             local Screensaver = require("ui/screensaver")
@@ -357,6 +369,9 @@ function Kindle:outofScreenSaver()
     self.powerd:afterResume()
 end
 
+-- On stock, there's a distinction between OutOfSS (which *requests* closing the SS) and ExitingSS, which fires once they're *actually* closed...
+function Kindle:exitingScreenSaver() end
+
 function Kindle:usbPlugOut()
     -- NOTE: See usbPlugIn(), we don't have anything fancy to do here either.
 end
@@ -382,14 +397,24 @@ function Kindle:UIManagerReady(uimgr)
 end
 
 function Kindle:setEventHandlers(uimgr)
+    -- These custom fake events *will* pass an argument...
+    self.input.fake_event_args.IntoSS = {}
+    self.input.fake_event_args.OutOfSS = {}
+
     UIManager.event_handlers.Suspend = function()
         self.powerd:toggleSuspend()
     end
-    UIManager.event_handlers.IntoSS = function()
-        self:intoScreenSaver()
+    UIManager.event_handlers.IntoSS = function(input_event)
+        -- Retrieve the argument set by Input:handleKeyBoardEv
+        local arg = table.remove(self.input.fake_event_args[input_event])
+        self:intoScreenSaver(arg)
     end
-    UIManager.event_handlers.OutOfSS = function()
-        self:outofScreenSaver()
+    UIManager.event_handlers.OutOfSS = function(input_event)
+        local arg = table.remove(self.input.fake_event_args[input_event])
+        self:outofScreenSaver(arg)
+    end
+    UIManager.event_handlers.ExitingSS = function()
+        self:exitingScreenSaver()
     end
     UIManager.event_handlers.Charging = function()
         self:_beforeCharging()

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -376,14 +376,16 @@ function Kindle:usbPlugOut()
     -- NOTE: See usbPlugIn(), we don't have anything fancy to do here either.
 end
 
-function Kindle:wakeupFromSuspend()
-    self.powerd:wakeupFromSuspend()
+function Kindle:wakeupFromSuspend(ts)
+    logger.dbg("Kindle:wakeupFromSuspend", ts)
+    self.powerd:wakeupFromSuspend(ts)
     self.last_suspend_time = time.boottime_or_realtime_coarse() - self.suspend_time
     self.total_suspend_time = self.total_suspend_time + self.last_suspend_time
 end
 
-function Kindle:readyToSuspend()
-    self.powerd:readyToSuspend()
+function Kindle:readyToSuspend(delay)
+    logger.dbg("Kindle:readyToSuspend", delay)
+    self.powerd:readyToSuspend(delay)
     self.suspend_time = time.boottime_or_realtime_coarse()
 end
 
@@ -400,6 +402,8 @@ function Kindle:setEventHandlers(uimgr)
     -- These custom fake events *will* pass an argument...
     self.input.fake_event_args.IntoSS = {}
     self.input.fake_event_args.OutOfSS = {}
+    self.input.fake_event_args.WakeupFromSuspend = {}
+    self.input.fake_event_args.ReadyToSuspend = {}
 
     UIManager.event_handlers.Suspend = function()
         self.powerd:toggleSuspend()
@@ -424,11 +428,13 @@ function Kindle:setEventHandlers(uimgr)
         self:usbPlugOut()
         self:_afterNotCharging()
     end
-    UIManager.event_handlers.WakeupFromSuspend = function()
-        self:wakeupFromSuspend()
+    UIManager.event_handlers.WakeupFromSuspend = function(input_event)
+        local arg = table.remove(self.input.fake_event_args[input_event])
+        self:wakeupFromSuspend(arg)
     end
-    UIManager.event_handlers.ReadyToSuspend = function()
-        self:readyToSuspend()
+    UIManager.event_handlers.ReadyToSuspend = function(input_event)
+        local arg = table.remove(self.input.fake_event_args[input_event])
+        self:readyToSuspend(arg)
     end
 end
 

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -243,8 +243,7 @@ function KindlePowerD:initWakeupMgr()
     if not self.device:supportsScreensaver() then return end
     if self.lipc_handle == nil then return end
 
-    function KindlePowerD:wakeupFromSuspend()
-        logger.dbg("Kindle wakeupFromSuspend")
+    function KindlePowerD:wakeupFromSuspend(ts)
         -- Give the device a few seconds to settle.
         -- This filters out user input resumes -> device will resume to active
         -- Also the Kindle stays in Ready to suspend for 10 seconds
@@ -252,8 +251,7 @@ function KindlePowerD:initWakeupMgr()
         UIManager:scheduleIn(15, self.checkUnexpectedWakeup, self)
     end
 
-    function KindlePowerD:readyToSuspend()
-        logger.dbg("Kindle readyToSuspend")
+    function KindlePowerD:readyToSuspend(delay)
         if self.device.wakeup_mgr:isWakeupAlarmScheduled() then
             local now = os.time()
             local alarm = self.device.wakeup_mgr:getWakeupAlarmEpoch()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -489,7 +489,15 @@ function InputDialog:onTap(arg, ges)
         return
     end
     if self:isKeyboardVisible() then
-        self:onCloseKeyboard()
+        -- NOTE: If you're unlucky enough to tap inside of a border between keys,
+        --       this falls outside of the ges_events range of a VirtualKey, so it is *NOT* caught by VK.
+        --       Instead, since we're flagged is_always_active, it goes to us,
+        --       so we'll have to double check that it wasn't inside of the whole VK region,
+        --       otherwise tapping inside a border would close the VK ;p.
+        -- Poke at keyboard_frame directly, as the top-level dimen never gets updated coordinates...
+        if self._input_widget.keyboard and self._input_widget.keyboard.dimen and ges.pos:notIntersectWith(self._input_widget.keyboard[1][1].dimen) then
+            self:onCloseKeyboard()
+        end
     else
         if ges.pos:notIntersectWith(self.dialog_frame.dimen) then
             self:onCloseDialog()


### PR DESCRIPTION
We currently don't do anything with it, but this might help someone come up with fancier smartcover handling, like we do on Kobo...

Requires https://github.com/koreader/koreader-base/pull/1723

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11350)
<!-- Reviewable:end -->
