### PR TITLE
ReadHistory: On remove, trust the index from FileManagerHistory if possible

### DIFF
--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -207,8 +207,12 @@ function FileManagerHistory:onMenuHold(item)
             text = _("Remove from history"),
             callback = function()
                 UIManager:close(self.histfile_dialog)
-                -- The item's idx field is tied to the current *view*, so we can only pass it as-is when there's no filtering involved.
-                require("readhistory"):removeItem(item, self._manager.filter == "all" and item.idx or nil)
+                -- The item's idx field is tied to the current *view*, so we can only pass it as-is when there's no filtering *at all* involved.
+                local index = item.idx
+                if self._manager.search_string or self._manager.selected_colections or self._manager.filter ~= "all" then
+                    index = nil
+                end
+                require("readhistory"):removeItem(item, index)
                 self._manager:updateItemTable()
             end,
         },

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -207,7 +207,7 @@ function FileManagerHistory:onMenuHold(item)
             text = _("Remove from history"),
             callback = function()
                 UIManager:close(self.histfile_dialog)
-                require("readhistory"):removeItem(item)
+                require("readhistory"):removeItem(item, item.idx)
                 self._manager:updateItemTable()
             end,
         },

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -207,7 +207,8 @@ function FileManagerHistory:onMenuHold(item)
             text = _("Remove from history"),
             callback = function()
                 UIManager:close(self.histfile_dialog)
-                require("readhistory"):removeItem(item, item.idx)
+                -- The item's idx field is tied to the current *view*, so we can only pass it as-is when there's no filtering involved.
+                require("readhistory"):removeItem(item, self._manager.filter == "all" and item.idx or nil)
                 self._manager:updateItemTable()
             end,
         },

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -311,7 +311,7 @@ function ReadHistory:removeItemByPath(path)
 end
 
 function ReadHistory:removeItem(item, idx, no_flush)
-    local index = idx or self:getIndexByTime(item.time, item.file:gsub(".*/", ""))
+    local index = idx or item.idx or self:getIndexByTime(item.time, item.file:gsub(".*/", ""))
     table.remove(self.hist, index)
     os.remove(DocSettings:getHistoryPath(item.file))
     if not no_flush then

--- a/frontend/readhistory.lua
+++ b/frontend/readhistory.lua
@@ -311,7 +311,7 @@ function ReadHistory:removeItemByPath(path)
 end
 
 function ReadHistory:removeItem(item, idx, no_flush)
-    local index = idx or item.idx or self:getIndexByTime(item.time, item.file:gsub(".*/", ""))
+    local index = idx or self:getIndexByTime(item.time, item.file:gsub(".*/", ""))
     table.remove(self.hist, index)
     os.remove(DocSettings:getHistoryPath(item.file))
     if not no_flush then


### PR DESCRIPTION
No need to look it up when we already provide it ;).

(Noticed because I had an item that refused to get removed on an old device. And because I'm an idiot, I fixed it without backing up the history.lua -_-".)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12253)
<!-- Reviewable:end -->
