### PR TITLE
ReaderFooter: Add page-turn item

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -74,6 +74,8 @@ local symbol_prefix = {
         mem_usage = C_("FooterLetterPrefix", "M:"),
         -- @translators This is the footer letter prefix for Wi-Fi status.
         wifi_status = C_("FooterLetterPrefix", "W:"),
+        -- @translators This is the footer letter prefix for page turning status.
+        page_turning_inverted = C_("FooterLetterPrefix", "Pg:"),
     },
     icons = {
         time = "⌚",
@@ -89,6 +91,8 @@ local symbol_prefix = {
         mem_usage = "",
         wifi_status = "",
         wifi_status_off = "",
+        page_turning_inverted = "PgT:I",
+        page_turning_regular = "PgT:R",
     },
     compact_items = {
         time = nil,
@@ -105,6 +109,8 @@ local symbol_prefix = {
         mem_usage = C_("FooterCompactItemsPrefix", "M"),
         wifi_status = "",
         wifi_status_off = "",
+        page_turning_inverted = "PgT:I",
+        page_turning_regular = "PgT:R",
     }
 }
 if BD.mirroredUILayout() then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -383,7 +383,7 @@ local footerTextGeneratorMap = {
                 return symbol_prefix.icons.page_turning_inverted
             else
                 -- @translators This is the invert reading order indicator.
-                return T(_("%1I"), prefix)
+                return T(_("%1On"), prefix)
             end
         elseif footer.settings.all_at_once and footer.settings.hide_empty_generators then
             return ""
@@ -392,7 +392,7 @@ local footerTextGeneratorMap = {
                 return symbol_prefix.icons.page_turning_regular
             else
                 -- @translators This is the normal reading order indicator.
-                return T(_("%1N"), prefix)
+                return T(_("%1Off"), prefix)
             end
         end
     end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -48,6 +48,7 @@ local MODE = {
     frontlight_warmth = 16,
     custom_text = 17,
     book_author = 18,
+    page_turning_inverted = 19, -- includes both page-turn-button and swipe-and-tap inversion
 }
 
 local symbol_prefix = {
@@ -68,7 +69,7 @@ local symbol_prefix = {
         -- @translators This is the footer letter prefix for frontlight level.
         frontlight = C_("FooterLetterPrefix", "L:"),
         -- @translators This is the footer letter prefix for frontlight warmth (redshift).
-        frontlight_warmth = C_("FooterLetterPrefix", "R:"),
+        frontlight_warmth = C_("FooterLetterPrefix", "LW:"),
         -- @translators This is the footer letter prefix for memory usage.
         mem_usage = C_("FooterLetterPrefix", "M:"),
         -- @translators This is the footer letter prefix for Wi-Fi status.
@@ -367,6 +368,26 @@ local footerTextGeneratorMap = {
             end
         end
     end,
+    page_turning_inverted = function(footer)
+        local symbol_type = footer.settings.item_prefix
+        local prefix = symbol_prefix[symbol_type].page_turning_inverted
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") or G_reader_settings:isTrue("input_invert_left_page_turn_keys") or
+           G_reader_settings:isTrue("input_invert_right_page_turn_keys") or G_reader_settings:isTrue("inverse_reading_order") then
+            if symbol_type == "icons" or symbol_type == "compact_items" then
+                return symbol_prefix.icons.page_turning_inverted
+            else
+                return T(_("%1".. "I"), prefix)
+            end
+        elseif footer.settings.all_at_once and footer.settings.hide_empty_generators then
+            return ""
+        else
+            if symbol_type == "icons" or symbol_type == "compact_items" then
+                return symbol_prefix.icons.page_turning_regular
+            else
+                return T(_("%1".. "R"), prefix)
+            end
+        end
+    end,
     book_author = function(footer)
         local text = footer.ui.doc_props.authors
         return footer:getFittedText(text, footer.settings.book_author_max_width_pct)
@@ -422,6 +443,7 @@ ReaderFooter.default_settings = {
     frontlight = false,
     mem_usage = false,
     wifi_status = false,
+    page_turning_inverted = false,
     book_author = false,
     book_title = false,
     book_chapter = false,
@@ -945,6 +967,7 @@ function ReaderFooter:textOptionTitles(option)
         frontlight_warmth = T(_("Warmth level (%1)"), symbol_prefix[symbol].frontlight_warmth),
         mem_usage = T(_("KOReader memory usage (%1)"), symbol_prefix[symbol].mem_usage),
         wifi_status = T(_("Wi-Fi status (%1)"), symbol_prefix[symbol].wifi_status),
+        page_turning_inverted = T(_("Page turning inverted (%1)"), symbol_prefix[symbol].page_turning_inverted),
         book_author = _("Book author"),
         book_title = _("Book title"),
         book_chapter = _("Chapter title"),
@@ -1338,6 +1361,7 @@ function ReaderFooter:addToMainMenu(menu_items)
     if Device:hasFastWifiStatusQuery() then
         table.insert(footer_items, getMinibarOption("wifi_status"))
     end
+    table.insert(footer_items, getMinibarOption("page_turning_inverted"))
     table.insert(footer_items, getMinibarOption("book_author"))
     table.insert(footer_items, getMinibarOption("book_title"))
     table.insert(footer_items, getMinibarOption("book_chapter"))

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -68,7 +68,7 @@ local symbol_prefix = {
         chapter_time_to_read = C_("FooterLetterPrefix", "TC:"),
         -- @translators This is the footer letter prefix for frontlight level.
         frontlight = C_("FooterLetterPrefix", "L:"),
-        -- @translators This is the footer letter prefix for frontlight warmth (redshift).
+        -- @translators This is the footer letter prefix for light warmth of the frontlight (redshift).
         frontlight_warmth = C_("FooterLetterPrefix", "LW:"),
         -- @translators This is the footer letter prefix for memory usage.
         mem_usage = C_("FooterLetterPrefix", "M:"),

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -91,8 +91,8 @@ local symbol_prefix = {
         mem_usage = "",
         wifi_status = "",
         wifi_status_off = "",
-        page_turning_inverted = "PgT:I",
-        page_turning_regular = "PgT:R",
+        page_turning_inverted = "⇄",
+        page_turning_regular = "⇉",
     },
     compact_items = {
         time = nil,
@@ -109,8 +109,8 @@ local symbol_prefix = {
         mem_usage = C_("FooterCompactItemsPrefix", "M"),
         wifi_status = "",
         wifi_status_off = "",
-        page_turning_inverted = "PgT:I",
-        page_turning_regular = "PgT:R",
+        page_turning_inverted = "⇄",
+        page_turning_regular = "⇉",
     }
 }
 if BD.mirroredUILayout() then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -390,7 +390,7 @@ local footerTextGeneratorMap = {
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_regular
             else
-                return T(_("%1".. "R"), prefix)
+                return T(_("%1".. "N"), prefix)
             end
         end
     end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -382,7 +382,7 @@ local footerTextGeneratorMap = {
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_inverted
             else
-                return T(_("%1".. "I"), prefix)
+                return T(_("%1I"), prefix)
             end
         elseif footer.settings.all_at_once and footer.settings.hide_empty_generators then
             return ""
@@ -390,7 +390,7 @@ local footerTextGeneratorMap = {
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_regular
             else
-                return T(_("%1".. "N"), prefix)
+                return T(_("%1N"), prefix)
             end
         end
     end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -382,6 +382,7 @@ local footerTextGeneratorMap = {
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_inverted
             else
+                -- @translators This is the invert reading order indicator.
                 return T(_("%1I"), prefix)
             end
         elseif footer.settings.all_at_once and footer.settings.hide_empty_generators then
@@ -390,6 +391,7 @@ local footerTextGeneratorMap = {
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_regular
             else
+                -- @translators This is the normal reading order indicator.
                 return T(_("%1N"), prefix)
             end
         end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -382,7 +382,6 @@ local footerTextGeneratorMap = {
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_inverted
             else
-                -- @translators This is the invert reading order indicator.
                 return T(_("%1 On"), prefix)
             end
         elseif footer.settings.all_at_once and footer.settings.hide_empty_generators then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -383,7 +383,7 @@ local footerTextGeneratorMap = {
                 return symbol_prefix.icons.page_turning_inverted
             else
                 -- @translators This is the invert reading order indicator.
-                return T(_("%1On"), prefix)
+                return T(_("%1 On"), prefix)
             end
         elseif footer.settings.all_at_once and footer.settings.hide_empty_generators then
             return ""
@@ -391,8 +391,7 @@ local footerTextGeneratorMap = {
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_regular
             else
-                -- @translators This is the normal reading order indicator.
-                return T(_("%1Off"), prefix)
+                return T(_("%1 Off"), prefix)
             end
         end
     end,

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -308,9 +308,19 @@ function DeviceListener:onToggleFlashOnPagesWithImages()
     G_reader_settings:flipNilOrTrue("refresh_on_pages_with_images")
 end
 
-function DeviceListener:onSwapPageTurnButtons()
+function DeviceListener:onSwapPageTurnButtons(show_notification)
     G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
     Device:invertButtons()
+    local new_text
+    if G_reader_settings:isTrue("input_invert_page_turn_keys") then
+        new_text = _("Page-turn buttons inverted.")
+    else
+        new_text = _("Page-turn buttons no longer inverted.")
+    end
+    if show_notification then
+        Notification:notify(new_text)
+    end
+    return true
 end
 
 function DeviceListener:onToggleKeyRepeat(toggle)

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -311,13 +311,13 @@ end
 function DeviceListener:onSwapPageTurnButtons(show_notification)
     G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
     Device:invertButtons()
-    local new_text
-    if G_reader_settings:isTrue("input_invert_page_turn_keys") then
-        new_text = _("Page-turn buttons inverted.")
-    else
-        new_text = _("Page-turn buttons no longer inverted.")
-    end
     if show_notification then
+        local new_text
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") then
+            new_text = _("Page-turn buttons inverted.")
+        else
+            new_text = _("Page-turn buttons no longer inverted.")
+        end
         Notification:notify(new_text)
     end
     return true

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -80,7 +80,7 @@ local settingsList = {
     touch_input_off = {category="none", event="IgnoreTouchInput", arg=true, title=_("Disable touch input"), device=true},
     toggle_touch_input = {category="none", event="IgnoreTouchInput", title=_("Toggle touch input"), device=true, separator=true},
     ----
-    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
+    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg=true, title=_("Invert page turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
     ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},


### PR DESCRIPTION
### what’s new:

* Adds page-turn item to status bar to indicate inversion active. (somewhat proposed here https://github.com/koreader/koreader/pull/11963#issuecomment-2146336376)
<p align="center">
<img src="https://github.com/user-attachments/assets/38910175-c67f-4d01-b5fd-1342ef057463" width=40% height=40%> 
<img src="https://github.com/user-attachments/assets/93b05d5e-38f2-4f4b-9c4f-9376cd7a82e3" width=40% height=40%> 
</p>

* Show notification when inverting page-turn buttons from gestures. closes #12239

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12249)
<!-- Reviewable:end -->
