### PR TITLE
bump crengine: minor fixes (ruby, a crash, non-linear flows)

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1378,6 +1378,11 @@ function CreDocument:setBatteryState(state)
     self._document:setBatteryState(state)
 end
 
+function CreDocument:setPageInfoOverride(pageinfo)
+    logger.dbg("CreDocument: set page info", pageinfo)
+    self._document:setPageInfoOverride(pageinfo)
+end
+
 function CreDocument:isXPointerInCurrentPage(xp)
     logger.dbg("CreDocument: check xpointer in current page", xp)
     return self._document:isXPointerInCurrentPage(xp)


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/565, https://github.com/koreader/koreader-base/pull/1792 : 
- html5.css: really ensure ruby centering
  Closes #11771.
- getRenderedWidths(): fix possible crash with 0-width images
  Closes #11680.
- Page splitting: ignore empty non-linear flows
  See https://github.com/koreader/koreader/issues/8623#issuecomment-2068168592.
- LvDocView header: allow overriding "page/total %"

CreDocument: add setPageInfoOverride() to allow tweaking top status bar display of page number/count/% (to be implemented in a later commit). Will help solving #11561 (and may be others).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11863)
<!-- Reviewable:end -->
