### PR TITLE
Kobo: Track frontlight state more accurately on suspend/resume

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -126,6 +126,8 @@ function BasePowerD:frontlightIntensity()
 end
 
 function BasePowerD:toggleFrontlight(done_callback)
+    print("BasePowerD:toggleFrontlight")
+    print(debug.traceback())
     if not self.device:hasFrontlight() then return false end
     if self:isFrontlightOn() then
         return self:turnOffFrontlight(done_callback)
@@ -135,6 +137,8 @@ function BasePowerD:toggleFrontlight(done_callback)
 end
 
 function BasePowerD:turnOffFrontlight(done_callback)
+    print("BasePowerD:turnOffFrontlight")
+    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOff() then return false end
     local cb_handled = self:turnOffFrontlightHW(done_callback)
@@ -147,6 +151,8 @@ function BasePowerD:turnOffFrontlight(done_callback)
 end
 
 function BasePowerD:turnOnFrontlight(done_callback)
+    print("BasePowerD:turnOnFrontlight")
+    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOn() then return false end
     if self.fl_intensity == self.fl_min then return false end  --- @fixme what the hell?

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -108,10 +108,8 @@ function BasePowerD:isFrontlightOn()
 end
 
 function BasePowerD:_decideFrontlightState()
-    print("BasePowerD:_decideFrontlightState")
     assert(self.device:hasFrontlight())
     self.is_fl_on = self:isFrontlightOnHW()
-    print("Setting self.is_fl_on to", self.is_fl_on)
 end
 
 function BasePowerD:isFrontlightOff()
@@ -128,8 +126,6 @@ function BasePowerD:frontlightIntensity()
 end
 
 function BasePowerD:toggleFrontlight(done_callback)
-    print("BasePowerD:toggleFrontlight")
-    print(debug.traceback())
     if not self.device:hasFrontlight() then return false end
     if self:isFrontlightOn() then
         return self:turnOffFrontlight(done_callback)
@@ -139,13 +135,10 @@ function BasePowerD:toggleFrontlight(done_callback)
 end
 
 function BasePowerD:turnOffFrontlight(done_callback)
-    print("BasePowerD:turnOffFrontlight")
-    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOff() then return false end
     local cb_handled = self:turnOffFrontlightHW(done_callback)
     self.is_fl_on = false
-    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()
@@ -154,14 +147,11 @@ function BasePowerD:turnOffFrontlight(done_callback)
 end
 
 function BasePowerD:turnOnFrontlight(done_callback)
-    print("BasePowerD:turnOnFrontlight")
-    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOn() then return false end
     if self.fl_intensity == self.fl_min then return false end  --- @fixme what the hell?
     local cb_handled = self:turnOnFrontlightHW(done_callback)
     self.is_fl_on = true
-    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -108,8 +108,10 @@ function BasePowerD:isFrontlightOn()
 end
 
 function BasePowerD:_decideFrontlightState()
+    print("BasePowerD:_decideFrontlightState")
     assert(self.device:hasFrontlight())
     self.is_fl_on = self:isFrontlightOnHW()
+    print("Setting self.is_fl_on to", self.is_fl_on)
 end
 
 function BasePowerD:isFrontlightOff()
@@ -143,6 +145,7 @@ function BasePowerD:turnOffFrontlight(done_callback)
     if self:isFrontlightOff() then return false end
     local cb_handled = self:turnOffFrontlightHW(done_callback)
     self.is_fl_on = false
+    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()
@@ -158,6 +161,7 @@ function BasePowerD:turnOnFrontlight(done_callback)
     if self.fl_intensity == self.fl_min then return false end  --- @fixme what the hell?
     local cb_handled = self:turnOnFrontlightHW(done_callback)
     self.is_fl_on = true
+    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -251,7 +251,7 @@ function KoboPowerD:isFrontlightOnHW()
         return ret
     end
     print("KoboPowerD:isFrontlightOnHW:", self.hw_intensity, self.fl_ramp_down_running, self.fl_ramp_up_running)
-    return self.hw_intensity > 0
+    return self.hw_intensity > 0 and not self.fl_ramp_down_running
 end
 
 function KoboPowerD:_setIntensityHW(intensity)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -250,7 +250,6 @@ function KoboPowerD:isFrontlightOnHW()
         self.initial_is_fl_on = nil
         return ret
     end
-    print("KoboPowerD:isFrontlightOnHW:", self.hw_intensity, self.fl_intensity, self.fl_ramp_down_running, self.fl_ramp_up_running)
     return self.hw_intensity > 0 and not self.fl_ramp_down_running
 end
 
@@ -361,10 +360,7 @@ function KoboPowerD:turnOffFrontlightRamp(curr_ramp_intensity, end_intensity, do
 end
 
 function KoboPowerD:turnOffFrontlightHW(done_callback)
-    --print("KoboPowerD:turnOffFrontlightHW")
-    --print(debug.traceback())
     if not self:isFrontlightOnHW() then
-        print("turnOffFrontlightHW: early abort because fl is already off")
         return
     end
 
@@ -430,8 +426,6 @@ function KoboPowerD:turnOnFrontlightRamp(curr_ramp_intensity, end_intensity, don
 end
 
 function KoboPowerD:turnOnFrontlightHW(done_callback)
-    --print("KoboPowerD:turnOnFrontlightHW")
-    --print(debug.traceback())
     -- NOTE: Insane workaround for the first toggle after a startup with the FL off.
     -- The light is actually off, but hw_intensity couldn't have been set to a sane value because of a number of interactions.
     -- So, fix it now, so we pass the isFrontlightOnHW check (which checks if hw_intensity > fl_min).
@@ -439,7 +433,6 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
         self.hw_intensity = self.fl_min
     end
     if self:isFrontlightOnHW() then
-        print("turnOnFrontlightHW: early abort because fl is already on")
         return
     end
 
@@ -478,13 +471,11 @@ function KoboPowerD:_suspendFrontlight()
     --       we'd delay setting self.fl_was_on to the pre-ramp value at the end of the ramp (via the ramp's done_callback),
     --       except for the fact that if the frontlight is off, turnOffFrontlight will abort early, so we can't ;).
     self.fl_was_on = self.is_fl_on
-    print("Setting self.fl_was_on:", self.fl_was_on)
     self:turnOffFrontlight()
 end
 
 -- Turn off front light before suspend.
 function KoboPowerD:beforeSuspend()
-    print("KoboPowerD:beforeSuspend")
     -- Inhibit user input and emit the Suspend event.
     self.device:_beforeSuspend()
 
@@ -507,7 +498,6 @@ end
 
 function KoboPowerD:_resumeFrontlight()
     -- Don't bother if the light was already off on suspend
-    print("Reading self.fl_was_on:", self.fl_was_on)
     if self.fl_was_on then
         -- Turn the frontlight back on
         self:turnOnFrontlight()
@@ -516,7 +506,6 @@ end
 
 -- Restore front light state after resume.
 function KoboPowerD:afterResume()
-    print("KoboPowerD:afterResume")
     -- Set the system clock to the hardware clock's time.
     RTC:HCToSys()
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -489,7 +489,7 @@ function KoboPowerD:beforeSuspend()
     -- to prevent as many things as we can from interfering with the smoothness of the ramp
     if self.fl then
         -- If there's already a resume toggle pending, cancel it.
-        UIManager:unschedule(self._resumeFrontlight)
+        --UIManager:unschedule(self._resumeFrontlight)
         -- Turn off the frontlight
         -- NOTE: Funky delay mainly to yield to the EPDC's refresh on UP systems.
         --       (Neither yieldToEPDC nor nextTick & friends quite cut it here)...
@@ -521,7 +521,7 @@ function KoboPowerD:afterResume()
     -- so we'll delay this ever so slightly so as to appear as smooth as possible...
     if self.fl then
         -- If there's already a suspend toggle pending, cancel it.
-        UIManager:unschedule(self._suspendFrontlight)
+        --UIManager:unschedule(self._suspendFrontlight)
 
         -- Turn the frontlight back on
         -- NOTE: There's quite likely *more* resource contention than on suspend here :/.

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -314,8 +314,8 @@ function KoboPowerD:isChargedHW()
     return false
 end
 
-function KoboPowerD:_startRampDown(start_intensity, done_callback)
-    self:turnOffFrontlightRamp(start_intensity, self.fl_min, done_callback)
+function KoboPowerD:_startRampDown(done_callback)
+    self:turnOffFrontlightRamp(self.fl_intensity, self.fl_min, done_callback)
     self.fl_ramp_down_running = true
 end
 
@@ -378,7 +378,7 @@ function KoboPowerD:turnOffFrontlightHW(done_callback)
                 -- NOTE: Similarly, some controllers *really* don't like to be interleaved with screen refreshes,
                 --       so we wait until the next UI frame for the refreshes to go through first...
                 if self.device.frontlight_settings.delay_ramp_start then
-                    UIManager:nextTick(self._startRampDown, self, self.fl_intensity, done_callback)
+                    UIManager:nextTick(self._startRampDown, self, done_callback)
                 else
                     self:turnOffFrontlightRamp(self.fl_intensity, self.fl_min, done_callback)
                     self.fl_ramp_down_running = true
@@ -394,8 +394,8 @@ function KoboPowerD:turnOffFrontlightHW(done_callback)
     return true
 end
 
-function KoboPowerD:_startRampUp(end_intensity, done_callback)
-    self:turnOnFrontlightRamp(self.fl_min, end_intensity, done_callback)
+function KoboPowerD:_startRampUp(done_callback)
+    self:turnOnFrontlightRamp(self.fl_min, self.fl_intensity, done_callback)
     self.fl_ramp_up_running = true
 end
 
@@ -446,7 +446,7 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
             else
                 -- Same deal as in turnOffFrontlightHW
                 if self.device.frontlight_settings.delay_ramp_start then
-                    UIManager:nextTick(self._startRampUp, self, self.fl_intensity, done_callback)
+                    UIManager:nextTick(self._startRampUp, self, done_callback)
                 else
                     self:turnOnFrontlightRamp(self.fl_min, self.fl_intensity, done_callback)
                     self.fl_ramp_up_running = true


### PR DESCRIPTION
Hopefully in the least intrusive way possible, because frontlight handling code is hell.

`self.fl_was_on` could go out of sync with the expected state when resume->suspend events happened in very quick succession, leading to it being set to false, preventing the frontlight from being turned back on on the next resume.

Fix #12246

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12256)
<!-- Reviewable:end -->
