### PR TITLE
[plugin] Autosuspend and Autostandby: reset counter on page turn using remote http call

### DIFF
--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -114,6 +114,8 @@ function AutoStandby:onInputEvent()
     UIManager:scheduleIn(AutoStandby.delay, AutoStandby.allow, AutoStandby)
 end
 
+AutoStandby.onPageUpdate = AutoStandby.onInputEvent
+
 -- Prevent standby (by timer)
 function AutoStandby:prevent()
     if not AutoStandby.preventing then

--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -232,6 +232,8 @@ function AutoSuspend:onInputEvent()
     self.last_action_time = UIManager:getElapsedTimeSinceBoot()
 end
 
+AutoSuspend.onPageUpdate = AutoSuspend.onInputEvent
+
 function AutoSuspend:_unschedule_standby()
     if self.is_standby_scheduled and self.standby_task then
         logger.dbg("AutoSuspend: unschedule standby timer")


### PR DESCRIPTION
Extension of #11984 to close automatic suspend when using remote page turners (using http endpoints of httpserver ) as mentioned in comments of #12043

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12050)
<!-- Reviewable:end -->
