### PR TITLE
GetText: fix crash if a value is used as unique value and as singular/plural

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -58,7 +58,7 @@ Returns a translation.
     local translation = _("A meaningful message.")
 --]]
 function GetText_mt.__call(gettext, msgid)
-    return gettext.translation[msgid] or gettext.wrapUntranslated(msgid)
+    return gettext.translation[msgid] and gettext.translation[msgid][0] or gettext.translation[msgid] or gettext.wrapUntranslated(msgid)
 end
 
 local function c_escape(what_full, what)


### PR DESCRIPTION


Concretely 1 second, %1 seconds since #11549 added `1 second` all by itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11643)
<!-- Reviewable:end -->
