### PR TITLE
[AltStatusBar] Fix when showing (almost) empty

### DIFF
--- a/frontend/apps/reader/modules/readercoptlistener.lua
+++ b/frontend/apps/reader/modules/readercoptlistener.lua
@@ -304,7 +304,11 @@ function ReaderCoptListener:setAndSave(setting, property, value)
     self.document._document:setIntProperty(property, value)
     G_reader_settings:saveSetting(setting, value)
     self.page_info_override = self.page_number == 1 or self.page_count == 1 or self.reading_percent == 1
-    self:updatePageInfoOverride()
+    if self.page_info_override then
+        self:updatePageInfoOverride()
+    else
+        self.document:setPageInfoOverride("") -- Don't forget to restore CRE default behaviour.
+    end
     -- Have crengine redraw it (even if hidden by the menu at this time)
     self.ui.rolling:updateBatteryState()
     self:updateHeader()


### PR DESCRIPTION
With enabled battery percentage shown and some other (e.g. reading percentage) the alt status bar shows the expected line. But when disabling everything except battery percentage, then the reading percentage keeps being shown.

So when using this `self:page_info_override` caching trick, we have to restore the cre default again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12003)
<!-- Reviewable:end -->
