### PR TITLE
rotation gesture limited to devices with GSensors

### DIFF
--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -759,6 +759,8 @@ function Gestures:addToMainMenu(menu_items)
             text = _("Spread and pinch"),
             sub_item_table = self:genSubItemTable({"spread_gesture", "pinch_gesture"}),
         })
+    end
+    if Device:hasGSensor()
         table.insert(menu_items.gesture_manager.sub_item_table, {
             text = _("Rotation"),
             sub_item_table = self:genSubItemTable({"rotate_cw", "rotate_ccw"}),

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -760,7 +760,7 @@ function Gestures:addToMainMenu(menu_items)
             sub_item_table = self:genSubItemTable({"spread_gesture", "pinch_gesture"}),
         })
     end
-    if Device:hasGSensor()
+    if Device:hasGSensor() then
         table.insert(menu_items.gesture_manager.sub_item_table, {
             text = _("Rotation"),
             sub_item_table = self:genSubItemTable({"rotate_cw", "rotate_ccw"}),


### PR DESCRIPTION
this PR removes the option to set rotation gestures from the gesture manager on devices that do not support it, i.e those with no `GSensor`. 

NOTE: you are still able to set other gestures (just not the one where one physically rotates the device) to rotate the screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11741)
<!-- Reviewable:end -->
