### PR TITLE
Fix early unhighlight after Add to vocab builder

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1592,7 +1592,7 @@ dbg:guard(ReaderHighlight, "lookup",
 function ReaderHighlight:getSelectedWordContext(nb_words)
     if not self.selected_text then return end
     local ok, prev_context, next_context = pcall(self.ui.document.getSelectedWordContext, self.ui.document,
-                                                 self.selected_text.text, nb_words, self.selected_text.pos0, self.selected_text.pos1)
+                                                 self.selected_text.text, nb_words, self.selected_text.pos0, self.selected_text.pos1, true)
     if ok then
         return prev_context, next_context
     end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -766,7 +766,7 @@ function CreDocument:getNextVisibleChar(xp)
     return self._document:getNextVisibleChar(xp)
 end
 
-function CreDocument:getSelectedWordContext(word, nb_words, pos0, pos1)
+function CreDocument:getSelectedWordContext(word, nb_words, pos0, pos1, restore_selection)
     local pos_start = pos0
     local pos_end = pos1
 
@@ -784,6 +784,15 @@ function CreDocument:getSelectedWordContext(word, nb_words, pos0, pos1)
 
     local prev = self:getTextFromXPointers(pos_start, pos0)
     local next = self:getTextFromXPointers(pos1, pos_end)
+
+    if restore_selection then
+        -- If pos0..pos1 was highlighted by crengine, getTextFromXPointers()
+        -- will have cleared this original selection, and crengine would then
+        -- not draw it any longer on next refresh.
+        -- If requested because it was highlighted, have crengine know again
+        -- about what should be selected and drawn.
+        self:getTextFromXPointers(pos0, pos1, true)
+    end
 
     return prev, next
 end


### PR DESCRIPTION
Getting text from xpointers to get the current selected word context would have crengine unhighlight that word. Allow to get it selected again when done getting context.
See https://github.com/koreader/koreader/issues/12250#issuecomment-2263754719.
Closes #12250.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12288)
<!-- Reviewable:end -->
