### PR TITLE
[Filechooser] 0% > 'on hold'

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -212,7 +212,7 @@ local FileChooser = Menu:extend{
             end,
         },
         percent_natural = {
-            -- sort 90% > 50% > 0% or on hold > unopened > 100% or finished
+            -- sort 90% > 50% > 0% > on hold > unopened > 100% or finished
             text = _("percent – unopened – finished last"),
             menu_order = 90,
             can_collate_mixed = false,
@@ -241,11 +241,11 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     local summary = doc_settings:readSetting("summary")
 
-                    -- books marked as "finished" or "on hold" should be considered the same as 100% and 0% respectively
+                    -- books marked as "finished" or "on hold" should be considered the same as 100% and less than 0% respectively
                     if summary and summary.status == "complete" then
                         sort_percent = 1.0
                     elseif summary and summary.status == "abandoned" then
-                        sort_percent = 0
+                        sort_percent = -0.01
                     end
 
                     percent_finished = doc_settings:readSetting("percent_finished")


### PR DESCRIPTION
This is a minor annoyance of mine, since the introduction of "sort_percent" (#11592) `0%` and `on hold` marked books intermingle with one another, which was not the original intention (in my mind at least).

As a remainder, "sort_percent" is a local variable used exclusively to organise books in only _this_ sorting mode (percent – unopened – finished last), so should not affect anyone or anything else.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12037)
<!-- Reviewable:end -->
