### PR TITLE
Page overlap: add dashed line marker

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -209,22 +209,26 @@ function ReaderView:paintTo(bb, x, y)
         end
     end
 
-    -- dim last read area
+    -- mark last read area of overlapped pages
     if not self.dim_area:isEmpty() and self:isOverlapAllowed() then
         if self.page_overlap_style == "dim" then
-            bb:dimRect(
-                self.dim_area.x, self.dim_area.y,
-                self.dim_area.w, self.dim_area.h
-            )
-        elseif self.page_overlap_style == "arrow" then
-            local center_offset = bit.rshift(self.arrow.height, 1)
-            -- Paint at the proper y origin depending on wheter we paged forward (dim_area.y == 0) or backward
-            self.arrow:paintTo(bb, 0, self.dim_area.y == 0 and self.dim_area.h - center_offset or self.dim_area.y - center_offset)
-        elseif self.page_overlap_style == "line" then
-            bb:paintRect(0, self.dim_area.y == 0 and self.dim_area.h or self.dim_area.y,
-                self.dim_area.w, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
+            bb:dimRect(self.dim_area.x, self.dim_area.y, self.dim_area.w, self.dim_area.h)
+        else
+            -- Paint at the proper y origin depending on whether we paged forward (dim_area.y == 0) or backward
+            local y = self.dim_area.y == 0 and self.dim_area.h or self.dim_area.y
+            if self.page_overlap_style == "arrow" then
+                local center_offset = bit.rshift(self.arrow.height, 1)
+                self.arrow:paintTo(bb, 0, y - center_offset)
+            elseif self.page_overlap_style == "line" then
+                bb:paintRect(0, y, self.dim_area.w, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
+            elseif self.page_overlap_style == "dashed_line" then
+                for i = 0, self.dim_area.w - 20, 20 do
+                    bb:paintRect(i, y, 14, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
+                end
+            end
         end
     end
+
     -- draw saved highlight
     if self.highlight_visible then
         self:drawSavedHighlight(bb, x, y)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -215,15 +215,15 @@ function ReaderView:paintTo(bb, x, y)
             bb:dimRect(self.dim_area.x, self.dim_area.y, self.dim_area.w, self.dim_area.h)
         else
             -- Paint at the proper y origin depending on whether we paged forward (dim_area.y == 0) or backward
-            local y = self.dim_area.y == 0 and self.dim_area.h or self.dim_area.y
+            local paint_y = self.dim_area.y == 0 and self.dim_area.h or self.dim_area.y
             if self.page_overlap_style == "arrow" then
                 local center_offset = bit.rshift(self.arrow.height, 1)
-                self.arrow:paintTo(bb, 0, y - center_offset)
+                self.arrow:paintTo(bb, 0, paint_y - center_offset)
             elseif self.page_overlap_style == "line" then
-                bb:paintRect(0, y, self.dim_area.w, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
+                bb:paintRect(0, paint_y, self.dim_area.w, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
             elseif self.page_overlap_style == "dashed_line" then
                 for i = 0, self.dim_area.w - 20, 20 do
-                    bb:paintRect(i, y, 14, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
+                    bb:paintRect(i, paint_y, 14, Size.line.medium, Blitbuffer.COLOR_DARK_GRAY)
                 end
             end
         end

--- a/frontend/ui/elements/page_overlap.lua
+++ b/frontend/ui/elements/page_overlap.lua
@@ -73,8 +73,8 @@ You can set how many lines are shown.]]),
 local page_overlap_styles = {
     {_("Arrow"), "arrow"},
     {_("Gray out"), "dim"},
-    {_("Horizontal line"), "line"},
-    {_("Horizontal dashed line"), "dashed_line"},
+    {_("Solid line"), "line"},
+    {_("Dashed line"), "dashed_line"},
 }
 for _, v in ipairs(page_overlap_styles) do
     local style_text, style = unpack(v)

--- a/frontend/ui/elements/page_overlap.lua
+++ b/frontend/ui/elements/page_overlap.lua
@@ -71,15 +71,17 @@ You can set how many lines are shown.]]),
 })
 
 local page_overlap_styles = {
-    arrow = _("Arrow"),
-    dim = _("Gray out"),
-    line = _("Horizontal line"),
+    {_("Arrow"), "arrow"},
+    {_("Gray out"), "dim"},
+    {_("Horizontal line"), "line"},
+    {_("Horizontal dashed line"), "dashed_line"},
 }
-for k, v in FFIUtil.orderedPairs(page_overlap_styles) do
+for _, v in ipairs(page_overlap_styles) do
+    local style_text, style = unpack(v)
     table.insert(PageOverlap.sub_item_table, {
         text_func = function()
-            local text = v
-            if G_reader_settings:readSetting("page_overlap_style") == k then
+            local text = style_text
+            if G_reader_settings:readSetting("page_overlap_style") == style then
                 text = text .. "   ★"
             end
             return text
@@ -88,14 +90,14 @@ for k, v in FFIUtil.orderedPairs(page_overlap_styles) do
             return ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
         end,
         checked_func = function()
-            return ReaderUI.instance.view.page_overlap_style == k
+            return ReaderUI.instance.view.page_overlap_style == style
         end,
         radio = true,
         callback = function()
-            ReaderUI.instance.view.page_overlap_style = k
+            ReaderUI.instance.view.page_overlap_style = style
         end,
         hold_callback = function(touchmenu_instance)
-            G_reader_settings:saveSetting("page_overlap_style", k)
+            G_reader_settings:saveSetting("page_overlap_style", style)
             touchmenu_instance:updateItems()
         end,
     })


### PR DESCRIPTION
Requested by our contributor in https://github.com/koreader/koreader/issues/11734#issuecomment-2104270288.

![1](https://github.com/koreader/koreader/assets/62179190/ca37118d-cb96-445e-9173-aea84117fd0a)

![2](https://github.com/koreader/koreader/assets/62179190/7552254c-4eb1-4f2b-9532-69decde207e3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11804)
<!-- Reviewable:end -->
