### PR TITLE
PathChooser: fix calling Folder shortcuts

### DIFF
--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -7,6 +7,7 @@ local ffiutil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 local util = require("util")
 local _ = require("gettext")
+local N_ = _.ngettext
 local T = ffiutil.template
 
 local PathChooser = FileChooser:extend{
@@ -112,18 +113,17 @@ function PathChooser:onMenuHold(item)
     end
     local title
     if attr.mode == "file" then
+        title = _("Choose this file?") .. "\n\n" .. BD.filepath(path) .. "\n"
         if self.detailed_file_info then
             local filesize = util.getFormattedSize(attr.size)
             local lastmod = os.date("%Y-%m-%d %H:%M", attr.modification)
-            title = T(_("Choose this file?\n\n%1\n\nFile size: %2 bytes\nLast modified: %3\n"),
-                        BD.filepath(path), filesize, lastmod)
-        else
-            title = T(_("Choose this file?\n\n%1\n"), BD.filepath(path))
+            title = title .. "\n" .. T(N_("File size: 1 byte", "File size: %1 bytes", attr.size), filesize) ..
+                             "\n" .. T(_("Last modified: %1"), lastmod) .. "\n"
         end
     elseif attr.mode == "directory" then
-        title = T(_("Choose this folder?\n\n%1\n"), BD.dirpath(path))
+        title = _("Choose this folder?") .. "\n\n" .. BD.dirpath(path) .. "\n"
     else -- just in case we get something else
-        title = T(_("Choose this path?\n\n%1\n"), BD.path(path))
+        title = _("Choose this path?") .. "\n\n" .. BD.path(path) .. "\n"
     end
     local onConfirm = self.onConfirm
     self.button_dialog = ButtonDialog:new{

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -1,7 +1,6 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local Device = require("device")
-local Event = require("ui/event")
 local FileChooser = require("ui/widget/filechooser")
 local UIManager = require("ui/uimanager")
 local ffiutil = require("ffi/util")
@@ -14,7 +13,6 @@ local PathChooser = FileChooser:extend{
     title = true, -- or a string
         -- if let to true, a generic title will be set in init()
     no_title = false,
-    show_path = true,
     is_popout = false,
     covers_fullscreen = true, -- set it to false if you set is_popout = true
     is_borderless = true,
@@ -117,15 +115,15 @@ function PathChooser:onMenuHold(item)
         if self.detailed_file_info then
             local filesize = util.getFormattedSize(attr.size)
             local lastmod = os.date("%Y-%m-%d %H:%M", attr.modification)
-            title = T(_("Choose this file?\n\n%1\n\nFile size: %2 bytes\nLast modified: %3"),
+            title = T(_("Choose this file?\n\n%1\n\nFile size: %2 bytes\nLast modified: %3\n"),
                         BD.filepath(path), filesize, lastmod)
         else
-            title = T(_("Choose this file?\n\n%1"), BD.filepath(path))
+            title = T(_("Choose this file?\n\n%1\n"), BD.filepath(path))
         end
     elseif attr.mode == "directory" then
-        title = T(_("Choose this folder?\n\n%1"), BD.dirpath(path))
+        title = T(_("Choose this folder?\n\n%1\n"), BD.dirpath(path))
     else -- just in case we get something else
-        title = T(_("Choose this path?\n\n%1"), BD.path(path))
+        title = T(_("Choose this path?\n\n%1\n"), BD.path(path))
     end
     local onConfirm = self.onConfirm
     self.button_dialog = ButtonDialog:new{
@@ -164,8 +162,11 @@ function PathChooser:showPlusMenu()
                     text = _("Folder shortcuts"),
                     callback = function()
                         UIManager:close(button_dialog)
-                        UIManager:broadcastEvent(Event:new("ShowFolderShortcutsDialog",
-                            function(path) self:changeToPath(path) end))
+                        local FileManagerShortcuts = require("apps/filemanager/filemanagershortcuts")
+                        local select_callback = function(path)
+                            self:changeToPath(path)
+                        end
+                        FileManagerShortcuts:onShowFolderShortcutsDialog(select_callback)
                     end,
                 },
             },


### PR DESCRIPTION
To reproduce the bug:
-open Folder shortcuts
-press the Plus icon to add a shortcut
-in PathChooser long-press the Home icon
-press Folder shortcuts button
-close Folder shortcuts, close PathChooser
-press a shortcut
Folder shortcuts window remains open.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11367)
<!-- Reviewable:end -->
