### PR TITLE
CoverBrowser: doc_settings cache improvement

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -130,24 +130,25 @@ end
 
 -- Generate all book status file dialog buttons in a row
 function filemanagerutil.genStatusButtonsRow(doc_settings_or_file, caller_callback)
-    local summary, status
+    local file, summary, status
     if type(doc_settings_or_file) == "table" then -- currently opened file
+        file = doc_settings_or_file:readSetting("doc_path")
         summary = doc_settings_or_file:readSetting("summary")
         status = summary.status
     else
-        status = filemanagerutil.getStatus(doc_settings_or_file)
+        file = doc_settings_or_file
+        status = filemanagerutil.getStatus(file)
     end
     local function genStatusButton(to_status)
         return {
             text = filemanagerutil.statusToString(to_status) .. (status == to_status and "  ✓" or ""),
-            id = to_status, -- used by covermenu
             enabled = status ~= to_status,
             callback = function()
                 if summary then -- currently opened file
                     summary.status = to_status
-                else
-                    filemanagerutil.setStatus(doc_settings_or_file, to_status)
                 end
+                filemanagerutil.setStatus(file, to_status)
+                UIManager:broadcastEvent(Event:new("UpdateCoverBrowserBookCache", file, to_status))
                 caller_callback()
             end,
         }
@@ -169,7 +170,6 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
     local has_custom_metadata_file = custom_metadata_file and true or false
     return {
         text = _("Reset"),
-        id = "reset", -- used by covermenu
         enabled = not button_disabled and (has_sidecar_file or has_custom_metadata_file or has_custom_cover_file),
         callback = function()
             local CheckButton = require("ui/widget/checkbutton")
@@ -191,6 +191,7 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
                         UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", file))
                     end
                     if data_to_purge.doc_settings then
+                        UIManager:broadcastEvent(Event:new("UpdateCoverBrowserBookCache", file))
                         require("readhistory"):fileSettingsPurged(file)
                     end
                     caller_callback()

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -147,7 +147,7 @@ function filemanagerutil.genStatusButtonsRow(doc_settings_or_file, caller_callba
             callback = function()
                 summary.status = to_status
                 filemanagerutil.setStatus(file, to_status)
-                UIManager:broadcastEvent(Event:new("DocSettingsChanged", file, { summary = summary }))
+                UIManager:broadcastEvent(Event:new("DocSettingsItemsChanged", file, { summary = summary })) -- for CoverBrowser
                 caller_callback()
             end,
         }
@@ -190,7 +190,7 @@ function filemanagerutil.genResetSettingsButton(file, caller_callback, button_di
                         UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", file))
                     end
                     if data_to_purge.doc_settings then
-                        UIManager:broadcastEvent(Event:new("UpdateCoverBrowserBookCache", file))
+                        UIManager:broadcastEvent(Event:new("DocSettingsItemsChanged", file)) -- for CoverBrowser
                         require("readhistory"):fileSettingsPurged(file)
                     end
                     caller_callback()

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -137,6 +137,7 @@ function filemanagerutil.genStatusButtonsRow(doc_settings_or_file, caller_callba
         status = summary.status
     else
         file = doc_settings_or_file
+        summary = {}
         status = filemanagerutil.getStatus(file)
     end
     local function genStatusButton(to_status)
@@ -144,11 +145,9 @@ function filemanagerutil.genStatusButtonsRow(doc_settings_or_file, caller_callba
             text = filemanagerutil.statusToString(to_status) .. (status == to_status and "  ✓" or ""),
             enabled = status ~= to_status,
             callback = function()
-                if summary then -- currently opened file
-                    summary.status = to_status
-                end
+                summary.status = to_status
                 filemanagerutil.setStatus(file, to_status)
-                UIManager:broadcastEvent(Event:new("UpdateCoverBrowserBookCache", file, to_status))
+                UIManager:broadcastEvent(Event:new("DocSettingsChanged", file, { summary = summary }))
                 caller_callback()
             end,
         }

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -419,7 +419,7 @@ function CoverMenu:onHistoryMenuHold(item)
     }
 
     -- Replace the "Book information" button callback to use directly our bookinfo
-    button = self.histfile_dialog:getButtonById("book_information")
+    local button = self.histfile_dialog:getButtonById("book_information")
     button.callback = function()
         FileManagerBookInfo:show(file, FileManagerBookInfo.extendProps(bookinfo))
         UIManager:close(self.histfile_dialog)
@@ -518,7 +518,7 @@ function CoverMenu:onCollectionsMenuHold(item)
     }
 
     -- Replace the "Book information" button callback to use directly our bookinfo
-    button = self.collfile_dialog:getButtonById("book_information")
+    local button = self.collfile_dialog:getButtonById("book_information")
     button.callback = function()
         FileManagerBookInfo:show(file, FileManagerBookInfo.extendProps(bookinfo))
         UIManager:close(self.collfile_dialog)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -313,7 +313,7 @@ function CoverMenu:updateItems(select_number)
                 }
 
                 -- Replace the "Book information" button callback to use directly our bookinfo
-                button = self.file_dialog:getButtonById("book_information")
+                local button = self.file_dialog:getButtonById("book_information")
                 button.callback = function()
                     FileManagerBookInfo:show(file, FileManagerBookInfo.extendProps(bookinfo))
                     UIManager:close(self.file_dialog)

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -40,8 +40,6 @@ local nb_drawings_since_last_collectgarbage = 0
 -- in the real Menu class or instance
 local CoverMenu = {}
 
-local book_statuses = {"reading", "abandoned", "complete"}
-
 function CoverMenu:updateCache(file, status, do_create, pages)
     if do_create then -- create new cache entry if absent
         if self.cover_info_cache[file] then return end
@@ -314,31 +312,6 @@ function CoverMenu:updateItems(select_number)
                     buttons = orig_buttons,
                 }
 
-                -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-                local button = self.file_dialog:getButtonById("reset")
-                if button then
-                    local orig_purge_callback = button.callback
-                    button.callback = function()
-                        -- Wipe the cache
-                        self:updateCache(file)
-                        -- And then purge the sidecar folder as expected
-                        orig_purge_callback()
-                    end
-                end
-
-                -- Fudge the status change button callbacks to also update the cover_info_cache
-                for _, status in ipairs(book_statuses) do
-                    button = self.file_dialog:getButtonById(status)
-                    if not button then break end -- status buttons are not shown
-                    local orig_status_callback = button.callback
-                    button.callback = function()
-                        -- Update the cache
-                        self:updateCache(file, status)
-                        -- And then set the status on file as expected
-                        orig_status_callback()
-                    end
-                end
-
                 -- Replace the "Book information" button callback to use directly our bookinfo
                 button = self.file_dialog:getButtonById("book_information")
                 button.callback = function()
@@ -445,31 +418,6 @@ function CoverMenu:onHistoryMenuHold(item)
         buttons = orig_buttons,
     }
 
-    -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-    local button = self.histfile_dialog:getButtonById("reset")
-    if button then
-        local orig_purge_callback = button.callback
-        button.callback = function()
-            -- Wipe the cache
-            self:updateCache(file)
-            -- And then purge the sidecar folder as expected
-            orig_purge_callback()
-        end
-    end
-
-    -- Fudge the status change button callbacks to also update the cover_info_cache
-    for _, status in ipairs(book_statuses) do
-        button = self.histfile_dialog:getButtonById(status)
-        if not button then break end -- status buttons are not shown
-        local orig_status_callback = button.callback
-        button.callback = function()
-            -- Update the cache
-            self:updateCache(file, status)
-            -- And then set the status on file as expected
-            orig_status_callback()
-        end
-    end
-
     -- Replace the "Book information" button callback to use directly our bookinfo
     button = self.histfile_dialog:getButtonById("book_information")
     button.callback = function()
@@ -568,31 +516,6 @@ function CoverMenu:onCollectionsMenuHold(item)
         title_align = orig_title_align,
         buttons = orig_buttons,
     }
-
-    -- Fudge the "Reset settings" button callback to also trash the cover_info_cache
-    local button = self.collfile_dialog:getButtonById("reset")
-    if button then
-        local orig_purge_callback = button.callback
-        button.callback = function()
-            -- Wipe the cache
-            self:updateCache(file)
-            -- And then purge the sidecar folder as expected
-            orig_purge_callback()
-        end
-    end
-
-    -- Fudge the status change button callbacks to also update the cover_info_cache
-    for _, status in ipairs(book_statuses) do
-        button = self.collfile_dialog:getButtonById(status)
-        if not button then break end -- status buttons are not shown
-        local orig_status_callback = button.callback
-        button.callback = function()
-            -- Update the cache
-            self:updateCache(file, status)
-            -- And then set the status on file as expected
-            orig_status_callback()
-        end
-    end
 
     -- Replace the "Book information" button callback to use directly our bookinfo
     button = self.collfile_dialog:getButtonById("book_information")

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -519,9 +519,8 @@ function CoverBrowser.initGrid(menu, display_mode)
 end
 
 function CoverBrowser:refreshFileManagerInstance(cleanup, post_init)
-    local fm = FileManager.instance
-    if fm then
-        local fc = fm.file_chooser
+    local fc = self.ui.file_chooser
+    if fc then
         if cleanup then -- clean instance properties we may have set
             if fc.showFileDialog_orig then
                 -- remove our showFileDialog that extended file_dialog with new buttons
@@ -574,6 +573,7 @@ function CoverBrowser:setupFileManagerDisplayMode(display_mode)
         FileChooser._recalculateDimen = _FileChooser__recalculateDimen_orig
         FileManager.tapPlus = _FileManager_tapPlus_orig
         -- Also clean-up what we added, even if it does not bother original code
+        FileChooser.updateCache = nil
         FileChooser._updateItemsBuildUI = nil
         FileChooser._do_cover_images = nil
         FileChooser._do_filename_only = nil
@@ -793,6 +793,19 @@ end
 
 function CoverBrowser:onInvalidateMetadataCache(file)
     BookInfoManager:deleteBookInfo(file)
+    return true
+end
+
+function CoverBrowser:onUpdateCoverBrowserBookCache(file, status)
+    if self.ui.file_chooser then
+        self.ui.file_chooser:updateCache(file, status)
+    end
+    if self.ui.history and self.ui.history.hist_menu then
+        self.ui.history.hist_menu:updateCache(file, status)
+    end
+    if self.ui.collections and self.ui.collections.coll_menu then
+        self.ui.collections.coll_menu:updateCache(file, status)
+    end
     return true
 end
 

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -796,7 +796,7 @@ function CoverBrowser:onInvalidateMetadataCache(file)
     return true
 end
 
-function CoverBrowser:onDocSettingsChanged(file, doc_settings)
+function CoverBrowser:onDocSettingsItemsChanged(file, doc_settings)
     local status -- nil to wipe the covermenu book cache
     if doc_settings then
         status = doc_settings.summary and doc_settings.summary.status

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -796,7 +796,12 @@ function CoverBrowser:onInvalidateMetadataCache(file)
     return true
 end
 
-function CoverBrowser:onUpdateCoverBrowserBookCache(file, status)
+function CoverBrowser:onDocSettingsChanged(file, doc_settings)
+    local status -- nil to wipe the covermenu book cache
+    if doc_settings then
+        status = doc_settings.summary and doc_settings.summary.status
+        if not status then return end -- changes not for us
+    end
     if self.ui.file_chooser then
         self.ui.file_chooser:updateCache(file, status)
     end
@@ -806,7 +811,6 @@ function CoverBrowser:onUpdateCoverBrowserBookCache(file, status)
     if self.ui.collections and self.ui.collections.coll_menu then
         self.ui.collections.coll_menu:updateCache(file, status)
     end
-    return true
 end
 
 function CoverBrowser:extractBooksInDirectory(path)


### PR DESCRIPTION
Use events.
Fixes unreported bug: changing book status in History over file browser didn't change the displayed status in file browser.
Optimizes cache handling: do not trash the cache by Reset button when resetting the custom cover/metadata only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11360)
<!-- Reviewable:end -->
