### PR TITLE
FileChooser collates: use "item.sort_percent" for sorting + extra `on-hold` handling

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -207,7 +207,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% > unopened > 100% or finished
+            -- sort 90% > 50% > 0% or on hold > unopened > 100% or finished
             text = _("percent - unopened - finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -235,9 +235,11 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     local summary = doc_settings:readSetting("summary")
 
-                    -- books marked as "finished" should be considered the same as 100%
+                    -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
                     if summary and summary.status == "complete" then
                         item.sort_percent = 1.0
+                    elseif summary and summary.status == "abandoned" then
+                        item.sort_percent = 0
                     end
 
                     percent_finished = doc_settings:readSetting("percent_finished")

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -215,14 +215,14 @@ local FileChooser = Menu:extend{
                 local natsort
                 natsort, cache = sort.natsort_cmp(cache)
                 local sortfunc =  function(a, b)
-                    if a.percent_finished == b.percent_finished then
+                    if a.sort_percent == b.sort_percent then
                         return natsort(a.text, b.text)
-                    elseif a.percent_finished == 1 then
+                    elseif a.sort_percent == 1 then
                         return false
-                    elseif b.percent_finished == 1 then
+                    elseif b.sort_percent == 1 then
                         return true
                     else
-                        return a.percent_finished > b.percent_finished
+                        return a.sort_percent > b.sort_percent
                     end
                 end
 
@@ -237,14 +237,14 @@ local FileChooser = Menu:extend{
 
                     -- books marked as "finished" should be considered the same as 100%
                     if summary and summary.status == "complete" then
-                        item.percent_finished = 1.0
-                        return
+                        item.sort_percent = 1.0
                     end
 
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers
-                item.percent_finished = math.floor((percent_finished or -1) * 100) / 100
+                item.sort_percent = item.sort_percent or math.floor((percent_finished or -1) * 100) / 100
+                item.percent_finished = percent_finished or 0
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -158,7 +158,7 @@ local FileChooser = Menu:extend{
                 return function(a, b)
                     if a.opened == b.opened then
                         if a.opened then
-                            return a.sort_percent < b.sort_percent
+                            return a.percent_finished < b.percent_finished
                         end
                         return ffiUtil.strcoll(a.text, b.text)
                     end
@@ -173,10 +173,8 @@ local FileChooser = Menu:extend{
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
 
-                percent_finished = percent_finished or 0
                 -- smooth 2 decimal points (0.00) instead of 16 decimal points
-                item.sort_percent = util.round_decimal(percent_finished, 2)
-                item.percent_finished = percent_finished
+                item.percent_finished = util.round_decimal(percent_finished or 0, 2)
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
@@ -190,7 +188,7 @@ local FileChooser = Menu:extend{
                 return function(a, b)
                     if a.opened == b.opened then
                         if a.opened then
-                            return a.sort_percent < b.sort_percent
+                            return a.percent_finished < b.percent_finished
                         end
                         return ffiUtil.strcoll(a.text, b.text)
                     end
@@ -205,10 +203,8 @@ local FileChooser = Menu:extend{
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
 
-                percent_finished = percent_finished or 0
                 -- smooth 2 decimal points (0.00) instead of 16 decimal points
-                item.sort_percent = util.round_decimal(percent_finished, 2)
-                item.percent_finished = percent_finished
+                item.percent_finished = util.round_decimal(percent_finished or 0, 2)
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -158,7 +158,7 @@ local FileChooser = Menu:extend{
                 return function(a, b)
                     if a.opened == b.opened then
                         if a.opened then
-                            return a.percent_finished < b.percent_finished
+                            return a.sort_percent < b.sort_percent
                         end
                         return ffiUtil.strcoll(a.text, b.text)
                     end
@@ -172,7 +172,11 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
-                item.percent_finished = percent_finished or 0
+
+                percent_finished = percent_finished or 0
+                -- smooth 2 decimal points (0.00) instead of 16 decimal points
+                item.sort_percent = util.round_decimal(percent_finished, 2)
+                item.percent_finished = percent_finished
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
@@ -186,7 +190,7 @@ local FileChooser = Menu:extend{
                 return function(a, b)
                     if a.opened == b.opened then
                         if a.opened then
-                            return a.percent_finished < b.percent_finished
+                            return a.sort_percent < b.sort_percent
                         end
                         return ffiUtil.strcoll(a.text, b.text)
                     end
@@ -200,7 +204,11 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
-                item.percent_finished = percent_finished or 0
+
+                percent_finished = percent_finished or 0
+                -- smooth 2 decimal points (0.00) instead of 16 decimal points
+                item.sort_percent = util.round_decimal(percent_finished, 2)
+                item.percent_finished = percent_finished
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
@@ -245,7 +253,7 @@ local FileChooser = Menu:extend{
 
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
-                -- smooth 2 decimal points (0.00) instead of 16 decimal numbers
+                -- smooth 2 decimal points (0.00) instead of 16 decimal points
                 item.sort_percent = sort_percent or util.round_decimal(percent_finished or -1, 2)
                 item.percent_finished = percent_finished or 0
             end,

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -230,6 +230,7 @@ local FileChooser = Menu:extend{
             end,
             item_func = function(item)
                 local percent_finished
+                local sort_percent
                 item.opened = DocSettings:hasSidecarFile(item.path)
                 if item.opened then
                     local doc_settings = DocSettings:open(item.path)
@@ -237,15 +238,15 @@ local FileChooser = Menu:extend{
 
                     -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
                     if summary and summary.status == "complete" then
-                        item.sort_percent = 1.0
+                        sort_percent = 1.0
                     elseif summary and summary.status == "abandoned" then
-                        item.sort_percent = 0
+                        sort_percent = 0
                     end
 
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers
-                item.sort_percent = item.sort_percent or math.floor((percent_finished or -1) * 100) / 100
+                item.sort_percent = sort_percent or math.floor((percent_finished or -1) * 100) / 100
                 item.percent_finished = percent_finished or 0
             end,
             mandatory_func = function(item)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -246,7 +246,7 @@ local FileChooser = Menu:extend{
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
                 -- smooth 2 decimal points (0.00) instead of 16 decimal numbers
-                item.sort_percent = sort_percent or math.floor((percent_finished or -1) * 100) / 100
+                item.sort_percent = sort_percent or util.round_decimal(percent_finished or -1, 2)
                 item.percent_finished = percent_finished or 0
             end,
             mandatory_func = function(item)

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -1537,4 +1537,12 @@ function util.wrapMethod(target_table, target_field_name, new_func, before_callb
     return wrapped
 end
 
+-- Round a given "num" to the decimal points of "points"
+-- (i.e. `round_decimal(0.000000001, 2)` will yield `0.00`)
+function util.round_decimal(num, points)
+    local op = 10 ^ points
+
+    return math.floor(num * op) / op
+end
+
 return util


### PR DESCRIPTION
Changes the sorting for `percent - unopened - finished last` to use a separate property from the percentage for display

re:
- https://github.com/koreader/koreader/pull/11524#issuecomment-1984110990 
- https://github.com/koreader/koreader/pull/11542#issuecomment-2018164346

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11592)
<!-- Reviewable:end -->
