### PR TITLE
Styletweaks menu: Ignore `._` files

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -632,7 +632,7 @@ You can enable individual tweaks on this book with a tap, or view more details a
                     local mode = lfs.attributes(dir.."/"..f, "mode")
                     if mode == "directory" then
                         table.insert(dir_list, f)
-                    elseif mode == "file" and string.match(f, "%.css$") then
+                    elseif mode == "file" and string.match(f, "%.css$") and not util.stringStartsWith(f, "._") then
                         table.insert(file_list, f)
                     end
                 end


### PR DESCRIPTION
Ignore files starting with "._" (metafiles by MacOS), that will otherwise show up in the Styletweaks menu. (These files are alrady ignored in the File manager, even when 'show hidden files' is enabled.)

<img width="236" alt="image" src="https://github.com/koreader/koreader/assets/95502269/40a6f755-f707-4df2-81b5-2e61af423bfe">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12022)
<!-- Reviewable:end -->
