### PR TITLE
fix missing android APK asset

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -34,6 +34,7 @@ update: all
 	rm -rfv $(ANDROID_LIBS)
 	# APK version
 	mkdir -p $(ANDROID_ASSETS)/module $(ANDROID_LIBS)
+	echo $(VERSION) >$(ANDROID_ASSETS)/module/version.txt
 	# We need strip the version, or versioned
 	# libraries won't be included in the APK.
 	for src in $(INSTALL_DIR)/koreader/libs/*; do \

--- a/make/android.mk
+++ b/make/android.mk
@@ -35,8 +35,8 @@ update: all
 	# APK version
 	mkdir -p $(ANDROID_ASSETS)/module $(ANDROID_LIBS)
 	echo $(VERSION) >$(ANDROID_ASSETS)/module/version.txt
-	# We need strip the version, or versioned
-	# libraries won't be included in the APK.
+	# We need to strip version numbers, as gradle will ignore
+	# versioned libraries and not include them in the APK.
 	for src in $(INSTALL_DIR)/koreader/libs/*; do \
 	  dst="$${src##*/}"; \
 	  dst="$${dst%%.[0-9]*}"; \


### PR DESCRIPTION
Missing `module/version.txt` would trigger a "new install" on every launch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12333)
<!-- Reviewable:end -->
