### PR TITLE
macos: fix bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,9 @@ jobs:
         if: steps.build-restore.outputs.cache-hit != 'true'
         run: make base
 
+      - name: Dump binaries runtime path & dependencies
+        run: make bindeps
+
       # }}}
 
       # Clean / save caches. {{{

--- a/platform/mac/do_mac_bundle.sh
+++ b/platform/mac/do_mac_bundle.sh
@@ -15,22 +15,24 @@
 # and can be translated using an xliff editor or an online service that support
 # IOS string format, like weblate.
 
+set -eo pipefail
+
 COPYRIGHT="Copyright © $(date +"%Y") KOReader"
 
 command_exists() {
     type "$1" >/dev/null 2>/dev/null
 }
 
-if [ -z "${1}" ]; then
+if ! [ -d "${1}" ]; then
     echo "${0}: can't find KOReader build, please specify a path"
     exit 1
-else
-    VERSION="$(cut -f2 -dv "${1}/koreader/git-rev" | cut -f1,2 -d-)"
-    APP_PATH="${1}/bundle"
-    APP_BUNDLE="${1}/../KOReader"
-    OSX_MAJOR=$(sw_vers -productVersion | cut -d "." -f1)
-    OSX_MINOR=$(sw_vers -productVersion | cut -d "." -f2)
 fi
+
+VERSION="$(cut -f2 -dv "${1}/koreader/git-rev" | cut -f1,2 -d-)"
+APP_PATH="${1}/bundle"
+APP_BUNDLE="${1}/../KOReader"
+OSX_MAJOR=$(sw_vers -productVersion | cut -d "." -f1)
+OSX_MINOR=$(sw_vers -productVersion | cut -d "." -f2)
 
 # minimum deployment target based on host version
 if [ -z "${MACOSX_DEPLOYMENT_TARGET}" ]; then
@@ -122,44 +124,9 @@ cat <<END >"${APP_PATH}/Contents/Info.plist"
 </plist>
 END
 
-# freeze shared libraries, so they can be loaded within the application bundle
-pushd "${APP_PATH}/Contents/koreader" || exit 1
-for dir in common libs; do
-    path=$(basename "${dir}")
-    pushd "${dir}" || exit 1
-    for library in *.so *.dylib; do
-        install_name_tool -id "${library}" "$(basename "${library}")"
-        # there may be more than one dependency to fix, so get all of them and iterate
-        dependencies=$(otool -L "${library}" | grep "Users.*x86_64" | tr -s " " | cut -f1 -d" ")
-        if [ -n "${dependencies}" ]; then
-            for dependency in ${dependencies}; do
-                filename=$(basename "${dependency}")
-                if [ ! "${library}" = "${filename}" ]; then
-                    install_name_tool -change "${dependency}" "${path}/${filename}" "${library}"
-                fi
-            done
-        fi
-    done
-    popd || exit 1
-done
+pushd "${APP_PATH}/Contents/koreader"
 
-# Brew has a tendency to infiltrate our builds and take over some of the dependencies...
-BREW="$(brew --prefix)/opt"
-# So, because it made us pick those up, ship 'em
-# FIXME: Double-check whether we still need it, or if we succeeded in getting glib built against our static copy.
-cp "${BREW}/gettext/lib/libintl.8.dylib" "${BREW}/libsodium/lib/libsodium.23.dylib" libs
-chmod 777 libs/libintl.8.dylib libs/libsodium.23.dylib
-# Update their name
-install_name_tool -id libintl.8.dylib libs/libintl.8.dylib
-install_name_tool -id libsodium.23.dylib libs/libsodium.23.dylib
-# And make sure anything that depends on them points to ours
-install_name_tool -change "${BREW}/gettext/lib/libintl.8.dylib" libs/libintl.8.dylib libs/libglib-2.0.dylib
-install_name_tool -change "${BREW}/libsodium/lib/libsodium.23.dylib" libs/libsodium.23.dylib libs/libczmq.1.dylib
-install_name_tool -change "${BREW}/libsodium/lib/libsodium.23.dylib" libs/libsodium.23.dylib libs/libfmq.1.dylib
-install_name_tool -change "${BREW}/libsodium/lib/libsodium.23.dylib" libs/libsodium.23.dylib libs/libzmq.4.dylib
-install_name_tool -change "${BREW}/libsodium/lib/libsodium.23.dylib" libs/libsodium.23.dylib libs/libzyre.1.dylib
-
-# prepare bundle for distribution
+# Prepare bundle for distribution.
 ln -s /usr/bin/tar tar
 mv COPYING README.md ../Resources/
 mv koreader ../MacOS/koreader
@@ -169,16 +136,15 @@ rm -rf cache clipboard history ota \
     plugins/autofrontlight.koplugin resources/fonts resources/icons/src \
     rocks/bin rocks/lib/luarocks screenshots spec tools
 
-# adjust reader.lua a bit.
-
+# Adjust reader.lua a bit.
 sed '1d' reader.lua >tempfile
 sed -i.backup 's/.\/reader.lua/koreader/' tempfile
 mv tempfile reader.lua
 rm -f tempfile*
 chmod -x reader.lua
-popd || exit 1
+popd
 
-# bundle translations, if any
+# Bundle translations, if any.
 for path in l10n/*; do
     lang=$(echo "${path}" | sed s'/l10n\///')
     if [ "${lang}" != "templates" ]; then
@@ -192,7 +158,7 @@ done
 
 mv "${APP_PATH}" "${APP_BUNDLE}.app"
 
-# package as 7z reduces size from 80MB to 30MB
+# Package as 7z reduces size from 80MB to 30MB.
 if command_exists "7z"; then
     7z a -l -m0=lzma2 -mx=9 "${APP_BUNDLE}-${VERSION}.7z" "${APP_BUNDLE}.app"
     rm -rfv "${APP_BUNDLE}.app"


### PR DESCRIPTION
The new build system should normally be free from "brew infections", and already have the proper runtime path and library names.

Cf. discussion in #11660.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11924)
<!-- Reviewable:end -->
