### PR TITLE
Highlights: update page numbers

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1158,8 +1158,10 @@ function ReaderBookmark:setHighlightedText(item, text)
     end
     -- highlight
     local hl = self.ui.highlight:getHighlightByDatetime(item.datetime)
-    hl.text = text
-    hl.edited = edited
+    if hl then -- skip orphaned bookmark
+        hl.text = text
+        hl.edited = edited
+    end
     -- bookmark
     local index = self:getBookmarkIndexBinarySearch(item) or self:getBookmarkIndexFullScan(item)
     local bm = self.bookmarks[index]

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2217,6 +2217,31 @@ function ReaderHighlight:onUpdateHoldPanRate()
     self:setupTouchZones()
 end
 
+function ReaderHighlight:updateHighlightPageNumbers()
+    local bookmarks = self.ui.bookmark.bookmarks
+    local highlights = {}
+    for i = #bookmarks, 1, -1 do
+        local bookmark = bookmarks[i]
+        if bookmark.highlighted then
+            local highlight = self:getHighlightByDatetime(bookmark.datetime)
+            if highlight then
+                local pageno = self.ui.paging and bookmark.page or self.document:getPageFromXPointer(bookmark.page)
+                if highlights[pageno] == nil then
+                    highlights[pageno] = {}
+                end
+                table.insert(highlights[pageno], highlight)
+            else -- orphan
+                table.remove(bookmarks, i)
+            end
+        end
+    end
+    self.view.highlight.saved = highlights
+end
+
+function ReaderHighlight:onCloseDocument()
+    self:updateHighlightPageNumbers()
+end
+
 function ReaderHighlight:onSaveSettings()
     self.ui.doc_settings:saveSetting("highlight_drawer", self.view.highlight.saved_drawer)
     self.ui.doc_settings:saveSetting("panel_zoom_enabled", self.panel_zoom_enabled)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2224,14 +2224,27 @@ function ReaderHighlight:updateHighlightPageNumbers()
         local bookmark = bookmarks[i]
         if bookmark.highlighted then
             local highlight = self:getHighlightByDatetime(bookmark.datetime)
+            if not highlight and (self.ui.rolling or bookmark.pos0.page == bookmark.pos1.page) then
+                -- restore highlight for orphaned bookmark
+                -- do not bother with restoring pboxes for pdf multi-page highlight, keep bookmark orphaned
+                highlight = {
+                    datetime = bookmark.datetime,
+                    text     = bookmark.notes,
+                    chapter  = bookmark.chapter,
+                    pos0     = bookmark.pos0,
+                    pos1     = bookmark.pos1,
+                    drawer   = self.view.highlight.saved_drawer,
+                }
+                if self.ui.paging then
+                    highlight.pboxes = self.document:getPageBoxesFromPositions(bookmark.page, bookmark.pos0, bookmark.pos1)
+                end
+            end
             if highlight then
                 local pageno = self.ui.paging and bookmark.page or self.document:getPageFromXPointer(bookmark.page)
                 if highlights[pageno] == nil then
                     highlights[pageno] = {}
                 end
                 table.insert(highlights[pageno], highlight)
-            else -- orphan
-                table.remove(bookmarks, i)
             end
         end
     end

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -156,6 +156,7 @@ end
 
 --- Parse and export highlights from the currently opened document.
 function Exporter:exportCurrentNotes()
+    self.ui.highlight:updateHighlightPageNumbers()
     local clippings = self:getDocumentClippings()
     self:exportClippings(clippings)
 end


### PR DESCRIPTION
Update highlight page numbers (table keys):
-on closing the document
-on exporting current document highlights
We iterate over bookmarks to save highlights in order by position.
We do it for fixed layout documents to save highlights in order by position.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11553)
<!-- Reviewable:end -->
