### PR TITLE
make auto crop default be page content

### DIFF
--- a/frontend/apps/reader/modules/readercropping.lua
+++ b/frontend/apps/reader/modules/readercropping.lua
@@ -21,8 +21,6 @@ function ReaderCropping:onPageCrop(mode)
     -- backup original zoom mode as cropping use "page" zoom mode
     self.orig_zoom_mode = self.view.zoom_mode
     if mode == "auto" then
-        --- @fixme: This is weird. "auto" crop happens to be the default, yet the default zoom mode/genus is "page", not "content".
-        ---         This effectively yields different results whether auto is enabled by default, or toggled at runtime...
         if self.document.configurable.text_wrap ~= 1 then
             self:setCropZoomMode(true)
         end

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -238,7 +238,7 @@ function ReaderZooming:onReadSettings(config)
         -- Validate it
         zoom_mode = self.zoom_mode_label[zoom_mode] and zoom_mode or self.DEFAULT_ZOOM_MODE
     end
-    
+
     -- Import legacy zoom_factor settings
     if config:has("zoom_factor") and config:hasNot("kopt_zoom_factor") then
         config:saveSetting("kopt_zoom_factor", config:readSetting("zoom_factor"))

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -240,6 +240,12 @@ function ReaderZooming:onReadSettings(config)
         zoom_mode = self.zoom_mode_label[zoom_mode] and zoom_mode or self.DEFAULT_ZOOM_MODE
     end
 
+    -- auto crop needs to be page content
+    local trim_page = config:readSetting("kopt_trim_page")
+                             or G_reader_settings:readSetting("kopt_trim_page") or G_defaults:readSetting("DKOPTREADER_CONFIG_TRIM_PAGE")
+    local temp_zoom_mode = zoom_mode:match("page(.*)")
+    zoom_mode = trim_page == 1 and temp_zoom_mode and "content"..temp_zoom_mode or zoom_mode
+
     -- Import legacy zoom_factor settings
     if config:has("zoom_factor") and config:hasNot("kopt_zoom_factor") then
         config:saveSetting("kopt_zoom_factor", config:readSetting("zoom_factor"))

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -230,23 +230,15 @@ function ReaderZooming:onReadSettings(config)
         -- Otherwise, build it from the split genus & type settings
         local zoom_mode_genus = config:readSetting("kopt_zoom_mode_genus")
                              or G_reader_settings:readSetting("kopt_zoom_mode_genus")
+                             or 3 -- autocrop is default then pagewidth will be the default as well
         local zoom_mode_type = config:readSetting("kopt_zoom_mode_type")
                             or G_reader_settings:readSetting("kopt_zoom_mode_type")
-        if zoom_mode_genus or zoom_mode_type then
-            zoom_mode = self:combo_to_mode(zoom_mode_genus, zoom_mode_type)
-        end
+        zoom_mode = self:combo_to_mode(zoom_mode_genus, zoom_mode_type)
 
         -- Validate it
         zoom_mode = self.zoom_mode_label[zoom_mode] and zoom_mode or self.DEFAULT_ZOOM_MODE
     end
-
-    -- auto crop needs to be page content
-    local trim_page = config:readSetting("kopt_trim_page")
-                             or G_reader_settings:readSetting("kopt_trim_page")
-                             or G_defaults:readSetting("DKOPTREADER_CONFIG_TRIM_PAGE")
-    local temp_zoom_mode = zoom_mode:match("page(.*)")
-    zoom_mode = trim_page == 1 and temp_zoom_mode and "content"..temp_zoom_mode or zoom_mode
-
+    
     -- Import legacy zoom_factor settings
     if config:has("zoom_factor") and config:hasNot("kopt_zoom_factor") then
         config:saveSetting("kopt_zoom_factor", config:readSetting("zoom_factor"))

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -242,7 +242,8 @@ function ReaderZooming:onReadSettings(config)
 
     -- auto crop needs to be page content
     local trim_page = config:readSetting("kopt_trim_page")
-                             or G_reader_settings:readSetting("kopt_trim_page") or G_defaults:readSetting("DKOPTREADER_CONFIG_TRIM_PAGE")
+                             or G_reader_settings:readSetting("kopt_trim_page")
+                             or G_defaults:readSetting("DKOPTREADER_CONFIG_TRIM_PAGE")
     local temp_zoom_mode = zoom_mode:match("page(.*)")
     zoom_mode = trim_page == 1 and temp_zoom_mode and "content"..temp_zoom_mode or zoom_mode
 

--- a/spec/unit/readerhighlight_spec.lua
+++ b/spec/unit/readerhighlight_spec.lua
@@ -231,6 +231,7 @@ describe("Readerhighlight module", function()
                 document = DocumentRegistry:openDocument(sample_pdf),
                 _testsuite = true,
             }
+            readerui.document.configurable.trim_page = 3
             readerui:handleEvent(Event:new("SetScrollMode", true))
         end)
         teardown(function()


### PR DESCRIPTION
Based on:

```
function ReaderCropping:setCropZoomMode(confirmed)
    if confirmed then
        -- if original zoom mode is "page???", set zoom mode to "content???"
        local zoom_mode_type = self.orig_zoom_mode:match("page(.*)")
        self:setZoomMode(zoom_mode_type
                    and "content"..zoom_mode_type
                    or self.orig_zoom_mode)
        self.ui:handleEvent(Event:new("InitScrollPageStates"))
    else
        self:setZoomMode(self.orig_zoom_mode)
    end
end
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11438)
<!-- Reviewable:end -->
