### PR TITLE
Kindle oasis has no ambient brightness sensor

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -560,7 +560,6 @@ local KindleOasis = Kindle:extend{
     model = "KindleOasis",
     isTouchDevice = yes,
     hasFrontlight = yes,
-    hasLightSensor = yes,
     hasKeys = yes,
     hasGSensor = yes,
     display_dpi = 300,


### PR DESCRIPTION
I did not notice an ambient brightness sensor, nor adaptive brightness feature. (Ref: https://www.geekwire.com/2016/kindle-oasis-review-amazons-premium-e-reader-use-premium-features/)

Was it previously wrongly configured?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11456)
<!-- Reviewable:end -->
