### PR TITLE
Update bug_report.md with new location of verbose logging toggle.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ Please try to include the relevant sections in your issue description.
 You can upload the whole `crash.log` file (zipped if necessary) on GitHub by dragging and dropping it onto this textbox.
 
 If your issue doesn't directly concern a Lua crash, we'll quite likely need you to reproduce the issue with *verbose* debug logging enabled before providing the logs to us.
-To do so, go to `Top menu - Hamburger menu - Help - Report a bug` and tap `Enable verbose logging`. Restart as requested, then repeat the steps for your issue.
+To do so, go to `Top menu → Hamburger menu → Help → Report a bug` and tap `Enable verbose logging`. Restart as requested, then repeat the steps for your issue.
 
 If you instead opt to inline it, please do so behind a spoiler tag:
 <details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,9 +30,6 @@ You can upload the whole `crash.log` file (zipped if necessary) on GitHub by dra
 If your issue doesn't directly concern a Lua crash, we'll quite likely need you to reproduce the issue with *verbose* debug logging enabled before providing the logs to us.
 To do so, go to `Top menu - Hamburger menu - Help - Report a bug` and tap `Enable verbose logging`. Restart as requested, then repeat the steps for your issue.
 
-Alternatively, from the file manager, go to [Tools] → More tools → Developer options, and tick both `Enable debug logging` and `Enable verbose debug logging`.
-You'll need to restart KOReader after toggling these on as well.
-
 If you instead opt to inline it, please do so behind a spoiler tag:
 <details>
   <summary>crash.log</summary>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,8 +28,10 @@ Please try to include the relevant sections in your issue description.
 You can upload the whole `crash.log` file (zipped if necessary) on GitHub by dragging and dropping it onto this textbox.
 
 If your issue doesn't directly concern a Lua crash, we'll quite likely need you to reproduce the issue with *verbose* debug logging enabled before providing the logs to us.
-To do so, from the file manager, go to [Tools] → More tools → Developer options, and tick both `Enable debug logging` and `Enable verbose debug logging`.
-You'll need to restart KOReader after toggling these on.
+To do so, go to `Top menu - Hamburger menu - Help - Report a bug` and tap `Enable verbose logging`. Restart as requested, then repeat the steps for your issue.
+
+Alternatively, from the file manager, go to [Tools] → More tools → Developer options, and tick both `Enable debug logging` and `Enable verbose debug logging`.
+You'll need to restart KOReader after toggling these on as well.
 
 If you instead opt to inline it, please do so behind a spoiler tag:
 <details>


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/11276

Rewording suggestions welcome!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12042)
<!-- Reviewable:end -->
