### PR TITLE
Kindle: Fix missing Amazon UI screensaver after exiting KOreader

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1454,6 +1454,9 @@ function KindleTouch:exit()
     end
 
     if self.framework_lipc_handle then
+        -- Fixes missing *stock Amazon UI* screensavers on exiting out of "no framework" started KOReader
+        -- module was unloaded in frameworkStopped() function but wasn't (re)loaded on KOReader exit
+        self.framework_lipc_handle:set_string_property("com.lab126.blanket", "load", "screensaver")
         self.framework_lipc_handle:close()
     end
 


### PR DESCRIPTION
This fixes the problem on Kindle devices that after exiting out of KOReader **that was started with "--framework_stop" param** stock Amazon UI screensaver image would not be displayed because "screensaver" blanket module was unloaded by KOReader ( here in [in frameworkStopped()](https://github.com/koreader/koreader/blob/12c3c190b012e8c4b070d3e0b4e66b2878a89c7a/frontend/device/kindle/device.lua#L130) function ) and never (re)loaded on exit.

Tested on Kindle PW5 with firmware 5.16.2.1.1 and confirmed that it fixes the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11794)
<!-- Reviewable:end -->
