### PR TITLE
[Gestures.plugin] Rotation gesture renamed

### DIFF
--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -760,7 +760,7 @@ function Gestures:addToMainMenu(menu_items)
             sub_item_table = self:genSubItemTable({"spread_gesture", "pinch_gesture"}),
         })
         table.insert(menu_items.gesture_manager.sub_item_table, {
-            text = _("Two-finger half-moon swipe"),
+            text = _("Two-finger rotation"),
             sub_item_table = self:genSubItemTable({"rotate_cw", "rotate_ccw"}),
         })
     end


### PR DESCRIPTION
Following up on my horrible embarrassment here #11741, this PR should make it clearer to users how the [currently named: rotation] multitouch-gesture really is triggered. 

Worry not little Timmy, who like me, thought it had something to do with physically rotating their device.

edit: was tempted to use the stupendous terms `deasil` and `widdershins` but I guess I'll be boring this time. /s

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11753)
<!-- Reviewable:end -->
