### PR TITLE
[CoverImage] Honor rotation after opening of a book

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -781,7 +781,7 @@ function ReaderView:onSetRotationMode(rotation)
     if rotation ~= nil then
         local old_rotation = Screen:getRotationMode()
         if rotation == old_rotation then
-            return true
+            return
         end
 
         -- NOTE: We cannot rely on getScreenMode, as it actually checks the screen dimensions, instead of the rotation mode.
@@ -798,7 +798,7 @@ function ReaderView:onSetRotationMode(rotation)
             Screen:setRotationMode(rotation)
             UIManager:setDirty(self.dialog, "full")
             Notification:notify(T(_("Rotation mode set to: %1"), optionsutil:getOptionText("SetRotationMode", rotation)))
-            return true
+            return
         end
 
         Screen:setRotationMode(rotation)
@@ -810,7 +810,7 @@ function ReaderView:onSetRotationMode(rotation)
     self.ui:onScreenResize(new_screen_size)
     self.ui:handleEvent(Event:new("InitScrollPageStates"))
     Notification:notify(T(_("Rotation mode set to: %1"), optionsutil:getOptionText("SetRotationMode", rotation)))
-    return true
+    return
 end
 
 function ReaderView:onSetDimensions(dimensions)

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -113,8 +113,7 @@ function CoverImage:createCoverImage(doc_settings)
     if self:coverEnabled() and doc_settings:nilOrFalse("exclude_cover_image") then
         local cover_image, custom_cover = FileManagerBookInfo:getCoverImage(self.ui.document)
         if cover_image then
-            local s_w, s_h = Screen:getWidth(), Screen:getHeight()
-            local cache_file = self:getCacheFile(custom_cover, s_w, s_h)
+            local cache_file = self:getCacheFile(custom_cover)
             if lfs.attributes(cache_file, "mode") == "file" then
                 logger.dbg("CoverImage: cache file already exists")
                 ffiutil.copyFile(cache_file, self.cover_image_path)
@@ -122,8 +121,16 @@ function CoverImage:createCoverImage(doc_settings)
                 return
             end
 
+            local s_w, s_h = Screen:getWidth(), Screen:getHeight()
             local i_w, i_h = cover_image:getWidth(), cover_image:getHeight()
             local scale_factor = math.min(s_w / i_w, s_h / i_h)
+
+            if Screen:getRotationMode() == Screen.DEVICE_ROTATED_UPSIDE_DOWN
+                or Screen:getRotationMode() == Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE then
+                    print("xxxxx rotating")
+                cover_image:rotate(180) -- this does not work ????
+            end
+
 
             if self.cover_image_background == "none" or scale_factor == 1 then
                 local act_format = self.cover_image_format == "auto" and getExtension(self.cover_image_path) or self.cover_image_format
@@ -200,9 +207,9 @@ function CoverImage:onReaderReady(doc_settings)
     self:createCoverImage(doc_settings)
 end
 
-function CoverImage:onRotationUpdate()
-    logger.dbg("CoverImage: onRotationUpdate")
-    self.createCoverImage(self.ui.doc_settings)
+function CoverImage:onSetRotationMode(rotation)
+    logger.dbg("CoverImage: onSetRotationMode", rotation)
+    self:createCoverImage(self.ui.doc_settings)
 end
 
 function CoverImage:fallbackEnabled()
@@ -217,13 +224,13 @@ end
 -- cache handling functions
 ---------------------------
 
-function CoverImage:getCacheFile(custom_cover, s_w, s_h)
+function CoverImage:getCacheFile(custom_cover)
     local custom_cover_mtime = custom_cover and lfs.attributes(custom_cover, "modification") or ""
     local dummy, document_name = util.splitFilePathName(self.ui.document.file)
     -- use document_name here. Title may contain characters not allowed on every filesystem (esp. vfat on /sdcard)
     local key = document_name .. custom_cover_mtime .. self.cover_image_quality .. self.cover_image_stretch_limit
         .. self.cover_image_background .. self.cover_image_format .. tostring(self.cover_image_grayscale)
-        .. s_w .. s_h
+        .. Screen:getRotationMode()
 
     return self.cover_image_cache_path .. self.cover_image_cache_prefix .. md5(key) .. "." .. getExtension(self.cover_image_path)
 end

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -126,11 +126,12 @@ function CoverImage:createCoverImage(doc_settings)
             local scale_factor = math.min(s_w / i_w, s_h / i_h)
 
             if Screen:getRotationMode() == Screen.DEVICE_ROTATED_UPSIDE_DOWN
-                or Screen:getRotationMode() == Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE then
-                    print("xxxxx rotating")
-                cover_image:rotate(180) -- this does not work ????
-            end
+                or Screen:getRotationMode() == Screen.DEVICE_ROTATED_CLOCKWISE then
 
+                local flipped_cover = cover_image:rotatedCopy(180)
+                cover_image:free()
+                cover_image = flipped_cover
+            end
 
             if self.cover_image_background == "none" or scale_factor == 1 then
                 local act_format = self.cover_image_format == "auto" and getExtension(self.cover_image_path) or self.cover_image_format
@@ -484,7 +485,9 @@ function CoverImage:menuEntryCache()
                     end
                     return T(_("Maximum number of cached covers: %1"), number)
                 end,
-                help_text = _("If set to zero the number of cache files is unlimited.\nIf set to -1 the cache is disabled."),
+                help_text = string.format("%s\n\n%s",
+                    _("If set to zero the number of cache files is unlimited.\nIf set to -1 the cache is disabled."),
+                    _("Each screen orientation requires its own cache file.")),
                 checked_func = function()
                     return self.cover_image_cache_maxfiles >= 0
                 end,


### PR DESCRIPTION
If rotation changes, create a new cache entry and use that if necessary.

See #11713

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11752)
<!-- Reviewable:end -->
