### PR TITLE
better flatpak support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ KOR_BASE?=base
 
 include $(KOR_BASE)/Makefile.defs
 
+RELEASE_DATE := $(shell git show -s --format=format:"%cd" --date=short HEAD)
 # We want VERSION to carry the version of the KOReader main repo, not that of koreader-base
-VERSION:=$(shell git describe HEAD)
+VERSION := $(shell git describe HEAD)
 # Only append date if we're not on a whole version, like v2018.11
 ifneq (,$(findstring -,$(VERSION)))
-	VERSION:=$(VERSION)_$(shell git show -s --format=format:"%cd" --date=short HEAD)
+	VERSION := $(VERSION)_$(RELEASE_DATE)
 endif
 
 # releases do not contain tests and misc data

--- a/datastorage.lua
+++ b/datastorage.lua
@@ -17,7 +17,7 @@ function DataStorage:getDataDir()
         local package_name = app_id:match("^(.-)_")
         -- confined ubuntu app has write access to this dir
         data_dir = string.format("%s/%s", os.getenv("XDG_DATA_HOME"), package_name)
-    elseif os.getenv("APPIMAGE") or os.getenv("KO_MULTIUSER") then
+    elseif os.getenv("APPIMAGE") or os.getenv("FLATPAK") or os.getenv("KO_MULTIUSER") then
         if os.getenv("XDG_CONFIG_HOME") then
             data_dir = string.format("%s/%s", os.getenv("XDG_CONFIG_HOME"), "koreader")
             if lfs.attributes(os.getenv("XDG_CONFIG_HOME"), "mode") ~= "directory" then

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -120,6 +120,12 @@ local Desktop = Device:extend{
     hasExitOptions = notOSX,
 }
 
+local Flatpak = Device:extend{
+    model = "Flatpak",
+    isDesktop = yes,
+    canExternalDictLookup = no,
+}
+
 local Emulator = Device:extend{
     model = "Emulator",
     isEmulator = yes,
@@ -436,6 +442,8 @@ io.write("Starting SDL in " .. SDL.getBasePath() .. "\n")
 -------------- device probe ------------
 if os.getenv("APPIMAGE") then
     return AppImage
+elseif os.getenv("FLATPAK") then
+    return Flatpak
 elseif os.getenv("KO_MULTIUSER") then
     return Desktop
 elseif os.getenv("UBUNTU_APPLICATION_ISOLATION") then

--- a/make/appimage.mk
+++ b/make/appimage.mk
@@ -7,9 +7,9 @@ update: all
 	# remove old package if any
 	rm -f koreader-appimage-$(MACHINE)-$(VERSION).appimage
 	$(SYMLINK) $(abspath $(APPIMAGE_DIR)/AppRun) $(INSTALL_DIR)/koreader/
-	$(SYMLINK) $(abspath $(APPIMAGE_DIR)/koreader.appdata.xml) $(INSTALL_DIR)/koreader/
 	$(SYMLINK) $(abspath $(APPIMAGE_DIR)/koreader.desktop) $(INSTALL_DIR)/koreader/
 	$(SYMLINK) $(abspath resources/koreader.png) $(INSTALL_DIR)/koreader/
+    sed -e 's/%%VERSION%%/$(VERSION)/' -e 's/%%DATE%%/$(RELEASE_DATE)/' $(APPIMAGE_DIR)/koreader.appdata.xml >$(INSTALL_DIR)/koreader/koreader.appdata.xml
 	# TODO at best this is DebUbuntu specific
 	$(SYMLINK) /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 $(INSTALL_DIR)/koreader/libs/libSDL2.so
 	# required for our stock Ubuntu SDL even though we don't use sound

--- a/make/linux.mk
+++ b/make/linux.mk
@@ -9,6 +9,7 @@ update: all
 		$(INSTALL_DIR)/linux/share/applications \
 		$(INSTALL_DIR)/linux/share/doc/koreader \
 		$(INSTALL_DIR)/linux/share/man/man1
+    sed -e 's/%%VERSION%%/$(VERSION)/' -e 's/%%DATE%%/$(RELEASE_DATE)/' $(PLATFORM_DIR)/appimage/koreader.appdata.xml >$(INSTALL_DIR)/linux/koreader.appdata.xml
 	cp -pv resources/koreader.png $(INSTALL_DIR)/linux/share/pixmaps
 	cp -pv $(LINUX_DIR)/koreader.desktop $(INSTALL_DIR)/linux/share/applications
 	cp -pv $(LINUX_DIR)/copyright COPYING $(INSTALL_DIR)/linux/share/doc/koreader

--- a/platform/appimage/koreader.appdata.xml
+++ b/platform/appimage/koreader.appdata.xml
@@ -50,5 +50,8 @@
     <category>Viewer</category>
     <category>Literature</category>
   </categories>
+  <releases>
+    <release version="%%VERSION%%" date="%%DATE%%"/>
+  </releases>
   <content_rating type="oars-1.1"/>
 </component>

--- a/platform/linux/do_debian_package.sh
+++ b/platform/linux/do_debian_package.sh
@@ -65,6 +65,7 @@ fi
 mkdir -p tmp-debian/usr
 chmod 0755 tmp-debian/usr
 tar -xf "${1}" -C tmp-debian/usr
+rm -f tmp-debian/usr/koreader.appdata.xml
 ARCH="$(echo "${1}" | cut -d '-' -f3)"
 VERSION="$(cut -f2 -dv "tmp-debian/usr/lib/koreader/git-rev" | cut -f1,2 -d-)"
 DEB_ARCH="$(uname_to_debian "${ARCH}")"


### PR DESCRIPTION

Add a flavor to represent flatpak limitations (No OTA updates. Cannot restart, reboot, poweroff... )

Include appstream metadata in generic linux packages. Related to https://github.com/flathub/rocks.koreader.KOReader/issues/42

Add version and release data to appstream metadata at build time for appimage/linux flavors. 


Maybe @benoit-pierre could come up with a better `make` | `sed` foo? Thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11833)
<!-- Reviewable:end -->
