### PR TITLE
Allow numbers in measure text: fixes a crash in table of contents when debugging on

### DIFF
--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -178,7 +178,7 @@ function TextWidget:updateSize()
 end
 dbg:guard(TextWidget, "updateSize",
     function(self)
-        assert(type(self.text) == "string",
+        assert(type(self.text) == "string" or type(self.text) == "number",
             "Wrong text type (expected string)")
     end)
 

--- a/frontend/ui/widget/textwidget.lua
+++ b/frontend/ui/widget/textwidget.lua
@@ -179,7 +179,7 @@ end
 dbg:guard(TextWidget, "updateSize",
     function(self)
         assert(type(self.text) == "string" or type(self.text) == "number",
-            "Wrong text type (expected string)")
+            "Wrong self.text type (expected string or number)")
     end)
 
 function TextWidget:_measureWithXText()
@@ -324,8 +324,8 @@ function TextWidget:setText(text)
 end
 dbg:guard(TextWidget, "setText",
     function(self, text)
-        assert(type(text) == "string",
-            "Wrong text type (expected string)")
+        assert(type(text) == "string" or type(text) == "number",
+            "Wrong text type (expected string or number)")
     end)
 
 function TextWidget:setMaxWidth(max_width)


### PR DESCRIPTION
Currently I get

```
08/07/24-20:48:39 DEBUG Found font: DroidSansMono.ttf in ./fonts/droid/DroidSansMono.ttf 
./luajit: frontend/ui/widget/textwidget.lua:181: Wrong text type (expected string)
stack traceback:
	[C]: in function 'assert'
	frontend/ui/widget/textwidget.lua:181: in function 'pre_guard'
	frontend/dbg.lua:46: in function 'updateSize'
	frontend/ui/widget/textwidget.lua:303: in function 'getWidth'
	frontend/ui/widget/menu.lua:199: in function 'init'
	frontend/ui/widget/widget.lua:46: in function 'new'
	frontend/ui/widget/menu.lua:1081: in function 'updateItems'
	frontend/ui/widget/menu.lua:1000: in function 'init'
	frontend/ui/widget/widget.lua:46: in function 'new'
	frontend/apps/reader/modules/readertoc.lua:833: in function 'onShowToc'
	frontend/apps/reader/modules/readertoc.lua:1019: in function 'callback'
	...
	frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
	frontend/ui/widget/container/widgetcontainer.lua:83: in function 'propagateEvent'
	frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
	frontend/ui/uimanager.lua:911: in function 'sendEvent'
	frontend/ui/uimanager.lua:53: in function '__default__'
	frontend/ui/uimanager.lua:1438: in function 'handleInputEvent'
	frontend/ui/uimanager.lua:1538: in function 'handleInput'
	frontend/ui/uimanager.lua:1582: in function 'run'
	./reader.lua:265: in main chunk
	[C]: at 0x558965ec97bd
```

This crash is caused by a too strict assert in `updateSize()`. In fact we convert any value not a string with tostring in namely method

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12310)
<!-- Reviewable:end -->
