### PR TITLE
[Status bar] Major UI makeover

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -297,15 +297,15 @@ function ReaderCoptListener:getAltStatusBarMenu()
                     local status = _(" ")
                     if self.battery == 1 then
                         if self.battery_percent == 1 then
-                            status = _(": percentage")
+                            status = _("(percentage)")
                         else
-                            status = _(": icon")
+                            status = _("(icon)")
                         end
                     end
-                    return T(_("Battery status".. "%1"), status)
+                    return T(_("Battery status %1"), status)
                 end,
                 checked_func = function()
-                    return self.battery == 1 and self.battery_percent == 0 or self.battery_percent == 1
+                    return self.battery == 1 and ( self.battery_percent == 0 or self.battery_percent == 1 )
                 end,
                 sub_item_table = {
                     {

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -294,15 +294,15 @@ function ReaderCoptListener:getAltStatusBarMenu()
             },
             {
                 text_func = function()
-                    local status = _(" ")
+                    local status = _("Battery status")
                     if self.battery == 1 then
                         if self.battery_percent == 1 then
-                            status = _("(percentage)")
+                            status = _("Battery status: percentage")
                         else
-                            status = _("(icon)")
+                            status = _("Battery status: icon")
                         end
                     end
-                    return T(_("Battery status %1"), status)
+                    return T(_("%1"), status)
                 end,
                 checked_func = function()
                     return self.battery == 1 and ( self.battery_percent == 0 or self.battery_percent == 1 )

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -211,7 +211,7 @@ function ReaderCoptListener:getAltStatusBarMenu()
         separator = true,
         sub_item_table = {
             {
-                text = _("About alternate status bar"),
+                text = _("About alternative status bar"),
                 keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -207,7 +207,7 @@ The alternative status bar can be configured here.]])
 
 function ReaderCoptListener:getAltStatusBarMenu()
     return {
-        text = _("Alt status bar"),
+        text = _("Alternative status bar"),
         separator = true,
         sub_item_table = {
             {
@@ -294,15 +294,18 @@ function ReaderCoptListener:getAltStatusBarMenu()
             },
             {
                 text_func = function()
-                    local status = _("off")
+                    local status = _(" ")
                     if self.battery == 1 then
                         if self.battery_percent == 1 then
-                            status = _("percentage")
+                            status = _(": percentage")
                         else
-                            status = _("icon")
+                            status = _(": icon")
                         end
                     end
-                    return T(_("Battery status: %1"), status)
+                    return T(_("Battery status".. "%1"), status)
+                end,
+                checked_func = function()
+                    return self.battery == 1 and self.battery_percent == 0 or self.battery_percent == 1
                 end,
                 sub_item_table = {
                     {

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -211,7 +211,7 @@ function ReaderCoptListener:getAltStatusBarMenu()
         separator = true,
         sub_item_table = {
             {
-                text = _("About alternative status bar"),
+                text = _("About alt status bar"),
                 keep_menu_open = true,
                 callback = function()
                     UIManager:show(InfoMessage:new{

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -207,7 +207,7 @@ The alternative status bar can be configured here.]])
 
 function ReaderCoptListener:getAltStatusBarMenu()
     return {
-        text = _("Alternative status bar"),
+        text = _("Alt status bar"),
         separator = true,
         sub_item_table = {
             {

--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -302,10 +302,10 @@ function ReaderCoptListener:getAltStatusBarMenu()
                             status = _("Battery status: icon")
                         end
                     end
-                    return T(_("%1"), status)
+                    return status
                 end,
                 checked_func = function()
-                    return self.battery == 1 and ( self.battery_percent == 0 or self.battery_percent == 1 )
+                    return self.battery == 1
                 end,
                 sub_item_table = {
                     {

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1454,7 +1454,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
         }
     })
-    ---------------------------------
     -- footer_items
     local footer_items = {}
     table.insert(sub_items, {

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -679,7 +679,7 @@ local option_help_text = {}
 option_help_text["pages_left_book"] = _("Can be configured to include or exclude the current page.")
 option_help_text["percentage"] = _("Progress percentage can be shown with zero, one or two decimal places.")
 option_help_text["mem_usage"] = _("Show memory usage in MiB.")
-option_help_text["reclaim_height"] = _("When status bar is unlocked and hidden, this setting will utilise the entirety of screen real state and will temporarily overlap status bar and text when unhidden.")
+option_help_text["reclaim_height"] = _("When status bar is hidden, this setting will utilize the entirety of screen real state (for your book) and will temporarily overlap status bar and text when unhidden.")
 option_help_text["custom_text"] = ReaderFooter.set_custom_text
 
 function ReaderFooter:updateFooterContainer()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1527,7 +1527,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 callback = function()
                     self.settings.auto_refresh_time = not self.settings.auto_refresh_time
                     self:rescheduleFooterAutoRefreshIfNeeded()
-                end
+                end,
             },
             {
                 text = _("Hide inactive items"),

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1018,11 +1018,11 @@ function ReaderFooter:addToMainMenu(menu_items)
             text_func = function()
                 return self:textOptionTitles(option)
             end,
-            help_text = type(option_help_text[option]) == "string" 
-                and option_help_text[option], 
-            help_text_func = type(option_help_text[option]) == "function" and 
-                function(touchmenu_instance) 
-                    option_help_text[option](self, touchmenu_instance) 
+            help_text = type(option_help_text[option]) == "string"
+                and option_help_text[option],
+            help_text_func = type(option_help_text[option]) == "function" and
+                function(touchmenu_instance)
+                    option_help_text[option](self, touchmenu_instance)
                 end,
             checked_func = function()
                 return self.settings[option] == true

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -679,7 +679,7 @@ local option_help_text = {}
 option_help_text["pages_left_book"] = _("Can be configured to include or exclude the current page.")
 option_help_text["percentage"] = _("Progress percentage can be shown with zero, one or two decimal places.")
 option_help_text["mem_usage"] = _("Show memory usage in MiB.")
-option_help_text["reclaim_height"] = _("When status bar is hidden, this setting will utilize the entirety of screen real state (for your book) and will temporarily overlap status bar and text when unhidden.")
+option_help_text["reclaim_height"] = _("When status bar is hidden, this setting will utilize the entirety of screen real state (for your book) and will temporarily overlap status bar and text when shown.")
 option_help_text["custom_text"] = ReaderFooter.set_custom_text
 
 function ReaderFooter:updateFooterContainer()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1097,7 +1097,7 @@ function ReaderFooter:addToMainMenu(menu_items)
         text = _("Settings"),
         sub_item_table = {
             {
-                text = _("Sort items"),
+                text = _("Sort complications"),
                 separator = true,
                 callback = function()
                     local item_table = {}
@@ -1107,7 +1107,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     local SortWidget = require("ui/widget/sortwidget")
                     local sort_item
                     sort_item = SortWidget:new{
-                        title = _("Sort footer items"),
+                        title = _("Sort footer complications"),
                         item_table = item_table,
                         callback = function()
                             for i=1, #sort_item.item_table do
@@ -1124,7 +1124,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             getMinibarOption("all_at_once", self.updateFooterTextGenerator),
             {
-                text = _("Hide empty items"),
+                text = _("Hide empty complications"),
                 help_text = _([[This will hide values like 0 or off.]]),
                 enabled_func = function()
                     return self.settings.all_at_once == true
@@ -1218,7 +1218,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                         keep_menu_open = true,
                     },
                     {
-                        text = _("Use bold font"),
+                        text = _("Use boldface"),
                         checked_func = function()
                             return self.settings.text_font_bold == true
                         end,
@@ -1291,7 +1291,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 keep_menu_open = true,
             },
             {
-                text = _("Maximum width of items"),
+                text = _("Maximum width of text complications"),
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1406,7 +1406,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     elseif self.settings.item_prefix == "letters" then
                         prefix_text = C_("Status bar", "Letters")
                     end
-                    return T(_("Item style: %1"), prefix_text)
+                    return T(_("Complication symbol: %1"), prefix_text)
                 end,
                 sub_item_table = {
                     {
@@ -1463,11 +1463,11 @@ function ReaderFooter:addToMainMenu(menu_items)
                 text_func = function()
                     local separator = self:get_separator_symbol()
                     separator = separator ~= "" and separator or "none"
-                    return T(_("Item separator: %1"), separator)
+                    return T(_("Complication separator: %1"), separator)
                 end,
                 sub_item_table = {
                     {
-                        text = _("Vertical line (|)"),
+                        text = _("Pipe (|)"),
                         checked_func = function()
                             return self.settings.items_separator == "bar"
                         end,
@@ -1516,7 +1516,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("No decimal point (%1)"), self:progressPercentage(0))
+                            return T(_("No decimal places (%1)"), self:progressPercentage(0))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "0"
@@ -1528,7 +1528,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     },
                     {
                         text_func = function()
-                            return T(_("1 digit after decimal point (%1)"), self:progressPercentage(1))
+                            return T(_("1 decimal place (%1)"), self:progressPercentage(1))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "1"
@@ -1540,7 +1540,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     },
                     {
                         text_func = function()
-                            return T(_("2 digits after decimal point (%1)"), self:progressPercentage(2))
+                            return T(_("2 decimal places (%1)"), self:progressPercentage(2))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "2"
@@ -1553,7 +1553,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 },
             },
             {
-                text = _("Include current page in pages left"),
+                text = _("Count current page in pages left"),
                 help_text = _([[
 Normally, the current page is not counted as remaining, so "pages left" (in a book or chapter with n pages) will run from n-1 to 0 on the last page.
 With this enabled, the current page is included, so the count goes from n to 1 instead.]]),
@@ -1637,7 +1637,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                 end,
             },
             {
-                text = _("Chapter progress"),
+                text = _("Show progress in chapter"),
                 help_text = _("Show progress bar for the current chapter, instead of the whole book."),
                 enabled_func = function()
                     return not self.settings.disable_progress_bar
@@ -1651,11 +1651,11 @@ With this enabled, the current page is included, so the count goes from n to 1 i
             },
             {
                 text_func = function()
-                    local text = _("alongside items")
+                    local text = _("alongside complications")
                     if self.settings.progress_bar_position == "above" then
-                        text = _("above items")
+                        text = _("above complications")
                     elseif self.settings.progress_bar_position == "below" then
-                        text = _("below items")
+                        text = _("below complications")
                     end
                     return T(_("Position: %1"), text)
                 end,
@@ -1664,7 +1664,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                 end,
                 sub_item_table = {
                     {
-                        text = _("Above items"),
+                        text = _("Above complications"),
                         checked_func = function()
                             return self.settings.progress_bar_position == "above"
                         end,
@@ -1674,7 +1674,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                         end,
                     },
                     {
-                        text = _("Alongside items"),
+                        text = _("Alongside complications"),
                         checked_func = function()
                             return self.settings.progress_bar_position == "alongside"
                         end,
@@ -1692,7 +1692,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                         end
                     },
                     {
-                        text = _("Below items"),
+                        text = _("Below complications"),
                         checked_func = function()
                             return self.settings.progress_bar_position == "below"
                         end,
@@ -1741,7 +1741,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                         end,
                     },
                     {
-                        text = _("Set size"),
+                        text = _("Set height"),
                         callback = function()
                             local value, value_min, value_max, default_value
                             if self.settings.progress_style_thin then
@@ -1763,7 +1763,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                                 value_hold_step = 2,
                                 value_max = value_max,
                                 default_value = default_value,
-                                title_text = _("Progress bar size"),
+                                title_text = _("Progress bar height"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     if self.settings.progress_style_thin then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1452,12 +1452,10 @@ function ReaderFooter:addToMainMenu(menu_items)
     })
     ----------- footer_items
     local footer_items = {}
-    local items
     table.insert(sub_items, {
         text = _("Items"),
         sub_item_table = footer_items,
     })
-    table.insert(sub_items, items)
     table.insert(footer_items, getMinibarOption("page_progress"))
     table.insert(footer_items, getMinibarOption("pages_left_book"))
     table.insert(footer_items, getMinibarOption("time"))

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -963,7 +963,7 @@ end
 function ReaderFooter:textOptionTitles(option)
     local symbol = self.settings.item_prefix
     local option_titles = {
-        all_at_once = _("Show all selected complications at once"),
+        all_at_once = _("Show all selected items at once"),
         reclaim_height = _("Overlay status bar"),
         bookmark_count = T(_("Bookmark count (%1)"), symbol_prefix[symbol].bookmark_count),
         page_progress = T(_("Current page (%1)"), "/"),
@@ -1120,7 +1120,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Switch to chapter progress bar"),
+                text = _("Show chapter progress bar instead"),
                 help_text = _("Show progress bar for the current chapter, instead of the whole book."),
                 enabled_func = function()
                     return not self.settings.disable_progress_bar

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1885,7 +1885,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
             },
             {
                 text_func = function()
-                    return T(_("Items height: %1"), self.settings.container_height)
+                    return T(_("Height: %1"), self.settings.container_height)
                 end,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1563,6 +1563,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     return T(_("Progress percentage format: %1"),
                         self:progressPercentage(tonumber(self.settings.progress_pct_format)))
                 end,
+                separator = true,
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1600,64 +1601,6 @@ With this feature enabled, the current page is factored in, resulting in the cou
                             self:refreshFooter(true)
                         end,
                     },
-                },
-            },
-            {
-                text = _("Max percentage of screen width used for text items"),
-                separator = true,
-                sub_item_table = {
-                    {
-                        text_func = function()
-                            return T(_("Book-title item: %1".. "%"), self.settings.book_title_max_width_pct)
-                        end,
-                        callback = function(touchmenu_instance)
-                            local SpinWidget = require("ui/widget/spinwidget")
-                            local items = SpinWidget:new{
-                                value = self.settings.book_title_max_width_pct,
-                                value_min = 10,
-                                value_step = 5,
-                                value_hold_step = 20,
-                                value_max = 100,
-                                unit = "%",
-                                title_text = _("Max length of book-title item"),
-                                info_text = _("Maximum percentage of screen width used for book-title"),
-                                keep_shown_on_apply = true,
-                                callback = function(spin)
-                                    self.settings.book_title_max_width_pct = spin.value
-                                    self:refreshFooter(true, true)
-                                    if touchmenu_instance then touchmenu_instance:updateItems() end
-                                end
-                            }
-                            UIManager:show(items)
-                        end,
-                        keep_menu_open = true,
-                    },
-                    {
-                        text_func = function()
-                            return T(_("Chapter-title item: %1".. "%"), self.settings.book_chapter_max_width_pct)
-                        end,
-                        callback = function(touchmenu_instance)
-                            local SpinWidget = require("ui/widget/spinwidget")
-                            local items = SpinWidget:new{
-                                value = self.settings.book_chapter_max_width_pct,
-                                value_min = 10,
-                                value_step = 5,
-                                value_hold_step = 20,
-                                value_max = 100,
-                                unit = "%",
-                                title_text = _("Max length of chapter-title item"),
-                                info_text = _("Maximum percentage of screen width used for chapter-title item"),
-                                keep_shown_on_apply = true,
-                                callback = function(spin)
-                                    self.settings.book_chapter_max_width_pct = spin.value
-                                    self:refreshFooter(true, true)
-                                    if touchmenu_instance then touchmenu_instance:updateItems() end
-                                end
-                            }
-                            UIManager:show(items)
-                        end,
-                        keep_menu_open = true,
-                    }
                 },
             },
             {
@@ -1726,11 +1669,11 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 text_func = function()
                     local prefix_text = ""
                     if self.settings.item_prefix == "icons" then
-                        prefix_text = C_("Status bar", "Icons")
+                        prefix_text = C_("Status bar", "icons")
                     elseif self.settings.item_prefix == "compact_items" then
-                        prefix_text = C_("Status bar", "Compact")
+                        prefix_text = C_("Status bar", "compact")
                     elseif self.settings.item_prefix == "letters" then
-                        prefix_text = C_("Status bar", "Letters")
+                        prefix_text = C_("Status bar", "letters")
                     end
                     return T(_("Item symbols: %1"), prefix_text)
                 end,
@@ -1741,7 +1684,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                             for _, letter in pairs(symbol_prefix.icons) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "icons (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "Icons (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "icons"
@@ -1757,7 +1700,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                             for _, letter in pairs(symbol_prefix.letters) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "letters (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "Letters (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "letters"
@@ -1773,7 +1716,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                             for _, letter in pairs(symbol_prefix.compact_items) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "compact (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "Compact (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "compact_items"
@@ -1791,6 +1734,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     separator = separator ~= "" and separator or "none"
                     return T(_("Item separator: %1"), separator)
                 end,
+                separator = true,
                 sub_item_table = {
                     {
                         text = _("Vertical bar (|)"),
@@ -1832,6 +1776,63 @@ With this feature enabled, the current page is factored in, resulting in the cou
                             self:refreshFooter(true)
                         end,
                     },
+                },
+            },
+            {
+                text = _("Max pct. of screen width used for text items"),
+                sub_item_table = {
+                    {
+                        text_func = function()
+                            return T(_("Book-title item: %1".. "%"), self.settings.book_title_max_width_pct)
+                        end,
+                        callback = function(touchmenu_instance)
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            local items = SpinWidget:new{
+                                value = self.settings.book_title_max_width_pct,
+                                value_min = 10,
+                                value_step = 5,
+                                value_hold_step = 20,
+                                value_max = 100,
+                                unit = "%",
+                                title_text = _("Max length of book-title item"),
+                                info_text = _("Maximum percentage of screen width used for book-title"),
+                                keep_shown_on_apply = true,
+                                callback = function(spin)
+                                    self.settings.book_title_max_width_pct = spin.value
+                                    self:refreshFooter(true, true)
+                                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                                end
+                            }
+                            UIManager:show(items)
+                        end,
+                        keep_menu_open = true,
+                    },
+                    {
+                        text_func = function()
+                            return T(_("Chapter-title item: %1".. "%"), self.settings.book_chapter_max_width_pct)
+                        end,
+                        callback = function(touchmenu_instance)
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            local items = SpinWidget:new{
+                                value = self.settings.book_chapter_max_width_pct,
+                                value_min = 10,
+                                value_step = 5,
+                                value_hold_step = 20,
+                                value_max = 100,
+                                unit = "%",
+                                title_text = _("Max length of chapter-title item"),
+                                info_text = _("Maximum percentage of screen width used for chapter-title item"),
+                                keep_shown_on_apply = true,
+                                callback = function(spin)
+                                    self.settings.book_chapter_max_width_pct = spin.value
+                                    self:refreshFooter(true, true)
+                                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                                end
+                            }
+                            UIManager:show(items)
+                        end,
+                        keep_menu_open = true,
+                    }
                 },
             },
             {
@@ -1984,7 +1985,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
     -- quick access to this setting for "@NiLuJe, and for people that do like him." -- @poire-z (2024)
     table.insert(sub_items, getMinibarOption("reclaim_height"))
     table.insert(sub_items, {
-        text = _("Show status bar divider"),
+        text = _("Show status bar separator"),
         checked_func = function()
             return self.settings.bottom_horizontal_separator == true
         end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1188,86 +1188,11 @@ function ReaderFooter:addToMainMenu(menu_items)
                 },
             },
             {
-                text = _("Show initial-position marker"),
-                checked_func = function()
-                    return self.settings.initial_marker == true
-                end,
-                callback = function()
-                    self.settings.initial_marker = not self.settings.initial_marker
-                    self.progress_bar.initial_pos_marker = self.settings.initial_marker
-                    self:refreshFooter(true)
-                end
-            },
-            {
-                text = _("Show chapter markers"),
-                checked_func = function()
-                    return self.settings.toc_markers == true and not self.settings.chapter_progress_bar
-                end,
-                enabled_func = function()
-                    return not self.settings.progress_style_thin and not self.settings.chapter_progress_bar
-                end,
-                callback = function()
-                    self.settings.toc_markers = not self.settings.toc_markers
-                    self:setTocMarkers()
-                    self:refreshFooter(true)
-                end
-            },
-            {
-                text_func = function()
-                    local markers_width_text = _("thick")
-                    if self.settings.toc_markers_width == 1 then
-                        markers_width_text = _("thin")
-                    elseif self.settings.toc_markers_width == 2 then
-                        markers_width_text = _("medium")
-                    end
-                    return T(_("Chapter marker width (%1)"), markers_width_text)
-                end,
-                enabled_func = function()
-                    return not self.settings.progress_style_thin and not self.settings.chapter_progress_bar
-                        and self.settings.toc_markers
-                end,
-                sub_item_table = {
-                    {
-                        text = _("Thin"),
-                        checked_func = function()
-                            return self.settings.toc_markers_width == 1
-                        end,
-                        callback = function()
-                            self.settings.toc_markers_width = 1  -- unscaled_size_check: ignore
-                            self:setTocMarkers()
-                            self:refreshFooter(true)
-                        end,
-                    },
-                    {
-                        text = _("Medium"),
-                        checked_func = function()
-                            return self.settings.toc_markers_width == 2
-                        end,
-                        callback = function()
-                            self.settings.toc_markers_width = 2  -- unscaled_size_check: ignore
-                            self:setTocMarkers()
-                            self:refreshFooter(true)
-                        end,
-                    },
-                    {
-                        text = _("Thick"),
-                        checked_func = function()
-                            return self.settings.toc_markers_width == 3
-                        end,
-                        callback = function()
-                            self.settings.toc_markers_width = 3  -- unscaled_size_check: ignore
-                            self:setTocMarkers()
-                            self:refreshFooter(true)
-                        end
-                    },
-                },
-            },
-            {
                 text_func = function()
                     if self.settings.progress_style_thin then
-                        return _("Style: thin")
+                        return _("Thickness and height: (thin)")
                     else
-                        return _("Style: thick")
+                        return _("Thickness and height: (thick)")
                     end
                 end,
                 enabled_func = function()
@@ -1298,6 +1223,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             self.progress_bar:updateStyle(false, bar_height)
                             self:refreshFooter(true, true)
                         end,
+                        separator = true,
                     },
                     {
                         text = _("Set height"),
@@ -1447,13 +1373,92 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
                 keep_menu_open = true,
                 separator = true,
-            }
+            },
+            {
+                text = _("Show initial-position marker"),
+                checked_func = function()
+                    return self.settings.initial_marker == true
+                end,
+                enabled_func = function()
+                    return not self.settings.disable_progress_bar
+                end,
+                callback = function()
+                    self.settings.initial_marker = not self.settings.initial_marker
+                    self.progress_bar.initial_pos_marker = self.settings.initial_marker
+                    self:refreshFooter(true)
+                end
+            },
+            {
+                text = _("Show chapter markers"),
+                checked_func = function()
+                    return self.settings.toc_markers == true and not self.settings.chapter_progress_bar
+                end,
+                enabled_func = function()
+                    return not self.settings.progress_style_thin and not self.settings.chapter_progress_bar 
+                        and not self.settings.disable_progress_bar
+                end,
+                callback = function()
+                    self.settings.toc_markers = not self.settings.toc_markers
+                    self:setTocMarkers()
+                    self:refreshFooter(true)
+                end
+            },
+            {
+                text_func = function()
+                    local markers_width_text = _("thick")
+                    if self.settings.toc_markers_width == 1 then
+                        markers_width_text = _("thin")
+                    elseif self.settings.toc_markers_width == 2 then
+                        markers_width_text = _("medium")
+                    end
+                    return T(_("Chapter marker width (%1)"), markers_width_text)
+                end,
+                enabled_func = function()
+                    return not self.settings.progress_style_thin and not self.settings.chapter_progress_bar
+                        and self.settings.toc_markers and not self.settings.disable_progress_bar
+                end,
+                sub_item_table = {
+                    {
+                        text = _("Thin"),
+                        checked_func = function()
+                            return self.settings.toc_markers_width == 1
+                        end,
+                        callback = function()
+                            self.settings.toc_markers_width = 1  -- unscaled_size_check: ignore
+                            self:setTocMarkers()
+                            self:refreshFooter(true)
+                        end,
+                    },
+                    {
+                        text = _("Medium"),
+                        checked_func = function()
+                            return self.settings.toc_markers_width == 2
+                        end,
+                        callback = function()
+                            self.settings.toc_markers_width = 2  -- unscaled_size_check: ignore
+                            self:setTocMarkers()
+                            self:refreshFooter(true)
+                        end,
+                    },
+                    {
+                        text = _("Thick"),
+                        checked_func = function()
+                            return self.settings.toc_markers_width == 3
+                        end,
+                        callback = function()
+                            self.settings.toc_markers_width = 3  -- unscaled_size_check: ignore
+                            self:setTocMarkers()
+                            self:refreshFooter(true)
+                        end
+                    },
+                },
+            },
         }
     })
-    ----------- COMPLICATIONS
-    local about_text = _([[A complication is any feature that offers additional information beyond the content of your book. Examples of
-common complications include time, percentage read, pages left, and the battery indicator. You can choose which complications to display
-on the status bar from this page.]])
+    ----------- COMPLICATIONS (FOOTER_ITEMS)
+    local about_text = _("A complication is any feature that provides additional information beyond the content of your book. Examples of "..
+    "common complications include time, percentage read, pages left, and the battery indicator. You can choose which complications to "..
+    "display on the status bar from this page.")
     local complication_subitems = {}
     table.insert(sub_items, {
         text = _("Complications"),
@@ -1495,7 +1500,7 @@ on the status bar from this page.]])
     table.insert(complication_subitems, getMinibarOption("book_title"))
     table.insert(complication_subitems, getMinibarOption("book_chapter"))
     table.insert(complication_subitems, getMinibarOption("custom_text"))
-    -------- CONFIGURE COMPLICATIONS
+    -------- CONFIGURE COMPLICATIONS (FOOTER_ITEMS)
     table.insert(sub_items, {
         separator = true,
         text = _("Configure complications"),
@@ -1528,6 +1533,18 @@ on the status bar from this page.]])
             },
             getMinibarOption("all_at_once", self.updateFooterTextGenerator),
             {
+                text = _("Auto refresh complications"),
+                help_text = _("This option allows certain complications to update without needing a full-page update. For example, the time"..
+                " complication will update every minute regardless of user input."),
+                checked_func = function()
+                    return self.settings.auto_refresh_time == true
+                end,
+                callback = function()
+                    self.settings.auto_refresh_time = not self.settings.auto_refresh_time
+                    self:rescheduleFooterAutoRefreshIfNeeded()
+                end
+            },
+            {
                 text = _("Hide empty complications"),
                 help_text = _([[This option will hide values like 0 or off.]]),
                 enabled_func = function()
@@ -1539,6 +1556,22 @@ on the status bar from this page.]])
                 callback = function()
                     self.settings.hide_empty_generators = not self.settings.hide_empty_generators
                     self:refreshFooter(true, true)
+                end,
+            },
+            {
+                text = _("Count current page in pages left"),
+                help_text = _("By default, KOReader does not include the current page when calculating pages left. For example, in a book ".. 
+                "or chapter with n pages the 'pages left' complication will range from 'n-1' to 0 (last page). With this feature activated, "..
+                "the current page is factored in, resulting in the count going from n to 1 instead."),
+                enabled_func = function()
+                    return self.settings.pages_left or self.settings.pages_left_book
+                end,
+                checked_func = function()
+                    return self.settings.pages_left_includes_current_page == true
+                end,
+                callback = function()
+                    self.settings.pages_left_includes_current_page = not self.settings.pages_left_includes_current_page
+                    self:refreshFooter(true)
                 end,
             },
             {
@@ -1586,33 +1619,110 @@ on the status bar from this page.]])
                 },
             },
             {
-                text = _("Count current page in pages left"),
-                help_text = _([[
-By default, KOReader does not include the current page when calculating pages left. For example, in a book or chapter with n pages the "pages
-left" complication will range from 'n-1' to 0 (last page). With this feature activated, the current page is factored in, resulting in the count
-going from n to 1 instead.]]),
-                enabled_func = function()
-                    return self.settings.pages_left or self.settings.pages_left_book
-                end,
-                checked_func = function()
-                    return self.settings.pages_left_includes_current_page == true
-                end,
-                callback = function()
-                    self.settings.pages_left_includes_current_page = not self.settings.pages_left_includes_current_page
-                    self:refreshFooter(true)
-                end,
+                text = _("Maximum lenght for text complications"),
+                separator = true,
+                sub_item_table = {
+                    {
+                        text_func = function()
+                            return T(_("Lenght of book-title complication: %1".. "%"), self.settings.book_title_max_width_pct)
+                        end,
+                        callback = function(touchmenu_instance)
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            local items = SpinWidget:new{
+                                value = self.settings.book_title_max_width_pct,
+                                value_min = 10,
+                                value_step = 5,
+                                value_hold_step = 20,
+                                value_max = 100,
+                                unit = "%",
+                                title_text = _("Max lenght of book-title complication"),
+                                info_text = _("Maximum percentage of screen width used for book-title complication"),
+                                keep_shown_on_apply = true,
+                                callback = function(spin)
+                                    self.settings.book_title_max_width_pct = spin.value
+                                    self:refreshFooter(true, true)
+                                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                                end
+                            }
+                            UIManager:show(items)
+                        end,
+                        keep_menu_open = true,
+                    },
+                    {
+                        text_func = function()
+                            return T(_("Lenght of chapter-title complication: %1".. "%"), self.settings.book_chapter_max_width_pct)
+                        end,
+                        callback = function(touchmenu_instance)
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            local items = SpinWidget:new{
+                                value = self.settings.book_chapter_max_width_pct,
+                                value_min = 10,
+                                value_step = 5,
+                                value_hold_step = 20,
+                                value_max = 100,
+                                unit = "%",
+                                title_text = _("Max lenght of chapter-title complication"),
+                                info_text = _("Maximum percentage of screen width used for chapter-title complication"),
+                                keep_shown_on_apply = true,
+                                callback = function(spin)
+                                    self.settings.book_chapter_max_width_pct = spin.value
+                                    self:refreshFooter(true, true)
+                                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                                end
+                            }
+                            UIManager:show(items)
+                        end,
+                        keep_menu_open = true,
+                    }
+                },
             },
             {
-                text = _("Auto refresh complications"),
-                help_text = _([[This option allows certain complications to update without needing a full-page update. For example, the time
-                complication will update every minute regardless of user input.]]),
-                checked_func = function()
-                    return self.settings.auto_refresh_time == true
+                text_func = function()
+                    local align_text
+                    if self.settings.align == "left" then
+                        align_text = _("Left")
+                    elseif self.settings.align == "right" then
+                        align_text = _("Right")
+                    else
+                        align_text = _("Center")
+                    end
+                    return T(_("Alignment: %1"), align_text)
                 end,
-                callback = function()
-                    self.settings.auto_refresh_time = not self.settings.auto_refresh_time
-                    self:rescheduleFooterAutoRefreshIfNeeded()
-                end
+                enabled_func = function()
+                    return self.settings.disable_progress_bar or self.settings.progress_bar_position ~= "alongside"
+                end,
+                sub_item_table = {
+                    {
+                        text = _("Left"),
+                        checked_func = function()
+                            return self.settings.align == "left"
+                        end,
+                        callback = function()
+                            self.settings.align = "left"
+                            self:refreshFooter(true)
+                        end,
+                    },
+                    {
+                        text = _("Center"),
+                        checked_func = function()
+                            return self.settings.align == "center"
+                        end,
+                        callback = function()
+                            self.settings.align = "center"
+                            self:refreshFooter(true)
+                        end,
+                    },
+                    {
+                        text = _("Right"),
+                        checked_func = function()
+                            return self.settings.align == "right"
+                        end,
+                        callback = function()
+                            self.settings.align = "right"
+                            self:refreshFooter(true)
+                        end,
+                    },
+                }
             },
             {
                 text_func = function()
@@ -1727,112 +1837,6 @@ going from n to 1 instead.]]),
                     UIManager:show(items_font)
                 end,
                 keep_menu_open = true,
-            },
-            {
-                text = _("Maximum lenght for text complications"),
-                sub_item_table = {
-                    {
-                        text_func = function()
-                            return T(_("Book title: %1 %"), self.settings.book_title_max_width_pct)
-                        end,
-                        callback = function(touchmenu_instance)
-                            local SpinWidget = require("ui/widget/spinwidget")
-                            local items = SpinWidget:new{
-                                value = self.settings.book_title_max_width_pct,
-                                value_min = 10,
-                                value_step = 5,
-                                value_hold_step = 20,
-                                value_max = 100,
-                                unit = "%",
-                                title_text = _("Maximum lenght of book-title complication"),
-                                info_text = _("Maximum percentage of screen width used for book-title complication"),
-                                keep_shown_on_apply = true,
-                                callback = function(spin)
-                                    self.settings.book_title_max_width_pct = spin.value
-                                    self:refreshFooter(true, true)
-                                    if touchmenu_instance then touchmenu_instance:updateItems() end
-                                end
-                            }
-                            UIManager:show(items)
-                        end,
-                        keep_menu_open = true,
-                    },
-                    {
-                        text_func = function()
-                            return T(_("Current chapter: %1 %"), self.settings.book_chapter_max_width_pct)
-                        end,
-                        callback = function(touchmenu_instance)
-                            local SpinWidget = require("ui/widget/spinwidget")
-                            local items = SpinWidget:new{
-                                value = self.settings.book_chapter_max_width_pct,
-                                value_min = 10,
-                                value_step = 5,
-                                value_hold_step = 20,
-                                value_max = 100,
-                                unit = "%",
-                                title_text = _("Maximum lenght of chapter-title complication"),
-                                info_text = _("Maximum percentage of screen width used for chapter-title complication"),
-                                keep_shown_on_apply = true,
-                                callback = function(spin)
-                                    self.settings.book_chapter_max_width_pct = spin.value
-                                    self:refreshFooter(true, true)
-                                    if touchmenu_instance then touchmenu_instance:updateItems() end
-                                end
-                            }
-                            UIManager:show(items)
-                        end,
-                        keep_menu_open = true,
-                    }
-                },
-            },
-            {
-                text_func = function()
-                    local align_text
-                    if self.settings.align == "left" then
-                        align_text = _("Left")
-                    elseif self.settings.align == "right" then
-                        align_text = _("Right")
-                    else
-                        align_text = _("Center")
-                    end
-                    return T(_("Alignment: %1"), align_text)
-                end,
-                separator = true,
-                enabled_func = function()
-                    return self.settings.disable_progress_bar or self.settings.progress_bar_position ~= "alongside"
-                end,
-                sub_item_table = {
-                    {
-                        text = _("Center"),
-                        checked_func = function()
-                            return self.settings.align == "center"
-                        end,
-                        callback = function()
-                            self.settings.align = "center"
-                            self:refreshFooter(true)
-                        end,
-                    },
-                    {
-                        text = _("Left"),
-                        checked_func = function()
-                            return self.settings.align == "left"
-                        end,
-                        callback = function()
-                            self.settings.align = "left"
-                            self:refreshFooter(true)
-                        end,
-                    },
-                    {
-                        text = _("Right"),
-                        checked_func = function()
-                            return self.settings.align == "right"
-                        end,
-                        callback = function()
-                            self.settings.align = "right"
-                            self:refreshFooter(true)
-                        end,
-                    },
-                }
             },
             {
                 text_func = function()
@@ -1950,10 +1954,10 @@ going from n to 1 instead.]]),
     })
     local configure_complications_sub_table = sub_items[#sub_items].sub_item_table -- will pick the last item of sub_items
     if Device:hasBattery() then
-        table.insert(configure_complications_sub_table , 4, {
+        table.insert(configure_complications_sub_table , 5, {
             text_func = function()
                 if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200 or 100) then
-                    return T(_("Hide battery complication when higher than: %1 %"), self.settings.battery_hide_threshold)
+                    return T(_("Hide battery complication when higher than: %1".. "%"), self.settings.battery_hide_threshold)
                 else
                     return _("Hide battery complication at custom threshold")
                 end
@@ -2005,7 +2009,7 @@ going from n to 1 instead.]]),
             self:refreshFooter(true, true)
         end,
     })
-    -- these next settings are useless on non-touch devices so we take them off
+    -- the next couple of settings are useless on non-touch devices so we take them off there
     if Device:isTouchDevice() then
         table.insert(sub_items, {
             text = _("Lock status bar"),

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -676,11 +676,11 @@ end
 
 -- Help text string, or function, to be shown, or executed, on a long press on menu item
 local option_help_text = {}
-option_help_text[MODE.pages_left_book] = _("Can be configured to include or exclude the current page.")
-option_help_text[MODE.percentage] = _("Progress percentage can be shown with zero, one or two decimal places.")
-option_help_text[MODE.mem_usage] = _("Show memory usage in MiB.")
---option_help_text[MODE.reclaim_height] = _("When status bar is unlocked and hidden, this setting will utilise the entirety of screen real state and will temporarily overlap status bar and text when unhidden.")
-option_help_text[MODE.custom_text] = ReaderFooter.set_custom_text
+option_help_text["pages_left_book"] = _("Can be configured to include or exclude the current page.")
+option_help_text["percentage"] = _("Progress percentage can be shown with zero, one or two decimal places.")
+option_help_text["mem_usage"] = _("Show memory usage in MiB.")
+option_help_text["reclaim_height"] = _("When status bar is unlocked and hidden, this setting will utilise the entirety of screen real state and will temporarily overlap status bar and text when unhidden.")
+option_help_text["custom_text"] = ReaderFooter.set_custom_text
 
 function ReaderFooter:updateFooterContainer()
     local margin_span = HorizontalSpan:new{ width = self.horizontal_margin }
@@ -1018,11 +1018,11 @@ function ReaderFooter:addToMainMenu(menu_items)
             text_func = function()
                 return self:textOptionTitles(option)
             end,
-            help_text = type(option_help_text[MODE[option]]) == "string"
-                and option_help_text[MODE[option]],
-            help_text_func = type(option_help_text[MODE[option]]) == "function" and
-                function(touchmenu_instance)
-                    option_help_text[MODE[option]](self, touchmenu_instance)
+            help_text = type(option_help_text[option]) == "string" 
+                and option_help_text[option], 
+            help_text_func = type(option_help_text[option]) == "function" and 
+                function(touchmenu_instance) 
+                    option_help_text[option](self, touchmenu_instance) 
                 end,
             checked_func = function()
                 return self.settings[option] == true

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -9,7 +9,6 @@ local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
-local InfoMessage = require("ui/widget/infomessage")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
@@ -964,7 +963,7 @@ function ReaderFooter:textOptionTitles(option)
     local symbol = self.settings.item_prefix
     local option_titles = {
         all_at_once = _("Show all selected items at once"),
-        reclaim_height = _("Overlay status bar"),
+        reclaim_height = _("Overlap status bar"),
         bookmark_count = T(_("Bookmark count (%1)"), symbol_prefix[symbol].bookmark_count),
         page_progress = T(_("Current page (%1)"), "/"),
         pages_left_book = T(_("Pages left in book (%1)"), symbol_prefix[symbol].pages_left_book),
@@ -972,14 +971,14 @@ function ReaderFooter:textOptionTitles(option)
             and T(_("Current time (%1)"), symbol_prefix[symbol].time) or _("Current time"),
         chapter_progress = T(_("Current page in chapter (%1)"), " ⁄⁄ "),
         pages_left = T(_("Pages left in chapter (%1)"), symbol_prefix[symbol].pages_left),
-        battery = T(_("Battery status (%1)"), symbol_prefix[symbol].battery),
+        battery = T(_("Battery percentage (%1)"), symbol_prefix[symbol].battery),
         percentage = symbol_prefix[symbol].percentage
             and T(_("Progress percentage (%1)"), symbol_prefix[symbol].percentage) or _("Progress percentage"),
         book_time_to_read = symbol_prefix[symbol].book_time_to_read
-            and T(_("Time left to read book (%1)"),symbol_prefix[symbol].book_time_to_read) or _("Time left to read book"),
-        chapter_time_to_read = T(_("Time left to read chapter (%1)"), symbol_prefix[symbol].chapter_time_to_read),
-        frontlight = T(_("Frontlight level (%1)"), symbol_prefix[symbol].frontlight),
-        frontlight_warmth = T(_("Frontlight warmth level (%1)"), symbol_prefix[symbol].frontlight_warmth),
+            and T(_("Time left to finish book (%1)"),symbol_prefix[symbol].book_time_to_read) or _("Time left to finish book"),
+        chapter_time_to_read = T(_("Time left to finish chapter (%1)"), symbol_prefix[symbol].chapter_time_to_read),
+        frontlight = T(_("Brightness level (%1)"), symbol_prefix[symbol].frontlight),
+        frontlight_warmth = T(_("Warmth level (%1)"), symbol_prefix[symbol].frontlight_warmth),
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
         book_title = _("Book title"),
@@ -1120,7 +1119,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Show chapter progress bar instead"),
+                text = _("Show chapter-progress bar instead"),
                 help_text = _("Show progress bar for the current chapter, instead of the whole book."),
                 enabled_func = function()
                     return not self.settings.disable_progress_bar
@@ -1268,12 +1267,12 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    local text = _("static margins (10)")
+                    local text = _("static margins: 10")
                     local cur_width = self.settings.progress_margin_width
                     if cur_width == 0 then
-                        text = _("no margins (0)")
+                        text = _("no margins: 0")
                     elseif cur_width == Screen:scaleBySize(material_pixels) then
-                        text = T(_("static margins (%1)"), material_pixels)
+                        text = T(_("static margins: %1"), material_pixels)
                     end
                     if self.settings.progress_margin and not self.ui.document.info.has_pages then
                         text = T(_("same as book margins (%1)"), self.book_margins_footer_width)
@@ -1286,7 +1285,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 sub_item_table_func = function()
                     local common = {
                         {
-                            text = _("No margins (0)"),
+                            text = _("No margins: 0"),
                             checked_func = function()
                                 return self.settings.progress_margin_width == 0
                                     and not self.settings.progress_margin
@@ -1302,7 +1301,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 if self.ui.document.info.has_pages then
                                     return _("Same as book margins")
                                 end
-                                return T(_("Same as book margins (%1)"), self.book_margins_footer_width)
+                                return T(_("Same as book margins: %1"), self.book_margins_footer_width)
                             end,
                             checked_func = function()
                                 return self.settings.progress_margin and not self.ui.document.info.has_pages
@@ -1319,7 +1318,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     }
                     local function customMargin(px)
                         return {
-                            text = T(_("Static margins (%1)"), px),
+                            text = T(_("Static margins: %1"), px),
                             checked_func = function()
                                 return self.settings.progress_margin_width == Screen:scaleBySize(px)
                                     and not self.settings.progress_margin
@@ -1345,7 +1344,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Screen width assigned to progress bar: %1 %"), self.settings.progress_bar_min_width_pct)
+                    return T(_("Screen width assigned to progress bar: %1".. "%"), self.settings.progress_bar_min_width_pct)
                 end,
                 enabled_func = function()
                     return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
@@ -1531,8 +1530,8 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end
             },
             {
-                text = _("Hide empty items"),
-                help_text = _([[This option will hide values like 0 or off.]]),
+                text = _("Hide null value items"),
+                help_text = _([[This option will hide null (or inactive) values from temporarily appearing on the status bar. For example, if the frontlight is 'off' (i.e 0 brightness), no symbols or values will be displayed until the brightness is set to a value >= 1.]]),
                 enabled_func = function()
                     return self.settings.all_at_once == true
                 end,
@@ -1568,7 +1567,7 @@ With this feature activated, the current page is factored in, resulting in the c
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("No decimal places (%1)"), self:progressPercentage(0))
+                            return T(_("No decimal places: %1"), self:progressPercentage(0))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "0"
@@ -1580,7 +1579,7 @@ With this feature activated, the current page is factored in, resulting in the c
                     },
                     {
                         text_func = function()
-                            return T(_("1 decimal place (%1)"), self:progressPercentage(1))
+                            return T(_("1 decimal place: %1"), self:progressPercentage(1))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "1"
@@ -1592,7 +1591,7 @@ With this feature activated, the current page is factored in, resulting in the c
                     },
                     {
                         text_func = function()
-                            return T(_("2 decimal places (%1)"), self:progressPercentage(2))
+                            return T(_("2 decimal places: %1"), self:progressPercentage(2))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "2"
@@ -1605,12 +1604,12 @@ With this feature activated, the current page is factored in, resulting in the c
                 },
             },
             {
-                text = _("Maximum length for text items"),
+                text = _("Max percentage of screen width used for text items"),
                 separator = true,
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Length of book-title items: %1".. "%"), self.settings.book_title_max_width_pct)
+                            return T(_("Book-title item: %1".. "%"), self.settings.book_title_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1622,7 +1621,7 @@ With this feature activated, the current page is factored in, resulting in the c
                                 value_max = 100,
                                 unit = "%",
                                 title_text = _("Max length of book-title item"),
-                                info_text = _("Maximum percentage of screen width used for book-title item"),
+                                info_text = _("Maximum percentage of screen width used for book-title"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_title_max_width_pct = spin.value
@@ -1636,7 +1635,7 @@ With this feature activated, the current page is factored in, resulting in the c
                     },
                     {
                         text_func = function()
-                            return T(_("Length of chapter-title item: %1".. "%"), self.settings.book_chapter_max_width_pct)
+                            return T(_("Chapter-title item: %1".. "%"), self.settings.book_chapter_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1834,7 +1833,7 @@ With this feature activated, the current page is factored in, resulting in the c
                     elseif self.settings.item_prefix == "letters" then
                         prefix_text = C_("Status bar", "Letters")
                     end
-                    return T(_("Complication symbols: %1"), prefix_text)
+                    return T(_("Item symbols: %1"), prefix_text)
                 end,
                 sub_item_table = {
                     {
@@ -1843,7 +1842,7 @@ With this feature activated, the current page is factored in, resulting in the c
                             for _, letter in pairs(symbol_prefix.icons) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "Icons (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "icons (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "icons"
@@ -1859,7 +1858,7 @@ With this feature activated, the current page is factored in, resulting in the c
                             for _, letter in pairs(symbol_prefix.letters) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "Letters (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "letters (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "letters"
@@ -1875,7 +1874,7 @@ With this feature activated, the current page is factored in, resulting in the c
                             for _, letter in pairs(symbol_prefix.compact_items) do
                                 table.insert(sym_tbl, letter)
                             end
-                            return T(C_("Status bar", "Compact (%1)"), table.concat(sym_tbl, " "))
+                            return T(C_("Status bar", "compact (%1)"), table.concat(sym_tbl, " "))
                         end,
                         checked_func = function()
                             return self.settings.item_prefix == "compact_items"
@@ -1891,11 +1890,11 @@ With this feature activated, the current page is factored in, resulting in the c
                 text_func = function()
                     local separator = self:get_separator_symbol()
                     separator = separator ~= "" and separator or "none"
-                    return T(_("Items separator: %1"), separator)
+                    return T(_("Item separator: %1"), separator)
                 end,
                 sub_item_table = {
                     {
-                        text = _("Pipe (|)"),
+                        text = _("Vertical bar (|)"),
                         checked_func = function()
                             return self.settings.items_separator == "bar"
                         end,
@@ -1983,7 +1982,7 @@ With this feature activated, the current page is factored in, resulting in the c
         })
     end
     ----------- More status bar options
-    -- quick access to this setting for "@NiLuJe, and for people that do like him." -- poire-z (2024)
+    -- quick access to this setting for "@NiLuJe, and for people that do like him." -- @poire-z (2024)
     table.insert(sub_items, getMinibarOption("reclaim_height"))
     table.insert(sub_items, {
         text = _("Show status bar divider"),

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1093,8 +1093,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             end,
         }
     end
-    ---------------------
-    -------Progress bar
+
     table.insert(sub_items, {
         text = _("Progress bar"),
         separator = true,
@@ -1520,7 +1519,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             getMinibarOption("all_at_once", self.updateFooterTextGenerator),
             {
                 text = _("Auto refresh items"),
-                help_text = _("This option allows certain items to update without needing a full-page update. For example, the time item will update every minute regardless of user input."),
+                help_text = _("This option allows certain items to update without needing user interaction (i.e page refresh). For example, the time item will update every minute regardless of user input."),
                 checked_func = function()
                     return self.settings.auto_refresh_time == true
                 end,
@@ -1547,7 +1546,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 text = _("Include current page in pages left"),
                 help_text = _([[
 By default, KOReader does not include the current page when calculating pages left. For example, in a book or chapter with n pages the 'pages left' item will range from 'n−1' to 0 (last page).
-With this feature activated, the current page is factored in, resulting in the count going from n to 1 instead.]]),
+With this feature enabled, the current page is factored in, resulting in the count going from n to 1 instead.]]),
                 enabled_func = function()
                     return self.settings.pages_left or self.settings.pages_left_book
                 end,
@@ -1663,54 +1662,6 @@ With this feature activated, the current page is factored in, resulting in the c
             },
             {
                 text_func = function()
-                    local align_text
-                    if self.settings.align == "left" then
-                        align_text = _("Left")
-                    elseif self.settings.align == "right" then
-                        align_text = _("Right")
-                    else
-                        align_text = _("Center")
-                    end
-                    return T(_("Alignment: %1"), align_text)
-                end,
-                enabled_func = function()
-                    return self.settings.disable_progress_bar or self.settings.progress_bar_position ~= "alongside"
-                end,
-                sub_item_table = {
-                    {
-                        text = _("Left"),
-                        checked_func = function()
-                            return self.settings.align == "left"
-                        end,
-                        callback = function()
-                            self.settings.align = "left"
-                            self:refreshFooter(true)
-                        end,
-                    },
-                    {
-                        text = _("Center"),
-                        checked_func = function()
-                            return self.settings.align == "center"
-                        end,
-                        callback = function()
-                            self.settings.align = "center"
-                            self:refreshFooter(true)
-                        end,
-                    },
-                    {
-                        text = _("Right"),
-                        checked_func = function()
-                            return self.settings.align == "right"
-                        end,
-                        callback = function()
-                            self.settings.align = "right"
-                            self:refreshFooter(true)
-                        end,
-                    },
-                }
-            },
-            {
-                text_func = function()
                     local font_weight = ""
                     if self.settings.text_font_bold == true then
                         font_weight = ", " .. _("bold")
@@ -1770,58 +1721,6 @@ With this feature activated, the current page is factored in, resulting in the c
                         keep_menu_open = true,
                     },
                 }
-            },
-            {
-                text_func = function()
-                    return T(_("Container height: %1"), self.settings.container_height)
-                end,
-                callback = function(touchmenu_instance)
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local container_height = self.settings.container_height
-                    local items_font = SpinWidget:new{
-                        value = container_height,
-                        value_min = 7,
-                        value_max = 98,
-                        default_value = G_defaults:readSetting("DMINIBAR_CONTAINER_HEIGHT"),
-                        ok_text = _("Set height"),
-                        title_text = _("Container height"),
-                        keep_shown_on_apply = true,
-                        callback = function(spin)
-                            self.settings.container_height = spin.value
-                            self.height = Screen:scaleBySize(self.settings.container_height)
-                            self:refreshFooter(true, true)
-                            if touchmenu_instance then touchmenu_instance:updateItems() end
-                        end,
-                    }
-                    UIManager:show(items_font)
-                end,
-                keep_menu_open = true,
-            },
-            {
-                text_func = function()
-                    return T(_("Container bottom margin: %1"), self.settings.container_bottom_padding)
-                end,
-                callback = function(touchmenu_instance)
-                    local SpinWidget = require("ui/widget/spinwidget")
-                    local container_bottom_padding = self.settings.container_bottom_padding
-                    local items_font = SpinWidget:new{
-                        value = container_bottom_padding,
-                        value_min = 0,
-                        value_max = 49,
-                        default_value = 1,
-                        ok_text = _("Set margin"),
-                        title_text = _("Container bottom margin"),
-                        keep_shown_on_apply = true,
-                        callback = function(spin)
-                            self.settings.container_bottom_padding = spin.value
-                            self.bottom_padding = Screen:scaleBySize(self.settings.container_bottom_padding)
-                            self:refreshFooter(true, true)
-                            if touchmenu_instance then touchmenu_instance:updateItems() end
-                        end,
-                    }
-                    UIManager:show(items_font)
-                end,
-                keep_menu_open = true,
             },
             {
                 text_func = function()
@@ -1935,11 +1834,111 @@ With this feature activated, the current page is factored in, resulting in the c
                     },
                 },
             },
+            {
+                text_func = function()
+                    local align_text
+                    if self.settings.align == "left" then
+                        align_text = _("Left")
+                    elseif self.settings.align == "right" then
+                        align_text = _("Right")
+                    else
+                        align_text = _("Center")
+                    end
+                    return T(_("Alignment: %1"), align_text)
+                end,
+                enabled_func = function()
+                    return self.settings.disable_progress_bar or self.settings.progress_bar_position ~= "alongside"
+                end,
+                sub_item_table = {
+                    {
+                        text = _("Left"),
+                        checked_func = function()
+                            return self.settings.align == "left"
+                        end,
+                        callback = function()
+                            self.settings.align = "left"
+                            self:refreshFooter(true)
+                        end,
+                    },
+                    {
+                        text = _("Center"),
+                        checked_func = function()
+                            return self.settings.align == "center"
+                        end,
+                        callback = function()
+                            self.settings.align = "center"
+                            self:refreshFooter(true)
+                        end,
+                    },
+                    {
+                        text = _("Right"),
+                        checked_func = function()
+                            return self.settings.align == "right"
+                        end,
+                        callback = function()
+                            self.settings.align = "right"
+                            self:refreshFooter(true)
+                        end,
+                    },
+                }
+            },    
+            {
+                text_func = function()
+                    return T(_("Container height: %1"), self.settings.container_height)
+                end,
+                callback = function(touchmenu_instance)
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local container_height = self.settings.container_height
+                    local items_font = SpinWidget:new{
+                        value = container_height,
+                        value_min = 7,
+                        value_max = 98,
+                        default_value = G_defaults:readSetting("DMINIBAR_CONTAINER_HEIGHT"),
+                        ok_text = _("Set height"),
+                        title_text = _("Container height"),
+                        keep_shown_on_apply = true,
+                        callback = function(spin)
+                            self.settings.container_height = spin.value
+                            self.height = Screen:scaleBySize(self.settings.container_height)
+                            self:refreshFooter(true, true)
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                    }
+                    UIManager:show(items_font)
+                end,
+                keep_menu_open = true,
+            },
+            {
+                text_func = function()
+                    return T(_("Container bottom margin: %1"), self.settings.container_bottom_padding)
+                end,
+                callback = function(touchmenu_instance)
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local container_bottom_padding = self.settings.container_bottom_padding
+                    local items_font = SpinWidget:new{
+                        value = container_bottom_padding,
+                        value_min = 0,
+                        value_max = 49,
+                        default_value = 1,
+                        ok_text = _("Set margin"),
+                        title_text = _("Container bottom margin"),
+                        keep_shown_on_apply = true,
+                        callback = function(spin)
+                            self.settings.container_bottom_padding = spin.value
+                            self.bottom_padding = Screen:scaleBySize(self.settings.container_bottom_padding)
+                            self:refreshFooter(true, true)
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                    }
+                    UIManager:show(items_font)
+                end,
+                keep_menu_open = true,
+            },    
         }
     })
-    local configure_complications_sub_table = sub_items[#sub_items].sub_item_table -- will pick the last item of sub_items
+    local configure_items_sub_table = sub_items[#sub_items].sub_item_table -- will pick the last item of sub_items
     if Device:hasBattery() then
-        table.insert(configure_complications_sub_table , 5, {
+        table.insert(configure_items_sub_table , 5, {
             text_func = function()
                 if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200 or 100) then
                     return T(_("Hide battery item when higher than: %1".. "%"), self.settings.battery_hide_threshold)
@@ -1981,7 +1980,7 @@ With this feature activated, the current page is factored in, resulting in the c
             keep_menu_open = true,
         })
     end
-    ----------- More status bar options
+    -- More status bar options
     -- quick access to this setting for "@NiLuJe, and for people that do like him." -- @poire-z (2024)
     table.insert(sub_items, getMinibarOption("reclaim_height"))
     table.insert(sub_items, {

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1343,7 +1343,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Screen width assigned to progress bar: %1".. "%"), self.settings.progress_bar_min_width_pct)
+                    return T(_("Minimum progress bar width: %1".. "%"), self.settings.progress_bar_min_width_pct)
                 end,
                 enabled_func = function()
                     return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
@@ -1358,7 +1358,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                         value_hold_step = 20,
                         value_max = 50,
                         unit = "%",
-                        title_text = _("Minimum progress bar length"),
+                        title_text = _("Minimum progress bar width"),
                         text = _("Minimum percentage of screen width assigned to progress bar"),
                         keep_shown_on_apply = true,
                         callback = function(spin)
@@ -1794,7 +1794,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max size of book-title item"),
+                                title_text = _("Book-title item"),
                                 info_text = _("Maximum percentage of screen width used for book-title"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
@@ -1820,7 +1820,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max size of chapter-title item"),
+                                title_text = _("Chapter-title item"),
                                 info_text = _("Maximum percentage of screen width used for chapter-title item"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
@@ -1885,7 +1885,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
             },
             {
                 text_func = function()
-                    return T(_("Items mini-bar height: %1"), self.settings.container_height)
+                    return T(_("Items height: %1"), self.settings.container_height)
                 end,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")
@@ -1896,7 +1896,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                         value_max = 98,
                         default_value = G_defaults:readSetting("DMINIBAR_CONTAINER_HEIGHT"),
                         ok_text = _("Set height"),
-                        title_text = _("Container height"),
+                        title_text = _("Items container height"),
                         keep_shown_on_apply = true,
                         callback = function(spin)
                             self.settings.container_height = spin.value

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1135,11 +1135,11 @@ function ReaderFooter:addToMainMenu(menu_items)
             {
                 separator = true,
                 text_func = function()
-                    local text = _("alongside complications")
+                    local text = _("alongside items")
                     if self.settings.progress_bar_position == "above" then
-                        text = _("above complications")
+                        text = _("above items")
                     elseif self.settings.progress_bar_position == "below" then
-                        text = _("below complications")
+                        text = _("below items")
                     end
                     return T(_("Position: %1"), text)
                 end,
@@ -1148,7 +1148,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
                 sub_item_table = {
                     {
-                        text = _("Above complications"),
+                        text = _("Above items"),
                         checked_func = function()
                             return self.settings.progress_bar_position == "above"
                         end,
@@ -1158,7 +1158,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Alongside complications"),
+                        text = _("Alongside items"),
                         checked_func = function()
                             return self.settings.progress_bar_position == "alongside"
                         end,
@@ -1176,7 +1176,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                         end
                     },
                     {
-                        text = _("Below complications"),
+                        text = _("Below items"),
                         checked_func = function()
                             return self.settings.progress_bar_position == "below"
                         end,
@@ -1455,58 +1455,45 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
         }
     })
-    ----------- complications (footer_items)
-    local about_text = _("A complication is any feature that provides additional information beyond the content of your book. Examples of "..
-    "common complications include time, percentage read, pages left, and the battery indicator. You can choose which complications to "..
-    "display on the status bar from this page.")
-    local complication_subitems = {}
+    ----------- footer_items
+    local footer_items = {}
     table.insert(sub_items, {
-        text = _("Complications"),
-        sub_item_table = complication_subitems,
+        text = _("Items"),
+        sub_item_table = footer_items,
     })
-    table.insert(sub_items, complications)
-    table.insert(complication_subitems, {    
-        text = _("About complications"),
-        keep_menu_open = true,
-        callback = function()
-            UIManager:show(InfoMessage:new{
-                text = about_text,
-            })
-        end,
-        separator = true,
-    })
-    table.insert(complication_subitems, getMinibarOption("page_progress"))
-    table.insert(complication_subitems, getMinibarOption("pages_left_book"))
-    table.insert(complication_subitems, getMinibarOption("time"))
-    table.insert(complication_subitems, getMinibarOption("chapter_progress"))
-    table.insert(complication_subitems, getMinibarOption("pages_left"))
+    table.insert(sub_items, items)
+    table.insert(footer_items, getMinibarOption("page_progress"))
+    table.insert(footer_items, getMinibarOption("pages_left_book"))
+    table.insert(footer_items, getMinibarOption("time"))
+    table.insert(footer_items, getMinibarOption("chapter_progress"))
+    table.insert(footer_items, getMinibarOption("pages_left"))
     if Device:hasBattery() then
-        table.insert(complication_subitems, getMinibarOption("battery"))
+        table.insert(footer_items, getMinibarOption("battery"))
     end
-    table.insert(complication_subitems, getMinibarOption("bookmark_count"))
-    table.insert(complication_subitems, getMinibarOption("percentage"))
-    table.insert(complication_subitems, getMinibarOption("book_time_to_read"))
-    table.insert(complication_subitems, getMinibarOption("chapter_time_to_read"))
+    table.insert(footer_items, getMinibarOption("bookmark_count"))
+    table.insert(footer_items, getMinibarOption("percentage"))
+    table.insert(footer_items, getMinibarOption("book_time_to_read"))
+    table.insert(footer_items, getMinibarOption("chapter_time_to_read"))
     if Device:hasFrontlight() then
-        table.insert(complication_subitems, getMinibarOption("frontlight"))
+        table.insert(footer_items, getMinibarOption("frontlight"))
     end
     if Device:hasNaturalLight() then
-        table.insert(complication_subitems, getMinibarOption("frontlight_warmth"))
+        table.insert(footer_items, getMinibarOption("frontlight_warmth"))
     end
-    table.insert(complication_subitems, getMinibarOption("mem_usage"))
+    table.insert(footer_items, getMinibarOption("mem_usage"))
     if Device:hasFastWifiStatusQuery() then
-        table.insert(complication_subitems, getMinibarOption("wifi_status"))
+        table.insert(footer_items, getMinibarOption("wifi_status"))
     end
-    table.insert(complication_subitems, getMinibarOption("book_title"))
-    table.insert(complication_subitems, getMinibarOption("book_chapter"))
-    table.insert(complication_subitems, getMinibarOption("custom_text"))
+    table.insert(footer_items, getMinibarOption("book_title"))
+    table.insert(footer_items, getMinibarOption("book_chapter"))
+    table.insert(footer_items, getMinibarOption("custom_text"))
     -------- configure footer_items
     table.insert(sub_items, {
         separator = true,
-        text = _("Configure complications"),
+        text = _("Configure items"),
         sub_item_table = {
             {
-                text = _("Arrange complications in status bar"),
+                text = _("Arrange items in status bar"),
                 separator = true,
                 callback = function()
                     local item_table = {}
@@ -1516,7 +1503,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     local SortWidget = require("ui/widget/sortwidget")
                     local sort_item
                     sort_item = SortWidget:new{
-                        title = _("Arrange complications"),
+                        title = _("Arrange items"),
                         item_table = item_table,
                         callback = function()
                             for i=1, #sort_item.item_table do
@@ -1533,9 +1520,9 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             getMinibarOption("all_at_once", self.updateFooterTextGenerator),
             {
-                text = _("Auto refresh complications"),
-                help_text = _("This option allows certain complications to update without needing a full-page update. For example, the time"..
-                " complication will update every minute regardless of user input."),
+                text = _("Auto refresh items"),
+                help_text = _("This option allows certain items to update without needing a full-page update. For example, the time"..
+                " item will update every minute regardless of user input."),
                 checked_func = function()
                     return self.settings.auto_refresh_time == true
                 end,
@@ -1545,7 +1532,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end
             },
             {
-                text = _("Hide empty complications"),
+                text = _("Hide empty items"),
                 help_text = _([[This option will hide values like 0 or off.]]),
                 enabled_func = function()
                     return self.settings.all_at_once == true
@@ -1559,9 +1546,9 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Count current page in pages left"),
+                text = _("Include current page in pages left"),
                 help_text = _("By default, KOReader does not include the current page when calculating pages left. For example, in a book ".. 
-                "or chapter with n pages the 'pages left' complication will range from 'n-1' to 0 (last page). With this feature activated, "..
+                "or chapter with n pages the 'pages left' item will range from 'n-1' to 0 (last page). With this feature activated, "..
                 "the current page is factored in, resulting in the count going from n to 1 instead."),
                 enabled_func = function()
                     return self.settings.pages_left or self.settings.pages_left_book
@@ -1619,12 +1606,12 @@ function ReaderFooter:addToMainMenu(menu_items)
                 },
             },
             {
-                text = _("Maximum length for text complications"),
+                text = _("Maximum length for text items"),
                 separator = true,
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Length of book-title complication: %1".. "%"), self.settings.book_title_max_width_pct)
+                            return T(_("Length of book-title items: %1".. "%"), self.settings.book_title_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1635,8 +1622,8 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max length of book-title complication"),
-                                info_text = _("Maximum percentage of screen width used for book-title complication"),
+                                title_text = _("Max length of book-title item"),
+                                info_text = _("Maximum percentage of screen width used for book-title item"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_title_max_width_pct = spin.value
@@ -1650,7 +1637,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     },
                     {
                         text_func = function()
-                            return T(_("Length of chapter-title complication: %1".. "%"), self.settings.book_chapter_max_width_pct)
+                            return T(_("Length of chapter-title item: %1".. "%"), self.settings.book_chapter_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1661,8 +1648,8 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max length of chapter-title complication"),
-                                info_text = _("Maximum percentage of screen width used for chapter-title complication"),
+                                title_text = _("Max length of chapter-title item"),
+                                info_text = _("Maximum percentage of screen width used for chapter-title item"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_chapter_max_width_pct = spin.value
@@ -1730,12 +1717,12 @@ function ReaderFooter:addToMainMenu(menu_items)
                     if self.settings.text_font_bold == true then
                         font_weight = ", " .. _("bold")
                     end
-                    return T(_("Complications font: %1%2"), self.settings.text_font_size, font_weight)
+                    return T(_("Items font: %1%2"), self.settings.text_font_size, font_weight)
                 end,
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Complications font size: %1"), self.settings.text_font_size)
+                            return T(_("Items font size: %1"), self.settings.text_font_size)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1746,7 +1733,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_max = 36,
                                 default_value = 14,
                                 ok_text = _("Set size"),
-                                title_text = _("Set font size for complications"),
+                                title_text = _("Set font size for items"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.text_font_size = spin.value
@@ -1766,7 +1753,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                         keep_menu_open = true,
                     },
                     {
-                        text = _("Use boldface"),
+                        text = _("Items in bold"),
                         checked_func = function()
                             return self.settings.text_font_bold == true
                         end,
@@ -1905,7 +1892,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 text_func = function()
                     local separator = self:get_separator_symbol()
                     separator = separator ~= "" and separator or "none"
-                    return T(_("Complication separator: %1"), separator)
+                    return T(_("Items separator: %1"), separator)
                 end,
                 sub_item_table = {
                     {
@@ -1957,9 +1944,9 @@ function ReaderFooter:addToMainMenu(menu_items)
         table.insert(configure_complications_sub_table , 5, {
             text_func = function()
                 if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200 or 100) then
-                    return T(_("Hide battery complication when higher than: %1".. "%"), self.settings.battery_hide_threshold)
+                    return T(_("Hide battery item when higher than: %1".. "%"), self.settings.battery_hide_threshold)
                 else
-                    return _("Hide battery complication at custom threshold")
+                    return _("Hide battery item at custom threshold")
                 end
             end,
             checked_func = function()
@@ -1978,7 +1965,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     default_value = Device:hasAuxBattery() and 200 or 100,
                     unit = "%",
                     value_hold_step = 10,
-                    title_text = _("Set minimum threshold to hide battery complication"),
+                    title_text = _("Set minimum threshold to hide battery item"),
                     callback = function(spin)
                         self.settings.battery_hide_threshold = spin.value
                         self:refreshFooter(true, true)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1267,12 +1267,12 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    local text = _("static margins: 10")
+                    local text = _("static margins (10)")
                     local cur_width = self.settings.progress_margin_width
                     if cur_width == 0 then
-                        text = _("no margins: 0")
+                        text = _("no margins (0)")
                     elseif cur_width == Screen:scaleBySize(material_pixels) then
-                        text = T(_("static margins: %1"), material_pixels)
+                        text = T(_("static margins (%1)"), material_pixels)
                     end
                     if self.settings.progress_margin and not self.ui.document.info.has_pages then
                         text = T(_("same as book margins (%1)"), self.book_margins_footer_width)
@@ -1285,7 +1285,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 sub_item_table_func = function()
                     local common = {
                         {
-                            text = _("No margins: 0"),
+                            text = _("No margins (0)"),
                             checked_func = function()
                                 return self.settings.progress_margin_width == 0
                                     and not self.settings.progress_margin
@@ -1301,7 +1301,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 if self.ui.document.info.has_pages then
                                     return _("Same as book margins")
                                 end
-                                return T(_("Same as book margins: %1"), self.book_margins_footer_width)
+                                return T(_("Same as book margins (%1)"), self.book_margins_footer_width)
                             end,
                             checked_func = function()
                                 return self.settings.progress_margin and not self.ui.document.info.has_pages
@@ -1318,7 +1318,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     }
                     local function customMargin(px)
                         return {
-                            text = T(_("Static margins: %1"), px),
+                            text = T(_("Static margins (%1)"), px),
                             checked_func = function()
                                 return self.settings.progress_margin_width == Screen:scaleBySize(px)
                                     and not self.settings.progress_margin
@@ -1530,7 +1530,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end
             },
             {
-                text = _("Hide null value items"),
+                text = _("Hide inactive items"),
                 help_text = _([[This option will hide null (or inactive) values from temporarily appearing on the status bar. For example, if the frontlight is 'off' (i.e 0 brightness), no symbols or values will be displayed until the brightness is set to a value >= 1.]]),
                 enabled_func = function()
                     return self.settings.all_at_once == true
@@ -1567,7 +1567,7 @@ With this feature activated, the current page is factored in, resulting in the c
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("No decimal places: %1"), self:progressPercentage(0))
+                            return T(_("No decimal places (%1)"), self:progressPercentage(0))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "0"
@@ -1579,7 +1579,7 @@ With this feature activated, the current page is factored in, resulting in the c
                     },
                     {
                         text_func = function()
-                            return T(_("1 decimal place: %1"), self:progressPercentage(1))
+                            return T(_("1 decimal place (%1)"), self:progressPercentage(1))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "1"
@@ -1591,7 +1591,7 @@ With this feature activated, the current page is factored in, resulting in the c
                     },
                     {
                         text_func = function()
-                            return T(_("2 decimal places: %1"), self:progressPercentage(2))
+                            return T(_("2 decimal places (%1)"), self:progressPercentage(2))
                         end,
                         checked_func = function()
                             return self.settings.progress_pct_format == "2"

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -9,6 +9,7 @@ local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
+local InfoMessage = require("ui/widget/infomessage")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
@@ -962,7 +963,7 @@ end
 function ReaderFooter:textOptionTitles(option)
     local symbol = self.settings.item_prefix
     local option_titles = {
-        all_at_once = _("Show all at once"),
+        all_at_once = _("Show all selected complications at once"),
         reclaim_height = _("Overlay status bar"),
         bookmark_count = T(_("Bookmark count (%1)"), symbol_prefix[symbol].bookmark_count),
         page_progress = T(_("Current page (%1)"), "/"),
@@ -1097,7 +1098,7 @@ function ReaderFooter:addToMainMenu(menu_items)
         text = _("Settings"),
         sub_item_table = {
             {
-                text = _("Sort complications"),
+                text = _("Arrange complications"),
                 separator = true,
                 callback = function()
                     local item_table = {}
@@ -1107,7 +1108,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     local SortWidget = require("ui/widget/sortwidget")
                     local sort_item
                     sort_item = SortWidget:new{
-                        title = _("Sort footer complications"),
+                        title = _("Arrange complications"),
                         item_table = item_table,
                         callback = function()
                             for i=1, #sort_item.item_table do
@@ -1149,7 +1150,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end
             },
             {
-                text = _("Show footer separator"),
+                text = _("Show status bar separator"),
                 checked_func = function()
                     return self.settings.bottom_horizontal_separator == true
                 end,
@@ -1168,7 +1169,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Hold footer to skim"),
+                text = _("Hold status bar to skim"),
                 checked_func = function()
                     return self.settings.skim_widget_on_hold == true
                 end,
@@ -1182,12 +1183,12 @@ function ReaderFooter:addToMainMenu(menu_items)
                     if self.settings.text_font_bold == true then
                         font_weight = ", " .. _("bold")
                     end
-                    return T(_("Font: %1%2"), self.settings.text_font_size, font_weight)
+                    return T(_("Complications font: %1%2"), self.settings.text_font_size, font_weight)
                 end,
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Font size: %1"), self.settings.text_font_size)
+                            return T(_("Complications font size: %1"), self.settings.text_font_size)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1198,7 +1199,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_max = 36,
                                 default_value = 14,
                                 ok_text = _("Set size"),
-                                title_text = _("Footer font size"),
+                                title_text = _("Complications font size"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.text_font_size = spin.value
@@ -1291,7 +1292,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 keep_menu_open = true,
             },
             {
-                text = _("Maximum width of text complications"),
+                text = _("Maximum lenght of text complications"),
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1307,7 +1308,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_max = 100,
                                 unit = "%",
                                 title_text = _("Maximum width"),
-                                info_text = _("Maximum book title width in percentage of screen width"),
+                                info_text = _("Maximum book title length in percentage of screen width"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_title_max_width_pct = spin.value
@@ -1333,7 +1334,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_max = 100,
                                 unit = "%",
                                 title_text = _("Maximum width"),
-                                info_text = _("Maximum chapter width in percentage of screen width"),
+                                info_text = _("Maximum chapter length in percentage of screen width"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_chapter_max_width_pct = spin.value
@@ -1406,7 +1407,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     elseif self.settings.item_prefix == "letters" then
                         prefix_text = C_("Status bar", "Letters")
                     end
-                    return T(_("Complication symbol: %1"), prefix_text)
+                    return T(_("Complication symbols: %1"), prefix_text)
                 end,
                 sub_item_table = {
                     {
@@ -1637,7 +1638,7 @@ With this enabled, the current page is included, so the count goes from n to 1 i
                 end,
             },
             {
-                text = _("Show progress in chapter"),
+                text = _("Switch to chapter progress bar"),
                 help_text = _("Show progress bar for the current chapter, instead of the whole book."),
                 enabled_func = function()
                     return not self.settings.disable_progress_bar

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -982,7 +982,7 @@ function ReaderFooter:textOptionTitles(option)
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
         book_title = _("Book title"),
-        book_chapter = _("Current chapter"),
+        book_chapter = _("Chapter title"),
         custom_text = T(_("Custom text (long press to edit): \'%1\'%2"), self.custom_text,
             self.custom_text_repetitions > 1 and
             string.format(" × %d", self.custom_text_repetitions) or ""),
@@ -1882,7 +1882,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                         end,
                     },
                 }
-            },    
+            },
             {
                 text_func = function()
                     return T(_("Container height: %1"), self.settings.container_height)
@@ -1934,7 +1934,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     UIManager:show(items_font)
                 end,
                 keep_menu_open = true,
-            },    
+            },
         }
     })
     local configure_items_sub_table = sub_items[#sub_items].sub_item_table -- will pick the last item of sub_items
@@ -1963,7 +1963,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     default_value = Device:hasAuxBattery() and 200 or 100,
                     unit = "%",
                     value_hold_step = 10,
-                    title_text = _("Set minimum threshold to hide battery item"),
+                    title_text = _("Minimum threshold to hide battery item"),
                     callback = function(spin)
                         self.settings.battery_hide_threshold = spin.value
                         self:refreshFooter(true, true)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -499,6 +499,9 @@ function ReaderFooter:init()
     if not Device:hasBattery() then
         MODE.battery = nil
     end
+    if not Device:hasNaturalLight() then
+        MODE.frontlight_warmth = nil
+    end
 
     -- self.mode_index will be an array of MODE names, with an additional element
     -- with key 0 for "off", which feels a bit strange but seems to work...
@@ -676,6 +679,7 @@ local option_help_text = {}
 option_help_text[MODE.pages_left_book] = _("Can be configured to include or exclude the current page.")
 option_help_text[MODE.percentage] = _("Progress percentage can be shown with zero, one or two decimal places.")
 option_help_text[MODE.mem_usage] = _("Show memory usage in MiB.")
+--option_help_text[MODE.reclaim_height] = _("When status bar is unlocked and hidden, this setting will utilise the entirety of screen real state and will temporarily overlap status bar and text when unhidden.")
 option_help_text[MODE.custom_text] = ReaderFooter.set_custom_text
 
 function ReaderFooter:updateFooterContainer()
@@ -1450,7 +1454,8 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
         }
     })
-    ----------- footer_items
+    ---------------------------------
+    -- footer_items
     local footer_items = {}
     table.insert(sub_items, {
         text = _("Items"),
@@ -1481,7 +1486,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     table.insert(footer_items, getMinibarOption("book_title"))
     table.insert(footer_items, getMinibarOption("book_chapter"))
     table.insert(footer_items, getMinibarOption("custom_text"))
-    -------- configure footer_items
+    -- configure footer_items
     table.insert(sub_items, {
         separator = true,
         text = _("Configure items"),
@@ -1980,8 +1985,10 @@ With this feature enabled, the current page is factored in, resulting in the cou
         })
     end
     -- More status bar options
-    -- quick access to this setting for "@NiLuJe, and for people that do like him." -- @poire-z (2024)
-    table.insert(sub_items, getMinibarOption("reclaim_height"))
+    -- Easy access for "@NiLuJe, and for people that do like him." -- @poire-z (2024)
+    if Device:isTouchDevice() then -- this setting requires a touch screen to be useful
+        table.insert(sub_items, getMinibarOption("reclaim_height"))
+    end
     table.insert(sub_items, {
         text = _("Show status bar separator"),
         checked_func = function()
@@ -1992,7 +1999,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
             self:refreshFooter(true, true)
         end,
     })
-    -- the next couple of settings are useless on non-touch devices so we take them off there
+    -- the next couple of settings are also useless on non-touch devices so we take them off there
     if Device:isTouchDevice() then
         table.insert(sub_items, {
             text = _("Lock status bar"),

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1094,8 +1094,8 @@ function ReaderFooter:addToMainMenu(menu_items)
             end,
         }
     end
-    -- we call up the user interface
-    -------PROGRESS BAR
+    ---------------------
+    -------Progress bar
     table.insert(sub_items, {
         text = _("Progress bar"),
         separator = true,
@@ -1455,7 +1455,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
         }
     })
-    ----------- COMPLICATIONS (FOOTER_ITEMS)
+    ----------- complications (footer_items)
     local about_text = _("A complication is any feature that provides additional information beyond the content of your book. Examples of "..
     "common complications include time, percentage read, pages left, and the battery indicator. You can choose which complications to "..
     "display on the status bar from this page.")
@@ -1500,7 +1500,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     table.insert(complication_subitems, getMinibarOption("book_title"))
     table.insert(complication_subitems, getMinibarOption("book_chapter"))
     table.insert(complication_subitems, getMinibarOption("custom_text"))
-    -------- CONFIGURE COMPLICATIONS (FOOTER_ITEMS)
+    -------- configure footer_items
     table.insert(sub_items, {
         separator = true,
         text = _("Configure complications"),
@@ -1619,12 +1619,12 @@ function ReaderFooter:addToMainMenu(menu_items)
                 },
             },
             {
-                text = _("Maximum lenght for text complications"),
+                text = _("Maximum length for text complications"),
                 separator = true,
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Lenght of book-title complication: %1".. "%"), self.settings.book_title_max_width_pct)
+                            return T(_("Length of book-title complication: %1".. "%"), self.settings.book_title_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1635,7 +1635,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max lenght of book-title complication"),
+                                title_text = _("Max length of book-title complication"),
                                 info_text = _("Maximum percentage of screen width used for book-title complication"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
@@ -1650,7 +1650,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     },
                     {
                         text_func = function()
-                            return T(_("Lenght of chapter-title complication: %1".. "%"), self.settings.book_chapter_max_width_pct)
+                            return T(_("Length of chapter-title complication: %1".. "%"), self.settings.book_chapter_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")
@@ -1661,7 +1661,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max lenght of chapter-title complication"),
+                                title_text = _("Max length of chapter-title complication"),
                                 info_text = _("Maximum percentage of screen width used for chapter-title complication"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
@@ -1996,7 +1996,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             keep_menu_open = true,
         })
     end
-    ----------- MORE STATUS BAR OPTIONS
+    ----------- More status bar options
     -- quick access to this setting for "@NiLuJe, and for people that do like him." -- poire-z (2024)
     table.insert(sub_items, getMinibarOption("reclaim_height"))
     table.insert(sub_items, {

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1392,7 +1392,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     return self.settings.toc_markers == true and not self.settings.chapter_progress_bar
                 end,
                 enabled_func = function()
-                    return not self.settings.progress_style_thin and not self.settings.chapter_progress_bar 
+                    return not self.settings.progress_style_thin and not self.settings.chapter_progress_bar
                         and not self.settings.disable_progress_bar
                 end,
                 callback = function()
@@ -2017,7 +2017,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
             end,
         })
     end
-    
+
     -- Settings menu: keep the same parent page for going up from submenu
     for i = 1, #configure_items_sub_table do
         configure_items_sub_table[i].menu_item_id = i

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1126,7 +1126,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             getMinibarOption("all_at_once", self.updateFooterTextGenerator),
             {
                 text = _("Hide empty complications"),
-                help_text = _([[This will hide values like 0 or off.]]),
+                help_text = _([[This option will hide values like 0 or off.]]),
                 enabled_func = function()
                     return self.settings.all_at_once == true
                 end,
@@ -1308,7 +1308,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_max = 100,
                                 unit = "%",
                                 title_text = _("Maximum width"),
-                                info_text = _("Maximum book title length in percentage of screen width"),
+                                info_text = _("Maximum percentage of screen width used for book title complication"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_title_max_width_pct = spin.value
@@ -1334,7 +1334,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                                 value_max = 100,
                                 unit = "%",
                                 title_text = _("Maximum width"),
-                                info_text = _("Maximum chapter length in percentage of screen width"),
+                                info_text = _("Maximum percentage of screen width used for chapter title complication"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_chapter_max_width_pct = spin.value
@@ -1556,8 +1556,9 @@ function ReaderFooter:addToMainMenu(menu_items)
             {
                 text = _("Count current page in pages left"),
                 help_text = _([[
-Normally, the current page is not counted as remaining, so "pages left" (in a book or chapter with n pages) will run from n-1 to 0 on the last page.
-With this enabled, the current page is included, so the count goes from n to 1 instead.]]),
+By default, KOReader does not include the current page when calculating pages left. For example, in a book or chapter with n pages the "pages
+left" complication will range from 'n-1' to 0 (last page). With this feature activated, the current page is factored in, resulting in the count
+going from n to 1 instead.]]),
                 enabled_func = function()
                     return self.settings.pages_left or self.settings.pages_left_book
                 end,
@@ -1966,31 +1967,51 @@ With this enabled, the current page is included, so the count goes from n to 1 i
             }
         }
     })
-    table.insert(sub_items, getMinibarOption("page_progress"))
-    table.insert(sub_items, getMinibarOption("pages_left_book"))
-    table.insert(sub_items, getMinibarOption("time"))
-    table.insert(sub_items, getMinibarOption("chapter_progress"))
-    table.insert(sub_items, getMinibarOption("pages_left"))
+    local about_text = _([[A complication is any feature that offers additional information beyond the content of your book. Examples of
+    common complications include time, percentage read, pages left, and battery indicator. You can choose which complications to display
+    on the status bar from this page.]])
+    
+    local complication_subitems = {}
+    table.insert(sub_items, {
+        text = _("Complications"),
+        sub_item_table = complication_subitems,
+    })
+    table.insert(sub_items, complications)
+    table.insert(complication_subitems, {    
+        text = _("About complications"),
+        keep_menu_open = true,
+        callback = function()
+            UIManager:show(InfoMessage:new{
+                text = about_text,
+            })
+        end,
+        separator = true,
+    })
+    table.insert(complication_subitems, getMinibarOption("page_progress"))
+    table.insert(complication_subitems, getMinibarOption("pages_left_book"))
+    table.insert(complication_subitems, getMinibarOption("time"))
+    table.insert(complication_subitems, getMinibarOption("chapter_progress"))
+    table.insert(complication_subitems, getMinibarOption("pages_left"))
     if Device:hasBattery() then
-        table.insert(sub_items, getMinibarOption("battery"))
+        table.insert(complication_subitems, getMinibarOption("battery"))
     end
-    table.insert(sub_items, getMinibarOption("bookmark_count"))
-    table.insert(sub_items, getMinibarOption("percentage"))
-    table.insert(sub_items, getMinibarOption("book_time_to_read"))
-    table.insert(sub_items, getMinibarOption("chapter_time_to_read"))
+    table.insert(complication_subitems, getMinibarOption("bookmark_count"))
+    table.insert(complication_subitems, getMinibarOption("percentage"))
+    table.insert(complication_subitems, getMinibarOption("book_time_to_read"))
+    table.insert(complication_subitems, getMinibarOption("chapter_time_to_read"))
     if Device:hasFrontlight() then
-        table.insert(sub_items, getMinibarOption("frontlight"))
+        table.insert(complication_subitems, getMinibarOption("frontlight"))
     end
     if Device:hasNaturalLight() then
-        table.insert(sub_items, getMinibarOption("frontlight_warmth"))
+        table.insert(complication_subitems, getMinibarOption("frontlight_warmth"))
     end
-    table.insert(sub_items, getMinibarOption("mem_usage"))
+    table.insert(complication_subitems, getMinibarOption("mem_usage"))
     if Device:hasFastWifiStatusQuery() then
-        table.insert(sub_items, getMinibarOption("wifi_status"))
+        table.insert(complication_subitems, getMinibarOption("wifi_status"))
     end
-    table.insert(sub_items, getMinibarOption("book_title"))
-    table.insert(sub_items, getMinibarOption("book_chapter"))
-    table.insert(sub_items, getMinibarOption("custom_text"))
+    table.insert(complication_subitems, getMinibarOption("book_title"))
+    table.insert(complication_subitems, getMinibarOption("book_chapter"))
+    table.insert(complication_subitems, getMinibarOption("custom_text"))
 
     -- Settings menu: keep the same parent page for going up from submenu
     for i = 1, #sub_items[settings_submenu_num].sub_item_table do

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1190,9 +1190,9 @@ function ReaderFooter:addToMainMenu(menu_items)
             {
                 text_func = function()
                     if self.settings.progress_style_thin then
-                        return _("Thickness and height: (thin)")
+                        return _("Thickness and height: thin")
                     else
-                        return _("Thickness and height: (thick)")
+                        return _("Thickness and height: thick")
                     end
                 end,
                 enabled_func = function()
@@ -1411,7 +1411,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                     elseif self.settings.toc_markers_width == 2 then
                         markers_width_text = _("medium")
                     end
-                    return T(_("Chapter marker width (%1)"), markers_width_text)
+                    return T(_("Chapter marker width: %1"), markers_width_text)
                 end,
                 enabled_func = function()
                     return not self.settings.progress_style_thin and not self.settings.chapter_progress_bar
@@ -1546,7 +1546,9 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Include current page in pages left"),
-                help_text = _("By default, KOReader does not include the current page when calculating pages left. For example, in a book or chapter with n pages the 'pages left' item will range from 'n-1' to 0 (last page). With this feature activated, the current page is factored in, resulting in the count going from n to 1 instead."),
+                help_text = _([[
+By default, KOReader does not include the current page when calculating pages left. For example, in a book or chapter with n pages the 'pages left' item will range from 'n−1' to 0 (last page).
+With this feature activated, the current page is factored in, resulting in the count going from n to 1 instead.]]),
                 enabled_func = function()
                     return self.settings.pages_left or self.settings.pages_left_book
                 end,
@@ -1714,12 +1716,12 @@ function ReaderFooter:addToMainMenu(menu_items)
                     if self.settings.text_font_bold == true then
                         font_weight = ", " .. _("bold")
                     end
-                    return T(_("Items font: %1%2"), self.settings.text_font_size, font_weight)
+                    return T(_("Item font: %1%2"), self.settings.text_font_size, font_weight)
                 end,
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Items font size: %1"), self.settings.text_font_size)
+                            return T(_("Item font size: %1"), self.settings.text_font_size)
                         end,
                         callback = function(touchmenu_instance)
                             local SpinWidget = require("ui/widget/spinwidget")

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1521,8 +1521,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             getMinibarOption("all_at_once", self.updateFooterTextGenerator),
             {
                 text = _("Auto refresh items"),
-                help_text = _("This option allows certain items to update without needing a full-page update. For example, the time"..
-                " item will update every minute regardless of user input."),
+                help_text = _("This option allows certain items to update without needing a full-page update. For example, the time item will update every minute regardless of user input."),
                 checked_func = function()
                     return self.settings.auto_refresh_time == true
                 end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1779,7 +1779,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 },
             },
             {
-                text = _("Max size used for text items"),
+                text = _("Text-items max size"),
                 sub_item_table = {
                     {
                         text_func = function()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1094,6 +1094,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             end,
         }
     end
+    -- we call up the user interface
     -------PROGRESS BAR
     table.insert(sub_items, {
         text = _("Progress bar"),
@@ -1418,7 +1419,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Minimum width: %1 %"), self.settings.progress_bar_min_width_pct)
+                    return T(_("Screen width assigned to progress bar: %1 %"), self.settings.progress_bar_min_width_pct)
                 end,
                 enabled_func = function()
                     return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
@@ -1433,7 +1434,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                         value_hold_step = 20,
                         value_max = 50,
                         unit = "%",
-                        title_text = _("Minimum width"),
+                        title_text = _("Minimum progress bar length"),
                         text = _("Minimum percentage of screen width assigned to progress bar"),
                         keep_shown_on_apply = true,
                         callback = function(spin)
@@ -1451,7 +1452,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     })
     ----------- COMPLICATIONS
     local about_text = _([[A complication is any feature that offers additional information beyond the content of your book. Examples of
-common complications include time, percentage read, pages left, and battery indicator. You can choose which complications to display
+common complications include time, percentage read, pages left, and the battery indicator. You can choose which complications to display
 on the status bar from this page.]])
     local complication_subitems = {}
     table.insert(sub_items, {
@@ -1602,7 +1603,9 @@ going from n to 1 instead.]]),
                 end,
             },
             {
-                text = _("Auto refresh"),
+                text = _("Auto refresh complications"),
+                help_text = _([[This option allows certain complications to update without needing a full-page update. For example, the time
+                complication will update every minute regardless of user input.]]),
                 checked_func = function()
                     return self.settings.auto_refresh_time == true
                 end,
@@ -1633,7 +1636,7 @@ going from n to 1 instead.]]),
                                 value_max = 36,
                                 default_value = 14,
                                 ok_text = _("Set size"),
-                                title_text = _("Complications font size"),
+                                title_text = _("Set font size for complications"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.text_font_size = spin.value
@@ -1726,7 +1729,7 @@ going from n to 1 instead.]]),
                 keep_menu_open = true,
             },
             {
-                text = _("Maximum lenght of text complications"),
+                text = _("Maximum lenght for text complications"),
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1741,8 +1744,8 @@ going from n to 1 instead.]]),
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Maximum lenght of book title complication"),
-                                info_text = _("Maximum percentage of screen width used for book title complication"),
+                                title_text = _("Maximum lenght of book-title complication"),
+                                info_text = _("Maximum percentage of screen width used for book-title complication"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_title_max_width_pct = spin.value
@@ -1767,8 +1770,8 @@ going from n to 1 instead.]]),
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Maximum lenght of chapter title complication"),
-                                info_text = _("Maximum percentage of screen width used for chapter title complication"),
+                                title_text = _("Maximum lenght of chapter-title complication"),
+                                info_text = _("Maximum percentage of screen width used for chapter-title complication"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_chapter_max_width_pct = spin.value
@@ -1945,13 +1948,14 @@ going from n to 1 instead.]]),
             },
         }
     })
+    local configure_complications_sub_table = sub_items[#sub_items].sub_item_table -- will pick the last item of sub_items
     if Device:hasBattery() then
-        table.insert(sub_items[settings_submenu_num].sub_item_table, 4, {
+        table.insert(configure_complications_sub_table , 4, {
             text_func = function()
                 if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200 or 100) then
                     return T(_("Hide battery complication when higher than: %1 %"), self.settings.battery_hide_threshold)
                 else
-                    return _("Hide battery complication when percent higher than")
+                    return _("Hide battery complication at custom threshold")
                 end
             end,
             checked_func = function()
@@ -1970,7 +1974,7 @@ going from n to 1 instead.]]),
                     default_value = Device:hasAuxBattery() and 200 or 100,
                     unit = "%",
                     value_hold_step = 10,
-                    title_text = _("Hide battery complication threshold"),
+                    title_text = _("Set minimum threshold to hide battery complication"),
                     callback = function(spin)
                         self.settings.battery_hide_threshold = spin.value
                         self:refreshFooter(true, true)
@@ -1989,7 +1993,7 @@ going from n to 1 instead.]]),
         })
     end
     ----------- MORE STATUS BAR OPTIONS
-    -- quick access to this setting for "@NiLuJe, and for people that do like him." -- poire-z 2024
+    -- quick access to this setting for "@NiLuJe, and for people that do like him." -- poire-z (2024)
     table.insert(sub_items, getMinibarOption("reclaim_height"))
     table.insert(sub_items, {
         text = _("Show status bar divider"),
@@ -2001,6 +2005,7 @@ going from n to 1 instead.]]),
             self:refreshFooter(true, true)
         end,
     })
+    -- these next settings are useless on non-touch devices so we take them off
     if Device:isTouchDevice() then
         table.insert(sub_items, {
             text = _("Lock status bar"),

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -998,7 +998,6 @@ function ReaderFooter:addToMainMenu(menu_items)
     }
 
     -- menu item to fake footer tapping when touch area is disabled
-    local settings_submenu_num = 1
     local DTAP_ZONE_MINIBAR = G_defaults:readSetting("DTAP_ZONE_MINIBAR")
     if DTAP_ZONE_MINIBAR.h == 0 or DTAP_ZONE_MINIBAR.w == 0 then
         table.insert(sub_items, {
@@ -1008,7 +1007,6 @@ function ReaderFooter:addToMainMenu(menu_items)
             end,
             callback = function() self:onToggleFooterMode() end,
         })
-        settings_submenu_num = 2
     end
 
     local getMinibarOption = function(option, callback)
@@ -1454,6 +1452,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     })
     ----------- footer_items
     local footer_items = {}
+    local items
     table.insert(sub_items, {
         text = _("Items"),
         sub_item_table = footer_items,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1531,7 +1531,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Hide inactive items"),
-                help_text = _([[This option will hide null (or inactive) values from temporarily appearing on the status bar. For example, if the frontlight is 'off' (i.e 0 brightness), no symbols or values will be displayed until the brightness is set to a value >= 1.]]),
+                help_text = _([[This option will hide inactive items from appearing on the status bar. For example, if the frontlight is 'off' (i.e 0 brightness), no symbols or values will be displayed until the brightness is set to a value >= 1.]]),
                 enabled_func = function()
                     return self.settings.all_at_once == true
                 end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1458,7 +1458,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     -- footer_items
     local footer_items = {}
     table.insert(sub_items, {
-        text = _("Items"),
+        text = _("Status bar items"),
         sub_item_table = footer_items,
     })
     table.insert(footer_items, getMinibarOption("page_progress"))

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1259,7 +1259,6 @@ function ReaderFooter:addToMainMenu(menu_items)
                             }
                             UIManager:show(items)
                         end,
-                        separator = true,
                         keep_menu_open = true,
                     },
                 },
@@ -1796,6 +1795,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 unit = "%",
                                 title_text = _("Book-title item"),
                                 info_text = _("Maximum percentage of screen width used for book-title"),
+                                book_title_max_width_pct = 30,
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_title_max_width_pct = spin.value
@@ -1822,6 +1822,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 unit = "%",
                                 title_text = _("Chapter-title item"),
                                 info_text = _("Maximum percentage of screen width used for chapter-title item"),
+                                book_chapter_max_width_pct = 30,
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_chapter_max_width_pct = spin.value

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -963,7 +963,7 @@ function ReaderFooter:textOptionTitles(option)
     local symbol = self.settings.item_prefix
     local option_titles = {
         all_at_once = _("Show all at once"),
-        reclaim_height = _("Reclaim bar height from bottom margin"),
+        reclaim_height = _("Overlay status bar"),
         bookmark_count = T(_("Bookmark count (%1)"), symbol_prefix[symbol].bookmark_count),
         page_progress = T(_("Current page (%1)"), "/"),
         pages_left_book = T(_("Pages left in book (%1)"), symbol_prefix[symbol].pages_left_book),
@@ -975,15 +975,15 @@ function ReaderFooter:textOptionTitles(option)
         percentage = symbol_prefix[symbol].percentage
             and T(_("Progress percentage (%1)"), symbol_prefix[symbol].percentage) or _("Progress percentage"),
         book_time_to_read = symbol_prefix[symbol].book_time_to_read
-            and T(_("Book time to read (%1)"),symbol_prefix[symbol].book_time_to_read) or _("Book time to read"),
-        chapter_time_to_read = T(_("Chapter time to read (%1)"), symbol_prefix[symbol].chapter_time_to_read),
+            and T(_("Time left to read book (%1)"),symbol_prefix[symbol].book_time_to_read) or _("Time left to read book"),
+        chapter_time_to_read = T(_("Time left to read chapter (%1)"), symbol_prefix[symbol].chapter_time_to_read),
         frontlight = T(_("Frontlight level (%1)"), symbol_prefix[symbol].frontlight),
-        frontlight_warmth = T(_("Frontlight warmth (%1)"), symbol_prefix[symbol].frontlight_warmth),
+        frontlight_warmth = T(_("Frontlight warmth level (%1)"), symbol_prefix[symbol].frontlight_warmth),
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
         book_title = _("Book title"),
         book_chapter = _("Current chapter"),
-        custom_text = T(_("Custom text: \'%1\'%2"), self.custom_text,
+        custom_text = T(_("Custom text (long press to edit): \'%1\'%2"), self.custom_text,
             self.custom_text_repetitions > 1 and
             string.format(" × %d", self.custom_text_repetitions) or ""),
     }

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1779,7 +1779,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 },
             },
             {
-                text = _("Text-items max size"),
+                text = _("Item max width"),
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1911,7 +1911,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
             },
             {
                 text_func = function()
-                    return T(_("Items mini-bar bottom margin: %1"), self.settings.container_bottom_padding)
+                    return T(_("Bottom margin: %1"), self.settings.container_bottom_padding)
                 end,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1546,9 +1546,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text = _("Include current page in pages left"),
-                help_text = _("By default, KOReader does not include the current page when calculating pages left. For example, in a book ".. 
-                "or chapter with n pages the 'pages left' item will range from 'n-1' to 0 (last page). With this feature activated, "..
-                "the current page is factored in, resulting in the count going from n to 1 instead."),
+                help_text = _("By default, KOReader does not include the current page when calculating pages left. For example, in a book or chapter with n pages the 'pages left' item will range from 'n-1' to 0 (last page). With this feature activated, the current page is factored in, resulting in the count going from n to 1 instead."),
                 enabled_func = function()
                     return self.settings.pages_left or self.settings.pages_left_book
                 end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2019,8 +2019,8 @@ With this feature enabled, the current page is factored in, resulting in the cou
     end
     
     -- Settings menu: keep the same parent page for going up from submenu
-    for i = 1, #sub_items[settings_submenu_num].sub_item_table do
-        sub_items[settings_submenu_num].sub_item_table[i].menu_item_id = i
+    for i = 1, #configure_items_sub_table do
+        configure_items_sub_table[i].menu_item_id = i
     end
 
     -- If using crengine, add Alt status bar items at top

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1779,7 +1779,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 },
             },
             {
-                text = _("Max pct. of screen width used for text items"),
+                text = _("Max size used for text items"),
                 sub_item_table = {
                     {
                         text_func = function()
@@ -1794,7 +1794,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max length of book-title item"),
+                                title_text = _("Max size of book-title item"),
                                 info_text = _("Maximum percentage of screen width used for book-title"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
@@ -1820,7 +1820,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Max length of chapter-title item"),
+                                title_text = _("Max size of chapter-title item"),
                                 info_text = _("Maximum percentage of screen width used for chapter-title item"),
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
@@ -1885,7 +1885,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
             },
             {
                 text_func = function()
-                    return T(_("Container height: %1"), self.settings.container_height)
+                    return T(_("Items mini-bar height: %1"), self.settings.container_height)
                 end,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")
@@ -1911,7 +1911,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
             },
             {
                 text_func = function()
-                    return T(_("Container bottom margin: %1"), self.settings.container_bottom_padding)
+                    return T(_("Items mini-bar bottom margin: %1"), self.settings.container_bottom_padding)
                 end,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -253,7 +253,7 @@ describe("Readerfooter module", function()
                         footer.footer_text.text)
 
         -- disable show all at once, page progress should be on the first
-        tapFooterMenu(fake_menu, "Show all at once")
+        tapFooterMenu(fake_menu, "Show all selected items at once")
         assert.are.same('1 / 2', footer.footer_text.text)
 
         -- disable page progress, time should follow
@@ -269,7 +269,7 @@ describe("Readerfooter module", function()
         assert.are.same('0%', footer.footer_text.text)
 
         -- disable battery, percentage should follow
-        tapFooterMenu(fake_menu, "Battery status".." ()")
+        tapFooterMenu(fake_menu, "Battery percentage".." ()")
         assert.are.same('⤠ 50%', footer.footer_text.text)
 
         -- disable percentage, book time to read should follow
@@ -277,15 +277,15 @@ describe("Readerfooter module", function()
         assert.are.same('⏳ N/A', footer.footer_text.text)
 
         -- disable book time to read, chapter time to read should follow
-        tapFooterMenu(fake_menu, "Book time to read".." (⏳)")
+        tapFooterMenu(fake_menu, "Time left to finish book".." (⏳)")
         assert.are.same('⤻ N/A', footer.footer_text.text)
 
         -- disable chapter time to read, text should be empty
-        tapFooterMenu(fake_menu, "Chapter time to read".." (⤻)")
+        tapFooterMenu(fake_menu, "Time left to finish chapter".." (⤻)")
         assert.are.same('', footer.footer_text.text)
 
         -- reenable chapter time to read, text should be chapter time to read
-        tapFooterMenu(fake_menu, "Chapter time to read".." (⤻)")
+        tapFooterMenu(fake_menu, "Time left to finish chapter".." (⤻)")
         assert.are.same('⤻ N/A', footer.footer_text.text)
         readerui:closeDocument()
         readerui:onClose()
@@ -528,7 +528,7 @@ describe("Readerfooter module", function()
         assert.is.same(1, found)
 
         -- disable auto refresh time
-        tapFooterMenu(fake_menu, "Auto refresh")
+        tapFooterMenu(fake_menu, "Auto refresh items")
         found = 0
         for _,task in ipairs(UIManager._task_queue) do
             if task.action == footer.autoRefreshFooter then
@@ -538,7 +538,7 @@ describe("Readerfooter module", function()
         assert.is.same(0, found)
 
         -- enable auto refresh time again
-        tapFooterMenu(fake_menu, "Auto refresh")
+        tapFooterMenu(fake_menu, "Auto refresh items")
         found = 0
         for _,task in ipairs(UIManager._task_queue) do
             if task.action == footer.autoRefreshFooter then
@@ -699,7 +699,7 @@ describe("Readerfooter module", function()
 
         -- test in all at once mode
         tapFooterMenu(fake_menu, "Progress percentage".." (⤠)")
-        tapFooterMenu(fake_menu, "Show all at once")
+        tapFooterMenu(fake_menu, "Show all selected items at once")
         assert.is.same(false, footer.has_no_mode)
         tapFooterMenu(fake_menu, "Progress percentage".." (⤠)")
         assert.is.same(true, footer.has_no_mode)


### PR DESCRIPTION
As discussed in #11605 and #11533, here is my proposal for the new and improved `status bar` menu.

No changes were made to the logic besides, adding a few `if isTouch()` statements to a couple of settings that shouldn't be available to non-touch devices (`lock status bar` and `hold to skim`) and any necessary changes for the correct operation of the menu. Also a `checked function` was added to the battery complication on the alternative status bar.

Most of the settings were reworded and/or rewritten. Please don't take it personally if I changed yours.

In defence of "complications": The word is borrowed from horology (science of time and timekeeping) were it refers to features on mechanical watches (smart ones too) that convey information not related to hours, minutes or seconds.
In the KOReader context, they refer to all features that convey any type of information on the status bar. I have decided, against your better judgement, to use the word in this PR as no better alternative was put forward and, all other possible replacements seem to fall short of the goal. 

Some suggestions like "components" and "elements" were straight up rejected by other GitHub users, others like "status icons", "symbols", "status indicators", and all possible permutations of those fail to completely convey the idea of "Information". For example, 45/254 (page 45 of 254) is neither a symbol, or "icon" or "indicator", it is simply a piece of information. Besides, some of those same terms are already being used in a different context within the 'status bar' menu.

I encourage EVERYONE to download the files and run them on your machines, as that is the only way in which all of these changes will make sense. Read all the menus, play with them, in short; go have fun.

Due to the sheer number of changes, providing a pdf (like in #11549) documenting all changes would be a monster task I am not happy to go through right now. So I would appreciate it if one of **you** could kindly provide screenshots like the ones found here https://github.com/koreader/koreader/pull/11533#issuecomment-2053635809, although bear in mind, those are from an older state of development. But again, preferably run it locally.

Special thanks to @poire-z who provided unrelenting support throughout the redevelopment of the menu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11678)
<!-- Reviewable:end -->
