### PR TITLE
OPDS: Fix browsing a Calibre content server

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -279,6 +279,7 @@ function OPDSBrowser:fetchFeed(item_url, headers_only)
         text = text,
         icon = icon,
     })
+    logger.dbg(string.format("OPDS: Failed to fetch catalog `%s`: %s", item_url, text))
 end
 
 -- Parses feed to catalog
@@ -353,11 +354,22 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                         hrefs[link.rel] = build_href(link.href)
                     end
                 end
+                -- OpenSearch
                 if link.type:find(self.search_type) then
                     if link.href then
                         table.insert(item_table, { -- the first item in each subcatalog
                             text       = "\u{f002} " .. _("Search"), -- append SEARCH icon
                             url        = build_href(self:getSearchTemplate(build_href(link.href))),
+                            searchable = true,
+                       })
+                    end
+                end
+                -- Calibre search
+                if link.type:find(self.search_template_type) and link.rel and link.rel:find("search") then
+                    if link.href then
+                        table.insert(item_table, {
+                            text       = "\u{f002} " .. _("Search"),
+                            url        = build_href(link.href:gsub("{searchTerms}", "%%s")),
                             searchable = true,
                        })
                     end

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -345,6 +345,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
         return url.absolute(item_url, href)
     end
 
+    local has_opensearch = false
     local hrefs = {}
     if feed.link then
         for __, link in ipairs(feed.link) do
@@ -362,11 +363,12 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                             url        = build_href(self:getSearchTemplate(build_href(link.href))),
                             searchable = true,
                         })
+                        has_opensearch = true
                     end
                 end
-                -- Calibre search
+                -- Calibre search (also matches the actual template for OpenSearch!)
                 if link.type:find(self.search_template_type) and link.rel and link.rel:find("search") then
-                    if link.href then
+                    if link.href and not has_opensearch then
                         table.insert(item_table, {
                             text       = "\u{f002} " .. _("Search"),
                             url        = build_href(link.href:gsub("{searchTerms}", "%%s")),

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -497,7 +497,8 @@ function OPDSBrowser:updateCatalog(item_url, paths_updated)
             self:addSubCatalog(item_url)
         end
         if self.page_num <= 1 then
-            self:onNextPage()
+            -- Request more content, but don't change the page
+            self:onNextPage(true)
         end
     end
 end
@@ -886,7 +887,7 @@ function OPDSBrowser:onHoldReturn()
 end
 
 -- Menu action on next-page chevron tap (request and show more catalog entries)
-function OPDSBrowser:onNextPage()
+function OPDSBrowser:onNextPage(fill_only)
     -- self.page_num comes from menu.lua
     local page_num = self.page_num
     -- fetch more entries until we fill out one page or reach the end
@@ -900,8 +901,10 @@ function OPDSBrowser:onNextPage()
             break
         end
     end
-    -- We also *do* want to paginate, so call the base class.
-    Menu.onNextPage(self)
+    if not fill_only then
+        -- We also *do* want to paginate, so call the base class.
+        Menu.onNextPage(self)
+    end
     return true
 end
 

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -361,7 +361,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                             text       = "\u{f002} " .. _("Search"), -- append SEARCH icon
                             url        = build_href(self:getSearchTemplate(build_href(link.href))),
                             searchable = true,
-                       })
+                        })
                     end
                 end
                 -- Calibre search
@@ -371,7 +371,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                             text       = "\u{f002} " .. _("Search"),
                             url        = build_href(link.href:gsub("{searchTerms}", "%%s")),
                             searchable = true,
-                       })
+                        })
                     end
                 end
             end
@@ -497,7 +497,7 @@ function OPDSBrowser:updateCatalog(item_url, paths_updated)
             self:addSubCatalog(item_url)
         end
         if self.page_num <= 1 then
-            self:onNext()
+            self:onNextPage()
         end
     end
 end
@@ -507,7 +507,10 @@ function OPDSBrowser:appendCatalog(item_url)
     local menu_table = self:genItemTableFromURL(item_url)
     if #menu_table > 0 then
         for _, item in ipairs(menu_table) do
-            table.insert(self.item_table, item)
+            -- Don't append multiple search entries
+            if not item.searchable then
+                table.insert(self.item_table, item)
+            end
         end
         self.item_table.hrefs = menu_table.hrefs
         self:switchItemTable(self.catalog_title, self.item_table, -1)
@@ -883,7 +886,7 @@ function OPDSBrowser:onHoldReturn()
 end
 
 -- Menu action on next-page chevron tap (request and show more catalog entries)
-function OPDSBrowser:onNext()
+function OPDSBrowser:onNextPage()
     -- self.page_num comes from menu.lua
     local page_num = self.page_num
     -- fetch more entries until we fill out one page or reach the end
@@ -897,6 +900,8 @@ function OPDSBrowser:onNext()
             break
         end
     end
+    -- We also *do* want to paginate, so call the base class.
+    Menu.onNextPage(self)
     return true
 end
 


### PR DESCRIPTION
* Actually log failures, besides showing the completely unhelpful InfoMessage.
* Handle searches on Calibre.
* Fix content fill on pagination. I have no frickin' clue how the hell this ever worked, as it was using the wrong handler name.

Fix #11968

(Rebase me).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11972)
<!-- Reviewable:end -->
