### PR TITLE
Gesture manager: make long-pressing on top left corner non adjustable in FM

### DIFF
--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -299,7 +299,7 @@ function Gestures:genMenu(ges)
 end
 
 function Gestures:genSubItem(ges, separator, hold_callback)
-    local reader_only = {tap_top_left_corner=true, tap_top_right_corner=true,}
+    local reader_only = {tap_top_left_corner=true, tap_top_right_corner=true, hold_top_left_corner=true,}
     local enabled_func
     if reader_only[ges] then
        enabled_func = function() return self.ges_mode == "gesture_reader" end


### PR DESCRIPTION
It is overridden by the folder tree, so the Gesture manager setting doesn't work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11971)
<!-- Reviewable:end -->
