### PR TITLE
tests: fix EPUB test, again

### DIFF
--- a/spec/unit/document_spec.lua
+++ b/spec/unit/document_spec.lua
@@ -67,7 +67,14 @@ describe("EPUB document module", function()
     end)
     it("should register droid sans fallback", function()
         local face_list = cre.getFontFaces()
-        assert.is_equal(face_list[1], "Droid Sans Mono")
+        local has_droid_sans = false
+        for i, v in ipairs(face_list) do
+            if v == "Droid Sans Mono" then
+                has_droid_sans = true
+                break
+            end
+        end
+        assert.is_true(has_droid_sans)
         assert.is_true(#face_list >= 10)
     end)
     it("should close document", function()


### PR DESCRIPTION
The `droid sans fallback` test incorrectly assumes `Droid Sans Mono` will be the first font in the list of fallback fonts, but the list is alphabetically sorted.

Cf. https://github.com/koreader/koreader/pull/10566

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11776)
<!-- Reviewable:end -->
