### PR TITLE
WebDav:listFolder - skip adding phantom items

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -128,7 +128,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             local is_current_dir = self:isCurrentDirectory( util.urlDecode(item_fullpath), address, folder_path )
 
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
-            item_name = util.htmlEntitiesToUtf8(item_name)
+            item_name = util.htmlEntitiesToUtf8(item_name) -- avoid adding phantom items
             if "/" .. item_name == path then do break end end
             local is_not_collection = item:find("<[^:]*:resourcetype/>") or
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -118,7 +118,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
 
     if res_data ~= "" then
         -- iterate through the <d:response> tags, each containing an entry
-        for item in res_data:gmatch("<[^:]*:response[^>]*>(.-)</[^:]*:response>") do
+        for item in res_data:gmatch("<[^:]*:response[^>]*>(.-)</[^:]*:response>") do repeat
             --logger.dbg("WebDav catalog item=", item)
             -- <d:href> is the path and filename of the entry.
             local item_fullpath = item:match("<[^:]*:href[^>]*>(.*)</[^:]*:href>")
@@ -129,7 +129,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
 
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
             item_name = util.htmlEntitiesToUtf8(item_name)
-
+            if "/" .. item_name == path then do break end end
             local is_not_collection = item:find("<[^:]*:resourcetype/>") or
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
 
@@ -151,7 +151,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
                     type = "file",
                 })
             end
-        end
+        until true end
     else
         return nil
     end

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -118,18 +118,18 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
 
     if res_data ~= "" then
         -- iterate through the <d:response> tags, each containing an entry
-        for item in res_data:gmatch("<[^:]*:response[^>]*>(.-)</[^:]*:response>") do repeat
+        for item in res_data:gmatch("<[^:]*:response[^>]*>(.-)</[^:]*:response>") do
             --logger.dbg("WebDav catalog item=", item)
             -- <d:href> is the path and filename of the entry.
             local item_fullpath = item:match("<[^:]*:href[^>]*>(.*)</[^:]*:href>")
             if string.sub( item_fullpath, -1 ) == "/" then
                 item_fullpath = string.sub( item_fullpath, 1, -2 )
             end
-            local is_current_dir = self:isCurrentDirectory( util.urlDecode(item_fullpath), address, folder_path )
 
-            local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
+            local item_name = util.urlDecode(FFIUtil.basename(item_fullpath))
             item_name = util.htmlEntitiesToUtf8(item_name)
-            if item_name == string.sub(folder_path, -#item_name) then do break end end -- avoid adding phantom items
+            local is_current_dir = item_name == string.sub(folder_path, -#item_name)
+
             local is_not_collection = item:find("<[^:]*:resourcetype/>") or
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
 
@@ -151,7 +151,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
                     type = "file",
                 })
             end
-        until true end
+        end
     else
         return nil
     end

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -129,7 +129,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
 
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
             item_name = util.htmlEntitiesToUtf8(item_name)
-            if "/" .. item_name == folder_path then do break end end -- avoid adding phantom items
+            if item_name == string.sub(folder_path, -#item_name) then do break end end -- avoid adding phantom items
             local is_not_collection = item:find("<[^:]*:resourcetype/>") or
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
 

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -128,8 +128,8 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             local is_current_dir = self:isCurrentDirectory( util.urlDecode(item_fullpath), address, folder_path )
 
             local item_name = util.urlDecode( FFIUtil.basename( item_fullpath ) )
-            item_name = util.htmlEntitiesToUtf8(item_name) -- avoid adding phantom items
-            if "/" .. item_name == path then do break end end
+            item_name = util.htmlEntitiesToUtf8(item_name)
+            if "/" .. item_name == folder_path then do break end end -- avoid adding phantom items
             local is_not_collection = item:find("<[^:]*:resourcetype/>") or
                 item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
 


### PR DESCRIPTION
Closes #12025 

This is my try to fix the issue when a WebDav folder contains a phantom item with exact same name as that of the current folder itself. This phantom item is, of course, non-interactable.

So, in the `for` loop where all url-decoded items are added to the `webdav_list` table, I check whether current-iteration item is phantom ("path to current item with trailing slash" is equal to "path of current folder") or real.

Any suggestions or comments are appreciated! :D

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12034)
<!-- Reviewable:end -->
