### PR TITLE
make: handle old build data directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ endif
 	install -d $(INSTALL_DIR)/koreader/{screenshots,fonts/host,ota}
 	# Note: the data dir is distinct from the one in base/build/…!
 	@echo "[*] Install data files"
+	! test -L $(INSTALL_DIR)/koreader/data || rm $(INSTALL_DIR)/koreader/data
 	install -d $(INSTALL_DIR)/koreader/data
 	$(SYMLINK) $(OUTPUT_DIR_DATAFILES) $(CR3GUI_DATADIR_FILES) $(INSTALL_DIR)/koreader/data/
 ifneq (,$(IS_RELEASE))


### PR DESCRIPTION
This will avoid replacing data files in crengine with symlinks, when building the latest master without cleaning first.

Note: `build/x86_64-pc-linux-gnu-debug/data` will still be a symlink, so a clean is still needed to avoid creating build artifacts in crengine checkout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12259)
<!-- Reviewable:end -->
