### PR TITLE
NT: add Hot swapping dictionaries button and edit button into FocusManager's layout

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -718,6 +718,12 @@ function DictQuickLookup:init()
         self.movable,
     }
 
+    -- NT: add dict_title.left_button and lookup_edit_button to FocusManager.
+    -- It is better to add these two buttons into self.movable, but it is not a FocusManager.
+    -- Only self.button_table is a FocusManager, so workaground is inserting these two buttons into self.button_table.layout.
+    table.insert(self.button_table.layout, 1, { self.dict_title.left_button });
+    table.insert(self.button_table.layout, 2, { lookup_edit_button });
+
     -- We're a new window
     table.insert(DictQuickLookup.window_list, self)
 end


### PR DESCRIPTION
fix #11783

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11803)
<!-- Reviewable:end -->
