### PR TITLE
Reader: use existing module instances on start

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -273,7 +273,7 @@ else
         if start_with == "history" then
             FileManager.instance.history:onShowHist()
         elseif start_with == "favorites" then
-            FileManager.instance.collections:onShowColl("favorites")
+            FileManager.instance.collections:onShowColl()
         elseif start_with == "folder_shortcuts" then
             FileManager.instance.folder_shortcuts:onShowFolderShortcutsDialog()
         end

--- a/reader.lua
+++ b/reader.lua
@@ -271,20 +271,11 @@ else
         -- Always open FM modules on top of filemanager, so closing 'em doesn't result in an exit
         -- because of an empty widget stack, and so they can interact with the FM instance as expected.
         if start_with == "history" then
-            local FileManagerHistory = require("apps/filemanager/filemanagerhistory")
-            FileManagerHistory:new{
-                ui = FileManager.instance,
-            }:onShowHist()
+            FileManager.instance.history:onShowHist()
         elseif start_with == "favorites" then
-            local FileManagerCollection = require("apps/filemanager/filemanagercollection")
-            FileManagerCollection:new{
-                ui = FileManager.instance,
-            }:onShowColl("favorites")
+            FileManager.instance.collections:onShowColl("favorites")
         elseif start_with == "folder_shortcuts" then
-            local FileManagerShortcuts = require("apps/filemanager/filemanagershortcuts")
-            FileManagerShortcuts:new{
-                ui = FileManager.instance,
-            }:onShowFolderShortcutsDialog()
+            FileManager.instance.folder_shortcuts:onShowFolderShortcutsDialog()
         end
         exit_code = UIManager:run()
     end


### PR DESCRIPTION
Fixes https://github.com/koreader/koreader/pull/11360#issuecomment-1960141453.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11485)
<!-- Reviewable:end -->
