### PR TITLE
Fix for OTA updates w/ zsync

### DIFF
--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -84,6 +84,10 @@ function OTAManager:getFilename(kind)
     end
 end
 
+function OTAManager:getZsyncFilename()
+    return self:getFilename("ota")
+end
+
 function OTAManager:checkUpdate()
     if Device:isDeprecated() then return -1 end
     local http = require("socket.http")


### PR DESCRIPTION
Fixes #12115

Kobos, Kindles, Remarkables, Cervantes and Pocketbooks that updated to latest (couple of?) nightlies need to perform a manual update.

Sorry :/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12120)
<!-- Reviewable:end -->
