### PR TITLE
LS msg percentages only reach 100% at final page

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -148,7 +148,11 @@ function Screensaver:expandSpecial(message, fallback)
             time_left_chapter = self:_calcAverageTimeForPages(ui.toc:getChapterPagesLeft(currentpage) or doc:getTotalPagesLeft(currentpage))
             time_left_document = self:_calcAverageTimeForPages(doc:getTotalPagesLeft(currentpage))
         end
-        percent = math.min( Math.round((currentpage * 100) / totalpages), 99)
+        if currentpage == totalpages then
+            percent = 100
+        else
+            percent = math.min( Math.round((currentpage * 100) / totalpages), 99)
+        end
         props = ui.doc_props
     elseif DocSettings:hasSidecarFile(lastfile) then
         -- If there's no ReaderUI instance, but the file has sidecar data, use that
@@ -156,7 +160,11 @@ function Screensaver:expandSpecial(message, fallback)
         totalpages = doc_settings:readSetting("doc_pages") or totalpages
         percent = doc_settings:readSetting("percent_finished") or percent
         currentpage = Math.round(percent * totalpages)
-        percent = math.min( Math.round(percent * 100), 99)
+        if currentpage == totalpages then
+            percent = 100
+        else
+            percent = math.min( Math.round(percent * 100), 99)
+        end
         props = FileManagerBookInfo.extendProps(doc_settings:readSetting("doc_props"), lastfile)
         -- Unable to set time_left_chapter and time_left_document without ReaderUI, so leave N/A
     end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -167,7 +167,7 @@ function Screensaver:expandSpecial(message, fallback)
         elseif currentpage == totalpages then
             percent = 100
         else
-            percent = Math.round(Math.clamp(percent, 1, 99))
+            percent = Math.round(Math.clamp(percent * 100, 1, 99))
         end
         props = FileManagerBookInfo.extendProps(doc_settings:readSetting("doc_props"), lastfile)
         -- Unable to set time_left_chapter and time_left_document without ReaderUI, so leave N/A

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -148,10 +148,12 @@ function Screensaver:expandSpecial(message, fallback)
             time_left_chapter = self:_calcAverageTimeForPages(ui.toc:getChapterPagesLeft(currentpage) or doc:getTotalPagesLeft(currentpage))
             time_left_document = self:_calcAverageTimeForPages(doc:getTotalPagesLeft(currentpage))
         end
-        if currentpage == totalpages then
+        if currentpage == 1 then
+            percent = 0
+        elseif currentpage == totalpages then
             percent = 100
         else
-            percent = math.min( Math.round((currentpage * 100) / totalpages), 99)
+            percent = Math.round(Math.clamp(((currentpage * 100) / totalpages), 1, 99))
         end
         props = ui.doc_props
     elseif DocSettings:hasSidecarFile(lastfile) then
@@ -160,10 +162,12 @@ function Screensaver:expandSpecial(message, fallback)
         totalpages = doc_settings:readSetting("doc_pages") or totalpages
         percent = doc_settings:readSetting("percent_finished") or percent
         currentpage = Math.round(percent * totalpages)
-        if currentpage == totalpages then
+        if currentpage == 1 then
+            percent = 0
+        elseif currentpage == totalpages then
             percent = 100
         else
-            percent = math.min( Math.round(percent * 100), 99)
+            percent = Math.round(Math.clamp(((currentpage * 100) / totalpages), 1, 99))
         end
         props = FileManagerBookInfo.extendProps(doc_settings:readSetting("doc_props"), lastfile)
         -- Unable to set time_left_chapter and time_left_document without ReaderUI, so leave N/A

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -148,7 +148,13 @@ function Screensaver:expandSpecial(message, fallback)
             time_left_chapter = self:_calcAverageTimeForPages(ui.toc:getChapterPagesLeft(currentpage) or doc:getTotalPagesLeft(currentpage))
             time_left_document = self:_calcAverageTimeForPages(doc:getTotalPagesLeft(currentpage))
         end
-        percent = Math.round((currentpage * 100) / totalpages)
+        if currentpage == 1 then
+            percent = 0
+        elseif ((currentpage / totalpages) * 100) < 1 then
+            percent = 1
+        else
+            percent = math.floor((currentpage * 100) / totalpages)
+        end
         props = ui.doc_props
     elseif DocSettings:hasSidecarFile(lastfile) then
         -- If there's no ReaderUI instance, but the file has sidecar data, use that
@@ -156,7 +162,7 @@ function Screensaver:expandSpecial(message, fallback)
         totalpages = doc_settings:readSetting("doc_pages") or totalpages
         percent = doc_settings:readSetting("percent_finished") or percent
         currentpage = Math.round(percent * totalpages)
-        percent = Math.round(percent * 100)
+        percent = math.floor(percent * 100)
         props = FileManagerBookInfo.extendProps(doc_settings:readSetting("doc_props"), lastfile)
         -- Unable to set time_left_chapter and time_left_document without ReaderUI, so leave N/A
     end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -148,13 +148,7 @@ function Screensaver:expandSpecial(message, fallback)
             time_left_chapter = self:_calcAverageTimeForPages(ui.toc:getChapterPagesLeft(currentpage) or doc:getTotalPagesLeft(currentpage))
             time_left_document = self:_calcAverageTimeForPages(doc:getTotalPagesLeft(currentpage))
         end
-        if currentpage == 1 then
-            percent = 0
-        elseif ((currentpage / totalpages) * 100) < 1 then
-            percent = 1
-        else
-            percent = math.floor((currentpage * 100) / totalpages)
-        end
+        percent = math.min( Math.round((currentpage * 100) / totalpages), 99)
         props = ui.doc_props
     elseif DocSettings:hasSidecarFile(lastfile) then
         -- If there's no ReaderUI instance, but the file has sidecar data, use that
@@ -162,7 +156,7 @@ function Screensaver:expandSpecial(message, fallback)
         totalpages = doc_settings:readSetting("doc_pages") or totalpages
         percent = doc_settings:readSetting("percent_finished") or percent
         currentpage = Math.round(percent * totalpages)
-        percent = math.floor(percent * 100)
+        percent = math.min( Math.round(percent * 100), 99)
         props = FileManagerBookInfo.extendProps(doc_settings:readSetting("doc_props"), lastfile)
         -- Unable to set time_left_chapter and time_left_document without ReaderUI, so leave N/A
     end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -167,7 +167,7 @@ function Screensaver:expandSpecial(message, fallback)
         elseif currentpage == totalpages then
             percent = 100
         else
-            percent = Math.round(Math.clamp(((currentpage * 100) / totalpages), 1, 99))
+            percent = Math.round(Math.clamp(percent, 1, 99))
         end
         props = FileManagerBookInfo.extendProps(doc_settings:readSetting("doc_props"), lastfile)
         -- Unable to set time_left_chapter and time_left_document without ReaderUI, so leave N/A

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -207,7 +207,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% > unopened > 100% or finished
+            -- sort 90% > 50% > 0% or on hold > unopened > 100% or finished
             text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -238,6 +238,12 @@ local FileChooser = Menu:extend{
                     -- books marked as "finished" should be considered the same as 100%
                     if summary and summary.status == "complete" then
                         item.percent_finished = 1.0
+                        return
+                    end
+
+                    -- books marked as "on hold" should be considered the same as 0%
+                    if summary and summary.status == "abandoned" then
+                        item.percent_finished = 0.0
                         return
                     end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -207,7 +207,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% or on hold > unopened > 100% or finished
+            -- sort 90% > 50% > 0% > unopened > 100% or finished
             text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -235,14 +235,12 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     local summary = doc_settings:readSetting("summary")
 
-                    -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
+                    -- books marked as "finished" should be considered the same as 100%
                     if summary and summary.status == "complete" then
-                        item.percent_finished = 1
-                        return
-                    elseif summary and summary.status == "abandoned" then
-                        item.percent_finished = 0
+                        item.percent_finished = 1.0
                         return
                     end
+
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -235,18 +235,14 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     local summary = doc_settings:readSetting("summary")
 
-                    -- books marked as "finished" should be considered the same as 100%
+                    -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
                     if summary and summary.status == "complete" then
-                        item.percent_finished = 1.0
+                        item.percent_finished = 1
+                        return
+                    elseif summary and summary.status == "abandoned" then
+                        item.percent_finished = 0
                         return
                     end
-
-                    -- books marked as "on hold" should be considered the same as 0%
-                    if summary and summary.status == "abandoned" then
-                        item.percent_finished = 0.0
-                        return
-                    end
-
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers


### PR DESCRIPTION
percentages shown on the Lock Screen message will now truncate instead of round up. 

fixes #11516

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11541)
<!-- Reviewable:end -->
