### PR TITLE
Menu widget: fix item property name

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -535,7 +535,7 @@ function ReaderBookmark:onShowBookmark(match_table)
                             UIManager:close(textviewer)
                             bookmark:setHighlightedText(item)
                             if bookmark.show_edited_only then
-                                table.remove(item_table, item.index)
+                                table.remove(item_table, item.ind)
                             end
                             bookmark.refresh()
                         end,
@@ -559,7 +559,7 @@ function ReaderBookmark:onShowBookmark(match_table)
                                 ok_text = _("Remove"),
                                 ok_callback = function()
                                     bookmark:removeHighlight(item)
-                                    table.remove(item_table, item.index)
+                                    table.remove(item_table, item.ind)
                                     bm_menu:switchItemTable(nil, item_table, -1)
                                     UIManager:close(textviewer)
                                 end,

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -535,7 +535,7 @@ function ReaderBookmark:onShowBookmark(match_table)
                             UIManager:close(textviewer)
                             bookmark:setHighlightedText(item)
                             if bookmark.show_edited_only then
-                                table.remove(item_table, item.ind)
+                                table.remove(item_table, item.idx)
                             end
                             bookmark.refresh()
                         end,
@@ -559,7 +559,7 @@ function ReaderBookmark:onShowBookmark(match_table)
                                 ok_text = _("Remove"),
                                 ok_callback = function()
                                     bookmark:removeHighlight(item)
-                                    table.remove(item_table, item.ind)
+                                    table.remove(item_table, item.idx)
                                     bm_menu:switchItemTable(nil, item_table, -1)
                                     UIManager:close(textviewer)
                                 end,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1065,7 +1065,7 @@ function Menu:updateItems(select_number)
         -- calculate index in item_table
         local i = (self.page - 1) * self.perpage + c
         if i <= #self.item_table then
-            self.item_table[i].index = i -- item.index is valid only for items that have been displayed
+            self.item_table[i].ind = i -- index is valid only for items that have been displayed
             local item_shortcut = nil
             local shortcut_style = "square"
             if self.is_enable_shortcut then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1065,7 +1065,7 @@ function Menu:updateItems(select_number)
         -- calculate index in item_table
         local i = (self.page - 1) * self.perpage + c
         if i <= #self.item_table then
-            self.item_table[i].ind = i -- index is valid only for items that have been displayed
+            self.item_table[i].idx = i -- index is valid only for items that have been displayed
             local item_shortcut = nil
             local shortcut_style = "square"
             if self.is_enable_shortcut then


### PR DESCRIPTION
`index` is generated and used by ToC. Fixes https://github.com/koreader/koreader/pull/11484#issuecomment-1988036886.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11534)
<!-- Reviewable:end -->
