### PR TITLE
FileManager: less lfs calls when selecting files

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1,7 +1,6 @@
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonDialog = require("ui/widget/buttondialog")
-local CenterContainer = require("ui/widget/container/centercontainer")
 local CheckButton = require("ui/widget/checkbutton")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -571,7 +571,7 @@ function FileChooser:onMenuSelect(item)
     -- parent directory of dir without permission get nil mode
     -- we need to change to parent path in this case
     if item.is_file then
-        self:onFileSelect(item.path)
+        self:onFileSelect(item)
     else
         self:changeToPath(item.path, item.is_go_up and self.path)
     end
@@ -583,7 +583,7 @@ function FileChooser:onMenuHold(item)
     return true
 end
 
-function FileChooser:onFileSelect(file)
+function FileChooser:onFileSelect(item)
     UIManager:close(self)
     return true
 end
@@ -620,12 +620,18 @@ end
 
 -- Used in file manager select mode to select all files in a folder,
 -- that are visible in all file browser pages, without subfolders.
-function FileChooser:selectAllFilesInFolder()
+function FileChooser:selectAllFilesInFolder(do_select)
     for _, item in ipairs(self.item_table) do
         if item.is_file then
-            self.filemanager.selected_files[item.path] = true
+            if do_select then
+                self.filemanager.selected_files[item.path] = true
+                item.dim = true
+            else
+                item.dim = nil
+            end
         end
     end
+    self:updateItems()
 end
 
 return FileChooser


### PR DESCRIPTION
Fix my old bad code to avoid rescanning the storage and rebuilding the item table when selecting/deselecting files.
Just dim/undim the items instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11476)
<!-- Reviewable:end -->
