### PR TITLE
FileChooser: "percent - unopened - finished last" consider status "complete" as 100%

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -237,7 +237,7 @@ local FileChooser = Menu:extend{
                     local summary = doc_settings:readSetting("summary")
 
                     -- books marked as "finished" should be considered the same as 100%
-                    if summary.status == "complete" then
+                    if summary and summary.status == "complete" then
                         item.percent_finished = 1.0
                         return
                     end

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -233,7 +233,6 @@ local FileChooser = Menu:extend{
                 item.opened = DocSettings:hasSidecarFile(item.path)
                 if item.opened then
                     local doc_settings = DocSettings:open(item.path)
-                    percent_finished = doc_settings:readSetting("percent_finished")
                     local summary = doc_settings:readSetting("summary")
 
                     -- books marked as "finished" should be considered the same as 100%
@@ -241,6 +240,8 @@ local FileChooser = Menu:extend{
                         item.percent_finished = 1.0
                         return
                     end
+
+                    percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers
                 item.percent_finished = math.floor((percent_finished or -1) * 100) / 100

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -207,7 +207,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% > unopened > 100%
+            -- sort 90% > 50% > 0% > unopened > 100% or finished
             text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -234,6 +234,13 @@ local FileChooser = Menu:extend{
                 if item.opened then
                     local doc_settings = DocSettings:open(item.path)
                     percent_finished = doc_settings:readSetting("percent_finished")
+                    local summary = doc_settings:readSetting("summary")
+
+                    -- books marked as "finished" should be considered the same as 100%
+                    if summary.status == "complete" then
+                        item.percent_finished = 1.0
+                        return
+                    end
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers
                 item.percent_finished = math.floor((percent_finished or -1) * 100) / 100


### PR DESCRIPTION
This PR adds onto the new filechooser sort `percent - unopened - finished last` to consider book status `complete` (Text: `Finished`) the same as 100%

re #11369

> `90% > 50% > 0% > unopened > 100% or finished`

https://github.com/koreader/koreader/pull/11369#issuecomment-1893897867

PS: it seems like the macos build is failing, but i do not see why

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11472)
<!-- Reviewable:end -->
