### PR TITLE
Add sort: `90% > 50% > 0% > unopened > 100%`

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -215,17 +215,20 @@ local FileChooser = Menu:extend{
                 local natsort
                 natsort, cache = sort.natsort_cmp(cache)
                 return function(a, b)
-                    if a.percent_finished == b.percent_finished then
+                    -- smooth 2 decmial points (0.00) instead of 16 decimal numbers
+                    local apercent = math.floor(a.percent_finished * 100) / 100
+                    local bpercent = math.floor(b.percent_finished * 100) / 100
+                    if apercent == bpercent then
                         return natsort(a.text, b.text)
                     end
-                    if a.percent_finished == 1 then
+                    if apercent == 1 then
                         return false
                     end
-                    if b.percent_finished == 1 then
+                    if bpercent == 1 then
                         return true
                     end
 
-                    return a.percent_finished > b.percent_finished
+                    return apercent > bpercent
                 end, cache
             end,
             item_func = function(item)
@@ -235,7 +238,7 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
-                item.percent_finished = percent_finished or 0
+                item.percent_finished = percent_finished or -1
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -206,6 +206,41 @@ local FileChooser = Menu:extend{
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
             end,
         },
+        percent_natural = {
+            -- sort 90% > 50% > 0% > unopened > 100%
+            text = _("percent - unopened last natural"),
+            menu_order = 90,
+            can_collate_mixed = false,
+            init_sort_func = function(cache)
+                local natsort
+                natsort, cache = sort.natsort_cmp(cache)
+                return function(a, b)
+                    if a.percent_finished == b.percent_finished then
+                        return natsort(a.text, b.text)
+                    end
+                    if a.percent_finished == 1 then
+                        return false
+                    end
+                    if b.percent_finished == 1 then
+                        return true
+                    end
+
+                    return a.percent_finished > b.percent_finished
+                end, cache
+            end,
+            item_func = function(item)
+                local percent_finished
+                item.opened = DocSettings:hasSidecarFile(item.path)
+                if item.opened then
+                    local doc_settings = DocSettings:open(item.path)
+                    percent_finished = doc_settings:readSetting("percent_finished")
+                end
+                item.percent_finished = percent_finished or 0
+            end,
+            mandatory_func = function(item)
+                return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
+            end,
+        },
     },
 }
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -214,19 +214,19 @@ local FileChooser = Menu:extend{
             init_sort_func = function(cache)
                 local natsort
                 natsort, cache = sort.natsort_cmp(cache)
-                return function(a, b)
+                local sortfunc =  function(a, b)
                     if a.percent_finished == b.percent_finished then
                         return natsort(a.text, b.text)
-                    end
-                    if a.percent_finished == 1 then
+                    elseif a.percent_finished == 1 then
                         return false
-                    end
-                    if b.percent_finished == 1 then
+                    elseif b.percent_finished == 1 then
                         return true
+                    else
+                        return a.percent_finished > b.percent_finished
                     end
+                end
 
-                    return a.percent_finished > b.percent_finished
-                end, cache
+                return sortfunc, cache
             end,
             item_func = function(item)
                 local percent_finished

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -208,27 +208,24 @@ local FileChooser = Menu:extend{
         },
         percent_natural = {
             -- sort 90% > 50% > 0% > unopened > 100%
-            text = _("percent - unopened last natural"),
+            text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
             init_sort_func = function(cache)
                 local natsort
                 natsort, cache = sort.natsort_cmp(cache)
                 return function(a, b)
-                    -- smooth 2 decmial points (0.00) instead of 16 decimal numbers
-                    local apercent = math.floor(a.percent_finished * 100) / 100
-                    local bpercent = math.floor(b.percent_finished * 100) / 100
-                    if apercent == bpercent then
+                    if a.percent_finished == b.percent_finished then
                         return natsort(a.text, b.text)
                     end
-                    if apercent == 1 then
+                    if a.percent_finished == 1 then
                         return false
                     end
-                    if bpercent == 1 then
+                    if b.percent_finished == 1 then
                         return true
                     end
 
-                    return apercent > bpercent
+                    return a.percent_finished > b.percent_finished
                 end, cache
             end,
             item_func = function(item)
@@ -238,7 +235,8 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
-                item.percent_finished = percent_finished or -1
+                -- smooth 2 decimal points (0.00) instead of 16 decimal numbers
+                item.percent_finished = math.floor((percent_finished or -1) * 100) / 100
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"


### PR DESCRIPTION
This PR adds a new collate to sort `90% > 50% > 0% > unopened > 100%`, which is useful to directly have currently reading files / books at the front and finished books at the back instead of having to go through multiple pages (on long series'); and mostly benefits with #8472.

i would still like a better name for this sort than the current one

original (fork) PR: https://github.com/poire-z/koreader/pull/2

sorting example screenshot:

![percent_unopened_new_1](https://github.com/koreader/koreader/assets/10911626/7cbf8ec5-7430-4cb7-8e69-0f041015c3f1)

behavior:
- sort `90% > 50% > 0% > unopened > 100%` (non-reverse)
- sort using natsort (like `name (natural sorting)`) for same percentage
- smooth percentage to 2 decimal points instead of the numbers initial 16 decimal points (lua didnt provide a function for this to my knowledge)
- initialize un-opened files / books with `-1` to be distinct of opened but first-page files / books

why? because the closest `percent - unopened first (reverse)` sorts 100% (finished) books at the front and sorts unopened books from highest to lowest and the other 3 modes (`percent - unopened first`, `percent - unopened last`, `percent - unopened last (reverse)`) dont even sort closely to how i would like to see it, examples:

<details>
<summary>Screenshot examples for <code>percent</code> sortings</summary>

`percent - unopened first`:
![percent_unopened_first_1](https://github.com/koreader/koreader/assets/10911626/d8ceeba1-f3a4-4d98-9bc4-da2ed87ea2c9)
![percent_unopened_first_2](https://github.com/koreader/koreader/assets/10911626/29852258-3c28-4b8d-a3fc-5b32438a77e3)


`percent - unopened first (reverse)`:
![percent_unopened_first_reverse_1](https://github.com/koreader/koreader/assets/10911626/4800a749-645e-4a85-b114-54bf6a0057f5)
![percent_unopened_first_reverse_2](https://github.com/koreader/koreader/assets/10911626/f0412d24-f282-4952-9f6f-f8f46e5e3670)


`percent - unopened last`:
![percent_unopened_last_1](https://github.com/koreader/koreader/assets/10911626/f63a3236-2844-4347-b51c-5d6dd2a739dc)
![percent_unopened_last_2](https://github.com/koreader/koreader/assets/10911626/1b628b2e-264a-457e-8596-366d92fbf4e7)


`percent - unopened last (reverse)`:
![percent_unopened_last_reverse_1](https://github.com/koreader/koreader/assets/10911626/a4fa1c3b-b2d8-49e5-b252-e27ff650da96)
![percent_unopened_last_reverse_2](https://github.com/koreader/koreader/assets/10911626/8a740dd8-30c5-461d-8d73-7ff0f99052ce)


`percent - unopened last natural` (the new sort of this PR):
![percent_unopened_new_1](https://github.com/koreader/koreader/assets/10911626/7cbf8ec5-7430-4cb7-8e69-0f041015c3f1)
![percent_unopened_new_2](https://github.com/koreader/koreader/assets/10911626/5b533150-d7bf-4a1b-97e1-9ea698afbfc1)


`percent - unopened last natural (reverse)` (the new sort of this PR):
![percent_unopened_new_reverse_1](https://github.com/koreader/koreader/assets/10911626/8ad846d0-95ce-47e7-be47-dbfc01a195a8)
![percent_unopened_new_reverse_2](https://github.com/koreader/koreader/assets/10911626/7e92c4e9-990a-4c51-a37a-41f68dadd726)


</details>

---

personally i would also like a toggle to sort the last opened book at the very front regardless of percentage, but this is out-of-scope for this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11369)
<!-- Reviewable:end -->
