### PR TITLE
Sleep screen wording fixes

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -47,7 +47,7 @@ return {
                 sub_item_table = {
                     genMenuItem(_("Black fill"), "screensaver_img_background", "black"),
                     genMenuItem(_("White fill"), "screensaver_img_background", "white"),
-                    genMenuItem(_("Leave background as-is"), "screensaver_img_background", "none", nil, true),
+                    genMenuItem(_("No fill"), "screensaver_img_background", "none", nil, true),
                     -- separator
                     {
                         text_func = function()
@@ -67,7 +67,7 @@ return {
                 },
             },
             {
-                text = _("Delay screen update after wake-up"),
+                text = _("Wake-up screen delay"),
                 sub_item_table = {
                     genMenuItem(_("No delay"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
@@ -133,7 +133,7 @@ return {
             },
             {
                 text = _("Background fill"),
-                help_text = _("This option will only become available, if you have selected 'Leave screen as-is' as screensaver and have 'Sleep screen message' on."),
+                help_text = _("This option will only become available, if you have selected 'Leave screen as-is' as sleep screen and have 'Sleep screen message' on."),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
                 end,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -67,7 +67,7 @@ return {
                 },
             },
             {
-                text = _("Wake-up screen delay"),
+                text = _("Postpone screen update after wake-up"),
                 sub_item_table = {
                     genMenuItem(_("No delay"), "screensaver_delay", "disable"),
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -133,7 +133,7 @@ return {
             },
             {
                 text = _("Background fill"),
-                help_text = _("This option will only become available, if you have selected 'Leave screen as-is' as sleep screen and have 'Sleep screen message' on."),
+                help_text = _("This option will only become available, if you have selected 'Leave screen as-is' as wallpaper and have 'Sleep screen message' on."),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "disable" and G_reader_settings:isTrue("screensaver_show_message")
                 end,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -140,7 +140,7 @@ return {
                 sub_item_table = {
                     genMenuItem(_("Black fill"), "screensaver_msg_background", "black"),
                     genMenuItem(_("White fill"), "screensaver_msg_background", "white"),
-                    genMenuItem(_("Leave background as-is"), "screensaver_msg_background", "none", nil, true),
+                    genMenuItem(_("No fill"), "screensaver_msg_background", "none", nil, true),
                 },
             },
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -314,7 +314,7 @@ function Screensaver:setMessage()
                              or self.default_screensaver_message
     local input_dialog
     input_dialog = InputDialog:new{
-        title = _("Screensaver message"),
+        title = _("Sleep screen message"),
         description = _([[
 Enter a custom message to be displayed on the sleep screen. The following escape sequences are available:
   %T title


### PR DESCRIPTION
fixing minor issues with #11549

**Bug:** There appears to be a problem with the `edit sleep screen message` setting, as it shows the older version of the description (not the new and improved `Enter a custom message to be displayed on the sleep screen. The following escape sequences are available:`, see image attached

![IMG_5443](https://github.com/koreader/koreader/assets/97603719/0501d896-88c6-4d88-8f9a-7e77b1b357cd)

but I can't see why. it was working fine on my kindle 5 testing machine.

@Frenzie if you are not happy with **the** change, change it back, I promise I won't meddle anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11647)
<!-- Reviewable:end -->
