### PR TITLE
Panel zoom: Properly handle `renderPage()` not rendering the whole page

### DIFF
--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -541,7 +541,11 @@ function Document:getPagePart(pageno, rect, rotation)
     }
     local tile = self:renderPage(pageno, scaled_rect, zoom, rotation, 1.0)
     local target = Blitbuffer.new(scaled_rect.w, scaled_rect.h, self.render_color and self.color_bb_type or nil)
-    target:blitFrom(tile.bb, 0, 0, scaled_rect.x, scaled_rect.y, scaled_rect.w, scaled_rect.h)
+    target:blitFrom(tile.bb,
+        0, 0,
+        scaled_rect.x - tile.excerpt.x,
+        scaled_rect.y - tile.excerpt.y,
+        scaled_rect.w, scaled_rect.h)
     return target
 end
 


### PR DESCRIPTION
When zooming to a small panel on a device with a large display, the resulting zoom factor often causes `renderPage()` to only render the panel itself instead of the whole page.  `getPagePart()` needs to account for that when extracting the panel from the rendered tile.

Fixes half of #7961 (namely the black/half-black rectangles)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12296)
<!-- Reviewable:end -->
