### PR TITLE
ConfigDialog: fix "toggle with more options"

### DIFF
--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -546,10 +546,14 @@ function ConfigOption:init()
                 local row_count = self.options[c].row_count or 1
                 local toggle_height = Screen:scaleBySize(self.options[c].height
                                                          or (30 * row_count))
+                local toggle, args = {}, {} -- keep options intact
+                for i = 1, #self.options[c].toggle do
+                    toggle[i] = self.options[c].toggle[i]
+                    args[i] = self.options[c].args[i]
+                end
                 if self.options[c].more_options then
-                    table.insert(self.options[c].toggle, "⋮")
-                    table.insert(self.options[c].args, "⋮")
-                    self.options[c].more_options = false
+                    table.insert(toggle, "⋮")
+                    table.insert(args, "⋮")
                 end
                 local switch = ToggleSwitch:new{
                     width = math.min(max_toggle_width, toggle_width),
@@ -558,17 +562,17 @@ function ConfigOption:init()
                     font_size = item_font_size,
                     name = self.options[c].name,
                     name_text = name_text,
-                    toggle = self.options[c].toggle,
+                    toggle = toggle,
                     alternate = self.options[c].alternate,
                     values = self.options[c].values,
-                    args = self.options[c].args,
+                    args = args,
                     event = self.options[c].event,
                     hide_on_apply = self.options[c].hide_on_apply,
                     config = self.config,
                     enabled = enabled,
                     row_count = row_count,
                     callback = function(arg)
-                        if self.options[c].toggle[arg] == "⋮" then
+                        if toggle[arg] == "⋮" then
                             if self.options[c].show_true_value_func and not self.options[c].more_options_param.show_true_value_func then
                                 self.options[c].more_options_param.show_true_value_func = self.options[c].show_true_value_func
                             end


### PR DESCRIPTION
Fix unreported crash.

For example, "Word spacing". If we go to the Gesture manager before opening the bottom menu:

![1](https://github.com/koreader/koreader/assets/62179190/ca6d9c46-812c-4085-91f1-3002c10d96d6)

After opening the bottom menu:

![2](https://github.com/koreader/koreader/assets/62179190/5980ab40-67f0-44bf-889d-998fcd756034)

Will crash on triggering action `⋮` with a gesture or a profile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12093)
<!-- Reviewable:end -->
