### PR TITLE
Wallabag: match `text/html` mimetype as starting with rather than exactly

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -554,14 +554,15 @@ function Wallabag:download(article)
 
     -- If the article links to a supported file, we will download it directly.
     -- All webpages are HTML. Ignore them since we want the Wallabag EPUB instead!
-    if article.mimetype ~= "text/html" then
+    if type(article.mimetype) == "string" and article.mimetype:find("^text/html") then
+        logger.dbg("Wallabag: ignoring EPUB in favor of mimetype: ", article.mimetype)
         if DocumentRegistry:hasProvider(nil, article.mimetype) then
             file_ext = "."..DocumentRegistry:mimeToExt(article.mimetype)
             item_url = article.url
         -- A function represents `null` in our JSON.decode, because `nil` would just disappear.
         -- In that case, fall back to the file extension.
         elseif type(article.mimetype) == "function" and DocumentRegistry:hasProvider(article.url) then
-            file_ext = ""
+            file_ext = "."..util.getFileNameSuffix(article.url)
             item_url = article.url
         end
     end


### PR DESCRIPTION
Previously unnoticed or changed Wallabag behavior can provide a mimetype of for example `text/html; utf-8`, which wouldn't be an exact match to `text/html`.

Fixes #11481.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11492)
<!-- Reviewable:end -->
