### PR TITLE
PocketBook: Open links in the on-device web browser

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -442,40 +442,9 @@ function PocketBook:canOpenLink()
 end
 
 function PocketBook:openLink(link)
-    if not link or type(link) ~= "string" then return end
-
-    -- SendRequestToNoWait only available in PocketBook SDK since 5.17
-    local inkview_SendRequestTo
-    if pcall(function() local _ = inkview.SendRequestToNoWait end) then
-        inkview_SendRequestTo = function(t, r, d, l) inkview.SendRequestToNoWait(t, r, d, l, 0) end
-    else
-        inkview_SendRequestTo = function(t, r, d, l) inkview.SendRequestTo(t, r, d, l, 0, 2000) end
-    end
-
-    local appname = "browser.app"
-    local task = inkview.FindTaskByAppName(appname)
-    if task > 0 then
-        local data = ffi.new("void *[1]")
-        local len = ffi.new("int[1]")
-        inkview.PackParameters(1, ffi.new("const char *[1]", {link}), data, len)
-        inkview_SendRequestTo(task, C.REQ_OPENBOOK2, data[0], len[0])
-        C.free(data[0])
-        inkview.SetActiveTask(task, 0)
-    else
-        local _, bin = getBrowser()
-        local args = ffi.new("const char *[3]", {bin, link, nil})
-        inkview.NewTask(bin, ffi.cast("char **", args), appname, appname, nil, C.TASK_MAKEACTIVE)
-    end
-    -- the above logic is available in newer PocketBook SDKs [1] as OpenTask:
-    --
-    --     ffi.cdef[[ int OpenTask(const char *, int, const char **, int); ]]
-    --
-    --     local argv = ffi.new("const char *[1]", {link})
-    --     inkview.OpenTask("/usr/bin/browser.app", 1, argv, C.TASK_MAKEACTIVE)
-    --
-    -- we're using an older SDK for compatibility, so we need to handle this manually
-    --
-    -- [1]: https://github.com/pocketbook/SDK_6.3.0/blob/6.5/SDK-B288/usr/arm-obreey-linux-gnueabi/sysroot/usr/local/include/inkview.h
+    local found, bin = getBrowser()
+    if not found or not link or type(link) ~= "string" then return end
+    inkview.OpenBook(bin, link, 0)
 end
 
 -- Pocketbook HW rotation modes start from landsape, CCW


### PR DESCRIPTION
Many PocketBook devices include a web browser, but when clicking a link in KOReader, there was no option to open the link in the browser, there was only an option to show a QR code (which can then be scanned by a smartphone).

This commit implements `canOpenLink`/`openLink` on PocketBook using the "browser.app", if available.

Tested on PB740 (InkPad 3).

Fixes: https://github.com/koreader/koreader/issues/11782
Related: https://github.com/koreader/koreader/issues/6597

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11787)
<!-- Reviewable:end -->
