### PR TITLE
Fix Norwegian Bokmål-English Wiktionary download link

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -2073,7 +2073,7 @@ local dictionaries = {
         lang_out = "eng",
         entries = 20431,
         license = "Dual-licensed under CC-BY-SA 3.0 and GFDL",
-        url = "https://github.com/Vuizur/Wiktionary-Dictionaries/raw/master/Norwegian%20Bokmål-English%20Wiktionary%20dictionary%20stardict.tar.gz",
+        url = "https://github.com/Vuizur/Wiktionary-Dictionaries/raw/master/Norwegian%20Bokm%C3%A5l-English%20Wiktionary%20dictionary%20stardict.tar.gz",
     },
     {
         name = "Norwegian Nynorsk-English Wiktionary",


### PR DESCRIPTION
Fixes #11970.

Apparently UTF-8 doesn't work unless it's URL-encoded.