### PR TITLE
Fix Arabic keyboard layout (ظ key) 

### DIFF
--- a/frontend/ui/data/keyboardlayouts/ar_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ar_keyboard.lua
@@ -27,6 +27,7 @@ local raa = ar_popup.raa
 local sheen = ar_popup.sheen
 local taa = ar_popup.taa
 local thaa = ar_popup.thaa
+local th_aa = ar_popup.th_aa
 local thaal = ar_popup.thaal
 local dhad = ar_popup.dhad
 local ghayn = ar_popup.ghayn
@@ -96,7 +97,7 @@ return {
             { "'",                       taamarbouta,  "'",    "]", },
             {  arabic_comma,             waw,          "#",    "↑", },
             { ".",                       zay,          "@",    "↓", },
-            { "؟",                       thaa,         "!",    _at, },
+            { "؟",                       th_aa,         "!",    _at, },
             { label = "",
               width = 1.5,
               bold = false


### PR DESCRIPTION
As reported in #12005: ث was duplicated; ظ was missing.

Fixed layout: 

![image](https://github.com/koreader/koreader/assets/95502269/732c089e-03f3-4ef8-b6a6-40c63b8561af)

Closes #12005.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12063)
<!-- Reviewable:end -->
