### PR TITLE
ReaderStatus: update status modification time

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -219,6 +219,7 @@ end
 -- Otherwise we change status from reading/abandoned to complete or from complete to reading.
 function ReaderStatus:onMarkBook(mark_read)
     self.summary.status = (not mark_read and self.summary.status == "complete") and "reading" or "complete"
+    self.summary.modified = os.date("%Y-%m-%d", os.time())
     -- If History is called over Reader, it will read the file to get the book status, so save and flush
     self.settings:saveSetting("summary", self.summary)
     self.settings:flush()


### PR DESCRIPTION
In the "End of the book" action.
Closes https://github.com/koreader/koreader/issues/11564 (No idea how we got a book without modification time but the time stamp must be updated in any case)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11568)
<!-- Reviewable:end -->
