### PR TITLE
ReaderToc: add option to show chapter lengths

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -717,7 +717,9 @@ function ReaderToc:onShowToc()
             v.indent = toc_indent * (v.depth-1)
             v.text = self:cleanUpTocTitle(v.title, true)
             if items_show_chapter_length then
-                v.text = v.text .. T("  (%1)", v.chapter_length)
+                v.post_text = T("(%1)", v.chapter_length)
+            else
+                v.post_text = nil
             end
             v.bidi_wrap_func = BD.auto
             v.mandatory = v.page

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1190,7 +1190,7 @@ Enabling this option will restrict display to the chapter titles of progress bar
         end,
     }
     menu_items.toc_items_show_chapter_length = {
-        text = _("Show chapter page counts"),
+        text = _("Show chapter length"),
         keep_menu_open = true,
         checked_func = function()
             return not G_reader_settings:nilOrFalse("toc_items_show_chapter_length")

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1188,7 +1188,7 @@ Enabling this option will restrict display to the chapter titles of progress bar
         end,
     }
     menu_items.toc_items_show_chapter_length = {
-        text = _("Append chapter length"),
+        text = _("Show chapter page counts"),
         keep_menu_open = true,
         checked_func = function()
             return not G_reader_settings:nilOrFalse("toc_items_show_chapter_length")

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -316,7 +316,6 @@ function ReaderToc:validateAndFixToc()
 end
 
 function ReaderToc:completeTocWithChapterLengths()
-    logger.warn("ReaderToc:completeTocWithChapterLengths")
     local toc = self.toc
     local first = 1
     local last = #toc
@@ -331,7 +330,7 @@ function ReaderToc:completeTocWithChapterLengths()
         for j=#prev_item_by_level, depth, -1 do
             local prev_item = prev_item_by_level[j]
             if prev_item then
-                prev_item.length = page - prev_item.page
+                prev_item.chapter_length = page - prev_item.page
             end
             prev_item_by_level[j] = nil
         end
@@ -342,7 +341,7 @@ function ReaderToc:completeTocWithChapterLengths()
     for j=#prev_item_by_level, 0, -1 do
         local prev_item = prev_item_by_level[j]
         if prev_item then
-            prev_item.length = page - prev_item.page
+            prev_item.chapter_length = page - prev_item.page
         end
     end
 end
@@ -718,7 +717,7 @@ function ReaderToc:onShowToc()
             v.indent = toc_indent * (v.depth-1)
             v.text = self:cleanUpTocTitle(v.title, true)
             if items_show_chapter_length then
-                v.text = v.text .. T("  (%1)", v.length)
+                v.text = v.text .. T("  (%1)", v.chapter_length)
             end
             v.bidi_wrap_func = BD.auto
             v.mandatory = v.page

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -35,6 +35,7 @@ local order = {
         "----------------------------",
         "toc_items_per_page",
         "toc_items_font_size",
+        "toc_items_show_chapter_length",
         "toc_items_with_dots",
         "----------------------------",
         "toc_alt_toc",

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -184,6 +184,12 @@ function MenuItem:init()
     self.face = Font:getFace(self.font, self.font_size)
     -- Font for "mandatory" on the right
     self.info_face = Font:getFace(self.infont, self.infont_size)
+    -- Font for post_text if any: for now, this is only used with TOC, showing
+    -- the chapter pages count: if feels best to use the face of the main text,
+    -- but with the size of the mandatory font (showing some number too).
+    if self.post_text then
+        self.post_text_face = Font:getFace(self.font, self.infont_size)
+    end
 
     -- "mandatory" is the text on the right: file size, page number...
     -- Padding before mandatory
@@ -219,10 +225,23 @@ function MenuItem:init()
         text = self.bidi_wrap_func(text)
     end
 
+    -- Note: support for post_text is currently implemented only when single_line=true
+    local post_text_widget
+    local post_text_left_padding = Size.padding.large
+    local post_text_right_padding = self.with_dots and 0 or Size.padding.large
     local dots_widget
     local dots_left_padding = Size.padding.small
     local dots_right_padding = Size.padding.small
     if self.single_line then  -- items only in single line
+        if self.post_text then
+            post_text_widget = TextWidget:new{
+                text = self.post_text,
+                face = self.post_text_face,
+                bold = self.bold,
+                fgcolor = self.dim and Blitbuffer.COLOR_DARK_GRAY or nil,
+            }
+            available_width = available_width - post_text_widget:getWidth() - post_text_left_padding - post_text_right_padding
+        end
         -- No font size change: text will be truncated if it overflows
         item_name = TextWidget:new{
             text = text,
@@ -271,6 +290,9 @@ function MenuItem:init()
             if dots_widget then
                 dots_widget.forced_height = self.dimen.h
             end
+            if post_text_widget then
+                post_text_widget.forced_height = self.dimen.h
+            end
             -- And adjust their baselines for proper centering and alignment
             -- (We made sure the font sizes wouldn't exceed self.dimen.h, so we
             -- get only non-negative pad_top here, and we're moving them down.)
@@ -288,6 +310,9 @@ function MenuItem:init()
             mandatory_widget.forced_baseline = mdtr_baseline
             if dots_widget then
                 dots_widget.forced_baseline = mdtr_baseline
+            end
+            if post_text_widget then
+                post_text_widget.forced_baseline = mdtr_baseline
             end
         end
 
@@ -374,6 +399,8 @@ function MenuItem:init()
                 width = state_width,
             },
             item_name,
+            post_text_widget and HorizontalSpan:new{ width = post_text_left_padding },
+            post_text_widget,
         }
     }
 
@@ -1083,6 +1110,7 @@ function Menu:updateItems(select_number)
                 state_w = self.state_w or 0,
                 text = Menu.getMenuText(self.item_table[i]),
                 bidi_wrap_func = self.item_table[i].bidi_wrap_func,
+                post_text = self.item_table[i].post_text,
                 mandatory = self.item_table[i].mandatory,
                 mandatory_func = self.item_table[i].mandatory_func,
                 mandatory_dim = self.item_table[i].mandatory_dim or self.item_table[i].dim,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -185,8 +185,8 @@ function MenuItem:init()
     -- Font for "mandatory" on the right
     self.info_face = Font:getFace(self.infont, self.infont_size)
     -- Font for post_text if any: for now, this is only used with TOC, showing
-    -- the chapter pages count: if feels best to use the face of the main text,
-    -- but with the size of the mandatory font (showing some number too).
+    -- the chapter length: if feels best to use the face of the main text, but
+    -- with the size of the mandatory font (which shows some number too).
     if self.post_text then
         self.post_text_face = Font:getFace(self.font, self.infont_size)
     end


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/10261#issuecomment-1523993704

> If the lengths can be toggled on/off (so they won't bother anyone), then I think this would be more useful:
`Act V (15) .......   2804`

![image](https://github.com/koreader/koreader/assets/24273478/1bbbc23c-98c3-4606-bca0-ca5843058d64)
It is static and states the full chapter length (including the subchapters), it does not update in any way when expanding/collapsing.
(Not heavily tested in the bad ToCs jungle.)

![image](https://github.com/koreader/koreader/assets/24273478/2a194467-8757-477b-abb9-97f78354e696)

Alternative wording suggestion welcome.
Pinging @jonnyl2, you can test it by just downloading and replacing this file:
https://raw.githubusercontent.com/poire-z/koreader/0b5f2375c02207f70b34f7813c761378c9d2583d/frontend/apps/reader/modules/readertoc.lua
(and if not replacing the other, you'll find the setting at the bottom or 2nd page of the first menu, marked "new").
You can experiment with the spacing or different kind of parens by editing line 729:
`v.text = v.text .. T("  (%1)", v.length)`

Closes #10261.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11546)
<!-- Reviewable:end -->
