### PR TITLE
CoverBrowser: fix collection mark position in mosaic mode

### DIFF
--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -752,8 +752,8 @@ function MosaicMenuItem:paintTo(bb, x, y)
         end
         local iy = 0
         local rect_size = corner_mark_size - target.bordersize
-        bb:paintRect(x+ix+rect_ix, y+target.bordersize, rect_size, rect_size, Blitbuffer.COLOR_GRAY)
-        collection_mark:paintTo(bb, x+ix, y+iy)
+        bb:paintRect(x+ix+rect_ix, target.dimen.y+target.bordersize, rect_size, rect_size, Blitbuffer.COLOR_GRAY)
+        collection_mark:paintTo(bb, x+ix, target.dimen.y+iy)
     end
 
     if self.do_hint_opened and self.been_opened then


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/11954.