### PR TITLE
Individually Invert page turners on kindle

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -313,16 +313,6 @@ function DeviceListener:onSwapPageTurnButtons()
     Device:invertButtons()
 end
 
-function DeviceListener:onSwapLeftPageTurnButtons()
-    G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
-    Device:invertButtonsLeft()
-end
-
-function DeviceListener:onSwapRightPageTurnButtons()
-    G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
-    Device:invertButtonsRight()
-end
-
 function DeviceListener:onToggleKeyRepeat(toggle)
     if toggle == true then
         G_reader_settings:makeFalse("input_no_key_repeat")

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -313,6 +313,16 @@ function DeviceListener:onSwapPageTurnButtons()
     Device:invertButtons()
 end
 
+function DeviceListener:onSwapLeftPageTurnButtons()
+    G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
+    Device:invertButtonsLeft()
+end
+
+function DeviceListener:onSwapRightPageTurnButtons()
+    G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
+    Device:invertButtonsRight()
+end
+
 function DeviceListener:onToggleKeyRepeat(toggle)
     if toggle == true then
         G_reader_settings:makeFalse("input_no_key_repeat")

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -170,6 +170,30 @@ function Device:invertButtons()
     end
 end
 
+function Device:invertButtonsLeft()
+    if self:hasKeys() and self.input and self.input.event_map then
+        for key, value in pairs(self.input.event_map) do
+            if value == "LPgFwd" then
+                self.input.event_map[key] = "LPgBack"
+            elseif value == "LPgBack" then
+                self.input.event_map[key] = "LPgFwd"
+            end
+        end
+    end
+end
+
+function Device:invertButtonsRight()
+    if self:hasKeys() and self.input and self.input.event_map then
+        for key, value in pairs(self.input.event_map) do
+            if value == "RPgFwd" then
+                self.input.event_map[key] = "RPgBack"
+            elseif value == "RPgBack" then
+                self.input.event_map[key] = "RPgFwd"
+            end
+        end
+    end
+end
+
 function Device:init()
     if not self.screen then
         error("screen/framebuffer must be implemented")

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -19,6 +19,28 @@ local PhysicalButtons = {
     },
 }
 
+if Device:hasScreenKB() or Device:hasSymKey() then
+    table.remove(PhysicalButtons.sub_item_table, 1)
+    table.insert(PhysicalButtons.sub_item_table, {
+        text = _("Invert left side page-turn buttons"),
+            checked_func = function()
+                return G_reader_settings:isTrue("input_invert_left_page_turn_keys")
+            end,
+            callback = function()
+                UIManager:broadcastEvent(Event:new("SwapLeftPageTurnButtons"))
+            end,
+    })
+    table.insert(PhysicalButtons.sub_item_table, {
+        text = _("Invert right side page-turn buttons"),
+            checked_func = function()
+                return G_reader_settings:isTrue("input_invert_right_page_turn_keys")
+            end,
+            callback = function()
+                UIManager:broadcastEvent(Event:new("SwapRightPageTurnButtons"))
+            end,
+    })
+end
+
 if Device:canKeyRepeat() then
     table.insert(PhysicalButtons.sub_item_table, {
         text = _("Disable key repeat"),

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -23,7 +23,7 @@ local PhysicalButtons = {
     },
 }
 
-if Device:hasScreenKB() or Device:hasSymKey() then
+if Device:hasDPad() and Device:useDPadAsActionKeys() then
     table.insert(PhysicalButtons.sub_item_table, {
         text = _("Invert left-side page turn buttons"),
         enabled_func = function()

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -9,35 +9,44 @@ local PhysicalButtons = {
     sub_item_table = {
         {
             text = _("Invert page turn buttons"),
+            enabled_func = function()
+                return not (G_reader_settings:isTrue("input_invert_left_page_turn_keys") or G_reader_settings:isTrue("input_invert_right_page_turn_keys"))
+            end,
             checked_func = function()
                 return G_reader_settings:isTrue("input_invert_page_turn_keys")
             end,
             callback = function()
                 UIManager:broadcastEvent(Event:new("SwapPageTurnButtons"))
             end,
+            separator = true,
         }
     },
 }
 
 if Device:hasScreenKB() or Device:hasSymKey() then
-    table.remove(PhysicalButtons.sub_item_table, 1)
     table.insert(PhysicalButtons.sub_item_table, {
         text = _("Invert left side page-turn buttons"),
-            checked_func = function()
-                return G_reader_settings:isTrue("input_invert_left_page_turn_keys")
-            end,
-            callback = function()
-                UIManager:broadcastEvent(Event:new("SwapLeftPageTurnButtons"))
-            end,
+        enabled_func = function()
+            return not G_reader_settings:isTrue("input_invert_page_turn_keys")
+        end,
+        checked_func = function()
+            return G_reader_settings:isTrue("input_invert_left_page_turn_keys")
+        end,
+        callback = function()
+            UIManager:broadcastEvent(Event:new("SwapLeftPageTurnButtons"))
+        end,
     })
     table.insert(PhysicalButtons.sub_item_table, {
         text = _("Invert right side page-turn buttons"),
-            checked_func = function()
-                return G_reader_settings:isTrue("input_invert_right_page_turn_keys")
-            end,
-            callback = function()
-                UIManager:broadcastEvent(Event:new("SwapRightPageTurnButtons"))
-            end,
+        enabled_func = function()
+            return not G_reader_settings:isTrue("input_invert_page_turn_keys")
+        end,
+        checked_func = function()
+            return G_reader_settings:isTrue("input_invert_right_page_turn_keys")
+        end,
+        callback = function()
+            UIManager:broadcastEvent(Event:new("SwapRightPageTurnButtons"))
+        end,
     })
 end
 

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -33,7 +33,8 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
             return G_reader_settings:isTrue("input_invert_left_page_turn_keys")
         end,
         callback = function()
-            UIManager:broadcastEvent(Event:new("SwapLeftPageTurnButtons"))
+            G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
+            Device:invertButtonsLeft()
         end,
     })
     table.insert(PhysicalButtons.sub_item_table, {
@@ -45,7 +46,8 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
             return G_reader_settings:isTrue("input_invert_right_page_turn_keys")
         end,
         callback = function()
-            UIManager:broadcastEvent(Event:new("SwapRightPageTurnButtons"))
+            G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
+            Device:invertButtonsRight()
         end,
     })
 end

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -25,7 +25,7 @@ local PhysicalButtons = {
 
 if Device:hasScreenKB() or Device:hasSymKey() then
     table.insert(PhysicalButtons.sub_item_table, {
-        text = _("Invert left side page-turn buttons"),
+        text = _("Invert left-side page turn buttons"),
         enabled_func = function()
             return not G_reader_settings:isTrue("input_invert_page_turn_keys")
         end,
@@ -37,7 +37,7 @@ if Device:hasScreenKB() or Device:hasSymKey() then
         end,
     })
     table.insert(PhysicalButtons.sub_item_table, {
-        text = _("Invert right side page-turn buttons"),
+        text = _("Invert right-side page turn buttons"),
         enabled_func = function()
             return not G_reader_settings:isTrue("input_invert_page_turn_keys")
         end,


### PR DESCRIPTION
As seen on this [picture](https://newatlas.com/4th-gen-kindle-review/20722/), K4 is ergonomically designed to be held with one hand (one's hand wrapped around the back and both thumb and middle finger on either `PgFwd` buttons).

![90 copy](https://github.com/koreader/koreader/assets/97603719/5169f005-1580-4c3a-a0ac-b8d76a08b363)

This PR allows users to individually invert left and right page turners such that it can be operated just with one hand. It also closes #9350 

Not sure if there are any other devices with two sets of page turn buttons, so currently limited to kindle, excluding kindle Voyage, but could be added too, albeit with some gymnastics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11963)
<!-- Reviewable:end -->
