### PR TITLE
[i18n] ReaderSearch: add translation context to "All" button

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -12,6 +12,7 @@ local Utf8Proc = require("ffi/utf8proc")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local logger = require("logger")
 local _ = require("gettext")
+local C_ = _.pgettext
 local Screen = Device.screen
 local T = require("ffi/util").template
 
@@ -188,8 +189,8 @@ function ReaderSearch:onShowFulltextSearchInput()
                     end,
                 },
                 {
-                    -- @translators Search all entries in entire document
-                    text = _("All"),
+                    -- @translators Find all results in entire document, button displayed on the search bar, should be short.
+                    text = C_("Search text", "All"),
                     callback = function()
                         self:searchCallback()
                     end,


### PR DESCRIPTION
Cf. https://github.com/koreader/koreader/pull/11313/files#r1439406753

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11352)
<!-- Reviewable:end -->
