### PR TITLE
Minimize DocSettings:open() calls

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -269,18 +269,18 @@ function FileManager:setupLayout()
         }
 
         if is_file then
-            self.bookinfo = nil
+            self.book_props = nil -- in 'self' to provide access to it in CoverBrowser
             local has_provider = DocumentRegistry:hasProvider(file)
             local has_sidecar = DocSettings:hasSidecarFile(file)
             if has_provider or has_sidecar then
-                self.bookinfo = file_manager.coverbrowser and file_manager.coverbrowser:getBookInfo(file)
+                self.book_props = file_manager.coverbrowser and file_manager.coverbrowser:getBookInfo(file)
                 local doc_settings_or_file
                 if has_sidecar then
                     doc_settings_or_file = DocSettings:open(file)
-                    if not self.bookinfo then
+                    if not self.book_props then
                         local props = doc_settings_or_file:readSetting("doc_props")
-                        self.bookinfo = FileManagerBookInfo.extendProps(props, file)
-                        self.bookinfo.has_cover = true -- to enable "Book cover" button, we do not know if cover exists
+                        self.book_props = FileManagerBookInfo.extendProps(props, file)
+                        self.book_props.has_cover = true -- to enable "Book cover" button, we do not know if cover exists
                     end
                 else
                     doc_settings_or_file = file
@@ -300,12 +300,12 @@ function FileManager:setupLayout()
                         file_manager:showOpenWithDialog(file)
                     end,
                 },
-                filemanagerutil.genBookInformationButton(file, self.bookinfo, close_dialog_callback),
+                filemanagerutil.genBookInformationButton(file, self.book_props, close_dialog_callback),
             })
             if has_provider then
                 table.insert(buttons, {
-                    filemanagerutil.genBookCoverButton(file, self.bookinfo, close_dialog_callback),
-                    filemanagerutil.genBookDescriptionButton(file, self.bookinfo, close_dialog_callback),
+                    filemanagerutil.genBookCoverButton(file, self.book_props, close_dialog_callback),
+                    filemanagerutil.genBookDescriptionButton(file, self.book_props, close_dialog_callback),
                 })
             end
             if Device:canExecuteScript(file) then

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -51,7 +51,7 @@ end
 function FileManagerCollection:onMenuHold(item)
     local file = item.file
     self.collfile_dialog = nil
-    self.bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
+    self.book_props = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
 
     local function close_dialog_callback()
         UIManager:close(self.collfile_dialog)
@@ -71,17 +71,17 @@ function FileManagerCollection:onMenuHold(item)
     local doc_settings_or_file
     if is_currently_opened then
         doc_settings_or_file = self.ui.doc_settings
-        if not self.bookinfo then
-            self.bookinfo = self.ui.doc_props
-            self.bookinfo.has_cover = true
+        if not self.book_props then
+            self.book_props = self.ui.doc_props
+            self.book_props.has_cover = true
         end
     else
         if DocSettings:hasSidecarFile(file) then
             doc_settings_or_file = DocSettings:open(file)
-            if not self.bookinfo then
+            if not self.book_props then
                 local props = doc_settings_or_file:readSetting("doc_props")
-                self.bookinfo = FileManagerBookInfo.extendProps(props, file)
-                self.bookinfo.has_cover = true
+                self.book_props = FileManagerBookInfo.extendProps(props, file)
+                self.book_props.has_cover = true
             end
         else
             doc_settings_or_file = file
@@ -102,11 +102,11 @@ function FileManagerCollection:onMenuHold(item)
     })
     table.insert(buttons, {
         filemanagerutil.genShowFolderButton(file, close_dialog_menu_callback),
-        filemanagerutil.genBookInformationButton(file, self.bookinfo, close_dialog_callback),
+        filemanagerutil.genBookInformationButton(file, self.book_props, close_dialog_callback),
     })
     table.insert(buttons, {
-        filemanagerutil.genBookCoverButton(file, self.bookinfo, close_dialog_callback),
-        filemanagerutil.genBookDescriptionButton(file, self.bookinfo, close_dialog_callback),
+        filemanagerutil.genBookCoverButton(file, self.book_props, close_dialog_callback),
+        filemanagerutil.genBookDescriptionButton(file, self.book_props, close_dialog_callback),
     })
 
     if Device:canExecuteScript(file) then

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -2,6 +2,8 @@ local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local CheckButton = require("ui/widget/checkbutton")
 local ConfirmBox = require("ui/widget/confirmbox")
+local DocSettings = require("docsettings")
+local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
 local InputDialog = require("ui/widget/inputdialog")
 local Menu = require("ui/widget/menu")
 local UIManager = require("ui/uimanager")
@@ -62,32 +64,25 @@ function FileManagerHistory:fetchStatuses(count)
 end
 
 function FileManagerHistory:updateItemTable()
-    -- try to stay on current page
-    local select_number = nil
-    if self.hist_menu.page and self.hist_menu.perpage and self.hist_menu.page > 0 then
-        select_number = (self.hist_menu.page - 1) * self.hist_menu.perpage + 1
-    end
     self.count = { all = #require("readhistory").hist,
         reading = 0, abandoned = 0, complete = 0, deleted = 0, new = 0, }
     local item_table = {}
     for _, v in ipairs(require("readhistory").hist) do
         if self:isItemMatch(v) then
-            if self.is_frozen and v.status == "complete" then
-                v.mandatory_dim = true
-            end
+            v.mandatory_dim = (self.is_frozen and v.status == "complete") and true or nil
             table.insert(item_table, v)
         end
         if self.statuses_fetched then
             self.count[v.status] = self.count[v.status] + 1
         end
     end
-    local subtitle
+    local subtitle = ""
     if self.search_string then
         subtitle = T(_("Search results (%1)"), #item_table)
     elseif self.filter ~= "all" then
         subtitle = T(_("Status: %1 (%2)"), filter_text[self.filter]:lower(), #item_table)
     end
-    self.hist_menu:switchItemTable(nil, item_table, select_number, nil, subtitle or "")
+    self.hist_menu:switchItemTable(nil, item_table, -1, nil, subtitle)
 end
 
 function FileManagerHistory:isItemMatch(item)
@@ -137,7 +132,7 @@ function FileManagerHistory:onMenuHold(item)
     end
     local function close_dialog_update_callback()
         UIManager:close(self.histfile_dialog)
-        if self._manager.filter ~= "all" then
+        if self._manager.filter ~= "all" or self._manager.is_frozen then
             self._manager:fetchStatuses(false)
         else
             self._manager.statuses_fetched = false
@@ -148,13 +143,31 @@ function FileManagerHistory:onMenuHold(item)
     local is_currently_opened = file == (self.ui.document and self.ui.document.file)
 
     local buttons = {}
+    local doc_settings_or_file
+    if is_currently_opened then
+        doc_settings_or_file = self.ui.doc_settings
+        if not self.bookinfo then
+            self.bookinfo = self.ui.doc_props
+            self.bookinfo.has_cover = true
+        end
+    else
+        if DocSettings:hasSidecarFile(file) then
+            doc_settings_or_file = DocSettings:open(file)
+            if not self.bookinfo then
+                local props = doc_settings_or_file:readSetting("doc_props")
+                self.bookinfo = FileManagerBookInfo.extendProps(props, file)
+                self.bookinfo.has_cover = true
+            end
+        else
+            doc_settings_or_file = file
+        end
+    end
     if not item.dim then
-        local doc_settings_or_file = is_currently_opened and self.ui.doc_settings or file
         table.insert(buttons, filemanagerutil.genStatusButtonsRow(doc_settings_or_file, close_dialog_update_callback))
         table.insert(buttons, {}) -- separator
     end
     table.insert(buttons, {
-        filemanagerutil.genResetSettingsButton(file, close_dialog_update_callback, is_currently_opened),
+        filemanagerutil.genResetSettingsButton(doc_settings_or_file, close_dialog_update_callback, is_currently_opened),
         filemanagerutil.genAddRemoveFavoritesButton(file, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -121,7 +121,7 @@ end
 function FileManagerHistory:onMenuHold(item)
     local file = item.file
     self.histfile_dialog = nil
-    self.bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
+    self.book_props = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
 
     local function close_dialog_callback()
         UIManager:close(self.histfile_dialog)
@@ -146,17 +146,17 @@ function FileManagerHistory:onMenuHold(item)
     local doc_settings_or_file
     if is_currently_opened then
         doc_settings_or_file = self.ui.doc_settings
-        if not self.bookinfo then
-            self.bookinfo = self.ui.doc_props
-            self.bookinfo.has_cover = true
+        if not self.book_props then
+            self.book_props = self.ui.doc_props
+            self.book_props.has_cover = true
         end
     else
         if DocSettings:hasSidecarFile(file) then
             doc_settings_or_file = DocSettings:open(file)
-            if not self.bookinfo then
+            if not self.book_props then
                 local props = doc_settings_or_file:readSetting("doc_props")
-                self.bookinfo = FileManagerBookInfo.extendProps(props, file)
-                self.bookinfo.has_cover = true
+                self.book_props = FileManagerBookInfo.extendProps(props, file)
+                self.book_props.has_cover = true
             end
         else
             doc_settings_or_file = file
@@ -195,11 +195,11 @@ function FileManagerHistory:onMenuHold(item)
     })
     table.insert(buttons, {
         filemanagerutil.genShowFolderButton(file, close_dialog_menu_callback, item.dim),
-        filemanagerutil.genBookInformationButton(file, self.bookinfo, close_dialog_callback, item.dim),
+        filemanagerutil.genBookInformationButton(file, self.book_props, close_dialog_callback, item.dim),
     })
     table.insert(buttons, {
-        filemanagerutil.genBookCoverButton(file, self.bookinfo, close_dialog_callback, item.dim),
-        filemanagerutil.genBookDescriptionButton(file, self.bookinfo, close_dialog_callback, item.dim),
+        filemanagerutil.genBookCoverButton(file, self.book_props, close_dialog_callback, item.dim),
+        filemanagerutil.genBookDescriptionButton(file, self.book_props, close_dialog_callback, item.dim),
     })
 
     self.histfile_dialog = ButtonDialog:new{

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -272,23 +272,23 @@ function filemanagerutil.genShowFolderButton(file, caller_callback, button_disab
     }
 end
 
-function filemanagerutil.genBookInformationButton(file, bookinfo, caller_callback, button_disabled)
+function filemanagerutil.genBookInformationButton(file, book_props, caller_callback, button_disabled)
     return {
         text = _("Book information"),
         enabled = not button_disabled,
         callback = function()
             caller_callback()
             local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
-            FileManagerBookInfo:show(file, bookinfo and FileManagerBookInfo.extendProps(bookinfo))
+            FileManagerBookInfo:show(file, book_props and FileManagerBookInfo.extendProps(book_props))
         end,
     }
 end
 
-function filemanagerutil.genBookCoverButton(file, bookinfo, caller_callback, button_disabled)
-    local has_cover = bookinfo and bookinfo.has_cover
+function filemanagerutil.genBookCoverButton(file, book_props, caller_callback, button_disabled)
+    local has_cover = book_props and book_props.has_cover
     return {
         text = _("Book cover"),
-        enabled = (not button_disabled and (not bookinfo or has_cover)) and true or false,
+        enabled = (not button_disabled and (not book_props or has_cover)) and true or false,
         callback = function()
             caller_callback()
             local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
@@ -297,12 +297,12 @@ function filemanagerutil.genBookCoverButton(file, bookinfo, caller_callback, but
     }
 end
 
-function filemanagerutil.genBookDescriptionButton(file, bookinfo, caller_callback, button_disabled)
-    local description = bookinfo and bookinfo.description
+function filemanagerutil.genBookDescriptionButton(file, book_props, caller_callback, button_disabled)
+    local description = book_props and book_props.description
     return {
         text = _("Book description"),
         -- enabled for deleted books if description is kept in CoverBrowser bookinfo cache
-        enabled = (not (button_disabled or bookinfo) or description) and true or false,
+        enabled = (not (button_disabled or book_props) or description) and true or false,
         callback = function()
             caller_callback()
             local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -470,20 +470,21 @@ function ReaderUI:init()
     -- And have an extended and customized copy in memory for quick access.
     self.doc_props = FileManagerBookInfo.extendProps(props, self.document.file)
 
-    -- Set "reading" status if there is no status.
-    local summary = self.doc_settings:readSetting("summary", {})
-    if summary.status == nil then
-        summary.status = "reading"
-        summary.modified = os.date("%Y-%m-%d", os.time())
-    end
-
     local md5 = self.doc_settings:readSetting("partial_md5_checksum")
     if md5 == nil then
         md5 = util.partialMD5(self.document.file)
         self.doc_settings:saveSetting("partial_md5_checksum", md5)
     end
 
-    require("readhistory"):addItem(self.document.file) -- (will update "lastfile")
+    local summary = self.doc_settings:readSetting("summary", {})
+    if summary.status == nil then
+        summary.status = "reading"
+        summary.modified = os.date("%Y-%m-%d", os.time())
+    end
+
+    if summary.status ~= "complete" or not G_reader_settings:isTrue("history_freeze_finished_books") then
+        require("readhistory"):addItem(self.document.file) -- (will update "lastfile")
+    end
 
     -- After initialisation notify that document is loaded and rendered
     -- CREngine only reports correct page count after rendering is done

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -86,14 +86,15 @@ end
 
 --- Returns the preferred registered document handler or fallback provider.
 -- @string file
+-- @bool include_aux include auxiliary (non-document) providers
 -- @treturn table provider
-function DocumentRegistry:getProvider(file)
+function DocumentRegistry:getProvider(file, include_aux)
     local providers = self:getProviders(file)
-    if providers then
+    if providers or include_aux then
         -- associated provider
         local provider_key = DocumentRegistry:getAssociatedProviderKey(file)
         local provider = provider_key and self.known_providers[provider_key]
-        if provider and not provider.order then -- excluding auxiliary
+        if provider and (not provider.order or include_aux) then -- excluding auxiliary by default
             return provider
         end
         -- highest weighted provider

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -247,7 +247,7 @@ function CoverMenu:updateItems(select_number)
                 -- and store it as self.file_dialog, and UIManager:show() it.
                 self.showFileDialog_orig(self, file)
 
-                local bookinfo = self.bookinfo -- getBookInfo(file) called by FileManager
+                local bookinfo = self.book_props -- getBookInfo(file) called by FileManager
                 if not bookinfo or bookinfo._is_directory then
                     -- If no bookinfo (yet) about this file, or it's a directory, let the original dialog be
                     return true
@@ -326,7 +326,7 @@ function CoverMenu:onHistoryMenuHold(item)
     self.onMenuHold_orig(self, item)
     local file = item.file
 
-    local bookinfo = self.bookinfo -- getBookInfo(file) called by FileManagerHistory
+    local bookinfo = self.book_props -- getBookInfo(file) called by FileManagerHistory
     if not bookinfo then
         -- If no bookinfo (yet) about this file, let the original dialog be
         return true
@@ -397,7 +397,7 @@ function CoverMenu:onCollectionsMenuHold(item)
     self.onMenuHold_orig(self, item)
     local file = item.file
 
-    local bookinfo = self.bookinfo -- getBookInfo(file) called by FileManagerCollection
+    local bookinfo = self.book_props -- getBookInfo(file) called by FileManagerCollection
     if not bookinfo then
         -- If no bookinfo (yet) about this file, let the original dialog be
         return true


### PR DESCRIPTION
Recently added features (status buttons in file popup dialogs, aux providers support, frozen history for finished books) caused extra `DocSettings:open()` calls. Opening a book from the file browser gives 4 calls, popup file dialog gives 3 calls.
With this PR the number of calls is reduced: 2 calls while opening a book (that is the required minimum), 1 call for the popup dialog in FM, Hist, Coll.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11437)
<!-- Reviewable:end -->
