### PR TITLE
Kindle Scribe: Fix KindleUI L and R orientations when restarting KOReader book in landscape

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1399,14 +1399,10 @@ function KindleScribe:init()
             logger.dbg("orientation_code =", orientation_code)
             local rotation_mode = 0
             if orientation_code then
-                if orientation_code == "U" then
+                if orientation_code == "U" or "L" then
                     rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
-                elseif orientation_code == "R" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_CLOCKWISE
-                elseif orientation_code == "D" then
+                elseif orientation_code == "D" or "R" then
                     rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
-                elseif orientation_code == "L" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_COUNTER_CLOCKWISE
                 end
             end
             if rotation_mode > 0 then


### PR DESCRIPTION
Fixes #11743 

It turns out that KOReader can only digest `U` or `D` orientations.
These are `0` and `2` in the list below:
```
self.screen.DEVICE_ROTATED_UPRIGHT =  0 
self.screen.DEVICE_ROTATED_CLOCKWISE =  1 
self.screen.DEVICE_ROTATED_UPSIDE_DOWN =  2 
self.screen.DEVICE_ROTATED_COUNTER_CLOCKWISE =  3
```
`1` and `3` cause the touch to be misaligned with the visible rendered UI by 90 degrees if a KOReader book has been exited in KOReader's "landscape" orientation, and I don't really know why. Probably, because KOReader "rotates" the UI (or touch layer?) by 90 degrees when it is in "landscape" mode.

Having `U`/`L` and `D`/`R` in the same groups worked well.
If Kindle is started in `L`, KOREader will greet the user in the same orientation, if the KOReader book has been left in that "landscape" orientation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11780)
<!-- Reviewable:end -->
