### PR TITLE
Add wifi support to Cervantes Touch Light devices

### DIFF
--- a/platform/cervantes/disable-wifi.sh
+++ b/platform/cervantes/disable-wifi.sh
@@ -7,5 +7,5 @@ killall udhcpc wpa_supplicant 2>/dev/null
 ifconfig eth0 down 2>/dev/null
 if [ "${PCB_ID}" -ne 23 ]; then #For pcb_id==23 we avoid removing the module as it's known to freeze the wifi subsystem
     MODULE="8189fs"
-    modprobe -r $MODULE 2>/dev/null
+    modprobe -r ${MODULE} 2>/dev/null
 fi

--- a/platform/cervantes/disable-wifi.sh
+++ b/platform/cervantes/disable-wifi.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
+PCB_ID=$(/usr/bin/ntxinfo /dev/mmcblk0 | grep pcb | cut -d ":" -f2)
+
 # disable wifi and remove all modules
 killall udhcpc wpa_supplicant 2>/dev/null
 ifconfig eth0 down 2>/dev/null
-modprobe -r 8189fs 2>/dev/null
+if [ "${PCB_ID}" -ne 23 ]; then #For pcb_id==23 we avoid removing the module as it's known to freeze the wifi subsystem
+    MODULE="8189fs"
+    modprobe -r $MODULE 2>/dev/null
+fi

--- a/platform/cervantes/disable-wifi.sh
+++ b/platform/cervantes/disable-wifi.sh
@@ -5,7 +5,7 @@ PCB_ID=$(/usr/bin/ntxinfo /dev/mmcblk0 | grep pcb | cut -d ":" -f2)
 # disable wifi and remove all modules
 killall udhcpc wpa_supplicant 2>/dev/null
 ifconfig eth0 down 2>/dev/null
-if [ "${PCB_ID}" -ne 23 ]; then #For pcb_id==23 we avoid removing the module as it's known to freeze the wifi subsystem
+if [ "${PCB_ID}" -ne 22 ] && [ "${PCB_ID}" -ne 23 ]; then #For pcb_id==22 or 23 we avoid removing the module as it's known to freeze the wifi subsystem
     MODULE="8189fs"
     modprobe -r ${MODULE} 2>/dev/null
 fi

--- a/platform/cervantes/enable-wifi.sh
+++ b/platform/cervantes/enable-wifi.sh
@@ -9,7 +9,7 @@
 
 # select wifi driver based on pcb.
 PCB_ID=$(/usr/bin/ntxinfo /dev/mmcblk0 | grep pcb | cut -d ":" -f2)
-if [ "${PCB_ID}" -eq 23 ]; then
+if [ "${PCB_ID}" -eq 22 ] || [ "${PCB_ID}" -eq 23 ]; then
     MODULE="dhd"
     WPA_DRIVER="nl80211"
 else
@@ -28,3 +28,4 @@ ifconfig eth0 up
 sleep 1
 
 wpa_supplicant -i eth0 -C /var/run/wpa_supplicant -B -D ${WPA_DRIVER} 2>/dev/null
+sleep 1

--- a/platform/cervantes/enable-wifi.sh
+++ b/platform/cervantes/enable-wifi.sh
@@ -19,12 +19,12 @@ fi
 
 ./disable-wifi.sh
 
-if ! lsmod | grep -q $MODULE; then
-    modprobe $MODULE
+if ! lsmod | grep -q ${MODULE}; then
+    modprobe ${MODULE}
     sleep 1
 fi
 
 ifconfig eth0 up
 sleep 1
 
-wpa_supplicant -i eth0 -C /var/run/wpa_supplicant -B -D $WPA_DRIVER 2>/dev/null
+wpa_supplicant -i eth0 -C /var/run/wpa_supplicant -B -D ${WPA_DRIVER} 2>/dev/null

--- a/platform/cervantes/enable-wifi.sh
+++ b/platform/cervantes/enable-wifi.sh
@@ -6,14 +6,25 @@
 
 # Do not run this script twice (ie: when no wireless is available or wireless
 # association to ap failed.
+
+# select wifi driver based on pcb.
+PCB_ID=$(/usr/bin/ntxinfo /dev/mmcblk0 | grep pcb | cut -d ":" -f2)
+if [ "${PCB_ID}" -eq 23 ]; then
+    MODULE="dhd"
+    WPA_DRIVER="nl80211"
+else
+    MODULE="8189fs"
+    WPA_DRIVER="wext"
+fi
+
 ./disable-wifi.sh
 
-if ! lsmod | grep -q 8189fs; then
-    modprobe 8189fs
+if ! lsmod | grep -q $MODULE; then
+    modprobe $MODULE
     sleep 1
 fi
 
 ifconfig eth0 up
 sleep 1
 
-wpa_supplicant -i eth0 -C /var/run/wpa_supplicant -B -D wext 2>/dev/null
+wpa_supplicant -i eth0 -C /var/run/wpa_supplicant -B -D $WPA_DRIVER 2>/dev/null


### PR DESCRIPTION
This PR adds wifi support for the older Cervantes Touch Light device (PCB_ID==23) which uses a different wifi driver than the newer models. 

To enable wifi, the module to insert is "dhd" rather than 8189fs, and wpa_supplicant needs to use the "nl80211" driver.
Disabling wifi has also been changed to avoid removing the "dhd" module as it leaves the wifi subsystem completely frozen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12148)
<!-- Reviewable:end -->
