### PR TITLE
appimage: get full path before changing to assets dir

### DIFF
--- a/platform/appimage/AppRun
+++ b/platform/appimage/AppRun
@@ -4,14 +4,22 @@ export LC_ALL="en_US.UTF-8"
 # working directory of koreader
 KOREADER_DIR="${0%/*}"
 
+if [ $# -eq 1 ] && [ -e "$(pwd)/${1}" ]; then
+    ARGS="$(pwd)/${1}"
+else
+    ARGS="${*}"
+fi
+
 # we're always starting from our working directory
 cd "${KOREADER_DIR}" || exit
 
 RETURN_VALUE=85
 
 while [ ${RETURN_VALUE} -eq 85 ]; do
-    ./reader.lua "$@"
+    ./reader.lua "${ARGS}"
     RETURN_VALUE=$?
+    # do not restart with saved arguments
+    ARGS="${HOME}"
 done
 
 exit ${RETURN_VALUE}


### PR DESCRIPTION
Like in https://github.com/koreader/koreader/blob/master/platform/debian/koreader.sh

If **one and only one** argument is passed and the argument is a path that exists on the filesystem get its absolute path and pass it to lua, because assets dir != pwd and it is impossible to resolve relative paths from there.

Needs to be improved, here on in the future, to handle short options. The most effective way would be to pass `pwd` as a parameter and let the frontend to join `pwd` and `path`. So the frontend takes care of everything :)

Feedback welcome.

Closes #11518

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11552)
<!-- Reviewable:end -->
