### PR TITLE
Don't send empty string as note in readwise export

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -243,7 +243,7 @@ function MyClipping:parseAnnotations(annotations, book)
                 page    = item.pageno,
                 time    = self:getTime(item.datetime),
                 text    = self:getText(item.text),
-                note    = self:getText(item.note),
+                note    = item.note and self:getText(item.note),
                 chapter = item.chapter,
                 drawer  = item.drawer,
             }

--- a/plugins/exporter.koplugin/target/readwise.lua
+++ b/plugins/exporter.koplugin/target/readwise.lua
@@ -104,7 +104,7 @@ function ReadwiseExporter:createHighlights(booknotes)
                 author = booknotes.author ~= "" and booknotes.author:gsub("\n", ", ") or nil, -- optional author
                 source_type = "koreader",
                 category = "books",
-                note = clipping.note,
+                note = clipping.note ~= "" and clipping.note or nil,
                 location = clipping.page,
                 location_type = "order",
                 highlighted_at = os.date("!%Y-%m-%dT%TZ", clipping.time),

--- a/plugins/exporter.koplugin/target/readwise.lua
+++ b/plugins/exporter.koplugin/target/readwise.lua
@@ -104,7 +104,7 @@ function ReadwiseExporter:createHighlights(booknotes)
                 author = booknotes.author ~= "" and booknotes.author:gsub("\n", ", ") or nil, -- optional author
                 source_type = "koreader",
                 category = "books",
-                note = clipping.note ~= "" and clipping.note or nil,
+                note = clipping.note,
                 location = clipping.page,
                 location_type = "order",
                 highlighted_at = os.date("!%Y-%m-%dT%TZ", clipping.time),


### PR DESCRIPTION
Recently Readwise started complaining about `note` being required to be filled when sending `"note": ""`, now `nil` is sent instead of `""`.

Not sure if this is koreader recently using different value for empty highlight's note, or Readwise Api changes, anyway exporting works again after this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11912)
<!-- Reviewable:end -->
