### PR TITLE
Create submenu for Noto fonts

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -28,6 +28,13 @@ local ReaderFont = InputContainer:extend{
 
 -- Keep a list of the new fonts seen at launch
 local newly_added_fonts = nil -- not yet filled
+local system_and_UI_fonts = { -- const
+        ["Noto Naskh Arabic"] = true,
+        ["Noto Sans Arabic UI"] = true,
+        ["Noto Sans Bengali UI"] = true,
+        ["Noto Sans Devanagari UI"] = true,
+        ["Noto Sans CJK SC"] = true,
+}
 
 function ReaderFont:init()
     self:registerKeyEvents()
@@ -792,6 +799,10 @@ function ReaderFont:addToRecentlySelectedList(face)
 end
 
 function ReaderFont:sortFaceList(face_list)
+    -- Remove UI fonts fonts from our list unless showing all system fonts
+    util.arrayRemove(face_list, function(t, i, j)
+        return not system_and_UI_fonts[face_list[i]] or G_reader_settings:isTrue("system_fonts")
+    end)
     self.fonts_recently_selected = G_reader_settings:readSetting("cre_fonts_recently_selected")
     if not self.fonts_recently_selected then
         -- Init this list with the alphabetical list we got


### PR DESCRIPTION
The long list of Noto Sans, Serif and Naskh fonts make the font list unwieldy. Here's a PR that puts those into a subfolder, making it easier to find other fonts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12171)
<!-- Reviewable:end -->
