### PR TITLE
Fallback onto first image if no cover is found

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -366,7 +366,7 @@ function BookInfo:getCoverImage(doc, file, force_orig)
     end
     if doc then
         cover_bb = doc:getCoverPageImage()
-        if not cover_bb and doc.loadDocument then -- try falling back to first page image
+        if not cover_bb and doc.loadDocument and G_reader_settings:readSetting("cover_fallback") then
             local img_pos = Geom:new{x = 50, y = 50}
             doc:gotoPage(0)
             doc._document:loadDocument(doc.file, false)

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -3,6 +3,7 @@ This module provides a way to display book information (filename and book metada
 ]]
 
 local BD = require("ui/bidi")
+local Geom = require("ui/geometry")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
@@ -365,6 +366,13 @@ function BookInfo:getCoverImage(doc, file, force_orig)
     end
     if doc then
         cover_bb = doc:getCoverPageImage()
+        if not cover_bb and doc.loadDocument then -- try falling back to first page image
+            local img_pos = Geom:new{x = 50, y = 50}
+            doc:gotoPage(0)
+            doc._document:loadDocument(doc.file, false)
+            doc:render()
+            cover_bb = doc:getImageFromPosition(img_pos, true, false)
+        end
         if not is_doc then
             doc:close()
         end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -168,6 +168,11 @@ function FileManagerMenu:setUpdateItemTable()
                 separator = true,
             },
             {
+                text = _("Use cover fallback image"),
+                checked_func = function() return G_reader_settings:readSetting("cover_fallback") end,
+                callback = function() FileChooser:toggleCoverFallback() end,
+            },
+            {
                 text = _("Classic mode settings"),
                 sub_item_table = {
                     {

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -24,6 +24,7 @@ local FileChooser = Menu:extend{
     show_finished    = G_reader_settings:readSetting("show_finished", true), -- books marked as finished
     show_hidden      = G_reader_settings:readSetting("show_hidden", false), -- folders/files starting with "."
     show_unsupported = G_reader_settings:readSetting("show_unsupported", false), -- set to true to ignore file_filter
+    cover_fallback = G_reader_settings:readSetting("cover_fallback", false), -- set to true to use first image as cover fallback
     file_filter = nil, -- function defined in the caller, returns true for files to be shown
     -- NOTE: Input is *always* a relative entry name
     exclude_dirs = { -- const
@@ -564,6 +565,12 @@ function FileChooser:toggleShowFilesMode(mode)
     -- modes: "show_finished", "show_hidden", "show_unsupported"
     FileChooser[mode] = not FileChooser[mode]
     G_reader_settings:saveSetting(mode, FileChooser[mode])
+    self:refreshPath()
+end
+
+function FileChooser:toggleCoverFallback()
+    local newValue = not G_reader_settings:readSetting("cover_fallback")
+    G_reader_settings:saveSetting("cover_fallback", newValue)
     self:refreshPath()
 end
 


### PR DESCRIPTION
Fixes #2917. Small PR that tries to use the first image on the first page as a fallback cover if none other is found. 
If no cover is found, it simply loads the whole document, goes to the first page and tries to open the image there.
I tested extracting and caching book information, the "Cover image" button, and the screensaver and everything seems to work fine on the simulated devices as well as on my Kobo Clara 2E.

Please tell me if this can be merged and if I should change anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11491)
<!-- Reviewable:end -->
