### PR TITLE
BookMap on devices with useDPadAsActionKeys()

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -640,7 +640,7 @@ Except when in two columns mode, where this is limited to showing only the previ
                 if G_reader_settings:readSetting("highlight_non_touch_interval") == 1 then
                     return T(_("Interval to speed-up rate: %1 second"), G_reader_settings:readSetting("highlight_non_touch_interval") or 1)
                 else
-                    return T(_("Interval to speed-up rate: %1 seconds"), G_reader_settings:readSetting("highlight_non_touch_interval"))
+                    return T(_("Interval to speed-up rate: %1 seconds"), G_reader_settings:readSetting("highlight_non_touch_interval") or 1)
                 end
             end,
             enabled_func = function()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -601,11 +601,11 @@ Except when in two columns mode, where this is limited to showing only the previ
     if not Device:isTouchDevice() and Device:hasDPad() then
         table.insert(menu_items.long_press.sub_item_table, {
             text_func = function()
-                return T(_("Rate of movement in content selection: %1"), G_reader_settings:readSetting("highlight_non_touch_factor", 4))
+                return T(_("Rate of movement in content selection: %1"), G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
             end,
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_factor", 4)
+                local curr_val = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
                 local spin_widget = SpinWidget:new{
                     value = curr_val,
                     value_min = 0.25,
@@ -638,9 +638,9 @@ Except when in two columns mode, where this is limited to showing only the previ
         table.insert(menu_items.long_press.sub_item_table, {
             text_func = function()
                 if G_reader_settings:readSetting("highlight_non_touch_interval") == 1 then
-                    return T(_("Interval to speed-up rate: %1 second"), G_reader_settings:readSetting("highlight_non_touch_interval", 1))
+                    return T(_("Interval to speed-up rate: %1 second"), G_reader_settings:readSetting("highlight_non_touch_interval") or 1)
                 else
-                    return T(_("Interval to speed-up rate: %1 seconds"), G_reader_settings:readSetting("highlight_non_touch_interval", 1))
+                    return T(_("Interval to speed-up rate: %1 seconds"), G_reader_settings:readSetting("highlight_non_touch_interval"))
                 end
             end,
             enabled_func = function()
@@ -648,7 +648,7 @@ Except when in two columns mode, where this is limited to showing only the previ
             end,
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval", 1)
+                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
                 local spin_widget = SpinWidget:new{
                     value = curr_val,
                     value_min = 0.1,
@@ -2289,8 +2289,8 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
                 -- quadruple press: 64 single distances, almost move to screen edge
                 if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
                     -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local x_inter = (G_reader_settings:readSetting("highlight_non_touch_interval") or 1)
-                    if diff < time.s( x_inter ) then
+                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+                    if diff < time.s( t_inter ) then
                         move_distance = self._last_indicator_move_args.distance * 4
                     end
                 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -19,7 +19,7 @@ local ffiUtil = require("ffi/util")
 local time = require("ui/time")
 local _ = require("gettext")
 local C_ = _.pgettext
-local NC_ = _.npgettext
+local N_ = _.npgettext
 local T = ffiUtil.template
 local Screen = Device.screen
 
@@ -639,7 +639,7 @@ Except when in two columns mode, where this is limited to showing only the previ
         table.insert(menu_items.long_press.sub_item_table, {
             text_func = function()
                 local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                return T(NC_("Speed-up rate interval: %1 second", "Speed-up rate interval: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
+                return T(N_("Speed-up rate interval: %1 second", "Speed-up rate interval: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
             end,
             enabled_func = function()
                 return not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -19,6 +19,7 @@ local ffiUtil = require("ffi/util")
 local time = require("ui/time")
 local _ = require("gettext")
 local C_ = _.pgettext
+local NC_ = _.npgettext
 local T = ffiUtil.template
 local Screen = Device.screen
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -602,11 +602,11 @@ Except when in two columns mode, where this is limited to showing only the previ
     if not Device:isTouchDevice() and Device:hasDPad() then
         table.insert(menu_items.long_press.sub_item_table, {
             text_func = function()
-                return T(_("Rate of movement in content selection: %1"), G_reader_settings:readSetting("highlight_non_touch_factor" or 4))
+                return T(_("Rate of movement in content selection: %1"), G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
             end,
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_factor" or 4)
+                local curr_val = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
                 local spin_widget = SpinWidget:new{
                     value = curr_val,
                     value_min = 0.25,
@@ -638,7 +638,7 @@ Except when in two columns mode, where this is limited to showing only the previ
         })
         table.insert(menu_items.long_press.sub_item_table, {
             text_func = function()
-                local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval" or 1)
+                local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
                 return T(NC_("Speed-up rate interval: %1 second", "Speed-up rate interval: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
             end,
             enabled_func = function()
@@ -646,7 +646,7 @@ Except when in two columns mode, where this is limited to showing only the previ
             end,
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval" or 1)
+                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
                 local spin_widget = SpinWidget:new{
                     value = curr_val,
                     value_min = 0.1,
@@ -2272,7 +2272,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
         local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
         local quick_move_distance_dy = self.view.visible_area.h * (1/5)
         -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
-        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor" or 4))
+        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
         local rect = self._current_indicator_pos:copy()
         if quick_move then
             rect.x = rect.x + quick_move_distance_dx * dx
@@ -2287,7 +2287,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
                 -- quadruple press: 64 single distances, almost move to screen edge
                 if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
                     -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval" or 1)
+                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
                     if diff < time.s( t_inter ) then
                         move_distance = self._last_indicator_move_args.distance * 4
                     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -601,11 +601,11 @@ Except when in two columns mode, where this is limited to showing only the previ
     if not Device:isTouchDevice() and Device:hasDPad() then
         table.insert(menu_items.long_press.sub_item_table, {
             text_func = function()
-                return T(_("Rate of movement in content selection: %1"), G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
+                return T(_("Rate of movement in content selection: %1"), G_reader_settings:readSetting("highlight_non_touch_factor" or 4))
             end,
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
+                local curr_val = G_reader_settings:readSetting("highlight_non_touch_factor" or 4)
                 local spin_widget = SpinWidget:new{
                     value = curr_val,
                     value_min = 0.25,
@@ -637,18 +637,15 @@ Except when in two columns mode, where this is limited to showing only the previ
         })
         table.insert(menu_items.long_press.sub_item_table, {
             text_func = function()
-                if G_reader_settings:readSetting("highlight_non_touch_interval") == 1 then
-                    return T(_("Interval to speed-up rate: %1 second"), G_reader_settings:readSetting("highlight_non_touch_interval") or 1)
-                else
-                    return T(_("Interval to speed-up rate: %1 seconds"), G_reader_settings:readSetting("highlight_non_touch_interval") or 1)
-                end
+                local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval" or 1)
+                return T(NC_("Speed-up rate interval: %1 second", "Speed-up rate interval: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
             end,
             enabled_func = function()
                 return not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
             end,
             callback = function(touchmenu_instance)
                 local SpinWidget = require("ui/widget/spinwidget")
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval" or 1)
                 local spin_widget = SpinWidget:new{
                     value = curr_val,
                     value_min = 0.1,
@@ -2274,7 +2271,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
         local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
         local quick_move_distance_dy = self.view.visible_area.h * (1/5)
         -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
-        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
+        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor" or 4))
         local rect = self._current_indicator_pos:copy()
         if quick_move then
             rect.x = rect.x + quick_move_distance_dx * dx
@@ -2289,7 +2286,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
                 -- quadruple press: 64 single distances, almost move to screen edge
                 if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
                     -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval" or 1)
                     if diff < time.s( t_inter ) then
                         move_distance = self._last_indicator_move_args.distance * 4
                     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2274,7 +2274,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
         local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
         local quick_move_distance_dy = self.view.visible_area.h * (1/5)
         -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
-        local move_distance = Size.item.height_default / G_reader_settings:readSetting("highlight_non_touch_factor", 4)
+        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
         local rect = self._current_indicator_pos:copy()
         if quick_move then
             rect.x = rect.x + quick_move_distance_dx * dx
@@ -2289,7 +2289,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
                 -- quadruple press: 64 single distances, almost move to screen edge
                 if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
                     -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local x_inter = G_reader_settings:readSetting("highlight_non_touch_interval", 1)
+                    local x_inter = (G_reader_settings:readSetting("highlight_non_touch_interval") or 1)
                     if diff < time.s( x_inter ) then
                         move_distance = self._last_indicator_move_args.distance * 4
                     end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2274,7 +2274,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
         local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
         local quick_move_distance_dy = self.view.visible_area.h * (1/5)
         -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
-        local move_distance = Size.item.height_default / G_reader_settings:readSetting("highlight_non_touch_factor")
+        local move_distance = Size.item.height_default / G_reader_settings:readSetting("highlight_non_touch_factor", 4)
         local rect = self._current_indicator_pos:copy()
         if quick_move then
             rect.x = rect.x + quick_move_distance_dx * dx

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2289,7 +2289,7 @@ function ReaderHighlight:onMoveHighlightIndicator(args)
                 -- quadruple press: 64 single distances, almost move to screen edge
                 if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
                     -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local x_inter = G_reader_settings:readSetting("highlight_non_touch_interval")
+                    local x_inter = G_reader_settings:readSetting("highlight_non_touch_interval", 1)
                     if diff < time.s( x_inter ) then
                         move_distance = self._last_indicator_move_args.distance * 4
                     end

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -88,7 +88,7 @@ function ReaderThumbnail:addToMainMenu(menu_items)
         end,
     }
     -- PageBrowser still needs some work before we can let it run on non-touch devices with useDPadAsActionKeys
-    if Device:useDPadAsActionKeys() then return end
+    if Device:hasDPad() and Device:useDPadAsActionKeys() then return end
     menu_items.page_browser = {
         text = _("Page browser"),
         callback = function()

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -21,7 +21,7 @@ local _ = require("gettext")
 local ReaderThumbnail = WidgetContainer:extend{}
 
 function ReaderThumbnail:init()
-    if not Device:isTouchDevice() and not useDPadAsActionKeys() then
+    if not Device:isTouchDevice() and not Device:useDPadAsActionKeys() then
         -- The BookMap and PageBrowser widgets depend too much on gestures,
         -- making them work with not enough keys on Non-Touch would be hard and very limited, so
         -- just don't make them available.
@@ -77,7 +77,7 @@ function ReaderThumbnail:addToMainMenu(menu_items)
         end,
     }
     -- PageBrowser still needs some work before we can let it run on non-touch devices with useDPadAsActionKeys
-    if useDPadAsActionKeys() then return end
+    if Device:useDPadAsActionKeys() then return end
     menu_items.page_browser = {
         text = _("Page browser"),
         callback = function()

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -21,10 +21,11 @@ local _ = require("gettext")
 local ReaderThumbnail = WidgetContainer:extend{}
 
 function ReaderThumbnail:init()
-    if not Device:isTouchDevice() then
+    if not Device:isTouchDevice() and not useDPadAsActionKeys() then
         -- The BookMap and PageBrowser widgets depend too much on gestures,
-        -- making them work with keys would be hard and very limited, so
+        -- making them work with not enough keys on Non-Touch would be hard and very limited, so
         -- just don't make them available.
+        -- We will only let BookMap run on useDPadAsActionKeys devices.
         return
     end
 
@@ -75,6 +76,8 @@ function ReaderThumbnail:addToMainMenu(menu_items)
             self:onShowBookMap(true)
         end,
     }
+    -- PageBrowser still needs some work before we can let it run on non-touch devices with useDPadAsActionKeys
+    if useDPadAsActionKeys() then return end
     menu_items.page_browser = {
         text = _("Page browser"),
         callback = function()

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -65,7 +65,7 @@ function ReaderThumbnail:init()
 end
 
 function ReaderThumbnail:registerKeyEvents()
-    if Device:useDPadAsActionKeys() then
+    if Device:hasDPad() and Device:useDPadAsActionKeys() then
         if Device:hasKeyboard() then
             self.key_events.ShowBookMap = { { "Shift", "Down" } }
         else

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -21,6 +21,7 @@ local _ = require("gettext")
 local ReaderThumbnail = WidgetContainer:extend{}
 
 function ReaderThumbnail:init()
+    self:registerKeyEvents()
     if not Device:isTouchDevice() and not Device:useDPadAsActionKeys() then
         -- The BookMap and PageBrowser widgets depend too much on gestures,
         -- making them work with not enough keys on Non-Touch would be hard and very limited, so
@@ -59,6 +60,16 @@ function ReaderThumbnail:init()
         else
             schedule_step = 0
             self:ensureTileGeneration()
+        end
+    end
+end
+
+function ReaderThumbnail:registerKeyEvents()
+    if Device:useDPadAsActionKeys() then
+        if Device:hasKeyboard() then
+            self.key_events.ShowBookMap = { { "Shift", "Down" } }
+        else
+            self.key_events.ShowBookMap = { { "ScreenKB", "Down" } }
         end
     end
 end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -530,11 +530,9 @@ function ReaderUI:registerKeyEvents()
             if Device:hasKeyboard() then
                 self.key_events.KeyToggleWifi = { { "Shift", "Home" }, event = "ToggleWifi" }
                 self.key_events.OpenLastDoc = { { "Shift", "Back" } }
-                self.key_events.ShowBookMap = { { "Shift", "Down" }, event = "ShowBookMap" }
             else -- Currently exclusively targets Kindle 4.
                 self.key_events.KeyToggleWifi = { { "ScreenKB", "Home" }, event = "ToggleWifi" }
                 self.key_events.OpenLastDoc = { { "ScreenKB", "Back" } }
-                self.key_events.ShowBookMap = { { "ScreenKB", "Down" }, event = "ShowBookMap" }
             end
         end
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -530,9 +530,11 @@ function ReaderUI:registerKeyEvents()
             if Device:hasKeyboard() then
                 self.key_events.KeyToggleWifi = { { "Shift", "Home" }, event = "ToggleWifi" }
                 self.key_events.OpenLastDoc = { { "Shift", "Back" } }
+                self.key_events.ShowBookMap = { { "Shift", "Down" }, event = "ShowBookMap" }
             else -- Currently exclusively targets Kindle 4.
                 self.key_events.KeyToggleWifi = { { "ScreenKB", "Home" }, event = "ToggleWifi" }
                 self.key_events.OpenLastDoc = { { "ScreenKB", "Back" } }
+                self.key_events.ShowBookMap = { { "ScreenKB", "Down" }, event = "ShowBookMap" }
             end
         end
     end

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1199,7 +1199,6 @@ function BookMapWidget:showMenu()
         }},
         {{
             text = _("Available gestures"),
-            enabled_func = function() return Device:isTouchDevice() end,
             align = "left",
             callback = function()
                 self:showGestures()
@@ -1229,7 +1228,7 @@ function BookMapWidget:showMenu()
             end,
         }},
         not self.overview_mode and {{
-            text = _("Switch current/initial views"),
+            text = _("Switch current/initial view"),
             align = "left",
             enabled_func = function() return self.toc_depth > 0 end,
             callback = function()
@@ -1275,7 +1274,7 @@ function BookMapWidget:showMenu()
         },
         not self.overview_mode and {
             {
-                text = _("Page slot width"),
+                text = _("Bar width"),
                 callback = function() end,
                 align = "left",
                 -- Below, minus increases page per row and plus decreases it.
@@ -1354,11 +1353,9 @@ end
 
 function BookMapWidget:showAbout()
     local text = _([[
-Book map displays an overview of the book content.
+The book map provides a summary of the book's content, showing chapters and pages visually. If statistics are on, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time. 
 
-If statistics are enabled, black bars are shown for already read pages (gray for pages read in the current reading session). Their heights vary depending on the time spent reading the page.
-Chapters are shown above the pages they encompass.
-Under the pages, these indicators may be shown:
+Map Legends:
 ▲ current page
 ❶ ❷ … previous locations
 ▒ highlighted text
@@ -1368,17 +1365,24 @@ Under the pages, these indicators may be shown:
 
     if self.overview_mode then
         text = text .. "\n\n" .. _([[
-In overview mode, the book map is always in grid mode and made to fit on a single screen. Chapter levels can be changed for the most comfortable overview.]])
+When in overview mode, the book map is always displayed in grid mode to fit on one screen. The chapter levels can be easily adjusted for the most convenient overview experience.]])
     else
         text = text .. "\n\n" .. _([[
-On a newly opened book, the book map will start in grid mode showing all chapter levels, fitting on a single screen, to give the best initial overview of the book's content.]])
+When you first open a book, the book map will begin in grid mode, displaying all chapter levels on one screen for a comprehensive overview of the book's content.]])
     end
     UIManager:show(InfoMessage:new{ text = text })
 end
 
 function BookMapWidget:showGestures()
     local text
-    if self.overview_mode then
+    if not Device:isTouchDevice() then
+        text = _([[
+Use settings in this menu to change the level of chapters to include in the book map, the view type (grid or flat) and the width of page slots.
+
+Use "ScreenKB/Shift" + "Up/Down" to scroll or use the page turn buttons to move at a faster rate.
+
+Press back to exit the book map.]])
+    elseif self.overview_mode then
         text = _([[
 Tap on a location in the book to browse thumbnails of the pages there.
 

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1208,17 +1208,6 @@ function BookMapWidget:onShowBookMapMenu()
             end,
         }},
         {{
-            text = _("Page browser on tap"),
-            enabled_func = function() return Device:isTouchDevice() end,
-            checked_func = function()
-                return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")
-            end,
-            align = "left",
-            callback = function()
-                G_reader_settings:flipNilOrTrue("book_map_tap_to_page_browser")
-            end,
-        }},
-        {{
             text = _("Alternative theme"),
             checked_func = function()
                 return G_reader_settings:isTrue("book_map_alt_theme")
@@ -1332,6 +1321,17 @@ function BookMapWidget:onShowBookMapMenu()
             }
         },
     }
+    if Device:isTouchDevice() then
+        table.insert(buttons, 3, {{
+        text = _("Page browser on tap"),
+        checked_func = function()
+            return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")
+        end,
+        align = "left",
+        callback = function()
+            G_reader_settings:flipNilOrTrue("book_map_tap_to_page_browser")
+        end,
+    }})
     -- Remove false buttons from the list if overview_mode
     for i = #buttons, 1, -1 do
         if not buttons[i] then

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1353,7 +1353,7 @@ end
 
 function BookMapWidget:showAbout()
     local text = _([[
-The book map provides a summary of the book's content, showing chapters and pages visually. If statistics are enabled, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time. 
+The book map provides a summary of the book's content, showing chapters and pages visually. If statistics are enabled, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time.
 
 Map Legend:
 ▲ current page

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -632,13 +632,17 @@ function BookMapWidget:init()
     self.covers_fullscreen = true -- hint for UIManager:_repaint()
 
     if Device:hasKeys() then
-        self.key_events = {
-            Close = { { Input.group.Back } },
-            ScrollRowUp = { { "Up" } },
-            ScrollRowDown = { { "Down" } },
-            ScrollPageUp = { { Input.group.PgBack } },
-            ScrollPageDown = { { Input.group.PgFwd } },
-        }
+        self.key_events.Close = { { Device.input.group.Back } }
+        self.key_events.ShowMenu = { { "Menu" } }
+        self.key_events.ScrollPageUp = { { Input.group.PgBack } }
+        self.key_events.ScrollPageDown = { { Input.group.PgFwd } }
+        if Device:hasKeyboard() then
+            self.key_events.ScrollRowUp = { { "Shift", "Up" } }
+            self.key_events.ScrollRowDown = { { "Shift", "Down" } }
+        elseif Device:hasScreenKB() then
+            self.key_events.ScrollRowUp = { { "ScreenKB", "Up" } }
+            self.key_events.ScrollRowDown = { { "ScreenKB", "Down" } }
+        end
     end
     if Device:isTouchDevice() then
         self.ges_events = {
@@ -1202,6 +1206,7 @@ function BookMapWidget:showMenu()
         }},
         {{
             text = _("Page browser on tap"),
+            enabled_func = function() return Device:isTouchDevice() end,
             checked_func = function()
                 return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")
             end,
@@ -1341,6 +1346,11 @@ function BookMapWidget:showMenu()
     }
     UIManager:show(button_dialog)
 end
+
+function BookMapWidget:onShowMenu()
+    self:showMenu()
+end
+
 function BookMapWidget:showAbout()
     local text = _([[
 Book map displays an overview of the book content.

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1199,6 +1199,7 @@ function BookMapWidget:showMenu()
         }},
         {{
             text = _("Available gestures"),
+            enabled_func = function() return Device:isTouchDevice() end,
             align = "left",
             callback = function()
                 self:showGestures()

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1277,7 +1277,7 @@ function BookMapWidget:onShowBookMapMenu()
         },
         not self.overview_mode and {
             {
-                text = _("Page-bar width"),
+                text = _("Page-slot width"),
                 callback = function() end,
                 align = "left",
                 -- Below, minus increases page per row and plus decreases it.

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1332,6 +1332,7 @@ function BookMapWidget:onShowBookMapMenu()
             G_reader_settings:flipNilOrTrue("book_map_tap_to_page_browser")
         end,
     }})
+    end
     -- Remove false buttons from the list if overview_mode
     for i = #buttons, 1, -1 do
         if not buttons[i] then

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1274,7 +1274,7 @@ function BookMapWidget:showMenu()
         },
         not self.overview_mode and {
             {
-                text = _("Bar width"),
+                text = _("Page-bar width"),
                 callback = function() end,
                 align = "left",
                 -- Below, minus increases page per row and plus decreases it.

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1357,7 +1357,7 @@ function BookMapWidget:showAbout()
     local text = _([[
 Book map provides a summary of a book's content, showing chapters and pages visually. If statistics are enabled, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time.
 
-Map Legend:
+Map legend:
 ▲ current page
 ❶ ❷ … previous locations
 ▒ highlighted text

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1353,9 +1353,9 @@ end
 
 function BookMapWidget:showAbout()
     local text = _([[
-The book map provides a summary of the book's content, showing chapters and pages visually. If statistics are on, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time. 
+The book map provides a summary of the book's content, showing chapters and pages visually. If statistics are enabled, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time. 
 
-Map Legends:
+Map Legend:
 ▲ current page
 ❶ ❷ … previous locations
 ▒ highlighted text

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1353,7 +1353,7 @@ end
 
 function BookMapWidget:showAbout()
     local text = _([[
-The book map provides a summary of the book's content, showing chapters and pages visually. If statistics are enabled, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time.
+Book map provides a summary of a book's content, showing chapters and pages visually. If statistics are enabled, black bars represent pages already read (gray for pages read in the current session), with varying heights based on reading time.
 
 Map Legend:
 ▲ current page

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1208,6 +1208,16 @@ function BookMapWidget:onShowBookMapMenu()
             end,
         }},
         {{
+            text = _("Page browser on tap"),
+            checked_func = function()
+                return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")
+            end,
+            align = "left",
+            callback = function()
+                G_reader_settings:flipNilOrTrue("book_map_tap_to_page_browser")
+            end,
+        }},
+        {{
             text = _("Alternative theme"),
             checked_func = function()
                 return G_reader_settings:isTrue("book_map_alt_theme")
@@ -1321,17 +1331,9 @@ function BookMapWidget:onShowBookMapMenu()
             }
         },
     }
-    if Device:isTouchDevice() then
-        table.insert(buttons, 3, {{
-        text = _("Page browser on tap"),
-        checked_func = function()
-            return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")
-        end,
-        align = "left",
-        callback = function()
-            G_reader_settings:flipNilOrTrue("book_map_tap_to_page_browser")
-        end,
-    }})
+    -- remove "Page browser on tap" from non-touch devices
+    if not Device:isTouchDevice() then
+        table.remove(buttons, 3)
     end
     -- Remove false buttons from the list if overview_mode
     for i = #buttons, 1, -1 do

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -636,12 +636,15 @@ function BookMapWidget:init()
         self.key_events.ShowBookMapMenu = { { "Menu" } }
         self.key_events.ScrollPageUp = { { Input.group.PgBack } }
         self.key_events.ScrollPageDown = { { Input.group.PgFwd } }
-        if Device:hasKeyboard() then
+        if Device:hasSymKey() then
             self.key_events.ScrollRowUp = { { "Shift", "Up" } }
             self.key_events.ScrollRowDown = { { "Shift", "Down" } }
         elseif Device:hasScreenKB() then
             self.key_events.ScrollRowUp = { { "ScreenKB", "Up" } }
             self.key_events.ScrollRowDown = { { "ScreenKB", "Down" } }
+        else
+            self.key_events.ScrollRowUp = { { "Up" } }
+            self.key_events.ScrollRowDown = { { "Down" } }
         end
     end
     if Device:isTouchDevice() then
@@ -706,7 +709,7 @@ function BookMapWidget:init()
         fullscreen = true,
         title = title,
         left_icon = "appbar.menu",
-        left_icon_tap_callback = function() self:showMenu() end,
+        left_icon_tap_callback = function() self:onShowBookMapMenu() end,
         left_icon_hold_callback = not self.overview_mode and function()
             self:toggleDefaultSettings() -- toggle between user settings and default view
         end,
@@ -1185,7 +1188,7 @@ function BookMapWidget:update()
 end
 
 
-function BookMapWidget:showMenu()
+function BookMapWidget:onShowBookMapMenu()
     local button_dialog
     -- Width of our -/+ buttons, so it looks fine with Button's default font size of 20
     local plus_minus_width = Screen:scaleBySize(60)
@@ -1345,10 +1348,6 @@ function BookMapWidget:showMenu()
         end,
     }
     UIManager:show(button_dialog)
-end
-
-function BookMapWidget: onShowBookMapMenu()
-    self:showMenu()
 end
 
 function BookMapWidget:showAbout()

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -633,7 +633,7 @@ function BookMapWidget:init()
 
     if Device:hasKeys() then
         self.key_events.Close = { { Device.input.group.Back } }
-        self.key_events.ShowMenu = { { "Menu" } }
+        self.key_events.ShowBookMapMenu = { { "Menu" } }
         self.key_events.ScrollPageUp = { { Input.group.PgBack } }
         self.key_events.ScrollPageDown = { { Input.group.PgFwd } }
         if Device:hasKeyboard() then
@@ -1347,7 +1347,7 @@ function BookMapWidget:showMenu()
     UIManager:show(button_dialog)
 end
 
-function BookMapWidget:onShowMenu()
+function BookMapWidget: onShowBookMapMenu()
     self:showMenu()
 end
 

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -94,6 +94,8 @@ function ButtonDialog:init()
             self.key_events.Close = { { { "Back", "Left", "Menu" } } }
         elseif not Device:isTouchDevice() then
             self.key_events.Close = { { { "Back", "Menu" } } }
+        else
+            self.key_events.Close = { { Device.input.group.Back } }
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -90,12 +90,15 @@ function ButtonDialog:init()
         self.width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * self.width_factor)
     end
     if self.dismissable then
-        if Device:hasFewKeys() then
-            self.key_events.Close = { { { "Back", "Left", "Menu" } } }
-        elseif not Device:isTouchDevice() then
-            self.key_events.Close = { { { "Back", "Menu" } } }
-        else
-            self.key_events.Close = { { Device.input.group.Back } }
+        if Device:hasKeys() then -- NB! Documentation + not adding unnecessary things to memory.
+            local back_group = util.tableDeepCopy(Device.input.group.Back)
+            if Device:hasFewKeys() then -- with left added
+                table.insert(back_group, "Left")
+                self.key_events.Close = { { back_group } }
+            else -- regular
+                table.insert(back_group, "Menu")
+                self.key_events.Close = { { back_group } }
+            end
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -54,10 +54,10 @@ local ScrollableContainer = require("ui/widget/container/scrollablecontainer")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
-local util = require("util")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = Device.screen
+local util = require("util")
 
 local ButtonDialog = InputContainer:extend{
     buttons = nil,
@@ -91,12 +91,12 @@ function ButtonDialog:init()
         self.width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * self.width_factor)
     end
     if self.dismissable then
-        if Device:hasKeys() then -- NB! Documentation + not adding unnecessary things to memory.
+        if Device:hasKeys() then
             local back_group = util.tableDeepCopy(Device.input.group.Back)
-            if Device:hasFewKeys() then -- with left added
+            if Device:hasFewKeys() then
                 table.insert(back_group, "Left")
                 self.key_events.Close = { { back_group } }
-            else -- regular
+            else
                 table.insert(back_group, "Menu")
                 self.key_events.Close = { { back_group } }
             end

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -92,7 +92,7 @@ function ButtonDialog:init()
     if self.dismissable then
         if Device:hasFewKeys() then
             self.key_events.Close = { { { "Back", "Left", "Menu" } } }
-        else
+        elseif not Device:isTouchDevice() then
             self.key_events.Close = { { { "Back", "Menu" } } }
         end
         if Device:isTouchDevice() then

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -90,9 +90,10 @@ function ButtonDialog:init()
         self.width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * self.width_factor)
     end
     if self.dismissable then
-        if Device:hasKeys() then
-            local close_keys = Device:hasFewKeys() and { "Back", "Left" } or Device.input.group.Back
-            self.key_events.Close = { { close_keys } }
+        if Device:hasFewKeys() then
+            self.key_events.Close = { { { "Back", "Left", "Menu" } } }
+        else
+            self.key_events.Close = { { { "Back", "Menu" } } }
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -54,6 +54,7 @@ local ScrollableContainer = require("ui/widget/container/scrollablecontainer")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local UIManager = require("ui/uimanager")
+local util = require("util")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = Device.screen


### PR DESCRIPTION
as first discussed here #11908. This PR brings the book map to non-touch devices that `useDPadAsActionKeys()`.

Book map can be accessed from the menu or by using the following shortcut: `ScreenKB` + `Down` or `Shift` + `Down` depending on whether you use a K4 device or a kindle with keyboard respectively.

Inside the book map, a user can toggle the hamburger menu by pressing the `Menu` key and make any adjustment from there. `ScreenKB` (or `Shift`) + `Up/Down` allows it to scroll and Page turn buttons to move by whole full page turns. `Back` key allows user to exit the map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11916)
<!-- Reviewable:end -->
