### PR TITLE
CoverBrowser: use bookinfo cache in Classic mode

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -269,8 +269,10 @@ function FileManager:setupLayout()
         }
 
         if is_file then
+            self.bookinfo = nil
             local has_provider = DocumentRegistry:hasProvider(file)
             if has_provider or DocSettings:hasSidecarFile(file) then
+                self.bookinfo = file_manager.coverbrowser and file_manager.coverbrowser:getBookInfo(file)
                 table.insert(buttons, filemanagerutil.genStatusButtonsRow(file, close_dialog_refresh_callback))
                 table.insert(buttons, {}) -- separator
                 table.insert(buttons, {
@@ -286,12 +288,12 @@ function FileManager:setupLayout()
                         file_manager:showOpenWithDialog(file)
                     end,
                 },
-                filemanagerutil.genBookInformationButton(file, close_dialog_callback),
+                filemanagerutil.genBookInformationButton(file, self.bookinfo, close_dialog_callback),
             })
             if has_provider then
                 table.insert(buttons, {
-                    filemanagerutil.genBookCoverButton(file, close_dialog_callback),
-                    filemanagerutil.genBookDescriptionButton(file, close_dialog_callback),
+                    filemanagerutil.genBookCoverButton(file, self.bookinfo, close_dialog_callback),
+                    filemanagerutil.genBookDescriptionButton(file, self.bookinfo, close_dialog_callback),
                 })
             end
             if Device:canExecuteScript(file) then

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -1,3 +1,4 @@
+local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local Device = require("device")
 local DocumentRegistry = require("document/documentregistry")
@@ -36,14 +37,12 @@ function FileManagerCollection:updateItemTable()
 end
 
 function FileManagerCollection:onMenuChoice(item)
-    local file = item.file
     if self.ui.document then
-        if self.ui.document.file ~= file then
-            self.ui:switchDocument(file)
+        if self.ui.document.file ~= item.file then
+            self.ui:switchDocument(item.file)
         end
     else
-        local ReaderUI = require("apps/reader/readerui")
-        ReaderUI:showReader(file)
+        self.ui:openFile(item.file)
     end
 end
 
@@ -97,7 +96,7 @@ function FileManagerCollection:onMenuHold(item)
     end
 
     self.collfile_dialog = ButtonDialog:new{
-        title = item.text,
+        title = BD.filename(item.text),
         title_align = "center",
         buttons = buttons,
     }

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -50,6 +50,8 @@ end
 function FileManagerCollection:onMenuHold(item)
     local file = item.file
     self.collfile_dialog = nil
+    self.bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
+
     local function close_dialog_callback()
         UIManager:close(self.collfile_dialog)
     end
@@ -81,11 +83,11 @@ function FileManagerCollection:onMenuHold(item)
     })
     table.insert(buttons, {
         filemanagerutil.genShowFolderButton(file, close_dialog_menu_callback),
-        filemanagerutil.genBookInformationButton(file, close_dialog_callback),
+        filemanagerutil.genBookInformationButton(file, self.bookinfo, close_dialog_callback),
     })
     table.insert(buttons, {
-        filemanagerutil.genBookCoverButton(file, close_dialog_callback),
-        filemanagerutil.genBookDescriptionButton(file, close_dialog_callback),
+        filemanagerutil.genBookCoverButton(file, self.bookinfo, close_dialog_callback),
+        filemanagerutil.genBookDescriptionButton(file, self.bookinfo, close_dialog_callback),
     })
 
     if Device:canExecuteScript(file) then

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -16,7 +16,6 @@ local lfs = require("libs/libkoreader-lfs")
 local util = require("util")
 local _ = require("gettext")
 local N_ = _.ngettext
-local Screen = require("device").screen
 local T = require("ffi/util").template
 
 local FileSearcher = WidgetContainer:extend{
@@ -24,9 +23,6 @@ local FileSearcher = WidgetContainer:extend{
     include_subfolders = true,
     include_metadata = false,
 }
-
-function FileSearcher:init()
-end
 
 function FileSearcher:onShowFileSearch(search_string)
     local search_dialog
@@ -225,28 +221,26 @@ function FileSearcher:showSearchResultsMessage(no_results)
 end
 
 function FileSearcher:showSearchResults(results)
-    local menu_container = CenterContainer:new{
-        dimen = Screen:getSize(),
-    }
     self.search_menu = Menu:new{
+        title = T(_("Search results (%1)"), #results),
+        subtitle = T(_("Query: %1"), self.search_string),
+        item_table = results,
         ui = self.ui,
         covers_fullscreen = true, -- hint for UIManager:_repaint()
         is_borderless = true,
         is_popout = false,
-        show_parent = menu_container,
+        title_bar_fm_style = true,
         onMenuSelect = self.onMenuSelect,
         onMenuHold = self.onMenuHold,
         handle_hold_on_hold_release = true,
     }
-    table.insert(menu_container, self.search_menu)
     self.search_menu.close_callback = function()
-        UIManager:close(menu_container)
+        UIManager:close(self.search_menu)
         if self.ui.file_chooser then
             self.ui.file_chooser:refreshPath()
         end
     end
-    self.search_menu:switchItemTable(T(_("Search results (%1)"), #results), results)
-    UIManager:show(menu_container)
+    UIManager:show(self.search_menu)
     if self.no_metadata_count ~= 0 then
         self:showSearchResultsMessage()
     end

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -254,7 +254,7 @@ end
 
 function FileSearcher:onMenuSelect(item)
     local file = item.path
-    local dialog
+    local bookinfo, dialog
     local function close_dialog_callback()
         UIManager:close(dialog)
     end
@@ -266,6 +266,7 @@ function FileSearcher:onMenuSelect(item)
     if item.is_file then
         local is_currently_opened = self.ui.document and self.ui.document.file == file
         if DocumentRegistry:hasProvider(file) or DocSettings:hasSidecarFile(file) then
+            bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
             local doc_settings_or_file = is_currently_opened and self.ui.doc_settings or file
             table.insert(buttons, filemanagerutil.genStatusButtonsRow(doc_settings_or_file, close_dialog_callback))
             table.insert(buttons, {}) -- separator
@@ -293,7 +294,7 @@ function FileSearcher:onMenuSelect(item)
                     FileManager:showDeleteFileDialog(file, post_delete_callback)
                 end,
             },
-            filemanagerutil.genBookInformationButton(file, close_dialog_callback),
+            filemanagerutil.genBookInformationButton(file, bookinfo, close_dialog_callback),
         })
     end
     table.insert(buttons, {
@@ -308,8 +309,17 @@ function FileSearcher:onMenuSelect(item)
             end,
         },
     })
+    local title = file
+    if bookinfo then
+        if bookinfo.title then
+            title = title .. "\n\n" .. T(_("Title: %1"), bookinfo.title)
+        end
+        if bookinfo.authors then
+            title = title .. "\n" .. T(_("Authors: %1"), bookinfo.authors:gsub("[\n\t]", "|"))
+        end
+    end
     dialog = ButtonDialog:new{
-        title = file,
+        title = title .. "\n",
         buttons = buttons,
     }
     UIManager:show(dialog)

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -1,6 +1,5 @@
 local ButtonDialog = require("ui/widget/buttondialog")
 local CheckButton = require("ui/widget/checkbutton")
-local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -126,6 +126,8 @@ end
 
 function FileManagerHistory:onMenuHold(item)
     self.histfile_dialog = nil
+    self.bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(item.file)
+
     local function close_dialog_callback()
         UIManager:close(self.histfile_dialog)
     end
@@ -180,11 +182,11 @@ function FileManagerHistory:onMenuHold(item)
     })
     table.insert(buttons, {
         filemanagerutil.genShowFolderButton(item.file, close_dialog_menu_callback, item.dim),
-        filemanagerutil.genBookInformationButton(item.file, close_dialog_callback, item.dim),
+        filemanagerutil.genBookInformationButton(item.file, self.bookinfo, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {
-        filemanagerutil.genBookCoverButton(item.file, close_dialog_callback, item.dim),
-        filemanagerutil.genBookDescriptionButton(item.file, close_dialog_callback, item.dim),
+        filemanagerutil.genBookCoverButton(item.file, self.bookinfo, close_dialog_callback, item.dim),
+        filemanagerutil.genBookDescriptionButton(item.file, self.bookinfo, close_dialog_callback, item.dim),
     })
 
     self.histfile_dialog = ButtonDialog:new{

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -119,14 +119,14 @@ function FileManagerHistory:onMenuChoice(item)
             self.ui:switchDocument(item.file)
         end
     else
-        local ReaderUI = require("apps/reader/readerui")
-        ReaderUI:showReader(item.file)
+        self.ui:openFile(item.file)
     end
 end
 
 function FileManagerHistory:onMenuHold(item)
+    local file = item.file
     self.histfile_dialog = nil
-    self.bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(item.file)
+    self.bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
 
     local function close_dialog_callback()
         UIManager:close(self.histfile_dialog)
@@ -135,7 +135,7 @@ function FileManagerHistory:onMenuHold(item)
         UIManager:close(self.histfile_dialog)
         self._manager.hist_menu.close_callback()
     end
-    local function status_button_callback()
+    local function close_dialog_update_callback()
         UIManager:close(self.histfile_dialog)
         if self._manager.filter ~= "all" then
             self._manager:fetchStatuses(false)
@@ -145,17 +145,17 @@ function FileManagerHistory:onMenuHold(item)
         self._manager:updateItemTable()
         self._manager.files_updated = true -- sidecar folder may be created/deleted
     end
-    local is_currently_opened = item.file == (self.ui.document and self.ui.document.file)
+    local is_currently_opened = file == (self.ui.document and self.ui.document.file)
 
     local buttons = {}
     if not item.dim then
-        local doc_settings_or_file = is_currently_opened and self.ui.doc_settings or item.file
-        table.insert(buttons, filemanagerutil.genStatusButtonsRow(doc_settings_or_file, status_button_callback))
+        local doc_settings_or_file = is_currently_opened and self.ui.doc_settings or file
+        table.insert(buttons, filemanagerutil.genStatusButtonsRow(doc_settings_or_file, close_dialog_update_callback))
         table.insert(buttons, {}) -- separator
     end
     table.insert(buttons, {
-        filemanagerutil.genResetSettingsButton(item.file, status_button_callback, is_currently_opened),
-        filemanagerutil.genAddRemoveFavoritesButton(item.file, close_dialog_callback, item.dim),
+        filemanagerutil.genResetSettingsButton(file, close_dialog_update_callback, is_currently_opened),
+        filemanagerutil.genAddRemoveFavoritesButton(file, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {
         {
@@ -168,7 +168,7 @@ function FileManagerHistory:onMenuHold(item)
                     self._manager.files_updated = true
                 end
                 local FileManager = require("apps/filemanager/filemanager")
-                FileManager:showDeleteFileDialog(item.file, post_delete_callback)
+                FileManager:showDeleteFileDialog(file, post_delete_callback)
             end,
         },
         {
@@ -181,12 +181,12 @@ function FileManagerHistory:onMenuHold(item)
         },
     })
     table.insert(buttons, {
-        filemanagerutil.genShowFolderButton(item.file, close_dialog_menu_callback, item.dim),
-        filemanagerutil.genBookInformationButton(item.file, self.bookinfo, close_dialog_callback, item.dim),
+        filemanagerutil.genShowFolderButton(file, close_dialog_menu_callback, item.dim),
+        filemanagerutil.genBookInformationButton(file, self.bookinfo, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {
-        filemanagerutil.genBookCoverButton(item.file, self.bookinfo, close_dialog_callback, item.dim),
-        filemanagerutil.genBookDescriptionButton(item.file, self.bookinfo, close_dialog_callback, item.dim),
+        filemanagerutil.genBookCoverButton(file, self.bookinfo, close_dialog_callback, item.dim),
+        filemanagerutil.genBookDescriptionButton(file, self.bookinfo, close_dialog_callback, item.dim),
     })
 
     self.histfile_dialog = ButtonDialog:new{

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -276,7 +276,7 @@ function filemanagerutil.genBookCoverButton(file, bookinfo, caller_callback, but
     local has_cover = bookinfo and bookinfo.has_cover
     return {
         text = _("Book cover"),
-        enabled = not button_disabled and (not bookinfo or has_cover) and true or false,
+        enabled = (not button_disabled and (not bookinfo or has_cover)) and true or false,
         callback = function()
             caller_callback()
             local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
@@ -289,7 +289,8 @@ function filemanagerutil.genBookDescriptionButton(file, bookinfo, caller_callbac
     local description = bookinfo and bookinfo.description
     return {
         text = _("Book description"),
-        enabled = not (button_disabled or bookinfo) or description and true or false,
+        -- enabled for deleted books if description is kept in CoverBrowser bookinfo cache
+        enabled = (not (button_disabled or bookinfo) or description) and true or false,
         callback = function()
             caller_callback()
             local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -260,38 +260,40 @@ function filemanagerutil.genShowFolderButton(file, caller_callback, button_disab
     }
 end
 
-function filemanagerutil.genBookInformationButton(file, caller_callback, button_disabled)
+function filemanagerutil.genBookInformationButton(file, bookinfo, caller_callback, button_disabled)
     return {
         text = _("Book information"),
-        id = "book_information", -- used by covermenu
         enabled = not button_disabled,
         callback = function()
             caller_callback()
-            require("apps/filemanager/filemanagerbookinfo"):show(file)
+            local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
+            FileManagerBookInfo:show(file, bookinfo and FileManagerBookInfo.extendProps(bookinfo))
         end,
     }
 end
 
-function filemanagerutil.genBookCoverButton(file, caller_callback, button_disabled)
+function filemanagerutil.genBookCoverButton(file, bookinfo, caller_callback, button_disabled)
+    local has_cover = bookinfo and bookinfo.has_cover
     return {
         text = _("Book cover"),
-        id = "book_cover", -- used by covermenu
-        enabled = not button_disabled,
+        enabled = not button_disabled and (not bookinfo or has_cover) and true or false,
         callback = function()
             caller_callback()
-            require("apps/filemanager/filemanagerbookinfo"):onShowBookCover(file)
+            local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
+            FileManagerBookInfo:onShowBookCover(file)
         end,
     }
 end
 
-function filemanagerutil.genBookDescriptionButton(file, caller_callback, button_disabled)
+function filemanagerutil.genBookDescriptionButton(file, bookinfo, caller_callback, button_disabled)
+    local description = bookinfo and bookinfo.description
     return {
         text = _("Book description"),
-        id = "book_description", -- used by covermenu
-        enabled = not button_disabled,
+        enabled = not (button_disabled or bookinfo) or description and true or false,
         callback = function()
             caller_callback()
-            require("apps/filemanager/filemanagerbookinfo"):onShowBookDescription(nil, file)
+            local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
+            FileManagerBookInfo:onShowBookDescription(description, file)
         end,
     }
 end

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -1,7 +1,6 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local DocSettings = require("docsettings")
-local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local InfoMessage = require("ui/widget/infomessage")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -1,4 +1,5 @@
 local BD = require("ui/bidi")
+local ButtonDialog = require("ui/widget/buttondialog")
 local DocSettings = require("docsettings")
 local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local InfoMessage = require("ui/widget/infomessage")
@@ -232,8 +233,7 @@ function CoverMenu:updateItems(select_number)
     -- we replace it by ours.
     -- (FileManager may replace file_chooser.showFileDialog after we've been called once, so we need
     -- to replace it again if it is not ours)
-    if not self.showFileDialog_ours -- never replaced
-            or self.showFileDialog ~= self.showFileDialog_ours then -- it is no more ours
+    if self.showFileDialog and self.showFileDialog ~= self.showFileDialog_ours then
         -- We need to do it at nextTick, once FileManager has instantiated
         -- its FileChooser completely
         UIManager:nextTick(function()
@@ -248,7 +248,7 @@ function CoverMenu:updateItems(select_number)
                 -- and store it as self.file_dialog, and UIManager:show() it.
                 self.showFileDialog_orig(self, file)
 
-                local bookinfo = BookInfoManager:getBookInfo(file)
+                local bookinfo = self.bookinfo -- getBookInfo(file) called by FileManager
                 if not bookinfo or bookinfo._is_directory then
                     -- If no bookinfo (yet) about this file, or it's a directory, let the original dialog be
                     return true
@@ -292,7 +292,6 @@ function CoverMenu:updateItems(select_number)
                 table.insert(orig_buttons, {
                     { -- Allow a new extraction (multiple interruptions, book replaced)...
                         text = _("Refresh cached book information"),
-                        enabled = bookinfo and true or false,
                         callback = function()
                             -- Wipe the cache
                             self:updateCache(file)
@@ -304,38 +303,11 @@ function CoverMenu:updateItems(select_number)
                 })
 
                 -- Create the new ButtonDialog, and let UIManager show it
-                -- (all button callback fudging must be done after this block to stick)
-                local ButtonDialog = require("ui/widget/buttondialog")
                 self.file_dialog = ButtonDialog:new{
                     title = orig_title,
                     title_align = orig_title_align,
                     buttons = orig_buttons,
                 }
-
-                -- Replace the "Book information" button callback to use directly our bookinfo
-                local button = self.file_dialog:getButtonById("book_information")
-                button.callback = function()
-                    FileManagerBookInfo:show(file, FileManagerBookInfo.extendProps(bookinfo))
-                    UIManager:close(self.file_dialog)
-                end
-
-                button = self.file_dialog:getButtonById("book_cover")
-                if button and not bookinfo.has_cover then
-                    button:disable()
-                end
-
-                button = self.file_dialog:getButtonById("book_description")
-                if button then
-                    if bookinfo.description then
-                        button.callback = function()
-                            UIManager:close(self.file_dialog)
-                            FileManagerBookInfo:onShowBookDescription(bookinfo.description)
-                        end
-                    else
-                        button:disable()
-                    end
-                end
-
                 UIManager:show(self.file_dialog)
                 return true
             end
@@ -355,7 +327,7 @@ function CoverMenu:onHistoryMenuHold(item)
     self.onMenuHold_orig(self, item)
     local file = item.file
 
-    local bookinfo = BookInfoManager:getBookInfo(file)
+    local bookinfo = self.bookinfo -- getBookInfo(file) called by FileManagerHistory
     if not bookinfo then
         -- If no bookinfo (yet) about this file, let the original dialog be
         return true
@@ -398,7 +370,6 @@ function CoverMenu:onHistoryMenuHold(item)
     table.insert(orig_buttons, {
         { -- Allow a new extraction (multiple interruptions, book replaced)...
             text = _("Refresh cached book information"),
-            enabled = bookinfo and true or false,
             callback = function()
                 -- Wipe the cache
                 self:updateCache(file)
@@ -410,38 +381,11 @@ function CoverMenu:onHistoryMenuHold(item)
     })
 
     -- Create the new ButtonDialog, and let UIManager show it
-    -- (all button callback replacement must be done after this block to stick)
-    local ButtonDialog = require("ui/widget/buttondialog")
     self.histfile_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,
         buttons = orig_buttons,
     }
-
-    -- Replace the "Book information" button callback to use directly our bookinfo
-    local button = self.histfile_dialog:getButtonById("book_information")
-    button.callback = function()
-        FileManagerBookInfo:show(file, FileManagerBookInfo.extendProps(bookinfo))
-        UIManager:close(self.histfile_dialog)
-    end
-
-    button = self.histfile_dialog:getButtonById("book_cover")
-    if button and not bookinfo.has_cover then
-        button:disable()
-    end
-
-    button = self.histfile_dialog:getButtonById("book_description")
-    if button then
-        if bookinfo.description then
-            button.callback = function()
-                UIManager:close(self.histfile_dialog)
-                FileManagerBookInfo:onShowBookDescription(bookinfo.description)
-            end
-        else
-            button:disable()
-        end
-    end
-
     UIManager:show(self.histfile_dialog)
     return true
 end
@@ -454,7 +398,7 @@ function CoverMenu:onCollectionsMenuHold(item)
     self.onMenuHold_orig(self, item)
     local file = item.file
 
-    local bookinfo = BookInfoManager:getBookInfo(file)
+    local bookinfo = self.bookinfo -- getBookInfo(file) called by FileManagerCollection
     if not bookinfo then
         -- If no bookinfo (yet) about this file, let the original dialog be
         return true
@@ -497,7 +441,6 @@ function CoverMenu:onCollectionsMenuHold(item)
     table.insert(orig_buttons, {
         { -- Allow a new extraction (multiple interruptions, book replaced)...
             text = _("Refresh cached book information"),
-            enabled = bookinfo and true or false,
             callback = function()
                 -- Wipe the cache
                 self:updateCache(file)
@@ -509,38 +452,11 @@ function CoverMenu:onCollectionsMenuHold(item)
     })
 
     -- Create the new ButtonDialog, and let UIManager show it
-    -- (all button callback replacement must be done after this block to stick)
-    local ButtonDialog = require("ui/widget/buttondialog")
     self.collfile_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,
         buttons = orig_buttons,
     }
-
-    -- Replace the "Book information" button callback to use directly our bookinfo
-    local button = self.collfile_dialog:getButtonById("book_information")
-    button.callback = function()
-        FileManagerBookInfo:show(file, FileManagerBookInfo.extendProps(bookinfo))
-        UIManager:close(self.collfile_dialog)
-    end
-
-    button = self.collfile_dialog:getButtonById("book_cover")
-    if button and not bookinfo.has_cover then
-        button:disable()
-    end
-
-    button = self.collfile_dialog:getButtonById("book_description")
-    if button then
-        if bookinfo.description then
-            button.callback = function()
-                UIManager:close(self.collfile_dialog)
-                FileManagerBookInfo:onShowBookDescription(bookinfo.description)
-            end
-        else
-            button:disable()
-        end
-    end
-
     UIManager:show(self.collfile_dialog)
     return true
 end
@@ -616,7 +532,6 @@ function CoverMenu:tapPlus()
     })
 
     -- Create the new ButtonDialog, and let UIManager show it
-    local ButtonDialog = require("ui/widget/buttondialog")
     self.file_dialog = ButtonDialog:new{
         title = orig_title,
         title_align = orig_title_align,


### PR DESCRIPTION
Getting bookinfo from the cache db is much faster than opening a book, let's use it in Classic mode too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11404)
<!-- Reviewable:end -->
