### PR TITLE
ReaderView: Fix tap zone inversion for the top/bottom type

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1178,8 +1178,12 @@ function ReaderView:getTapZones()
         end
     end
     if self.inverse_reading_order ~= BD.mirroredUILayout() then -- mirrored reading
+        -- left_right
         forward_zone.ratio_x = 1 - forward_zone.ratio_x - forward_zone.ratio_w
         backward_zone.ratio_x = 1 - backward_zone.ratio_x - backward_zone.ratio_w
+        -- top_bottom
+        forward_zone.ratio_y = 1 - forward_zone.ratio_y - forward_zone.ratio_h
+        backward_zone.ratio_y = 1 - backward_zone.ratio_y - backward_zone.ratio_h
     end
     return forward_zone, backward_zone
 end


### PR DESCRIPTION
Fixes the `Invert page turn taps and swipes` option not working if the type for tap zones was set to `top/bottom`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12127)
<!-- Reviewable:end -->
