### PR TITLE
Sleep screen menu reworked

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -452,7 +452,7 @@ To:
 
     if Device:supportsScreensaver() then
         self.menu_items.screensaver = {
-            text = _("Lock Screen"),
+            text = _("Lock screen"),
             sub_item_table = require("ui/elements/screensaver_menu"),
         }
     end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -452,7 +452,7 @@ To:
 
     if Device:supportsScreensaver() then
         self.menu_items.screensaver = {
-            text = _("Screensaver"),
+            text = _("Lock Screen"),
             sub_item_table = require("ui/elements/screensaver_menu"),
         }
     end

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -452,7 +452,7 @@ To:
 
     if Device:supportsScreensaver() then
         self.menu_items.screensaver = {
-            text = _("Lock screen"),
+            text = _("Sleep screen"),
             sub_item_table = require("ui/elements/screensaver_menu"),
         }
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -285,7 +285,7 @@ function ReaderMenu:setUpdateItemTable()
         end
         table.insert(screensaver_sub_item_table, ss_book_settings)
         self.menu_items.screensaver = {
-            text = _("Screensaver"),
+            text = _("Lock Screen"),
             sub_item_table = screensaver_sub_item_table,
         }
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -254,7 +254,7 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:supportsScreensaver() then
         local ss_book_settings = {
-            text = _("Do not show this book cover on lock screen"),
+            text = _("Do not show this book cover on sleep screen"),
             enabled_func = function()
                 if self.ui and self.ui.document then
                     local screensaverType = G_reader_settings:readSetting("screensaver_type")
@@ -285,7 +285,7 @@ function ReaderMenu:setUpdateItemTable()
         end
         table.insert(screensaver_sub_item_table, ss_book_settings)
         self.menu_items.screensaver = {
-            text = _("Lock screen"),
+            text = _("Sleep screen"),
             sub_item_table = screensaver_sub_item_table,
         }
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -254,7 +254,7 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:supportsScreensaver() then
         local ss_book_settings = {
-            text = _("Exclude this book's content and cover from screensaver"),
+            text = _("Don't show this book cover on lock screen"),
             enabled_func = function()
                 if self.ui and self.ui.document then
                     local screensaverType = G_reader_settings:readSetting("screensaver_type")

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -254,7 +254,7 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:supportsScreensaver() then
         local ss_book_settings = {
-            text = _("Do not show current book cover on lock screen"),
+            text = _("Do not show this book cover on lock screen"),
             enabled_func = function()
                 if self.ui and self.ui.document then
                     local screensaverType = G_reader_settings:readSetting("screensaver_type")

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -285,7 +285,7 @@ function ReaderMenu:setUpdateItemTable()
         end
         table.insert(screensaver_sub_item_table, ss_book_settings)
         self.menu_items.screensaver = {
-            text = _("Lock Screen"),
+            text = _("Lock screen"),
             sub_item_table = screensaver_sub_item_table,
         }
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -254,7 +254,7 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:supportsScreensaver() then
         local ss_book_settings = {
-            text = _("Don't show this book cover on lock screen"),
+            text = _("Do not show current book cover on lock screen"),
             enabled_func = function()
                 if self.ui and self.ui.document then
                     local screensaverType = G_reader_settings:readSetting("screensaver_type")

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -65,7 +65,7 @@ local settingsList = {
     ----
 
     -- Device
-    exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit screensaver"), device=true},
+    exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit sleep screen"), device=true},
     start_usbms = {category="none", event="RequestUSBMS", title=_("Start USB storage"), device=true, condition=Device:canToggleMassStorage()},
     suspend = {category="none", event="RequestSuspend", title=_("Suspend"), device=true, condition=Device:canSuspend()},
     restart = {category="none", event="Restart", title=_("Restart KOReader"), device=true, condition=Device:canRestart()},

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20231217
+local CURRENT_MIGRATION_DATE = 20240408
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -644,6 +644,17 @@ if last_migration_date < 20231217 then
             new_shortcuts[item.folder] = { text = item.text, time = now + i }
         end
         G_reader_settings:saveSetting("folder_shortcuts", new_shortcuts)
+    end
+end
+
+-- 20240408, drop sleep screen/screensaver image_file setting in favor of document cover
+if last_migration_date < 20240408 then
+    logger.info("Performing one-time migration for 20240408")
+
+    local image_file = G_reader_settings:readSetting("screensaver_type") == "image_file" and G_reader_settings:readSetting("screensaver_image")
+    if image_file then
+        G_reader_settings:saveSetting("screensaver_type", "document_cover")
+        G_reader_settings:saveSetting("screensaver_document_cover", image_file)
     end
 end
 

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -44,7 +44,7 @@ return {
                 
         
             {
-                text = _("Fill-in Borders"),
+                text = _("Border Fill"),
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_img_background", "black"),
                     genMenuItem(_("White"), "screensaver_img_background", "white"),
@@ -54,7 +54,7 @@ return {
                             text_func = function()
                                 local percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage")
                                 if G_reader_settings:isTrue("screensaver_stretch_images") and percentage then
-                                    return T(_("Stretch to fit screen (with limit: %1 %)"), percentage)
+                                    return T(_("Stretch to Fit Screen (with limit: %1 %)"), percentage)
                                 end
                                 return _("Stretch Cover to Fit Screen")
                             end,
@@ -74,7 +74,7 @@ return {
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
-                    genMenuItem(_("Unlock with tap"), "screensaver_delay", "tap"),
+                    genMenuItem(_("Unlock with a tap"), "screensaver_delay", "tap"),
                     genMenuItem(_("Unlock with 'Exit Screensaver' gesture"), "screensaver_delay", "gesture"),
                 },
             },
@@ -102,7 +102,9 @@ return {
                 end,
             },
             {
-                text = _("Fill-in Background"), 
+                text = _("Background Fill"),
+                help_text = _([[This option will only become available, if you have selected 'Lock the screen in current state' 
+                    as screensaver and have 'Lock screen message' on.]]),
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_msg_background", "black"),
                     genMenuItem(_("White"), "screensaver_msg_background", "white"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -45,8 +45,8 @@ return {
                             or G_reader_settings:readSetting("screensaver_type") == "document_cover"
                 end,
                 sub_item_table = {
-                    genMenuItem(_("Black"), "screensaver_img_background", "black"),
-                    genMenuItem(_("White"), "screensaver_img_background", "white"),
+                    genMenuItem(_("Black fill"), "screensaver_img_background", "black"),
+                    genMenuItem(_("White fill"), "screensaver_img_background", "white"),
                     genMenuItem(_("Current state"), "screensaver_img_background", "none", nil, true),
                     -- separator
                         {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -33,14 +33,14 @@ return {
         text = _("Screensaver"),
         sub_item_table = {
             
-                genMenuItem(_("Show book cover on lock screen"), "screensaver_type", "cover", hasLastFile),
-                genMenuItem(_("Show custom image on lock screen"), "screensaver_type", "image_file"),
-                genMenuItem(_("Show multiple custom images on lock screen"), "screensaver_type", "random_image"),
-                genMenuItem(_("Show document cover on lock screen"), "screensaver_type", "document_cover"),
-                genMenuItem(_("Show reading progress on lock screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
-                genMenuItem(_("Show book status on lock screen"), "screensaver_type", "bookstatus", hasLastFile),
-                genMenuItem(_("Lock the screen in current state"), "screensaver_type", "disable", nil, true),
-                separator = true,
+            genMenuItem(_("Show book cover on lock screen"), "screensaver_type", "cover", hasLastFile),
+            genMenuItem(_("Show custom image on lock screen"), "screensaver_type", "image_file"),
+            genMenuItem(_("Use slide show on lock screen"), "screensaver_type", "random_image"),
+            genMenuItem(_("Show document cover on lock screen"), "screensaver_type", "document_cover"),
+            genMenuItem(_("Show reading progress on lock screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
+            genMenuItem(_("Show book status on lock screen"), "screensaver_type", "bookstatus", hasLastFile),
+            genMenuItem(_("Lock the screen in current state"), "screensaver_type", "disable", nil, true),
+            separator = true,
                 
         
             {
@@ -140,7 +140,7 @@ return {
                 end,
             },
             {
-                text = _("Folder used for custom images"),
+                text = _("Select slide show folder"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFolder()
@@ -148,7 +148,7 @@ return {
             },
             
             {
-                text = _("Document Cover"),
+                text = _("Select Document Cover"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFile(true)

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -44,7 +44,7 @@ return {
                     return G_reader_settings:readSetting("screensaver_type") == "cover"
                             or G_reader_settings:readSetting("screensaver_type") == "random_image"
                             or G_reader_settings:readSetting("screensaver_type") == "image_file"
-                            or G_reader_settings:readSetting("screensaver_type") == "document_cover" 
+                            or G_reader_settings:readSetting("screensaver_type") == "document_cover"
                 end,
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_img_background", "black"),
@@ -81,7 +81,7 @@ return {
             },
             {
                 text = _("Custom images"),
-                enabled_func = function() 
+                enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "image_file"
                             or G_reader_settings:readSetting("screensaver_type") == "random_image"
                             or G_reader_settings:readSetting("screensaver_type") == "document_cover"
@@ -89,7 +89,7 @@ return {
                 sub_item_table = {
                     {
                         text = _("Select custom image"),
-                        enabled_func = function() 
+                        enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "image_file"
                         end,
                         keep_menu_open = true,
@@ -99,7 +99,7 @@ return {
                     },
                     {
                         text = _("Select shuffle folder"),
-                        enabled_func = function() 
+                        enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "random_image"
                         end,
                         keep_menu_open = true,
@@ -109,7 +109,7 @@ return {
                     },
                     {
                         text = _("Select document cover"),
-                        enabled_func = function() 
+                        enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "document_cover"
                         end,
                         keep_menu_open = true,
@@ -136,7 +136,7 @@ return {
             },
             {
             text = _("Edit sleep screen message"),
-            enabled_func = function() 
+            enabled_func = function()
                 return G_reader_settings:isTrue("screensaver_show_message")
             end,
             keep_menu_open = true,
@@ -159,7 +159,7 @@ return {
             },
             {
                 text = _("Message position"),
-                enabled_func = function() 
+                enabled_func = function()
                     return G_reader_settings:isTrue("screensaver_show_message")
                 end,
                 sub_item_table = {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -91,7 +91,7 @@ return {
                         end,
                         keep_menu_open = true,
                         callback = function()
-                            Screensaver:chooseFile(true)
+                            Screensaver:chooseFile()
                         end,
                     },
                     {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -69,7 +69,7 @@ return {
             {
                 text = _("Delay screen update after wake-up"),
                 sub_item_table = {
-                    genMenuItem(_("Off"), "screensaver_delay", "disable"),
+                    genMenuItem(_("No delay"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -75,8 +75,8 @@ return {
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
-                    genMenuItem(_("Awake with a tap"), "screensaver_delay", "tap"),
-                    genMenuItem(_("Awake with 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
+                    genMenuItem(_("Until a tap"), "screensaver_delay", "tap"),
+                    genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay"), "screensaver_delay", "gesture"),
                 },
             },
             {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -70,7 +70,7 @@ return {
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
                     genMenuItem(_("Unlock with a tap"), "screensaver_delay", "tap"),
-                    genMenuItem(_("Unlock with 'exit Screensaver' gesture"), "screensaver_delay", "gesture"),
+                    genMenuItem(_("Unlock with 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
                 },
             },
         },
@@ -90,6 +90,11 @@ return {
             },
             {
             text = _("Edit sleep screen message"),
+            enabled_func = function() 
+                if not G_reader_settings:isTrue("screensaver_show_message") then
+                    return false    
+                end
+            end,
             keep_menu_open = true,
                 callback = function()
                     Screensaver:setMessage()
@@ -99,6 +104,13 @@ return {
                 text = _("Background fill"),
                 help_text = _([[This option will only become available, if you have selected 'Lock the screen in current state'
                     as screensaver and have 'Sleep screen message' on.]]),
+                enabled_func = function() 
+                    if G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message") then
+                        return true    
+                    else
+                        return false
+                    end 
+                end,
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_msg_background", "black"),
                     genMenuItem(_("White"), "screensaver_msg_background", "white"),
@@ -107,6 +119,11 @@ return {
             },
             {
                 text = _("Message position"),
+                enabled_func = function() 
+                    if not G_reader_settings:isTrue("screensaver_show_message") then
+                        return false    
+                    end
+                end,
                 sub_item_table = {
                     genMenuItem(_("Top"), "screensaver_message_position", "top"),
                     genMenuItem(_("Middle"), "screensaver_message_position", "middle"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -39,7 +39,7 @@ return {
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
             separator = true,
             {
-                text = _("Image border fill"),
+                text = _("Border fill"),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "cover"
                             or G_reader_settings:readSetting("screensaver_type") == "random_image"

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -28,112 +28,131 @@ local function genMenuItem(text, setting, value, enabled_func, separator)
 end
 
 return {
-    genMenuItem(_("Use last book's cover as screensaver"), "screensaver_type", "cover", hasLastFile),
-    genMenuItem(_("Use book status as screensaver"), "screensaver_type", "bookstatus", hasLastFile),
-    genMenuItem(_("Use random image from folder as screensaver"), "screensaver_type", "random_image"),
-    genMenuItem(_("Use document cover as screensaver"), "screensaver_type", "document_cover"),
-    genMenuItem(_("Use image as screensaver"), "screensaver_type", "image_file"),
-    genMenuItem(_("Use reading progress as screensaver"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
-    genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
-    -- separator
+
     {
-        text = _("Add message to screensaver"),
-        checked_func = function()
-            return G_reader_settings:isTrue("screensaver_show_message")
-        end,
-        callback = function()
-            G_reader_settings:toggle("screensaver_show_message")
-        end,
-        separator = true,
+        text = _("Lock Screen"),
+        sub_item_table = {
+            
+                genMenuItem(_("Show book cover on lock screen"), "screensaver_type", "cover", hasLastFile),
+                genMenuItem(_("Show custom image on lock screen"), "screensaver_type", "image_file"),
+                genMenuItem(_("Show multiple custom images on lock screen"), "screensaver_type", "random_image"),
+                genMenuItem(_("Show document cover on lock screen"), "screensaver_type", "document_cover"),
+                genMenuItem(_("Show reading progress on lock screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
+                genMenuItem(_("Show book status on lock screen"), "screensaver_type", "bookstatus", hasLastFile),
+                genMenuItem(_("Lock the screen in current state"), "screensaver_type", "disable", nil, true),
+                separator = true,
+                
+        
+            {
+                text = _("Fill-in Borders"),
+                sub_item_table = {
+                    genMenuItem(_("Black"), "screensaver_img_background", "black"),
+                    genMenuItem(_("White"), "screensaver_img_background", "white"),
+                    genMenuItem(_("Leave as-is"), "screensaver_img_background", "none", nil, true),
+                    -- separator
+                        {
+                            text_func = function()
+                                local percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage")
+                                if G_reader_settings:isTrue("screensaver_stretch_images") and percentage then
+                                    return T(_("Stretch to fit screen (with limit: %1 %)"), percentage)
+                                end
+                                return _("Stretch to Fit Screen")
+                            end,
+                            checked_func = function()
+                                return G_reader_settings:isTrue("screensaver_stretch_images")
+                            end,
+                            callback = function(touchmenu_instance)
+                                Screensaver:setStretchLimit(touchmenu_instance)
+                            end,
+                        },
+                },
+            },
+            {
+                text = _("Unlock Screen Delay"),
+                sub_item_table = {
+                    genMenuItem(_("Never"), "screensaver_delay", "disable"),
+                    genMenuItem(_("1 second"), "screensaver_delay", "1"),
+                    genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
+                    genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
+                    genMenuItem(_("Unlock with tap"), "screensaver_delay", "tap"),
+                    genMenuItem(_("Unlock with 'Exit Screensaver' gesture"), "screensaver_delay", "gesture"),
+                },
+            },
+        },
     },
-    -- separator
+
     {
-        text = _("Settings"),
+        text = _("Lock Screen Message"),
         sub_item_table = {
             {
-                text = _("Screensaver folder"),
-                keep_menu_open = true,
+                text = _("Add Custom Message to Lock Screen"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("screensaver_show_message")
+                end,
                 callback = function()
-                    Screensaver:chooseFolder()
+                    G_reader_settings:toggle("screensaver_show_message")
+                end,
+                separator = true,
+            },
+            {
+            text = _("Edit Lock Screen Message"),
+            keep_menu_open = true,
+                callback = function()
+                    Screensaver:setMessage()
                 end,
             },
             {
-                text = _("Screensaver image"),
+                text = _("Sidebars"), 
+                sub_item_table = {
+                    genMenuItem(_("Black"), "screensaver_msg_background", "black"),
+                    genMenuItem(_("White"), "screensaver_msg_background", "white"),
+                    genMenuItem(_("Leave as-is"), "screensaver_msg_background", "none", nil, true),
+                },
+            },
+            {
+                text = _("Position"),
+                sub_item_table = {
+                    genMenuItem(_("Top"), "screensaver_message_position", "top"),
+                    genMenuItem(_("Middle"), "screensaver_message_position", "middle"),
+                    genMenuItem(_("Bottom"), "screensaver_message_position", "bottom", nil, true),
+                },
+            },
+            {
+                text = _("Hide reboot/poweroff Message"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("screensaver_hide_fallback_msg")
+                end,
+                callback = function()
+                    G_reader_settings:toggle("screensaver_hide_fallback_msg")
+                end,
+            }, 
+        },
+    },
+
+    {
+        text = _("Custom Images"),
+        sub_item_table = {
+            {
+                text = _("Select Custom Image"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFile()
                 end,
             },
             {
-                text = _("Document cover"),
+                text = _("Select folder with custom images"),
+                keep_menu_open = true,
+                callback = function()
+                    Screensaver:chooseFolder()
+                end,
+            },
+            
+            {
+                text = _("Document Cover"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFile(true)
                 end,
-            },
-            {
-                text = _("Screensaver message"),
-                keep_menu_open = true,
-                callback = function()
-                    Screensaver:setMessage()
-                end,
-            },
-            {
-                text = _("Covers and images settings"),
-                sub_item_table = {
-                    genMenuItem(_("Black background"), "screensaver_img_background", "black"),
-                    genMenuItem(_("White background"), "screensaver_img_background", "white"),
-                    genMenuItem(_("Leave background as-is"), "screensaver_img_background", "none", nil, true),
-                    -- separator
-                    {
-                        text_func = function()
-                            local percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage")
-                            if G_reader_settings:isTrue("screensaver_stretch_images") and percentage then
-                                return T(_("Stretch to fit screen (with limit: %1 %)"), percentage)
-                            end
-                            return _("Stretch to fit screen")
-                        end,
-                        checked_func = function()
-                            return G_reader_settings:isTrue("screensaver_stretch_images")
-                        end,
-                        callback = function(touchmenu_instance)
-                            Screensaver:setStretchLimit(touchmenu_instance)
-                        end,
-                    },
-                },
-            },
-            {
-                text = _("Message settings"),
-                sub_item_table = {
-                    genMenuItem(_("Black background behind message"), "screensaver_msg_background", "black"),
-                    genMenuItem(_("White background behind message"), "screensaver_msg_background", "white"),
-                    genMenuItem(_("Leave background as-is behind message"), "screensaver_msg_background", "none", nil, true),
-                    -- separator
-                    genMenuItem(_("Message position: top"), "screensaver_message_position", "top"),
-                    genMenuItem(_("Message position: middle"), "screensaver_message_position", "middle"),
-                    genMenuItem(_("Message position: bottom"), "screensaver_message_position", "bottom", nil, true),
-                    -- separator
-                    {
-                        text = _("Hide reboot/poweroff message"),
-                        checked_func = function()
-                            return G_reader_settings:isTrue("screensaver_hide_fallback_msg")
-                        end,
-                        callback = function()
-                            G_reader_settings:toggle("screensaver_hide_fallback_msg")
-                        end,
-                    },
-                },
-            },
-            {
-                text = _("Keep the screensaver on screen after wakeup"),
-                sub_item_table = {
-                    genMenuItem(_("Disable"), "screensaver_delay", "disable"),
-                    genMenuItem(_("For 1 second"), "screensaver_delay", "1"),
-                    genMenuItem(_("For 3 second"), "screensaver_delay", "3"),
-                    genMenuItem(_("For 5 second"), "screensaver_delay", "5"),
-                    genMenuItem(_("Until a tap"), "screensaver_delay", "tap"),
-                    genMenuItem(_("Until 'Exit screensaver' gesture"), "screensaver_delay", "gesture"),
-                },
             },
         },
     },

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -36,7 +36,7 @@ return {
             genMenuItem(_("Show document cover on sleep screen"), "screensaver_type", "document_cover"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
-            genMenuItem(_("Lock the screen in current state"), "screensaver_type", "disable", nil, true),
+            genMenuItem(_("Put screen to sleep in current state"), "screensaver_type", "disable", nil, true),
             separator = true,
             {
                 text = _("Border fill"),
@@ -69,14 +69,14 @@ return {
                 },
             },
             {
-                text = _("Unlock screen delay"),
+                text = _("Awake screen delay"),
                 sub_item_table = {
                     genMenuItem(_("Off"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
-                    genMenuItem(_("Unlock with a tap"), "screensaver_delay", "tap"),
-                    genMenuItem(_("Unlock with 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
+                    genMenuItem(_("Awake with a tap"), "screensaver_delay", "tap"),
+                    genMenuItem(_("Awake with 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
                 },
             },
             {
@@ -146,7 +146,7 @@ return {
             },
             {
                 text = _("Background fill"),
-                help_text = _([[This option will only become available, if you have selected 'Lock the screen in current state'
+                help_text = _([[This option will only become available, if you have selected 'Put screen to sleep in current state'
                     as screensaver and have 'Sleep screen message' on.]]),
                enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -44,7 +44,7 @@ return {
                 
         
             {
-                text = _("Border Fill"),
+                text = _("Border fill"),
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_img_background", "black"),
                     genMenuItem(_("White"), "screensaver_img_background", "white"),
@@ -54,9 +54,9 @@ return {
                             text_func = function()
                                 local percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage")
                                 if G_reader_settings:isTrue("screensaver_stretch_images") and percentage then
-                                    return T(_("Stretch to Fit Screen (with limit: %1 %)"), percentage)
+                                    return T(_("Stretch to fit screen (with limit: %1 %)"), percentage)
                                 end
-                                return _("Stretch Cover to Fit Screen")
+                                return _("Stretch cover to fit screen")
                             end,
                             checked_func = function()
                                 return G_reader_settings:isTrue("screensaver_stretch_images")
@@ -68,24 +68,24 @@ return {
                 },
             },
             {
-                text = _("Unlock Screen Delay"),
+                text = _("Unlock screen delay"),
                 sub_item_table = {
                     genMenuItem(_("Never"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
                     genMenuItem(_("Unlock with a tap"), "screensaver_delay", "tap"),
-                    genMenuItem(_("Unlock with 'Exit Screensaver' gesture"), "screensaver_delay", "gesture"),
+                    genMenuItem(_("Unlock with 'exit Screensaver' gesture"), "screensaver_delay", "gesture"),
                 },
             },
         },
     },
 
     {
-        text = _("Lock Screen Message"),
+        text = _("Lock screen message"),
         sub_item_table = {
             {
-                text = _("Add Custom Message to Lock Screen"),
+                text = _("Add custom message to lock screen"),
                 checked_func = function()
                     return G_reader_settings:isTrue("screensaver_show_message")
                 end,
@@ -95,14 +95,14 @@ return {
                 separator = true,
             },
             {
-            text = _("Edit Lock Screen Message"),
+            text = _("Edit lock screen message"),
             keep_menu_open = true,
                 callback = function()
                     Screensaver:setMessage()
                 end,
             },
             {
-                text = _("Background Fill"),
+                text = _("Background fill"),
                 help_text = _([[This option will only become available, if you have selected 'Lock the screen in current state' 
                     as screensaver and have 'Lock screen message' on.]]),
                 sub_item_table = {
@@ -112,7 +112,7 @@ return {
                 },
             },
             {
-                text = _("Message Position"),
+                text = _("Message position"),
                 sub_item_table = {
                     genMenuItem(_("Top"), "screensaver_message_position", "top"),
                     genMenuItem(_("Middle"), "screensaver_message_position", "middle"),
@@ -120,7 +120,7 @@ return {
                 },
             },
             {
-                text = _("Hide reboot/poweroff Message"),
+                text = _("Hide reboot/poweroff message"),
                 checked_func = function()
                     return G_reader_settings:isTrue("screensaver_hide_fallback_msg")
                 end,
@@ -132,10 +132,10 @@ return {
     },
 
     {
-        text = _("Custom Images"),
+        text = _("Custom images"),
         sub_item_table = {
             {
-                text = _("Select Custom Image"),
+                text = _("Select custom image"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFile()
@@ -150,7 +150,7 @@ return {
             },
             
             {
-                text = _("Select Document Cover"),
+                text = _("Select document cover"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFile(true)

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -35,7 +35,7 @@ return {
             
             genMenuItem(_("Show book cover on lock screen"), "screensaver_type", "cover", hasLastFile),
             genMenuItem(_("Show custom image on lock screen"), "screensaver_type", "image_file"),
-            genMenuItem(_("Use slide show on lock screen"), "screensaver_type", "random_image"),
+            genMenuItem(_("Shuffle images on lock screen"), "screensaver_type", "random_image"),
             genMenuItem(_("Show document cover on lock screen"), "screensaver_type", "document_cover"),
             genMenuItem(_("Show reading progress on lock screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on lock screen"), "screensaver_type", "bookstatus", hasLastFile),
@@ -142,7 +142,7 @@ return {
                 end,
             },
             {
-                text = _("Select slide show folder"),
+                text = _("Select shuffle folder"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFolder()

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -31,9 +31,8 @@ return {
         text = _("Wallpaper"),
         sub_item_table = {
             genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
-            genMenuItem(_("Show custom image on sleep screen"), "screensaver_type", "image_file"),
+            genMenuItem(_("Show custom image or cover on sleep screen"), "screensaver_type", "document_cover"),
             genMenuItem(_("Use random image from folder on sleep screen"), "screensaver_type", "random_image"),
-            genMenuItem(_("Show document cover on sleep screen"), "screensaver_type", "document_cover"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
@@ -43,7 +42,6 @@ return {
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "cover"
                             or G_reader_settings:readSetting("screensaver_type") == "random_image"
-                            or G_reader_settings:readSetting("screensaver_type") == "image_file"
                             or G_reader_settings:readSetting("screensaver_type") == "document_cover"
                 end,
                 sub_item_table = {
@@ -82,19 +80,18 @@ return {
             {
                 text = _("Custom images"),
                 enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") == "image_file"
-                            or G_reader_settings:readSetting("screensaver_type") == "random_image"
-                            or G_reader_settings:readSetting("screensaver_type") == "document_cover"
+                    return G_reader_settings:readSetting("screensaver_type") == "random_image"
+                           or G_reader_settings:readSetting("screensaver_type") == "document_cover"
                 end,
                 sub_item_table = {
                     {
-                        text = _("Select custom image"),
+                        text = _("Select image or document cover"),
                         enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") == "image_file"
+                            return G_reader_settings:readSetting("screensaver_type") == "document_cover"
                         end,
                         keep_menu_open = true,
                         callback = function()
-                            Screensaver:chooseFile()
+                            Screensaver:chooseFile(true)
                         end,
                     },
                     {
@@ -105,16 +102,6 @@ return {
                         keep_menu_open = true,
                         callback = function()
                             Screensaver:chooseFolder()
-                        end,
-                    },
-                    {
-                        text = _("Select document cover"),
-                        enabled_func = function()
-                            return G_reader_settings:readSetting("screensaver_type") == "document_cover"
-                        end,
-                        keep_menu_open = true,
-                        callback = function()
-                            Screensaver:chooseFile(true)
                         end,
                     },
                 },

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -32,7 +32,7 @@ return {
         sub_item_table = {
             genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
             genMenuItem(_("Show custom image or cover on sleep screen"), "screensaver_type", "document_cover"),
-            genMenuItem(_("Use random image from folder on sleep screen"), "screensaver_type", "random_image"),
+            genMenuItem(_("Show random image from folder on sleep screen"), "screensaver_type", "random_image"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -76,7 +76,7 @@ return {
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
                     genMenuItem(_("Until a tap"), "screensaver_delay", "tap"),
-                    genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay"), "screensaver_delay", "gesture"),
+                    genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
                 },
             },
             {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -39,7 +39,7 @@ return {
             genMenuItem(_("Leave screen in current state"), "screensaver_type", "disable", nil, true),
             separator = true,
             {
-                text = _("Border fill"),
+                text = _("Image border fill"),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "cover"
                             or G_reader_settings:readSetting("screensaver_type") == "random_image"

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -41,29 +41,29 @@ return {
                 text = _("Border fill"),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "cover"
-                            or G_reader_settings:readSetting("screensaver_type") == "random_image"
-                            or G_reader_settings:readSetting("screensaver_type") == "document_cover"
+                           or G_reader_settings:readSetting("screensaver_type") == "document_cover"
+                           or G_reader_settings:readSetting("screensaver_type") == "random_image"
                 end,
                 sub_item_table = {
                     genMenuItem(_("Black fill"), "screensaver_img_background", "black"),
                     genMenuItem(_("White fill"), "screensaver_img_background", "white"),
                     genMenuItem(_("Leave background as-is"), "screensaver_img_background", "none", nil, true),
                     -- separator
-                        {
-                            text_func = function()
-                                local percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage")
-                                if G_reader_settings:isTrue("screensaver_stretch_images") and percentage then
-                                    return T(_("Stretch to fit screen (with limit: %1 %)"), percentage)
-                                end
-                                return _("Stretch cover to fit screen")
-                            end,
-                            checked_func = function()
-                                return G_reader_settings:isTrue("screensaver_stretch_images")
-                            end,
-                            callback = function(touchmenu_instance)
-                                Screensaver:setStretchLimit(touchmenu_instance)
-                            end,
-                        },
+                    {
+                        text_func = function()
+                            local percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage")
+                            if G_reader_settings:isTrue("screensaver_stretch_images") and percentage then
+                                return T(_("Stretch to fit screen (with limit: %1 %)"), percentage)
+                            end
+                            return _("Stretch cover to fit screen")
+                        end,
+                        checked_func = function()
+                            return G_reader_settings:isTrue("screensaver_stretch_images")
+                        end,
+                        callback = function(touchmenu_instance)
+                            Screensaver:setStretchLimit(touchmenu_instance)
+                        end,
+                    },
                 },
             },
             {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -36,7 +36,7 @@ return {
             genMenuItem(_("Show document cover on sleep screen"), "screensaver_type", "document_cover"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
-            genMenuItem(_("Put screen to sleep in current state"), "screensaver_type", "disable", nil, true),
+            genMenuItem(_("Leave screen in current state"), "screensaver_type", "disable", nil, true),
             separator = true,
             {
                 text = _("Border fill"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -36,7 +36,7 @@ return {
             genMenuItem(_("Show document cover on sleep screen"), "screensaver_type", "document_cover"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
-            genMenuItem(_("Leave screen in current state"), "screensaver_type", "disable", nil, true),
+            genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
             separator = true,
             {
                 text = _("Image border fill"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -69,7 +69,7 @@ return {
                 },
             },
             {
-                text = _("Awake screen delay"),
+                text = _("Screen wake-up delay"),
                 sub_item_table = {
                     genMenuItem(_("Off"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -32,7 +32,7 @@ return {
         sub_item_table = {
             genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
             genMenuItem(_("Show custom image on sleep screen"), "screensaver_type", "image_file"),
-            genMenuItem(_("Shuffle images on sleep screen"), "screensaver_type", "random_image"),
+            genMenuItem(_("Use random image from folder on sleep screen"), "screensaver_type", "random_image"),
             genMenuItem(_("Show document cover on sleep screen"), "screensaver_type", "document_cover"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -122,11 +122,11 @@ return {
                 separator = true,
             },
             {
-            text = _("Edit sleep screen message"),
-            enabled_func = function()
-                return G_reader_settings:isTrue("screensaver_show_message")
-            end,
-            keep_menu_open = true,
+                text = _("Edit sleep screen message"),
+                enabled_func = function()
+                    return G_reader_settings:isTrue("screensaver_show_message")
+                end,
+                keep_menu_open = true,
                 callback = function()
                     Screensaver:setMessage()
                 end,
@@ -135,7 +135,7 @@ return {
                 text = _("Background fill"),
                 help_text = _([[This option will only become available, if you have selected 'Put screen to sleep in current state'
                     as screensaver and have 'Sleep screen message' on.]]),
-               enabled_func = function()
+                enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
                 end,
                 sub_item_table = {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -40,6 +40,10 @@ return {
             separator = true,
             {
                 text = _("Border fill"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") == "cover" or G_reader_settings:readSetting("screensaver_type") == "random_image"
+                    or G_reader_settings:readSetting("screensaver_type") == "image_file" or G_reader_settings:readSetting("screensaver_type") == "document_cover" 
+                end,
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_img_background", "black"),
                     genMenuItem(_("White"), "screensaver_img_background", "white"),
@@ -91,9 +95,7 @@ return {
             {
             text = _("Edit sleep screen message"),
             enabled_func = function() 
-                if not G_reader_settings:isTrue("screensaver_show_message") then
-                    return false    
-                end
+                return G_reader_settings:isTrue("screensaver_show_message")
             end,
             keep_menu_open = true,
                 callback = function()
@@ -104,25 +106,19 @@ return {
                 text = _("Background fill"),
                 help_text = _([[This option will only become available, if you have selected 'Lock the screen in current state'
                     as screensaver and have 'Sleep screen message' on.]]),
-                enabled_func = function() 
-                    if G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message") then
-                        return true    
-                    else
-                        return false
-                    end 
+               enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
                 end,
                 sub_item_table = {
-                    genMenuItem(_("Black"), "screensaver_msg_background", "black"),
-                    genMenuItem(_("White"), "screensaver_msg_background", "white"),
+                    genMenuItem(_("Black fill"), "screensaver_msg_background", "black"),
+                    genMenuItem(_("White fill"), "screensaver_msg_background", "white"),
                     genMenuItem(_("Current state"), "screensaver_msg_background", "none", nil, true),
                 },
             },
             {
                 text = _("Message position"),
                 enabled_func = function() 
-                    if not G_reader_settings:isTrue("screensaver_show_message") then
-                        return false    
-                    end
+                    return G_reader_settings:isTrue("screensaver_show_message")
                 end,
                 sub_item_table = {
                     genMenuItem(_("Top"), "screensaver_message_position", "top"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -28,7 +28,7 @@ local function genMenuItem(text, setting, value, enabled_func, separator)
 end
 return {
     {
-        text = _("Screensaver"),
+        text = _("Wallpaper"),
         sub_item_table = {
             genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
             genMenuItem(_("Show custom image on sleep screen"), "screensaver_type", "image_file"),
@@ -69,12 +69,52 @@ return {
             {
                 text = _("Unlock screen delay"),
                 sub_item_table = {
-                    genMenuItem(_("Never"), "screensaver_delay", "disable"),
+                    genMenuItem(_("Off"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
                     genMenuItem(_("Unlock with a tap"), "screensaver_delay", "tap"),
                     genMenuItem(_("Unlock with 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
+                },
+            },
+            {
+                text = _("Custom images"),
+                enabled_func = function() 
+                    return G_reader_settings:readSetting("screensaver_type") == "image_file"
+                    or G_reader_settings:readSetting("screensaver_type") == "random_image"
+                    or G_reader_settings:readSetting("screensaver_type") == "document_cover"
+                end,
+                sub_item_table = {
+                    {
+                        text = _("Select custom image"),
+                        enabled_func = function() 
+                            return G_reader_settings:readSetting("screensaver_type") == "image_file"
+                        end,
+                        keep_menu_open = true,
+                        callback = function()
+                            Screensaver:chooseFile()
+                        end,
+                    },
+                    {
+                        text = _("Select shuffle folder"),
+                        enabled_func = function() 
+                            return G_reader_settings:readSetting("screensaver_type") == "random_image"
+                        end,
+                        keep_menu_open = true,
+                        callback = function()
+                            Screensaver:chooseFolder()
+                        end,
+                    },
+                    {
+                        text = _("Select document cover"),
+                        enabled_func = function() 
+                            return G_reader_settings:readSetting("screensaver_type") == "document_cover"
+                        end,
+                        keep_menu_open = true,
+                        callback = function()
+                            Screensaver:chooseFile(true)
+                        end,
+                    },
                 },
             },
         },
@@ -133,32 +173,6 @@ return {
                 end,
                 callback = function()
                     G_reader_settings:toggle("screensaver_hide_fallback_msg")
-                end,
-            },
-        },
-    },
-    {
-        text = _("Custom images"),
-        sub_item_table = {
-            {
-                text = _("Select custom image"),
-                keep_menu_open = true,
-                callback = function()
-                    Screensaver:chooseFile()
-                end,
-            },
-            {
-                text = _("Select shuffle folder"),
-                keep_menu_open = true,
-                callback = function()
-                    Screensaver:chooseFolder()
-                end,
-            },
-            {
-                text = _("Select document cover"),
-                keep_menu_open = true,
-                callback = function()
-                    Screensaver:chooseFile(true)
                 end,
             },
         },

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -98,7 +98,7 @@ return {
                         end,
                     },
                     {
-                        text = _("Select shuffle folder"),
+                        text = _("Select random image folder"),
                         enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "random_image"
                         end,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -67,7 +67,7 @@ return {
                 },
             },
             {
-                text = _("Screen wake-up delay"),
+                text = _("Delay screen update after wake-up"),
                 sub_item_table = {
                     genMenuItem(_("Off"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -41,8 +41,10 @@ return {
             {
                 text = _("Border fill"),
                 enabled_func = function()
-                    return G_reader_settings:readSetting("screensaver_type") == "cover" or G_reader_settings:readSetting("screensaver_type") == "random_image"
-                    or G_reader_settings:readSetting("screensaver_type") == "image_file" or G_reader_settings:readSetting("screensaver_type") == "document_cover" 
+                    return G_reader_settings:readSetting("screensaver_type") == "cover"
+                            or G_reader_settings:readSetting("screensaver_type") == "random_image"
+                            or G_reader_settings:readSetting("screensaver_type") == "image_file"
+                            or G_reader_settings:readSetting("screensaver_type") == "document_cover" 
                 end,
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_img_background", "black"),
@@ -81,8 +83,8 @@ return {
                 text = _("Custom images"),
                 enabled_func = function() 
                     return G_reader_settings:readSetting("screensaver_type") == "image_file"
-                    or G_reader_settings:readSetting("screensaver_type") == "random_image"
-                    or G_reader_settings:readSetting("screensaver_type") == "document_cover"
+                            or G_reader_settings:readSetting("screensaver_type") == "random_image"
+                            or G_reader_settings:readSetting("screensaver_type") == "document_cover"
                 end,
                 sub_item_table = {
                     {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -26,23 +26,18 @@ local function genMenuItem(text, setting, value, enabled_func, separator)
         separator = separator,
     }
 end
-
 return {
-
     {
         text = _("Screensaver"),
         sub_item_table = {
-            
-            genMenuItem(_("Show book cover on lock screen"), "screensaver_type", "cover", hasLastFile),
-            genMenuItem(_("Show custom image on lock screen"), "screensaver_type", "image_file"),
-            genMenuItem(_("Shuffle images on lock screen"), "screensaver_type", "random_image"),
-            genMenuItem(_("Show document cover on lock screen"), "screensaver_type", "document_cover"),
-            genMenuItem(_("Show reading progress on lock screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
-            genMenuItem(_("Show book status on lock screen"), "screensaver_type", "bookstatus", hasLastFile),
+            genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
+            genMenuItem(_("Show custom image on sleep screen"), "screensaver_type", "image_file"),
+            genMenuItem(_("Shuffle images on sleep screen"), "screensaver_type", "random_image"),
+            genMenuItem(_("Show document cover on sleep screen"), "screensaver_type", "document_cover"),
+            genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
+            genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
             genMenuItem(_("Lock the screen in current state"), "screensaver_type", "disable", nil, true),
             separator = true,
-                
-        
             {
                 text = _("Border fill"),
                 sub_item_table = {
@@ -80,12 +75,11 @@ return {
             },
         },
     },
-
     {
-        text = _("Lock screen message"),
+        text = _("Sleep screen message"),
         sub_item_table = {
             {
-                text = _("Add custom message to lock screen"),
+                text = _("Add custom message to sleep screen"),
                 checked_func = function()
                     return G_reader_settings:isTrue("screensaver_show_message")
                 end,
@@ -95,7 +89,7 @@ return {
                 separator = true,
             },
             {
-            text = _("Edit lock screen message"),
+            text = _("Edit sleep screen message"),
             keep_menu_open = true,
                 callback = function()
                     Screensaver:setMessage()
@@ -103,8 +97,8 @@ return {
             },
             {
                 text = _("Background fill"),
-                help_text = _([[This option will only become available, if you have selected 'Lock the screen in current state' 
-                    as screensaver and have 'Lock screen message' on.]]),
+                help_text = _([[This option will only become available, if you have selected 'Lock the screen in current state'
+                    as screensaver and have 'Sleep screen message' on.]]),
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_msg_background", "black"),
                     genMenuItem(_("White"), "screensaver_msg_background", "white"),
@@ -127,10 +121,9 @@ return {
                 callback = function()
                     G_reader_settings:toggle("screensaver_hide_fallback_msg")
                 end,
-            }, 
+            },
         },
     },
-
     {
         text = _("Custom images"),
         sub_item_table = {
@@ -148,7 +141,6 @@ return {
                     Screensaver:chooseFolder()
                 end,
             },
-            
             {
                 text = _("Select document cover"),
                 keep_menu_open = true,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -48,7 +48,7 @@ return {
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_img_background", "black"),
                     genMenuItem(_("White"), "screensaver_img_background", "white"),
-                    genMenuItem(_("Leave as-is"), "screensaver_img_background", "none", nil, true),
+                    genMenuItem(_("Current state"), "screensaver_img_background", "none", nil, true),
                     -- separator
                         {
                             text_func = function()
@@ -56,7 +56,7 @@ return {
                                 if G_reader_settings:isTrue("screensaver_stretch_images") and percentage then
                                     return T(_("Stretch to fit screen (with limit: %1 %)"), percentage)
                                 end
-                                return _("Stretch to Fit Screen")
+                                return _("Stretch Cover to Fit Screen")
                             end,
                             checked_func = function()
                                 return G_reader_settings:isTrue("screensaver_stretch_images")
@@ -102,15 +102,15 @@ return {
                 end,
             },
             {
-                text = _("Sidebars"), 
+                text = _("Fill-in Background"), 
                 sub_item_table = {
                     genMenuItem(_("Black"), "screensaver_msg_background", "black"),
                     genMenuItem(_("White"), "screensaver_msg_background", "white"),
-                    genMenuItem(_("Leave as-is"), "screensaver_msg_background", "none", nil, true),
+                    genMenuItem(_("Current state"), "screensaver_msg_background", "none", nil, true),
                 },
             },
             {
-                text = _("Position"),
+                text = _("Message Position"),
                 sub_item_table = {
                     genMenuItem(_("Top"), "screensaver_message_position", "top"),
                     genMenuItem(_("Middle"), "screensaver_message_position", "middle"),
@@ -140,7 +140,7 @@ return {
                 end,
             },
             {
-                text = _("Select folder with custom images"),
+                text = _("Folder used for custom images"),
                 keep_menu_open = true,
                 callback = function()
                     Screensaver:chooseFolder()

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -30,7 +30,7 @@ end
 return {
 
     {
-        text = _("Lock Screen"),
+        text = _("Screensaver"),
         sub_item_table = {
             
                 genMenuItem(_("Show book cover on lock screen"), "screensaver_type", "cover", hasLastFile),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -47,7 +47,7 @@ return {
                 sub_item_table = {
                     genMenuItem(_("Black fill"), "screensaver_img_background", "black"),
                     genMenuItem(_("White fill"), "screensaver_img_background", "white"),
-                    genMenuItem(_("Current state"), "screensaver_img_background", "none", nil, true),
+                    genMenuItem(_("Leave background as-is"), "screensaver_img_background", "none", nil, true),
                     -- separator
                         {
                             text_func = function()
@@ -133,15 +133,14 @@ return {
             },
             {
                 text = _("Background fill"),
-                help_text = _([[This option will only become available, if you have selected 'Put screen to sleep in current state'
-                    as screensaver and have 'Sleep screen message' on.]]),
+                help_text = _("This option will only become available, if you have selected 'Leave screen as-is' as screensaver and have 'Sleep screen message' on."),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
                 end,
                 sub_item_table = {
                     genMenuItem(_("Black fill"), "screensaver_msg_background", "black"),
                     genMenuItem(_("White fill"), "screensaver_msg_background", "white"),
-                    genMenuItem(_("Current state"), "screensaver_msg_background", "none", nil, true),
+                    genMenuItem(_("Leave background as-is"), "screensaver_msg_background", "none", nil, true),
                 },
             },
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -261,26 +261,15 @@ function Screensaver:chooseFolder()
     filemanagerutil.showChooseDialog(title_header, caller_callback, current_path)
 end
 
-function Screensaver:chooseFile(document_cover)
+function Screensaver:chooseFile()
     local title_header, current_path, file_filter, caller_callback
-    if document_cover then
-        title_header = _("Current screensaver document cover:")
-        current_path = G_reader_settings:readSetting("screensaver_document_cover")
-        file_filter = function(filename)
-            return DocumentRegistry:hasProvider(filename)
-        end
-        caller_callback = function(path)
-            G_reader_settings:saveSetting("screensaver_document_cover", path)
-        end
-    else
-        title_header = _("Current screensaver image:")
-        current_path = G_reader_settings:readSetting("screensaver_image")
-        file_filter = function(filename)
-            return DocumentRegistry:isImageFile(filename)
-        end
-        caller_callback = function(path)
-            G_reader_settings:saveSetting("screensaver_image", path)
-        end
+    title_header = _("Current sleep screen image or document cover:")
+    current_path = G_reader_settings:readSetting("screensaver_document_cover")
+    file_filter = function(filename)
+        return DocumentRegistry:hasProvider(filename)
+    end
+    caller_callback = function(path)
+        G_reader_settings:saveSetting("screensaver_document_cover", path)
     end
     filemanagerutil.showChooseDialog(title_header, caller_callback, current_path, nil, file_filter)
 end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -315,7 +315,7 @@ function Screensaver:setMessage()
     input_dialog = InputDialog:new{
         title = _("Screensaver message"),
         description = _([[
-Enter the message to be displayed by the screensaver. The following escape sequences can be used:
+Enter your custom message to be displayed on the lock screen. The following escape sequences are available:
   %T title
   %A author(s)
   %S series

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -315,7 +315,7 @@ function Screensaver:setMessage()
     input_dialog = InputDialog:new{
         title = _("Screensaver message"),
         description = _([[
-Enter a custom message to be displayed on the lock screen. The following escape sequences are available:
+Enter a custom message to be displayed on the sleep screen. The following escape sequences are available:
   %T title
   %A author(s)
   %S series

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -383,7 +383,6 @@ end
 function Screensaver:modeIsImage()
     return self.screensaver_type == "cover"
         or self.screensaver_type == "random_image"
-        or self.screensaver_type == "image_file"
 end
 
 function Screensaver:withBackground()
@@ -453,14 +452,6 @@ function Screensaver:setup(event, event_message)
     end
     if self.screensaver_type == "bookstatus" then
         if not ui or not lastfile or lfs.attributes(lastfile, "mode") ~= "file" or (ui.doc_settings and ui.doc_settings:isTrue("exclude_screensaver")) then
-            self.screensaver_type = "random_image"
-        end
-    end
-    -- NB Kept around to support old settings.
-    if self.screensaver_type == "image_file" then
-        self.image_file = G_reader_settings:readSetting(self.prefix .. "screensaver_image")
-                       or G_reader_settings:readSetting("screensaver_image")
-        if self.image_file == nil or lfs.attributes(self.image_file, "mode") ~= "file" then
             self.screensaver_type = "random_image"
         end
     end
@@ -536,7 +527,7 @@ function Screensaver:show()
 
     -- Build the main widget for the effective mode, all the sanity checks were handled in setup
     local widget = nil
-    if self.screensaver_type == "cover" or self.screensaver_type == "image_file" or self.screensaver_type == "random_image" then
+    if self.screensaver_type == "cover" or self.screensaver_type == "random_image" then
         local widget_settings = {
             width = Screen:getWidth(),
             height = Screen:getHeight(),

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -315,7 +315,7 @@ function Screensaver:setMessage()
     input_dialog = InputDialog:new{
         title = _("Screensaver message"),
         description = _([[
-Enter your custom message to be displayed on the lock screen. The following escape sequences are available:
+Enter a custom message to be displayed on the lock screen. The following escape sequences are available:
   %T title
   %A author(s)
   %S series

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -207,7 +207,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% > unopened > 100% or finished
+            -- sort 90% > 50% > 0% or on hold > unopened > 100% or finished
             text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -238,6 +238,12 @@ local FileChooser = Menu:extend{
                     -- books marked as "finished" should be considered the same as 100%
                     if summary and summary.status == "complete" then
                         item.percent_finished = 1.0
+                        return
+                    end
+
+                    -- books marked as "on hold" should be considered the same as 0%
+                    if summary and summary.status == "abandoned" then
+                        item.percent_finished = 0.0
                         return
                     end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -207,7 +207,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% or on hold > unopened > 100% or finished
+            -- sort 90% > 50% > 0% > unopened > 100% or finished
             text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -235,14 +235,12 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     local summary = doc_settings:readSetting("summary")
 
-                    -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
+                    -- books marked as "finished" should be considered the same as 100%
                     if summary and summary.status == "complete" then
-                        item.percent_finished = 1
-                        return
-                    elseif summary and summary.status == "abandoned" then
-                        item.percent_finished = 0
+                        item.percent_finished = 1.0
                         return
                     end
+
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -235,18 +235,14 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     local summary = doc_settings:readSetting("summary")
 
-                    -- books marked as "finished" should be considered the same as 100%
+                    -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
                     if summary and summary.status == "complete" then
-                        item.percent_finished = 1.0
+                        item.percent_finished = 1
+                        return
+                    elseif summary and summary.status == "abandoned" then
+                        item.percent_finished = 0
                         return
                     end
-
-                    -- books marked as "on hold" should be considered the same as 0%
-                    if summary and summary.status == "abandoned" then
-                        item.percent_finished = 0.0
-                        return
-                    end
-
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers


### PR DESCRIPTION
This PR brings a complete make over to the Lock Screen, currently know as 'screensaver' menu.

NO changes have been made to functionality, this is a strictly cosmetic but comprehensive update.

The following image, showcases the new arrangement of the menu: most names have been changed for ease of use but again no changes to back end code (you can see that though). 

[Book1.pdf](https://github.com/koreader/koreader/files/14595479/Book1.pdf)

Regarding "Hide reboot/poweroff Message", what the **ck does that do? I have never seen such a message and I don't have that selected. Anyway, I was not be able to place it correctly, so please let me know so it can be moved (if needed) to the appropriate place. 

Regarding the newly named "background fill" option, could someone please help me make it so that is greyed out when both conditions ('Lock the screen in current state' and 'Add Lock screen message') are not met...

I made these changes because, honestly, the top menu is like the Wild West, if anyone else is happy and on board, I could work on renaming and rearranging the whole top menu in a much more cohesive way. 

Blimey, this took a lot longer than I expected... 🤓

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11549)
<!-- Reviewable:end -->
