### PR TITLE
Kindle Scribe: fix gyro device detection (again)

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1429,7 +1429,7 @@ function KindleScribe:init()
         end
     end
     -- Get accelerometer device
-    local std_out = io.popen("grep -A4 'accel' /proc/bus/input/devices | grep -o 'event[0-9]'", "r")
+    local std_out = io.popen("grep -A4 'acc' /proc/bus/input/devices | grep -o 'event[0-9]'", "r")
     if std_out then
         local gyro_dev = std_out:read("*line")
         std_out:close()


### PR DESCRIPTION
Fixes #11691 

It turned out there might another type of accelerometer declaration. 

I didn’t quite feel creating another edge case, so instead I shortened current searching keyword “accel” to “acc”. 

@NiLuJe @Frenzie 
Please wait before merge: I want to test this on my own Scribe first. 

Also, I don’t know what to do if there are multiple “acc” matches. (Is this even possible?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11696)
<!-- Reviewable:end -->
