### PR TITLE
ImageWidget: Don't attempt to pan if we haven't rendered the bb yet

### DIFF
--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -844,6 +844,7 @@ function ImageViewer:onCloseWidget()
         self._scaled_image_func(false) -- invoke :free() on the creimage object
         self._scaled_image_func = nil
     end
+    self._image_wg = nil
 
     -- Those, on the other hand, are always initialized, but may not actually be in our widget tree right now,
     -- depending on what we needed to show, so they might not get sent a CloseWidget event.

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -480,6 +480,10 @@ function ImageWidget:getPanByCenterRatio(x, y)
 end
 
 function ImageWidget:panBy(x, y)
+    if not self._bb then
+        return
+    end
+
     -- update center ratio from new offset
     self.center_x_ratio = (x + self._offset_x + self.width/2) / self._bb_w
     self.center_y_ratio = (y + self._offset_y + self.height/2) / self._bb_h
@@ -595,8 +599,10 @@ end
 -- BlitBuffer zombies
 function ImageWidget:free()
     --print("ImageWidget:free on", self, "for BB?", self._bb, self._bb_disposable)
-    if self._bb and self._bb_disposable and self._bb.free then
-        self._bb:free()
+    if self._bb then
+        if self._bb_disposable and self._bb.free then
+            self._bb:free()
+        end
         self._bb = nil
     end
     -- reset self.scale_factor to its initial value, in case


### PR DESCRIPTION
Input events from ImageViewer can be caught between it clearing an old ImageWidget & instantiating a new one, but before the new one has had a chance to actually render anything.

Fix #12327

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12331)
<!-- Reviewable:end -->
