### PR TITLE
File browser reshuffle 2.0

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -187,7 +187,7 @@ function FileManagerMenu:setUpdateItemTable()
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Book entries per page: %1"),
+                            return T(_("Entries per page: %1"),
                                 G_reader_settings:readSetting("items_per_page") or FileChooser.items_per_page_default)
                         end,
                         help_text = _([[This sets the number of entries per page in:
@@ -219,14 +219,14 @@ function FileManagerMenu:setUpdateItemTable()
                             local items_per_page = G_reader_settings:readSetting("items_per_page") or FileChooser.items_per_page_default
                             local items_font_size = FileChooser.font_size
                                 or G_reader_settings:readSetting("items_font_size") or FileChooser.getItemFontSize(items_per_page)
-                            return T(_("File name font size: %1"), items_font_size)
+                            return T(_("Entries font size: %1"), items_font_size)
                         end,
                         callback = function(touchmenu_instance)
                             local items_per_page = G_reader_settings:readSetting("items_per_page") or FileChooser.items_per_page_default
                             local default_value = FileChooser.getItemFontSize(items_per_page)
                             local current_value = FileChooser.font_size or G_reader_settings:readSetting("items_font_size") or default_value
                             local widget = SpinWidget:new{
-                                title_text =  _("File name font size"),
+                                title_text =  _("Entries font size"),
                                 value = current_value,
                                 value_min = 10,
                                 value_max = 72,
@@ -249,7 +249,7 @@ function FileManagerMenu:setUpdateItemTable()
                         end,
                     },
                     {
-                        text = _("Auto reduce filename-font-size to fit whole text"),
+                        text = _("Auto reduce font-size to fit more text"),
                         checked_func = function()
                             return G_reader_settings:isTrue("items_multilines_show_more_text")
                         end,
@@ -313,11 +313,11 @@ function FileManagerMenu:setUpdateItemTable()
                         separator = true,
                     },
                     {
-                        text = _("Clear deleted files from history"),
+                        text = _("Remove deleted files from history"),
                         callback = function()
                             UIManager:show(ConfirmBox:new{
-                                text = _("Clear deleted files from history?"),
-                                ok_text = _("Clear"),
+                                text = _("Remove deleted files from history?"),
+                                ok_text = _("Remove"),
                                 ok_callback = function()
                                     require("readhistory"):clearMissing()
                                 end,
@@ -325,7 +325,7 @@ function FileManagerMenu:setUpdateItemTable()
                         end,
                     },
                     {
-                        text = _("Auto-remove deleted or purged entries from history"),
+                        text = _("Auto-remove deleted or purged files from history"),
                         checked_func = function()
                             return G_reader_settings:isTrue("autoremove_deleted_items_from_history")
                         end,

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -149,7 +149,7 @@ function FileManagerMenu:setUpdateItemTable()
 
     -- setting tab
     self.menu_items.filebrowser_settings = {
-        text = _("File Management"),
+        text = _("Settings"),
         sub_item_table = {
             {
                 text = _("Show finished books"),
@@ -290,7 +290,7 @@ function FileManagerMenu:setUpdateItemTable()
                 },
             },
             {
-                text = _("History tab"),
+                text = _("History"),
                 sub_item_table = {
                     {
                         text = _("Shorten date/time"),

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -216,12 +216,15 @@ function FileManagerMenu:setUpdateItemTable()
                     },
                     {
                         text_func = function()
-                            return T(_("File name font size: %1"), FileChooser.font_size)
+                            local items_per_page = G_reader_settings:readSetting("items_per_page") or FileChooser.items_per_page_default
+                            local items_font_size = FileChooser.font_size
+                                or G_reader_settings:readSetting("items_font_size") or FileChooser.getItemFontSize(items_per_page)
+                            return T(_("File name font size: %1"), items_font_size)
                         end,
                         callback = function(touchmenu_instance)
-                            local current_value = FileChooser.font_size
-                            local default_value = FileChooser.getItemFontSize(G_reader_settings:readSetting("items_per_page")
-                                or FileChooser.items_per_page_default)
+                            local items_per_page = G_reader_settings:readSetting("items_per_page") or FileChooser.items_per_page_default
+                            local default_value = FileChooser.getItemFontSize(items_per_page)
+                            local current_value = FileChooser.font_size or G_reader_settings:readSetting("items_font_size") or default_value
                             local widget = SpinWidget:new{
                                 title_text =  _("File name font size"),
                                 value = current_value,

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -81,6 +81,7 @@ function CoverBrowser:init()
 end
 
 function CoverBrowser:addToMainMenu(menu_items)
+    local fc = self.ui.file_chooser
     local modes = {
         { _("Classic (filename only)") },
         { _("Mosaic"), "mosaic_image" },
@@ -133,11 +134,7 @@ function CoverBrowser:addToMainMenu(menu_items)
     table.insert(sub_item_table, {
         text = _("Hide book covers"),
         enabled_func = function()
-            return filemanager_display_mode == "mosaic_image"
-                or filemanager_display_mode == "mosaic_text"
-                or filemanager_display_mode == "list_image_meta"
-                or filemanager_display_mode == "list_only_meta"
-                or filemanager_display_mode == "list_image_filename"
+            return not fc.display_mode_type == false
         end,
         checked_func = function()
             return filemanager_display_mode == "mosaic_text" or filemanager_display_mode == "list_only_meta"
@@ -157,9 +154,7 @@ function CoverBrowser:addToMainMenu(menu_items)
     table.insert(sub_item_table, {
         text = _("Replace book title with file name"),
         enabled_func = function()
-            return filemanager_display_mode == "list_image_meta"
-                or filemanager_display_mode == "list_image_filename"
-                or filemanager_display_mode == "list_only_meta"
+            return fc.display_mode_type == "list"
         end,
         checked_func = function()
             return filemanager_display_mode == "list_image_filename"
@@ -293,16 +288,11 @@ function CoverBrowser:addToMainMenu(menu_items)
     table.insert(sub_item_table, menu_items.filebrowser_settings.sub_item_table[5])
     table.remove(menu_items.filebrowser_settings.sub_item_table, 5)
 
-    local fc = self.ui.file_chooser
     table.insert(sub_item_table, {
         text = _("Mosaic and list view properties"),
         separator = true,
         enabled_func = function()
-            return filemanager_display_mode == "mosaic_image"
-                or filemanager_display_mode == "mosaic_text"
-                or filemanager_display_mode == "list_image_meta"
-                or filemanager_display_mode == "list_only_meta"
-                or filemanager_display_mode == "list_image_filename"
+            return not fc.display_mode_type == false
         end,
         sub_item_table = {
             {
@@ -310,7 +300,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     return T(_("Grid size in portrait-mosaic mode: %1 × %2"), fc.nb_cols_portrait, fc.nb_rows_portrait)
                 end,
                 enabled_func = function()
-                    return filemanager_display_mode == "mosaic_image" or filemanager_display_mode == "mosaic_text"
+                    return fc.display_mode_type == "mosaic"
                 end,
                 -- Best to not "keep_menu_open = true", to see how this apply on the full view
                 callback = function()
@@ -362,7 +352,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     return T(_("Grid size in landscape-mosaic mode: %1 × %2"), fc.nb_cols_landscape, fc.nb_rows_landscape)
                 end,
                 enabled_func = function()
-                    return filemanager_display_mode == "mosaic_image" or filemanager_display_mode == "mosaic_text"
+                    return fc.display_mode_type == "mosaic"
                 end,
                 callback = function()
                     local nb_cols = fc.nb_cols_landscape
@@ -415,9 +405,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     return T(_("Books per page in list view: %1"), fc.files_per_page or 10)
                 end,
                 enabled_func = function()
-                    return filemanager_display_mode == "list_image_meta"
-                        or filemanager_display_mode == "list_image_filename"
-                        or filemanager_display_mode == "list_only_meta"
+                    return fc.display_mode_type == "list"
                 end,
                 callback = function()
                     local files_per_page = fc.files_per_page or 10
@@ -457,7 +445,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     {
                         text = _("Show progress bar"),
                         enabled_func = function()
-                            return filemanager_display_mode == "mosaic_image" or filemanager_display_mode == "mosaic_text"
+                            return fc.display_mode_type == "mosaic"
                         end,
                         checked_func = function() return BookInfoManager:getSetting("show_progress_in_mosaic") end,
                         callback = function()
@@ -469,7 +457,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     {
                         text = _("Show progress information"),
                         enabled_func = function()
-                            return not (filemanager_display_mode == "mosaic_image" or filemanager_display_mode == "mosaic_text")
+                            return fc.display_mode_type == "list"
                         end,
                         checked_func = function() return not BookInfoManager:getSetting("hide_page_info") end,
                         callback = function()
@@ -480,8 +468,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     {
                         text = _("Show number of pages read instead of percentage"),
                         enabled_func = function() 
-                            return not BookInfoManager:getSetting("hide_page_info")
-                                and not (filemanager_display_mode == "mosaic_image" or filemanager_display_mode == "mosaic_text")
+                            return not BookInfoManager:getSetting("hide_page_info") and fc.display_mode_type == "list"
                             end,
                         checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,
                         callback = function()
@@ -492,8 +479,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     {
                         text = _("Show number of pages left to read"),
                         enabled_func = function()
-                            return not BookInfoManager:getSetting("hide_page_info")
-                                and not (filemanager_display_mode == "mosaic_image" or filemanager_display_mode == "mosaic_text")
+                            return not BookInfoManager:getSetting("hide_page_info") and fc.display_mode_type == "list"
                         end,
                         checked_func = function() return BookInfoManager:getSetting("show_pages_left_in_progress") end,
                         callback = function()
@@ -504,9 +490,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     {
                         text = _("Show file metadata"),
                         enabled_func = function()
-                            return filemanager_display_mode == "list_image_meta"
-                                or filemanager_display_mode == "list_image_filename"
-                                or filemanager_display_mode == "list_only_meta"
+                            return fc.display_mode_type == "list"
                         end,
                         checked_func = function()
                             return not BookInfoManager:getSetting("hide_file_info")
@@ -551,9 +535,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             {
                 text = _("Series"),
                 enabled_func = function()
-                    return filemanager_display_mode == "list_image_meta"
-                        or filemanager_display_mode == "list_image_filename"
-                        or filemanager_display_mode == "list_only_meta"
+                    return fc.display_mode_type == "list"
                 end,
                 sub_item_table = {
                     {

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -93,13 +93,13 @@ function CoverBrowser:addToMainMenu(menu_items)
         sub_item_table[i] = {
             text = text,
             checked_func = function()
-                if filemanager_display_mode == "mosaic_text" then 
+                if filemanager_display_mode == "mosaic_text" then
                     return mode == "mosaic_image"
                 elseif filemanager_display_mode == "list_only_meta" then
                     return mode == "list_image_meta"
                 elseif filemanager_display_mode == "list_image_filename" then
                     return mode == "list_image_meta"
-                else 
+                else
                     return mode == filemanager_display_mode
                 end
             end,
@@ -148,7 +148,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                 self:setupFileManagerDisplayMode("list_image_meta")
             else
                 self:setupFileManagerDisplayMode("list_only_meta")
-            end  
+            end
         end,
     })
     table.insert(sub_item_table, {
@@ -468,7 +468,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     },
                     {
                         text = _("Show number of pages read instead of percentage"),
-                        enabled_func = function() 
+                        enabled_func = function()
                             return not BookInfoManager:getSetting("hide_page_info") and fc.display_mode_type == "list"
                             end,
                         checked_func = function() return BookInfoManager:getSetting("show_pages_read_as_progress") end,

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -84,7 +84,7 @@ function CoverBrowser:addToMainMenu(menu_items)
     local fc = self.ui.file_chooser
     local modes = {
         { _("Classic (filename only)") },
-        { _("Mosaic"), "mosaic_image" },
+        { _("Grid"), "mosaic_image" },
         { _("Detailed list"), "list_image_meta" },
     }
     local sub_item_table, history_sub_item_table, collection_sub_item_table = {}, {}, {}
@@ -134,7 +134,7 @@ function CoverBrowser:addToMainMenu(menu_items)
     table.insert(sub_item_table, {
         text = _("Hide book covers"),
         enabled_func = function()
-            return not fc.display_mode_type == false
+            return fc.display_mode_type and true or false
         end,
         checked_func = function()
             return filemanager_display_mode == "mosaic_text" or filemanager_display_mode == "list_only_meta"
@@ -171,7 +171,7 @@ function CoverBrowser:addToMainMenu(menu_items)
     ------------------------------------------------------------
     -- add these settings to File browser Settings submenu
     if menu_items.filebrowser_settings == nil then return end
-    table.insert(menu_items.filebrowser_settings.sub_item_table, 9, {
+    table.insert(menu_items.filebrowser_settings.sub_item_table, {
         text = _("Book info cache management"),
         sub_item_table = {
             {
@@ -268,14 +268,14 @@ function CoverBrowser:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("History tab"),
+                text = _("History"),
                 enabled_func = function()
                     return not BookInfoManager:getSetting("unified_display_mode")
                 end,
                 sub_item_table = history_sub_item_table,
             },
             {
-                text = _("Collections tab"),
+                text = _("Collections"),
                 enabled_func = function()
                     return not BookInfoManager:getSetting("unified_display_mode")
                 end,
@@ -285,19 +285,20 @@ function CoverBrowser:addToMainMenu(menu_items)
         }
     })
 
+-- Classic view properties
     table.insert(sub_item_table, menu_items.filebrowser_settings.sub_item_table[5])
     table.remove(menu_items.filebrowser_settings.sub_item_table, 5)
 
     table.insert(sub_item_table, {
-        text = _("Mosaic and list view properties"),
+        text = _("Grid and list view properties"),
         separator = true,
         enabled_func = function()
-            return not fc.display_mode_type == false
+            return fc.display_mode_type and true or false
         end,
         sub_item_table = {
             {
                 text_func = function()
-                    return T(_("Grid size in portrait-mosaic mode: %1 × %2"), fc.nb_cols_portrait, fc.nb_rows_portrait)
+                    return T(_("Grid size in portrait mode: %1 × %2"), fc.nb_cols_portrait, fc.nb_rows_portrait)
                 end,
                 enabled_func = function()
                     return fc.display_mode_type == "mosaic"
@@ -308,7 +309,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     local nb_rows = fc.nb_rows_portrait
                     local DoubleSpinWidget = require("/ui/widget/doublespinwidget")
                     local widget = DoubleSpinWidget:new{
-                        title_text = _("Portrait mosaic view"),
+                        title_text = _("Portrait grid view"),
                         width_factor = 0.6,
                         left_text = _("Columns"),
                         left_value = nb_cols,
@@ -349,7 +350,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Grid size in landscape-mosaic mode: %1 × %2"), fc.nb_cols_landscape, fc.nb_rows_landscape)
+                    return T(_("Grid size in landscape mode: %1 × %2"), fc.nb_cols_landscape, fc.nb_rows_landscape)
                 end,
                 enabled_func = function()
                     return fc.display_mode_type == "mosaic"
@@ -359,7 +360,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     local nb_rows = fc.nb_rows_landscape
                     local DoubleSpinWidget = require("/ui/widget/doublespinwidget")
                     local widget = DoubleSpinWidget:new{
-                        title_text = _("Landscape mosaic view"),
+                        title_text = _("Landscape grid view"),
                         width_factor = 0.6,
                         left_text = _("Columns"),
                         left_value = nb_cols,
@@ -488,7 +489,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Show file metadata"),
+                        text = _("Show file properties"),
                         enabled_func = function()
                             return fc.display_mode_type == "list"
                         end,
@@ -515,7 +516,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Show visual cue for books in history tab"),
+                        text = _("Show visual cue for open books in history"),
                         checked_func = function() return BookInfoManager:getSetting("history_hint_opened") end,
                         callback = function()
                             BookInfoManager:toggleSetting("history_hint_opened")
@@ -523,7 +524,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Show visual cue for books added to collections"),
+                        text = _("Show visual cue for open books in collections"),
                         checked_func = function() return BookInfoManager:getSetting("collections_hint_opened") end,
                         callback = function()
                             BookInfoManager:toggleSetting("collections_hint_opened")


### PR DESCRIPTION
Original PR here #11781

From the makers of the wildly successful Sleep screen rework #11549 and the yet to be merged status bar makeover #11678, We present to you the 'new kid in town', the new file browser (file cabinet) menu.

There has been a far less aggressive approach here, most of the work pertains the reduction of "view modes" and rewording of settings. Some logic was added for the functioning of the simpler view modes but besides that no changes in functionality were added or removed.

I am conflicted about the use of the word "mosaic" here, as what we get is a standard grid view that has nothing to do with actual mosaics, I would love to hear what you think, should it go, should it stay?

the following screenshots were captured on a non-touch kindle 4, so some options might not appear there. Anyway without any further ado, 

Here it is the menu upon opening:
<img src="https://github.com/koreader/koreader/assets/97603719/27dc2747-ab58-42d8-a484-5062a3da6c3a" width=40% height=40%>

after going to the `Library view`:


<img src="https://github.com/koreader/koreader/assets/97603719/56b12111-96e2-4861-9dc8-7a8be086d5f7" width=40% height=40%>
<img src="https://github.com/koreader/koreader/assets/97603719/d8cfa1e4-bb60-40b8-8d2f-faff2e2ed41e" width=40% height=40%>

Inside `mosaic and list view properties`:
<img src="https://github.com/koreader/koreader/assets/97603719/9b0afe74-07e9-4ef1-8ef6-2bfb3c00fcaa" width=40% height=40%>

and finally, inside the `file management` submenu:
<img src="https://github.com/koreader/koreader/assets/97603719/00018cf8-2f78-4b53-a2ae-6fd2c52998e6" width=40% height=40%>

> [!IMPORTANT]
> I would like to have the classic view properties greyed out when 'classic mode' NOT selected but the usual `enable function` does not work in that case, any help there would be greatly appreciated.

Last but not least, thanks to @Frenzie for his help, patience and support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11792)
<!-- Reviewable:end -->
