### PR TITLE
Explicitly set `hasColorScreen = no` for B&W devices

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -67,6 +67,9 @@ local PocketBook = Generic:extend{
     -- Will be set appropriately at init
     isB288SoC = no,
 
+    -- Most of the devices are B&W.
+    hasColorScreen = no,
+
     -- Private per-model kludges
     _fb_init = function() end,
     _model_init = function() end,


### PR DESCRIPTION
See the discussion in https://github.com/koreader/koreader-base/pull/1752/files/279a9d9fdeb4ae108a98f635d451f5d3ab0ffcea#r1546370061.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11608)
<!-- Reviewable:end -->
