### PR TITLE
Profiles: make sure to close menu/quickmenu before executing action

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1079,7 +1079,9 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_size = 22,
             callback = function()
                 UIManager:close(quickmenu)
-                Dispatcher:execute(settings, { qm_show = false })
+                UIManager:nextTick(function()
+                    Dispatcher:execute(settings, { qm_show = false })
+                end)
             end,
         }})
     end
@@ -1093,7 +1095,9 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_bold = false,
             callback = function()
                 UIManager:close(quickmenu)
-                Dispatcher:execute({[v.key] = settings[v.key]})
+                UIManager:nextTick(function()
+                    Dispatcher:execute({[v.key] = settings[v.key]})
+                end)
                 if keep_open_on_apply and not util.stringStartsWith(v.key, "touch_input") then
                     quickmenu:setTitle(title)
                     UIManager:show(quickmenu)
@@ -1102,7 +1106,9 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             hold_callback = function()
                 if v.key:sub(1, 13) == "profile_exec_" then
                     UIManager:close(quickmenu)
-                    UIManager:sendEvent(Event:new(settingsList[v.key].event, settingsList[v.key].arg, { qm_show = true }))
+                    UIManager:nextTick(function()
+                        UIManager:sendEvent(Event:new(settingsList[v.key].event, settingsList[v.key].arg, { qm_show = true }))
+                    end)
                 end
             end,
         }})

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -124,14 +124,14 @@ function Profiles:getSubMenuItems()
                 text = _("Execute"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    self:onProfileExecute(k, { qm_show = false })
+                    UIManager:nextTick(self.onProfileExecute, self, k, { qm_show = false })
                 end,
             },
             {
                 text = _("Show as QuickMenu"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    self:onProfileExecute(k, { qm_show = true })
+                    UIManager:nextTick(self.onProfileExecute, self, k, { qm_show = true })
                 end,
             },
             {


### PR DESCRIPTION
Mainly a difference without distinction, but in some edge cases like screenshots it keeps the menu on the screen. See <https://github.com/koreader/koreader/pull/12293#issuecomment-2269680044>.

The "Show as QuickMenu" is really just for balance; it makes little to no difference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12299)
<!-- Reviewable:end -->
