### PR TITLE
bump crengine: better conformance to the HTML Standard rendering

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -173,6 +173,7 @@ function CreDocument:init()
     self.default_css = "./data/epub.css"
     if file_type == "fb2" or file_type == "fb3" then
         self.default_css = "./data/fb2.css"
+        self.is_fb2 = true -- FB2 won't look good with any html-oriented stylesheet
     end
 
     -- This mode must be the same as the default one set as ReaderView.view_mode

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -420,6 +420,13 @@ Further small adjustments can be done with 'Line Spacing' in the bottom menu.]])
         {
             title = _("Font size and families"),
             {
+                id = "font_no_presentational_hints",
+                title = _("Ignore font related HTML presentational hints"),
+                description = _("Ignore HTML attributes that contribute to styles on the elements <body> (bgcolor, text…) and <font> (face, size, color…)."),
+                css = [[body, font { -cr-hint: no-presentational; }]],
+                separator = true,
+            },
+            {
                 id = "font_family_all_inherit",
                 title = _("Ignore publisher font families"),
                 description = _("Disable font-family specified in embedded styles."),
@@ -564,6 +571,13 @@ body, h1, h2, h3, h4, h5, h6, div, li, td, th { text-indent: 0 !important; }
         title = _("Tables, links, images"),
         {
             title = _("Tables"),
+            {
+                id = "table_no_presentational_hints",
+                title = _("Ignore tables related HTML presentational hints"),
+                description = _("Ignore HTML attributes that contribute to styles on the <table> element and its sub-elements (ie. align, valign, frame, rules, border, cellpading, cellspacing…)."),
+                css = [[table, caption, colgroup, col, thead, tbody, tfoot, tr, td, th { -cr-hint: no-presentational; }]],
+                separator = true,
+            },
             {
                 id = "table_full_width",
                 title = _("Full-width tables"),

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -915,6 +915,84 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
     -- to look more alike wikipedia web pages (that the user can ignore
     -- with "Embedded Style" off)
     epub:add("OEBPS/stylesheet.css", [[
+/* Generic styling picked from our epub.css (see it for comments),
+   to give this epub a book look even if used with html5.css */
+body {
+  text-align: justify;
+}
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0.7em;
+  margin-bottom: 0.5em;
+  hyphens: none;
+}
+h1 { font-size: 150%; }
+h2 { font-size: 140%; }
+h3 { font-size: 130%; }
+h4 { font-size: 120%; }
+h5 { font-size: 110%; }
+h6 { font-size: 100%; }
+p {
+  text-indent: 1.2em;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+blockquote {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  margin-left: 2em;
+  margin-right: 1em;
+}
+blockquote:dir(rtl) {
+  margin-left: 1em;
+  margin-right: 2em;
+}
+dl {
+  margin-left: 0;
+}
+dt {
+  margin-left: 0;
+  margin-top: 0.3em;
+  font-weight: bold;
+}
+dd {
+  margin-left: 1.3em;
+}
+dd:dir(rtl) {
+  margin-left: unset;
+  margin-right: 1.3em;
+}
+pre {
+  text-align: left;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+hr {
+  border-style: solid;
+}
+table {
+  font-size: 80%;
+  margin: 3px 0;
+  border-spacing: 1px;
+}
+table table { /* stop imbricated tables from getting smaller */
+  font-size: 100%;
+}
+th, td {
+  padding: 3px;
+}
+th {
+  background-color: #DDD;
+  text-align: center;
+}
+table caption {
+  padding: 4px;
+  background-color: #EEE;
+}
+sup { font-size: 70%; }
+sub { font-size: 70%; }
+
+/* Specific for our Wikipedia EPUBs */
+
 /* Make section headers looks left aligned and avoid some page breaks */
 h1, h2 {
     page-break-before: always;
@@ -978,10 +1056,7 @@ a.newwikinonexistent {
 
 /* Don't waste left margin for TOC, notes and other lists */
 ul, ol {
-    margin-left: 0;
-}
-ul:dir(rtl), ol:dir(rtl) {
-    margin-right: 0;
+    margin: 0;
 }
 /* OL in Wikipedia pages may inherit their style-type from a wrapping div,
  * ensure they fallback to decimal with inheritance */
@@ -1176,6 +1251,11 @@ table {
 .citation {
     font-style: italic;
 }
+abbr.abbr {
+    /* Prevent these from looking like a link */
+    text-decoration: inherit;
+}
+
 /* hide some view/edit/discuss short links displayed as "v m d" */
 .nv-view, .nv-edit, .nv-talk {
     display: none;

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -1275,6 +1275,11 @@ function util.prettifyCSS(css_text, condensed)
             s = s:gsub(";", "\b")
             return s
         end)
+        -- Protect ',' inside () (ie. ":is(td, th)") by replacing them with rare control chars
+        css_text = css_text:gsub("%b()/", function(s)
+            s = s:gsub(",", "\v")
+            return s
+        end)
         -- Cleanup declarations (the most nested ones only, which may be
         -- contained in "@supports (...) {...}" or "@media (...) {...}")
         css_text = css_text:gsub(" *{([^{}]*)} *", function(s)


### PR DESCRIPTION
#### bump crengine: better conformance to the HTML Standard rendering

Includes:
- Hyphenation: update French.pattern https://github.com/koreader/crengine/pull/553
- [CI] Add stylelint to help prevent typos in CSS https://github.com/koreader/crengine/pull/556
- https://github.com/koreader/crengine/pull/555 : 
- In-page footnotes: better handle duplicated ids 
- lvrend: handle in-page footnotes in table `<caption>`
- lvstsheet: fix compiler warnings
- LVString: ignore CJK chars in `lStr_findWordBounds()`
  Closes #11478.
- lvtext: `AddLine()`: handle some CJK + space edge case
  See https://github.com/koreader/koreader/issues/11478#issuecomment-1951424809.
- EPUB: look for EPUB3 cover even when EPUB2 cover advertized
  See around https://github.com/koreader/koreader/pull/11491#issuecomment-1963021880.
- List items: proper per-specs positionning and sizing
  Closed https://github.com/koreader/crengine/issues/521.
- epub.css: add/use `@media (-cr-max-cre-dom-version: 20180527)`
- fb2def.h: add more HTML element and attributes names
- CSS: generic support for handling presentational hints
  Closed https://github.com/koreader/crengine/issues/551
- CSS: add support for private `-cr-apply-func`:
- ldomDocumentWriterFilter: remove attribute to CSS conversion
- lvrend: more proper rendering of block images
- lvrend: keep margin_left/right updated when "auto"
- CSS: add support for handling HTML's `align=` attribute
- lvrend: fix HR and images positionning when floats involved
- epub.css, html5.css: minor updates for easier stylesheet switch
- epub.css, html5.css: major updates for better conformance
  Closes #10770.
- fb2.css: fix CI stylelint warnings

Also update to libunibreak 6.0.

#### ReaderTypeset: tweak Style> menu logic and defaults

- Reword and document most menu items.
- Handle internally two default styles, one applying only to FB2/FB2 books, and the other to all other formats.
- Also don't reset the stylesheet to epub.css when toggling Embedded Styles to off.
- Closes #11494.

#### Style tweaks: add tweak to avoid some presentational hints


#### util.prettifyCSS(): handle better :is() and similar


#### Wikipedia: tweak EPUB css to force epub.css look

Include in the EPUB stylesheet most of our epub.css tweaks, so we get our expected styling even when html5.css is used as the default stylesheet.
(Users liking the "web page" look can still get it by enabling some of our existing style tweaks.)
Discussed around https://github.com/koreader/koreader/issues/10770#issuecomment-1949267769.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11527)
<!-- Reviewable:end -->
