### PR TITLE
UI: Add a verbose debug logging checkbox next to "Report a bug" 

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -753,7 +753,7 @@ function ReaderFooter:updateFooterContainer()
     }
 
     self.footer_positioner = BottomContainer:new{
-        dimen = Geom:new{},
+        dimen = Geom:new(),
         self.footer_content,
     }
     self[1] = self.footer_positioner

--- a/frontend/dbg.lua
+++ b/frontend/dbg.lua
@@ -86,6 +86,13 @@ function Dbg:v(...)
     end
 end
 
+--- Conditional logging with a stable ref.
+function Dbg.log(...)
+    if Dbg.is_on then
+        return LvDEBUG(...)
+    end
+end
+
 --- Simple traceback.
 function Dbg:traceback()
     return LvDEBUG(debug.traceback())

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -2,10 +2,10 @@ local Generic = require("device/generic/device")
 local Geom = require("ui/geometry")
 local UIManager
 local WakeupMgr = require("device/wakeupmgr")
-local time = require("ui/time")
 local ffiUtil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
+local time = require("ui/time")
 local util = require("util")
 local _ = require("gettext")
 

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -1,6 +1,8 @@
 local BD = require("ui/bidi")
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local InfoMessage = require("ui/widget/infomessage")
+local Notification = require("ui/widget/notification")
 local UIManager = require("ui/uimanager")
 local Version = require("version")
 local dbg = require("dbg")
@@ -51,38 +53,21 @@ common_info.about = {
         })
     end
 }
-common_info.debug_logging = {
-    text = _("Enable verbose debug logging"),
-    checked_func = function()
-        return G_reader_settings:isTrue("debug_verbose")
-    end,
-    callback = function()
-        -- Unlike in the dev options, we flip everything at once.
-        if G_reader_settings:isTrue("debug_verbose") then
-            dbg:setVerbose(false)
-            dbg:turnOff()
-            G_reader_settings:makeFalse("debug_verbose")
-            G_reader_settings:makeFalse("debug")
-        else
-            dbg:turnOn()
-            dbg:setVerbose(true)
-            G_reader_settings:makeTrue("debug")
-            G_reader_settings:makeTrue("debug_verbose")
-        end
-        -- Also unlike the dev options, explicitly ask for a restart,
-        -- to make sure framebuffer pulls in a logger.dbg ref that doesn't point to noop on init ;).
-        UIManager:askForRestart()
-    end,
-}
 common_info.report_bug = {
-    text = _("Report a bug"),
+    text_func = function()
+        local label = _("Report a bug")
+        if G_reader_settings:isTrue("debug_verbose") then
+            label = label .. " " .. _("(verbose logging is enabled)")
+        end
+        return label
+    end,
     keep_menu_open = true,
-    callback_func = function()
+    callback = function(touchmenu_instance)
         local DataStorage = require("datastorage")
         local log_path = string.format("%s/%s", DataStorage:getDataDir(), "crash.log")
         local common_msg = T(_("Please report bugs to \nhttps://github.com/koreader/koreader/issues\n\nVersion:\n%1\n\nDetected device:\n%2"),
             Version:getCurrentRevision(), Device:info())
-        local log_msg = T(_("Reproduce the issue with verbose debug logging enabled, and attach %1 to your bug report."), log_path)
+        local log_msg = T(_("Verbose logs will make our investigations easier. If possible, try to reproduce the issue while it's enabled, and attach %1 to your bug report."), log_path)
 
         if Device:isAndroid() then
             local android = require("android")
@@ -95,8 +80,37 @@ common_info.report_bug = {
         else
             msg = common_msg
         end
-        UIManager:show(InfoMessage:new{
+        UIManager:show(ConfirmBox:new{
             text = msg,
+            icon = "notice-info",
+            no_ok_button = true,
+            other_buttons_first = true,
+            other_buttons = {{
+                {
+                    text = G_reader_settings:isTrue("debug_verbose") and _("Disable verbose logging") or _("Enable verbose logging"),
+                    callback = function()
+                        -- Flip verbose logging on dismissal
+                        -- Unlike in the dev options, we flip everything at once.
+                        if G_reader_settings:isTrue("debug_verbose") then
+                            dbg:setVerbose(false)
+                            dbg:turnOff()
+                            G_reader_settings:makeFalse("debug_verbose")
+                            G_reader_settings:makeFalse("debug")
+                            Notification:notify(_("Verbose logging disabled"), Notification.SOURCE_ALWAYS_SHOW)
+                        else
+                            dbg:turnOn()
+                            dbg:setVerbose(true)
+                            G_reader_settings:makeTrue("debug")
+                            G_reader_settings:makeTrue("debug_verbose")
+                            Notification:notify(_("Verbose logging enabled"), Notification.SOURCE_ALWAYS_SHOW)
+                        end
+                        touchmenu_instance:updateItems()
+                        -- Also unlike the dev options, explicitly ask for a restart,
+                        -- to make sure framebuffer pulls in a logger.dbg ref that doesn't point to noop on init ;).
+                        UIManager:askForRestart()
+                    end,
+                }
+            }},
         })
     end
 }

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -182,6 +182,7 @@ local order = {
         "----------------------------",
         "search_menu",
         "----------------------------",
+        "debug_logging",
         "report_bug",
         "----------------------------",
         "system_statistics", -- if enabled (Plugin)

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -182,7 +182,6 @@ local order = {
         "----------------------------",
         "search_menu",
         "----------------------------",
-        "debug_logging",
         "report_bug",
         "----------------------------",
         "system_statistics", -- if enabled (Plugin)

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -242,7 +242,6 @@ local order = {
         "----------------------------",
         "search_menu",
         "----------------------------",
-        "debug_logging",
         "report_bug",
         "----------------------------",
         "system_statistics",  -- if enabled (Plugin)

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -242,6 +242,7 @@ local order = {
         "----------------------------",
         "search_menu",
         "----------------------------",
+        "debug_logging",
         "report_bug",
         "----------------------------",
         "system_statistics",  -- if enabled (Plugin)

--- a/frontend/ui/geometry.lua
+++ b/frontend/ui/geometry.lua
@@ -35,7 +35,12 @@ local Geom = {
 }
 
 function Geom:new(o)
-    if not o then o = {} end
+    if not o then
+        o = {
+            x = 0, y = 0,
+            w = 0, h = 0,
+        }
+    end
     setmetatable(o, self)
     self.__index = self
     return o

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -292,7 +292,7 @@ function ConfigOption:init()
                 local name_text_max_width = name_widget_width
                 local face = Font:getFace(name_font_face, name_font_size)
                 local option_name_container = RightContainer:new{
-                    dimen = Geom:new{ w = name_widget_width, h = option_height},
+                    dimen = Geom:new{ w = name_widget_width, h = option_height },
                 }
                 local option_name = Button:new{
                     text = name_text,
@@ -828,7 +828,7 @@ function MenuBar:init()
     table.insert(menu_bar, spacing)
     table.insert(line_bar, spacing_line)
 
-    self.dimen = Geom:new{ w = Screen:getWidth(), h = bar_height}
+    self.dimen = Geom:new{ x = 0, y = 0, w = Screen:getWidth(), h = bar_height }
     local vertical_menu = VerticalGroup:new{
         line_bar,
         menu_bar,

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -51,6 +51,7 @@ local ConfirmBox = InputContainer:extend{
     cancel_callback = function() end,
     other_buttons = nil,
     other_buttons_first = false, -- set to true to place other buttons above Cancel-OK row
+    no_ok_button = false,
     margin = Size.margin.default,
     padding = Size.padding.default,
     dismissable = true, -- set to false if any button callback is required
@@ -120,6 +121,9 @@ function ConfirmBox:init()
             end,
         },
     }}
+    if self.no_ok_button then
+        table.remove(buttons[1], 2)
+    end
 
     if self.other_buttons then -- additional rows
         local rownum = self.other_buttons_first and 0 or 1

--- a/frontend/ui/widget/container/framecontainer.lua
+++ b/frontend/ui/widget/container/framecontainer.lua
@@ -101,9 +101,6 @@ function FrameContainer:paintTo(bb, x, y)
     else
         self.dimen.x = x
         self.dimen.y = y
-        -- Possibly redundant
-        self.dimen.w = my_size.w
-        self.dimen.h = my_size.h
     end
     local container_width = self.width or my_size.w
     local container_height = self.height or my_size.h

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -36,9 +36,6 @@ function UnderlineContainer:paintTo(bb, x, y)
     else
         self.dimen.x = x
         self.dimen.y = y
-        -- Possibly redundant
-        self.dimen.w = container_size.w
-        self.dimen.h = container_size.h
     end
     local content_size = self[1]:getSize()
     local p_y = y

--- a/frontend/ui/widget/container/widgetcontainer.lua
+++ b/frontend/ui/widget/container/widgetcontainer.lua
@@ -55,6 +55,7 @@ function WidgetContainer:paintTo(bb, x, y)
         self.dimen = Geom:new{x = 0, y = 0, w = content_size.w, h = content_size.h}
     end
 
+    -- NOTE: Clunky `or` left in on the off-chance we're passed a dimen that isn't a proper Geom object...
     x = x + (self.dimen.x or 0)
     y = y + (self.dimen.y or 0)
     if self.align == "top" then

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -524,9 +524,6 @@ function ImageWidget:paintTo(bb, x, y)
     else
         self.dimen.x = x
         self.dimen.y = y
-        -- Possibly redundant
-        self.dimen.w = size.w
-        self.dimen.h = size.h
     end
     logger.dbg("blitFrom", x, y, self._offset_x, self._offset_y, size.w, size.h)
     local do_alpha = false

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -489,11 +489,11 @@ function InputDialog:onTap(arg, ges)
         return
     end
     if self:isKeyboardVisible() then
-        -- NOTE: If you're unlucky enough to tap inside of a border between keys,
-        --       this falls outside of the ges_events range of a VirtualKey, so it is *NOT* caught by VK.
-        --       Instead, since we're flagged is_always_active, it goes to us,
-        --       so we'll have to double check that it wasn't inside of the whole VK region,
-        --       otherwise tapping inside a border would close the VK ;p.
+        -- NOTE: While VirtualKey will attempt to cover the gap between keys in its hitbox (i.e., the grey border),
+        --       a tap *may* still fall outside of the ges_events range of a VirtualKey (e.g., on the very edges of the board's frame).
+        --       In which case, since we're flagged is_always_active, it goes to us,
+        --       so we'll have to double check that it wasn't inside of the whole VirtualKeyboard region,
+        --       otherwise we'd risk spuriously closing the keyboard ;p.
         -- Poke at keyboard_frame directly, as the top-level dimen never gets updated coordinates...
         if self._input_widget.keyboard and self._input_widget.keyboard.dimen and ges.pos:notIntersectWith(self._input_widget.keyboard.dimen) then
             self:onCloseKeyboard()

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -194,7 +194,7 @@ function KeyValueItem:init()
         HorizontalGroup:new{
             dimen = content_dimen,
             LeftContainer:new{
-                dimen = {
+                dimen = Geom:new{
                     w = key_w,
                     h = content_dimen.h
                 },

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -395,6 +395,7 @@ function MenuItem:init()
         vertical_align = "center",
         padding = 0,
         dimen = Geom:new{
+            x = 0, y = 0,
             w = self.content_width,
             h = self.dimen.h
         },
@@ -633,6 +634,7 @@ function Menu:_recalculateDimen()
     local item_height = math.floor(height_dim / self.perpage)
     self.span_width = math.floor((height_dim - (self.perpage * item_height)) / 2 - 1)
     self.item_dimen = Geom:new{
+        x = 0, y = 0,
         w = self.inner_dimen.w,
         h = item_height,
     }
@@ -864,6 +866,7 @@ function Menu:init()
         dimen = self.inner_dimen:copy(),
         WidgetContainer:new{
             dimen = Geom:new{
+                x = 0, y = 0,
                 w = self.screen_w,
                 h = self.page_return_arrow:getSize().h,
             },

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -41,7 +41,7 @@ local T = FFIUtil.template
 Widget that displays a shortcut icon for menu item.
 --]]
 local ItemShortCutIcon = WidgetContainer:extend{
-    dimen = Geom:new{ w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
+    dimen = Geom:new{ x = 0, y = 0, w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
     key = nil,
     bordersize = Size.border.default,
     radius = 0,
@@ -74,7 +74,7 @@ function ItemShortCutIcon:init()
         bordersize = self.bordersize,
         radius = radius,
         background = background,
-        dimen = self.dimen,
+        dimen = self.dimen:copy(),
         CenterContainer:new{
             dimen = self.dimen,
             TextWidget:new{
@@ -112,10 +112,14 @@ local MenuItem = InputContainer:extend{
 
 function MenuItem:init()
     self.content_width = self.dimen.w - 2 * Size.padding.fullscreen
-    local shortcut_icon_dimen = Geom:new()
+    local icon_width = math.floor(self.dimen.h * 4/5)
+    local shortcut_icon_dimen = Geom:new{
+        x = 0,
+        y = 0,
+        w = icon_width,
+        h = icon_width,
+    }
     if self.shortcut then
-        shortcut_icon_dimen.w = math.floor(self.dimen.h * 4/5)
-        shortcut_icon_dimen.h = shortcut_icon_dimen.w
         self.content_width = self.content_width - shortcut_icon_dimen.w - Size.span.horizontal_default
     end
 
@@ -1078,7 +1082,7 @@ function Menu:updateItems(select_number)
                 font_size = self.font_size,
                 infont = "infont",
                 infont_size = infont_size,
-                dimen = self.item_dimen:new(),
+                dimen = self.item_dimen:copy(),
                 shortcut = item_shortcut,
                 shortcut_style = shortcut_style,
                 table = self.item_table[i],

--- a/frontend/ui/widget/notification.lua
+++ b/frontend/ui/widget/notification.lua
@@ -30,6 +30,7 @@ local SOURCE_BOTTOM_MENU_MORE     = 0x0008 -- three dots in bottom menu
 local SOURCE_BOTTOM_MENU_PROGRESS = 0x0010 -- progress indicator on bottom menu
 local SOURCE_DISPATCHER           = 0x0020 -- dispatcher
 local SOURCE_OTHER                = 0x0040 -- all other sources (e.g. keyboard)
+local SOURCE_ALWAYS_SHOW          = 0x8000 -- display this, no matter the display preferences
 
 -- All bottom menu bits
 local SOURCE_BOTTOM_MENU = SOURCE_BOTTOM_MENU_ICON +
@@ -71,6 +72,7 @@ local Notification = InputContainer:extend{
     SOURCE_BOTTOM_MENU_PROGRESS = SOURCE_BOTTOM_MENU_PROGRESS,
     SOURCE_DISPATCHER = SOURCE_DISPATCHER,
     SOURCE_OTHER = SOURCE_OTHER,
+    SOURCE_ALWAYS_SHOW = SOURCE_ALWAYS_SHOW,
 
     SOURCE_BOTTOM_MENU = SOURCE_BOTTOM_MENU,
 
@@ -79,6 +81,7 @@ local Notification = InputContainer:extend{
     SOURCE_MORE = SOURCE_MORE,
     SOURCE_DEFAULT = SOURCE_DEFAULT,
     SOURCE_ALL = SOURCE_ALL,
+
     _past_messages = {}, -- a static class member to store the N last messages text
 }
 
@@ -148,7 +151,7 @@ function Notification:setNotifySource(source)
 end
 
 function Notification:resetNotifySource()
-    self.notify_source = Notification.SOURCE_OTHER
+    self.notify_source = SOURCE_OTHER
 end
 
 function Notification:getNotifySource()
@@ -158,8 +161,8 @@ end
 -- Display a notification popup if `source` or `self.notify_source` is not masked by the `notification_sources_to_show_mask` setting
 function Notification:notify(arg, source, refresh_after)
     source = source or self.notify_source
-    local mask = G_reader_settings:readSetting("notification_sources_to_show_mask") or self.SOURCE_DEFAULT
-    if source and band(mask, source) ~= 0 then
+    local mask = G_reader_settings:readSetting("notification_sources_to_show_mask") or SOURCE_DEFAULT
+    if source and (source == SOURCE_ALWAYS_SHOW or band(mask, source) ~= 0) then
         UIManager:show(Notification:new{
             text = arg,
          })

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -119,9 +119,6 @@ function ProgressWidget:paintTo(bb, x, y)
     else
         self.dimen.x = x
         self.dimen.y = y
-        -- Possibly redundant
-        self.dimen.w = my_size.w
-        self.dimen.h = my_size.h
     end
     if self.dimen.w == 0 or self.dimen.h == 0 then return end
 

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -257,7 +257,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
     }
     self[1] = WidgetContainer:new{
         align = "center",
-        dimen =Geom:new{
+        dimen = Geom:new{
             x = 0, y = 0,
             w = self.screen_width,
             h = self.screen_height,

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1012,7 +1012,7 @@ function TextBoxWidget:_renderImage(start_row_idx)
             margin = 0,
             padding = 0,
             RightContainer:new{
-                dimen = {
+                dimen = Geom:new{
                     w = image.width,
                     h = status_height,
                 },
@@ -1189,7 +1189,7 @@ function TextBoxWidget:getSize()
         self:_updateLayout()
     end
 
-    return Geom:new{w = self.width, h = self._bb:getHeight()}
+    return Geom:new{x = 0, y = 0, w = self.width, h = self._bb:getHeight()}
 end
 
 function TextBoxWidget:paintTo(bb, x, y)

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -53,7 +53,7 @@ local scale_by_size = Screen:scaleBySize(1000000) * (1/1000000)
 -- ItemShortCutIcon (for keyboard navigation) is private to menu.lua and can't be accessed,
 -- so we need to redefine it
 local ItemShortCutIcon = WidgetContainer:extend{
-    dimen = Geom:new{ w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
+    dimen = Geom:new{ x = 0, y = 0, w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
     key = nil,
     bordersize = Size.border.default,
     radius = 0,
@@ -82,7 +82,7 @@ function ItemShortCutIcon:init()
         bordersize = self.bordersize,
         radius = radius,
         background = background,
-        dimen = self.dimen,
+        dimen = self.dimen:copy(),
         CenterContainer:new{
             dimen = self.dimen,
             TextWidget:new{
@@ -122,9 +122,13 @@ function ListMenuItem:init()
     -- As done in MenuItem
     -- Squared letter for keyboard navigation
     if self.shortcut then
-        local shortcut_icon_dimen = Geom:new()
-        shortcut_icon_dimen.w = math.floor(self.dimen.h*2/5)
-        shortcut_icon_dimen.h = shortcut_icon_dimen.w
+        local icon_width = math.floor(self.dimen.h*2/5)
+        local shortcut_icon_dimen = Geom:new{
+            x = 0,
+            y = 0,
+            w = icon_width,
+            h = icon_width,
+        }
         -- To keep a simpler widget structure, this shortcut icon will not
         -- be part of it, but will be painted over the widget in our paintTo
         self.shortcut_icon = ItemShortCutIcon:new{
@@ -1015,7 +1019,7 @@ function ListMenu:_updateItemsBuildUI()
                 text = getMenuText(entry),
                 show_parent = self.show_parent,
                 mandatory = entry.mandatory,
-                dimen = self.item_dimen:new(),
+                dimen = self.item_dimen:copy(),
                 shortcut = item_shortcut,
                 shortcut_style = shortcut_style,
                 menu = self,

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -959,6 +959,7 @@ function ListMenu:_recalculateDimen()
     self.item_height = math.floor(available_height / self.perpage) - Size.line.thin
     self.item_width = self.inner_dimen.w
     self.item_dimen = Geom:new{
+        x = 0, y = 0,
         w = self.item_width,
         h = self.item_height
     }

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -52,7 +52,7 @@ local progress_widget
 -- ItemShortCutIcon (for keyboard navigation) is private to menu.lua and can't be accessed,
 -- so we need to redefine it
 local ItemShortCutIcon = WidgetContainer:extend{
-    dimen = Geom:new{ w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
+    dimen = Geom:new{ x = 0, y = 0, w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
     key = nil,
     bordersize = Size.border.default,
     radius = 0,
@@ -81,7 +81,7 @@ function ItemShortCutIcon:init()
         bordersize = self.bordersize,
         radius = radius,
         background = background,
-        dimen = self.dimen,
+        dimen = self.dimen:copy(),
         CenterContainer:new{
             dimen = self.dimen,
             TextWidget:new{
@@ -373,9 +373,12 @@ function MosaicMenuItem:init()
     -- As done in MenuItem
     -- Squared letter for keyboard navigation
     if self.shortcut then
-        local shortcut_icon_dimen = Geom:new()
-        shortcut_icon_dimen.w = math.floor(self.dimen.h*1/5)
-        shortcut_icon_dimen.h = shortcut_icon_dimen.w
+        local icon_width = math.floor(self.dimen.h*1/5)
+        local shortcut_icon_dimen = Geom:new{
+            x = 0, y = 0,
+            w = icon_width,
+            h = icon_width,
+        }
         -- To keep a simpler widget structure, this shortcut icon will not
         -- be part of it, but will be painted over the widget in our paintTo
         self.shortcut_icon = ItemShortCutIcon:new{
@@ -979,7 +982,7 @@ function MosaicMenu:_updateItemsBuildUI()
                 text = getMenuText(entry),
                 show_parent = self.show_parent,
                 mandatory = entry.mandatory,
-                dimen = self.item_dimen:new(),
+                dimen = self.item_dimen:copy(),
                 shortcut = item_shortcut,
                 shortcut_style = shortcut_style,
                 menu = self,

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -419,6 +419,7 @@ function MosaicMenuItem:init()
         vertical_align = "top",
         padding = 0,
         dimen = Geom:new{
+            x = 0, y = 0,
             w = self.width,
             h = self.height
         },
@@ -523,8 +524,8 @@ function MosaicMenuItem:update()
             radius = Screen:scaleBySize(10),
             OverlapGroup:new{
                 dimen = dimen_in,
-                CenterContainer:new{ dimen=dimen_in, directory},
-                BottomContainer:new{ dimen=dimen_in, nbitems},
+                CenterContainer:new{ dimen = dimen_in, directory},
+                BottomContainer:new{ dimen = dimen_in, nbitems},
             },
         }
     else
@@ -890,6 +891,7 @@ function MosaicMenu:_recalculateDimen()
     self.item_height = math.floor((self.inner_dimen.h - self.others_height - (1+self.nb_rows)*self.item_margin) / self.nb_rows)
     self.item_width = math.floor((self.inner_dimen.w - (1+self.nb_cols)*self.item_margin) / self.nb_cols)
     self.item_dimen = Geom:new{
+        x = 0, y = 0,
         w = self.item_width,
         h = self.item_height
     }

--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -139,7 +139,8 @@ Background = InputContainer:new{
         bordersize = 0,
         dimen = Screen:getSize(),
         Widget:new{
-            dimen = {
+            dimen = Geom:new{
+                x = 0, y = 0,
                 w = Screen:getWidth(),
                 h = Screen:getHeight(),
             }


### PR DESCRIPTION
@hius07 mentioned something to that effect a few weeks back, I liked it ;p.

To make it slightly more user-friendly (and warrant the code duplication ;p), this always flips debug + verbose at once, and looks disabled if you only have debug w/o verbose enabled. It also requests a restart, for framebuffer's sake (it pulls a ref to logger.dbg on init, but Logger mutates its methods at runtime depending on the log level, so this doesn't track updates to the logging level).

(Also implement an actual `dbg.log` function that *will* keep track of the current status, in case something like that comes up again in the future).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11366)
<!-- Reviewable:end -->
