### PR TITLE
ConfigDialog: Don't enforce 0x0 dimensions on initial display

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -673,10 +673,10 @@ function ReaderPaging:onInitScrollPageStates(orig_mode)
     if self.view.page_scroll and self.view.state.page then
         self.orig_page = self.current_page
         self.view.page_states = {}
-        local blank_area = Geom:new{}
+        local blank_area = Geom:new()
         blank_area:setSizeTo(self.view.visible_area)
         while blank_area.h > 0 do
-            local offset = Geom:new{}
+            local offset = Geom:new()
             -- caculate position in current page
             if self.current_page == self.orig_page then
                 local page_area = self.view:getPageArea(
@@ -823,7 +823,7 @@ function ReaderPaging:genPageStatesFromTop(top_page_state, blank_area, offset)
             current_page = self.ui.document:getNextPage(current_page)
             if current_page == 0 then break end -- end of document reached
             self:_gotoPage(current_page, "scrolling")
-            state = self:getNextPageState(blank_area, Geom:new{})
+            state = self:getNextPageState(blank_area, Geom:new())
             table.insert(page_states, state)
         end
     end
@@ -848,7 +848,7 @@ function ReaderPaging:genPageStatesFromBottom(bottom_page_state, blank_area, off
             current_page = self.ui.document:getPrevPage(current_page)
             if current_page == 0 then break end -- start of document reached
             self:_gotoPage(current_page, "scrolling")
-            state = self:getPrevPageState(blank_area, Geom:new{})
+            state = self:getPrevPageState(blank_area, Geom:new())
             table.insert(page_states, 1, state)
         end
     end
@@ -869,7 +869,7 @@ function ReaderPaging:onScrollPanRel(diff)
     if diff == 0 then return true end
     logger.dbg("pan relative height:", diff)
     local offset = Geom:new{x = 0, y = diff}
-    local blank_area = Geom:new{}
+    local blank_area = Geom:new()
     blank_area:setSizeTo(self.view.visible_area)
     local new_page_states
     if diff > 0 then
@@ -913,7 +913,7 @@ function ReaderPaging:onScrollPageRel(page_diff)
             return true
         end
 
-        local blank_area = Geom:new{}
+        local blank_area = Geom:new()
         blank_area:setSizeTo(self.view.visible_area)
         local overlap = self.overlap
         local offset = Geom:new{
@@ -923,7 +923,7 @@ function ReaderPaging:onScrollPageRel(page_diff)
         self.view.page_states = self:genPageStatesFromTop(last_page_state, blank_area, offset)
     elseif page_diff < 0 then
         -- page up, first page should be moved to bottom
-        local blank_area = Geom:new{}
+        local blank_area = Geom:new()
         blank_area:setSizeTo(self.view.visible_area)
         local overlap = self.overlap
         local first_page_state = table.remove(self.view.page_states, 1)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -418,7 +418,7 @@ function ReaderView:getScrollPagePosition(pos)
 end
 
 function ReaderView:getScrollPageRect(page, rect_p)
-    local rect_s = Geom:new{}
+    local rect_s = Geom:new()
     for _, state in ipairs(self.page_states) do
         local trans_p = Geom:new(rect_p):copy()
         trans_p:transformByScale(state.zoom, state.zoom)
@@ -463,7 +463,7 @@ function ReaderView:getSinglePagePosition(pos)
 end
 
 function ReaderView:getSinglePageRect(rect_p)
-    local rect_s = Geom:new{}
+    local rect_s = Geom:new()
     local trans_p = Geom:new(rect_p):copy()
     trans_p:transformByScale(self.state.zoom, self.state.zoom)
     if self.visible_area:intersectWith(trans_p) then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -79,7 +79,7 @@ end
 local function _getRandomImage(dir)
     if not dir then return end
     local match_func = function(file) -- images, ignore macOS resource forks
-        return not util.stringStartsWith(file, "._") and DocumentRegistry:isImageFile(file)
+        return not util.stringStartsWith(ffiUtil.basename(file), "._") and DocumentRegistry:isImageFile(file)
     end
     return filemanagerutil.getRandomFile(dir, match_func)
 end

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -921,7 +921,7 @@ function ConfigDialog:update()
         config_dialog = self,
     }
 
-    local old_dimen = self.dialog_frame and self.dialog_frame.dimen and self.dialog_frame.dimen:copy() or Geom:new{}
+    local old_dimen = self.dialog_frame and self.dialog_frame.dimen and self.dialog_frame.dimen:copy() or Geom:new()
     self.dialog_frame = FrameContainer:new{
         background = Blitbuffer.COLOR_WHITE,
         padding_bottom = 0, -- ensured by MenuBar
@@ -930,9 +930,6 @@ function ConfigDialog:update()
             self.config_menubar,
         },
     }
-    -- Ensure we have a sane-ish Geom object *before* paintTo gets called,
-    -- to avoid weirdness in race-y SwipeCloseMenu calls...
-    self.dialog_frame.dimen = old_dimen
 
     -- Reset the focusmanager cursor
     self:moveFocusTo(self.panel_index, #self.layout, FocusManager.NOT_FOCUS)
@@ -940,6 +937,16 @@ function ConfigDialog:update()
     self[1] = BottomContainer:new{
         dimen = Screen:getSize(),
         self.dialog_frame,
+    }
+
+    -- Ensure we have a sane Geom object *before* paintTo gets called,
+    -- to avoid weirdness in strange race-y SwipeCloseMenu calls...
+    local dialog_size = self.dialog_frame:getSize()
+    self.dialog_frame.dimen = Geom:new{
+        x = old_dimen.x,
+        y = old_dimen.y,
+        w = dialog_size.w,
+        h = dialog_size.h
     }
 end
 

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -921,7 +921,6 @@ function ConfigDialog:update()
         config_dialog = self,
     }
 
-    local old_dimen = self.dialog_frame and self.dialog_frame.dimen and self.dialog_frame.dimen:copy() or Geom:new()
     self.dialog_frame = FrameContainer:new{
         background = Blitbuffer.COLOR_WHITE,
         padding_bottom = 0, -- ensured by MenuBar
@@ -937,16 +936,6 @@ function ConfigDialog:update()
     self[1] = BottomContainer:new{
         dimen = Screen:getSize(),
         self.dialog_frame,
-    }
-
-    -- Ensure we have a sane Geom object *before* paintTo gets called,
-    -- to avoid weirdness in strange race-y SwipeCloseMenu calls...
-    local dialog_size = self.dialog_frame:getSize()
-    self.dialog_frame.dimen = Geom:new{
-        x = old_dimen.x,
-        y = old_dimen.y,
-        w = dialog_size.w,
-        h = dialog_size.h
     }
 end
 

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -171,7 +171,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
             left_vertical_group,
         },
         CenterContainer:new{
-            dimen = Geom:new{},
+            dimen = Geom:new(),
             separator_vertical_group,
         },
         CenterContainer:new{

--- a/frontend/ui/widget/fixedtextwidget.lua
+++ b/frontend/ui/widget/fixedtextwidget.lua
@@ -17,7 +17,7 @@ end
 function FixedTextWidget:getSize()
     self:updateSize()
     if self._length == 0 then
-        return Geom:new{}
+        return Geom:new()
     end
     return TextWidget.getSize(self)
 end

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -483,7 +483,7 @@ function TouchMenu:init()
     -- borders are pushed off-(screen-)width and so not visible.
     -- We'll then be similar to bottom menu ConfigDialog (where this
     -- nice effect is caused by some width calculations bug).
-    if not self.dimen then self.dimen = Geom:new{} end
+    if not self.dimen then self.dimen = Geom:new() end
     self.show_parent = self.show_parent or self
     if not self.close_callback then
         self.close_callback = function()


### PR DESCRIPTION
FrameContainer now behaves like other widgets, and no longer re-computes dimensions in paintTo *if you provide a dimen*.
Since we do here, for.... reasons I'm not entirely sure still make any sense, make sure we actually compute valid dimensions, instead of an empty rect from Geom:new ;).

Or, better yet, let FrameContainer do that itself, since the pre-computations were done as a workaround for a weird race with swipe handlers, and the Geom methods in question now have nil guards in place, so we don't need two layers of protection ;).

Fix #11389
Regression since d33bb0452cc696abd4c5d570555381b3405d2486

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11391)
<!-- Reviewable:end -->
