### PR TITLE
ReaderStatistics: disable for filepaths starting /tmp/

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -105,6 +105,16 @@ function ReaderStatistics:init()
         return -- disable in PIC documents
     end
 
+    if self.document and self.document.file and self.document.file:match("^/tmp/") then
+        -- entirely disable for temporary files, including disabling event handlers
+        for n,v in pairs(ReaderStatistics) do
+            if n:match("^on") and type(v) == "function" then
+                self[n] = function() end
+            end
+        end
+        return
+    end
+
     self.is_doc = false
     self.is_doc_not_frozen = false -- freeze finished books statistics
 


### PR DESCRIPTION
Compiling statistics for temporary files is presumably never wanted, and slows things down significantly (this greatly affects the gemini plugin).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12292)
<!-- Reviewable:end -->
