### PR TITLE
Register Calibre start/stop connection actions

### DIFF
--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -74,8 +74,8 @@ function Calibre:onDispatcherRegisterActions()
     Dispatcher:registerAction("calibre_browse_series", { category="none", event="CalibreBrowseBy", arg="series", title=_("Browse all calibre series"), general=true,})
     Dispatcher:registerAction("calibre_browse_authors", { category="none", event="CalibreBrowseBy", arg="authors", title=_("Browse all calibre authors"), general=true,})
     Dispatcher:registerAction("calibre_browse_titles", { category="none", event="CalibreBrowseBy", arg="title", title=_("Browse all calibre titles"), general=true, separator=true,})
-    Dispatcher:registerAction("calibre_start_connection", { category="none", event="StartWirelessConnection", title=_("Calibre Wireless Connect"), general=true,})
-    Dispatcher:registerAction("calibre_close_connection", { category="none", event="CloseWirelessConnection", title=_("Calibre Wireless Disconnect"), general=true,})
+    Dispatcher:registerAction("calibre_start_connection", { category="none", event="StartWirelessConnection", title=_("Calibre wireless connect"), general=true,})
+    Dispatcher:registerAction("calibre_close_connection", { category="none", event="CloseWirelessConnection", title=_("Calibre wireless disconnect"), general=true,})
 end
 
 function Calibre:init()

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -56,15 +56,15 @@ function Calibre:onCloseWirelessConnection()
     self:closeWirelessConnection()
 end
 
-function Calibre:closeWirelessConnection()
-    if CalibreWireless.calibre_socket then
-        CalibreWireless:disconnect()
-    end
-end
-
 function Calibre:startWirelessConnection()
     if not CalibreWireless.calibre_socket then
         CalibreWireless:connect()
+    end
+end
+
+function Calibre:closeWirelessConnection()
+    if CalibreWireless.calibre_socket then
+        CalibreWireless:disconnect()
     end
 end
 

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -48,9 +48,23 @@ function Calibre:onClose()
     self:closeWirelessConnection()
 end
 
+function Calibre:onStartWirelessConnection()
+    self:startWirelessConnection()
+end
+
+function Calibre:onCloseWirelessConnection()
+    self:closeWirelessConnection()
+end
+
 function Calibre:closeWirelessConnection()
     if CalibreWireless.calibre_socket then
         CalibreWireless:disconnect()
+    end
+end
+
+function Calibre:startWirelessConnection()
+    if not CalibreWireless.calibre_socket then
+        CalibreWireless:connect()
     end
 end
 
@@ -60,6 +74,8 @@ function Calibre:onDispatcherRegisterActions()
     Dispatcher:registerAction("calibre_browse_series", { category="none", event="CalibreBrowseBy", arg="series", title=_("Browse all calibre series"), general=true,})
     Dispatcher:registerAction("calibre_browse_authors", { category="none", event="CalibreBrowseBy", arg="authors", title=_("Browse all calibre authors"), general=true,})
     Dispatcher:registerAction("calibre_browse_titles", { category="none", event="CalibreBrowseBy", arg="title", title=_("Browse all calibre titles"), general=true, separator=true,})
+    Dispatcher:registerAction("calibre_start_connection", { category="none", event="StartWirelessConnection", title=_("Calibre Wireless Connect"), general=true,})
+    Dispatcher:registerAction("calibre_close_connection", { category="none", event="CloseWirelessConnection", title=_("Calibre Wireless Disconnect"), general=true,})
 end
 
 function Calibre:init()


### PR DESCRIPTION
I added actions to start/stop the wireless connection to Calibre. This way it's possible start the connection with a gesture / add it to a gesture quick menu.
This is my first PR here, so I hope I've done everything right.
![FileManager_2024-05-12_174223](https://github.com/koreader/koreader/assets/30938717/501f9b7a-e326-42e6-b37a-7ea767f77218)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11806)
<!-- Reviewable:end -->
