### PR TITLE
SDL: Return true in NetworkMgr:isConnected on !hasWifiToggle platforms

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -396,6 +396,11 @@ end
 function Device:initNetworkManager(NetworkMgr)
     function NetworkMgr:isWifiOn() return true end
     function NetworkMgr:isConnected()
+        if not Device:hasWifiToggle() then
+            -- NOTE: This is necessary so as not to confuse NetworkMghr's beforeWifiAction framework.
+            --       c.f., the default implementation in `NetworkMgr` itself for more details.
+            return true
+        end
         -- Pull the default gateway first, so we don't even try to ping anything if there isn't one...
         local default_gw = Device:getDefaultRoute()
         if not default_gw then


### PR DESCRIPTION
...so as not to break the beforeWifiction shenanigans...

Which is most of them, only the Emulator subclass sets it, for... reasons.

(That Emulator quirk is also why we can't simply scrap the whole thing to use NetworkMgr's default imps).

Fix #12203 (thanks to @benoit-pierre for spotting that one).

This was clearly an oversight on my part when working on #10669

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12217)
<!-- Reviewable:end -->
