### PR TITLE
Footer and header tweaks and fixes

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -265,9 +265,12 @@ local footerTextGeneratorMap = {
         if footer.pageno then
             if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
                 -- (Page labels might not be numbers)
-                return ("%s %s / %s"):format(prefix,
-                                          footer.ui.pagemap:getCurrentPageLabel(true),
-                                          footer.ui.pagemap:getLastPageLabel(true))
+                local label, idx, count = footer.ui.pagemap:getCurrentPageLabel(false) -- luacheck: no unused
+                local remaining = count - idx
+                if footer.settings.pages_left_includes_current_page then
+                    remaining = remaining + 1
+                end
+                return ("%s %s / %s"):format(prefix, remaining, footer.ui.pagemap:getLastPageLabel(true))
             end
             if footer.ui.document:hasHiddenFlows() then
                 -- i.e., if we are hiding non-linear fragments and there's anything to hide,
@@ -2488,6 +2491,9 @@ function ReaderFooter:getChapterProgress(get_percentage, pageno)
         current = current + 1
     else
         current = pageno
+        if self.ui.document:hasHiddenFlows() then
+            current = self.ui.document:getPageNumberInFlow(pageno)
+        end
     end
     local total = self.ui.toc:getChapterPageCount(pageno) or self.pages
     if get_percentage then

--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -280,8 +280,11 @@ function ReaderPageMap:getCurrentPageLabel(clean_label)
     -- For consistency, getPageMapCurrentPageLabel() returns the last page
     -- label shown in the view if there are more than one (or the previous
     -- one if there is none).
-    local label = self.ui.document:getPageMapCurrentPageLabel()
-    return clean_label and self:cleanPageLabel(label) or label
+    local label, idx, count = self.ui.document:getPageMapCurrentPageLabel()
+    if clean_label then
+        label = self:cleanPageLabel(label)
+    end
+    return label, idx, count
 end
 
 function ReaderPageMap:getFirstPageLabel(clean_label)


### PR DESCRIPTION
#### ReaderFooter: fix minor issues with pages left & chapter progress

When using Reference page numbers, "Pages left" was showing the same info as "Current page", because Reference pages, being strings, couldn't be used for arithmetics. But we can just count the number of items left in the Reference pages array of strings.
Closes #11561 (I think I've seen this discussed elsewhere too.)

Also fix edge case with "page progress" with hidden flow when we are before the first chapter with a hidden flow before.
Noticed at https://github.com/koreader/koreader/issues/10193#issuecomment-2106274054.

#### AltStatusBar: show page info similar as in footer

We now build the "page/total %" string ourselves, with the same logic as used in the footer (including when hidden flows or reference page numbers are used) and give it to crengine to be displayed instead of its own way of doing it.
Uses bits previously added by https://github.com/koreader/koreader/pull/11863.
Discussed in and around https://github.com/koreader/koreader/issues/9020#issuecomment-2045865939.
(Not super tested, we'll see.)

#### userpatch: add a few helpers that can be used in userpatches

Make the few tricks we discovered readily available, which should make user patch simpler.
Example of how to use them at https://github.com/koreader/koreader/pull/11838#issuecomment-2124493747.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11873)
<!-- Reviewable:end -->
