### PR TITLE
android: fix building with kodev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,12 @@ ifneq (,$(wildcard make/$(TARGET).mk))
   include make/$(TARGET).mk
 endif
 
+android-ndk:
+	$(MAKE) -C $(KOR_BASE)/toolchain $(ANDROID_NDK_HOME)
+
+android-sdk:
+	$(MAKE) -C $(KOR_BASE)/toolchain $(ANDROID_HOME)
+
 # for gettext
 DOMAIN=koreader
 TEMPLATE_DIR=l10n/templates
@@ -210,4 +216,4 @@ static-check:
 doc:
 	make -C doc
 
-.PHONY: all base clean doc test
+.PHONY: all android-ndk android-sdk base clean doc test

--- a/make/android.mk
+++ b/make/android.mk
@@ -4,12 +4,6 @@ ANDROID_ASSETS = $(ANDROID_LAUNCHER_DIR)/assets/module
 ANDROID_LIBS_ROOT = $(ANDROID_LAUNCHER_DIR)/libs
 ANDROID_LIBS_ABI = $(ANDROID_LIBS_ROOT)/$(ANDROID_ABI)
 
-android-ndk:
-	$(MAKE) -C $(KOR_BASE)/toolchain $(ANDROID_NDK_HOME)
-
-android-sdk:
-	$(MAKE) -C $(KOR_BASE)/toolchain $(ANDROID_HOME)
-
 androiddev: update
 	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) dev
 
@@ -70,4 +64,4 @@ update: all
 	cp $(ANDROID_LAUNCHER_DIR)/bin/NativeActivity.apk \
 		koreader-android-$(ANDROID_ARCH)$(KODEDUG_SUFFIX)-$(VERSION).apk
 
-.PHONY: android-ndk android-sdk androiddev update
+.PHONY: androiddev update


### PR DESCRIPTION
If the Android NDK and/or SDK are not setup, `kodev` will try to invoke the `android-ndk` and/or `android-sdk` make targets.  This can't be done with `TARGET=android`, as `base/Makefile.defs` will error out trying to call the (missing) compiler to get the target machine. Those rules need to be available to all targets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11817)
<!-- Reviewable:end -->
