### PR TITLE
bump crengine: text selection and footnotes fixes and tweaks 

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1058,7 +1058,9 @@ function ReaderLink:onGoToPageLink(ges, internal_links_only, max_distance)
         for _, link in ipairs(links) do
             -- link.uri may be an empty string with some invalid links: ignore them
             if link.section or (link.uri and link.uri ~= "") then
-                if link.segments then
+                -- Note: we may get segments empty in some conditions (in which
+                -- case we'll fallback to the 'else' branch and using x/y)
+                if link.segments and #link.segments > 0 then
                     -- With segments, each is a horizontal segment, with start_x < end_x,
                     -- and we should compute the distance from gesture position to
                     -- each segment.

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -965,6 +965,8 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
 .footnote, .footnotes, .fn,
 .note, .note1, .note2, .note3,
 .ntb, .ntb-txt, .ntb-txt-j,
+.fnote, .fnote1,
+.duokan-footnote-item, /* Common chinese books */
 .przypis, .przypis1, /* Polish footnotes */
 .voetnoten /* Dutch footnotes */
 {
@@ -1114,6 +1116,21 @@ If the footnote text uses variable or absolute font sizes, line height or vertic
         font-size: inherit !important;
         line-height: inherit !important;
         vertical-align: inherit !important;
+}
+                ]],
+            },
+            {
+                id = "inpage_footnote_combine_non_linear",
+                title = _("Combine footnotes in a non-linear flow"),
+                description = _([[
+This will mark each section of consecutive footnotes (at their original location in the book) as being non-linear.
+The menu checkbox "Hide non-linear fragments" will then be available after the document is reopened, allowing to hide these sections from the regular flow: they will be skipped when turning pages and not considered in the various book & chapter progress and time to read features.]]),
+                priority = 6,
+                css = [[
+*, autoBoxing {
+    -cr-hint: late;
+    -cr-only-if: inpage-footnote;
+        -cr-hint: non-linear-combining;
 }
                 ]],
             },

--- a/plugins/httpinspector.koplugin/main.lua
+++ b/plugins/httpinspector.koplugin/main.lua
@@ -1,7 +1,5 @@
---[[--
-This plugin allows for inspecting KOReader's internal objects,
-calling methods, sending events... over HTTP.
---]]--
+-- This plugin allows for inspecting KOReader's internal objects,
+-- calling methods, sending events... over HTTP.
 
 local DataStorage = require("datastorage")
 local Device =  require("device")


### PR DESCRIPTION
#### Fix docs CI failing after previous commit

See https://github.com/koreader/koreader/pull/11457#issuecomment-1948237158

#### bump crengine: text selection and footnotes fixes and tweaks

Includes https://github.com/koreader/koreader-base/pull/1737 and https://github.com/koreader/crengine/pull/554 : 
- `LvDocView`: allow setting custom title/authors/series
- `elementFromPoint()`: fix possible crash when float at end of document
  Closes #11409.
- Non-linear fragments: fix generic handling on erm_final
  Noticed around https://github.com/koreader/koreader/issues/10193#issuecomment-1915204376.
- `DrawBorder`: fix bottom border inset/outset drawing
- `getSegmentRects()`: allow segments to include images
  Closes #11451.
- `getRangeText()`: allow gathering images
- Allow standalone image in link to trigger in-page footnotes
  Closes #11451.
- `ldomDocument::render()`: avoid uneeded deserialization on each page turn
- lvtinydom: add `ldomNode::getAllInnerAttributeValues()`
- `LVFootNote`: avoid retrieving internal CompactArray object
- In-page footnotes: allows for multiple `id=` inside them
  Problem met in a few koreader issues, latest one at https://github.com/koreader/koreader/issues/11411#issuecomment-1925925214.

cre.cpp:
- rename `overrideDocumentProp()` to `setAltDocumentProp()`
Will help #11463 to do it stuff more properly.
- `isLinkToFootnote()`: handle image-only links
 Closes #11451
- text selection functions: add includeImages param
 Should help going forward with #11460.

#### Style tweaks: add inpage foootnote classnames and a tweak

Suggested around https://github.com/koreader/koreader/issues/10193#issuecomment-1913713671 and https://github.com/koreader/koreader/issues/11451#issuecomment-1937431353.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11468)
<!-- Reviewable:end -->
