### PR TITLE
Footnote popup: fix XHTML handling

### DIFF
--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -293,8 +293,11 @@ function FootnoteWidget:init()
     local padding_bottom = Size.padding.large
     local htmlwidget_height = self.height - padding_top - padding_bottom
 
+    -- We always get balanced XHTML from crengine for HTML snippets, so we
+    -- pass is_xhtml=true to avoid side effects from MuPDF's HTML5 parser.
     self.htmlwidget = ScrollHtmlWidget:new{
         html_body = self.html,
+        is_xhtml = true,
         css = css,
         default_font_size = font_size,
         width = htmlwidget_width,

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -17,6 +17,7 @@ local Screen = Device.screen
 
 local ScrollHtmlWidget = InputContainer:extend{
     html_body = nil,
+    is_xhtml = false,
     css = nil,
     default_font_size = Screen:scaleBySize(24), -- same as infofont
     htmlbox_widget = nil,
@@ -39,7 +40,7 @@ function ScrollHtmlWidget:init()
         html_link_tapped_callback = self.html_link_tapped_callback,
     }
 
-    self.htmlbox_widget:setContent(self.html_body, self.css, self.default_font_size)
+    self.htmlbox_widget:setContent(self.html_body, self.css, self.default_font_size, self.is_xhtml)
 
     self.v_scroll_bar = VerticalScrollBar:new{
         enable = self.htmlbox_widget.page_count > 1,


### PR DESCRIPTION
Latest MuPDF update changed HTML parsing, and use a better HTML5 parser, which may cause some issues with the XHTML we get from crengine.
So, for footnote popups, be sure we use MuPDF's XHTML parser.
See https://github.com/koreader/koreader/issues/12144#issuecomment-2223853977.
Closes #12144.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12158)
<!-- Reviewable:end -->
