### PR TITLE
Footer: add book authors item

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -381,19 +381,24 @@ local footerTextGeneratorMap = {
         end
     end,
     book_author = function(footer)
-        local author = footer.ui.doc_props.authors:gsub(" ", "\u{00A0}") -- replace space with no-break-space
-        local author_widget = TextWidget:new{
-            text = author,
-            max_width = footer._saved_screen_width * footer.settings.book_author_max_width_pct * (1/100),
-            face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
-            bold = footer.settings.text_font_bold,
-        }
-        local fitted_author_text, add_ellipsis = author_widget:getFittedText()
-        author_widget:free()
-        if add_ellipsis then
-            fitted_author_text = fitted_author_text .. "…"
+        local author = footer.ui.doc_props.authors
+        if author and author ~= "" then
+            author = author:gsub(" ", "\u{00A0}") -- replace space with no-break-space
+            local author_widget = TextWidget:new{
+                text = author,
+                max_width = footer._saved_screen_width * footer.settings.book_author_max_width_pct * (1/100),
+                face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
+                bold = footer.settings.text_font_bold,
+            }
+            local fitted_author_text, add_ellipsis = author_widget:getFittedText()
+            author_widget:free()
+            if add_ellipsis then
+                fitted_author_text = fitted_author_text .. "…"
+            end
+            return BD.auto(fitted_author_text)
+        else
+            return ""
         end
-        return BD.auto(fitted_author_text)
     end,
     book_title = function(footer)
         local title = footer.ui.doc_props.display_title:gsub(" ", "\u{00A0}") -- replace space with no-break-space

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1326,7 +1326,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Minimum progress bar width: %1".. "\u{202F}%"), self.settings.progress_bar_min_width_pct)
+                    return T(_("Minimum progress bar width: %1\u{202F}%"), self.settings.progress_bar_min_width_pct)
                 end,
                 enabled_func = function()
                     return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
@@ -1602,7 +1602,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Book-author item: %1".. "\u{202F}%"), self.settings.book_author_max_width_pct)
+                            return T(_("Book-author item: %1\u{202F}%"), self.settings.book_author_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
@@ -1628,7 +1628,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     },
                     {
                         text_func = function()
-                            return T(_("Book-title item: %1".. "\u{202F}%"), self.settings.book_title_max_width_pct)
+                            return T(_("Book-title item: %1\u{202F}%"), self.settings.book_title_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
@@ -1654,7 +1654,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     },
                     {
                         text_func = function()
-                            return T(_("Chapter-title item: %1".. "\u{202F}%"), self.settings.book_chapter_max_width_pct)
+                            return T(_("Chapter-title item: %1\u{202F}%"), self.settings.book_chapter_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
@@ -1748,7 +1748,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
         table.insert(configure_items_sub_table , 5, {
             text_func = function()
                 if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200 or 100) then
-                    return T(_("Hide battery item when higher than: %1".. "\u{202F}%"), self.settings.battery_hide_threshold)
+                    return T(_("Hide battery item when higher than: %1\u{202F}%"), self.settings.battery_hide_threshold)
                 else
                     return _("Hide battery item at custom threshold")
                 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -43,7 +43,7 @@ local MODE = {
     frontlight = 9,
     mem_usage = 10,
     wifi_status = 11,
-    book_author = 12,
+    book_authors = 12,
     book_title = 13,
     book_chapter = 14,
     bookmark_count = 15,
@@ -380,20 +380,20 @@ local footerTextGeneratorMap = {
             end
         end
     end,
-    book_author = function(footer)
-        local author = footer.ui.doc_props.authors:gsub(" ", "\u{00A0}") -- replace space with no-break-space
-        local author_widget = TextWidget:new{
-            text = author,
-            max_width = footer._saved_screen_width * footer.settings.book_author_max_width_pct * (1/100),
+    book_authors = function(footer)
+        local authors = footer.ui.doc_props.authors:gsub(" ", "\u{00A0}") -- replace space with no-break-space
+        local authors_widget = TextWidget:new{
+            text = authors,
+            max_width = footer._saved_screen_width * footer.settings.book_authors_max_width_pct * (1/100),
             face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
             bold = footer.settings.text_font_bold,
         }
-        local fitted_author_text, add_ellipsis = author_widget:getFittedText()
-        author_widget:free()
+        local fitted_authors_text, add_ellipsis = authors_widget:getFittedText()
+        authors_widget:free()
         if add_ellipsis then
-            fitted_author_text = fitted_author_text .. "…"
+            fitted_authors_text = fitted_authors_text .. "…"
         end
-        return BD.auto(fitted_author_text)
+        return BD.auto(fitted_authors_text)
     end,
     book_title = function(footer)
         local title = footer.ui.doc_props.display_title:gsub(" ", "\u{00A0}") -- replace space with no-break-space
@@ -475,7 +475,7 @@ ReaderFooter.default_settings = {
     frontlight = false,
     mem_usage = false,
     wifi_status = false,
-    book_author = false,
+    book_authors = false,
     book_title = false,
     book_chapter = false,
     bookmark_count = false,
@@ -488,7 +488,7 @@ ReaderFooter.default_settings = {
     container_bottom_padding = 1, -- unscaled_size_check: ignore
     progress_margin_width = Screen:scaleBySize(Device:isAndroid() and material_pixels or 10), -- default margin (like self.horizontal_margin)
     progress_bar_min_width_pct = 20,
-    book_author_max_width_pct = 30,
+    book_authors_max_width_pct = 30,
     book_title_max_width_pct = 30,
     book_chapter_max_width_pct = 30,
     skim_widget_on_hold = false,
@@ -993,7 +993,7 @@ function ReaderFooter:textOptionTitles(option)
         frontlight_warmth = T(_("Warmth level (%1)"), symbol_prefix[symbol].frontlight_warmth),
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
-        book_author = _("Book author"),
+        book_authors = _("Book authors"),
         book_title = _("Book title"),
         book_chapter = _("Chapter title"),
         custom_text = T(_("Custom text (long press to edit): \'%1\'%2"), self.custom_text,
@@ -1422,7 +1422,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     if Device:hasFastWifiStatusQuery() then
         table.insert(footer_items, getMinibarOption("wifi_status"))
     end
-    table.insert(footer_items, getMinibarOption("book_author"))
+    table.insert(footer_items, getMinibarOption("book_authors"))
     table.insert(footer_items, getMinibarOption("book_title"))
     table.insert(footer_items, getMinibarOption("book_chapter"))
     table.insert(footer_items, getMinibarOption("custom_text"))
@@ -1597,22 +1597,22 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Book-author item: %1".. "\u{202F}%"), self.settings.book_author_max_width_pct)
+                            return T(_("Book-authors item: %1".. "\u{202F}%"), self.settings.book_authors_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
-                                value = self.settings.book_author_max_width_pct,
+                                value = self.settings.book_authors_max_width_pct,
                                 value_min = 10,
                                 value_step = 5,
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Book-author item"),
-                                info_text = _("Maximum percentage of screen width used for book-author"),
-                                book_author_max_width_pct = 30,
+                                title_text = _("Book-authors item"),
+                                info_text = _("Maximum percentage of screen width used for book-authors"),
+                                book_authors_max_width_pct = 30,
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
-                                    self.settings.book_author_max_width_pct = spin.value
+                                    self.settings.book_authors_max_width_pct = spin.value
                                     self:refreshFooter(true, true)
                                     if touchmenu_instance then touchmenu_instance:updateItems() end
                                 end
@@ -2566,4 +2566,3 @@ function ReaderFooter:onCloseWidget()
 end
 
 return ReaderFooter
-

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -43,12 +43,13 @@ local MODE = {
     frontlight = 9,
     mem_usage = 10,
     wifi_status = 11,
-    book_title = 12,
-    book_chapter = 13,
-    bookmark_count = 14,
-    chapter_progress = 15,
-    frontlight_warmth = 16,
-    custom_text = 17,
+    book_author = 12,
+    book_title = 13,
+    book_chapter = 14,
+    bookmark_count = 15,
+    chapter_progress = 16,
+    frontlight_warmth = 17,
+    custom_text = 18,
 }
 
 local symbol_prefix = {
@@ -379,6 +380,21 @@ local footerTextGeneratorMap = {
             end
         end
     end,
+    book_author = function(footer)
+        local author = footer.ui.doc_props.authors:gsub(" ", "\u{00A0}") -- replace space with no-break-space
+        local author_widget = TextWidget:new{
+            text = author,
+            max_width = footer._saved_screen_width * footer.settings.book_author_max_width_pct * (1/100),
+            face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
+            bold = footer.settings.text_font_bold,
+        }
+        local fitted_author_text, add_ellipsis = author_widget:getFittedText()
+        author_widget:free()
+        if add_ellipsis then
+            fitted_author_text = fitted_author_text .. "…"
+        end
+        return BD.auto(fitted_author_text)
+    end,
     book_title = function(footer)
         local title = footer.ui.doc_props.display_title:gsub(" ", "\u{00A0}") -- replace space with no-break-space
         local title_widget = TextWidget:new{
@@ -459,6 +475,7 @@ ReaderFooter.default_settings = {
     frontlight = false,
     mem_usage = false,
     wifi_status = false,
+    book_author = false,
     book_title = false,
     book_chapter = false,
     bookmark_count = false,
@@ -471,6 +488,7 @@ ReaderFooter.default_settings = {
     container_bottom_padding = 1, -- unscaled_size_check: ignore
     progress_margin_width = Screen:scaleBySize(Device:isAndroid() and material_pixels or 10), -- default margin (like self.horizontal_margin)
     progress_bar_min_width_pct = 20,
+    book_author_max_width_pct = 30,
     book_title_max_width_pct = 30,
     book_chapter_max_width_pct = 30,
     skim_widget_on_hold = false,
@@ -975,6 +993,7 @@ function ReaderFooter:textOptionTitles(option)
         frontlight_warmth = T(_("Warmth level (%1)"), symbol_prefix[symbol].frontlight_warmth),
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
+        book_author = _("Book author"),
         book_title = _("Book title"),
         book_chapter = _("Chapter title"),
         custom_text = T(_("Custom text (long press to edit): \'%1\'%2"), self.custom_text,
@@ -1403,9 +1422,11 @@ function ReaderFooter:addToMainMenu(menu_items)
     if Device:hasFastWifiStatusQuery() then
         table.insert(footer_items, getMinibarOption("wifi_status"))
     end
+    table.insert(footer_items, getMinibarOption("book_author"))
     table.insert(footer_items, getMinibarOption("book_title"))
     table.insert(footer_items, getMinibarOption("book_chapter"))
     table.insert(footer_items, getMinibarOption("custom_text"))
+
     -- configure footer_items
     table.insert(sub_items, {
         separator = true,
@@ -1574,6 +1595,32 @@ With this feature enabled, the current page is factored in, resulting in the cou
             {
                 text = _("Item max width"),
                 sub_item_table = {
+                    {
+                        text_func = function()
+                            return T(_("Book-author item: %1".. "\u{202F}%"), self.settings.book_author_max_width_pct)
+                        end,
+                        callback = function(touchmenu_instance)
+                            local items = SpinWidget:new{
+                                value = self.settings.book_author_max_width_pct,
+                                value_min = 10,
+                                value_step = 5,
+                                value_hold_step = 20,
+                                value_max = 100,
+                                unit = "%",
+                                title_text = _("Book-author item"),
+                                info_text = _("Maximum percentage of screen width used for book-author"),
+                                book_author_max_width_pct = 30,
+                                keep_shown_on_apply = true,
+                                callback = function(spin)
+                                    self.settings.book_author_max_width_pct = spin.value
+                                    self:refreshFooter(true, true)
+                                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                                end
+                            }
+                            UIManager:show(items)
+                        end,
+                        keep_menu_open = true,
+                    },
                     {
                         text_func = function()
                             return T(_("Book-title item: %1".. "\u{202F}%"), self.settings.book_title_max_width_pct)
@@ -2519,3 +2566,4 @@ function ReaderFooter:onCloseWidget()
 end
 
 return ReaderFooter
+

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1614,7 +1614,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 unit = "%",
                                 title_text = _("Book-author item"),
                                 info_text = _("Maximum percentage of screen width used for book-author"),
-                                book_author_max_width_pct = 30,
+                                default_value = self.default_settings.book_author_max_width_pct,
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_author_max_width_pct = spin.value
@@ -1640,7 +1640,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 unit = "%",
                                 title_text = _("Book-title item"),
                                 info_text = _("Maximum percentage of screen width used for book-title"),
-                                book_title_max_width_pct = 30,
+                                default_value = self.default_settings.book_title_max_width_pct,
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_title_max_width_pct = spin.value
@@ -1666,7 +1666,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                                 unit = "%",
                                 title_text = _("Chapter-title item"),
                                 info_text = _("Maximum percentage of screen width used for chapter-title item"),
-                                book_chapter_max_width_pct = 30,
+                                default_value = self.default_settings.book_chapter_max_width_pct,
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
                                     self.settings.book_chapter_max_width_pct = spin.value

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2571,3 +2571,4 @@ function ReaderFooter:onCloseWidget()
 end
 
 return ReaderFooter
+

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2571,4 +2571,3 @@ function ReaderFooter:onCloseWidget()
 end
 
 return ReaderFooter
-

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1326,7 +1326,7 @@ function ReaderFooter:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("Minimum progress bar width: %1\u{202F}%"), self.settings.progress_bar_min_width_pct)
+                    return T(_("Minimum progress bar width: %1\xE2\x80\xAF%"), self.settings.progress_bar_min_width_pct) -- U+202F NARROW NO-BREAK SPACE
                 end,
                 enabled_func = function()
                     return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
@@ -1602,7 +1602,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Book-author item: %1\u{202F}%"), self.settings.book_author_max_width_pct)
+                            return T(_("Book-author item: %1\xE2\x80\xAF%"), self.settings.book_author_max_width_pct) -- U+202F NARROW NO-BREAK SPACE
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
@@ -1628,7 +1628,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     },
                     {
                         text_func = function()
-                            return T(_("Book-title item: %1\u{202F}%"), self.settings.book_title_max_width_pct)
+                            return T(_("Book-title item: %1\xE2\x80\xAF%"), self.settings.book_title_max_width_pct) -- U+202F NARROW NO-BREAK SPACE
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
@@ -1654,7 +1654,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
                     },
                     {
                         text_func = function()
-                            return T(_("Chapter-title item: %1\u{202F}%"), self.settings.book_chapter_max_width_pct)
+                            return T(_("Chapter-title item: %1\xE2\x80\xAF%"), self.settings.book_chapter_max_width_pct) -- U+202F NARROW NO-BREAK SPACE
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
@@ -1748,7 +1748,7 @@ With this feature enabled, the current page is factored in, resulting in the cou
         table.insert(configure_items_sub_table , 5, {
             text_func = function()
                 if self.settings.battery_hide_threshold <= (Device:hasAuxBattery() and 200 or 100) then
-                    return T(_("Hide battery item when higher than: %1\u{202F}%"), self.settings.battery_hide_threshold)
+                    return T(_("Hide battery item when higher than: %1\xE2\x80\xAF%"), self.settings.battery_hide_threshold) -- U+202F NARROW NO-BREAK SPACE
                 else
                     return _("Hide battery item at custom threshold")
                 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -43,13 +43,13 @@ local MODE = {
     frontlight = 9,
     mem_usage = 10,
     wifi_status = 11,
-    book_authors = 12,
-    book_title = 13,
-    book_chapter = 14,
-    bookmark_count = 15,
-    chapter_progress = 16,
-    frontlight_warmth = 17,
-    custom_text = 18,
+    book_title = 12,
+    book_chapter = 13,
+    bookmark_count = 14,
+    chapter_progress = 15,
+    frontlight_warmth = 16,
+    custom_text = 17,
+    book_author = 18,
 }
 
 local symbol_prefix = {
@@ -380,20 +380,20 @@ local footerTextGeneratorMap = {
             end
         end
     end,
-    book_authors = function(footer)
-        local authors = footer.ui.doc_props.authors:gsub(" ", "\u{00A0}") -- replace space with no-break-space
-        local authors_widget = TextWidget:new{
-            text = authors,
-            max_width = footer._saved_screen_width * footer.settings.book_authors_max_width_pct * (1/100),
+    book_author = function(footer)
+        local author = footer.ui.doc_props.authors:gsub(" ", "\u{00A0}") -- replace space with no-break-space
+        local author_widget = TextWidget:new{
+            text = author,
+            max_width = footer._saved_screen_width * footer.settings.book_author_max_width_pct * (1/100),
             face = Font:getFace(footer.text_font_face, footer.settings.text_font_size),
             bold = footer.settings.text_font_bold,
         }
-        local fitted_authors_text, add_ellipsis = authors_widget:getFittedText()
-        authors_widget:free()
+        local fitted_author_text, add_ellipsis = author_widget:getFittedText()
+        author_widget:free()
         if add_ellipsis then
-            fitted_authors_text = fitted_authors_text .. "…"
+            fitted_author_text = fitted_author_text .. "…"
         end
-        return BD.auto(fitted_authors_text)
+        return BD.auto(fitted_author_text)
     end,
     book_title = function(footer)
         local title = footer.ui.doc_props.display_title:gsub(" ", "\u{00A0}") -- replace space with no-break-space
@@ -475,7 +475,7 @@ ReaderFooter.default_settings = {
     frontlight = false,
     mem_usage = false,
     wifi_status = false,
-    book_authors = false,
+    book_author = false,
     book_title = false,
     book_chapter = false,
     bookmark_count = false,
@@ -488,7 +488,7 @@ ReaderFooter.default_settings = {
     container_bottom_padding = 1, -- unscaled_size_check: ignore
     progress_margin_width = Screen:scaleBySize(Device:isAndroid() and material_pixels or 10), -- default margin (like self.horizontal_margin)
     progress_bar_min_width_pct = 20,
-    book_authors_max_width_pct = 30,
+    book_author_max_width_pct = 30,
     book_title_max_width_pct = 30,
     book_chapter_max_width_pct = 30,
     skim_widget_on_hold = false,
@@ -993,7 +993,7 @@ function ReaderFooter:textOptionTitles(option)
         frontlight_warmth = T(_("Warmth level (%1)"), symbol_prefix[symbol].frontlight_warmth),
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
-        book_authors = _("Book authors"),
+        book_author = _("Book author"),
         book_title = _("Book title"),
         book_chapter = _("Chapter title"),
         custom_text = T(_("Custom text (long press to edit): \'%1\'%2"), self.custom_text,
@@ -1422,7 +1422,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     if Device:hasFastWifiStatusQuery() then
         table.insert(footer_items, getMinibarOption("wifi_status"))
     end
-    table.insert(footer_items, getMinibarOption("book_authors"))
+    table.insert(footer_items, getMinibarOption("book_author"))
     table.insert(footer_items, getMinibarOption("book_title"))
     table.insert(footer_items, getMinibarOption("book_chapter"))
     table.insert(footer_items, getMinibarOption("custom_text"))
@@ -1597,22 +1597,22 @@ With this feature enabled, the current page is factored in, resulting in the cou
                 sub_item_table = {
                     {
                         text_func = function()
-                            return T(_("Book-authors item: %1".. "\u{202F}%"), self.settings.book_authors_max_width_pct)
+                            return T(_("Book-author item: %1".. "\u{202F}%"), self.settings.book_author_max_width_pct)
                         end,
                         callback = function(touchmenu_instance)
                             local items = SpinWidget:new{
-                                value = self.settings.book_authors_max_width_pct,
+                                value = self.settings.book_author_max_width_pct,
                                 value_min = 10,
                                 value_step = 5,
                                 value_hold_step = 20,
                                 value_max = 100,
                                 unit = "%",
-                                title_text = _("Book-authors item"),
-                                info_text = _("Maximum percentage of screen width used for book-authors"),
-                                book_authors_max_width_pct = 30,
+                                title_text = _("Book-author item"),
+                                info_text = _("Maximum percentage of screen width used for book-author"),
+                                book_author_max_width_pct = 30,
                                 keep_shown_on_apply = true,
                                 callback = function(spin)
-                                    self.settings.book_authors_max_width_pct = spin.value
+                                    self.settings.book_author_max_width_pct = spin.value
                                     self:refreshFooter(true, true)
                                     if touchmenu_instance then touchmenu_instance:updateItems() end
                                 end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240614
+local CURRENT_MIGRATION_DATE = 20240616
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -234,9 +234,9 @@ end
 
 -- 20210518, ReaderFooter, https://github.com/koreader/koreader/pull/7702
 -- 20210622, ReaderFooter, https://github.com/koreader/koreader/pull/7876
--- 20240614, ReaderFooter, https://github.com/koreader/koreader/pull/11999
-if last_migration_date < 20240614 then
-    logger.info("Performing one-time migration for 20240614")
+-- 20240616, ReaderFooter, https://github.com/koreader/koreader/pull/11999
+if last_migration_date < 20240616 then
+    logger.info("Performing one-time migration for 20240616")
 
     local ReaderFooter = require("apps/reader/modules/readerfooter")
     local settings = G_reader_settings:readSetting("footer", ReaderFooter.default_settings)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240408
+local CURRENT_MIGRATION_DATE = 20240609
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -234,8 +234,9 @@ end
 
 -- 20210518, ReaderFooter, https://github.com/koreader/koreader/pull/7702
 -- 20210622, ReaderFooter, https://github.com/koreader/koreader/pull/7876
-if last_migration_date < 20210622 then
-    logger.info("Performing one-time migration for 20210622")
+-- 20240609, ReaderFooter, https://github.com/koreader/koreader/pull/
+if last_migration_date < 20240609 then
+    logger.info("Performing one-time migration for 20240609")
 
     local ReaderFooter = require("apps/reader/modules/readerfooter")
     local settings = G_reader_settings:readSetting("footer", ReaderFooter.default_settings)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240609
+local CURRENT_MIGRATION_DATE = 20240614
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -235,8 +235,8 @@ end
 -- 20210518, ReaderFooter, https://github.com/koreader/koreader/pull/7702
 -- 20210622, ReaderFooter, https://github.com/koreader/koreader/pull/7876
 -- 20240609, ReaderFooter, https://github.com/koreader/koreader/pull/11999
-if last_migration_date < 20240609 then
-    logger.info("Performing one-time migration for 20240609")
+if last_migration_date < 20240614 then
+    logger.info("Performing one-time migration for 20240614")
 
     local ReaderFooter = require("apps/reader/modules/readerfooter")
     local settings = G_reader_settings:readSetting("footer", ReaderFooter.default_settings)

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -234,7 +234,7 @@ end
 
 -- 20210518, ReaderFooter, https://github.com/koreader/koreader/pull/7702
 -- 20210622, ReaderFooter, https://github.com/koreader/koreader/pull/7876
--- 20240609, ReaderFooter, https://github.com/koreader/koreader/pull/
+-- 20240609, ReaderFooter, https://github.com/koreader/koreader/pull/11999
 if last_migration_date < 20240609 then
     logger.info("Performing one-time migration for 20240609")
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -234,7 +234,7 @@ end
 
 -- 20210518, ReaderFooter, https://github.com/koreader/koreader/pull/7702
 -- 20210622, ReaderFooter, https://github.com/koreader/koreader/pull/7876
--- 20240609, ReaderFooter, https://github.com/koreader/koreader/pull/11999
+-- 20240614, ReaderFooter, https://github.com/koreader/koreader/pull/11999
 if last_migration_date < 20240614 then
     logger.info("Performing one-time migration for 20240614")
 


### PR DESCRIPTION
Closes #7642

@hius07 
I just copied the logic from Book title item, so max item width is the same (30%), so users will need to adjust them themselves.

Please let me know if I missed anything.

I added onetime-migration as well and tested on my Kindle Scribe with `koreader-kindlepw2-v2024.04-154-gc8f4008e9_2024-06-08` build. All good! Sorting, enable/disable all work.

Open question: currently it takes all `authors` field, which might include one author, two, or as many as it contains. Should there be a limiting number of authors (configurable)? Say, 3 or 4. I presume this could be done by regex-cutting up to `n` number of commas in the string :D 

Here is a screenshot:
![Reader_2024-06-09_023036](https://github.com/koreader/koreader/assets/6279855/871a6474-4457-4885-8b08-ee25d8b87918)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/11999)
<!-- Reviewable:end -->
