### PR TITLE
Replace tweak_buttons_func with an event instead

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -424,7 +424,7 @@ function ReaderDictionary:addToMainMenu(menu_items)
     end
 end
 
-function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tweak_buttons_func)
+function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link)
     logger.dbg("dict lookup word:", word, boxes)
     -- escape quotes and other funny characters in word
     word = self:cleanSelection(word, is_sane)
@@ -440,7 +440,7 @@ function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, tw
 
     -- Wrapped through Trapper, as we may be using Trapper:dismissablePopen() in it
     Trapper:wrap(function()
-        self:stardictLookup(word, self.enabled_dict_names, not disable_fuzzy_search, boxes, link, tweak_buttons_func)
+        self:stardictLookup(word, self.enabled_dict_names, not disable_fuzzy_search, boxes, link)
     end)
     return true
 end
@@ -932,7 +932,7 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     return results
 end
 
-function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, link, tweak_buttons_func)
+function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, link)
     if word == "" then
         return
     end
@@ -992,16 +992,15 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, 
         return
     end
 
-    self:showDict(word, tidyMarkup(results), boxes, link, tweak_buttons_func)
+    self:showDict(word, tidyMarkup(results), boxes, link)
 end
 
-function ReaderDictionary:showDict(word, results, boxes, link, tweak_buttons_func)
+function ReaderDictionary:showDict(word, results, boxes, link)
     if results and results[1] then
         logger.dbg("showing quick lookup window", #DictQuickLookup.window_list+1, ":", word, results)
         self.dict_window = DictQuickLookup:new{
             ui = self.ui,
             highlight = self.highlight,
-            tweak_buttons_func = tweak_buttons_func,
             dialog = self.dialog,
             -- original lookup word
             word = word,

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -526,9 +526,7 @@ function DictQuickLookup:init()
             })
         end
     end
-    if self.tweak_buttons_func then
-        self:tweak_buttons_func(buttons)
-    elseif self.ui then
+    if self.ui then
         self.ui:handleEvent(Event:new("DictButtonsReady", self, buttons))
     end
     -- Bottom buttons get a bit less padding so their line separators

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -528,6 +528,8 @@ function DictQuickLookup:init()
     end
     if self.tweak_buttons_func then
         self:tweak_buttons_func(buttons)
+    elseif self.ui then
+        self.ui:handleEvent(Event:new("DictButtonsReady", self, buttons))
     end
     -- Bottom buttons get a bit less padding so their line separators
     -- reach out from the content to the borders a bit more

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1928,7 +1928,6 @@ function VocabularyBuilderWidget:onClose()
     UIManager:close(self)
     DB:batchUpdateItems(self.item_table)
     self.main_content:clear()
-    return true
 end
 
 function VocabularyBuilderWidget:onCancel()

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1928,7 +1928,7 @@ end
 
 function VocabularyBuilderWidget:onCloseWidget()
     DB:batchUpdateItems(self.item_table)
-    for i=1,#self.main_content do self.main_content[i] = nil end
+    self.main_content:clear()
     UIManager:setDirty(self, "ui")
     return true
 end

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1212,6 +1212,49 @@ function VocabItemWidget:onShowBookAssignment(title_changed_cb)
     UIManager:show(sort_widget)
 end
 
+function VocabItemWidget:onDictButtonsReady(obj, buttons)
+    if self.item.due_time > os.time() then
+        return true
+    end
+    local tweaked_button_count = 0
+    local early_break
+    for j = 1, #buttons do
+        for k = 1, #buttons[j] do
+            if buttons[j][k].id == "highlight" and not buttons[j][k].enabled then
+                buttons[j][k] = {
+                    id = "got_it",
+                    text = _("Got it"),
+                    callback = function()
+                        self.show_parent:gotItFromDict(self.item.word)
+                        UIManager:close(obj)
+                    end
+                }
+                if tweaked_button_count == 1 then
+                    early_break = true
+                    break
+                end
+                tweaked_button_count = tweaked_button_count + 1
+            elseif buttons[j][k].id == "search" and not buttons[j][k].enabled then
+                buttons[j][k] = {
+                    id = "forgot",
+                    text = _("Forgot"),
+                    callback = function()
+                        self.show_parent:forgotFromDict(self.item.word)
+                        UIManager:close(obj)
+                    end
+                }
+                if tweaked_button_count == 1 then
+                    early_break = true
+                    break
+                end
+                tweaked_button_count = tweaked_button_count + 1
+            end
+        end
+        if early_break then break end
+    end
+    return true -- we consume the event here!
+end
+
 
 --[[--
 Container widget. Same as sortwidget
@@ -1906,49 +1949,6 @@ function VocabularyBuilderWidget:vocabItemIter()
             end
         end
     end
-end
-
-function VocabItemWidget:onDictButtonsReady(obj, buttons)
-    if self.item.due_time > os.time() then
-        return true
-    end
-    local tweaked_button_count = 0
-    local early_break
-    for j = 1, #buttons do
-        for k = 1, #buttons[j] do
-            if buttons[j][k].id == "highlight" and not buttons[j][k].enabled then
-                buttons[j][k] = {
-                    id = "got_it",
-                    text = _("Got it"),
-                    callback = function()
-                        self.show_parent:gotItFromDict(self.item.word)
-                        UIManager:close(obj)
-                    end
-                }
-                if tweaked_button_count == 1 then
-                    early_break = true
-                    break
-                end
-                tweaked_button_count = tweaked_button_count + 1
-            elseif buttons[j][k].id == "search" and not buttons[j][k].enabled then
-                buttons[j][k] = {
-                    id = "forgot",
-                    text = _("Forgot"),
-                    callback = function()
-                        self.show_parent:forgotFromDict(self.item.word)
-                        UIManager:close(obj)
-                    end
-                }
-                if tweaked_button_count == 1 then
-                    early_break = true
-                    break
-                end
-                tweaked_button_count = tweaked_button_count + 1
-            end
-        end
-        if early_break then break end
-    end
-    return true -- we consume the event here!
 end
 
 

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1918,9 +1918,12 @@ function VocabBuilder:addToMainMenu(menu_items)
     }
 end
 
-function VocabItemWidget:onDictButtonsReady(obj, buttons)
+function VocabItemWidget:onDictButtonsReady(popup_dict, buttons)
+    if self.item.word ~= popup_dict.word then
+        return
+    end
     if self.item.due_time > os.time() then
-        return nil
+        return true
     end
     local tweaked_button_count = 0
     local early_break
@@ -1931,7 +1934,7 @@ function VocabItemWidget:onDictButtonsReady(obj, buttons)
                     id = "got_it",
                     text = _("Got it"),
                     callback = function()
-                        self.widget:gotItFromDict(self.item.word)
+                        self.show_parent:gotItFromDict(self.item.word)
                         UIManager:sendEvent(Event:new("Close"))
                     end
                 }
@@ -1945,7 +1948,7 @@ function VocabItemWidget:onDictButtonsReady(obj, buttons)
                     id = "forgot",
                     text = _("Forgot"),
                     callback = function()
-                        self.widget:forgotFromDict(self.item.word)
+                        self.show_parent:forgotFromDict(self.item.word)
                         UIManager:sendEvent(Event:new("Close"))
                     end
                 }

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1908,7 +1908,7 @@ function VocabularyBuilderWidget:vocabItemIter()
     end
 end
 
-function VocabItemWidget:onDictButtonsReady(buttons)
+function VocabItemWidget:onDictButtonsReady(obj, buttons)
     if self.item.due_time > os.time() then
         return true
     end
@@ -1922,7 +1922,7 @@ function VocabItemWidget:onDictButtonsReady(buttons)
                     text = _("Got it"),
                     callback = function()
                         self.show_parent:gotItFromDict(self.item.word)
-                        UIManager:sendEvent(Event:new("Close"))
+                        UIManager:close(obj)
                     end
                 }
                 if tweaked_button_count == 1 then
@@ -1936,7 +1936,7 @@ function VocabItemWidget:onDictButtonsReady(buttons)
                     text = _("Forgot"),
                     callback = function()
                         self.show_parent:forgotFromDict(self.item.word)
-                        UIManager:sendEvent(Event:new("Close"))
+                        UIManager:close(obj)
                     end
                 }
                 if tweaked_button_count == 1 then
@@ -1978,7 +1978,7 @@ function VocabBuilder:onDictButtonsReady(obj, buttons)
     if UIManager:isWidgetShown(self.widget) and #obj.window_list == 0 then
         for vocabItem in self.widget:vocabItemIter() do
             if vocabItem.item.word == obj.word then
-                return vocabItem:onDictButtonsReady(buttons)
+                return vocabItem:onDictButtonsReady(obj, buttons)
             end
         end
         -- we should never get here

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1217,7 +1217,6 @@ end
 Container widget. Same as sortwidget
 --]]--
 local VocabularyBuilderWidget = FocusManager:extend{
-    id = "vocab_builder_widget",
     title = "",
     width = nil,
     height = nil,
@@ -2066,7 +2065,5 @@ function VocabBuilder:onWordLookedUp(word, title, is_manual)
     })
     return true
 end
-
--- register button in readerdictionary
 
 return VocabBuilder

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1925,9 +1925,10 @@ function VocabularyBuilderWidget:onMultiSwipe(arg, ges_ev)
 end
 
 function VocabularyBuilderWidget:onClose()
-    UIManager:close(self)
     DB:batchUpdateItems(self.item_table)
     self.main_content:clear()
+    UIManager:close(self)
+    -- UIManager:setDirty(self, "ui")
 end
 
 function VocabularyBuilderWidget:onCancel()

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -14,7 +14,6 @@ local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
-local DictQuickLookUp = require("ui/widget/dictquicklookup")
 local Dispatcher = require("dispatcher")
 local Event = require("ui/event")
 local Font = require("ui/font")
@@ -1919,8 +1918,8 @@ function VocabBuilder:addToMainMenu(menu_items)
     }
 end
 
-function VocabularyBuilderWidget:onDictButtonsReady(_, buttons)
-    if self.due_time > os.time() then
+function VocabItemWidget:onDictButtonsReady(obj, buttons)
+    if self.item.due_time > os.time() then
         return nil
     end
     local tweaked_button_count = 0
@@ -1932,7 +1931,7 @@ function VocabularyBuilderWidget:onDictButtonsReady(_, buttons)
                     id = "got_it",
                     text = _("Got it"),
                     callback = function()
-                        self.widget:gotItFromDict(self.word)
+                        self.widget:gotItFromDict(self.item.word)
                         UIManager:sendEvent(Event:new("Close"))
                     end
                 }
@@ -1946,7 +1945,7 @@ function VocabularyBuilderWidget:onDictButtonsReady(_, buttons)
                     id = "forgot",
                     text = _("Forgot"),
                     callback = function()
-                        self.widget:forgotFromDict(self.word)
+                        self.widget:forgotFromDict(self.item.word)
                         UIManager:sendEvent(Event:new("Close"))
                     end
                 }
@@ -2016,6 +2015,7 @@ function VocabBuilder:setupWidget()
             reload_items_callback = reload_items
         }
     end
+    self[1] = self.widget
 end
 
 function VocabBuilder:onDispatcherRegisterActions()

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1900,7 +1900,8 @@ function VocabularyBuilderWidget:vocabItemIter()
     return function()
         while true do
             i = i + 1
-            if i <= n and self.main_content[i].item then
+            if i > n then return nil end
+            if self.main_content[i].item then
                 return self.main_content[i]
             end
         end

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1975,12 +1975,13 @@ function VocabBuilder:addToMainMenu(menu_items)
 end
 
 function VocabBuilder:onDictButtonsReady(obj, buttons)
-    if UIManager:isWidgetShown(self.widget) then
+    if UIManager:isWidgetShown(self.widget) and #obj.window_list == 0 then
         for vocabItem in self.widget:vocabItemIter() do
             if vocabItem.item.word == obj.word then
                 return vocabItem:onDictButtonsReady(buttons)
             end
         end
+        -- we should never get here
     end
     if settings.enabled then
         -- words are added automatically, no need to add the button

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -1976,7 +1976,6 @@ end
 function VocabBuilder:onDictButtonsReady(obj, buttons)
     if UIManager:isWidgetShown(self.widget) then
         for vocabItem in self.widget:vocabItemIter() do
-            print(vocabItem)
             if vocabItem.item.word == obj.word then
                 return vocabItem:onDictButtonsReady(buttons)
             end


### PR DESCRIPTION
There is nothing really wrong with the current approach, considering it was added for one specific reason, giving the vocabbuilder plugin access to the popup dictionary.

I created a custom plugin which also adds a button to the popup dictionary, and up until now I didn't care about it overwriting what the vocabbuilder one does.

However, I got a [request](https://github.com/Ajatt-Tools/anki.koplugin/issues/22) last week for it not to do that :slightly_smiling_face: 

I tried getting around making changes to koreader itself by wrapping the `tweak_buttons_func` so it still calls the original one, but also my own on top of it. This didn't work out quite right because each time the user switches between reader and filemanager all plugins get reloaded, meaning it forgets about the function already being wrapped (since DictQuickLookup itself persists the whole time), and it wraps it again, meaning I end up with one extra button on each reload.

On top of that, vocabbuilder also sets this function to nil again at some points (when the setting to automatically add all words looked up is turned on)  which I can't detect at all currently

@NiLuJe suggested to make tweak_buttons_func a table instead where each plugin which wants to modify it can store their function in, that still didn't feel very clean to me, and it would mean we're still storing plugin state in the actual DictQuickLookup module directly itself which doesn't seem great to begin with.

I ended up creating a customt even instead, which plugins that care about which buttons appear in the popup dict can consume, it takes in the popup window itself, and the list of buttons. This list is modified in-place.
The upside of this is that you don't need to pass that tweak_buttons_func around anywhere in ReaderDictionary and no plugin state is stored in the persisting DictQuickLookup module


If people have suggestions for better ways to do this I would love to hear it. It would also be great if someone more familiar with vocabbuilder looks at it. I tested it and it seems to work fine but I'm not an active user so I might have missed something.

FYI this was discussed on Gitter first

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11777)
<!-- Reviewable:end -->
