### PR TITLE
Kobo: Refactor suspend in order to be able to catch input events sent during the 2s window of ntx madness

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1339,23 +1339,7 @@ function Kobo:suspend()
     logger.info("Kobo suspend: going to sleep . . .")
     UIManager:unschedule(self.checkUnexpectedWakeup)
     -- NOTE: Sleep as little as possible here, sleeping has a tendency to make
-    -- everything mysteriously hang...
-
-    -- Depending on device/FW version, some kernels do not support
-    -- wakeup_count, account for that
-    --
-    -- NOTE: ... and of course, it appears to be broken, which probably
-    -- explains why nickel doesn't use this facility...
-    -- (By broken, I mean that the system wakes up right away).
-    -- So, unless that changes, unconditionally disable it.
-
-    --[[
-    -- Go to sleep
-    if self.has_wakeup_count then
-        self.curr_wakeup_count = self.powerd.read_int_file("/sys/power/wakeup_count")
-        logger.dbg("Kobo suspend: Current WakeUp count:", self.curr_wakeup_count)
-    end
-    -]]
+    --       everything mysteriously hang...
 
     -- NOTE: Sets gSleep_Mode_Suspend to 1. Used as a flag throughout the
     --       kernel to suspend/resume various subsystems
@@ -1381,8 +1365,18 @@ function Kobo:_doSuspend()
     os.execute("sync")
     logger.dbg("Kobo suspend: synced FS")
 
+    -- Depending on device/FW version, some kernels do not support wakeup_count, account for that.
+    --
+    -- NOTE: ... and of course, it appears to be broken,
+    --       which probably explains why nickel doesn't use this facility...
+    --       (By broken, I mean that the system wakes up right away).
+    --       So, unless that changes, unconditionally disable it.
+
     --[[
     if self.has_wakeup_count then
+        self.curr_wakeup_count = self.powerd.read_int_file("/sys/power/wakeup_count")
+        logger.dbg("Kobo suspend: Current WakeUp count:", self.curr_wakeup_count)
+
         local ret = ffiUtil.writeToSysfs(self.curr_wakeup_count, "/sys/power/wakeup_count")
         if ret then
             logger.dbg("Kobo suspend: WakeUp count matched")

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1371,7 +1371,9 @@ function Kobo:suspend()
         if ret then
             logger.dbg("Kobo suspend: WakeUp count matched")
         else
-            logger.err("Kobo suspend: WakeUp count mismatch!")
+            logger.err("Kobo suspend: WakeUp count mismatch, aborting this suspend attempt!")
+            -- TODO: This means that there was at least one wakeup event since our read,
+            --       abort this attempt (i.e., don't write to state) and just schedule the wakeup guard.
         end
     end
     --]]
@@ -1411,13 +1413,6 @@ function Kobo:suspend()
     --       cf. nickel_suspend_strace.txt for more details.
     -- NOTE: On recent enough kernels, with debugfs enabled and mounted, see also
     --       /sys/kernel/debug/suspend_stats & /sys/kernel/debug/wakeup_sources
-
-    --[[
-    if self.has_wakeup_count then
-        self.curr_wakeup_count = self.powerd.read_int_file("/sys/power/wakeup_count")
-        logger.dbg("Kobo suspend: WakeUp count on resume:", self.curr_wakeup_count)
-    end
-    --]]
 
     -- NOTE: We unflag /sys/power/state-extended in Kobo:resume() to keep
     --       things tidy and easier to follow

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1369,7 +1369,7 @@ function Kobo:_doSuspend()
     --
     -- NOTE: ...and of course, it appears to be broken on older devices,
     --       which probably explains why nickel doesn't use this facility there...
-    --       (By broken, I mean that the system wakes up right away).
+    --       (By broken, I mean that the system wakes up right away despite the successful write).
     --       As we can't really divine where and when it'll work properly, unconditionally disable it.
     --[[
     if self.has_wakeup_count then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1367,14 +1367,13 @@ function Kobo:_doSuspend()
 
     -- Depending on device/FW version, some kernels do not support wakeup_count, account for that.
     --
-    -- NOTE: ... and of course, it appears to be broken,
-    --       which probably explains why nickel doesn't use this facility...
+    -- NOTE: ...and of course, it appears to be broken on older devices,
+    --       which probably explains why nickel doesn't use this facility there...
     --       (By broken, I mean that the system wakes up right away).
-    --       So, unless that changes, unconditionally disable it.
-
+    --       As we can't really divine where and when it'll work properly, unconditionally disable it.
     --[[
     if self.has_wakeup_count then
-        self.curr_wakeup_count = self.powerd.read_int_file("/sys/power/wakeup_count")
+        self.curr_wakeup_count = self.powerd:read_int_file("/sys/power/wakeup_count")
         logger.dbg("Kobo suspend: Current WakeUp count:", self.curr_wakeup_count)
 
         local ret = ffiUtil.writeToSysfs(self.curr_wakeup_count, "/sys/power/wakeup_count")

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1322,7 +1322,7 @@ function Kobo:suspend()
     -- If there's a _doSuspend still scheduled, something is going seriously wrong
     -- (e.g., we caught multiple Suspend events without a Resume in between)...
     if UIManager:unschedule(self._doSuspend) then
-        logger.warn("Kobo suspend: cancelled a pending suspend request via *suspend*. This most likely is a bug.")
+        logger.warn("Kobo suspend: cancelled a pending suspend request via *suspend*. This is most likely a bug.")
     end
 
     -- On MTK, any suspend/standby attempt while plugged-in will hang the kernel... -_-"

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1366,7 +1366,6 @@ function Kobo:_doSuspend()
     logger.dbg("Kobo suspend: synced FS")
 
     -- Depending on device/FW version, some kernels do not support wakeup_count, account for that.
-    --
     -- NOTE: ...and of course, it appears to be broken on older devices,
     --       which probably explains why nickel doesn't use this facility there...
     --       (By broken, I mean that the system wakes up right away despite the successful write).

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -1,7 +1,7 @@
 local BasePowerD = require("device/generic/powerd")
 local Math = require("optmath")
 local NickelConf = require("device/kobo/nickel_conf")
-local SysfsLight = require ("device/sysfs_light")
+local SysfsLight = require("device/sysfs_light")
 local UIManager
 local logger = require("logger")
 local RTC = require("ffi/rtc")


### PR DESCRIPTION
I don't even remember how badly things broke (at least on old devices) without it, despite it making absolutely no sense at all (state-extended just flips a global that dictates whether some things get flagged as wakeup sources or not).

So, don't rock the boat too much: we don't remove it, but instead of using a sleep, we use a task deadline instead, which ensures we'll keep processing input events in the right order in the meantime. We'll already have neutered input by this point, so we'll only process power events anyway.

That means that the only iffy things are potentially *when* and *where* we have to potentially cancel that task. Resume makes sense, of course, and we log an info message to make the log flow clear; but we also do so in suspend... just in case. With a warning log because that probably indicates something fishy went on.

Also cleanup the comments while I'm there, and actually rewrite the wakeup_count stuff properly so it could actually theoretically be used if ntx kernels were actually reliable. Spoiler alert: they're not, this is still horribly broken on at least Mk < 7. Works just fine on a Forma, though, so, yay.

Fix #12325

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12330)
<!-- Reviewable:end -->
