### PR TITLE
add Device:otaModel()

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -115,6 +115,18 @@ local Device = Generic:extend{
         end
     end,
 }
+function Device:otaModel()
+    -- "x86", "x64", "arm", "arm64", "ppc", "mips" or "mips64".
+    local arch = jit.arch
+    if arch == "arm64" then
+        return "android-arm64"
+    elseif arch == "x86" then
+        return "android-x86"
+    elseif arch == "x64" then
+        return "android-x86_64"
+    end
+    return "android"
+end
 
 function Device:init()
     self.screen = require("ffi/framebuffer_android"):new{device = self, debug = logger.dbg}

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -118,14 +118,17 @@ local Device = Generic:extend{
 function Device:otaModel()
     -- "x86", "x64", "arm", "arm64", "ppc", "mips" or "mips64".
     local arch = jit.arch
+    local model
     if arch == "arm64" then
-        return "android-arm64"
+        model = "android-arm64"
     elseif arch == "x86" then
-        return "android-x86"
+        model = "android-x86"
     elseif arch == "x64" then
-        return "android-x86_64"
+        model = "android-x86_64"
+    else
+        model = "android"
     end
-    return "android"
+    return model, "link"
 end
 
 function Device:init()

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -115,6 +115,7 @@ local Device = Generic:extend{
         end
     end,
 }
+
 function Device:otaModel()
     -- "x86", "x64", "arm", "arm64", "ppc", "mips" or "mips64".
     local arch = jit.arch

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -22,6 +22,7 @@ end
 
 local Cervantes = Generic:extend{
     model = "Cervantes",
+    ota_model = "cervantes",
     isCervantes = yes,
     isAlwaysPortrait = yes,
     isTouchDevice = yes,

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -519,7 +519,7 @@ function Device:standby(max_duration) end
 
 -- Returns a string, used to determine the platform to fetch OTA updates
 function Device:otaModel()
-    return self.ota_model or ""
+    return self.ota_model, "ota"
 end
 
 --[[--

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -516,6 +516,12 @@ function Device:simulateResume() end
 -- Put device into standby, input devices (buttons, touchscreen ...) stay enabled
 function Device:standby(max_duration) end
 
+
+-- Returns a string, used to determine the platform to fetch OTA updates
+function Device:otaModel()
+    return self.ota_model or ""
+end
+
 --[[--
 Device specific method for performing haptic feedback.
 

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -290,17 +290,19 @@ function Kindle:openInputDevices()
 end
 
 function Kindle:otaModel()
+    local model
     if self:isTouchDevice() or self.model == "Kindle4" then
         if isHardFP() then
-            return "kindlehf"
+            model = "kindlehf"
         elseif isWarioOrMore() then
-            return "kindlepw2"
+            model = "kindlepw2"
         else
-            return "kindle"
+            model = "kindle"
         end
     else
-        return "kindle-legacy"
+        model = "kindle-legacy"
     end
+    return model, "ota"
 end
 
 function Kindle:init()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -92,6 +92,7 @@ end
 
 local Kobo = Generic:extend{
     model = "Kobo",
+    ota_model = "kobo",
     isKobo = yes,
     isTouchDevice = yes, -- all of them are
     hasOTAUpdates = yes,

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -21,6 +21,7 @@ local app_name = "koreader.app"
 
 local PocketBook = Generic:extend{
     model = "PocketBook",
+    ota_model = "pocketbook",
     isPocketBook = yes,
     hasOTAUpdates = yes,
     hasWifiToggle = yes,

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -32,6 +32,7 @@ local isRm2, rm_model = getModel()
 local Remarkable = Generic:extend{
     isRemarkable = yes,
     model = rm_model,
+    ota_model = "remarkable",
     hasKeys = yes,
     needsScreenRefreshAfterResume = no,
     hasOTAUpdates = yes,
@@ -308,4 +309,3 @@ if isRm2 then
 else
     return Remarkable1
 end
-

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -108,6 +108,12 @@ local Device = Generic:extend{
     window = G_reader_settings:readSetting("sdl_window", {}),
 }
 
+function Device:otaModel()
+    if self.ota_model then
+        return self.ota_model, "link"
+    end
+end
+
 local AppImage = Device:extend{
     model = "AppImage",
     ota_model = "appimage",

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -110,6 +110,7 @@ local Device = Generic:extend{
 
 local AppImage = Device:extend{
     model = "AppImage",
+    ota_model = "appimage",
     hasOTAUpdates = yes,
     isDesktop = yes,
 }

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -50,12 +50,9 @@ local ota_channels = {
 }
 
 function OTAManager:getOTAType()
-    local ota_model = Device:otaModel()
-    if ota_model == "" then return end
-    if ota_model:find("android") or ota_model:find("appimage") then
-        return "link"
-    end
-    return "ota"
+    local platform, kind = Device:otaModel()
+    if not platform then return end
+    return kind
 end
 
 function OTAManager:getOTAServer()


### PR DESCRIPTION
Devices with a single target might want to specify it in `Device.ota_model`
Devices with multiple targets want to override the function or to specify `ota_model` variants for each target.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12014)
<!-- Reviewable:end -->
