### PR TITLE
Gesture: Add toggle for orientation lock

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -204,6 +204,19 @@ if Device:hasGSensor() then
         Notification:notify(new_text)
         return true
     end
+
+    function DeviceListener:onLockGSensor()
+        G_reader_settings:flipNilOrFalse("input_lock_gsensor")
+        Device:lockGSensor(G_reader_settings:isTrue("input_lock_gsensor"))
+        local new_text
+        if G_reader_settings:isTrue("input_lock_gsensor") then
+            new_text = _("Orientation locked.")
+        else
+            new_text = _("Orientation unlocked.")
+        end
+        Notification:notify(new_text)
+        return true
+    end
 end
 
 if not Device:isAlwaysFullscreen() then

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -83,6 +83,7 @@ local settingsList = {
     ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
+    lock_gsensor = {category="none", event="LockGSensor", title=_("Lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor()},
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
     iterate_rotation = {category="none", event="IterateRotation", title=_("Rotate by 90° CW"), device=true},
@@ -303,6 +304,7 @@ local dispatcher_menu_order = {
     ----
     "toggle_key_repeat",
     "toggle_gsensor",
+    "lock_gsensor",
     "rotation_mode",
     "toggle_rotation",
     "invert_rotation",

--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -57,8 +57,7 @@ If you need to do so, you'll have to use the UI toggles.]]),
                     return G_reader_settings:isTrue("input_lock_gsensor")
                 end,
                 callback = function()
-                    G_reader_settings:flipNilOrFalse("input_lock_gsensor")
-                    Device:lockGSensor(G_reader_settings:isTrue("input_lock_gsensor"))
+                    UIManager:broadcastEvent(Event:new("LockGSensor"))
                 end,
             })
         end


### PR DESCRIPTION
This adds a gesture to toggle the existing "Lock auto rotation to current orientation" option. This is an option that I tended to change relatively often as I switch between reading in bed (and swapping hands) and reading while eating or doing other things that make it harder to hold my device.

I'm hoping I've done everything correctly (and I've tested and verified it works on my device) but if not, let me know and I'll do my best to fix it up.

There's perhaps other cleanups/changes that could be made here since it's a bit confusing that the rotation options are under "Screen" in the settings but under "Device" in the gestures but I just wanted to get this working for me :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11795)
<!-- Reviewable:end -->
