### PR TITLE
Add dispatchable setting for rotating by 180 degrees

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -212,9 +212,8 @@ if not Device:isAlwaysFullscreen() then
     end
 end
 
-function DeviceListener:onIterateRotation(ccw)
-    -- Simply rotate by 90° CW or CCW
-    local step = ccw and -1 or 1
+function DeviceListener:onIterateRotation(step)
+    -- Simply rotate by 90° CW (1) or CCW (-1), or 180° (2)
     local arg = bit.band(Screen:getRotationMode() + step, 3)
     self.ui:handleEvent(Event:new("SetRotationMode", arg))
     return true

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -84,8 +84,9 @@ local settingsList = {
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
-    iterate_rotation = {category="none", event="IterateRotation", title=_("Rotate by 90° CW"), device=true},
-    iterate_rotation_ccw = {category="none", event="IterateRotation", arg=true, title=_("Rotate by 90° CCW"), device=true, separator=true},
+    iterate_rotation = {category="none", event="IterateRotation", arg=1, title=_("Rotate by 90° CW"), device=true},
+    iterate_rotation_ccw = {category="none", event="IterateRotation", arg=-1, title=_("Rotate by 90° CCW"), device=true},
+    iterate_rotation_180 = {category="none", event="IterateRotation", arg=2, title=_("Rotate by 180°"), device=true, separator=true},
     ----
     wifi_on = {category="none", event="InfoWifiOn", title=_("Turn on Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
     wifi_off = {category="none", event="InfoWifiOff", title=_("Turn off Wi-Fi"), device=true, condition=Device:hasWifiToggle()},
@@ -306,6 +307,7 @@ local dispatcher_menu_order = {
     "invert_rotation",
     "iterate_rotation",
     "iterate_rotation_ccw",
+    "iterate_rotation_180",
     ----
     "wifi_on",
     "wifi_off",


### PR DESCRIPTION
Hello! This is a simple change that adds a setting to rotate the e-book by 180 degrees, so that the user can configure a gesture to rotate the e-book 180 degrees directly.

Rotating by 180 degrees is useful for asymmetric-shaped e-readers such as Kobo Libra or Kindle Oasis, letting the user switch between holding the device with left or right hands. Currently, the user may use the accelerometer to achieve this, but one might end up rotating it to landscape first, which will cause KOReader to perform reflow of the text. Basically, I want to avoid triggering the intermediate reflow by rotating 180 degrees directly, but it is finicky to do this through the accelerometer -- you would need a steady hand.

So IMO adding this simple option will be able to solve this use case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11732)
<!-- Reviewable:end -->
