### PR TITLE
[InputText, DictQuickLookup] Shortcuts for NT kindle

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -105,6 +105,13 @@ function DictQuickLookup:init()
         self.key_events.ReadNextResult = { { Input.group.PgFwd } }
         self.key_events.Close = { { Input.group.Back } }
         self.key_events.ShowResultsMenu = { { "Menu" } }
+        if Device:hasKeyboard() then
+            self.key_events.ChangeToPrevDict = { { "Shift", "Left" } }
+            self.key_events.ChangeToNextDict = { { "Shift", "Right" } }
+        elseif Device:hasScreenKB() then
+            self.key_events.ChangeToPrevDict = { { "ScreenKB", "Left" } }
+            self.key_events.ChangeToNextDict = { { "ScreenKB", "Right" } }
+        end
     end
     if Device:isTouchDevice() then
         local range = Geom:new{
@@ -424,7 +431,7 @@ function DictQuickLookup:init()
                     vsync = true,
                     enabled = self:isPrevDictAvaiable(),
                     callback = function()
-                        self:changeToPrevDict()
+                        self:onChangeToPrevDict()
                     end,
                     hold_callback = function()
                         self:changeToFirstDict()
@@ -448,7 +455,7 @@ function DictQuickLookup:init()
                     vsync = true,
                     enabled = self:isNextDictAvaiable(),
                     callback = function()
-                        self:changeToNextDict()
+                        self:onChangeToNextDict()
                     end,
                     hold_callback = function()
                         self:changeToLastDict()
@@ -957,7 +964,7 @@ function DictQuickLookup:isNextDictAvaiable()
     return self.dict_index < #self.results
 end
 
-function DictQuickLookup:changeToPrevDict()
+function DictQuickLookup:onChangeToPrevDict()
     if self:isPrevDictAvaiable() then
         self:changeDictionary(self.dict_index - 1)
     elseif #self.results > 1 then -- restart at end if first reached
@@ -965,7 +972,7 @@ function DictQuickLookup:changeToPrevDict()
     end
 end
 
-function DictQuickLookup:changeToNextDict()
+function DictQuickLookup:onChangeToNextDict()
     if self:isNextDictAvaiable() then
         self:changeDictionary(self.dict_index + 1)
     elseif #self.results > 1 then -- restart at first if end reached
@@ -1076,13 +1083,13 @@ end
 ]]--
 
 function DictQuickLookup:onReadNextResult()
-    self:changeToNextDict()
+    self:onChangeToNextDict()
     return true
 end
 
 function DictQuickLookup:onReadPrevResult()
     local prev_index = self.dict_index
-    self:changeToPrevDict()
+    self:onChangeToPrevDict()
     if self.dict_index ~= prev_index then
         -- Jump directly to bottom of previous dict definition
         -- to keep "continuous reading with tap" consistent
@@ -1162,9 +1169,9 @@ function DictQuickLookup:onSwipe(arg, ges)
     -- or not ges.pos:intersectWith(self.dict_frame.dimen) then
         local direction = BD.flipDirectionIfMirroredUILayout(ges.direction)
         if direction == "west" then
-            self:changeToNextDict()
+            self:onChangeToNextDict()
         elseif direction == "east" then
-            self:changeToPrevDict()
+            self:onChangeToPrevDict()
         else
             if self.refresh_callback then self.refresh_callback() end
             -- update footer (time & battery)

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1257,12 +1257,14 @@ function DictQuickLookup:lookupInputWord(hint)
         buttons = {
             {
                 {
-                    text = _("Translate"),
+                    text = _("Search dictionary"),
+                    is_enter_default = not self.is_wiki,
                     callback = function()
                         local text = self.input_dialog:getInputText()
                         if text ~= "" then
                             UIManager:close(self.input_dialog)
-                            Translator:showTranslation(text, true)
+                            self.is_wiki = false
+                            self.ui:handleEvent(Event:new("LookupWord", text, true))
                         end
                     end,
                 },
@@ -1288,14 +1290,12 @@ function DictQuickLookup:lookupInputWord(hint)
                     end,
                 },
                 {
-                    text = _("Search dictionary"),
-                    is_enter_default = not self.is_wiki,
+                    text = _("Translate"),
                     callback = function()
                         local text = self.input_dialog:getInputText()
                         if text ~= "" then
                             UIManager:close(self.input_dialog)
-                            self.is_wiki = false
-                            self.ui:handleEvent(Event:new("LookupWord", text, true))
+                            Translator:showTranslation(text, true)
                         end
                     end,
                 },

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -595,11 +595,11 @@ function InputText:onKeyPress(key)
     end
     local handled = true
 
-    if not key["Ctrl"] and not key["Shift"] and not key["Alt"] then
+    if not key["Ctrl"] and not key["Shift"] and not key["Alt"] and not key["ScreenKB"] then
         if key["Backspace"] then
             self:delChar()
         elseif key["Del"] then
-            self:delNextChar()
+            self:delChar()
         elseif key["Left"] then
             self:leftChar()
         elseif key["Right"] then
@@ -633,6 +633,25 @@ function InputText:onKeyPress(key)
         end
     else
         handled = false
+    end
+    if key["ScreenKB"] or key["Shift"] then
+        if key["Back"] then
+            self:delChar()
+        elseif key["Left"] then
+            self:leftChar()
+        elseif key["Right"] then
+            self:rightChar()
+        elseif key["Up"] then
+            self:upLine()
+        elseif key["Down"] then
+            self:downLine()
+        elseif key["Home"] then
+            if self.keyboard:isVisible() then
+                self:onCloseKeyboard()
+            else
+                self:onShowKeyboard(ignore_first_hold_release)
+            end
+        end
     end
     if not handled and Device:hasDPad() then
         -- FocusManager may turn on alternative key maps.

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -610,8 +610,6 @@ function InputText:onKeyPress(key)
             self:downLine()
         elseif key["End"] then
             self:goToEnd()
-        elseif key["Home"] then
-            self:goToHome()
         elseif key["Press"] then
             self:addChars("\n")
         elseif key["Tab"] then
@@ -649,7 +647,7 @@ function InputText:onKeyPress(key)
             if self.keyboard:isVisible() then
                 self:onCloseKeyboard()
             else
-                self:onShowKeyboard(ignore_first_hold_release)
+                self:onShowKeyboard()
             end
         end
     end


### PR DESCRIPTION
Yet another PR that slightly improves use on NT kindles.

When a NT user selects a word for which their dictionary might either show a tautological definition or some variation of "alternative spelling", said user can now go to edit mode (as meta-lookup is not available on NT) and quickly make changes with shortcuts. For example: A user searching for the word "caftan" on Wiktionary will get "_Alternative spelling of_ **kaftan**", selecting edit and with this PR, said user is allowed to make the required adjustments much, much faster than by simply relying on the virtual keyboard.

Also, added a shortcut to toggle the VK without losing focus `Shift` + `Home` (`ScreenKB` + `Home`, not sure why anyone would want to do it on K4 nonetheless here it is). As seen here #11374 (not sure if this PR should close that ticket as it is kind of a workaround rather than a full working setting, let me know)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12078)
<!-- Reviewable:end -->
