### PR TITLE
Dictionary: Fix download message when connection fails

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1114,15 +1114,24 @@ function ReaderDictionary:downloadDictionary(dict, download_location, continue)
         --logger.dbg(headers)
         file_size = headers and headers["content-length"]
 
-        UIManager:show(ConfirmBox:new{
-            text =  T(_("Dictionary filesize is %1 (%2 bytes). Continue with download?"), util.getFriendlySize(file_size), util.getFormattedSize(file_size)),
-            ok_text =  _("Download"),
-            ok_callback = function()
-                -- call ourselves with continue = true
-                self:downloadDictionary(dict, download_location, true)
-            end,
-        })
-        return
+        if file_size then
+            UIManager:show(ConfirmBox:new{
+                text =  T(_("Dictionary filesize is %1 (%2 bytes). Continue with download?"), util.getFriendlySize(file_size), util.getFormattedSize(file_size)),
+                ok_text =  _("Download"),
+                ok_callback = function()
+                    -- call ourselves with continue = true
+                    self:downloadDictionary(dict, download_location, true)
+                end,
+            })
+            return
+        else
+            logger.dbg("ReaderDictionary: Request failed; response headers:", headers)
+            UIManager:show(InfoMessage:new{
+                text = _("Failed to fetch dictionary. Are you online?"),
+                --timeout = 3,
+            })
+            return false
+        end
     else
         UIManager:nextTick(function()
             UIManager:show(InfoMessage:new{


### PR DESCRIPTION
On a PocketBook device the WiFi connection is often not working (cf. #10183). When the connection drops after the initial online test.he current info message may show:

> "Dictionary filesize is %1 (nil bytes). Continue with download?" 

This PR tries to fail more gracefully by showing a custom error message.

(WiFi support on my PocketBook remains shaky though and probably needs more fundamental fixes that cannot be addressed in this PR..)

## Current behavior
![Screenshot from 2024-03-13 21-12-45](https://github.com/koreader/koreader/assets/2464627/6eeffab7-57b3-4c08-8db8-4860dbdfa038)

![Screenshot from 2024-03-13 21-12-57](https://github.com/koreader/koreader/assets/2464627/a4dbe644-ca18-418b-887b-5140129dc2f4)

![Screenshot from 2024-03-13 21-12-59](https://github.com/koreader/koreader/assets/2464627/2bfcda54-e529-426a-8322-86e2afd66aae)

## New behavior

![Screenshot from 2024-03-13 21-16-30](https://github.com/koreader/koreader/assets/2464627/777eb977-e13e-4e7e-9994-18e87d07b4f5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11548)
<!-- Reviewable:end -->
