### PR TITLE
'Use left and right keys for page turning' option added

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -52,10 +52,10 @@ function ReaderPaging:onGesture() end
 
 function ReaderPaging:registerKeyEvents()
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        if G_reader_settings:isTrue("left_right_turn_pages") then
+        if G_reader_settings:isTrue("left_right_keys_turn_pages") then
             self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd", "Right", " " } }, event = "GotoPosRel", args = 1, }
             self.key_events.GotoPrevPos = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoPosRel", args = -1, }
-        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
+        elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
             self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
             self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd", " " } }, event = "GotoPosRel", args = 1, }

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -52,99 +52,32 @@ function ReaderPaging:onGesture() end
 
 function ReaderPaging:registerKeyEvents()
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        self.key_events.GotoNextPos = {
-            { { "RPgFwd", "LPgFwd" } },
-            event = "GotoPosRel",
-            args = 1,
-        }
-        self.key_events.GotoPrevPos = {
-            { { "RPgBack", "LPgBack" } },
-            event = "GotoPosRel",
-            args = -1,
-        }
-        self.key_events.GotoNextChapter = {
-            { "Right" },
-            event = "GotoNextChapter",
-            args = 1,
-        }
-        self.key_events.GotoPrevChapter = {
-            { "Left" },
-            event = "GotoPrevChapter",
-            args = -1,
-        }
+        if G_reader_settings:isTrue("left_right_turn_pages") then
+            self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoPosRel", args = 1, }
+            self.key_events.GotoPrevPos = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoPosRel", args = -1, }
+        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
+            self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
+            self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
+            self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd" } }, event = "GotoPosRel", args = 1, }
+            self.key_events.GotoPrevPos = { { { "RPgBack", "LPgBack" } }, event = "GotoPosRel", args = -1, }
+        end
     elseif Device:hasKeys() then
-        self.key_events.GotoNextPage = {
-            { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and "Right" } },
-            event = "GotoViewRel",
-            args = 1,
-        }
-        self.key_events.GotoPrevPage = {
-            { { "RPgBack", "LPgBack", not Device:hasFewKeys() and "Left" } },
-            event = "GotoViewRel",
-            args = -1,
-        }
-        self.key_events.GotoNextPos = {
-            { "Down" },
-            event = "GotoPosRel",
-            args = 1,
-        }
-        self.key_events.GotoPrevPos = {
-            { "Up" },
-            event = "GotoPosRel",
-            args = -1,
-        }
+        self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and "Right" } }, event = "GotoViewRel", args = 1, }
+        self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", not Device:hasFewKeys() and "Left" } }, event = "GotoViewRel", args = -1, }
+        self.key_events.GotoNextPos = { { "Down" }, event = "GotoPosRel", args = 1, }
+        self.key_events.GotoPrevPos = { { "Up" }, event = "GotoPosRel", args = -1, }
     end
     if Device:hasKeyboard() then
-        self.key_events.GotoFirst = {
-            { "1" },
-            event = "GotoPercent",
-            args = 0,
-        }
-        self.key_events.Goto11 = {
-            { "2" },
-            event = "GotoPercent",
-            args = 11,
-        }
-        self.key_events.Goto22 = {
-            { "3" },
-            event = "GotoPercent",
-            args = 22,
-        }
-        self.key_events.Goto33 = {
-            { "4" },
-            event = "GotoPercent",
-            args = 33,
-        }
-        self.key_events.Goto44 = {
-            { "5" },
-            event = "GotoPercent",
-            args = 44,
-        }
-        self.key_events.Goto55 = {
-            { "6" },
-            event = "GotoPercent",
-            args = 55,
-        }
-        self.key_events.Goto66 = {
-            { "7" },
-            event = "GotoPercent",
-            args = 66,
-        }
-        self.key_events.Goto77 = {
-            { "8" },
-            event = "GotoPercent",
-            args = 77,
-        }
-        self.key_events.Goto88 = {
-            { "9" },
-            event = "GotoPercent",
-            args = 88,
-        }
-        self.key_events.GotoLast = {
-            { "0" },
-            event = "GotoPercent",
-            args = 100,
-        }
+        self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }
+        self.key_events.Goto11    = { { "2" }, event = "GotoPercent", args = 11,  }
+        self.key_events.Goto22    = { { "3" }, event = "GotoPercent", args = 22,  }
+        self.key_events.Goto33    = { { "4" }, event = "GotoPercent", args = 33,  }
+        self.key_events.Goto44    = { { "5" }, event = "GotoPercent", args = 44,  }
+        self.key_events.Goto55    = { { "6" }, event = "GotoPercent", args = 55,  }
+        self.key_events.Goto66    = { { "7" }, event = "GotoPercent", args = 66,  }
+        self.key_events.Goto77    = { { "8" }, event = "GotoPercent", args = 77,  }
+        self.key_events.Goto88    = { { "9" }, event = "GotoPercent", args = 88,  }
+        self.key_events.Goto99    = { { "0" }, event = "GotoPercent", args = 100, }
     end
 end
 

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -52,10 +52,10 @@ function ReaderPaging:onGesture() end
 
 function ReaderPaging:registerKeyEvents()
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        if G_reader_settings:isTrue("left_right_turn_pages") then
+        if G_reader_settings:isTrue("left_right_keys_turn_pages") then
             self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoPosRel", args = 1, }
             self.key_events.GotoPrevPos = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoPosRel", args = -1, }
-        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
+        elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
             self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
             self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd" } }, event = "GotoPosRel", args = 1, }

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -52,13 +52,13 @@ function ReaderPaging:onGesture() end
 
 function ReaderPaging:registerKeyEvents()
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        if G_reader_settings:isTrue("left_right_keys_turn_pages") then
-            self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoPosRel", args = 1, }
+        if G_reader_settings:isTrue("left_right_turn_pages") then
+            self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd", "Right", " " } }, event = "GotoPosRel", args = 1, }
             self.key_events.GotoPrevPos = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoPosRel", args = -1, }
-        elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
+        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
             self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
             self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
-            self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd" } }, event = "GotoPosRel", args = 1, }
+            self.key_events.GotoNextPos = { { { "RPgFwd", "LPgFwd", " " } }, event = "GotoPosRel", args = 1, }
             self.key_events.GotoPrevPos = { { { "RPgBack", "LPgBack" } }, event = "GotoPosRel", args = -1, }
         end
     elseif Device:hasKeys() then

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -117,22 +117,17 @@ function ReaderRolling:onGesture() end
 
 function ReaderRolling:registerKeyEvents()
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        if G_reader_settings:isTrue("left_right_keys_turn_pages") then
-            self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
-            self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
-        elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
+        if G_reader_settings:isTrue("left_right_turn_pages") then
+            self.key_events.GotoNextView = { { { "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { { "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
+        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
             self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
             self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
-            self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd" } }, event = "GotoViewRel", args = 1, }
-            self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack" } }, event = "GotoViewRel", args = -1, }
+            self.key_events.GotoNextView = { { "LPgFwd" }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { "LPgBack" }, event = "GotoViewRel", args = -1, }
         end
-        if Device:hasSymKey() then
-            self.key_events.MoveUp = { { "Shift", "RPgBack" }, event = "Panning", args = {0, -1}, }
-            self.key_events.MoveDown = { { "Shift", "RPgFwd" }, event = "Panning", args = {0,  1}, }
-        elseif Device:hasScreenKB() then
-            self.key_events.MoveUp = { { "ScreenKB", "RPgBack" }, event = "Panning", args = {0, -1}, }
-            self.key_events.MoveDown = { { "ScreenKB", "RPgFwd" }, event = "Panning", args = {0,  1}, }
-        end
+        self.key_events.MoveUp = { { "RPgBack" }, event = "Panning", args = {0, -1}, }
+        self.key_events.MoveDown = { { { "RPgFwd", " " } }, event = "Panning", args = {0,  1}, }
     elseif Device:hasDPad() then
         self.key_events.MoveUp = { { "Up" }, event = "Panning", args = {0, -1}, }
         self.key_events.MoveDown = { { "Down" }, event = "Panning", args = {0,  1}, }

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -117,10 +117,10 @@ function ReaderRolling:onGesture() end
 
 function ReaderRolling:registerKeyEvents()
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        if G_reader_settings:isTrue("left_right_turn_pages") then
+        if G_reader_settings:isTrue("left_right_keys_turn_pages") then
             self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
             self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
-        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
+        elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
             self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
             self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd" } }, event = "GotoViewRel", args = 1, }

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -116,127 +116,42 @@ end
 function ReaderRolling:onGesture() end
 
 function ReaderRolling:registerKeyEvents()
-    if Device:hasScreenKB() or Device:hasSymKey() then
-        self.key_events.GotoNextView = {
-            { { "RPgFwd", "LPgFwd" } },
-            event = "GotoViewRel",
-            args = 1,
-        }
-        self.key_events.GotoPrevView = {
-            { { "RPgBack", "LPgBack" } },
-            event = "GotoViewRel",
-            args = -1,
-        }
-        if Device:hasKeyboard() then
-            self.key_events.MoveUp = {
-                { "Shift", "RPgBack" },
-                event = "Panning",
-                args = {0, -1},
-            }
-            self.key_events.MoveDown = {
-                { "Shift", "RPgFwd" },
-                event = "Panning",
-                args = {0,  1},
-            }
-        end
-    elseif Device:hasKeys() then
-        self.key_events.GotoNextView = {
-            { { "RPgFwd", "LPgFwd", "Right" } },
-            event = "GotoViewRel",
-            args = 1,
-        }
-        self.key_events.GotoPrevView = {
-            { { "RPgBack", "LPgBack", "Left" } },
-            event = "GotoViewRel",
-            args = -1,
-        }
-    end
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        self.key_events.GotoNextChapter = {
-            { "Right" },
-            event = "GotoNextChapter",
-            args = 1,
-        }
-        self.key_events.GotoPrevChapter = {
-            { "Left" },
-            event = "GotoPrevChapter",
-            args = -1,
-        }
+        if G_reader_settings:isTrue("left_right_turn_pages") then
+            self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
+        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
+            self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
+            self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
+            self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd" } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack" } }, event = "GotoViewRel", args = -1, }
+        end
+        if Device:hasSymKey() then
+            self.key_events.MoveUp = { { "Shift", "RPgBack" }, event = "Panning", args = {0, -1}, }
+            self.key_events.MoveDown = { { "Shift", "RPgFwd" }, event = "Panning", args = {0,  1}, }
+        elseif Device:hasScreenKB() then
+            self.key_events.MoveUp = { { "ScreenKB", "RPgBack" }, event = "Panning", args = {0, -1}, }
+            self.key_events.MoveDown = { { "ScreenKB", "RPgFwd" }, event = "Panning", args = {0,  1}, }
+        end
     elseif Device:hasDPad() then
-        self.key_events.MoveUp = {
-            { "Up" },
-            event = "Panning",
-            args = {0, -1},
-        }
-        self.key_events.MoveDown = {
-            { "Down" },
-            event = "Panning",
-            args = {0,  1},
-        }
+        self.key_events.MoveUp = { { "Up" }, event = "Panning", args = {0, -1}, }
+        self.key_events.MoveDown = { { "Down" }, event = "Panning", args = {0,  1}, }
     end
-    if Device:hasScreenKB() then
-        self.key_events.MoveUp = {
-            { "ScreenKB", "RPgBack" },
-            event = "Panning",
-            args = {0, -1},
-        }
-        self.key_events.MoveDown = {
-            { "ScreenKB", "RPgFwd" },
-            event = "Panning",
-            args = {0,  1},
-        }
+    if Device:hasKeys() and not (Device:hasScreenKB() or Device:hasSymKey()) then
+        self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
+        self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
     end
     if Device:hasKeyboard() then
-        self.key_events.GotoFirst = {
-            { "1" },
-            event = "GotoPercent",
-            args = 0,
-        }
-        self.key_events.Goto11 = {
-            { "2" },
-            event = "GotoPercent",
-            args = 11,
-        }
-        self.key_events.Goto22 = {
-            { "3" },
-            event = "GotoPercent",
-            args = 22,
-        }
-        self.key_events.Goto33 = {
-            { "4" },
-            event = "GotoPercent",
-            args = 33,
-        }
-        self.key_events.Goto44 = {
-            { "5" },
-            event = "GotoPercent",
-            args = 44,
-        }
-        self.key_events.Goto55 = {
-            { "6" },
-            event = "GotoPercent",
-            args = 55,
-        }
-        self.key_events.Goto66 = {
-            { "7" },
-            event = "GotoPercent",
-            args = 66,
-        }
-        self.key_events.Goto77 = {
-            { "8" },
-            event = "GotoPercent",
-            args = 77,
-        }
-        self.key_events.Goto88 = {
-            { "9" },
-            event = "GotoPercent",
-            args = 88,
-        }
-        self.key_events.GotoLast = {
-            { "0" },
-            event = "GotoPercent",
-            args = 100,
-        }
+        self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }
+        self.key_events.Goto11    = { { "2" }, event = "GotoPercent", args = 11,  }
+        self.key_events.Goto22    = { { "3" }, event = "GotoPercent", args = 22,  }
+        self.key_events.Goto33    = { { "4" }, event = "GotoPercent", args = 33,  }
+        self.key_events.Goto44    = { { "5" }, event = "GotoPercent", args = 44,  }
+        self.key_events.Goto55    = { { "6" }, event = "GotoPercent", args = 55,  }
+        self.key_events.Goto66    = { { "7" }, event = "GotoPercent", args = 66,  }
+        self.key_events.Goto77    = { { "8" }, event = "GotoPercent", args = 77,  }
+        self.key_events.Goto88    = { { "9" }, event = "GotoPercent", args = 88,  }
+        self.key_events.Goto99    = { { "0" }, event = "GotoPercent", args = 100, }
     end
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -132,7 +132,7 @@ function ReaderRolling:registerKeyEvents()
         self.key_events.MoveUp = { { "Up" }, event = "Panning", args = {0, -1}, }
         self.key_events.MoveDown = { { "Down" }, event = "Panning", args = {0,  1}, }
     end
-    if Device:hasKeys() and not (Device:hasScreenKB() or Device:hasSymKey()) then
+    if (Device:hasDPad() and not Device:useDPadAsActionKeys()) or (Device:hasKeys() and not Device:useDPadAsActionKeys()) then
         self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
         self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
     end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -117,10 +117,10 @@ function ReaderRolling:onGesture() end
 
 function ReaderRolling:registerKeyEvents()
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
-        if G_reader_settings:isTrue("left_right_turn_pages") then
+        if G_reader_settings:isTrue("left_right_keys_turn_pages") then
             self.key_events.GotoNextView = { { { "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
             self.key_events.GotoPrevView = { { { "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
-        elseif G_reader_settings:nilOrFalse("left_right_turn_pages") then
+        elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
             self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
             self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextView = { { "LPgFwd" }, event = "GotoViewRel", args = 1, }

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -54,10 +54,10 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
     table.insert(PhysicalButtons.sub_item_table, {
         text = _("Use left and right keys for page turning"),
         checked_func = function()
-            return G_reader_settings:isTrue("left_right_turn_pages")
+            return G_reader_settings:isTrue("left_right_keys_turn_pages")
         end,
         callback = function()
-            G_reader_settings:flipNilOrFalse("left_right_turn_pages")
+            G_reader_settings:flipNilOrFalse("left_right_keys_turn_pages")
             UIManager:askForRestart()
         end,
     })

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -49,6 +49,17 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
             G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
             Device:invertButtonsRight()
         end,
+        separator = true,
+    })
+    table.insert(PhysicalButtons.sub_item_table, {
+        text = _("Use left and right keys for page turning"),
+        checked_func = function()
+            return G_reader_settings:isTrue("left_right_turn_pages")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("left_right_turn_pages")
+            UIManager:askForRestart()
+        end,
     })
 end
 


### PR DESCRIPTION
Rewrite of `registerKeyEvents` in both reader paging and rolling. Now setting `useDPadAsActionKeys() = false` reverts to previous key mapping (c. 2024.04). See #11887, #11900 and https://github.com/koreader/koreader/issues/12168#issuecomment-2231692603

Adds <kbd>spacebar</kbd> as `PgFwd` and removes need to use modifiers for `panning` when in continuous mode. (#11749)

Adds option to turn pages with <kbd>Left</kbd> and <kbd>Right</kbd> keys on devices with `useDPadAsActionKeys() = true`. closes #12168

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12174)
<!-- Reviewable:end -->
