### PR TITLE
Add ReaderLink::registerScheme for plugins handling non-http(s) links

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -67,6 +67,7 @@ local ReaderLink = InputContainer:extend{
     location_stack = nil, -- table, per-instance
     forward_location_stack = nil, -- table, per-instance
     _external_link_buttons = nil,
+    handledSchemes = {"http", "https"},
 }
 
 function ReaderLink:init()
@@ -223,6 +224,10 @@ function ReaderLink:init()
             end,
         }
     end
+end
+
+function ReaderLink:registerScheme(scheme)
+    table.insert(self.handledSchemes, scheme)
 end
 
 function ReaderLink:onGesture() end
@@ -824,8 +829,9 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
     end
     logger.dbg("ReaderLink:onGotoLink: External link:", link_url)
 
-    local is_http_link = link_url:find("^https?://") ~= nil
-    if is_http_link and self:onGoToExternalLink(link_url) then
+    local scheme = link_url:match("^(%w+)://")
+    local is_handled_external_link = scheme and util.arrayContains(self.handledSchemes, scheme)
+    if is_handled_external_link and self:onGoToExternalLink(link_url) then
         return true
     end
 


### PR DESCRIPTION
Currently, links with a scheme other than http or https are rejected. But plugins may want to handle them. This allows them to, by registering the scheme with self.ui.link:registerScheme("example") during the plugin's init. (Motivation: I am writing a plugin for the gemini protocol.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11889)
<!-- Reviewable:end -->
