### PR TITLE
NetworkMgr: Attempt to handle wpa_supplicant rescans better

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -176,7 +176,7 @@ function NetworkMgr:isConnected()
     end
 end
 function NetworkMgr:getNetworkInterfaceName() end
-function NetworkMgr:getConfiguredNetworks() end -- as per the *backend*, e.g., wpa_cli list_networks
+function NetworkMgr:getConfiguredNetworks() end -- From the *backend*, e.g., wpa_cli list_networks (as opposed to `getAllSavedNetworks`)
 function NetworkMgr:getNetworkList() end
 function NetworkMgr:getCurrentNetwork() end
 function NetworkMgr:authenticateNetwork(network) end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1122,8 +1122,8 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
     -- This happens fairly often on MTK, for instance...
     if Device:hasWifiManager() and not success and not ssid then
         local iter = 0
-        -- We wait 5s at most (FWIW, it takes less than 2s when this is needed on my end)
-        while not success and iter < 20 do
+        -- We wait 15s at most (like the restore-wifi-async script)
+        while not success and iter < 60 do
             -- Check every 250ms
             iter = iter + 1
             ffiutil.usleep(250 * 1e+3)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1129,11 +1129,17 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
             text = T(_(Device:isKindle() and "Connecting to network %1…" or "Connected to network %1"), BD.wrap(util.fixUtf8(ssid, "�"))),
             timeout = 3,
         })
+        logger.dbg("NetworkMgr: Connected to network", util.fixUtf8(ssid, "�"))
     else
         UIManager:show(InfoMessage:new{
             text = err_msg,
             timeout = 3,
         })
+        if ssid then
+            logger.dbg("NetworkMgr: Failed to connect:", err_msg, "; last attempt on ssid:", util.fixUtf8(ssid, "�"))
+        else
+            logger.dbg("NetworkMgr: Failed to connect:", err_msg, "; no preferred network found")
+        end
     end
 
     if not success then

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1120,9 +1120,9 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
 
     -- If we haven't even seen any of our preferred networks, wait a bit to see if wpa_supplicant managed to connect in the background anyway...
     -- This happens fairly often on MTK, for instance...
-    if Device:hasWifiManager() then
-        if not success and not ssid then
-            ffiutil.usleep(3 * 1e+6)
+    if Device:hasWifiManager() and not success and not ssid then
+        local iter = 0
+        while not success and iter < 20 do
             local nw = self:getCurrentNetwork()
             if nw then
                 success = true
@@ -1133,7 +1133,11 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
                         network.connected = true
                     end
                 end
-                logger.dbg("NetworkMgr: wpa_supplicant automatically connected to network", util.fixUtf8(ssid, "�"))
+                logger.dbg("NetworkMgr: wpa_supplicant automatically connected to network", util.fixUtf8(ssid, "�"), "(after", iter * 0.25, "seconds)")
+            else
+                -- Try again in 250ms
+                ffiutil.usleep(250 * 1e+3)
+                iter = iter + 1
             end
         end
     end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1122,8 +1122,12 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
     -- If we haven't even seen any of our preferred networks, wait a bit to see if wpa_supplicant manages to connect in the background anyway...
     -- This happens when we break too early from re-scans triggered by wpa_supplicant itself,
     -- c.f., WpaClient:scanThenGetResults in lj-wpaclient for more details.
-    if Device:hasWifiManager() and not success and not ssid and self:getConfiguredNetworks() then
-        local iter = 0
+    if Device:hasWifiManager() and not success and not ssid then
+        -- Don't bother if wpa_supplicant doesn't actually have any configured networks...
+        local configured_networks = self:getConfiguredNetworks()
+        local has_preferred_networks = configured_networks and #configured_networks > 0
+
+        local iter = has_preferred_networks and 0 or 60
         -- We wait 15s at most (like the restore-wifi-async script)
         while not success and iter < 60 do
             -- Check every 250ms

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1121,6 +1121,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
 
     -- If we haven't even seen any of our preferred networks, wait a bit to see if wpa_supplicant manages to connect in the background anyway...
     -- This happens when we break too early from re-scans triggered by wpa_supplicant itself,
+    -- which shouldn't really ever happen since https://github.com/koreader/lj-wpaclient/pull/11
     -- c.f., WpaClient:scanThenGetResults in lj-wpaclient for more details.
     if Device:hasWifiManager() and not success and not ssid then
         -- Don't bother if wpa_supplicant doesn't actually have any configured networks...

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1105,16 +1105,20 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
             if network.password then
                 -- If we hit a preferred network and we're not already connected,
                 -- attempt to connect to said preferred network....
+                logger.dbg("NetworkMgr: Attempting to authenticate on preferred network", util.fixUtf8(ssid, "�"))
                 success, err_msg = self:authenticateNetwork(network)
                 if success then
                     ssid = network.ssid
                     network.connected = true
                     break
+                else
+                     logger.dbg("NetworkMgr: authentication failed:", err_msg)
                 end
             end
         end
     end
 
+    -- FIXME: Or if (somehow) isConnected?
     if success then
         self:obtainIP()
         if complete_callback then

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1122,7 +1122,12 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
     -- This happens fairly often on MTK, for instance...
     if Device:hasWifiManager() and not success and not ssid then
         local iter = 0
+        -- We wait 5s at most (FWIW, it takes less than 2s when this is needed on my end)
         while not success and iter < 20 do
+            -- Check every 250ms
+            iter = iter + 1
+            ffiutil.usleep(250 * 1e+3)
+
             local nw = self:getCurrentNetwork()
             if nw then
                 success = true
@@ -1134,10 +1139,6 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
                     end
                 end
                 logger.dbg("NetworkMgr: wpa_supplicant automatically connected to network", util.fixUtf8(ssid, "�"), "(after", iter * 0.25, "seconds)")
-            else
-                -- Try again in 250ms
-                ffiutil.usleep(250 * 1e+3)
-                iter = iter + 1
             end
         end
     end

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1118,8 +1118,9 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
         end
     end
 
-    -- If we haven't even seen any of our preferred networks, wait a bit to see if wpa_supplicant managed to connect in the background anyway...
-    -- This happens fairly often on MTK, for instance...
+    -- If we haven't even seen any of our preferred networks, wait a bit to see if wpa_supplicant manages to connect in the background anyway...
+    -- This happens when we break too early from re-scans triggered by wpa_supplicant itself,
+    -- c.f., WpaClient:scanThenGetResults in lj-wpaclient for more details.
     if Device:hasWifiManager() and not success and not ssid then
         local iter = 0
         -- We wait 15s at most (like the restore-wifi-async script)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -176,6 +176,7 @@ function NetworkMgr:isConnected()
     end
 end
 function NetworkMgr:getNetworkInterfaceName() end
+function NetworkMgr:getConfiguredNetworks() end -- as per the *backend*, e.g., wpa_cli list_networks
 function NetworkMgr:getNetworkList() end
 function NetworkMgr:getCurrentNetwork() end
 function NetworkMgr:authenticateNetwork(network) end
@@ -1121,7 +1122,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
     -- If we haven't even seen any of our preferred networks, wait a bit to see if wpa_supplicant manages to connect in the background anyway...
     -- This happens when we break too early from re-scans triggered by wpa_supplicant itself,
     -- c.f., WpaClient:scanThenGetResults in lj-wpaclient for more details.
-    if Device:hasWifiManager() and not success and not ssid then
+    if Device:hasWifiManager() and not success and not ssid and self:getConfiguredNetworks() then
         local iter = 0
         -- We wait 15s at most (like the restore-wifi-async script)
         while not success and iter < 60 do

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1112,7 +1112,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
                     network.connected = true
                     break
                 else
-                     logger.dbg("NetworkMgr: authentication failed:", err_msg)
+                    logger.dbg("NetworkMgr: authentication failed:", err_msg)
                 end
             end
         end
@@ -1139,11 +1139,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
             text = err_msg,
             timeout = 3,
         })
-        if ssid then
-            logger.dbg("NetworkMgr: Failed to connect:", err_msg, "; last attempt on ssid:", util.fixUtf8(ssid, "�"))
-        else
-            logger.dbg("NetworkMgr: Failed to connect:", err_msg, "; no preferred network found")
-        end
+        logger.dbg("NetworkMgr: Failed to connect:", err_msg, "; last attempt on ssid:", ssid and util.fixUtf8(ssid, "�") or "<none>")
     end
 
     if not success then

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -216,8 +216,22 @@ function WpaSupplicant:getCurrentNetwork()
     return nw
 end
 
+function WpaSupplicant:getConfiguredNetworks()
+    local wcli, err = WpaClient.new(self.wpa_supplicant.ctrl_interface)
+    if wcli == nil then
+        return nil, T(CLIENT_INIT_ERR_MSG, err)
+    end
+
+    local nw
+    nw, err = wcli:listNetworks()
+    wcli:close()
+
+    return nw, err
+end
+
 function WpaSupplicant.init(network_mgr, options)
     network_mgr.wpa_supplicant = {ctrl_interface = options.ctrl_interface}
+    network_mgr.getConfiguredNetworks = WpaSupplicant.getConfiguredNetworks
     network_mgr.getNetworkList = WpaSupplicant.getNetworkList
     network_mgr.getCurrentNetwork = WpaSupplicant.getCurrentNetwork
     network_mgr.authenticateNetwork = WpaSupplicant.authenticateNetwork

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -8,6 +8,8 @@ local FFIUtil = require("ffi/util")
 local InfoMessage = require("ui/widget/infomessage")
 local WpaClient = require("lj-wpaclient/wpaclient")
 local UIManager = require("ui/uimanager")
+local logger = require("logger")
+local util = require("util")
 local _ = require("gettext")
 local T = FFIUtil.template
 
@@ -54,15 +56,17 @@ function WpaSupplicant:getNetworkList()
         network.signal_quality = network:getSignalQuality()
         local saved_nw = saved_networks:readSetting(network.ssid)
         if saved_nw then
-            --- @todo verify saved_nw.flags == network.flags? This will break if user changed the
-            -- network setting from [WPA-PSK-TKIP+CCMP][WPS][ESS] to [WPA-PSK-TKIP+CCMP][ESS]
+            --- @todo verify saved_nw.flags == network.flags?
+            -- This will break if user changed the network setting, e.g.,
+            -- from [WPA-PSK-TKIP+CCMP][WPS][ESS]
+            --   to [WPA-PSK-TKIP+CCMP][ESS]
             network.password = saved_nw.password
             network.psk = saved_nw.psk
         end
-        --- @todo also verify bssid if it is not set to any
-        if curr_network and curr_network.ssid == network.ssid then
+        if curr_network and curr_network.ssid == network.ssid and curr_network.bssid == network.bssid then
             network.connected = true
             network.wpa_supplicant_id = curr_network.id
+            logger.dbg("WpaSupplicant:getNetworkList: automatically connected to network", util.fixUtf8(curr_network.ssid, "�"))
         end
     end
     return list

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -50,9 +50,7 @@ function WpaSupplicant:getNetworkList()
 
     local saved_networks = self:getAllSavedNetworks()
     local curr_network = self:getCurrentNetwork()
-    local conn_network = wcli:getConnectedNetwork()
-    logger.dbg("curr_network:", curr_network)
-    logger.dbg("conn_network:", conn_network)
+    logger.dbg("WpaSupplicant:getNetworkList: Current network:", curr_network)
 
     for _, network in ipairs(list) do
         network.ssid = decodeSSID(network.ssid)
@@ -202,7 +200,13 @@ function WpaSupplicant:getCurrentNetwork()
     if wcli == nil then
         return nil, T(CLIENT_INIT_ERR_MSG, err)
     end
-    local nw = wcli:getCurrentNetwork()
+
+    -- Start by checking the status before looking for the CURRENT flag...
+    local nw = wcli:getConnectedNetwork()
+    -- Then fall back to the flag check...
+    if nw == nil then
+        nw = wcli:getCurrentNetwork()
+    end
     wcli:close()
     if nw ~= nil then
         nw.ssid = decodeSSID(nw.ssid)

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -50,6 +50,9 @@ function WpaSupplicant:getNetworkList()
 
     local saved_networks = self:getAllSavedNetworks()
     local curr_network = self:getCurrentNetwork()
+    local conn_network = wcli:getConnectedNetwork()
+    logger.dbg("curr_network:", curr_network)
+    logger.dbg("conn_network:", conn_network)
 
     for _, network in ipairs(list) do
         network.ssid = decodeSSID(network.ssid)
@@ -63,7 +66,7 @@ function WpaSupplicant:getNetworkList()
             network.password = saved_nw.password
             network.psk = saved_nw.psk
         end
-        if curr_network and curr_network.ssid == network.ssid and curr_network.bssid == network.bssid then
+        if curr_network and curr_network.ssid == network.ssid and (curr_network.bssid == "any" or curr_network.bssid == network.bssid) then
             network.connected = true
             network.wpa_supplicant_id = curr_network.id
             logger.dbg("WpaSupplicant:getNetworkList: automatically connected to network", util.fixUtf8(curr_network.ssid, "�"))

--- a/frontend/ui/network/wpa_supplicant.lua
+++ b/frontend/ui/network/wpa_supplicant.lua
@@ -50,7 +50,6 @@ function WpaSupplicant:getNetworkList()
 
     local saved_networks = self:getAllSavedNetworks()
     local curr_network = self:getCurrentNetwork()
-    logger.dbg("WpaSupplicant:getNetworkList: Current network:", curr_network)
 
     for _, network in ipairs(list) do
         network.ssid = decodeSSID(network.ssid)
@@ -202,10 +201,13 @@ function WpaSupplicant:getCurrentNetwork()
     end
 
     -- Start by checking the status before looking for the CURRENT flag...
-    local nw = wcli:getConnectedNetwork()
+    local nw
+    nw, err = wcli:getConnectedNetwork()
+    logger.dbg("WpaSupplicant:getCurrentNetwork: Connected network:", nw and nw or err)
     -- Then fall back to the flag check...
     if nw == nil then
-        nw = wcli:getCurrentNetwork()
+        nw, err = wcli:getCurrentNetwork()
+        logger.dbg("WpaSupplicant:getCurrentNetwork: Current network:", nw and nw or err)
     end
     wcli:close()
     if nw ~= nil then


### PR DESCRIPTION
Also, add a crapload of debug logging.

c.f., https://github.com/koreader/lj-wpaclient/pull/11 for all the gory details.

(PR is safe on its own, but stuff works better with everything merged, obviously ;p).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12236)
<!-- Reviewable:end -->
