### PR TITLE
Stop touching night mode when control_nightmode == false

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -512,7 +512,9 @@ function AutoWarmth:setWarmth(val, force_warmth)
     -- A value > 100 means to set night mode and set warmth to maximum.
     -- We use an offset of 1000 to "flag", that night mode is on.
     if val then
-        DeviceListener:onSetNightMode(self.control_nightmode and val > 100)
+        if self.control_nightmode then
+            DeviceListener:onSetNightMode(val > 100)
+        end
 
         if self.control_warmth and Device:hasNaturalLight() then
             val = math.min(val, 100) -- "mask" night mode


### PR DESCRIPTION
This is a regression introduced in #10762

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11685)
<!-- Reviewable:end -->
