### PR TITLE
Clear UI leftovers before doing an OTA-install

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -406,8 +406,8 @@ end
 function Device:install()
     local ConfirmBox = require("ui/widget/confirmbox")
     UIManager:show(ConfirmBox:new{
-        text = _("Update is ready. Install it now?"),
-        ok_text = _("Install"),
+        text = _("Update is ready. Install it?"),
+        ok_text = _("Now"),
         ok_callback = function()
             local save_quit = function()
                 self:saveSettings()
@@ -415,6 +415,13 @@ function Device:install()
             end
             UIManager:broadcastEvent(Event:new("Exit", save_quit))
         end,
+        cancel_text = _("Later"),
+        cancel_callback = function()
+            local InfoMessage = require("ui/widget/infomessage")
+            UIManager:show(InfoMessage:new{
+                text = _("The update will be applied the next time KOReader is started."),
+            })
+        end
     })
 end
 

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -405,7 +405,6 @@ end
 
 function Device:install()
     local ConfirmBox = require("ui/widget/confirmbox")
-    local ignore_events = {"swipe", "hold", "hold_release", "hold_pan", "touch", "pan", "pan_release"}
     UIManager:show(ConfirmBox:new{
         text = _("Update is ready. Install it now?"),
         ok_text = _("Install"),
@@ -421,10 +420,10 @@ function Device:install()
             local InfoMessage = require("ui/widget/infomessage")
             UIManager:show(InfoMessage:new{
                 text = _("The update will be applied the next time KOReader is started."),
-                ignore_events = ignore_events,
+                unmovable = true,
             })
         end,
-        ignore_events = ignore_events,
+        unmovable = true,
     })
 end
 

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -405,9 +405,10 @@ end
 
 function Device:install()
     local ConfirmBox = require("ui/widget/confirmbox")
+    local ignore_events = {"swipe", "hold", "hold_release", "hold_pan", "touch", "pan", "pan_release"}
     UIManager:show(ConfirmBox:new{
-        text = _("Update is ready. Install it?"),
-        ok_text = _("Now"),
+        text = _("Update is ready. Install it now?"),
+        ok_text = _("Install"),
         ok_callback = function()
             local save_quit = function()
                 self:saveSettings()
@@ -420,8 +421,10 @@ function Device:install()
             local InfoMessage = require("ui/widget/infomessage")
             UIManager:show(InfoMessage:new{
                 text = _("The update will be applied the next time KOReader is started."),
+                ignore_events = ignore_events,
             })
-        end
+        end,
+        ignore_events = ignore_events,
     })
 end
 

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -168,6 +168,7 @@ function ConfirmBox:init()
     }
     self.movable = MovableContainer:new{
         frame,
+        ignore_events = self.ignore_events,
     }
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),

--- a/frontend/ui/widget/confirmbox.lua
+++ b/frontend/ui/widget/confirmbox.lua
@@ -168,7 +168,7 @@ function ConfirmBox:init()
     }
     self.movable = MovableContainer:new{
         frame,
-        ignore_events = self.ignore_events,
+        unmovable = self.unmovable,
     }
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),

--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -36,6 +36,10 @@ local MovableContainer = InputContainer:extend{
     -- Events to ignore (ie: ignore_events={"hold", "hold_release"})
     ignore_events = nil,
 
+    -- This can be passed if a MovableContainer should be present (as a no-op),
+    -- so we don't need to change the widget layout.
+    unmovable = nil,
+
     -- Initial position can be set related to an existing widget
     -- 'anchor' should be a Geom object (a widget's 'dimen', or a point), and
     -- can be a function returning that object
@@ -59,7 +63,7 @@ local MovableContainer = InputContainer:extend{
 }
 
 function MovableContainer:init()
-    if Device:isTouchDevice() then
+    if Device:isTouchDevice() and not self.unmovable then
         local range = Geom:new{
             x = 0, y = 0,
             w = Screen:getWidth(),

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -169,7 +169,7 @@ function InfoMessage:init()
     }
     self.movable = MovableContainer:new{
         frame,
-        ignore_events = self.ignore_events,
+        unmovable = self.unmovable,
     }
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -169,6 +169,7 @@ function InfoMessage:init()
     }
     self.movable = MovableContainer:new{
         frame,
+        ignore_events = self.ignore_events,
     }
     self[1] = CenterContainer:new{
         dimen = Screen:getSize(),

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -92,6 +92,8 @@ ko_update_check() {
     NEWUPDATE="${KOREADER_DIR}/ota/koreader.updated.tar"
     INSTALLED="${KOREADER_DIR}/ota/koreader.installed.tar"
     if [ -f "${NEWUPDATE}" ]; then
+        # Clear screen to delete UI leftovers
+        ./fbink --cls
         ./fbink -q -y -7 -pmh "Updating KOReader"
         # Setup the FBInk daemon
         export FBINK_NAMED_PIPE="/tmp/koreader.fbink"


### PR DESCRIPTION
This is the logical continuation of #9114.

In #9114 the screen is cleared before downloading an update.

Then (unchanged by this PR) a ConfirmBox to ask for a confirmation of the new update is shown.
... no changes ...
After the successful download the user is asked to finally install the update.

Changes in this PR:
1.) Ask the user explicitly to update now or later. (No change in functionality,but only in texting, as later could have been selected by tapping outside the dialog before).
2.) Clear the screen before update, so that the user does only see whats happening (and not fragments of the book)..

Draft because: Does anybody know an easy solution to prevent the ConfirmBox to be movable (because moving it, shows some fragments of theold book's text)?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11412)
<!-- Reviewable:end -->
