### PR TITLE
NetworkMgr: fix debug trace

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -1106,7 +1106,7 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
             if network.password then
                 -- If we hit a preferred network and we're not already connected,
                 -- attempt to connect to said preferred network....
-                logger.dbg("NetworkMgr: Attempting to authenticate on preferred network", util.fixUtf8(ssid, "�"))
+                logger.dbg("NetworkMgr: Attempting to authenticate on preferred network", util.fixUtf8(network.ssid, "�"))
                 success, err_msg = self:authenticateNetwork(network)
                 if success then
                     ssid = network.ssid


### PR DESCRIPTION
Prevent crash:
```
./luajit: frontend/util.lua:1092: attempt to get length of local 'str' (a nil value)
stack traceback:
        frontend/util.lua:1092: in function 'fixUtf8'
        frontend/ui/network/manager.lua:1109: in function 'requestToTurnOnWifi'
[…]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12297)
<!-- Reviewable:end -->
