### PR TITLE
FileManager: safe initial path

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -731,7 +731,7 @@ function FileManager:reinit(path, focused_file)
     UIManager:flushSettings()
     self.dimen = Screen:getSize()
     -- backup the root path and path items
-    self.root_path = path or self.file_chooser.path
+    self.root_path = BaseUtil.realpath(path or self.file_chooser.path)
     local path_items_backup = {}
     for k, v in pairs(self.file_chooser.path_items) do
         path_items_backup[k] = v
@@ -1208,7 +1208,7 @@ function FileManager:showFiles(path, focused_file)
         FileManager.instance:onClose()
     end
 
-    path = path or G_reader_settings:readSetting("lastdir") or filemanagerutil.getDefaultDir()
+    path = BaseUtil.realpath(path or G_reader_settings:readSetting("lastdir") or filemanagerutil.getDefaultDir())
     G_reader_settings:saveSetting("lastdir", path)
     self:setRotationMode()
     local file_manager = FileManager:new{

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -558,7 +558,6 @@ function ReaderUI:showFileManager(file)
     local last_dir, last_file
     if file then
         last_dir = util.splitFilePathName(file)
-        last_dir = last_dir:match("(.*)/")
         last_file = file
     else
         last_dir, last_file = self:getLastDirFile(true)


### PR DESCRIPTION
We do not like trailing slash in the path (except root).
Closes https://github.com/koreader/koreader/issues/11772.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11774)
<!-- Reviewable:end -->
