### PR TITLE
MenuSearch: open upper menu when needed only

### DIFF
--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -1,6 +1,7 @@
 local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
+local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local Notification = require("ui/widget/notification")
 local UIManager = require("ui/uimanager")
@@ -12,28 +13,19 @@ local T = require("ffi/util").template
 
 local common_info = {}
 
-if Device:hasOTAUpdates() then
-    local OTAManager = require("ui/otamanager")
-    common_info.ota_update = OTAManager:getOTAMenuTable()
-end
-common_info.version = {
-    text = T(_("Version: %1"), Version:getShortVersion()),
-    keep_menu_open = true,
-    callback = function()
-        UIManager:show(InfoMessage:new{
-            text = Version:getCurrentRevision(),
-        })
-    end
-}
-common_info.help = {
-    text = _("Help"),
-}
+-- tools tab
 common_info.more_tools = {
     text = _("More tools"),
 }
 
-common_info.device = {
-    text = _("Device"),
+-- main tab
+if Device:hasOTAUpdates() then
+    local OTAManager = require("ui/otamanager")
+    common_info.ota_update = OTAManager:getOTAMenuTable()
+end
+
+common_info.help = {
+    text = _("Help"),
 }
 common_info.quickstart_guide = {
     text = _("Quickstart guide"),
@@ -43,15 +35,12 @@ common_info.quickstart_guide = {
         ReaderUI:showReader(QuickStart:getQuickStart())
     end
 }
-common_info.about = {
-    text = _("About"),
-    keep_menu_open = true,
+common_info.search_menu = {
+    text = _("Menu search"),
     callback = function()
-        UIManager:show(InfoMessage:new{
-            text = T(_("KOReader %1\n\nA document viewer for E Ink devices.\n\nLicensed under Affero GPL v3. All dependencies are free software.\n\nhttp://koreader.rocks"), BD.ltr(Version:getCurrentRevision())),
-            icon = "koreader",
-        })
-    end
+        UIManager:sendEvent(Event:new("ShowMenuSearch"))
+    end,
+    keep_menu_open = true,
 }
 common_info.report_bug = {
     text_func = function()
@@ -111,6 +100,25 @@ common_info.report_bug = {
                     end,
                 }
             }},
+        })
+    end
+}
+common_info.version = {
+    text = T(_("Version: %1"), Version:getShortVersion()),
+    keep_menu_open = true,
+    callback = function()
+        UIManager:show(InfoMessage:new{
+            text = Version:getCurrentRevision(),
+        })
+    end
+}
+common_info.about = {
+    text = _("About"),
+    keep_menu_open = true,
+    callback = function()
+        UIManager:show(InfoMessage:new{
+            text = T(_("KOReader %1\n\nA document viewer for E Ink devices.\n\nLicensed under Affero GPL v3. All dependencies are free software.\n\nhttp://koreader.rocks"), BD.ltr(Version:getCurrentRevision())),
+            icon = "koreader",
         })
     end
 }

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -271,8 +271,9 @@ common_settings.screen_eink_opt = require("ui/elements/screen_eink_opt_menu_tabl
 common_settings.screen_notification = require("ui/elements/screen_notification_menu_table")
 
 if Device:isTouchDevice() then
-    common_settings.menu_activate = require("ui/elements/menu_activate")
-    common_settings.screen_disable_double_tab = require("ui/elements/screen_disable_double_tap_table")
+    common_settings.taps_and_gestures = {
+        text = _("Taps and gestures"),
+    }
     common_settings.ignore_hold_corners = {
         text = _("Ignore long-press on corners"),
         checked_func = function()
@@ -281,6 +282,12 @@ if Device:isTouchDevice() then
         callback = function()
             UIManager:broadcastEvent(Event:new("IgnoreHoldCorners"))
         end,
+    }
+    common_settings.screen_disable_double_tab = require("ui/elements/screen_disable_double_tap_table")
+    common_settings.menu_activate = require("ui/elements/menu_activate")
+    common_settings.keyboard_layout = {
+        text = _("Keyboard"),
+        sub_item_table = require("ui/elements/menu_keyboard_layout"),
     }
 end
 
@@ -368,16 +375,6 @@ Please don't change any settings unless you know what you're doing.]])
     end
 end
 
-if Device:isTouchDevice() then
-    common_settings.keyboard_layout = {
-        text = _("Keyboard"),
-        sub_item_table = require("ui/elements/menu_keyboard_layout"),
-    }
-    common_settings.taps_and_gestures = {
-        text = _("Taps and gestures"),
-    }
-end
-
 common_settings.navigation = {
     text = _("Navigation"),
 }
@@ -398,7 +395,6 @@ local function genGenericMenuEntry(title, setting, value, default, radiomark)
         end,
     }
 end
-
 common_settings.back_to_exit = {
     text_func = function()
         local back_to_exit = G_reader_settings:readSetting("back_to_exit", "prompt") -- set "back_to_exit" to "prompt"
@@ -715,16 +711,11 @@ common_settings.document_end_action = {
 
 common_settings.language = Language:getLangMenuTable()
 
-common_settings.font_ui_fallbacks = require("ui/elements/font_ui_fallbacks")
-
-common_settings.screenshot = {
-    text = _("Screenshot folder"),
-    callback = function()
-        local Screenshoter = require("ui/widget/screenshoter")
-        Screenshoter:chooseFolder()
-    end,
-    keep_menu_open = true,
+common_settings.device = {
+    text = _("Device"),
 }
+
+common_settings.font_ui_fallbacks = require("ui/elements/font_ui_fallbacks")
 
 common_settings.units = {
     text = _("Units"),
@@ -743,10 +734,11 @@ common_settings.units = {
     },
 }
 
-common_settings.search_menu = {
-    text = _("Menu search"),
+common_settings.screenshot = {
+    text = _("Screenshot folder"),
     callback = function()
-        UIManager:sendEvent(Event:new("ShowMenuSearch"))
+        local Screenshoter = require("ui/widget/screenshoter")
+        Screenshoter:chooseFolder()
     end,
     keep_menu_open = true,
 }

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -1048,6 +1048,10 @@ function TouchMenu:search(search_for)
 end
 
 function TouchMenu:openMenu(path, with_animation)
+    if self.show_parent == self then -- MenuSearch called from dispatcher, menu generated but not opened yet
+        UIManager:sendEvent(Event:new("ShowMenu", nil, self))
+    end
+
     local parts = {}
     for part in util.gsplit(path, "%.", false) do -- path is ie. "2.3.3.1"
         table.insert(parts, tonumber(part))


### PR DESCRIPTION
If Menu Search is called from dispatcher, the upper menu goes opened, and remains opened on canceling the search results.
Fixing it: the menu will be shown when needed (for Open or Walk me there).

Also reordering code for some menu elements in accordance with the menus order (no any code changes).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11495)
<!-- Reviewable:end -->
