### PR TITLE
More VirtualKeyboard & dimen fixes

### DIFF
--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -93,11 +93,12 @@ end
 
 function FrameContainer:paintTo(bb, x, y)
     local my_size = self:getSize()
-    self.dimen = Geom:new{
-        x = x, y = y,
-        w = my_size.w,
-        h = my_size.h
-    }
+    if not self.dimen then
+        self.dimen = Geom:new{x = x, y = y, w = my_size.w, h = my_size.h}
+    else
+        self.dimen.x = x
+        self.dimen.y = y
+    end
     local container_width = self.width or my_size.w
     local container_height = self.height or my_size.h
 

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -94,10 +94,16 @@ end
 function FrameContainer:paintTo(bb, x, y)
     local my_size = self:getSize()
     if not self.dimen then
-        self.dimen = Geom:new{x = x, y = y, w = my_size.w, h = my_size.h}
+        self.dimen = Geom:new{
+            x = x, y = y,
+            w = my_size.w, h = my_size.h
+        }
     else
         self.dimen.x = x
         self.dimen.y = y
+        -- Possibly redundant
+        self.dimen.w = my_size.w
+        self.dimen.h = my_size.h
     end
     local container_width = self.width or my_size.w
     local container_height = self.height or my_size.h

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -72,10 +72,11 @@ function InputContainer:paintTo(bb, x, y)
 
     if not self.dimen then
         local content_size = self[1]:getSize()
-        self.dimen = Geom:new{x = 0, y = 0, w = content_size.w, h = content_size.h}
+        self.dimen = Geom:new{x = x, y = y, w = content_size.w, h = content_size.h}
+    else
+        self.dimen.x = x
+        self.dimen.y = y
     end
-    self.dimen.x = x
-    self.dimen.y = y
     if self.vertical_align == "center" then
         local content_size = self[1]:getSize()
         self[1]:paintTo(bb, x, y + math.floor((self.dimen.h - content_size.h)/2))

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -72,7 +72,10 @@ function InputContainer:paintTo(bb, x, y)
 
     if not self.dimen then
         local content_size = self[1]:getSize()
-        self.dimen = Geom:new{x = x, y = y, w = content_size.w, h = content_size.h}
+        self.dimen = Geom:new{
+            x = x, y = y,
+            w = content_size.w, h = content_size.h
+        }
     else
         self.dimen.x = x
         self.dimen.y = y

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -27,11 +27,19 @@ end
 
 function UnderlineContainer:paintTo(bb, x, y)
     local container_size = self:getSize()
-    self.dimen = Geom:new{
-        x = x, y = y,
-        w = container_size.w,
-        h = container_size.h
-    }
+    if not self.dimen then
+        self.dimen = Geom:new{
+            x = x, y = y,
+            w = container_size.w,
+            h = container_size.h
+        }
+    else
+        self.dimen.x = x
+        self.dimen.y = y
+        -- Possibly redundant
+        self.dimen.w = container_size.w
+        self.dimen.h = container_size.h
+    end
     local content_size = self[1]:getSize()
     local p_y = y
     if self.vertical_align == "center" then

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -515,11 +515,19 @@ function ImageWidget:paintTo(bb, x, y)
     if self.hide then return end
     -- self:_render is called in getSize method
     local size = self:getSize()
-    self.dimen = Geom:new{
-        x = x, y = y,
-        w = size.w,
-        h = size.h
-    }
+    if not self.dimen then
+        self.dimen = Geom:new{
+            x = x, y = y,
+            w = size.w,
+            h = size.h
+        }
+    else
+        self.dimen.x = x
+        self.dimen.y = y
+        -- Possibly redundant
+        self.dimen.w = size.w
+        self.dimen.h = size.h
+    end
     logger.dbg("blitFrom", x, y, self._offset_x, self._offset_y, size.w, size.h)
     local do_alpha = false
     if self.alpha == true then

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -495,7 +495,7 @@ function InputDialog:onTap(arg, ges)
         --       so we'll have to double check that it wasn't inside of the whole VK region,
         --       otherwise tapping inside a border would close the VK ;p.
         -- Poke at keyboard_frame directly, as the top-level dimen never gets updated coordinates...
-        if self._input_widget.keyboard and self._input_widget.keyboard.dimen and ges.pos:notIntersectWith(self._input_widget.keyboard[1][1].dimen) then
+        if self._input_widget.keyboard and self._input_widget.keyboard.dimen and ges.pos:notIntersectWith(self._input_widget.keyboard.dimen) then
             self:onCloseKeyboard()
         end
     else

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -110,11 +110,19 @@ end
 
 function ProgressWidget:paintTo(bb, x, y)
     local my_size = self:getSize()
-    self.dimen = Geom:new{
-        x = x, y = y,
-        w = my_size.w,
-        h = my_size.h
-    }
+    if not self.dimen then
+        self.dimen = Geom:new{
+            x = x, y = y,
+            w = my_size.w,
+            h = my_size.h
+        }
+    else
+        self.dimen.x = x
+        self.dimen.y = y
+        -- Possibly redundant
+        self.dimen.w = my_size.w
+        self.dimen.h = my_size.h
+    end
     if self.dimen.w == 0 or self.dimen.h == 0 then return end
 
     local _mirroredUI = BD.mirroredUILayout()

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -312,6 +312,7 @@ end
 
 function VirtualKey:paintTo(bb, x ,y)
     InputContainer.paintTo(self, bb, x, y)
+
     -- Fudge self.dimen to include the padding, to make sure said padding is covered by our ges_events range...
     -- Like Geom, floor coordinates & ceil dims, to fill the gaps without overlaps.
     local coords_padding = math.floor(self.keyboard.key_padding / 2)
@@ -359,7 +360,7 @@ function VirtualKey:update_keyboard(want_flash, want_a2)
     --       We flash the *full* keyboard when we release a hold.
     if want_flash then
         UIManager:setDirty(self.keyboard, function()
-            return "flashui", self.keyboard[1][1].dimen -- i.e., keyboard_frame
+            return "flashui", self.keyboard.dimen
         end)
     else
         local refresh_type = "ui"
@@ -367,6 +368,8 @@ function VirtualKey:update_keyboard(want_flash, want_a2)
             refresh_type = "a2"
         end
         -- Only repaint the key itself, not the full board...
+        -- NOTE: We use self[1] (i.e., FrameContainer),
+        --       because we fudge self.dimen to include the padding for the gesture hitbox...
         UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
         logger.dbg("update key", self.key)
         UIManager:setDirty(nil, refresh_type, self[1].dimen)
@@ -504,7 +507,7 @@ VirtualKeyPopup = FocusManager:extend{
 }
 
 function VirtualKeyPopup:onTapClose(arg, ges)
-    if ges.pos:notIntersectWith(self[1][1].dimen) then
+    if ges.pos:notIntersectWith(self.dimen) then
         UIManager:close(self)
         return true
     end
@@ -519,7 +522,7 @@ end
 function VirtualKeyPopup:onCloseWidget()
     self:free()
     UIManager:setDirty(nil, function()
-        return "ui", self[1][1].dimen -- i.e., keyboard_frame
+        return "ui", self.dimen
     end)
 end
 
@@ -706,6 +709,7 @@ function VirtualKeyPopup:init()
         }
     }
     keyboard_frame.dimen = keyboard_frame:getSize()
+    self.dimen = keyboard_frame.dimen
 
     self.ges_events.TapClose = {
         GestureRange:new{
@@ -762,7 +766,7 @@ function VirtualKeyPopup:init()
     UIManager:show(self)
     -- Ensure the post-paint refresh will be able to grab updated coordinates from keyboard_frame by using a refresh function
     UIManager:setDirty(self, function()
-        return "ui", keyboard_frame.dimen
+        return "ui", self.dimen
     end)
 end
 
@@ -938,7 +942,7 @@ function VirtualKeyboard:_refresh(want_flash, fullscreen)
         return
     end
     UIManager:setDirty(self, function()
-        return refresh_type, self[1][1].dimen -- i.e., keyboard_frame
+        return refresh_type, self.dimen
     end)
 end
 
@@ -1097,9 +1101,9 @@ function VirtualKeyboard:addKeys()
         dimen = Screen:getSize(),
         keyboard_frame,
     }
-    -- Beware, this won't be updated post-paint, so the coordinates will stay at (0, 0)
-    -- (i.e., only the size is accurate, not the position).
-    self.dimen = keyboard_frame:getSize()
+    -- Point our top-level dimen to the relevant widget, keyboard_frame
+    keyboard_frame.dimen = keyboard_frame:getSize()
+    self.dimen = keyboard_frame.dimen
 end
 
 function VirtualKeyboard:setLayer(key)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -310,6 +310,18 @@ function VirtualKey:init()
     self.flash_keyboard = G_reader_settings:nilOrTrue("flash_keyboard")
 end
 
+function VirtualKey:paintTo(bb, x ,y)
+    InputContainer.paintTo(self, bb, x, y)
+    -- Fudge self.dimen to include the padding, to make sure said padding is covered by our ges_events range...
+    -- Like Geom, floor coordinates & ceil dims, to fill the gaps without overlaps.
+    local coords_padding = math.floor(self.keyboard.key_padding / 2)
+    local dims_padding = self.keyboard.key_padding -- i.e., coords_padding + math.ceil(self.keyboard.key_padding / 2)
+    self.dimen.x = self.dimen.x - coords_padding
+    self.dimen.w = self[1].dimen.w + dims_padding
+    self.dimen.y = self.dimen.y - coords_padding
+    self.dimen.h = self[1].dimen.h + dims_padding
+end
+
 function VirtualKey:genKeyboardLayoutKeyChars()
     local positions = {
         "northeast",

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -310,8 +310,8 @@ function VirtualKey:init()
     self.flash_keyboard = G_reader_settings:nilOrTrue("flash_keyboard")
 end
 
-function VirtualKey:paintTo(bb, x ,y)
-    InputContainer.paintTo(self, bb, x, y)
+function VirtualKey:paintTo(...)
+    InputContainer.paintTo(self, ...)
 
     -- Fudge self.dimen to include the padding, to make sure said padding is covered by our ges_events range...
     -- Like Geom, floor coordinates & ceil dims, to fill the gaps without overlaps.


### PR DESCRIPTION
* Make the VirtualKey hitbox slightly larger, to encompass the padding between keys.
* Simplify `self.dimen` ref tracking in VirtualKeyboard, by fixing a few widgets `paintTo` methods to *not* break `self.dimen` references (namely, `FrameContainer` for VK, but there were a few other naughty pupils ;p).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11364)
<!-- Reviewable:end -->
