### PR TITLE
 Wallabag: properly deal with mimetype actually being content-type

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -342,7 +342,7 @@ function Wallabag:addToMainMenu(menu_items)
                         separator = true,
                     },
                     {
-                        text = _("Download original document if supported and not HTML"),
+                        text = _("Prefer original non-HTML document"),
                         keep_menu_open = true,
                         checked_func = function()
                             return self.download_original_document


### PR DESCRIPTION
A typo snuck in #11492, which should've read `not type(article.mimetype) == "string" or type(article.mimetype) == "string" and not article.mimetype:find("^text/html")`. But in most cases the behavior would've been identically broken because of the same underlying issue: Wallabag mimetype is actually HTTP content-type.

This PR shows two potential solutions while awaiting more concrete information about the actual problem observed in #11528.

Fixes #11528.

There would also be a new setting associated with the behavior in case people have different preferences. Hopefully inspiration will strike soon for the string.
<img src=https://github.com/koreader/koreader/assets/202757/1b8f5d06-6a4f-417c-b65b-61bea79c07a2 width=40%>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11532)
<!-- Reviewable:end -->
