### PR TITLE
Fix Pocketbook 616 Frontlight Widget Inoperable

### DIFF
--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -82,7 +82,8 @@ function FrontLightWidget:init()
 
     -- Input
     if Device:hasKeys() then
-        self.key_events.Close = { { Device.input.group.Back } }
+      local close_keys = Device:hasFewKeys() and { Device.input.group.Back, "Left" } or Device.input.group.Back
+      self.key_events.Close = { { close_keys } }
     end
     if Device:isTouchDevice() then
         self.ges_events = {


### PR DESCRIPTION
Fixes issue #8023
Related to issue #4029

The fix takes exactly the same approach as other PRs like #6195 to add some usability to devices with few hardware keys. The front-light widget can now be closed using the left key on the d-pad.

I was considering about experimenting with adding `"Left"` to `Device.input.group.Back` for devices with few keys, but that would be a much more bigger change and I think this quick fix just makes this widget operable on limited devices.

Tested on my PocketBook 616W

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11376)
<!-- Reviewable:end -->
