### PR TITLE
Kobo: Boost saturation for CFA refreshes (and add a dev setting to disable it)

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -629,6 +629,18 @@ To:
             end,
         })
     end
+    if Device:isKobo() and Device:hasColorScreen() then
+        table.insert(self.menu_items.developer_options.sub_item_table, {
+            text = _("Disable CFA post-processing"),
+            checked_func = function()
+                return G_reader_settings:isTrue("no_cfa_post_processing")
+            end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("no_cfa_post_processing")
+                UIManager:askForRestart()
+            end,
+        })
+    end
     table.insert(self.menu_items.developer_options.sub_item_table, {
         text = _("Anti-alias rounded corners"),
         checked_func = function()

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -631,6 +631,9 @@ To:
     end
     if Device:isKobo() and Device:hasColorScreen() then
         table.insert(self.menu_items.developer_options.sub_item_table, {
+            -- We default to a flag (G2) that slightly boosts saturation,
+            -- but it *is* a destructive process, so we want to allow disabling it.
+            -- @translators CFA is a technical term for the technology behind eInk's color panels. It stands for Color Film/Filter Array, leave the abbreviation alone ;).
             text = _("Disable CFA post-processing"),
             checked_func = function()
                 return G_reader_settings:isTrue("no_cfa_post_processing")

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -699,6 +699,7 @@ function Kobo:init()
             debug = logger.dbg,
             is_always_portrait = self.isAlwaysPortrait(),
             mxcfb_bypass_wait_for = mxcfb_bypass_wait_for,
+            no_cfa_post_processing = G_reader_settings:isTrue("no_cfa_post_processing"),
         }
         if self.screen.fb_bpp == 32 and not self:hasColorScreen() then
             -- Ensure we decode images properly, as our framebuffer is BGRA...


### PR DESCRIPTION
Being able to disable it can be interesting, because it *is* a somewhat destructive process.

Depends on https://github.com/koreader/koreader-base/pull/1794

Fix #11756

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11883)
<!-- Reviewable:end -->
