### PR TITLE
Do `flashui` refresh for first display of History page

### DIFF
--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -270,7 +270,7 @@ function FileManagerHistory:onShowHist(search_info)
         self.hist_menu = nil
         G_reader_settings:saveSetting("history_filter", self.filter)
     end
-    UIManager:show(self.hist_menu)
+    UIManager:show(self.hist_menu, "flashui")
     return true
 end
 


### PR DESCRIPTION
This fixes ghosting for color Pocketbook devices

Needs https://github.com/koreader/koreader-base/pull/1755.
Fixes #11602.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11603)
<!-- Reviewable:end -->
