### PR TITLE
Screensaver: fix menu wordings

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -85,7 +85,7 @@ return {
                 end,
                 sub_item_table = {
                     {
-                        text = _("Select image or document cover"),
+                        text = _("Choose image or document cover"),
                         enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "document_cover"
                         end,
@@ -95,7 +95,7 @@ return {
                         end,
                     },
                     {
-                        text = _("Select random image folder"),
+                        text = _("Choose random image folder"),
                         enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "random_image"
                         end,

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -265,7 +265,7 @@ local function addOverlayMessage(widget, widget_height, text)
 end
 
 function Screensaver:chooseFolder()
-    local title_header = _("Current screensaver folder:")
+    local title_header = _("Current random image folder:")
     local current_path = G_reader_settings:readSetting("screensaver_dir")
     local caller_callback = function(path)
         G_reader_settings:saveSetting("screensaver_dir", path)
@@ -275,7 +275,7 @@ end
 
 function Screensaver:chooseFile()
     local title_header, current_path, file_filter, caller_callback
-    title_header = _("Current sleep screen image or document cover:")
+    title_header = _("Current image or document cover:")
     current_path = G_reader_settings:readSetting("screensaver_document_cover")
     file_filter = function(filename)
         return DocumentRegistry:hasProvider(filename)


### PR DESCRIPTION
As we discussed some time ago: "select" to mark a group, "choose" to pick-up.

Before

![1](https://github.com/koreader/koreader/assets/62179190/92a2cb09-1204-4fd8-9c85-20841e96ece7)

After

![2](https://github.com/koreader/koreader/assets/62179190/b0aac755-7a5b-4f17-94f2-e832d4435eb6)
