### PR TITLE
Wikipedia EPUBs: add settings for include/highres images

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -113,6 +113,17 @@ function ReaderWikipedia:addToMainMenu(menu_items)
             })
         end,
     }
+    local function genChoiceMenuEntry(title, setting, value, default)
+        return {
+            text = title,
+            checked_func = function()
+                return G_reader_settings:readSetting(setting, default) == value
+            end,
+            callback = function()
+                G_reader_settings:saveSetting(setting, value)
+            end,
+        }
+    end
     menu_items.wikipedia_settings = {
         text = _("Wikipedia settings"),
         sub_item_table = {
@@ -170,6 +181,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                     UIManager:show(wikilang_input)
                     wikilang_input:onShowKeyboard()
                 end,
+                separator = true,
             },
             { -- setting used by dictquicklookup
                 text = _("Set Wikipedia 'Save as EPUB' folder"),
@@ -199,6 +211,41 @@ You can choose an existing folder, or use a default folder named "Wikipedia" in 
                 callback = function()
                     G_reader_settings:flipNilOrFalse("wikipedia_save_in_book_dir")
                 end,
+            },
+            { -- setting used in wikipedia.lua
+                text_func = function()
+                    local include_images = _("ask")
+                    if G_reader_settings:readSetting("wikipedia_epub_include_images") == true then
+                        include_images = _("always")
+                    elseif G_reader_settings:readSetting("wikipedia_epub_include_images") == false then
+                        include_images = _("never")
+                    end
+                    return T(_("Include images in EPUB: %1"), include_images)
+                end,
+                sub_item_table = {
+                    genChoiceMenuEntry(_("Ask"), "wikipedia_epub_include_images", nil),
+                    genChoiceMenuEntry(_("Include images"), "wikipedia_epub_include_images", true),
+                    genChoiceMenuEntry(_("Don't include images"), "wikipedia_epub_include_images", false),
+                },
+            },
+            { -- setting used in wikipedia.lua
+                text_func = function()
+                    local images_quality = _("ask")
+                    if G_reader_settings:readSetting("wikipedia_epub_highres_images") == true then
+                        images_quality = _("higher")
+                    elseif G_reader_settings:readSetting("wikipedia_epub_highres_images") == false then
+                        images_quality = _("standard")
+                    end
+                    return T(_("Images quality in EPUB: %1"), images_quality)
+                end,
+                enabled_func = function()
+                    return G_reader_settings:readSetting("wikipedia_epub_include_images") ~= false
+                end,
+                sub_item_table = {
+                    genChoiceMenuEntry(_("Ask"), "wikipedia_epub_highres_images", nil),
+                    genChoiceMenuEntry(_("Standard quality"), "wikipedia_epub_highres_images", false),
+                    genChoiceMenuEntry(_("Higher quality"), "wikipedia_epub_highres_images", true),
+                },
                 separator = true,
             },
             {

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -800,14 +800,18 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
     logger.dbg("Images found in html:", images)
 
     -- See what to do with images
-    local include_images = false
-    local use_img_2x = false
+    local include_images = G_reader_settings:readSetting("wikipedia_epub_include_images")
+    local use_img_2x = G_reader_settings:readSetting("wikipedia_epub_highres_images")
     if with_images then
         -- If no UI (Trapper:wrap() not called), UI:confirm() will answer true
         if #images > 0 then
-            include_images = UI:confirm(T(_("This article contains %1 images.\nWould you like to download and include them in the generated EPUB file?"), #images), _("Don't include"), _("Include"))
+            if include_images == nil then
+                include_images = UI:confirm(T(_("This article contains %1 images.\nWould you like to download and include them in the generated EPUB file?"), #images), _("Don't include"), _("Include"))
+            end
             if include_images then
-                use_img_2x = UI:confirm(_("Would you like to use slightly higher quality images? This will result in a bigger file size."), _("Standard quality"), _("Higher quality"))
+                if use_img_2x == nil then
+                    use_img_2x = UI:confirm(_("Would you like to use slightly higher quality images? This will result in a bigger file size."), _("Standard quality"), _("Higher quality"))
+                end
             end
         else
             UI:info(_("This article does not contain any images."))


### PR DESCRIPTION
Allows setting a default answer to the "Include image" and "slightly higher quality images" questions when saving a Wikipedia article as EPUB.
Closes #10356.

![image](https://github.com/koreader/koreader/assets/24273478/cd3e577e-8b77-4f86-81cb-a60eab1ca5e3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11544)
<!-- Reviewable:end -->
