### PR TITLE
make: improve `appimageupdate` rule, take 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,6 @@ WIN32_DIR=$(PLATFORM_DIR)/win32
 APPIMAGETOOL=appimagetool-x86_64.AppImage
 APPIMAGETOOL_URL=https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
 
-# Is fuse support available?
-USE_FUSE ?= $(wildcard /dev/fuse)
-
 # files to link from main directory
 INSTALL_FILES=reader.lua setupkoenv.lua frontend resources defaults.lua datastorage.lua \
 		l10n tools README.md COPYING
@@ -342,11 +339,6 @@ ifeq ("$(wildcard $(APPIMAGETOOL))","")
 	wget "$(APPIMAGETOOL_URL)"
 	chmod a+x "$(APPIMAGETOOL)"
 endif
-ifeq ($(USE_FUSE),)
-	# remove previously extracted appimagetool, if any
-	rm -rf squashfs-root
-	./$(APPIMAGETOOL) --appimage-extract
-endif
 	cd $(INSTALL_DIR) && pwd && \
 		rm -rf tmp && mkdir -p tmp && \
 		cp -Lr koreader tmp && \
@@ -356,7 +348,7 @@ endif
 
 	# generate AppImage
 	cd $(INSTALL_DIR)/tmp && \
-		ARCH=x86_64 ../../$(if $(USE_FUSE),$(APPIMAGETOOL),squashfs-root/AppRun) koreader && \
+		ARCH=x86_64 "$$OLDPWD/$(APPIMAGETOOL)" --appimage-extract-and-run koreader && \
 		mv *.AppImage ../../koreader-$(DIST)-$(MACHINE)-$(VERSION).AppImage
 
 androidupdate: all


### PR DESCRIPTION
The FUSE detection is false positive under Gitlab's pipeline, so just use the hidden `--appimage-extract-and-run` option to automatically and always "extract & run" the appimage tool.

Cf. https://github.com/koreader/koreader/pull/11669#discussion_r1561566031.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11671)
<!-- Reviewable:end -->
