### PR TITLE
[Menu] Remove title bar buttons from layout on hasSymKey or hasScreenKB

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1127,6 +1127,10 @@ end
 
 -- merge TitleBar layout into self FocusManager layout
 function Menu:mergeTitleBarIntoLayout()
+    if Device:hasSymKey() or Device:hasScreenKB() then
+        -- Title bar items can be accessed through key mappings on kindle
+        return
+    end
     local menu_item_layout_start_row = 1
     local titlebars = {self.title_bar, self.outer_title_bar}
     for _, v in ipairs(titlebars) do


### PR DESCRIPTION
### what's changing:

`mergeTitleBarIntoLayout()` was first introduced in #9041, but it's a solution that hasn't aged well. Kindle NT devices can now access all (bar one) of these "title bar" menus via key presses so, it makes little sense to keep this "solution" available there, particularly when it can in fact make the experience rather cumbersome. See #10301

* In FM, home (top left) can be accessed by pressing the <kbd>Home</kbd> key.
* In FM, plus menu can be accessed from the **TOP MENU**
* In widgets, hamburger menus (top left) can be accessed  by pressing <kbd>Menu</kbd> key. #11966

### what do we lose?:

the only thing that would be unavailable is long-press (hold) on the top-left items (home on FM, hamburger menu elsewhere), but those are not essential so, fair game?

* fixes #10301

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12328)
<!-- Reviewable:end -->
