### PR TITLE
Fix not passing a string to Menu text

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -191,7 +191,7 @@ function MenuItem:init()
         text_ellipsis_mandatory_padding = Size.span.horizontal_small
     end
     local mandatory_widget = TextWidget:new{
-        text = mandatory or "",
+        text = tostring(mandatory) or "",
         face = self.info_face,
         bold = self.bold,
         fgcolor = mandatory_dim and Blitbuffer.COLOR_DARK_GRAY or nil,


### PR DESCRIPTION
Alternative to https://github.com/koreader/koreader/pull/12310

The old code said `mandatory = mandatory and ""..mandatory or ""`, where `""..mandatory` is functionally equivalent to tostring() (though I suppose it's really equivalent to `""..tostring(mandatory)` unless the parser has a special case for that).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12316)
<!-- Reviewable:end -->
