### PR TITLE
FileChooser: "percent - unopened - finished last" consider status "on hold" as 0%

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -207,7 +207,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% > unopened > 100% or finished
+            -- sort 90% > 50% > 0% or on hold > unopened > 100% or finished
             text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -238,6 +238,12 @@ local FileChooser = Menu:extend{
                     -- books marked as "finished" should be considered the same as 100%
                     if summary and summary.status == "complete" then
                         item.percent_finished = 1.0
+                        return
+                    end
+
+                    -- books marked as "on hold" should be considered the same as 0%
+                    if summary and summary.status == "abandoned" then
+                        item.percent_finished = 0.0
                         return
                     end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -235,18 +235,14 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     local summary = doc_settings:readSetting("summary")
 
-                    -- books marked as "finished" should be considered the same as 100%
+                    -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
                     if summary and summary.status == "complete" then
-                        item.percent_finished = 1.0
+                        item.percent_finished = 1
+                        return
+                    elseif summary and summary.status == "abandoned" then
+                        item.percent_finished = 0
                         return
                     end
-
-                    -- books marked as "on hold" should be considered the same as 0%
-                    if summary and summary.status == "abandoned" then
-                        item.percent_finished = 0.0
-                        return
-                    end
-
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers


### PR DESCRIPTION
adds instruction for files labelled "on hold" to sorting function `percent - unopened - finished last`

`90% > 50% > 0% or on hold > unopened > 100% or finished`

continuation from #11524, #11472 and #11369

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11542)
<!-- Reviewable:end -->
