### PR TITLE
FocusManager: enable more keyboard shortcuts by default

### DIFF
--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -56,7 +56,6 @@ local function populateEventMappings()
 
         -- Advanced features: more event handlers can be enabled via settings.reader.lua
         table.insert(event_keys, { "HoldContext",    { { "ContextMenu" },  event = "Hold" } })
-        table.insert(event_keys, { "Hold",           { { "Sym", "AA" },    event = "Hold" } })
         -- half rows/columns move, it is helpful for slow device like Kindle DX to move quickly
         table.insert(event_keys, { "HalfFocusUp",    { { "Alt", "Up" },    event = "FocusHalfMove", args = {"up"} } })
         table.insert(event_keys, { "HalfFocusRight", { { "Alt", "Right" }, event = "FocusHalfMove", args = {"right"} } })
@@ -66,6 +65,8 @@ local function populateEventMappings()
         table.insert(event_keys, { "FocusNext",      { { "Tab" },          event = "FocusNext" } })
         table.insert(event_keys, { "FocusPrevious",  { { "Shift", "Tab" }, event = "FocusPrevious" } })
         local NORMAL_KEYS_END_INDEX = #event_keys
+
+        table.insert(event_keys, { "HoldSymAA",      { { "Sym", "AA" },    event = "Hold" } })
 
         for i = 1, FEW_KEYS_END_INDEX do
             local key_name = event_keys[i][1]

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -53,10 +53,9 @@ local function populateEventMappings()
         local FEW_KEYS_END_INDEX = #event_keys -- Few keys device: only setup up, down, right and press
 
         table.insert(event_keys, { "FocusLeft",  { { "Left" },  event = "FocusMove", args = {-1, 0} } })
-        local NORMAL_KEYS_END_INDEX = #event_keys
 
-        -- Advanced Feature: following event handlers can be enabled via settings.reader.lua
-        -- Key combinations (Sym+AA, Alt+Up, Tab, Shift+Tab and so on) are not used but shown as examples here
+        -- Advanced features: more event handlers can be enabled via settings.reader.lua
+        table.insert(event_keys, { "HoldContext",    { { "ContextMenu" },  event = "Hold" } })
         table.insert(event_keys, { "Hold",           { { "Sym", "AA" },    event = "Hold" } })
         -- half rows/columns move, it is helpful for slow device like Kindle DX to move quickly
         table.insert(event_keys, { "HalfFocusUp",    { { "Alt", "Up" },    event = "FocusHalfMove", args = {"up"} } })
@@ -66,6 +65,7 @@ local function populateEventMappings()
         -- for PC navigation behavior support
         table.insert(event_keys, { "FocusNext",      { { "Tab" },          event = "FocusNext" } })
         table.insert(event_keys, { "FocusPrevious",  { { "Shift", "Tab" }, event = "FocusPrevious" } })
+        local NORMAL_KEYS_END_INDEX = #event_keys
 
         for i = 1, FEW_KEYS_END_INDEX do
             local key_name = event_keys[i][1]

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -54,8 +54,8 @@ local function populateEventMappings()
 
         table.insert(event_keys, { "FocusLeft",  { { "Left" },  event = "FocusMove", args = {-1, 0} } })
 
-        -- Advanced features: more event handlers can be enabled via settings.reader.lua
         table.insert(event_keys, { "HoldContext",    { { "ContextMenu" },  event = "Hold" } })
+        table.insert(event_keys, { "HoldShift",      { { "Shift", "Press" }, event = "Hold" } })
         -- half rows/columns move, it is helpful for slow device like Kindle DX to move quickly
         table.insert(event_keys, { "HalfFocusUp",    { { "Alt", "Up" },    event = "FocusHalfMove", args = {"up"} } })
         table.insert(event_keys, { "HalfFocusRight", { { "Alt", "Right" }, event = "FocusHalfMove", args = {"right"} } })
@@ -66,6 +66,7 @@ local function populateEventMappings()
         table.insert(event_keys, { "FocusPrevious",  { { "Shift", "Tab" }, event = "FocusPrevious" } })
         local NORMAL_KEYS_END_INDEX = #event_keys
 
+        -- Advanced features: more event handlers can be enabled via settings.reader.lua
         table.insert(event_keys, { "HoldSymAA",      { { "Sym", "AA" },    event = "Hold" } })
 
         for i = 1, FEW_KEYS_END_INDEX do

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -54,8 +54,10 @@ local function populateEventMappings()
 
         table.insert(event_keys, { "FocusLeft",  { { "Left" },  event = "FocusMove", args = {-1, 0} } })
 
+        -- Advanced features: more event handlers can be enabled via settings.reader.lua in a similar manner
         table.insert(event_keys, { "HoldContext",    { { "ContextMenu" },  event = "Hold" } })
         table.insert(event_keys, { "HoldShift",      { { "Shift", "Press" }, event = "Hold" } })
+        table.insert(event_keys, { "HoldSymAA",      { { "Sym", "AA" },    event = "Hold" } })
         -- half rows/columns move, it is helpful for slow device like Kindle DX to move quickly
         table.insert(event_keys, { "HalfFocusUp",    { { "Alt", "Up" },    event = "FocusHalfMove", args = {"up"} } })
         table.insert(event_keys, { "HalfFocusRight", { { "Alt", "Right" }, event = "FocusHalfMove", args = {"right"} } })
@@ -65,9 +67,6 @@ local function populateEventMappings()
         table.insert(event_keys, { "FocusNext",      { { "Tab" },          event = "FocusNext" } })
         table.insert(event_keys, { "FocusPrevious",  { { "Shift", "Tab" }, event = "FocusPrevious" } })
         local NORMAL_KEYS_END_INDEX = #event_keys
-
-        -- Advanced features: more event handlers can be enabled via settings.reader.lua
-        table.insert(event_keys, { "HoldSymAA",      { { "Sym", "AA" },    event = "Hold" } })
 
         for i = 1, FEW_KEYS_END_INDEX do
             local key_name = event_keys[i][1]


### PR DESCRIPTION
Also add ContextMenu for hold.

@comphilip I don't see much of a reason not to enable these, unless there's a specific reason not to?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11871)
<!-- Reviewable:end -->
