### PR TITLE
ReaderBookmark: save bookmark page string

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1492,9 +1492,9 @@ function ReaderBookmark:updatePageStrings()
         local text, type = unpack(v)
         local enabled = true
         if type == "nonlinear" then
-            enabled = self.ui.rolling and self.ui.document:hasHiddenFlows()
+            enabled = (self.ui.rolling and self.ui.document:hasHiddenFlows()) and true or false
         elseif type == "label" then
-            enabled = self.ui.rolling and self.ui.pagemap and self.ui.pagemap:wantsPageLabels()
+            enabled = (self.ui.rolling and self.ui.pagemap and self.ui.pagemap:wantsPageLabels()) and true or false
         end
         table.insert(radio_buttons, {
             {

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -266,6 +266,9 @@ function MyClipping:parseHighlight(highlights, bookmarks, book)
                             clipping.note = bookmark_quote or bookmark.text
                         end
                     end
+                    if bookmark.page_string then
+                        clipping.page = bookmark.page_string
+                    end
                     bookmark_found = true
                     break
                 end


### PR DESCRIPTION
Bookmark page numbers for reflowable documents are not actual page numbers but some strings useless for users.
Exporter plugin and external programs that deal with our bookmarks (like KOHighlights) cannot get correct bookmark page number if a document layout has been changed.

This PR allows **manual** updating the page numbers and saving them to the book sdr file in bookmark property `page_string`.
Exporter plugin takes this string if it exists and put it as "page" in export results.
External programs can add support of it if they will.

Please note that we do not maintain this property **automatically**. Newly created bookmarks do not have it.

![1](https://github.com/koreader/koreader/assets/62179190/4fc3dbe8-ecad-4d74-82fb-870a9eb646cf)

![2](https://github.com/koreader/koreader/assets/62179190/f04e411b-38ec-474f-b5b4-81167a351877)

Pinging developers and heavy highlighters @noembryo, @isosphere, @mergen3107, @offset-torque, @ichnilatis-gr.
Is this feature useful?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11464)
<!-- Reviewable:end -->
