### PR TITLE
ScreenSaver: Fix a bunch of weird corner-cases

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -587,23 +587,21 @@ function Screensaver:show()
     local message_height
     if self.show_message then
         -- Handle user settings & fallbacks, with that prefix mess on top...
-        local screensaver_message
+        local screensaver_message = self.default_screensaver_message
         if G_reader_settings:has(self.prefix .. "screensaver_message") then
             screensaver_message = G_reader_settings:readSetting(self.prefix .. "screensaver_message")
-        else
-            if G_reader_settings:has("screensaver_message") then
-                screensaver_message = G_reader_settings:readSetting("screensaver_message")
-            else
-                -- In the absence of a custom message, use the event message if any, barring that, use the default message.
-                if self.event_message then
-                    screensaver_message = self.event_message
-                    -- The overlay is only ever populated with the event message, and we only want to show it once ;).
-                    self.overlay_message = nil
-                else
-                    screensaver_message = self.default_screensaver_message
-                end
+        elseif G_reader_settings:has("screensaver_message") then
+            screensaver_message = G_reader_settings:readSetting("screensaver_message")
+        end
+        -- If the message is set to the defaults (which is also the case when it's unset), prefer the event message if there is one.
+        if screensaver_message == self.default_screensaver_message then
+            if self.event_message then
+                screensaver_message = self.event_message
+                -- The overlay is only ever populated with the event message, and we only want to show it once ;).
+                self.overlay_message = nil
             end
         end
+
         -- NOTE: Only attempt to expand if there are special characters in the message.
         if screensaver_message:find("%%") then
             screensaver_message = self:expandSpecial(screensaver_message, self.event_message or self.default_screensaver_message)

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -581,25 +581,25 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
     fi
 done
 
-# Restore original fb bitdepth if need be...
-# Since we also (almost) always enforce Portrait, we also have to restore the original rotation no matter what ;).
-if [ -n "${ORIG_FB_BPP}" ]; then
-    echo "Restoring original fb bitdepth @ ${ORIG_FB_BPP}bpp & rotation @ ${ORIG_FB_ROTA}" >>crash.log 2>&1
-    ./fbdepth -d "${ORIG_FB_BPP}" -r "${ORIG_FB_ROTA}" >>crash.log 2>&1
-else
-    echo "Restoring original fb rotation @ ${ORIG_FB_ROTA}" >>crash.log 2>&1
-    ./fbdepth -r "${ORIG_FB_ROTA}" >>crash.log 2>&1
-fi
-
-# Restore original CPUFreq governor if need be...
-if [ -n "${ORIG_CPUFREQ_GOV}" ]; then
-    echo "${ORIG_CPUFREQ_GOV}" >"${CPUFREQ_SYSFS_PATH}/scaling_governor"
-
-    # NOTE: Leave DVFS alone, it'll be handled by Nickel if necessary.
-fi
-
 # If we requested a reboot/shutdown, no need to bother with this...
 if [ ${RETURN_VALUE} -ne ${KO_RC_HALT} ]; then
+    # Restore original fb bitdepth if need be...
+    # Since we also (almost) always enforce Portrait, we also have to restore the original rotation no matter what ;).
+    if [ -n "${ORIG_FB_BPP}" ]; then
+        echo "Restoring original fb bitdepth @ ${ORIG_FB_BPP}bpp & rotation @ ${ORIG_FB_ROTA}" >>crash.log 2>&1
+        ./fbdepth -d "${ORIG_FB_BPP}" -r "${ORIG_FB_ROTA}" >>crash.log 2>&1
+    else
+        echo "Restoring original fb rotation @ ${ORIG_FB_ROTA}" >>crash.log 2>&1
+        ./fbdepth -r "${ORIG_FB_ROTA}" >>crash.log 2>&1
+    fi
+
+    # Restore original CPUFreq governor if need be...
+    if [ -n "${ORIG_CPUFREQ_GOV}" ]; then
+        echo "${ORIG_CPUFREQ_GOV}" >"${CPUFREQ_SYSFS_PATH}/scaling_governor"
+
+        # NOTE: Leave DVFS alone, it'll be handled by Nickel if necessary.
+    fi
+
     if [ "${VIA_NICKEL}" = "true" ]; then
         if [ "${FROM_KFMON}" = "true" ]; then
             # KFMon is the only launcher that has a toggle to either reboot or restart Nickel on exit


### PR DESCRIPTION
* On devices with a broken wait_for ioctl, the workaround could apparently lead to a weird race with the framebuffer state change done on exit, which could lead to strange results when displaying "slow" cover content as the sleep screen (#12009).
Stop touching the framebuffer state on poweroff/reboot to deal with this, as that was perfectly useless in these instances anyway ;).
* Consistently prefer the "event" i.e., (powered off/reboot...) message over the *default* message when show_message is enabled. Previously, it only applied when a custom message was *unset*, which hasn't been technically achievable through the UI for... quite a while now (maybe... ever? :D).

Fix #12009

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12028)
<!-- Reviewable:end -->
