### PR TITLE
[i18n] GetText: fix fuzzy detection for certain strings

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -275,6 +275,8 @@ function GetText_mt.__index.changeLang(new_lang)
                     -- unescape \\ or msgid won't match
                     s = s:gsub("\\\\", "\\")
                     data[what] = (data[what] or "") .. s
+                elseif what and s == "" and fuzzy then -- luacheck: ignore 542
+                    -- Ignore the likes of msgid "" and msgstr ""
                 else
                     -- Don't save this fuzzy string and unset fuzzy for the next one.
                     fuzzy = false


### PR DESCRIPTION
Reported in <https://github.com/koreader/koreader/pull/11647#issue-2233008767>.

Probably overlooked in #5807

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11648)
<!-- Reviewable:end -->
