### PR TITLE
Kindle: Don't forget about fiveways on legacy devices & fix a couple input-scan misdetections

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -214,8 +214,8 @@ function Kindle:openInputDevices()
         FBInkInput = { fbink_input_scan = function() end }
     end
     local dev_count = ffi.new("size_t[1]")
-    -- We care about: the touchscreen, a properly scaled stylus, pagination buttons and a home button.
-    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_PAGINATION_BUTTONS, C.INPUT_HOME_BUTTON)
+    -- We care about: the touchscreen, a properly scaled stylus, pagination buttons, a home button and a fiveway.
+    local match_mask = bit.bor(C.INPUT_TOUCHSCREEN, C.INPUT_SCALED_TABLET, C.INPUT_PAGINATION_BUTTONS, C.INPUT_HOME_BUTTON, C.INPUT_DPAD)
     local devices = FBInkInput.fbink_input_scan(match_mask, 0, C.SCAN_ONLY, dev_count)
     if devices ~= nil then
         for i = 0, tonumber(dev_count[0]) - 1 do


### PR DESCRIPTION
* Kindle: Don't forget to open INPU_DPAD devices for the fiveways. Somehow managed to skip my mind, they're often on a separate input device.

Regression since #11807

* Update FBInk to fix a few cases of input_scan misdetection (on misconfigured drivers (e.g., no DIRECT prop on supported kernels), or old kernels with no EVIOCGPROP support).

Fix #11824

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11827)
<!-- Reviewable:end -->
