### PR TITLE
Annotations: fixes

### DIFF
--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -26,6 +26,11 @@ function ReaderAnnotation:buildAnnotation(bm, highlights, init)
         end
         pageno = self.ui.paging and bm.page or self.document:getPageFromXPointer(bm.page)
     end
+    if self.ui.paging and bm.pos0 and not bm.pos0.page then
+        -- old single-page reflow highlights do not have page in position
+        bm.pos0.page = bm.page
+        bm.pos1.page = bm.page
+    end
     if not hl then -- page bookmark or orphaned bookmark
         hl = {}
         if bm.highlighted then -- orphaned bookmark
@@ -38,13 +43,6 @@ function ReaderAnnotation:buildAnnotation(bm, highlights, init)
                     hl.pboxes = self.document:getPageBoxesFromPositions(bm.page, bm.pos0, bm.pos0)
                 end
             end
-        end
-    end
-    if self.ui.paging then
-        -- old single-page reflow highlights do not have page in position
-        if not bm.pos0.page then
-            bm.pos0.page = bm.page
-            bm.pos1.page = bm.page
         end
     end
     return { -- annotation

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1124,7 +1124,7 @@ function ReaderBookmark:setHighlightedText(item, text)
     self.ui.annotation.annotations[index].text_edited = edited
     -- item table
     item.text_orig = text
-    item.text = self.display_prefix[item.type] .. (item.note or text)
+    item.text = self:getBookmarkItemText(item)
     item.text_edited = edited
     if edited then
         self.refresh()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1119,6 +1119,7 @@ function ReaderHighlight:_getHighlightMenuAnchor()
         if self.ui.paging then
             text_box = self.view:pageToScreenTransform(self.ui.paging.current_page, text_box)
         end
+        if text_box == nil then return end -- fallback to "center"
         anchor_y = text_box.y + text_box.h + Size.padding.small -- do not stick to the box
         if anchor_y + dialog_box.h <= self.screen_h - Size.padding.small then -- enough room below box with gest_pos
             prefers_pop_down = true

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -222,7 +222,7 @@ function ReaderView:paintTo(bb, x, y)
             self.arrow:paintTo(bb, 0, self.dim_area.y == 0 and self.dim_area.h - center_offset or self.dim_area.y - center_offset)
         elseif self.page_overlap_style == "line" then
             bb:paintRect(0, self.dim_area.y == 0 and self.dim_area.h or self.dim_area.y,
-                self.dim_area.w, Size.line.medium, Blitbuffer.COLOR_BLACK)
+                self.dim_area.w, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
         end
     end
     -- draw saved highlight


### PR DESCRIPTION
This is a cumulative PR for "annotations and around" fixes.

(1) Fix displayed Bookmark list item text after editing the highlighted text (unreported).
(2) Fix crash on showing anchored highlight dialog if finding text_box fails (https://github.com/koreader/koreader/issues/10854#issuecomment-2093716444).
(3) Lighter line for marking overlapped pages (https://github.com/koreader/koreader/issues/11734).
(4) Fix pdf page bookmarks conversion to annotations (https://github.com/koreader/koreader/issues/11762).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11761)
<!-- Reviewable:end -->
