### PR TITLE
Menu button support for some widgets

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -105,6 +105,7 @@ function DictQuickLookup:init()
             ReadPrevResult = { { Input.group.PgBack } },
             ReadNextResult = { { Input.group.PgFwd } },
             Close = { { Input.group.Back } },
+            ShowMenu = { { "Menu" } },
         }
     end
     if Device:isTouchDevice() then
@@ -1326,6 +1327,10 @@ function DictQuickLookup:lookupWikipedia(get_fullpage, word, is_sane, lang)
     end
     -- Keep providing self.word_boxes so new windows keep being positionned to not hide it
     self.ui:handleEvent(Event:new("LookupWikipedia", word, is_sane, self.word_boxes, get_fullpage, lang))
+end
+
+function DictQuickLookup:onShowMenu()
+    return self:showResultsMenu()
 end
 
 function DictQuickLookup:showResultsMenu()

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -153,6 +153,7 @@ function SortWidget:init()
         self.key_events.Close = { { Device.input.group.Back } }
         self.key_events.NextPage = { { Device.input.group.PgFwd } }
         self.key_events.PrevPage = { { Device.input.group.PgBack } }
+        self.key_events.ShowWidgetMenu = { { "Menu" } }
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {
@@ -273,6 +274,11 @@ function SortWidget:init()
     }
     table.insert(self.layout, {
         self.footer_cancel,
+        self.footer_first_up,
+        self.footer_left,
+        self.footer_page,
+        self.footer_right,
+        self.footer_last_down,
         self.footer_ok,
     })
     local bottom_line = LineWidget:new{
@@ -473,6 +479,10 @@ function SortWidget:onSwipe(arg, ges_ev)
         -- so let it propagate
         return false
     end
+end
+
+function SortWidget:onShowWidgetMenu()
+    self:showMenu()
 end
 
 function SortWidget:showMenu()


### PR DESCRIPTION
PR adds `Menu` key support for some widget and fixes the problem where some virtual keys were not available for non-touch users.

closes #11862
would have closed #11783