### PR TITLE
Menu, DictQuickLookup, TextViewer: allow mousewheel scrolling

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1239,6 +1239,19 @@ function DictQuickLookup:onForwardingPan(arg, ges)
 end
 
 function DictQuickLookup:onForwardingPanRelease(arg, ges)
+    -- Allow scrolling with the mousewheel
+    if ges.from_mousewheel and ges.relative and ges.relative.y then
+        if ges.relative.y < 0 then
+            if not self.definition_widget[1]:onScrollDown() then
+                self:onReadNextResult()
+            end
+        elseif ges.relative.y > 0 then
+            if not self.definition_widget[1]:onScrollUp() then
+                self:onReadPrevResult()
+            end
+        end
+        return true
+    end
     -- We can forward onMovablePanRelease() does enough checks
     return self.movable:onMovablePanRelease(arg, ges)
 end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -931,6 +931,12 @@ function Menu:init()
             }
         }
     end
+    self.ges_events.Pan = { -- (for mousewheel scrolling support)
+        GestureRange:new{
+            ges = "pan",
+            range = self.dimen,
+        }
+    }
     self.ges_events.Close = self.on_close_ges
 
     if not Device:hasKeyboard() then
@@ -1384,6 +1390,17 @@ function Menu:onSwipe(arg, ges_ev)
         -- trigger full refresh
         UIManager:setDirty(nil, "full")
     end
+end
+
+function Menu:onPan(arg, ges_ev)
+    if ges_ev.mousewheel_direction then
+        if ges_ev.direction == "north" then
+            self:onNextPage()
+        elseif ges_ev.direction == "south" then
+            self:onPrevPage()
+        end
+    end
+    return true
 end
 
 function Menu:onMultiSwipe(arg, ges_ev)

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -444,6 +444,15 @@ function TextViewer:onForwardingPan(arg, ges)
 end
 
 function TextViewer:onForwardingPanRelease(arg, ges)
+    -- Allow scrolling with the mousewheel
+    if ges.from_mousewheel and ges.relative and ges.relative.y then
+        if ges.relative.y < 0 then
+            self.scroll_text_w:scrollText(1)
+        elseif ges.relative.y > 0 then
+            self.scroll_text_w:scrollText(-1)
+        end
+        return true
+    end
     -- We can forward onMovablePanRelease() does enough checks
     return self.movable:onMovablePanRelease(arg, ges)
 end

--- a/frontend/ui/widget/trapwidget.lua
+++ b/frontend/ui/widget/trapwidget.lua
@@ -54,6 +54,9 @@ function TrapWidget:init()
             SwipeDismiss = {
                 GestureRange:new{ ges = "swipe", range = full_screen, }
             },
+            PanReleaseDismiss = { -- emitted on mousewheel event
+                GestureRange:new{ ges = "pan_release", range = full_screen, }
+            },
         }
     end
     if self.text then
@@ -136,6 +139,10 @@ function TrapWidget:onHoldDismiss(_, ev)
 end
 
 function TrapWidget:onSwipeDismiss(_, ev)
+    return self:_dismissAndResend("Gesture", ev)
+end
+
+function TrapWidget:onPanReleaseDismiss(_, ev)
     return self:_dismissAndResend("Gesture", ev)
 end
 


### PR DESCRIPTION
We also need to catch it in TrapWidget so we can interrupt Wikipedia articles images loading.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11525)
<!-- Reviewable:end -->
