### PR TITLE
Support auto-detection of input devices via fbink_input

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -569,7 +569,7 @@ function Device:exit()
     G_reader_settings:close()
 
     -- I/O teardown
-    require("ffi/input"):closeAll()
+    self.input.teardown()
 end
 
 -- Lifted from busybox's libbb/inet_cksum.c

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -300,7 +300,7 @@ function Input:disableRotationMap()
 end
 
 --[[--
-Wrapper for Lua/C input open.
+Wrapper for our Lua/C input module's open.
 
 Note that we adhere to the "." syntax here for compatibility.
 
@@ -325,7 +325,7 @@ function Input.open(path, name)
 end
 
 --[[--
-Wrapper for Lua/C input close.
+Wrapper for our Lua/C input module's close.
 
 Note that we adhere to the "." syntax here for compatibility.
 --]]
@@ -338,6 +338,16 @@ function Input.close(path)
     else
         logger.warn("Tried to close an unknown input device @", path)
     end
+end
+
+--[[--
+Wrapper for our Lua/C input module's closeAll.
+
+Note that we adhere to the "." syntax here for compatibility.
+--]]
+function Input.teardown()
+    input.closeAll()
+    Input.opened_devices = {}
 end
 
 --[[--

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -313,13 +313,14 @@ function Input.open(path, name)
         if fd then
             Input.opened_devices[path] = fd
             if name then
-                logger.dbg("Opened input device", name, "@", path)
+                logger.dbg("Opened fd", fd, "for input device", name, "@", path)
             else
-                logger.dbg("Opened input device @", path)
+                logger.dbg("Opened fd", fd, "for input device @", path)
             end
         end
         -- No need to log failures, input will have raised an error already,
         -- and we want to make those fatal, so we don't protect this call.
+        return fd
     end
 end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -307,7 +307,7 @@ Note that we adhere to the "." syntax here for compatibility.
 The `name` argument is optional, and used for logging purposes only.
 --]]
 function Input.open(path, name)
-    -- Make sure we don't open the same device twice
+    -- Make sure we don't open the same device twice.
     if not Input.opened_devices[path] then
         local fd = input.open(path)
         if fd then
@@ -348,6 +348,21 @@ Note that we adhere to the "." syntax here for compatibility.
 function Input.teardown()
     input.closeAll()
     Input.opened_devices = {}
+end
+
+-- Wrappers for the custom FFI implementations with no concept of paths or fd
+if input.is_ffi then
+    -- None of the current implementations actually *take* any arguments...
+    -- (Or they think they do, but they don't... Lookin' at you, PB).
+    function Input.open(...)
+        return input.open(...)
+    end
+    function Input.close(...)
+        return input.close(...)
+    end
+    function Input.teardown(...)
+        return input.closeAll(...)
+    end
 end
 
 --[[--

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -334,6 +334,9 @@ function Input.close(path)
     if fd then
         local ok, err = input.close(fd)
         if ok or err == C.ENODEV then
+            -- Either the call succeeded,
+            -- or the backend had already caught an ENODEV in waitForInput and closed the fd internally.
+            -- Regardless, that device is gone, so clear its spot in the hashmap.
             Input.opened_devices[path] = nil
         end
     else

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -332,8 +332,10 @@ function Input.close(path)
     -- Make sure we actually know about this device
     local fd = Input.opened_devices[path]
     if fd then
-        input.close(fd)
-        Input.opened_devices[path] = nil
+        local ok, err = input.close(fd)
+        if ok or err == C.ENODEV then
+            Input.opened_devices[path] = nil
+        end
     else
         logger.warn("Tried to close an unknown input device @", path)
     end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -352,8 +352,7 @@ end
 
 -- Wrappers for the custom FFI implementations with no concept of paths or fd
 if input.is_ffi then
-    -- None of the current implementations actually *take* any arguments...
-    -- (Or they think they do, but they don't... Lookin' at you, PB).
+    -- Pass args as-is. None of 'em actually *take* arguments, but some may be invoked as methods...
     function Input.open(...)
         return input.open(...)
     end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -197,8 +197,7 @@ local Input = {
     end,
 
     -- open'ed input devices hashmap (key: path, value: fd number)
-    -- (Must be a class member, both because Input is a singleton and that state is process-wide anyway,
-    -- and because the FFI open/close wrappers aren't methods to boot).
+    -- Must be a class member, both because Input is a singleton and that state is process-wide anyway.
     opened_devices = {},
 }
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -336,6 +336,7 @@ function Input.close(path)
         if ok or err == C.ENODEV then
             -- Either the call succeeded,
             -- or the backend had already caught an ENODEV in waitForInput and closed the fd internally.
+            -- (Because the EvdevInputRemove Event comes from an UsbDevicePlugOut uevent forwarded as an... *input* EV_KEY event ;)).
             -- Regardless, that device is gone, so clear its spot in the hashmap.
             Input.opened_devices[path] = nil
         end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -300,7 +300,7 @@ function Input:disableRotationMap()
 end
 
 --[[--
-Wrapper for FFI input open.
+Wrapper for Lua/C input open.
 
 Note that we adhere to the "." syntax here for compatibility.
 
@@ -324,7 +324,7 @@ function Input.open(path, name)
 end
 
 --[[--
-Wrapper for FFI input close.
+Wrapper for Lua/C input close.
 
 Note that we adhere to the "." syntax here for compatibility.
 --]]

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -207,9 +207,6 @@ function Kindle:supportsScreensaver()
 end
 
 function Kindle:openInputDevices()
-    -- Keep track of what we opened to avoid duplicates since we may do two passes...
-    local opened = {}
-
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
     local FBInkInput = ffi.load("fbink_input")
     local dev_count = ffi.new("size_t[1]")
@@ -220,10 +217,7 @@ function Kindle:openInputDevices()
         for i = 0, tonumber(dev_count[0]) - 1 do
             local dev = devices[i]
             if dev.matched then
-                local path = ffi.string(dev.path)
-                logger.dbg("Opening input device", ffi.string(dev.name), "@", path)
-                self.input.open(path)
-                opened[path] = true
+                self.input.open(ffi.string(dev.path), ffi.string(dev.name))
             end
         end
         C.free(devices)
@@ -250,12 +244,7 @@ function Kindle:openInputDevices()
             for i = 0, tonumber(dev_count[0]) - 1 do
                 local dev = devices[i]
                 if dev.matched then
-                    local path = ffi.string(dev.path)
-                    if not opened[path] then
-                        logger.dbg("Opening (gyro event) input device", ffi.string(dev.name), "@", path)
-                        self.input.open(path)
-                        opened[path] = true
-                    end
+                    self.input.open(ffi.string(dev.path), ffi.string(dev.name))
                 end
             end
             C.free(devices)

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -213,8 +213,8 @@ function Kindle:openInputDevices()
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
     local FBInkInput = ffi.load("fbink_input")
     local dev_count = ffi.new("size_t[1]")
-    -- We care about: the touchscreen, a properly scaled stylus and pagination buttons.
-    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_PAGINATION_BUTTONS)
+    -- We care about: the touchscreen, a properly scaled stylus, pagination buttons and a home button.
+    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_PAGINATION_BUTTONS, C.INPUT_HOME_BUTTON)
     local devices = FBInkInput.fbink_input_scan(match_mask, 0, C.SCAN_ONLY, dev_count)
     if devices ~= nil then
         for i = 0, tonumber(dev_count[0]) - 1 do

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -293,6 +293,11 @@ function Kindle:init()
         self.canDeepSleep = false
     end
 
+    -- If the device-specific init hasn't done so already (devices without keys don't), instantiate Input.
+    if not self.input then
+        self.input = require("device/input"):new{ device = self }
+    end
+
     -- Auto-detect & open input devices
     self:openInputDevices()
 

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -208,7 +208,11 @@ end
 
 function Kindle:openInputDevices()
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
-    local FBInkInput = ffi.load("fbink_input")
+    local ok, FBInkInput = pcall(ffi.load, "fbink_input")
+    if not ok then
+        -- NOP fallback for the testsuite...
+        FBInkInput = { fbink_input_scan = function() end }
+    end
     local dev_count = ffi.new("size_t[1]")
     -- We care about: the touchscreen, a properly scaled stylus, pagination buttons and a home button.
     local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_PAGINATION_BUTTONS, C.INPUT_HOME_BUTTON)

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -210,8 +210,8 @@ function Kindle:openInputDevices()
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
     local FBInkInput = ffi.load("fbink_input")
     local dev_count = ffi.new("size_t[1]")
-    -- We care about: the touchscreen, a properly scaled stylus, the accelerometer and pagination buttons.
-    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_ACCELEROMETER, C.INPUT_PAGINATION_BUTTONS)
+    -- We care about: the touchscreen, a properly scaled stylus, the rotation event and pagination buttons.
+    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_ROTATION_EVENT, C.INPUT_PAGINATION_BUTTONS)
     local devices = FBInkInput.fbink_input_scan(match_mask, 0, C.SCAN_ONLY, dev_count)
     if devices ~= nil then
         for i = 0, tonumber(dev_count[0]) - 1 do

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -218,6 +218,7 @@ function Kindle:openInputDevices()
         for i = 0, tonumber(dev_count[0]) - 1 do
             local dev = devices[i]
             if dev.matched then
+                logger.dbg("Opening input device", ffi.string(dev.name), "@", ffi.string(dev.path))
                 self.input.open(dev.path)
             end
         end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -3,7 +3,6 @@ local UIManager
 local time = require("ui/time")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
-local util = require("util")
 
 -- We're going to need a few <linux/fb.h> & <linux/input.h> constants...
 local ffi = require("ffi")

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -243,7 +243,7 @@ function Kindle:openInputDevices()
     -- Getting the device where rotation events end up without catching a bunch of false-positives is... trickier,
     -- thanks to the inane event code being used...
     if self:hasGSensor() then
-        devices = FBInkInput.fbink_input_scan(C.INPUT_ROTATION_EVENT, C.INPUT_TABLET, C.SCAN_ONLY, dev_count)
+        devices = FBInkInput.fbink_input_scan(C.INPUT_ROTATION_EVENT, C.INPUT_TABLET, bit.bor(C.SCAN_ONLY, C.NO_RECAP), dev_count)
         if devices ~= nil then
             for i = 0, tonumber(dev_count[0]) - 1 do
                 local dev = devices[i]

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -210,9 +210,8 @@ function Kindle:openInputDevices()
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
     local FBInkInput = ffi.load("fbink_input")
     local dev_count = ffi.new("size_t[1]")
-    -- We care about: the touchscreen, the stylus, the accelerometer and pagination buttons.
-    -- FIXME: See how well this works out with fancy virtual input devices on modern devices...
-    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_TABLET, C.INPUT_ACCELEROMETER, C.INPUT_PAGINATION_BUTTONS)
+    -- We care about: the touchscreen, a properly scaled stylus, the accelerometer and pagination buttons.
+    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_ACCELEROMETER, C.INPUT_PAGINATION_BUTTONS)
     local devices = FBInkInput.fbink_input_scan(match_mask, 0, C.SCAN_ONLY, dev_count)
     if devices ~= nil then
         for i = 0, tonumber(dev_count[0]) - 1 do

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -243,7 +243,9 @@ function Kindle:openInputDevices()
     -- Getting the device where rotation events end up without catching a bunch of false-positives is... trickier,
     -- thanks to the inane event code being used...
     if self:hasGSensor() then
-        devices = FBInkInput.fbink_input_scan(C.INPUT_ROTATION_EVENT, C.INPUT_TABLET, bit.bor(C.SCAN_ONLY, C.NO_RECAP), dev_count)
+        -- i.e., we want something that reports EV_ABS:ABS_PRESSURE that isn't *also* a pen (because those are pretty much guaranteed to report pressure...).
+        --       And let's add that isn't also a touchscreen to the mix, because while not true at time of writing, that's an event touchscreens sure can support...
+        devices = FBInkInput.fbink_input_scan(C.INPUT_ROTATION_EVENT, bit.bor(C.INPUT_TABLET, C.INPUT_TOUCHSCREEN), bit.bor(C.SCAN_ONLY, C.NO_RECAP), dev_count)
         if devices ~= nil then
             for i = 0, tonumber(dev_count[0]) - 1 do
                 local dev = devices[i]

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -859,7 +859,7 @@ function Kobo:init()
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
     local ok, FBInkInput = pcall(ffi.load, "fbink_input")
     if not ok then
-        -- NOP fallback foir the testsuite...
+        -- NOP fallback for the testsuite...
         FBInkInput = { fbink_input_scan = NOP }
     end
     local dev_count = ffi.new("size_t[1]")

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -141,6 +141,7 @@ local Kobo = Generic:extend{
     battery_sysfs = "/sys/class/power_supply/mc13892_bat",
     -- Stable path to the NTX input device
     ntx_dev = "/dev/input/event0",
+    ntx_fd = nil,
     -- Stable path to the Touch input device
     touch_dev = "/dev/input/event1",
     -- Event code to use to detect contact pressure

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -857,7 +857,11 @@ function Kobo:init()
     self:initEventAdjustHooks()
 
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
-    local FBInkInput = ffi.load("fbink_input")
+    local ok, FBInkInput = pcall(ffi.load, "fbink_input")
+    if not ok then
+        -- NOP fallback foir the testsuite...
+        FBInkInput = { fbink_input_scan = NOP }
+    end
     local dev_count = ffi.new("size_t[1]")
     -- We care about: the touchscreen, the stylus, the power button, the sleep cover, and pagination buttons
     -- (and technically rotation events, but we'll get it with the device that provides the buttons on NTX).

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -872,11 +872,9 @@ function Kobo:init()
                 -- We need to single out whichever device provides pagination buttons or sleep cover events, as we'll want to tweak key repeat there...
                 -- The first one will do, as it's extremely likely to be event0, and that's pretty fairly set in stone on NTX boards.
                 if (bit.band(dev.type, C.INPUT_PAGINATION_BUTTONS) ~= 0 or bit.band(dev.type, C.INPUT_SLEEP_COVER) ~= 0) and not self.ntx_fd then
-                    logger.dbg("Opening (ntx_fd) input device", ffi.string(dev.name), "@", path)
-                    self.ntx_fd = self.input.open(path)
+                    self.ntx_fd = self.input.open(path, ffi.string(dev.name))
                 else
-                    logger.dbg("Opening input device", ffi.string(dev.name), "@", path)
-                    self.input.open(path)
+                    self.input.open(path, ffi.string(dev.name))
                 end
             end
         end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -868,13 +868,12 @@ function Kobo:init()
         for i = 0, tonumber(dev_count[0]) - 1 do
             local dev = devices[i]
             if dev.matched then
-                local path = ffi.string(dev.path)
                 -- We need to single out whichever device provides pagination buttons or sleep cover events, as we'll want to tweak key repeat there...
                 -- The first one will do, as it's extremely likely to be event0, and that's pretty fairly set in stone on NTX boards.
                 if (bit.band(dev.type, C.INPUT_PAGINATION_BUTTONS) ~= 0 or bit.band(dev.type, C.INPUT_SLEEP_COVER) ~= 0) and not self.ntx_fd then
-                    self.ntx_fd = self.input.open(path, ffi.string(dev.name))
+                    self.ntx_fd = self.input.open(ffi.string(dev.path), ffi.string(dev.name))
                 else
-                    self.input.open(path, ffi.string(dev.name))
+                    self.input.open(ffi.string(dev.path), ffi.string(dev.name))
                 end
             end
         end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -869,7 +869,8 @@ function Kobo:init()
             if dev.matched then
                 local path = ffi.string(dev.path)
                 -- We need to single out whichever device provides pagination buttons or sleep cover events, as we'll want to tweak key repeat there...
-                if bit.band(dev.type, C.INPUT_PAGINATION_BUTTONS) ~= 0 or bit.band(dev.type, C.INPUT_SLEEP_COVER) ~= 0 then
+                -- The first one will do, as it's extremely likely to be event0, and that's pretty fairly set in stone on NTX boards.
+                if (bit.band(dev.type, C.INPUT_PAGINATION_BUTTONS) ~= 0 or bit.band(dev.type, C.INPUT_SLEEP_COVER) ~= 0) and not self.ntx_fd then
                     logger.dbg("Opening (ntx_fd) input device", ffi.string(dev.name), "@", path)
                     self.ntx_fd = self.input.open(path)
                 else

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -614,7 +614,7 @@ function Kobo:getKeyRepeat()
     self.key_repeat = ffi.new("unsigned int[?]", C.REP_CNT)
     if C.ioctl(self.ntx_fd, C.EVIOCGREP, self.key_repeat) < 0 then
         local err = ffi.errno()
-        logger.warn("Device:getKeyRepeat: EVIOCGREP ioctl failed:", ffi.string(C.strerror(err)))
+        logger.warn("Device:getKeyRepeat: EVIOCGREP ioctl on fd", self.ntx_fd, "failed:", ffi.string(C.strerror(err)))
         return false
     else
         logger.dbg("Key repeat is set up to repeat every", self.key_repeat[C.REP_PERIOD], "ms after a delay of", self.key_repeat[C.REP_DELAY], "ms")
@@ -628,14 +628,14 @@ function Kobo:disableKeyRepeat()
     local key_repeat = ffi.new("unsigned int[?]", C.REP_CNT)
     if C.ioctl(self.ntx_fd, C.EVIOCSREP, key_repeat) < 0 then
         local err = ffi.errno()
-        logger.warn("Device:disableKeyRepeat: EVIOCSREP ioctl failed:", ffi.string(C.strerror(err)))
+        logger.warn("Device:disableKeyRepeat: EVIOCSREP ioctl on fd", self.ntx_fd, "failed:", ffi.string(C.strerror(err)))
     end
 end
 
 function Kobo:restoreKeyRepeat()
     if C.ioctl(self.ntx_fd, C.EVIOCSREP, self.key_repeat) < 0 then
         local err = ffi.errno()
-        logger.warn("Device:restoreKeyRepeat: EVIOCSREP ioctl failed:", ffi.string(C.strerror(err)))
+        logger.warn("Device:restoreKeyRepeat: EVIOCSREP ioctl on fd", self.ntx_fd, "failed:", ffi.string(C.strerror(err)))
     end
 end
 
@@ -652,7 +652,7 @@ function Kobo:toggleKeyRepeat(toggle)
         -- Check the current (kernel) state to know what to do
         if C.ioctl(self.ntx_fd, C.EVIOCGREP, key_repeat) < 0 then
             local err = ffi.errno()
-            logger.warn("Device:toggleKeyRepeat: EVIOCGREP ioctl failed:", ffi.string(C.strerror(err)))
+            logger.warn("Device:toggleKeyRepeat: EVIOCGREP ioctl on fd", self.ntx_fd, "failed:", ffi.string(C.strerror(err)))
             return false
         else
             if key_repeat[C.REP_DELAY] == 0 and key_repeat[C.REP_PERIOD] == 0 then
@@ -665,7 +665,7 @@ function Kobo:toggleKeyRepeat(toggle)
 
     if C.ioctl(self.ntx_fd, C.EVIOCSREP, key_repeat) < 0 then
         local err = ffi.errno()
-        logger.warn("Device:toggleKeyRepeat: EVIOCSREP ioctl failed:", ffi.string(C.strerror(err)))
+        logger.warn("Device:toggleKeyRepeat: EVIOCSREP ioctl on fd", self.ntx_fd, "failed:", ffi.string(C.strerror(err)))
         return false
     end
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -866,13 +866,14 @@ function Kobo:init()
         for i = 0, tonumber(dev_count[0]) - 1 do
             local dev = devices[i]
             if dev.matched then
+                local path = ffi.string(dev.path)
                 -- We need to single out whichever device provides pagination buttons or sleep cover events, as we'll want to tweak key repeat there...
                 if bit.band(dev.type, C.INPUT_PAGINATION_BUTTONS) ~= 0 or bit.band(dev.type, C.INPUT_SLEEP_COVER) ~= 0 then
-                    logger.dbg("Opening (ntx_fd) input device", ffi.string(dev.name), "@", ffi.string(dev.path))
-                    self.ntx_fd = self.input.open(dev.path)
+                    logger.dbg("Opening (ntx_fd) input device", ffi.string(dev.name), "@", path)
+                    self.ntx_fd = self.input.open(path)
                 else
-                    logger.dbg("Opening input device", ffi.string(dev.name), "@", ffi.string(dev.path))
-                    self.input.open(dev.path)
+                    logger.dbg("Opening input device", ffi.string(dev.name), "@", path)
+                    self.input.open(path)
                 end
             end
         end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -860,8 +860,9 @@ function Kobo:init()
     local dev_count = ffi.new("size_t[1]")
     -- We care about: the touchscreen, the stylus, the power button, the sleep cover, and pagination buttons
     -- (and technically rotation events, but we'll get it with the device that provides the buttons on NTX).
+    -- We exclude keyboards to play nice with the ExternalKeyboard plugin, which will handle potential keyboards on its own.
     local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_TABLET, C.INPUT_POWER_BUTTON, C.INPUT_SLEEP_COVER, C.INPUT_PAGINATION_BUTTONS)
-    local devices = FBInkInput.fbink_input_scan(match_mask, 0, C.SCAN_ONLY, dev_count)
+    local devices = FBInkInput.fbink_input_scan(match_mask, C.INPUT_KEYBOARD, C.SCAN_ONLY, dev_count)
     if devices ~= nil then
         for i = 0, tonumber(dev_count[0]) - 1 do
             local dev = devices[i]

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -868,8 +868,10 @@ function Kobo:init()
             if dev.matched then
                 -- We need to single out whichever device provides pagination buttons or sleep cover events, as we'll want to tweak key repeat there...
                 if bit.band(dev.type, C.INPUT_PAGINATION_BUTTONS) ~= 0 or bit.band(dev.type, C.INPUT_SLEEP_COVER) ~= 0 then
+                    logger.dbg("Opening (ntx_fd) input device", ffi.string(dev.name), "@", ffi.string(dev.path))
                     self.ntx_fd = self.input.open(dev.path)
                 else
+                    logger.dbg("Opening input device", ffi.string(dev.name), "@", ffi.string(dev.path))
                     self.input.open(dev.path)
                 end
             end

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -56,7 +56,7 @@ local PocketBook = Generic:extend{
         -- Works same as input.event_map, but for raw input EV_KEY translation
         keymap = { [scan] = event },
     }]]
-    -- Runtime state: whether raw input is actually used
+    -- We'll nil raw_input at runtime if it cannot be used.
 
     -- InkView may have started translating button codes based on rotation on newer devices...
     -- That historically wasn't the case, hence this defaulting to false.
@@ -240,6 +240,8 @@ function PocketBook:init()
     -- NOTE: This all happens in ffi/input_pocketbook.lua
 
     self._model_init()
+    -- NOTE: This is the odd one out actually calling input.open as a *method*,
+    --       which the imp supports to get access to self.input.raw_input
     if (not self.input.raw_input) or (not pcall(self.input.open, self.input)) then
         inkview.OpenScreen()
         -- Raw mode open failed (no permissions?), so we'll run the usual way.

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -57,8 +57,6 @@ local PocketBook = Generic:extend{
         keymap = { [scan] = event },
     }]]
     -- Runtime state: whether raw input is actually used
-    --- @fixme: Never actually set anywhere?
-    is_using_raw_input = nil,
 
     -- InkView may have started translating button codes based on rotation on newer devices...
     -- That historically wasn't the case, hence this defaulting to false.
@@ -242,8 +240,7 @@ function PocketBook:init()
     -- NOTE: This all happens in ffi/input_pocketbook.lua
 
     self._model_init()
-    --- @fixme: ffi/input_pocketbook's open implementation doesn't actually take any argument, it pokes at self.raw_input via self instead...
-    if (not self.input.raw_input) or (not pcall(self.input.open, self.input, self.raw_input)) then
+    if (not self.input.raw_input) or (not pcall(self.input.open, self.input)) then
         inkview.OpenScreen()
         -- Raw mode open failed (no permissions?), so we'll run the usual way.
         -- Disable touch coordinate translation as inkview will do that.

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -242,6 +242,7 @@ function PocketBook:init()
     -- NOTE: This all happens in ffi/input_pocketbook.lua
 
     self._model_init()
+    --- @fixme: ffi/input_pocketbook's open implementation doesn't actually take any argument, it pokes at self.raw_input via self instead...
     if (not self.input.raw_input) or (not pcall(self.input.open, self.input, self.raw_input)) then
         inkview.OpenScreen()
         -- Raw mode open failed (no permissions?), so we'll run the usual way.

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -62,11 +62,15 @@ function UIManager:init()
         UsbDevicePlugIn = function(input_event)
             -- Retrieve the argument set by Input:handleKeyBoardEv
             local evdev = table.remove(Input.fake_event_args[input_event])
-            self:broadcastEvent(Event:new("EvdevInputInsert", evdev))
+            local path = "/dev/input/event" .. tostring(evdev)
+
+            self:broadcastEvent(Event:new("EvdevInputInsert", path))
         end,
         UsbDevicePlugOut = function(input_event)
             local evdev = table.remove(Input.fake_event_args[input_event])
-            self:broadcastEvent(Event:new("EvdevInputRemove", evdev))
+            local path = "/dev/input/event" .. tostring(evdev)
+
+            self:broadcastEvent(Event:new("EvdevInputRemove", path))
         end,
     }
     self.poweroff_action = function()

--- a/plugins/externalkeyboard.koplugin/main.lua
+++ b/plugins/externalkeyboard.koplugin/main.lua
@@ -295,7 +295,7 @@ local function findKeyboards()
             if dev.matched then
                 -- Check if it provides a DPad, too.
                 local has_dpad = bit.band(dev.type, C.INPUT_DPAD) ~= 0
-                table.insert(keyboards, { event_path = ffi.string(dev.path), had_dpad = has_dpad })
+                table.insert(keyboards, { event_path = ffi.string(dev.path), has_dpad = has_dpad })
             end
         end
         C.free(devices)


### PR DESCRIPTION
* Kobo: Drop a bunch of if ladder crap and switch to auto-detection of input devices via fbink_input
* Kindle: Drop an even larger bundle of crap to do the same ;p. (re: #11392)
* ExternalKeyboard: Switch to fbink_input to whitelist keyboards instead of the manual parsing of caps via its FindKeyboard class
* Input: Extended open/close wrappers to handle logging & tracking of dupe open/close calls.

Depends on https://github.com/koreader/koreader-base/pull/1782 & https://github.com/koreader/koreader-base/pull/1785

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11807)
<!-- Reviewable:end -->
