### PR TITLE
PowerD: Keep track of frontlight state change by interactive callers for suspend/resume purposes

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -116,6 +116,7 @@ if Device:hasFrontlight() then
         else
             powerd:setIntensity(new_intensity)
         end
+        powerd:updateResumeFrontlightState()
         return true
     end
 
@@ -183,6 +184,7 @@ if Device:hasFrontlight() then
         if not powerd:toggleFrontlight(notif_cb) then
             Notification:notify(_("Frontlight unchanged."), notif_source)
         end
+        powerd:updateResumeFrontlightState()
     end
 
     function DeviceListener:onShowFlDialog()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -30,6 +30,7 @@ function BasePowerD:new(o)
     if o.device and o.device:hasFrontlight() then
         o.fl_intensity = o:frontlightIntensityHW()
         o:_decideFrontlightState()
+        o.fl_was_on = o.is_fl_on
     end
     --- @note: Post-init, as the min/max values may be computed at runtime on some platforms
     assert(o.fl_warmth_min < o.fl_warmth_max)

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -18,6 +18,7 @@ local BasePowerD = {
     last_aux_capacity_pull_time = time.s(-61),  -- timestamp of last pull
 
     is_fl_on = false,                 -- whether the frontlight is on
+    fl_was_on = nil,                  -- whether the frontlight *was* on before suspend
 }
 
 function BasePowerD:new(o)
@@ -112,6 +113,11 @@ function BasePowerD:_decideFrontlightState()
     assert(self.device:hasFrontlight())
     self.is_fl_on = self:isFrontlightOnHW()
     print("Setting self.is_fl_on to", self.is_fl_on)
+end
+
+-- Separate from _decideFrontlightState, as this is only called by *interactive* codepaths
+function BasePowerD:updateResumeFrontlightState()
+    self.fl_was_on = self:isFrontlightOn()
 end
 
 function BasePowerD:isFrontlightOff()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -109,10 +109,8 @@ function BasePowerD:isFrontlightOn()
 end
 
 function BasePowerD:_decideFrontlightState()
-    print("BasePowerD:_decideFrontlightState")
     assert(self.device:hasFrontlight())
     self.is_fl_on = self:isFrontlightOnHW()
-    print("Setting self.is_fl_on to", self.is_fl_on)
 end
 
 -- Separate from _decideFrontlightState, as this is only called by *interactive* codepaths
@@ -134,8 +132,6 @@ function BasePowerD:frontlightIntensity()
 end
 
 function BasePowerD:toggleFrontlight(done_callback)
-    print("BasePowerD:toggleFrontlight")
-    print(debug.traceback())
     if not self.device:hasFrontlight() then return false end
     if self:isFrontlightOn() then
         return self:turnOffFrontlight(done_callback)
@@ -145,13 +141,10 @@ function BasePowerD:toggleFrontlight(done_callback)
 end
 
 function BasePowerD:turnOffFrontlight(done_callback)
-    print("BasePowerD:turnOffFrontlight")
-    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOff() then return false end
     local cb_handled = self:turnOffFrontlightHW(done_callback)
     self.is_fl_on = false
-    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()
@@ -160,14 +153,11 @@ function BasePowerD:turnOffFrontlight(done_callback)
 end
 
 function BasePowerD:turnOnFrontlight(done_callback)
-    print("BasePowerD:turnOnFrontlight")
-    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOn() then return false end
     if self.fl_intensity == self.fl_min then return false end  --- @fixme what the hell?
     local cb_handled = self:turnOnFrontlightHW(done_callback)
     self.is_fl_on = true
-    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -108,8 +108,10 @@ function BasePowerD:isFrontlightOn()
 end
 
 function BasePowerD:_decideFrontlightState()
+    print("BasePowerD:_decideFrontlightState")
     assert(self.device:hasFrontlight())
     self.is_fl_on = self:isFrontlightOnHW()
+    print("Setting self.is_fl_on to", self.is_fl_on)
 end
 
 function BasePowerD:isFrontlightOff()
@@ -126,6 +128,8 @@ function BasePowerD:frontlightIntensity()
 end
 
 function BasePowerD:toggleFrontlight(done_callback)
+    print("BasePowerD:toggleFrontlight")
+    print(debug.traceback())
     if not self.device:hasFrontlight() then return false end
     if self:isFrontlightOn() then
         return self:turnOffFrontlight(done_callback)
@@ -135,10 +139,13 @@ function BasePowerD:toggleFrontlight(done_callback)
 end
 
 function BasePowerD:turnOffFrontlight(done_callback)
+    print("BasePowerD:turnOffFrontlight")
+    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOff() then return false end
     local cb_handled = self:turnOffFrontlightHW(done_callback)
     self.is_fl_on = false
+    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()
@@ -147,11 +154,14 @@ function BasePowerD:turnOffFrontlight(done_callback)
 end
 
 function BasePowerD:turnOnFrontlight(done_callback)
+    print("BasePowerD:turnOnFrontlight")
+    print(debug.traceback())
     if not self.device:hasFrontlight() then return end
     if self:isFrontlightOn() then return false end
     if self.fl_intensity == self.fl_min then return false end  --- @fixme what the hell?
     local cb_handled = self:turnOnFrontlightHW(done_callback)
     self.is_fl_on = true
+    print("Setting self.is_fl_on to", self.is_fl_on)
     self:stateChanged()
     if not cb_handled and done_callback then
         done_callback()

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -30,7 +30,7 @@ function BasePowerD:new(o)
     if o.device and o.device:hasFrontlight() then
         o.fl_intensity = o:frontlightIntensityHW()
         o:_decideFrontlightState()
-        o.fl_was_on = o.is_fl_on
+        o:updateResumeFrontlightState()
     end
     --- @note: Post-init, as the min/max values may be computed at runtime on some platforms
     assert(o.fl_warmth_min < o.fl_warmth_max)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -250,6 +250,7 @@ function KoboPowerD:isFrontlightOnHW()
         self.initial_is_fl_on = nil
         return ret
     end
+    print("KoboPowerD:isFrontlightOnHW:", self.hw_intensity, self.fl_intensity, self.fl_ramp_down_running, self.fl_ramp_up_running)
     return self.hw_intensity > 0 and not self.fl_ramp_down_running
 end
 
@@ -360,7 +361,10 @@ function KoboPowerD:turnOffFrontlightRamp(curr_ramp_intensity, end_intensity, do
 end
 
 function KoboPowerD:turnOffFrontlightHW(done_callback)
+    --print("KoboPowerD:turnOffFrontlightHW")
+    --print(debug.traceback())
     if not self:isFrontlightOnHW() then
+        print("turnOffFrontlightHW: early abort because fl is already off")
         return
     end
 
@@ -426,6 +430,8 @@ function KoboPowerD:turnOnFrontlightRamp(curr_ramp_intensity, end_intensity, don
 end
 
 function KoboPowerD:turnOnFrontlightHW(done_callback)
+    --print("KoboPowerD:turnOnFrontlightHW")
+    --print(debug.traceback())
     -- NOTE: Insane workaround for the first toggle after a startup with the FL off.
     -- The light is actually off, but hw_intensity couldn't have been set to a sane value because of a number of interactions.
     -- So, fix it now, so we pass the isFrontlightOnHW check (which checks if hw_intensity > fl_min).
@@ -433,6 +439,7 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
         self.hw_intensity = self.fl_min
     end
     if self:isFrontlightOnHW() then
+        print("turnOnFrontlightHW: early abort because fl is already on")
         return
     end
 
@@ -471,11 +478,13 @@ function KoboPowerD:_suspendFrontlight()
     --       we'd delay setting self.fl_was_on to the pre-ramp value at the end of the ramp (via the ramp's done_callback),
     --       except for the fact that if the frontlight is off, turnOffFrontlight will abort early, so we can't ;).
     self.fl_was_on = self.is_fl_on
+    print("Setting self.fl_was_on:", self.fl_was_on)
     self:turnOffFrontlight()
 end
 
 -- Turn off front light before suspend.
 function KoboPowerD:beforeSuspend()
+    print("KoboPowerD:beforeSuspend")
     -- Inhibit user input and emit the Suspend event.
     self.device:_beforeSuspend()
 
@@ -498,6 +507,7 @@ end
 
 function KoboPowerD:_resumeFrontlight()
     -- Don't bother if the light was already off on suspend
+    print("Reading self.fl_was_on:", self.fl_was_on)
     if self.fl_was_on then
         -- Turn the frontlight back on
         self:turnOnFrontlight()
@@ -506,6 +516,7 @@ end
 
 -- Restore front light state after resume.
 function KoboPowerD:afterResume()
+    print("KoboPowerD:afterResume")
     -- Set the system clock to the hardware clock's time.
     RTC:HCToSys()
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -469,7 +469,7 @@ function KoboPowerD:_suspendFrontlight()
     -- Things gan go sideways quick when you mix the userland ramp,
     -- delays all over the place, and quick successions of suspend/resume requests (e.g., jittery sleepcovers),
     -- so trust fl_was_on over the actual current state,
-    -- as the current state might not actually represent the pre-suspend reality...
+    -- as the current state might no longer actually represent the pre-suspend reality...
     -- Note that fl_was_on is also updated by *interactive* callers via `BasePowerD:updateResumeFrontlightState`,
     -- which is why we only need to handle it when it has not yet been set.
     if self.fl_was_on == nil then

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -466,12 +466,6 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
 end
 
 function KoboPowerD:_suspendFrontlight()
-    -- Things gan go sideways quick when you mix the userland ramp,
-    -- delays all over the place, and quick successions of suspend/resume requests (e.g., jittery sleepcovers),
-    -- so trust fl_was_on over the actual current state,
-    -- as the current state might no longer actually represent the pre-suspend reality...
-    -- c.f., #12246
-    -- Note that fl_was_on is updated by *interactive* callers via `BasePowerD:updateResumeFrontlightState`.
     self:turnOffFrontlight()
 end
 
@@ -497,6 +491,12 @@ end
 
 function KoboPowerD:_resumeFrontlight()
     -- Don't bother if the light was already off on suspend
+    -- NOTE: Things gan go sideways quick when you mix the userland ramp,
+    --       delays all over the place, and quick successions of suspend/resume requests (e.g., jittery sleepcovers),
+    --       so trust fl_was_on over the actual state on beforeSuspend,
+    --       as said state might no longer actually represent the pre-suspend reality...
+    --       c.f., #12246
+    -- Note that fl_was_on is updated by *interactive* callers via `BasePowerD:updateResumeFrontlightState`
     if self.fl_was_on then
         -- If the frontlight is currently on because of madness resulting from multiple concurrent suspend/resume requests,
         -- but at the wrong intensity, turn it straight off first so that turnOnFrontlight doesn't abort early...

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -462,14 +462,12 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
     return true
 end
 
--- NOTE: We delay those *slightly*, so tracking the fl_was_on state needs to be delayed with it,
---       or stuff gets wonky if you trip a resume/suspend in quick succession...
---       c.f., https://github.com/koreader/koreader/issues/12246#issuecomment-2261334603
 function KoboPowerD:_suspendFrontlight()
     -- Things gan go sideways quick when you mix the userland ramp,
     -- delays all over the place, and quick successions of suspend/resume requests (e.g., jittery sleepcovers),
     -- so trust fl_was_on over the actual current state,
     -- as the current state might no longer actually represent the pre-suspend reality...
+    -- c.f., #12246
     -- Note that fl_was_on is also updated by *interactive* callers via `BasePowerD:updateResumeFrontlightState`,
     -- which is why we only need to handle it when it has not yet been set.
     if self.fl_was_on == nil then
@@ -501,7 +499,7 @@ end
 function KoboPowerD:_resumeFrontlight()
     -- Don't bother if the light was already off on suspend
     if self.fl_was_on then
-        -- If the frontlight is actually on because of concurrent suspend/resume madness,
+        -- If the frontlight is currently on because of madness resulting from multiple concurrent suspend/resume requests,
         -- but at the wrong intensity, turn it straight off first so that turnOnFrontlight doesn't abort early...
         if self.is_fl_on and self.hw_intensity ~= self.fl_intensity then
             logger.warn("KoboPowerD:_resumeFrontlight: frontlight intensity is at", self.hw_intensity, "instead of the expected", self.fl_intensity)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -244,7 +244,7 @@ end
 
 function KoboPowerD:isFrontlightOnHW()
     if self.initial_is_fl_on ~= nil then -- happens only once after init()
-        -- give initial state to BasePowerD,
+        -- Pass our initial state to BasePowerD,
         -- which will reset our self.hw_intensity to 0 if self.initial_is_fl_on is false
         local ret = self.initial_is_fl_on
         self.initial_is_fl_on = nil

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -517,7 +517,7 @@ function KoboPowerD:_resumeFrontlight()
         -- If the frontlight is actually on because of concurrent suspend/resume madness,
         -- but at the wrong intensity, turn it straight off first so that turnOnFrontlight doesn't abort early...
         if self.is_fl_on and self.hw_intensity ~= self.fl_intensity then
-            logger.warn("KoboPowerD:_resumeFrontlight: frontlight is at", self.hw_intensity, "intensity instead of the expected", self.fl_intensity)
+            logger.warn("KoboPowerD:_resumeFrontlight: frontlight intensity is at", self.hw_intensity, "instead of the expected", self.fl_intensity)
             self:setIntensityHW(self.fl_min)
         end
         -- Turn the frontlight back on

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -495,6 +495,11 @@ function KoboPowerD:beforeSuspend()
     -- Handle the frontlight last,
     -- to prevent as many things as we can from interfering with the smoothness of the ramp
     if self.fl then
+        -- We only want the *last* scheduled suspend/resume frontlight task to run to avoid ramps running amok...
+        UIManager:unschedule(self._suspendFrontlight)
+        UIManager:unschedule(self._resumeFrontlight)
+        self:_stopFrontlightRamp()
+
         -- Turn off the frontlight
         -- NOTE: Funky delay mainly to yield to the EPDC's refresh on UP systems.
         --       (Neither yieldToEPDC nor nextTick & friends quite cut it here)...
@@ -534,6 +539,11 @@ function KoboPowerD:afterResume()
     -- There's a whole bunch of stuff happening before us in Generic:onPowerEvent,
     -- so we'll delay this ever so slightly so as to appear as smooth as possible...
     if self.fl then
+        -- Same reasoning as on suspend
+        UIManager:unschedule(self._suspendFrontlight)
+        UIManager:unschedule(self._resumeFrontlight)
+        self:_stopFrontlightRamp()
+
         -- Turn the frontlight back on
         -- NOTE: There's quite likely *more* resource contention than on suspend here :/.
         UIManager:scheduleIn(0.001, self._resumeFrontlight, self)

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -471,11 +471,7 @@ function KoboPowerD:_suspendFrontlight()
     -- so trust fl_was_on over the actual current state,
     -- as the current state might no longer actually represent the pre-suspend reality...
     -- c.f., #12246
-    -- Note that fl_was_on is also updated by *interactive* callers via `BasePowerD:updateResumeFrontlightState`,
-    -- which is why we only need to handle it when it has not yet been set.
-    if self.fl_was_on == nil then
-        self.fl_was_on = self.is_fl_on
-    end
+    -- Note that fl_was_on is updated by *interactive* callers via `BasePowerD:updateResumeFrontlightState`.
     self:turnOffFrontlight()
 end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -315,7 +315,7 @@ function KoboPowerD:isChargedHW()
 end
 
 function KoboPowerD:_startRampDown(done_callback)
-    self:turnOffFrontlightRamp(self.fl_intensity, self.fl_min, done_callback)
+    self:turnOffFrontlightRamp(self.hw_intensity, self.fl_min, done_callback)
     self.fl_ramp_down_running = true
 end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -250,7 +250,6 @@ function KoboPowerD:isFrontlightOnHW()
         self.initial_is_fl_on = nil
         return ret
     end
-    print("KoboPowerD:isFrontlightOnHW:", self.hw_intensity, self.fl_intensity, self.fl_ramp_down_running, self.fl_ramp_up_running)
     return self.hw_intensity > 0 and not self.fl_ramp_down_running
 end
 
@@ -361,10 +360,7 @@ function KoboPowerD:turnOffFrontlightRamp(curr_ramp_intensity, end_intensity, do
 end
 
 function KoboPowerD:turnOffFrontlightHW(done_callback)
-    --print("KoboPowerD:turnOffFrontlightHW")
-    --print(debug.traceback())
     if not self:isFrontlightOnHW() then
-        print("turnOffFrontlightHW: early abort because fl is already off")
         return
     end
 
@@ -430,8 +426,6 @@ function KoboPowerD:turnOnFrontlightRamp(curr_ramp_intensity, end_intensity, don
 end
 
 function KoboPowerD:turnOnFrontlightHW(done_callback)
-    --print("KoboPowerD:turnOnFrontlightHW")
-    --print(debug.traceback())
     -- NOTE: Insane workaround for the first toggle after a startup with the FL off.
     -- The light is actually off, but hw_intensity couldn't have been set to a sane value because of a number of interactions.
     -- So, fix it now, so we pass the isFrontlightOnHW check (which checks if hw_intensity > fl_min).
@@ -439,7 +433,6 @@ function KoboPowerD:turnOnFrontlightHW(done_callback)
         self.hw_intensity = self.fl_min
     end
     if self:isFrontlightOnHW() then
-        print("turnOnFrontlightHW: early abort because fl is already on")
         return
     end
 
@@ -473,7 +466,6 @@ end
 --       or stuff gets wonky if you trip a resume/suspend in quick succession...
 --       c.f., https://github.com/koreader/koreader/issues/12246#issuecomment-2261334603
 function KoboPowerD:_suspendFrontlight()
-    print("KoboPowerD:_suspendFrontlight")
     -- Things gan go sideways quick when you mix the userland ramp,
     -- delays all over the place, and quick successions of suspend/resume requests (e.g., jittery sleepcovers),
     -- so trust fl_was_on over the actual current state,
@@ -482,14 +474,12 @@ function KoboPowerD:_suspendFrontlight()
     -- which is why we only need to handle it when it has not yet been set.
     if self.fl_was_on == nil then
         self.fl_was_on = self.is_fl_on
-        print("==> Setting self.fl_was_on:", self.fl_was_on)
     end
     self:turnOffFrontlight()
 end
 
 -- Turn off front light before suspend.
 function KoboPowerD:beforeSuspend()
-    print("KoboPowerD:beforeSuspend")
     -- Inhibit user input and emit the Suspend event.
     self.device:_beforeSuspend()
 
@@ -509,10 +499,7 @@ function KoboPowerD:beforeSuspend()
 end
 
 function KoboPowerD:_resumeFrontlight()
-    print("KoboPowerD:_resumeFrontlight")
-
     -- Don't bother if the light was already off on suspend
-    print("<== Reading self.fl_was_on:", self.fl_was_on)
     if self.fl_was_on then
         -- If the frontlight is actually on because of concurrent suspend/resume madness,
         -- but at the wrong intensity, turn it straight off first so that turnOnFrontlight doesn't abort early...
@@ -527,7 +514,6 @@ end
 
 -- Restore front light state after resume.
 function KoboPowerD:afterResume()
-    print("KoboPowerD:afterResume")
     -- Set the system clock to the hardware clock's time.
     RTC:HCToSys()
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -84,7 +84,7 @@ function KoboPowerD:_syncKoboLightOnStart()
         self.fl_warmth = new_warmth
     end
 
-    -- In any case frontlight is off, ensure intensity is non-zero so untoggle works
+    -- In case frontlight is off, ensure hw_intensity is non-zero so toggle on works
     if self.initial_is_fl_on == false and self.hw_intensity == 0 then
         self.hw_intensity = 1
     end
@@ -372,7 +372,7 @@ function KoboPowerD:turnOffFrontlightHW(done_callback)
             --       otherwise you just see a single delayed step (1%) or two stuttery ones (2%) ;).
             -- FWIW, modern devices with a different PWM controller (i.e., with no controller-specific ramp_off_delay workarounds)
             -- deal with our 2% ramp without stuttering.
-            if self.device.frontlight_settings.ramp_off_delay > 0.0 and self.fl_intensity <= 2 then
+            if self.device.frontlight_settings.ramp_off_delay > 0.0 and self.hw_intensity <= 2 then
                 UIManager:scheduleIn(self.device.frontlight_settings.ramp_delay, self._endRampDown, self, self.fl_min, done_callback)
             else
                 -- NOTE: Similarly, some controllers *really* don't like to be interleaved with screen refreshes,
@@ -380,7 +380,7 @@ function KoboPowerD:turnOffFrontlightHW(done_callback)
                 if self.device.frontlight_settings.delay_ramp_start then
                     UIManager:nextTick(self._startRampDown, self, done_callback)
                 else
-                    self:turnOffFrontlightRamp(self.fl_intensity, self.fl_min, done_callback)
+                    self:turnOffFrontlightRamp(self.hw_intensity, self.fl_min, done_callback)
                     self.fl_ramp_down_running = true
                 end
             end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -314,6 +314,9 @@ function KoboPowerD:isChargedHW()
     return false
 end
 
+-- NOTE: When ramping down, we start from the *actual* intensity (hw_intensity),
+--       instead of the expected one (fl_intensity),
+--       in case a previously incomplete ramp was canceled and left us in an inconsistent state.
 function KoboPowerD:_startRampDown(done_callback)
     self:turnOffFrontlightRamp(self.hw_intensity, self.fl_min, done_callback)
     self.fl_ramp_down_running = true

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -509,9 +509,9 @@ function KoboPowerD:_resumeFrontlight()
     print("<== Reading self.fl_was_on:", self.fl_was_on)
     if self.fl_was_on then
         -- If the frontlight is actually on because of concurrent suspend/resume madness,
-        -- turn it straight off first so that turnOnFrontlight doesn't abort early...
+        -- but at the wrong intensity, turn it straight off first so that turnOnFrontlight doesn't abort early...
         --[[
-        if self.is_fl_on then
+        if self.hw_intensity ~= self.fl_intensity then
             self:setIntensityHW(self.fl_min)
         end
         --]]

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -487,7 +487,8 @@ function KoboPowerD:_suspendFrontlight()
     if self.concurrent_resume_requests == 0 then
         -- Things gan go sideways quick when you mix the userland ramp,
         -- delays all over the place, and quick successions of suspend/resume requests (e.g., jittery sleepcovers),
-        -- so trust previous fl_was_on values over the actual current state.
+        -- so trust previous fl_was_on values over the actual current state,
+        -- as the current state might not actually represent the pre-suspend reality...
         -- Yes, this means this'll effectively snapshot the state at the *first* suspend each KOReader run,
         -- but having only *manual* toggles update this is a bit of a nightmare, so I'm okay with the status quo.
         if self.fl_was_on == nil then

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -3,6 +3,7 @@ local Math = require("optmath")
 local NickelConf = require("device/kobo/nickel_conf")
 local SysfsLight = require ("device/sysfs_light")
 local UIManager
+local logger = require("logger")
 local RTC = require("ffi/rtc")
 
 -- Here, we only deal with the real hw intensity.
@@ -515,11 +516,10 @@ function KoboPowerD:_resumeFrontlight()
     if self.fl_was_on then
         -- If the frontlight is actually on because of concurrent suspend/resume madness,
         -- but at the wrong intensity, turn it straight off first so that turnOnFrontlight doesn't abort early...
-        --[[
         if self.hw_intensity ~= self.fl_intensity then
+            logger.warn("KoboPowerD:_resumeFrontlight: frontlight is at", self.hw_intensity, "intensity instead of the expected", self.is_fl_on and self.fl_intensity or self.fl_min)
             self:setIntensityHW(self.fl_min)
         end
-        --]]
         -- Turn the frontlight back on
         self:turnOnFrontlight()
     end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -516,8 +516,8 @@ function KoboPowerD:_resumeFrontlight()
     if self.fl_was_on then
         -- If the frontlight is actually on because of concurrent suspend/resume madness,
         -- but at the wrong intensity, turn it straight off first so that turnOnFrontlight doesn't abort early...
-        if self.hw_intensity ~= self.fl_intensity then
-            logger.warn("KoboPowerD:_resumeFrontlight: frontlight is at", self.hw_intensity, "intensity instead of the expected", self.is_fl_on and self.fl_intensity or self.fl_min)
+        if self.is_fl_on and self.hw_intensity ~= self.fl_intensity then
+            logger.warn("KoboPowerD:_resumeFrontlight: frontlight is at", self.hw_intensity, "intensity instead of the expected", self.fl_intensity)
             self:setIntensityHW(self.fl_min)
         end
         -- Turn the frontlight back on

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -17,7 +17,6 @@ local KoboPowerD = BasePowerD:new{
     battery_sysfs = nil,
     aux_battery_sysfs = nil,
     fl_warmth_min = 0, fl_warmth_max = 100,
-    fl_was_on = nil,
 
     concurrent_suspend_requests = 0,
     concurrent_resume_requests = 0,
@@ -489,8 +488,6 @@ function KoboPowerD:_suspendFrontlight()
         -- delays all over the place, and quick successions of suspend/resume requests (e.g., jittery sleepcovers),
         -- so trust previous fl_was_on values over the actual current state,
         -- as the current state might not actually represent the pre-suspend reality...
-        -- Yes, this means this'll effectively snapshot the state at the *first* suspend each KOReader run,
-        -- but having only *manual* toggles update this is a bit of a nightmare, so I'm okay with the status quo.
         if self.fl_was_on == nil then
             self.fl_was_on = self.is_fl_on
             print("==> Setting self.fl_was_on:", self.fl_was_on)

--- a/frontend/ui/widget/frontlightwidget.lua
+++ b/frontend/ui/widget/frontlightwidget.lua
@@ -512,6 +512,7 @@ function FrontLightWidget:setFrontLightIntensity(intensity)
     else
         self.powerd:setIntensity(self.fl.cur)
     end
+    self.powerd:updateResumeFrontlightState()
 
     -- Retrieve the real level set by PowerD (will be different from `intensity` on toggle)
     self.fl.cur = self.powerd:frontlightIntensity()


### PR DESCRIPTION
While #12256 papered over the tracking of a *single* suspend -> (resume->suspend) series of events, things still go out of sync if you tack on *more* suspend/resume events after that.

The upside is that our *actual* tracking of suspend/resume is solid, so at least we're actually doing the right thing as far as PM is concerned.

The downside is that on Kobo, the frontlight handling code is full of delays, and the ramping down/up itself also takes some time, so things can quickly overrun into the wrong event.

This means a couple of things:

* We need to cancel any scheduled frontlight toggles and ramps on Kobo, to ensure that only the one from the *last* event received goes through, in an attempt to limit the amount of potential crossover.
* Tracking fl_was_on *cannot* reliably be done from the suspend/resume handlers (especially on Kobo), as the ramps themselves may cross over the event barriers (and we potentially cancel the task anyway), so this was moved to the very few interactive callers that will actually change the frontlight state.
* On Kobo, crossover is still *somewhat* possible because the ramps take time. It's mostly harmless for the ramp down, we just need to tweak the ramp down to start from the actual intensity to avoid a weird jump on the initial step if there's an inconsistency. For the ramp up, we potentially need to manually kill the light first, because off -> on assumes it *really* starts from off ;).

Followup to #12256
Fix #12246 (again)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12283)
<!-- Reviewable:end -->
