### PR TITLE
make: fix android update sdcv

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -34,7 +34,7 @@ update: all
 	rm -vf $(ANDROID_LAUNCHER_DIR)/assets/libs/libluajit.so
 	# binaries are stored as shared libraries to prevent W^X exception on Android 10+
 	# https://developer.android.com/about/versions/10/behavior-changes-10#execute-permission
-	cp -pR $(INSTALL_DIR)/koreader/sdcv $(ANDROID_LIBS_ABI)/libsdcv.so
+	cp -pLR $(INSTALL_DIR)/koreader/sdcv $(ANDROID_LIBS_ABI)/libsdcv.so
 	echo "sdcv libsdcv.so" > $(ANDROID_ASSETS)/map.txt
 	# assets are compressed manually and stored inside the APK.
 	cd $(INSTALL_DIR)/koreader && \


### PR DESCRIPTION
I wanted to check https://github.com/koreader/koreader-base/pull/1886 on my old arm64 phone running Android 9, and could not get dictionary lookups to work…

The arm build, meanwhile, was still working fine until a reset of luajit-launcher to a pristine state. And the gradle build failed after fixing the update rule because apparently the change of type, symlink → file, is not handled. Yeah…

Close #12268.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12275)
<!-- Reviewable:end -->
