### PR TITLE
ci/macos: fix fallback cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           path: /Users/runner/Library/Caches/ccache
           key: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-${{ runner.arch }}-ccache-${{ hashFiles('base/cache-key') }}
-          restore-keys: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-ccache-
+          restore-keys: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-${{ runner.arch }}-ccache-
 
       - name: Install ccache
         if: steps.build-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
No wonder the macOS builds take so long…

Cf. https://github.com/koreader/koreader-base/pull/1843.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12188)
<!-- Reviewable:end -->
