### PR TITLE
make: fix `appimageupdate` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,8 +333,8 @@ appimageupdate: all
 	# TODO at best this is DebUbuntu specific
 	ln -sf /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 $(INSTALL_DIR)/koreader/libs/libSDL2.so
 	# required for our stock Ubuntu SDL even though we don't use sound
-	# the readlink is a half-hearted attempt at being generic; the echo libsndio.so.6.1 is specific to the nightly builds
-	ln -sf /usr/lib/x86_64-linux-gnu/$(shell readlink /usr/lib/x86_64-linux-gnu/libsndio.so || echo libsndio.so.6.1) $(INSTALL_DIR)/koreader/libs/
+	# the readlink is a half-hearted attempt at being generic; the echo libsndio.so.7.0 is specific to the nightly builds
+	ln -sf /usr/lib/x86_64-linux-gnu/$(shell readlink /usr/lib/x86_64-linux-gnu/libsndio.so || echo libsndio.so.7.0) $(INSTALL_DIR)/koreader/libs/
 	# also copy libbsd.so.0, cf. https://github.com/koreader/koreader/issues/4627
 	ln -sf /lib/x86_64-linux-gnu/libbsd.so.0 $(INSTALL_DIR)/koreader/libs/
 ifeq ("$(wildcard $(APPIMAGETOOL))","")


### PR DESCRIPTION
Update sdnio library soversion to account for new docker image based on Ubuntu 20.04.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11662)
<!-- Reviewable:end -->
