### PR TITLE
AltStatusBar: fix page info when not all 3 items enabled

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -125,23 +125,23 @@ function ReaderCoptListener:updatePageInfoOverride(pageno)
     end
 
     local page_info = ""
-    if self.page_number or self.page_count then
+    if self.page_number == 1 or self.page_count == 1 then
         page_info = page_info .. page_pre
-        if self.page_number then
+        if self.page_number == 1 then
             page_info = page_info .. page_number
-            if self.page_count then
+            if self.page_count == 1 then
                 page_info = page_info .. page_sep
             end
         end
-        if self.page_count then
+        if self.page_count == 1 then
             page_info = page_info .. page_count
         end
         page_info = page_info .. page_post
-        if self.reading_percent then
+        if self.reading_percent == 1 then
             page_info = page_info .. "  " -- (double space as done by crengine's own drawing)
         end
     end
-    if self.reading_percent then
+    if self.reading_percent == 1 then
         page_info = page_info .. percentage_pre .. percentage_fmt:format(percentage*100) .. percentage_post
     end
     self.document:setPageInfoOverride(page_info)


### PR DESCRIPTION
Fix issue noticed at https://github.com/koreader/koreader/pull/11873#issuecomment-2144485909.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11965)
<!-- Reviewable:end -->
