### PR TITLE
Fix PocketBook losing net access (#10183)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -387,6 +387,14 @@ function PocketBook:initNetworkManager(NetworkMgr)
         return band(inkview.QueryNetwork(), C.NET_CONNECTED) ~= 0
     end
     NetworkMgr.isWifiOn = NetworkMgr.isConnected
+
+    function NetworkMgr:isOnline()
+        -- Fail early if we don't even have a default route, otherwise we're
+        -- unlikely to be online and canResolveHostnames would never succeed
+        -- again because PocketBook's glibc parses /etc/resolv.conf on first
+        -- use only. See https://sourceware.org/bugzilla/show_bug.cgi?id=984
+        return NetworkMgr:hasDefaultRoute() and NetworkMgr:canResolveHostnames()
+    end
 end
 
 function PocketBook:getSoftwareVersion()

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -532,6 +532,12 @@ function NetworkMgr:isOnline()
         return true
     end
 
+    -- Fail early if we don't even have a default route.
+    -- On PocketBook devices, if the first call to socket.dns.toip(…) fails, it never succeeds again.
+    if not Device:getDefaultRoute() then
+        return false
+    end
+
     local socket = require("socket")
     -- Microsoft uses `dns.msftncsi.com` for Windows, see
     -- <https://technet.microsoft.com/en-us/library/ee126135#BKMK_How> for

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -307,6 +307,15 @@ function NetworkMgr:hasDefaultRoute()
     return ret ~= nil
 end
 
+function NetworkMgr:canResolveHostnames()
+    local socket = require("socket")
+    -- Microsoft uses `dns.msftncsi.com` for Windows, see
+    -- <https://technet.microsoft.com/en-us/library/ee126135#BKMK_How> for
+    -- more information. They also check whether <http://www.msftncsi.com/ncsi.txt>
+    -- returns `Microsoft NCSI`.
+    return socket.dns.toip("dns.msftncsi.com") ~= nil
+end
+
 -- Wrappers around turnOnWifi & turnOffWifi with proper Event signaling
 function NetworkMgr:enableWifi(wifi_cb, connectivity_cb, connectivity_widget, interactive)
     local status = self:requestToTurnOnWifi(wifi_cb, interactive)
@@ -565,18 +574,7 @@ function NetworkMgr:isOnline()
         return true
     end
 
-    -- Fail early if we don't even have a default route.
-    -- On PocketBook devices, if the first call to socket.dns.toip(…) fails, it never succeeds again.
-    if not self:hasDefaultRoute() then
-        return false
-    end
-
-    local socket = require("socket")
-    -- Microsoft uses `dns.msftncsi.com` for Windows, see
-    -- <https://technet.microsoft.com/en-us/library/ee126135#BKMK_How> for
-    -- more information. They also check whether <http://www.msftncsi.com/ncsi.txt>
-    -- returns `Microsoft NCSI`.
-    return socket.dns.toip("dns.msftncsi.com") ~= nil
+    return self:canResolveHostnames()
 end
 
 -- Update our cached network status

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -274,6 +274,39 @@ function NetworkMgr:ifHasAnAddress()
     return ok
 end
 
+-- The socket API equivalent of "ip route get 203.0.113.1 || ip route get 2001:db8::1".
+--
+-- These addresses are from special ranges reserved for documentation
+-- (RFC 5737, RFC 3849) and therefore likely to just use the default route.
+function NetworkMgr:hasDefaultRoute()
+    local socket = require("socket")
+
+    local s, ret, err
+    s, err = socket.udp()
+    if s == nil then
+        logger.err("NetworkMgr: socket.udp:", err)
+        return nil
+    end
+
+    ret, err = s:setpeername("203.0.113.1", "53")
+    if ret == nil then
+        -- Most likely "Network is unreachable", meaning there's no route to that address.
+        logger.dbg("NetworkMgr: socket.udp.setpeername:", err)
+
+        -- Try IPv6, may still succeed if this is an IPv6-only network.
+        ret, err = s:setpeername("2001:db8::1", "53")
+        if ret == nil then
+            -- Most likely "Network is unreachable", meaning there's no route to that address.
+            logger.dbg("NetworkMgr: socket.udp.setpeername:", err)
+        end
+    end
+
+    s:close()
+
+    -- If setpeername succeeded, we have a default route.
+    return ret ~= nil
+end
+
 -- Wrappers around turnOnWifi & turnOffWifi with proper Event signaling
 function NetworkMgr:enableWifi(wifi_cb, connectivity_cb, connectivity_widget, interactive)
     local status = self:requestToTurnOnWifi(wifi_cb, interactive)
@@ -534,7 +567,7 @@ function NetworkMgr:isOnline()
 
     -- Fail early if we don't even have a default route.
     -- On PocketBook devices, if the first call to socket.dns.toip(…) fails, it never succeeds again.
-    if not Device:getDefaultRoute() then
+    if not self:hasDefaultRoute() then
         return false
     end
 


### PR DESCRIPTION
On the PocketBook platform, for some reason, doing the `isOnline` check (`socket.dns.toip("dns.msftncsi.com")`) without having any network connection (`!isConnected`) results in the `isOnline` check never succeeding again even if connectivity is later acquired. Since `socket.dns.toip` is a simple wrapper around gethostbyname(3), we suspect the problem is somewhere deeper in PocketBook's libc, and thus we need to work around it somehow in KOReader.

This fix works around the problem by checking if we have a default route first before even attempting to check `isOnline`. If we don't, then `isOnline` is (almost) guaranteed to fail anyway.

We could alternatively check `isConnected` instead, but that only checks wireless connectivity on many platforms, and we could have internet access via USBNet instead. Checking for the default route via any interface should work reliably for both wireless and USBNet connectivity.

Fixes: https://github.com/koreader/koreader/issues/10183

---

We discussed a couple alternative ways to fix this in #10183:

* Only patch `isOnline` in `PocketBook:initNetworkManager` to not affect the other platforms. This made sense because I initially suggested skipping the `isOnline` check if `!isConnected`, and people were worried that this might break other platforms where `isConnected` only checks wireless connectivity, but there might be connectivity via USBNet instead. Checking that we have a default route via any interface should be okay on all platforms.

  (This approach already exists as a userpatch: https://github.com/koreader/koreader/issues/10183#issuecomment-2021018043)

* Tweak the logic in `runWhenOnline` and `willRerunWhenOnline` to check `isConnected` first. Same concerns with USBNet as mentioned earlier, just a slightly different implementation approach. This is implemented in https://github.com/koreader/koreader/compare/master...liskin:koreader:pocketbook-isonline-logicfix because the idea of checking for a default route came later.

---

The second commit ("NetworkMgr: Use cheaper/simpler hasDefaultRoute in isOnline") is not necessary, just (IMO) nice to have. Its commit message is:

> Device:getDefaultRoute parses /proc/net/route and converts the hex addresses to textual IP addresses, but in `isOnline` we don't care what address the gateway actually has, we only care about whether we have a default route into the Internet.
>
> This provides a simpler alternative that does the equivalent of "ip route get 1.1.1.1" and returns true if we have a route. It's also much easier to extend this for IPv6-only networks, although that isn't implemented yet (PocketBook has no IPv6 support).

This approach to checking a default route is inspired by https://pavel.network/best-way-to-get-default-outgoing-ip-address-on-linux/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11601)
<!-- Reviewable:end -->
