### PR TITLE
CRE call cache: don't wrap setViewMode

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1813,6 +1813,7 @@ function CreDocument:setupCallCache()
             -- Assume all set* may change rendering
             if name == "setBatteryState" then no_wrap = true -- except this one
             elseif name == "setPageInfoOverride" then no_wrap = true -- and this one
+            elseif name == "setViewMode" then no_wrap = true -- and this one
             elseif name:sub(1,3) == "set" then add_reset = true
             elseif name:sub(1,6) == "toggle" then add_reset = true
             elseif name:sub(1,6) == "update" then add_reset = true


### PR DESCRIPTION
Avoid highlights' xpointers to be recomputed when switching between page and scroll mode, which could make using "Auto-scroll when selection reaches a corner" really slow when having a large number of highlights.
Closes #12156.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12194)
<!-- Reviewable:end -->
