### PR TITLE
Add relevant nil guards to prevent reflow crashes

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1064,6 +1064,10 @@ function KoptInterface:getWordFromReflowPosition(doc, boxes, pos)
     local pageno = pos.page
 
     local scratch_reflowed_page_boxes = self:getReflowedTextBoxesFromScratch(doc, pageno)
+    if not DEBUG.dassert(scratch_reflowed_page_boxes and next(scratch_reflowed_page_boxes) ~= nil, "scratch_reflowed_page_boxes shouldn't be nil/{}") then
+        return
+    end
+
     local scratch_reflowed_word_box = self:getWordFromBoxes(scratch_reflowed_page_boxes, pos)
 
     local reflowed_page_boxes = self:getReflowedTextBoxes(doc, pageno)
@@ -1237,8 +1241,15 @@ function KoptInterface:getTextFromReflowPositions(doc, native_boxes, pos0, pos1)
     local reflowed_page_boxes = self:getReflowedTextBoxes(doc, pageno)
 
     local scratch_reflowed_word_box0 = self:getWordFromBoxes(scratch_reflowed_page_boxes, pos0)
+    if not DEBUG.dassert(scratch_reflowed_word_box0 and next(scratch_reflowed_word_box0) ~= nil, "scratch_reflowed_word_box0 shouldn't be nil/{}") then
+        return
+    end
     local reflowed_word_box0 = self:getWordFromBoxes(reflowed_page_boxes, pos0)
+
     local scratch_reflowed_word_box1 = self:getWordFromBoxes(scratch_reflowed_page_boxes, pos1)
+    if not DEBUG.dassert(scratch_reflowed_word_box1 and next(scratch_reflowed_word_box1) ~= nil, "scratch_reflowed_word_box1 shouldn't be nil/{}") then
+        return
+    end
     local reflowed_word_box1 = self:getWordFromBoxes(reflowed_page_boxes, pos1)
 
     local reflowed_pos_abs0 = scratch_reflowed_word_box0.box:center()


### PR DESCRIPTION
closes #10854 #9272  #4481

Highlighting is still broken in kobo-clara emulator with reflow on. Problem is upstream in `k2pdfopt`

```cpp
void k2pdfopt_get_word_boxes(KOPTContext *kctx, WILLUSBITMAP *src,
                int x, int y, int w, int h, int box_type) {
        static K2PDFOPT_SETTINGS _k2settings, *k2settings;
        PIX *pixs, *pixt, *pixb;
        int words;
        BOXA **pboxa;
        NUMA **pnai;

        k2settings = &_k2settings;
        /* Initialize settings */
        k2pdfopt_settings_init_from_koptcontext(k2settings, kctx);
        k2pdfopt_settings_quick_sanity_check(k2settings);
        /* Init for new source doc */
        k2pdfopt_settings_new_source_document_init(k2settings);  

        if (box_type == 0) {
                pboxa = &kctx->rboxa;
                pnai = &kctx->rnai;
        } else if (box_type == 1) {
                pboxa = &kctx->nboxa;
                pnai = &kctx->nnai;
        }

        if (*pboxa == NULL && *pnai == NULL && src->bpp == 8) {
                assert(x + w <= src->width);
                assert(y + h <= src->height);
                pixs = bitmap2pix(src, x, y, w, h);
                if (kctx->cjkchar) {
                        if (k2pdfopt_get_word_boxes_from_tesseract(pixs, kctx->cjkchar,
                                        pboxa, pnai) != 0) {
                                printf("failed to get word boxes from tesseract\n");
                        }
                } else {
                        pixb = pixConvertTo1(pixs, 128);
                        k2pdfopt_pixGetWordBoxesInTextlines(pixb,
                                        7*kctx->dev_dpi/150, 1, 10, 10, 300, 100,
                                        pboxa, pnai);
                        pixDestroy(&pixb);
                }
        
                if (kctx->debug == 1) {
                        //pixt = pixDrawBoxaRandom(pixs, kctx->boxa, 2);
                        //pixWrite("junkpixt", pixt, IFF_PNG);
                        //pixDestroy(&pixt);
                }
                pixDestroy(&pixs);
        }
}
```

Has a call to
```cpp
k2pdfopt_pixGetWordBoxesInTextlines(pixb,
                7*kctx->dev_dpi/150, 1, 10, 10, 300, 100,
                pboxa, pnai);
```

```cpp
7*kctx->dev_dpi/150 // this is 7 on emulator and 14 on kobo clara
```

if this value is too big, it causes
```cpp
L_ERROR("imin = %d is too small\n", procName, imin);
```
in  `pixWordMaskByDilation` (leptonica) - this means that no mask is returned, which causes a chain reaction of `null`/`nil` values resulting in crash. I'm not sure if we can do something more to fix it, but I'll look into it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11715)
<!-- Reviewable:end -->
