### PR TITLE
[ReaderHighlight] Group actions into a submenu

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -721,9 +721,9 @@ If you wish your highlights to be saved in the document, just move it to a writa
     end
     table.insert(menu_items.long_press.sub_item_table, {
         text_func = function()
-            local action = G_reader_settings:readSetting("default_highlight_action")
+            local multi_word = G_reader_settings:readSetting("default_highlight_action")
             for __, v in ipairs(long_press_action) do
-                if v[2] == action then
+                if v[2] == multi_word then
                     return T(_("Multi-word selection: %1"), v[1]:lower())
                 end
             end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -706,8 +706,9 @@ If you wish your highlights to be saved in the document, just move it to a writa
         },
     }
     -- actions
+    local sub_item_table = {}
     for i, v in ipairs(long_press_action) do
-        table.insert(menu_items.long_press.sub_item_table, {
+        table.insert(sub_item_table, {
             text = v[1],
             checked_func = function()
                 return G_reader_settings:readSetting("default_highlight_action", "ask") == v[2]
@@ -718,6 +719,17 @@ If you wish your highlights to be saved in the document, just move it to a writa
             end,
         })
     end
+    table.insert(menu_items.long_press.sub_item_table, {
+        text_func = function()
+            local multi_word = G_reader_settings:readSetting("default_highlight_action")
+            for __, v in ipairs(long_press_action) do
+                if v[2] == multi_word then
+                    return T(_("Multi-word selection: %1"), v[1]:lower())
+                end
+            end
+        end,
+        sub_item_table = sub_item_table,
+    })
     -- highlight dialog position
     local sub_item_table = {}
     for i, v in ipairs(highlight_dialog_position) do

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -706,9 +706,9 @@ If you wish your highlights to be saved in the document, just move it to a writa
         },
     }
     -- actions
-    local sub_item_table = {}
+    local sub_item_table_actions = {}
     for i, v in ipairs(long_press_action) do
-        table.insert(sub_item_table, {
+        table.insert(sub_item_table_actions, {
             text = v[1],
             checked_func = function()
                 return G_reader_settings:readSetting("default_highlight_action", "ask") == v[2]
@@ -721,14 +721,14 @@ If you wish your highlights to be saved in the document, just move it to a writa
     end
     table.insert(menu_items.long_press.sub_item_table, {
         text_func = function()
-            local multi_word = G_reader_settings:readSetting("default_highlight_action")
+            local action = G_reader_settings:readSetting("default_highlight_action")
             for __, v in ipairs(long_press_action) do
-                if v[2] == multi_word then
+                if v[2] == action then
                     return T(_("Multi-word selection: %1"), v[1]:lower())
                 end
             end
         end,
-        sub_item_table = sub_item_table,
+        sub_item_table = sub_item_table_actions,
     })
     -- highlight dialog position
     local sub_item_table = {}


### PR DESCRIPTION
Group all multiple-word-selection actions into a sub menu.

### before:

<img src="https://github.com/user-attachments/assets/c628d3ae-a956-4658-bb89-e468e8ecbc20" width=40% height=40%>
<img src="https://github.com/koreader/koreader/assets/97603719/12773fd2-712e-4382-99a6-83fefdfe9cdf" width=40% height=40%>

### after:

<img src="https://github.com/user-attachments/assets/0d454109-bd0d-4ffb-b782-03f0202ab622" width=40% height=40%>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12282)
<!-- Reviewable:end -->
